### PR TITLE
Fix: visual glitches in documentation (Safari)

### DIFF
--- a/docs/_sass/base.scss
+++ b/docs/_sass/base.scss
@@ -7,7 +7,7 @@
 
 ::selection {
   color: $white;
-  background: $link-color;
+  background: $grey-dk-300 !important;
 }
 
 html {

--- a/docs/_sass/layout.scss
+++ b/docs/_sass/layout.scss
@@ -154,7 +154,7 @@ html {
     padding-bottom: $sp-2;
 
     img {
-      max-width: none;
+      max-width: 100%;
     }
   }
 }


### PR DESCRIPTION
Change made by a member of the Bloomberg Managed Services Platform team.

**Describe your changes**
2 issues were detected in Safari:
- The logo was not respecting the max width of the container
- The highlight text colour was white in Safari making the text unreadable

Before:
<img width="1122" alt="image" src="https://github.com/bloomberg/blazingmq/assets/5774108/2e763408-ae56-4830-9eae-3fbfb74250c5">

After:
<img width="1064" alt="image" src="https://github.com/bloomberg/blazingmq/assets/5774108/68e00805-5a1d-4c35-b305-a8a380f5d5f0">


**Testing performed**
Checked in multiple browsers
