### PR TITLE
Fix: use existing domain in tutorials

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -135,7 +135,7 @@
 //
 //  // Populate the request
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
-//  req.uri() = "bmq://bmq.tutorial.hello/myQueue"
+//  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
 //
 //  // Now set the response callback to be invoked
@@ -207,7 +207,7 @@
 //..
 //  RequestManagerType::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
-//  req.uri() = "bmq://bmq.tutorial.hello/myQueue"
+//  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
 //
 //  // Now set the response callback to be invoked
@@ -251,7 +251,7 @@
 //..
 //  RequestManagerType::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
-//  req.uri() = "bmq://bmq.tutorial.hello/myQueue"
+//  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
 //
 //  // We don't set a response callback, which means that the RequestManager
@@ -292,7 +292,7 @@
 //..
 //  RequestManagerType::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
-//  req.uri() = "bmq://bmq.tutorial.hello/myQueue"
+//  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
 //
 //  // We can set either the response callback or the async notifier callback

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
@@ -477,7 +477,7 @@ static void testN1_decodeFromFile()
             bmqt::QueueFlagsUtil::setWriter(&flags);
             bmqt::QueueFlagsUtil::setAck(&flags);
 
-            params.uri()        = "bmq://bmq.tutorial.hello/test-queue";
+            params.uri()        = "bmq://bmq.test.mem.priority/test-queue";
             params.flags()      = flags;
             params.qId()        = 0;
             params.readCount()  = 0;
@@ -515,7 +515,7 @@ static void testN1_decodeFromFile()
             bmqt::QueueFlagsUtil::setWriter(&flags);
             bmqt::QueueFlagsUtil::setAck(&flags);
 
-            params.uri()        = "bmq://bmq.tutorial.hello/test-queue";
+            params.uri()        = "bmq://bmq.test.mem.priority/test-queue";
             params.flags()      = flags;
             params.qId()        = 0;
             params.readCount()  = 0;

--- a/src/tutorials/advanced/consumer.cpp
+++ b/src/tutorials/advanced/consumer.cpp
@@ -596,7 +596,7 @@ static void consume(bmqa::Session* session, QueueManager* queueManager)
     // so it doesn't really matter.  We believe it is far better for the
     // application to provide its own ids than for BlazingMQ to supply a queue
     // ids.
-    const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+    const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
 
     bmqt::CorrelationId   corrId(bmqt::CorrelationId::autoValue());
     bmqa::QueueId         queueId(corrId);

--- a/src/tutorials/advanced/producer.cpp
+++ b/src/tutorials/advanced/producer.cpp
@@ -774,7 +774,7 @@ static void produce(bmqa::Session* session, QueueManager* queueManager)
     // NOTE: it is designed this way because we believe it is better for the
     //       application to provide its own IDs than for BlazingMQ to supply a
     //       queue IDs.
-    const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+    const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
     const int  k_QUEUE_ID    = 1;
 
     bmqa::QueueId         queueId(k_QUEUE_ID);

--- a/src/tutorials/hello_world/consumer.cpp
+++ b/src/tutorials/hello_world/consumer.cpp
@@ -68,7 +68,7 @@ namespace {
 using ManagedHandler = bslma::ManagedPtr<bmqa::SessionEventHandler>;
 
 // CONSTANTS
-const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
 
 // FUNCTIONS
 bsl::function<void(int)> shutdownHandler;

--- a/src/tutorials/hello_world/producer.cpp
+++ b/src/tutorials/hello_world/producer.cpp
@@ -49,7 +49,7 @@ using namespace BloombergLP;
 
 namespace {
 typedef bsl::vector<bsl::string> TestMessages;
-const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
 const int  k_QUEUE_ID    = 1;
 }  // close unnamed namespace
 

--- a/src/tutorials/subscriptions/consumer.cpp
+++ b/src/tutorials/subscriptions/consumer.cpp
@@ -630,7 +630,7 @@ static void consume(bmqa::Session*            session,
     // so it doesn't really matter.  We believe it is far better for the
     // application to provide its own ids than for BlazingMQ to supply a queue
     // ids.
-    const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+    const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
 
     bsl::string        error;
     bmqt::QueueOptions queueOptions;

--- a/src/tutorials/subscriptions/producer.cpp
+++ b/src/tutorials/subscriptions/producer.cpp
@@ -788,7 +788,7 @@ static void produce(bmqa::Session* session, QueueManager* queueManager)
     // NOTE: it is designed this way because we believe it is better for the
     //       application to provide its own IDs than for BlazingMQ to supply a
     //       queue IDs.
-    const char k_QUEUE_URL[] = "bmq://bmq.tutorial.hello/test-queue";
+    const char k_QUEUE_URL[] = "bmq://bmq.test.mem.priority/test-queue";
     const int  k_QUEUE_ID    = 1;
 
     bmqa::QueueId         queueId(k_QUEUE_ID);


### PR DESCRIPTION
1. Tutorials: replace `bmq.tutorial.hello` with `bmq.test.mem.priority` which has its config in the repo: https://github.com/bloomberg/blazingmq/blob/main/src/applications/bmqbrkr/etc/domains/bmq.test.mem.priority.json

2. To avoid confusion, updated other mentions of domain `bmq.tutorial.hello`

8/8
https://github.com/search?q=repo%3Abloomberg%2Fblazingmq%20bmq.tutorial.hello&type=code