### PR TITLE
fix: Update mwcsys_executil.cpp

### DIFF
--- a/src/groups/mwc/mwcsys/mwcsys_executil.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_executil.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 // mwcsys_executil.cpp                                                -*-C++-*-
-#include <mwcsys_executil.h>
 
 #include <mwcscm_version.h>
 


### PR DESCRIPTION
Removed unused header mwcsys_executil.h

*Issue number of the reported bug or feature request: #36 *

**Describe your changes**
Tried to remove the unused <#include mwcsys_executil.h> from the codebase

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
