### PR TITLE
Fix: disable default allocator check for mwcex_bdlmtfixedthreadpoolexecutor

### DIFF
--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -8,14 +8,23 @@ set -euxo pipefail
 fetch_git() {
     local org=$1
     local repo=$2
-    local branch=${3:-"main"}
     mkdir -p srcs
-    curl -SL "https://github.com/${org}/${repo}/archive/refs/heads/${branch}.tar.gz" | tar -xzC srcs/
-    mv "srcs/${repo}-${branch}" "srcs/${repo}"
+
+    if [ -z "${3:-}" ]
+    then
+        # Clone the latest 'main' branch if no specific release tag provided
+        local branch="main"
+        curl -SL "https://github.com/${org}/${repo}/archive/refs/heads/${branch}.tar.gz" | tar -xzC srcs/
+        mv "srcs/${repo}-${branch}" "srcs/${repo}"
+    else
+        local tag=$3
+        curl -SL "https://github.com/${org}/${repo}/archive/refs/tags/${tag}.tar.gz" | tar -xzC srcs/
+        mv "srcs/${repo}-${tag}" "srcs/${repo}"
+    fi
 }
 
 fetch_deps() {
-    fetch_git bloomberg bde-tools
+    fetch_git bloomberg bde-tools 3.117.0.0
     fetch_git bloomberg bde
     fetch_git bloomberg ntf-core
 }

--- a/src/groups/mwc/mwcex/mwcex_bdlmtfixedthreadpoolexecutor.t.cpp
+++ b/src/groups/mwc/mwcex/mwcex_bdlmtfixedthreadpoolexecutor.t.cpp
@@ -264,5 +264,10 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    TEST_EPILOG(mwctst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    TEST_EPILOG(mwctst::TestHelper::e_CHECK_GBL_ALLOC);
+    // Default: there is a check in the 'bslmt_fastpostsemaphoreimpl.h':
+    //          BSLS.LOG BSLS_REVIEW failure: (level:R-OPT).
+    //          During this check some temporal objects constructed in
+    //          'bsls_review.h', including static counter.  This leads
+    //          to allocator check failure here.
 }


### PR DESCRIPTION
In the depths of `bsl_review` there are memory allocations, objects are built with default allocator:
https://github.com/bloomberg/bde/blob/e42f76cc29f355c4c9c0a45053ff5b6ef6a3f7d7/groups/bsl/bsls/bsls_review.h#L795

And especially this: `BSLS_REVIEW_REVIEW_COUNT_IMP` - this macro creates a static counter.