### PR TITLE
bmqeval_simpleevaluator.t: fix benchmark

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -88,7 +88,7 @@ static void testN1_SimpleEvaluator_GoogleBenchmark(benchmark::State& state)
     CompilationContext compilationContext(&localAllocator);
     SimpleEvaluator    evaluator;
 
-    ASSERT(evaluator.compile("false | (i64_42=42 & s_foo=\"foo\")",
+    ASSERT(evaluator.compile("false || (i64_42==42 && s_foo==\"foo\")",
                              compilationContext) == 0);
 
     ASSERT_EQ(evaluator.evaluate(evaluationContext), true);


### PR DESCRIPTION
**Describe your changes**
Benchmark uses alternate operators, now removed.

**Testing performed**
Build and run the benchmark:

```
~/dev/bmq/build/blazingmq/src/groups/bmq$ ./bmqeval_simpleevaluator.t.tsk -1
TEST /home/jleroy/dev/bmq/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp CASE -1
2023-08-17 11:32:53
Running ./bmqeval_simpleevaluator.t.tsk
Run on (8 X 2995.21 MHz CPU s)
CPU Caches:
  L1 Data 48K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 1280K (x4)
  L3 Unified 12288K (x1)
Load Average: 0.04, 0.11, 1.57
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
testN1_SimpleEvaluator_GoogleBenchmark        571 ns          571 ns      1000000
```
