### PR TITLE
Make unit tests build on Ubuntu 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ found in [this](https://github.com/bloomberg/blazingmq-sdk-java) repository.
 
 - [Documentation](#documentation)
 - [Quick Start](#quick-start)
+- [Building](#building)
 - [Installation](#installation)
 - [Contributions](#contributions)
 - [License](#license)
@@ -80,6 +81,22 @@ In the
 [companion](https://bloomberg.github.io/blazingmq/docs/getting_started/more_fun_with_blazingmq)
 article, readers can learn about some intermediate and advanced features of
 BlazingMQ and see them in action.
+
+---
+
+## Building
+
+[bin/build-ubuntu.sh](bin/build-ubuntu) and
+[bin/build-darwin.sh](bin/build-darwin) build BlazingMQ and its dependencies,
+respectively, on Ubuntu 22.04.2 LTS and Darwin 22.6.0. They can serve as a basis
+to build BlazingMQ on other systems.
+
+To build and run the unit tests:
+```
+cd build/blazingmq/
+make all.t
+ctest
+```
 
 ---
 

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -72,16 +72,17 @@ fi
 
 # :: Build the BlazingMQ repo :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 CMAKE_OPTIONS="\
-    -DBDE_BUILD_TARGET_64=1 \
+    -DBDE_BUILD_TARGET_SAFE=ON \
+    -DBDE_BUILD_TARGET_64=ON \
+    -DBDE_BUILD_TARGET_CPP17=ON \
     -DCMAKE_BUILD_TYPE=Debug \
     -DCMAKE_INSTALL_LIBDIR=${DIR_ROOT}/lib \
     -DCMAKE_INSTALL_PREFIX=${DIR_ROOT} \
-    -DCMAKE_MODULE_PATH=${DIR_THIRDPARTY}/bde-tools/cmake;${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem \
-    -DCMAKE_PREFIX_PATH=${DIR_ROOT} \
+    -DCMAKE_PREFIX_PATH=${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem \
     -DCMAKE_TOOLCHAIN_FILE=${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
-    -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-    -DFLEX_ROOT=/usr/lib/x86_64-linux-gnu"
+    -DFLEX_ROOT=/usr/lib/x86_64-linux-gnu \
+    -Dlibbenchmark=/usr/lib/x86_64-linux-gnu/libbenchmark.so"
 
 PKG_CONFIG_PATH="${DIR_ROOT}/lib64/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
 cmake -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" ${CMAKE_OPTIONS}


### PR DESCRIPTION
**Describe your changes**
Unit tests don't build on Ubuntu 20.

**Testing performed**
Build and run the tests.

**Additional context**
Problem was caused by an incorrect `benchmark.pc` file. Applied a work around that works on Ubuntu 22 as well.
