### PR TITLE
Make `bmqa_mocksession` match `bmqa_abstractsession` in `const`ness

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -1194,9 +1194,10 @@ MockSession::expect_configureQueue(BSLS_ANNOTATION_UNUSED QueueId* queueId,
 }
 
 MockSession::Call&
-MockSession::expect_configureQueueSync(BSLS_ANNOTATION_UNUSED QueueId* queueId,
-                                       const bmqt::QueueOptions&       options,
-                                       const bsls::TimeInterval&       timeout)
+MockSession::expect_configureQueueSync(
+    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    const bmqt::QueueOptions&             options,
+    const bsls::TimeInterval&             timeout)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -1256,8 +1257,9 @@ MockSession::expect_closeQueue(BSLS_ANNOTATION_UNUSED QueueId* queueId,
 }
 
 MockSession::Call&
-MockSession::expect_closeQueueSync(BSLS_ANNOTATION_UNUSED QueueId* queueId,
-                                   const bsls::TimeInterval&       timeout)
+MockSession::expect_closeQueueSync(
+    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    const bsls::TimeInterval&             timeout)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -1283,9 +1285,10 @@ MockSession::expect_closeQueueAsync(BSLS_ANNOTATION_UNUSED QueueId* queueId,
 }
 
 MockSession::Call&
-MockSession::expect_closeQueueAsync(BSLS_ANNOTATION_UNUSED QueueId* queueId,
-                                    const CloseQueueCallback&       callback,
-                                    const bsls::TimeInterval&       timeout)
+MockSession::expect_closeQueueAsync(
+    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    const CloseQueueCallback&       callback,
+    const bsls::TimeInterval&       timeout)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -1193,8 +1193,7 @@ MockSession::expect_configureQueue(BSLS_ANNOTATION_UNUSED QueueId* queueId,
     return call;
 }
 
-MockSession::Call&
-MockSession::expect_configureQueueSync(
+MockSession::Call& MockSession::expect_configureQueueSync(
     BSLS_ANNOTATION_UNUSED const QueueId* queueId,
     const bmqt::QueueOptions&             options,
     const bsls::TimeInterval&             timeout)
@@ -1256,8 +1255,7 @@ MockSession::expect_closeQueue(BSLS_ANNOTATION_UNUSED QueueId* queueId,
     return call;
 }
 
-MockSession::Call&
-MockSession::expect_closeQueueSync(
+MockSession::Call& MockSession::expect_closeQueueSync(
     BSLS_ANNOTATION_UNUSED const QueueId* queueId,
     const bsls::TimeInterval&             timeout)
 {
@@ -1284,11 +1282,10 @@ MockSession::expect_closeQueueAsync(BSLS_ANNOTATION_UNUSED QueueId* queueId,
     return d_calls.back();
 }
 
-MockSession::Call&
-MockSession::expect_closeQueueAsync(
+MockSession::Call& MockSession::expect_closeQueueAsync(
     BSLS_ANNOTATION_UNUSED const QueueId* queueId,
-    const CloseQueueCallback&       callback,
-    const bsls::TimeInterval&       timeout)
+    const CloseQueueCallback&             callback,
+    const bsls::TimeInterval&             timeout)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -1189,14 +1189,14 @@ class MockSession : public AbstractSession {
         QueueId*                  queueId,
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
     Call& expect_closeQueueSync(
-        QueueId*                  queueId,
+        const QueueId*            queueId,
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
 
     Call& expect_closeQueueAsync(
         QueueId*                  queueId,
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
     Call& expect_closeQueueAsync(
-        QueueId*                  queueId,
+        const QueueId*            queueId,
         const CloseQueueCallback& callback,
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
     Call& expect_configureQueue(
@@ -1204,7 +1204,7 @@ class MockSession : public AbstractSession {
         const bmqt::QueueOptions& options = bmqt::QueueOptions(),
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
     Call& expect_configureQueueSync(
-        QueueId*                  queueId,
+        const QueueId*            queueId,
         const bmqt::QueueOptions& options = bmqt::QueueOptions(),
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
     Call& expect_configureQueueAsync(


### PR DESCRIPTION
The `expect_XYZ` functions in `bmqa_mocksession` (e.g., `expect_configureQueueSync`) are run using the `BMQA_EXPECT_CALL` macro from a mock, and are meant to parallel the functions `XYZ` (e.g., `configureQueueSync`) in `bmqa_abstractsession`.  At the moment, several of these functions `expect_XYZ` differ from their corresponding `XYZ` functions in the `const`ness of their parameters:

  * `expect_closeQueueSync(QueueId*, ...)`, but `closeQueueSync(const QueueId*, ...)`

  * `expect_closeQueueAsync(QueueId*, ...)`, but `closeQueueAsync(const QueueId*, ...)`

  * `expect_configureQueueSync(QueueId*, ...)`, but `configureQueueSync(const QueueId*, ...)`

As a result, it is not possible to use `BMQA_EXPECT_CALL` from a mock session that implements the `AbstractSession` interface.

This patch changes the arguments to each `expect_XYZ` functions to take the same cv-qualifiers as their corresponding arguments in each `XYZ` function.

Fixes: #96 