### PR TITLE
Remove `const` from `AbstractSession` API

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_abstractsession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.cpp
@@ -97,9 +97,8 @@ void AbstractSession::loadMessageProperties(
 
 /// Queue management
 ///----------------
-int AbstractSession::getQueueId(
-    BSLS_ANNOTATION_UNUSED QueueId* queueId,
-    BSLS_ANNOTATION_UNUSED const bmqt::Uri& uri) const
+int AbstractSession::getQueueId(BSLS_ANNOTATION_UNUSED QueueId* queueId,
+                                BSLS_ANNOTATION_UNUSED const bmqt::Uri& uri)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(false && "Method is undefined in base protocol");
@@ -109,7 +108,7 @@ int AbstractSession::getQueueId(
 
 int AbstractSession::getQueueId(
     BSLS_ANNOTATION_UNUSED QueueId* queueId,
-    BSLS_ANNOTATION_UNUSED const bmqt::CorrelationId& correlationId) const
+    BSLS_ANNOTATION_UNUSED const bmqt::CorrelationId& correlationId)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(false && "Method is undefined in base protocol");
@@ -182,7 +181,7 @@ int AbstractSession::configureQueue(
 }
 
 ConfigureQueueStatus AbstractSession::configureQueueSync(
-    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    BSLS_ANNOTATION_UNUSED QueueId* queueId,
     BSLS_ANNOTATION_UNUSED const bmqt::QueueOptions& options,
     BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout)
 
@@ -208,7 +207,7 @@ int AbstractSession::configureQueueAsync(
 }
 
 void AbstractSession::configureQueueAsync(
-    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    BSLS_ANNOTATION_UNUSED QueueId* queueId,
     BSLS_ANNOTATION_UNUSED const bmqt::QueueOptions&     options,
     BSLS_ANNOTATION_UNUSED const ConfigureQueueCallback& callback,
     BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout)
@@ -228,7 +227,7 @@ int AbstractSession::closeQueue(
 }
 
 CloseQueueStatus AbstractSession::closeQueueSync(
-    BSLS_ANNOTATION_UNUSED const QueueId* queueId,
+    BSLS_ANNOTATION_UNUSED QueueId* queueId,
     BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout)
 {
     // PRECONDITIONS
@@ -250,7 +249,7 @@ int AbstractSession::closeQueueAsync(
 }
 
 void AbstractSession::closeQueueAsync(
-    BSLS_ANNOTATION_UNUSED const QueueId*            queueId,
+    BSLS_ANNOTATION_UNUSED QueueId*                  queueId,
     BSLS_ANNOTATION_UNUSED const CloseQueueCallback& callback,
     BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout)
 {

--- a/src/groups/bmq/bmqa/bmqa_abstractsession.h
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.h
@@ -167,14 +167,14 @@ class AbstractSession {
     /// specified `uri` and return 0 if such a queue was found, or leave
     /// `queueId` untouched and return a non-zero value if no queue
     /// corresponding to `uri` is currently open.
-    virtual int getQueueId(QueueId* queueId, const bmqt::Uri& uri) const;
+    virtual int getQueueId(QueueId* queueId, const bmqt::Uri& uri);
 
     /// Load in the specified `queueId` the queue corresponding to the
     /// specified `correlationId` and return 0 if such a queue was found, or
     /// leave `queueId` untouched and return a non-zero value if no queue
     /// corresponding to `correlationId` is currently open.
     virtual int getQueueId(QueueId*                   queueId,
-                           const bmqt::CorrelationId& correlationId) const;
+                           const bmqt::CorrelationId& correlationId);
 
     /// DEPRECATED: Use the `openQueueSync(QueueId *queueId...)` instead.
     ///             This method will be marked as
@@ -266,7 +266,7 @@ class AbstractSession {
     ///         thread(s) (i.e., from the EventHandler callback, if
     ///         provided) *WILL* lead to a *DEADLOCK*.
     virtual ConfigureQueueStatus configureQueueSync(
-        const QueueId*            queueId,
+        QueueId*                  queueId,
         const bmqt::QueueOptions& options,
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
 
@@ -280,7 +280,7 @@ class AbstractSession {
         const bsls::TimeInterval& timeout = bsls::TimeInterval());
 
     virtual void configureQueueAsync(
-        const QueueId*                queueId,
+        QueueId*                      queueId,
         const bmqt::QueueOptions&     options,
         const ConfigureQueueCallback& callback,
         const bsls::TimeInterval&     timeout = bsls::TimeInterval());
@@ -322,7 +322,7 @@ class AbstractSession {
     ///         thread(s) (i.e., from the EventHandler callback, if
     ///         provided) *WILL* lead to a *DEADLOCK*.
     virtual CloseQueueStatus
-    closeQueueSync(const QueueId*            queueId,
+    closeQueueSync(QueueId*                  queueId,
                    const bsls::TimeInterval& timeout = bsls::TimeInterval());
 
     /// DEPRECATED: Use the `closeQueueAsync(...)` with callback flavor
@@ -351,7 +351,7 @@ class AbstractSession {
     ///         EventHandler thread(s) (or if a SessionEventHandler was not
     ///         specified, from the thread invoking `nextEvent`).
     virtual void
-    closeQueueAsync(const QueueId*            queueId,
+    closeQueueAsync(QueueId*                  queueId,
                     const CloseQueueCallback& callback,
                     const bsls::TimeInterval& timeout = bsls::TimeInterval());
 

--- a/src/groups/bmq/bmqa/bmqa_abstractsession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.t.cpp
@@ -84,14 +84,14 @@ struct AbstractSessionTestImp : bsls::ProtocolTestImp<bmqa::AbstractSession> {
     }
 
     int getQueueId(bmqa::QueueId*   queueId,
-                   const bmqt::Uri& uri) const BSLS_KEYWORD_OVERRIDE
+                   const bmqt::Uri& uri) BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
     }
 
-    int getQueueId(bmqa::QueueId*             queueId,
-                   const bmqt::CorrelationId& correlationId) const
-        BSLS_KEYWORD_OVERRIDE
+    int
+    getQueueId(bmqa::QueueId*             queueId,
+               const bmqt::CorrelationId& correlationId) BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
     }
@@ -149,7 +149,7 @@ struct AbstractSessionTestImp : bsls::ProtocolTestImp<bmqa::AbstractSession> {
     }
 
     bmqa::ConfigureQueueStatus
-    configureQueueSync(const bmqa::QueueId*      queueId,
+    configureQueueSync(bmqa::QueueId*            queueId,
                        const bmqt::QueueOptions& options,
                        const bsls::TimeInterval& timeout) BSLS_KEYWORD_OVERRIDE
     {
@@ -164,7 +164,7 @@ struct AbstractSessionTestImp : bsls::ProtocolTestImp<bmqa::AbstractSession> {
         return markDone();
     }
 
-    void configureQueueAsync(const bmqa::QueueId*          queueId,
+    void configureQueueAsync(bmqa::QueueId*                queueId,
                              const bmqt::QueueOptions&     options,
                              const ConfigureQueueCallback& callback,
                              const bsls::TimeInterval&     timeout =
@@ -181,7 +181,7 @@ struct AbstractSessionTestImp : bsls::ProtocolTestImp<bmqa::AbstractSession> {
     }
 
     bmqa::CloseQueueStatus
-    closeQueueSync(const bmqa::QueueId*      queueId,
+    closeQueueSync(bmqa::QueueId*            queueId,
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE
     {
@@ -195,7 +195,7 @@ struct AbstractSessionTestImp : bsls::ProtocolTestImp<bmqa::AbstractSession> {
         return markDone();
     }
 
-    void closeQueueAsync(const bmqa::QueueId*      queueId,
+    void closeQueueAsync(bmqa::QueueId*            queueId,
                          const CloseQueueCallback& callback,
                          const bsls::TimeInterval& timeout =
                              bsls::TimeInterval()) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -1548,7 +1548,7 @@ void MockSession::loadMessageProperties(MessageProperties* buffer)
     *buffer = MessageProperties();
 }
 
-int MockSession::getQueueId(QueueId* queueId, const bmqt::Uri& uri) const
+int MockSession::getQueueId(QueueId* queueId, const bmqt::Uri& uri)
 {
     UriCorrIdToQueueMap::const_iterator iter =
         uriCorrIdToQueues(d_twoKeyHashMapBuffer).findByKey1(uri);
@@ -1569,7 +1569,7 @@ int MockSession::getQueueId(QueueId* queueId, const bmqt::Uri& uri) const
 }
 
 int MockSession::getQueueId(QueueId*                   queueId,
-                            const bmqt::CorrelationId& correlationId) const
+                            const bmqt::CorrelationId& correlationId)
 {
     UriCorrIdToQueueMap::const_iterator iter =
         uriCorrIdToQueues(d_twoKeyHashMapBuffer).findByKey2(correlationId);
@@ -1783,7 +1783,7 @@ int MockSession::configureQueue(QueueId*                  queueId,
 }
 
 ConfigureQueueStatus
-MockSession::configureQueueSync(const QueueId*            queueId,
+MockSession::configureQueueSync(QueueId*                  queueId,
                                 const bmqt::QueueOptions& options,
                                 const bsls::TimeInterval& timeout)
 {
@@ -1864,7 +1864,7 @@ int MockSession::configureQueueAsync(QueueId*                  queueId,
 }
 
 void MockSession::configureQueueAsync(
-    const QueueId*                                       queueId,
+    QueueId*                                             queueId,
     const bmqt::QueueOptions&                            options,
     BSLS_ANNOTATION_UNUSED const ConfigureQueueCallback& callback,
     const bsls::TimeInterval&                            timeout)
@@ -1927,7 +1927,7 @@ int MockSession::closeQueue(QueueId*                  queueId,
     return 0;
 }
 
-CloseQueueStatus MockSession::closeQueueSync(const QueueId*            queueId,
+CloseQueueStatus MockSession::closeQueueSync(QueueId*                  queueId,
                                              const bsls::TimeInterval& timeout)
 {
     // PRECONDITIONS
@@ -2007,7 +2007,7 @@ int MockSession::closeQueueAsync(QueueId*                  queueId,
 }
 
 void MockSession::closeQueueAsync(
-    const QueueId*                                   queueId,
+    QueueId*                                         queueId,
     BSLS_ANNOTATION_UNUSED const CloseQueueCallback& callback,
     const bsls::TimeInterval&                        timeout)
 {

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -1276,12 +1276,12 @@ class MockSession : public AbstractSession {
     /// Load `QueueId` object associated with the specified `uri` into the
     /// specified `queueId` output parameter.
     int getQueueId(QueueId*         queueId,
-                   const bmqt::Uri& uri) const BSLS_KEYWORD_OVERRIDE;
+                   const bmqt::Uri& uri) BSLS_KEYWORD_OVERRIDE;
 
     /// Load `QueueId` object associated with the specified `correlationId`
     /// into the specified `queueId` output parameter.
     int getQueueId(QueueId* queueId, const bmqt::CorrelationId& correlationId)
-        const BSLS_KEYWORD_OVERRIDE;
+        BSLS_KEYWORD_OVERRIDE;
 
     /// DEPRECATED: Use the `openQueueSync(QueueId *queueId...)` instead.
     ///             This method will be marked as
@@ -1361,7 +1361,7 @@ class MockSession : public AbstractSession {
     /// specified `options` to configure some advanced settings and return a
     /// result providing the status and context of the operation.  In
     /// general, a call to `configureQueueSync` emits nothing.
-    ConfigureQueueStatus configureQueueSync(const QueueId*            queueId,
+    ConfigureQueueStatus configureQueueSync(QueueId*                  queueId,
                                             const bmqt::QueueOptions& options,
                                             const bsls::TimeInterval& timeout)
         BSLS_KEYWORD_OVERRIDE;
@@ -1384,7 +1384,7 @@ class MockSession : public AbstractSession {
     /// call to `configureQueueAsync` does not emit a `SessionEvent`, but
     /// rather invokes the `callback` (if provided) instead when the
     /// corresponding `emitEvent` is called.
-    void configureQueueAsync(const QueueId*                queueId,
+    void configureQueueAsync(QueueId*                      queueId,
                              const bmqt::QueueOptions&     options,
                              const ConfigureQueueCallback& callback,
                              const bsls::TimeInterval&     timeout =
@@ -1404,7 +1404,7 @@ class MockSession : public AbstractSession {
     /// providing the status of the operation.  In general, a call to
     /// `closeQueueSync` emits nothing.
     CloseQueueStatus
-    closeQueueSync(const QueueId*            queueId,
+    closeQueueSync(QueueId*                  queueId,
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE;
 
@@ -1423,7 +1423,7 @@ class MockSession : public AbstractSession {
     /// requested operation.  In general, a call to `closeQueueAsync` does
     /// not emit a `SessionEvent`, but rather invokes the `callback` (if
     /// provided) instead when the corresponding `emitEvent` is called.
-    void closeQueueAsync(const QueueId*            queueId,
+    void closeQueueAsync(QueueId*                  queueId,
                          const CloseQueueCallback& callback,
                          const bsls::TimeInterval& timeout =
                              bsls::TimeInterval()) BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -854,7 +854,7 @@ void Session::loadMessageProperties(MessageProperties* buffer)
     *buffer = MessageProperties();
 }
 
-int Session::getQueueId(QueueId* queueId, const bmqt::Uri& uri) const
+int Session::getQueueId(QueueId* queueId, const bmqt::Uri& uri)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueId);
@@ -879,7 +879,7 @@ int Session::getQueueId(QueueId* queueId, const bmqt::Uri& uri) const
 }
 
 int Session::getQueueId(QueueId*                   queueId,
-                        const bmqt::CorrelationId& correlationId) const
+                        const bmqt::CorrelationId& correlationId)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueId);
@@ -1146,7 +1146,7 @@ int Session::configureQueue(QueueId*                  queueId,
 }
 
 ConfigureQueueStatus
-Session::configureQueueSync(const QueueId*            queueId,
+Session::configureQueueSync(QueueId*                  queueId,
                             const bmqt::QueueOptions& options,
                             const bsls::TimeInterval& timeout)
 {
@@ -1238,7 +1238,7 @@ int Session::configureQueueAsync(QueueId*                  queueId,
     return rc;
 }
 
-void Session::configureQueueAsync(const QueueId*                queueId,
+void Session::configureQueueAsync(QueueId*                      queueId,
                                   const bmqt::QueueOptions&     options,
                                   const ConfigureQueueCallback& callback,
                                   const bsls::TimeInterval&     timeout)
@@ -1325,7 +1325,7 @@ int Session::closeQueue(QueueId* queueId, const bsls::TimeInterval& timeout)
     return rc;
 }
 
-CloseQueueStatus Session::closeQueueSync(const QueueId*            queueId,
+CloseQueueStatus Session::closeQueueSync(QueueId*                  queueId,
                                          const bsls::TimeInterval& timeout)
 {
     // Validate parameters
@@ -1413,7 +1413,7 @@ int Session::closeQueueAsync(QueueId*                  queueId,
     return rc;
 }
 
-void Session::closeQueueAsync(const QueueId*            queueId,
+void Session::closeQueueAsync(QueueId*                  queueId,
                               const CloseQueueCallback& callback,
                               const bsls::TimeInterval& timeout)
 {

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -796,14 +796,14 @@ class Session : public AbstractSession {
     /// `queueId` untouched and return a non-zero value if no queue
     /// corresponding to `uri` is currently open.
     int getQueueId(QueueId*         queueId,
-                   const bmqt::Uri& uri) const BSLS_KEYWORD_OVERRIDE;
+                   const bmqt::Uri& uri) BSLS_KEYWORD_OVERRIDE;
 
     /// Load in the specified `queueId` the queue corresponding to the
     /// specified `correlationId` and return 0 if such a queue was found, or
     /// leave `queueId` untouched and return a non-zero value if no queue
     /// corresponding to `correlationId` is currently open.
     int getQueueId(QueueId* queueId, const bmqt::CorrelationId& correlationId)
-        const BSLS_KEYWORD_OVERRIDE;
+        BSLS_KEYWORD_OVERRIDE;
 
     /// DEPRECATED: Use the `openQueueSync(QueueId *queueId...)` instead.
     ///             This method will be marked as
@@ -913,7 +913,7 @@ class Session : public AbstractSession {
     ///         thread(s) (i.e., from the EventHandler callback, if
     ///         provided) *WILL* lead to a *DEADLOCK*.
     ConfigureQueueStatus
-    configureQueueSync(const QueueId*            queueId,
+    configureQueueSync(QueueId*                  queueId,
                        const bmqt::QueueOptions& options,
                        const bsls::TimeInterval& timeout =
                            bsls::TimeInterval()) BSLS_KEYWORD_OVERRIDE;
@@ -944,7 +944,7 @@ class Session : public AbstractSession {
     /// THREAD: The `callback` will *ALWAYS* be invoked from the
     ///         EventHandler thread(s) (or if a SessionEventHandler was not
     ///         specified, from the thread invoking `nextEvent`).
-    void configureQueueAsync(const QueueId*                queueId,
+    void configureQueueAsync(QueueId*                      queueId,
                              const bmqt::QueueOptions&     options,
                              const ConfigureQueueCallback& callback,
                              const bsls::TimeInterval&     timeout =
@@ -975,7 +975,7 @@ class Session : public AbstractSession {
     ///         thread(s) (i.e., from the EventHandler callback, if
     ///         provided) *WILL* lead to a *DEADLOCK*.
     CloseQueueStatus
-    closeQueueSync(const QueueId*            queueId,
+    closeQueueSync(QueueId*                  queueId,
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE;
 
@@ -1011,7 +1011,7 @@ class Session : public AbstractSession {
     /// THREAD: The `callback` will *ALWAYS* be invoked from the
     ///         EventHandler thread(s) (or if a SessionEventHandler was not
     ///         specified, from the thread invoking `nextEvent`).
-    void closeQueueAsync(const QueueId*            queueId,
+    void closeQueueAsync(QueueId*                  queueId,
                          const CloseQueueCallback& callback,
                          const bsls::TimeInterval& timeout =
                              bsls::TimeInterval()) BSLS_KEYWORD_OVERRIDE;


### PR DESCRIPTION
Existing consumers which implement the `AbstractSession` interface expect certain parameters and member functions to not be `const`. This API was changed recently, breaking such consumers.  This patch reverts this change.

*Issue number of the reported bug or feature request: #96*

**Describe your changes**
Removing `const` qualifiers from some member functions and parameters in `AbstractSession` and classes that inherit from it.

**Testing performed**
To ensure that the patch does not break our existing tests, we ran unit tests in this repo as well as tested against the soon-to-be open sourced Python SDK, which makes use of these interfaces.
