### PR TITLE
Add `DIR_INSTALL` variable to build scripts to ease installation of BlazingMQ and its dependencies

### DIFF
--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -25,7 +25,7 @@ if [ ! -f "$script_path" ] || [ "$(realpath "$0")" != "$(realpath "$script_path"
 fi
 
 # :: Set some initial constants :::::::::::::::::::::::::::::::::::::::::::::::
-DIR_ROOT="${DIR_ROOT:-$(pwd)}"
+DIR_ROOT="$(pwd)"
 
 DIR_THIRDPARTY="${DIR_ROOT}/thirdparty"
 mkdir -p "${DIR_THIRDPARTY}"

--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -33,6 +33,9 @@ mkdir -p "${DIR_THIRDPARTY}"
 DIR_BUILD="${DIR_BUILD:-${DIR_ROOT}/build}"
 mkdir -p "${DIR_BUILD}"
 
+DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}}"
+mkdir -p "${DIR_INSTALL}"
+
 
 # :: Clone dependencies :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if [ ! -d "${DIR_THIRDPARTY}/bde-tools" ]; then
@@ -54,10 +57,10 @@ PATH="${DIR_THIRDPARTY}/bde-tools/bin:$PATH"
 
 if [ ! -e "${DIR_BUILD}/bde/.complete" ]; then
     pushd "${DIR_THIRDPARTY}/bde"
-    eval "$(bbs_build_env -u opt_64_cpp17 -b "${DIR_BUILD}/bde")"
-    bbs_build configure --prefix="${DIR_ROOT}"
-    bbs_build build --prefix="${DIR_ROOT}"
-    bbs_build --install_dir="/" --prefix="${DIR_ROOT}" install
+    eval "$(bbs_build_env -u opt_64_cpp17 -b "${DIR_BUILD}/bde" -i "${DIR_INSTALL}")"
+    bbs_build configure --prefix="${DIR_INSTALL}"
+    bbs_build build --prefix="${DIR_INSTALL}"
+    bbs_build install --install_dir="/" --prefix="${DIR_INSTALL}"
     eval "$(bbs_build_env unset)"
     popd
     touch "${DIR_BUILD}/bde/.complete"-DBDE_BUILD_TARGET_64=1
@@ -66,7 +69,7 @@ fi
 if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     # Build and install NTF
     pushd "${DIR_THIRDPARTY}/ntf-core"
-    ./configure --prefix "${DIR_ROOT}" --output "${DIR_BUILD}/ntf"
+    ./configure --prefix "${DIR_INSTALL}" --output "${DIR_BUILD}/ntf"
     make -j 16
     make install
     popd
@@ -91,16 +94,16 @@ fi
 CMAKE_OPTIONS=(\
     -DBDE_BUILD_TARGET_64=1 \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_INSTALL_LIBDIR="${DIR_ROOT}/lib" \
-    -DCMAKE_INSTALL_PREFIX="${DIR_ROOT}" \
+    -DCMAKE_INSTALL_LIBDIR="lib" \
+    -DCMAKE_INSTALL_PREFIX="${DIR_INSTALL}" \
     -DCMAKE_MODULE_PATH="${DIR_THIRDPARTY}/bde-tools/cmake;${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem" \
-    -DCMAKE_PREFIX_PATH="${DIR_ROOT}" \
+    -DCMAKE_PREFIX_PATH="${DIR_INSTALL}" \
     -DCMAKE_TOOLCHAIN_FILE="${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/darwin/gcc-default.cmake" \
     -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DFLEX_ROOT="${FLEX_ROOT}")
 
-PKG_CONFIG_PATH="${DIR_ROOT}/lib/pkgconfig:${BREW_PKG_CONFIG_PATH}" \
+PKG_CONFIG_PATH="${DIR_INSTALL}/lib/pkgconfig:${BREW_PKG_CONFIG_PATH}" \
 cmake -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" "${CMAKE_OPTIONS[@]}"
 make -C "${DIR_BUILD}/blazingmq" -j 16
 

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -32,7 +32,7 @@ if [ ! -f "$script_path" ] || [ "$(realpath "$0")" != "$(realpath "$script_path"
 fi
 
 # :: Set some initial constants :::::::::::::::::::::::::::::::::::::::::::::::
-DIR_ROOT="${DIR_ROOT:-$(pwd)}"
+DIR_ROOT="$(pwd)"
 
 DIR_THIRDPARTY="${DIR_ROOT}/thirdparty"
 mkdir -p "${DIR_THIRDPARTY}"

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -40,6 +40,9 @@ mkdir -p "${DIR_THIRDPARTY}"
 DIR_BUILD="${DIR_BUILD:-${DIR_ROOT}/build}"
 mkdir -p "${DIR_BUILD}"
 
+DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}}"
+mkdir -p "${DIR_INSTALL}"
+
 # :: Clone dependencies :::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 if [ ! -d "${DIR_THIRDPARTY}/bde-tools" ]; then
@@ -60,10 +63,10 @@ PATH="${DIR_THIRDPARTY}/bde-tools/bin:$PATH"
 
 if [ ! -e "${DIR_BUILD}/bde/.complete" ]; then
     pushd "${DIR_THIRDPARTY}/bde"
-    eval "$(bbs_build_env -u opt_64_cpp17 -b "${DIR_BUILD}/bde")"
-    bbs_build configure --prefix="${DIR_ROOT}"
-    bbs_build build --prefix="${DIR_ROOT}"
-    bbs_build --install_dir="/" --prefix="${DIR_ROOT}" install
+    eval "$(bbs_build_env -u opt_64_cpp17 -b "${DIR_BUILD}/bde" -i "${DIR_INSTALL}")"
+    bbs_build configure --prefix="${DIR_INSTALL}"
+    bbs_build build --prefix="${DIR_INSTALL}"
+    bbs_build install --install_dir="/" --prefix="${DIR_INSTALL}"
     eval "$(bbs_build_env unset)"
     popd
     touch "${DIR_BUILD}/bde/.complete"
@@ -72,7 +75,7 @@ fi
 if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     # Build and install NTF
     pushd "${DIR_THIRDPARTY}/ntf-core"
-    ./configure --prefix "${DIR_ROOT}" --output "${DIR_BUILD}/ntf"
+    ./configure --prefix "${DIR_INSTALL}" --output "${DIR_BUILD}/ntf"
     make -j 16
     make install
     popd
@@ -83,16 +86,16 @@ fi
 CMAKE_OPTIONS=(\
     -DBDE_BUILD_TARGET_64=1 \
     -DCMAKE_BUILD_TYPE=Debug \
-    -DCMAKE_INSTALL_LIBDIR="${DIR_ROOT}/lib" \
-    -DCMAKE_INSTALL_PREFIX="${DIR_ROOT}" \
+    -DCMAKE_INSTALL_LIBDIR="lib" \
+    -DCMAKE_INSTALL_PREFIX="${DIR_INSTALL}" \
     -DCMAKE_MODULE_PATH="${DIR_THIRDPARTY}/bde-tools/cmake;${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem" \
-    -DCMAKE_PREFIX_PATH="${DIR_ROOT}" \
+    -DCMAKE_PREFIX_PATH="${DIR_INSTALL}" \
     -DCMAKE_TOOLCHAIN_FILE="${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake" \
     -DCMAKE_CXX_STANDARD=17 \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
     -DFLEX_ROOT=/usr/lib/x86_64-linux-gnu)
 
-PKG_CONFIG_PATH="${DIR_ROOT}/lib64/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
+PKG_CONFIG_PATH="${DIR_INSTALL}/lib64/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
 cmake -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" "${CMAKE_OPTIONS[@]}"
 make -C "${DIR_BUILD}/blazingmq" -j 16
 


### PR DESCRIPTION
**Describe your changes**
The build scripts currently install the build dependencies right within the source tree of BlazingMQ.  Consumers of the BlazingMQ API may wish to install BlazingMQ and its dependencies to a separate source tree (perhaps `/usr/local` or some other local install root) for easier building.  This PR allows users to configure the install root correctly, using a new `DIR_INSTALL` variable.  In the process, it makes `DIR_ROOT` non-configurable, as its remaining uses *must* have been the current source directory.

**Testing performed**
We built BlazingMQ using `./bin/build-darwin.sh` and with `DIR_INSTALL` set to a separate local install tree.  Each of BlazingMQ's dependencies build and install properly (verified manually), and BlazingMQ builds using these installed built dependencies.  Then, when installed using `cmake --install build/blazingmq/` (where `$DIR_BUILD` is `build`), build artifacts from BlazingMQ are properly installed in the `DIR_INSTALL` tree.

**Additional context**
These patches together end up removing most instances of `DIR_ROOT` from the script, as they untangle two unrelated uses of `DIR_ROOT`.

The build scripts still do not install BlazingMQ, though they do install its dependencies; this still must be done manually with `cmake --install`.  This is a strange asymmetry.  This patch maintains the current behavior, but we may want to revisit this.
