### PR TITLE
Collapse two `RUN` layers in the `Dockerfile`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,9 +2,8 @@ FROM docker.io/ubuntu:22.04 AS builder
 
 # Set up CA certificates first before installing other dependencies
 RUN apt-get update && \
-    apt-get -y install ca-certificates
-
-RUN apt-get install -y --no-install-recommends \
+    apt-get install -y ca-certificates && \
+    apt-get install -y --no-install-recommends \
     build-essential \
     gdb \
     curl \


### PR DESCRIPTION
**Describe your changes**
We currently have two adjacent `RUN` statements in the `Dockerfile` which both call `apt-get`.  The first of them updates apt’s package index and installs the `ca-certificates` package, while the second installs the BlazingMQ build dependencies and cleans apt’s package lists.  This results in a layer of non-trivial size that we would like to avoid.

This PR makes the minimal change to combine these two layers into a single layer, by unifying the two `RUN` statements.

**Testing performed**
`docker-compose -f docker/single-node/docker-compose.yaml up` and ensure that a single `RUN` statement is executed, and the broker builds and runs.
