### PR TITLE
Enhance bmqt_queueoptions.t subscription test with subscription expression validation

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_queueoptions.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_queueoptions.t.cpp
@@ -235,6 +235,21 @@ static void test4_subscriptionsTest()
         ASSERT(handles.emplace(handle).second);
     }
 
+    // Subscription expression validation
+    {
+        bmqt::Subscription       subscription;
+        bmqt::SubscriptionHandle handle(bmqt::CorrelationId::autoValue());
+
+        const bmqt::SubscriptionExpression expression(
+            "0invalid",
+            bmqt::SubscriptionExpression::e_VERSION_1);
+
+        subscription.setExpression(expression);
+        bsl::string error;
+        ASSERT(!obj.addOrUpdateSubscription(&error, handle, subscription));
+        ASSERT(!error.empty());
+    }
+
     bmqt::QueueOptions::SubscriptionsSnapshot snapshot(s_allocator_p);
     obj.loadSubscriptions(&snapshot);
 
@@ -276,5 +291,5 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    TEST_EPILOG(mwctst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    TEST_EPILOG(mwctst::TestHelper::e_CHECK_GBL_ALLOC);
 }


### PR DESCRIPTION
At the moment, `bmqt_queueoptions.t` subscription test (`test4_subscriptionsTest`) tests only valid subscription expression.

This test is enhanced to check that API behaves properly when invalid subscription expression is passed.

Also TEST_EPILOG was changed to `mwctst::TestHelper::e_CHECK_GBL_ALLOC` to avoid test failure due to `mwcu::MemOutStream` usage in `QueueOptions::addOrUpdateSubscription` in case of expression validation failure.
