### PR TITLE
Add support for building with vcpkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /build/
 /cmake.bld/
+/vcpkg_installed/
+compile_commands.json
+/out/
+/.cache/
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,23 @@ list( APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/etc/cmake" )
 include( BBVendor )
 include( TargetBMQStyleUor )
 
+if(DEFINED VCPKG_TOOLCHAIN)
+  find_package(bsl CONFIG PATH_SUFFIXES share/bde REQUIRED)
+  find_package(bal CONFIG PATH_SUFFIXES share/bde REQUIRED)
+  find_package(bdl CONFIG PATH_SUFFIXES share/bde REQUIRED)
+  find_package(nts REQUIRED)
+  find_package(ntc REQUIRED)
+
+  # vcpkg exports most other targets under a different name than what BdeBuildSystem uses to find
+  # targets. Because of this, if we detect that we're using vcpkg to provide targets, we alias them to the
+  # pkg-config style names BdeBuildSystem is trying to use.
+  find_package(benchmark CONFIG REQUIRED)
+  find_package(ZLIB REQUIRED)
+
+  add_library(benchmark ALIAS benchmark::benchmark)
+  add_library(zlib ALIAS ZLIB::ZLIB)
+endif()
+
 # -----------------------------------------------------------------------------
 #                                INITIALIZATION
 # -----------------------------------------------------------------------------

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,47 @@
+{
+    "version": 6,
+    "configurePresets": [
+        {
+            "name": "base",
+            "hidden": true,
+            "description": "Base configuration for a build of BlazingMQ",
+            "binaryDir": "cmake.bld",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BDE_BUILD_TARGET_SAFE": true,
+                "CMAKE_CXX_STANDARD": "17",
+                "BDE_BUILD_TARGET_CPP17": "17",
+                "CMAKE_INSTALL_LIBDIR": "lib64"
+            }
+        },
+        {
+            "name": "macos-arm64-vcpkg",
+            "description": "VCPKG based configuration for building on arm-based MacOS",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "inherits": "base",
+            "cacheVariables": {
+                "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
+                "FL_LIBRARY": "/opt/homebrew/opt/flex/lib/libfl.a",
+                "FLEX_INCLUDE_DIR": "/opt/homebrew/opt/flex/include"
+            }
+        },
+        {
+            "name": "macos-x64-vcpkg",
+            "description": "VCPKG based configuration for building on x86_64-based MacOS",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "inherits": "base",
+            "cacheVariables": {
+                "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
+                "FL_LIBRARY": "/usr/local/lib/opt/flex/lib/libfl.a",
+                "FLEX_INCLUDE_DIR": "/usr/local/lib/opt/flex/include"
+            }
+        },
+        {
+            "name": "linux-x64-vcpkg",
+            "description": "VCPKG based configuration for building on x86_64-based Linux",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "inherits": "base"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ BlazingMQ and see them in action.
 respectively, on Ubuntu 22.04.2 LTS and Darwin 22.6.0. They can serve as a basis
 to build BlazingMQ on other systems.
 
+### With vcpkg
+
+There is also support for building BlazingMQ with [vpckg](https://vcpkg.io/en/).
+
+Before attempting to build, you will have to acquire `flex`, `bison`, and `bde-tools` for your system, as vcpkg cannot fetch them. Both `flex` and `bison` can likely be installed through your system's package manager. Clone [`bde-tools`](https://github.com/bloomberg/bde-tools.git), we'll assume `blazingmq/thirdparty/bde-tools` for this guide.
+
+Once the prerequisite tools are installed, you should be able to build BlazingMQ with the following:
+
+```sh
+export VCPKG_ROOT=path/to/vcpkg
+cmake --preset [preset-name] -DCMAKE_PREFIX_PATH=thirdparty/bde-tools
+cmake --build cmake.bld
+```
+
+For a list of presets, please look at the `*-vcpkg` configurations in [`CMakePresets.json`](./CMakePresets.json).
+
 ---
 
 ## Installation

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "git",
+    "baseline": "130a670989867d645cadbc9b8ad0c97fcd429e04",
+    "repository": "https://github.com/microsoft/vcpkg"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "blazingmq",
+  "version": "1.13.3",
+  "dependencies": [
+    "bde",
+    "ntf-core",
+    "benchmark",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
**Describe your changes**
[vcpkg](https://vcpkg.io/en/) is a useful tool for providing libraries for C++ projects. With a few exceptions for system libraries and bde-tools, this PR adds build presets for CMake that utilize vcpkg as the package provider. 