### PR TITLE
Small fixes

### DIFF
--- a/src/applications/bmqbrkr/etc/clusters.json
+++ b/src/applications/bmqbrkr/etc/clusters.json
@@ -19,7 +19,6 @@
                 }
             ],
             "partitionConfig": {
-                "name": "local",
                 "flushAtShutdown": true,
                 "location": "localBMQ/storage/local",
                 "maxArchivedFileSets": 0,

--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -753,7 +753,7 @@
     <annotation>
       <documentation>
         Choice of all the various transport mode available to establish
-        connetivity with a node.
+        connectivity with a node.
 
         tcp.: TCP connectivity
       </documentation>


### PR DESCRIPTION
* Fix typo in `mqbcfg.xsd`.
* Remove `name` key in sample `clusters.json`. It was never needed, but was ignored.