### PR TITLE
Fix: ClientSession description during QueueHandle finalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build/
 /cmake.bld/
+/thirdparty/

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -570,9 +570,6 @@ class ClientSession : public mqbnet::Session,
     void closeQueueCb(const bsl::shared_ptr<mqbi::QueueHandle>& handle,
                       const bmqp_ctrlmsg::ControlMessage& handleParamsCtrlMsg);
 
-    void
-    finalizeClosedHandle(const bsl::shared_ptr<mqbi::QueueHandle>& handle);
-
     /// Return a pointer to the stats associated with an unknown queue.
     /// Note that these stats are lazily created in the first invocation of
     /// this method.


### PR DESCRIPTION
```
(gdb) f 0
#0  0x0000000001af4093 in BloombergLP::mqba::ClientSession::finalizeClosedHandle (this=0x7f1e5077b560, handle=const bsl::shared_ptr<BloombergLP::mqbi::QueueHandle> [ref:1,weak:0] = {...}) at /tmp/bmqbrkr-0.90.13/src/groups/mqb/mqba/mqba_clientsession.cpp:1346
warning: Source file is more recent than executable.
1346	    BALL_LOG_INFO << description() << ": Closed queue handle is finalized: "
```