### PR TITLE
Fix component documentation for `bmqt_subscription`

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -20,8 +20,8 @@
 //@PURPOSE: Provide a value-semantic types for subscription related API.
 //
 //@CLASSES:
-//  bmqt::Subscription_Handle:      uniquely identifies Subscription
-//  bmqt::Subscription_Expression:  Subscription criteria
+//  bmqt::SubscriptionHandle:       uniquely identifies Subscription
+//  bmqt::SubscriptionExpression:   Subscription criteria
 //  bmqt::Subscription:             Subscription parameters
 //
 //@DESCRIPTION: 'bmqt::Subscription' provides a value-semantic type carried


### PR DESCRIPTION
Currently, [the component-level documentation for
`bmqt_subscription`][bmqt_subscription] references `bmqt::Subscription_Handle` and `bmqt::Subscription_Expression` classes, which do not exist.  This results in broken links within our published documentation.  This patch corrects the documentation comment to correctly reference `bmqt::SubscriptionHandle` and `bmqt::SubscriptionExpression`, respectively.

Note that although this patch is very simple, it cannot be tested yet, until we can rebuild component-level documentation with Doxygen from source (see #118 for more details).

[bmqt_subscription]: https://bloomberg.github.io/blazingmq/docs/apidocs/cpp_apidocs/group__bmqt__subscription.html