### PR TITLE
Two version-related improvements

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -594,6 +594,73 @@ run(bsl::ostream& errorDescription, TaskEnvironment* taskEnv, bool wait = true)
 
 int main(int argc, const char* argv[])
 {
+
+    // Parse command line parameters
+    bsl::string configDir;
+    bsl::string instanceId = "default";
+    bsl::string hostName;
+    bsl::string hostTags;
+    bsl::string hostDataCenter;
+    int         port    = 0;
+    bool        version = false;
+
+    balcl::OptionInfo specTable[] = {
+        {"",
+         "config",
+         "Path to the configuration directory",
+         balcl::TypeInfo(&configDir),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"i|instanceId",
+         "instanceId",
+         "The instance ID ('default' if not provided)",
+         balcl::TypeInfo(&instanceId),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"h|hostName",
+         "hostName",
+         "Override host name",
+         balcl::TypeInfo(&hostName),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"t|hostTags",
+         "hostTags",
+         "Override host tags",
+         balcl::TypeInfo(&hostTags),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"d|hostDataCenter",
+         "hostDataCenter",
+         "Override host data center",
+         balcl::TypeInfo(&hostDataCenter),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"p|port",
+         "port",
+         "Override port",
+         balcl::TypeInfo(&port),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"v|version",
+         "version",
+         "Show version number",
+         balcl::TypeInfo(&version),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+    };
+
+    balcl::CommandLine commandLine(specTable);
+
+    if (commandLine.parse(argc, argv)) {
+        bsl::cerr << "PANIC [STARTUP] Failed to parse command line\n"
+                  << bsl::flush;
+        commandLine.printUsage();
+        return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
+    }
+
+    if (version) {
+        bsl::cout << bmqbrkrscm::Version::version() << "\n";
+        return 0;
+    }
+
+    if (configDir.empty()) {
+        bsl::cerr << "Error: No value supplied for the non-option argument "
+                     "\"config\".\n";
+    }
+
     printStartStopTrace("STARTING");
 
     ignoreSigpipe();
@@ -623,56 +690,6 @@ int main(int argc, const char* argv[])
 
     TaskEnvironment taskEnv;
     s_taskEnv_p = &taskEnv;
-
-    // Parse command line parameters
-    bsl::string configDir;
-    bsl::string instanceId = "default";
-    bsl::string hostName;
-    bsl::string hostTags;
-    bsl::string hostDataCenter;
-    int         port = 0;
-
-    balcl::OptionInfo specTable[] = {
-        {"",
-         "config",
-         "Path to the configuration directory",
-         balcl::TypeInfo(&configDir),
-         balcl::OccurrenceInfo::e_REQUIRED},
-        {"i|instanceId",
-         "instanceId",
-         "The instance ID ('default' if not provided)",
-         balcl::TypeInfo(&instanceId),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"h|hostName",
-         "hostName",
-         "Override host name",
-         balcl::TypeInfo(&hostName),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"t|hostTags",
-         "hostTags",
-         "Override host tags",
-         balcl::TypeInfo(&hostTags),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"d|hostDataCenter",
-         "hostDataCenter",
-         "Override host data center",
-         balcl::TypeInfo(&hostDataCenter),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"p|port",
-         "port",
-         "Override port",
-         balcl::TypeInfo(&port),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-    };
-
-    balcl::CommandLine commandLine(specTable);
-
-    if (commandLine.parse(argc, argv)) {
-        bsl::cerr << "PANIC [STARTUP] Failed to parse command line\n"
-                  << bsl::flush;
-        commandLine.printUsage();
-        return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
-    }
 
     const char* prefixEnvVar = bsl::getenv("BMQ_PREFIX");
     taskEnv.d_bmqPrefix      = (prefixEnvVar != 0 ? prefixEnvVar : "./");

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -594,7 +594,6 @@ run(bsl::ostream& errorDescription, TaskEnvironment* taskEnv, bool wait = true)
 
 int main(int argc, const char* argv[])
 {
-
     // Parse command line parameters
     bsl::string configDir;
     bsl::string instanceId = "default";
@@ -637,7 +636,7 @@ int main(int argc, const char* argv[])
          balcl::OccurrenceInfo::e_OPTIONAL},
         {"v|version",
          "version",
-         "Show version number",
+         "Show broker version number",
          balcl::TypeInfo(&version),
          balcl::OccurrenceInfo::e_OPTIONAL},
     };
@@ -652,13 +651,15 @@ int main(int argc, const char* argv[])
     }
 
     if (version) {
-        bsl::cout << bmqbrkrscm::Version::version() << "\n";
+        bsl::cout << "BlazingMQ broker version: "
+                  << bmqbrkrscm::Version::version() << "\n";
         return 0;
     }
 
     if (configDir.empty()) {
         bsl::cerr << "Error: No value supplied for the non-option argument "
                      "\"config\".\n";
+        return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
     }
 
     printStartStopTrace("STARTING");

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -299,6 +299,8 @@ static int getConfig(bsl::ostream&      errorDescription,
     }
 
     taskEnv->d_config.appConfig().etcDir() = configDir;
+    taskEnv->d_config.appConfig().brokerVersion() =
+        bmqbrkrscm::Version::versionAsInt();
     mqbcfg::BrokerConfig::set(taskEnv->d_config.appConfig());
 
     return rc_SUCCESS;


### PR DESCRIPTION
* Add command line switch (`--version` or `-v`) to query broker version.
* Let the broker set `appConfig.brokerVersion` from compiled-in `bmqbrkrscm_version`.

**Testing performed**
* `bmqbrkr.tsk --version` and `bmqbrkr.tsk -v`: displays the version
* `bmqbrkr.tsk`: print previous error message (missing config) and exit - as before
* Execute the `run` script: works as before