### PR TITLE
Fix WConversion warning

### DIFF
--- a/src/groups/mwc/mwctst/mwctst_blobtestutil.cpp
+++ b/src/groups/mwc/mwctst/mwctst_blobtestutil.cpp
@@ -59,7 +59,7 @@ bdlbb::Blob& BlobTestUtil::fromString(bdlbb::Blob*             blob,
         bsl::memcpy(bufData, dataStart, length);
         bsl::shared_ptr<char> buffer;
         buffer.reset(bufData, alloc);
-        bdlbb::BlobBuffer blobBuffer(buffer, length);
+        bdlbb::BlobBuffer blobBuffer(buffer, static_cast<int>(length));
         blob->appendDataBuffer(blobBuffer);
 
         if ((idx < format.size()) && format[idx] == '|') {


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This is a small `good first issue` contribution to fix -Wconversion warnings that pollutes the build log.

This particular PR deals with the following warning:
```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwctst/mwctst_blobtestutil.cpp:62:46: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
   62 |         bdlbb::BlobBuffer blobBuffer(buffer, length);

```

**Testing performed**
N/A
**Additional context**
Add any other context about your contribution here.
