### PR TITLE
Change C style numeric cast to static_cast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ compile_commands.json
 /.cache/
 CMakeUserPresets.json
 /thirdparty/
+/.vscode/

--- a/src/groups/bmq/bmqt/bmqt_version.cpp
+++ b/src/groups/bmq/bmqt/bmqt_version.cpp
@@ -37,8 +37,8 @@ Version::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
-    printer.printAttribute("major", int(d_major));
-    printer.printAttribute("minor", int(d_minor));
+    printer.printAttribute("major", static_cast<int>(d_major));
+    printer.printAttribute("minor", static_cast<int>(d_minor));
     printer.end();
 
     return stream;

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -2721,7 +2721,7 @@ int StorageUtil::processCommand(mqbcmd::StorageResult*     result,
     else if (command.isPartitionValue()) {
         const int partitionId = command.partition().partitionId();
 
-        if (partitionId < 0 || partitionId >= int(fileStores->size())) {
+        if (partitionId < 0 || partitionId >= static_cast<int>(fileStores->size())) {
             bdlma::LocalSequentialAllocator<256> localAllocator(allocator);
             mwcu::MemOutStream                   os(&localAllocator);
             os << "Invalid partitionId value: '" << partitionId << "'";

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -2721,7 +2721,8 @@ int StorageUtil::processCommand(mqbcmd::StorageResult*     result,
     else if (command.isPartitionValue()) {
         const int partitionId = command.partition().partitionId();
 
-        if (partitionId < 0 || partitionId >= static_cast<int>(fileStores->size())) {
+        if (partitionId < 0 ||
+            partitionId >= static_cast<int>(fileStores->size())) {
             bdlma::LocalSequentialAllocator<256> localAllocator(allocator);
             mwcu::MemOutStream                   os(&localAllocator);
             os << "Invalid partitionId value: '" << partitionId << "'";

--- a/src/groups/mwc/mwcst/mwcst_basictableinfoprovider.cpp
+++ b/src/groups/mwc/mwcst/mwcst_basictableinfoprovider.cpp
@@ -404,7 +404,8 @@ BasicTableInfoProvider::addColumn(const bslstl::StringRef& tableColumnName,
     ColumnFormat& column = d_columns.back();
 
     if (!d_columnGroups.empty()) {
-        column.d_columnGroupIndex = static_cast<int>(d_columnGroups.size()) - 1;
+        column.d_columnGroupIndex = static_cast<int>(d_columnGroups.size()) -
+                                    1;
     }
 
     return column;

--- a/src/groups/mwc/mwcst/mwcst_basictableinfoprovider.cpp
+++ b/src/groups/mwc/mwcst/mwcst_basictableinfoprovider.cpp
@@ -404,7 +404,7 @@ BasicTableInfoProvider::addColumn(const bslstl::StringRef& tableColumnName,
     ColumnFormat& column = d_columns.back();
 
     if (!d_columnGroups.empty()) {
-        column.d_columnGroupIndex = (int)d_columnGroups.size() - 1;
+        column.d_columnGroupIndex = static_cast<int>(d_columnGroups.size()) - 1;
     }
 
     return column;
@@ -421,10 +421,10 @@ int BasicTableInfoProvider::numRows() const
 int BasicTableInfoProvider::numColumns(int level) const
 {
     if (level == 0) {
-        return (int)d_columns.size();
+        return static_cast<int>(d_columns.size());
     }
     else {
-        return (int)d_columnGroups.size();
+        return static_cast<int>(d_columnGroups.size());
     }
 }
 

--- a/src/groups/mwc/mwcst/mwcst_printutil.cpp
+++ b/src/groups/mwc/mwcst/mwcst_printutil.cpp
@@ -117,9 +117,10 @@ const char* memoryHelper(bsls::Types::Int64* num,
 
     bsls::Types::Int64 div = (((bsls::Types::Int64)1) << shift);
     *num                   = bytes >> shift;
-    *remainder             = static_cast<int>(bsl::floor(
-        ((static_cast<double>(bytes - (*num << shift)) / static_cast<double>(div)) *
-         bsl::pow(10.0, precision))));
+    *remainder             = static_cast<int>(
+        bsl::floor(((static_cast<double>(bytes - (*num << shift)) /
+                     static_cast<double>(div)) *
+                    bsl::pow(10.0, precision))));
 
     if (negative) {
         *num = -*num;
@@ -257,8 +258,8 @@ bsl::ostream& PrintUtil::printValueWithSeparator(bsl::ostream& stream,
 
     if (precision > 0) {
         double absValue  = bsl::abs(value);
-        int    remainder = static_cast<int>(bsl::floor((absValue - bsl::floor(absValue)) *
-                                        bsl::pow(10.0, precision)));
+        int    remainder = static_cast<int>(bsl::floor(
+            (absValue - bsl::floor(absValue)) * bsl::pow(10.0, precision)));
 
         snprintf(pos - precision - 2,
                  precision + 2,

--- a/src/groups/mwc/mwcst/mwcst_printutil.cpp
+++ b/src/groups/mwc/mwcst/mwcst_printutil.cpp
@@ -76,9 +76,9 @@ const char* timeIntervalNsHelper(bsls::Types::Int64* num,
     }
 
     *num       = ns / div;
-    *remainder = (int)bsl::floor(
-        ((double)(ns - *num * div) / static_cast<double>(div)) *
-        bsl::pow(10.0, precision));
+    *remainder = static_cast<int>(bsl::floor(
+        (static_cast<double>(ns - *num * div) / static_cast<double>(div)) *
+        bsl::pow(10.0, precision)));
     return TIME_INTERVAL_NS_UNITS[level];
 }
 
@@ -117,9 +117,9 @@ const char* memoryHelper(bsls::Types::Int64* num,
 
     bsls::Types::Int64 div = (((bsls::Types::Int64)1) << shift);
     *num                   = bytes >> shift;
-    *remainder             = (int)bsl::floor(
-        (((double)(bytes - (*num << shift)) / static_cast<double>(div)) *
-         bsl::pow(10.0, precision)));
+    *remainder             = static_cast<int>(bsl::floor(
+        ((static_cast<double>(bytes - (*num << shift)) / static_cast<double>(div)) *
+         bsl::pow(10.0, precision))));
 
     if (negative) {
         *num = -*num;
@@ -257,8 +257,8 @@ bsl::ostream& PrintUtil::printValueWithSeparator(bsl::ostream& stream,
 
     if (precision > 0) {
         double absValue  = bsl::abs(value);
-        int    remainder = (int)bsl::floor((absValue - bsl::floor(absValue)) *
-                                        bsl::pow(10.0, precision));
+        int    remainder = static_cast<int>(bsl::floor((absValue - bsl::floor(absValue)) *
+                                        bsl::pow(10.0, precision)));
 
         snprintf(pos - precision - 2,
                  precision + 2,
@@ -279,7 +279,7 @@ bsl::ostream& PrintUtil::printStringCentered(bsl::ostream&            stream,
                                              const bslstl::StringRef& str)
 {
     bsl::streamsize width = stream.width();
-    if (width > (int)str.length()) {
+    if (width > static_cast<int>(str.length())) {
         bsl::streamsize left = (width + str.length()) / 2;
         stream.width(left);
         stream << str;
@@ -395,8 +395,8 @@ bsl::ostream& PrintUtil::printOrdinal(bsl::ostream&      stream,
 {
     stream << num;
 
-    int mod100 = (int)(num % 100);
-    int mod10  = (int)(num % 10);
+    int mod100 = static_cast<int>(num % 100);
+    int mod10  = static_cast<int>(num % 10);
 
     if (mod100 == 11 || mod100 == 12 || mod100 == 13) {
         return stream << "th";

--- a/src/groups/mwc/mwcst/mwcst_printutil.t.cpp
+++ b/src/groups/mwc/mwcst/mwcst_printutil.t.cpp
@@ -401,7 +401,7 @@ int main(int argc, char* argv[])
                 PrintUtil::printedMemoryLength(data.d_arg, data.d_precision);
 
             LOOP_ASSERT_EQUALS(LINE, ss.str(), data.d_expected_p);
-            LOOP_ASSERT_EQUALS(LINE, (int)ss.str().length(), expectedLength);
+            LOOP_ASSERT_EQUALS(LINE, static_cast<int>(ss.str().length()), expectedLength);
         }
 
 #undef TO_I64

--- a/src/groups/mwc/mwcst/mwcst_printutil.t.cpp
+++ b/src/groups/mwc/mwcst/mwcst_printutil.t.cpp
@@ -401,7 +401,9 @@ int main(int argc, char* argv[])
                 PrintUtil::printedMemoryLength(data.d_arg, data.d_precision);
 
             LOOP_ASSERT_EQUALS(LINE, ss.str(), data.d_expected_p);
-            LOOP_ASSERT_EQUALS(LINE, static_cast<int>(ss.str().length()), expectedLength);
+            LOOP_ASSERT_EQUALS(LINE,
+                               static_cast<int>(ss.str().length()),
+                               expectedLength);
         }
 
 #undef TO_I64

--- a/src/groups/mwc/mwcst/mwcst_statcontext.cpp
+++ b/src/groups/mwc/mwcst/mwcst_statcontext.cpp
@@ -727,7 +727,7 @@ int StatContext::valueIndex(const bslstl::StringRef& name) const
 {
     for (size_t i = 0; i < d_valueDefs_p->size(); ++i) {
         if ((*d_valueDefs_p)[i].d_name == name) {
-            return (int)i;
+            return static_cast<int>(i);
         }
     }
 

--- a/src/groups/mwc/mwcst/mwcst_statcontexttableinfoprovider.cpp
+++ b/src/groups/mwc/mwcst/mwcst_statcontexttableinfoprovider.cpp
@@ -333,7 +333,7 @@ void StatContextTableInfoProvider::addColumn(const bslstl::StringRef& name,
 {
     BSLS_ASSERT(!d_columnGroups.empty());
     d_columns.push_back(
-        ColumnInfo((int)d_columnGroups.size() - 1, name, column));
+        ColumnInfo(static_cast<int>(d_columnGroups.size()) - 1, name, column));
 }
 
 void StatContextTableInfoProvider::addColumn(const bslstl::StringRef& name,
@@ -342,7 +342,7 @@ void StatContextTableInfoProvider::addColumn(const bslstl::StringRef& name,
                                              const IntValueFunctor& func)
 {
     BSLS_ASSERT(!d_columnGroups.empty());
-    d_columns.push_back(ColumnInfo((int)d_columnGroups.size() - 1,
+    d_columns.push_back(ColumnInfo(static_cast<int>(d_columnGroups.size()) - 1,
                                    name,
                                    statValueIndex,
                                    printType,
@@ -355,7 +355,7 @@ void StatContextTableInfoProvider::addColumn(const bslstl::StringRef& name,
                                              const DoubleValueFunctor& func)
 {
     BSLS_ASSERT(!d_columnGroups.empty());
-    d_columns.push_back(ColumnInfo((int)d_columnGroups.size() - 1,
+    d_columns.push_back(ColumnInfo(static_cast<int>(d_columnGroups.size()) - 1,
                                    name,
                                    statValueIndex,
                                    printType,
@@ -427,16 +427,16 @@ void StatContextTableInfoProvider::addColumn(
 // ACCESSORS
 int StatContextTableInfoProvider::numRows() const
 {
-    return (int)d_rows.size();
+    return static_cast<int>(d_rows.size());
 }
 
 int StatContextTableInfoProvider::numColumns(int level) const
 {
     if (level == 0) {
-        return (int)d_columns.size();
+        return static_cast<int>(d_columns.size());
     }
     else {
-        return (int)d_columnGroups.size();
+        return static_cast<int>(d_columnGroups.size());
     }
 }
 

--- a/src/groups/mwc/mwcst/mwcst_statutil.cpp
+++ b/src/groups/mwc/mwcst/mwcst_statutil.cpp
@@ -95,7 +95,7 @@ double StatUtil::incrementsPerSecond(
         value.snapshot(secondSnapshot).snapshotTime() -
         value.snapshot(firstSnapshot).snapshotTime();
 
-    double divisor = (double)duration / DMCST_NS_PER_SEC;
+    double divisor = static_cast<double>(duration) / DMCST_NS_PER_SEC;
     return diff / divisor;
 }
 
@@ -145,7 +145,7 @@ double StatUtil::decrementsPerSecond(
         value.snapshot(secondSnapshot).snapshotTime() -
         value.snapshot(firstSnapshot).snapshotTime();
 
-    double divisor = (double)duration / DMCST_NS_PER_SEC;
+    double divisor = static_cast<double>(duration) / DMCST_NS_PER_SEC;
     return diff / divisor;
 }
 
@@ -198,7 +198,7 @@ StatUtil::ratePerSecond(const StatValue&                   value,
         value.snapshot(secondSnapshot).snapshotTime() -
         value.snapshot(firstSnapshot).snapshotTime();
 
-    double divisor = (double)duration / DMCST_NS_PER_SEC;
+    double divisor = static_cast<double>(duration) / DMCST_NS_PER_SEC;
     return diff / divisor;
 }
 

--- a/src/groups/mwc/mwcst/mwcst_statvalue.cpp
+++ b/src/groups/mwc/mwcst/mwcst_statvalue.cpp
@@ -39,7 +39,7 @@ bsls::Types::Int64 MIN_INT = bsl::numeric_limits<bsls::Types::Int64>::min();
 // PRIVATE MANIPULATORS
 void StatValue::aggregateLevel(int level, bsls::Types::Int64 snapshotTime)
 {
-    if (level + 1 >= (int)d_levelStartIndices.size() - 1) {
+    if (level + 1 >= static_cast<int>(d_levelStartIndices.size()) - 1) {
         // There is no higher aggregation level
         return;
     }

--- a/src/groups/mwc/mwcst/mwcst_tablerecords.cpp
+++ b/src/groups/mwc/mwcst/mwcst_tablerecords.cpp
@@ -200,12 +200,12 @@ const StatContext* TableRecords::context() const
 
 int TableRecords::numRecords() const
 {
-    return (int)d_records.size();
+    return static_cast<int>(d_records.size());
 }
 
 const TableRecords::Record& TableRecords::record(int index) const
 {
-    BSLS_ASSERT_SAFE(index < (int)d_records.size());
+    BSLS_ASSERT_SAFE(index < static_cast<int>(d_records.size()));
     return d_records[index];
 }
 

--- a/src/groups/mwc/mwcst/mwcst_tableschema.cpp
+++ b/src/groups/mwc/mwcst/mwcst_tableschema.cpp
@@ -295,7 +295,7 @@ TableSchema::addColumn(const bslstl::StringRef& name,
 // ACCESSORS
 int TableSchema::numColumns() const
 {
-    return (int)d_columns.size();
+    return static_cast<int>(d_columns.size());
 }
 
 const TableSchemaColumn& TableSchema::column(int index) const

--- a/src/groups/mwc/mwcst/mwcst_tableutil.cpp
+++ b/src/groups/mwc/mwcst/mwcst_tableutil.cpp
@@ -57,17 +57,17 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
 
     columnWidths[0].resize(info.numColumns(0), 0);
     for (size_t i = 0; i < columnWidths[0].size(); ++i) {
-        columnWidths[0][i] = info.getHeaderSize(0, (int)i);
+        columnWidths[0][i] = info.getHeaderSize(0, static_cast<int>(i));
 
         for (int row = 0; row < numRows; ++row) {
             columnWidths[0][i] = bsl::max(columnWidths[0][i],
-                                          info.getValueSize(row, (int)i));
+                                          info.getValueSize(row, static_cast<int>(i)));
         }
     }
 
     // Figure out widths of additional header cells
     for (size_t levelIdx = 1; levelIdx < columnWidths.size(); ++levelIdx) {
-        int               level            = (int)levelIdx;
+        int               level            = static_cast<int>(levelIdx);
         bsl::vector<int>& levelHeaders     = columnWidths[levelIdx];
         bsl::vector<int>& lastLevelHeaders = columnWidths[levelIdx - 1];
 
@@ -76,7 +76,7 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
         int lastUpdatedHeader = -1;
         int numSubHeaders     = 0;
         for (size_t col = 0; col < lastLevelHeaders.size(); ++col) {
-            int headerIdx = info.getParentHeader(level - 1, (int)col);
+            int headerIdx = info.getParentHeader(level - 1, static_cast<int>(col));
             levelHeaders[headerIdx] += lastLevelHeaders[col];
 
             if (lastUpdatedHeader == headerIdx) {
@@ -94,11 +94,11 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
                     int mod                = excess % numSubHeaders;
 
                     levelHeaders[lastUpdatedHeader] = headerSize;
-                    for (size_t hIdx = 0; (int)hIdx < numSubHeaders; ++hIdx) {
+                    for (size_t hIdx = 0; static_cast<int>(hIdx) < numSubHeaders; ++hIdx) {
                         // Add 'excessPerSubHeader' to each subHeader, and an
                         // extra '1' to 'mod' of them
                         lastLevelHeaders[col - hIdx - 1] +=
-                            excessPerSubHeader + ((int)hIdx < mod ? 1 : 0);
+                            excessPerSubHeader + (static_cast<int>(hIdx) < mod ? 1 : 0);
                     }
                 }
 
@@ -131,7 +131,7 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
     stream << bsl::setfill(' ');
 
     // Print the header rows
-    for (int level = (int)columnWidths.size() - 1; level >= 0; --level) {
+    for (int level = static_cast<int>(columnWidths.size()) - 1; level >= 0; --level) {
         stream << bsl::endl;
 
         for (size_t i = 0; i < columnWidths[level].size(); ++i) {
@@ -169,7 +169,7 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
             }
 
             stream << bsl::setw(columnWidths[0][col]);
-            info.printValue(stream, row, (int)col, columnWidths[0][col]);
+            info.printValue(stream, row, static_cast<int>(col), columnWidths[0][col]);
         }
         stream << bsl::endl;
     }

--- a/src/groups/mwc/mwcst/mwcst_tableutil.cpp
+++ b/src/groups/mwc/mwcst/mwcst_tableutil.cpp
@@ -60,8 +60,9 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
         columnWidths[0][i] = info.getHeaderSize(0, static_cast<int>(i));
 
         for (int row = 0; row < numRows; ++row) {
-            columnWidths[0][i] = bsl::max(columnWidths[0][i],
-                                          info.getValueSize(row, static_cast<int>(i)));
+            columnWidths[0][i] = bsl::max(
+                columnWidths[0][i],
+                info.getValueSize(row, static_cast<int>(i)));
         }
     }
 
@@ -76,7 +77,8 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
         int lastUpdatedHeader = -1;
         int numSubHeaders     = 0;
         for (size_t col = 0; col < lastLevelHeaders.size(); ++col) {
-            int headerIdx = info.getParentHeader(level - 1, static_cast<int>(col));
+            int headerIdx = info.getParentHeader(level - 1,
+                                                 static_cast<int>(col));
             levelHeaders[headerIdx] += lastLevelHeaders[col];
 
             if (lastUpdatedHeader == headerIdx) {
@@ -94,11 +96,14 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
                     int mod                = excess % numSubHeaders;
 
                     levelHeaders[lastUpdatedHeader] = headerSize;
-                    for (size_t hIdx = 0; static_cast<int>(hIdx) < numSubHeaders; ++hIdx) {
+                    for (size_t hIdx = 0;
+                         static_cast<int>(hIdx) < numSubHeaders;
+                         ++hIdx) {
                         // Add 'excessPerSubHeader' to each subHeader, and an
                         // extra '1' to 'mod' of them
                         lastLevelHeaders[col - hIdx - 1] +=
-                            excessPerSubHeader + (static_cast<int>(hIdx) < mod ? 1 : 0);
+                            excessPerSubHeader +
+                            (static_cast<int>(hIdx) < mod ? 1 : 0);
                     }
                 }
 
@@ -131,7 +136,8 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
     stream << bsl::setfill(' ');
 
     // Print the header rows
-    for (int level = static_cast<int>(columnWidths.size()) - 1; level >= 0; --level) {
+    for (int level = static_cast<int>(columnWidths.size()) - 1; level >= 0;
+         --level) {
         stream << bsl::endl;
 
         for (size_t i = 0; i < columnWidths[level].size(); ++i) {
@@ -169,7 +175,10 @@ int TableUtil::printTable(bsl::ostream& stream, const TableInfoProvider& info)
             }
 
             stream << bsl::setw(columnWidths[0][col]);
-            info.printValue(stream, row, static_cast<int>(col), columnWidths[0][col]);
+            info.printValue(stream,
+                            row,
+                            static_cast<int>(col),
+                            columnWidths[0][col]);
         }
         stream << bsl::endl;
     }

--- a/src/groups/mwc/mwcst/mwcst_testtableinfoprovider.cpp
+++ b/src/groups/mwc/mwcst/mwcst_testtableinfoprovider.cpp
@@ -55,13 +55,13 @@ void TestTableInfoProvider::addHeaderLevel(const Row& row)
 // ACCESSORS
 int TestTableInfoProvider::numRows() const
 {
-    return (int)d_table.size();
+    return static_cast<int>(d_table.size());
 }
 
 int TestTableInfoProvider::numColumns(int /*level*/) const
 {
     BSLS_ASSERT(d_headers.size() > 0);
-    return (int)d_headers[0].size();
+    return static_cast<int>(d_headers[0].size());
 }
 
 bool TestTableInfoProvider::hasTitle() const
@@ -71,7 +71,7 @@ bool TestTableInfoProvider::hasTitle() const
 
 int TestTableInfoProvider::numHeaderLevels() const
 {
-    return (int)d_headers.size();
+    return static_cast<int>(d_headers.size());
 }
 
 int TestTableInfoProvider::getValueSize(int row, int column) const

--- a/src/groups/mwc/mwcu/mwcu_operationchain.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_operationchain.t.cpp
@@ -176,7 +176,7 @@ struct ThrowException {
 
     // ACCESSORS
     BSLS_ANNOTATION_NORETURN
-    void operator()() const { throw int(42); }
+    void operator()() const { throw static_cast<int>(42); }
 };
 
 // ====================


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #126*

**Describe your changes**
1. Change all C style **numeric** cast statements i.e., `(double)val`, or `int(42)`, to `static_cast<T>(val)`

**Testing performed**
Currently experiencing vcpkg issues, but these changes are safe in nature. 
