### PR TITLE
C++20 fixes

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_storagecollectionutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storagecollectionutil.cpp
@@ -156,6 +156,31 @@ void StorageCollectionUtil::loadStorages(StorageList*       storages,
     }
 }
 
+namespace {
+
+template <class Predicate>
+struct Not1 {
+    Not1(const Predicate& predicate)
+    : d_predicate(predicate)
+    {
+    }
+
+    template <class Value>
+    bool operator()(const Value& value) const
+    {
+        return !d_predicate(value);
+    }
+    Predicate d_predicate;
+};
+
+template <class Predicate>
+Not1<Predicate> not_pred(const Predicate& predicate)
+{
+    return Not1<Predicate>(predicate);
+}
+
+}  // close anonymous namespace
+
 void StorageCollectionUtil::filterStorages(StorageList*         storages,
                                            const StorageFilter& filter)
 {
@@ -164,7 +189,7 @@ void StorageCollectionUtil::filterStorages(StorageList*         storages,
 
     StorageListIter iter = bsl::remove_if(storages->begin(),
                                           storages->end(),
-                                          bsl::not1(filter));
+                                          not_pred(filter));
     storages->erase(iter, storages->end());
 }
 


### PR DESCRIPTION
**Describe your changes**
[A clear and concise description of the changes you have made.
](std::not1 is removed from C++20. Since this code is expected to be built on C++03 as well as C++11 and newer, this patch embeds an adhoc version of 'not1' instead of, e.g., using a lambda expression.)

**Testing performed**
I ran the internal DPKG build for bmqbrkr.