### PR TITLE
Generating unique Subscription ids for each request

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_inpututil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.cpp
@@ -173,6 +173,8 @@ void InputUtil::verifyProperties(
 
             bsl::unordered_set<bsl::string> pairs;
 
+            pairs.insert("pairs_");
+
             while (it.hasNext()) {
                 bsl::string name = it.name();
 
@@ -201,7 +203,7 @@ void InputUtil::verifyProperties(
                     break;
                 }
                 case bmqt::PropertyType::e_SHORT: {
-                    BSLS_ASSERT_SAFE(it.getAsShort()() ==
+                    BSLS_ASSERT_SAFE(it.getAsShort() ==
                                      in.getPropertyAsShort(name));
                     break;
                 }

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -5245,9 +5245,8 @@ BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
 
             bmqp_ctrlmsg::Subscription subscription(d_allocator_p);
 
-            static bsls::AtomicUint s_nextId(0);
-
-            unsigned int internalSubscriptionId = s_nextId.add(1);
+            const unsigned int internalSubscriptionId =
+                ++d_nextInternalSubscriptionId;
 
             subscription.sId() = internalSubscriptionId;
             // Using unique id instead of 'SubscriptionHandle::id()'
@@ -5636,6 +5635,7 @@ BrokerSession::BrokerSession(
 , d_messageExpirationTimeoutHandle()
 , d_nextRequestGroupId(k_NON_BUFFERED_REQUEST_GROUP_ID)
 , d_queueRetransmissionTimeoutMap(allocator)
+, d_nextInternalSubscriptionId(bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_scheduler_p->clockType() ==

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -3533,10 +3533,9 @@ void BrokerSession::processPushEvent(const bmqp::Event& event)
             bmqt::CorrelationId         correlationId;
             unsigned int                subscriptionHandleId;
             const QueueManager::QueueSp queue =
-                    d_queueManager.observePushEvent(
-                            &correlationId,
-                            &subscriptionHandleId,
-                            *citer);
+                d_queueManager.observePushEvent(&correlationId,
+                                                &subscriptionHandleId,
+                                                *citer);
 
             BSLS_ASSERT(queue);
             queueEvent->insertQueue(citer->d_subscriptionId, queue);
@@ -3545,9 +3544,7 @@ void BrokerSession::processPushEvent(const bmqp::Event& event)
             // 'citer->d_subscriptionId' so that
             // 'bmqimp::Event::subscriptionId()' returns 'subscriptionHandle'
 
-            queueEvent->addCorrelationId(
-                    correlationId,
-                    subscriptionHandleId);
+            queueEvent->addCorrelationId(correlationId, subscriptionHandleId);
         }
 
         // Update event bytes
@@ -5275,10 +5272,9 @@ BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
             subscription.expression().text()    = from.expression().text();
 
             streamParams.subscriptions().emplace_back(subscription);
-            queue->registerInternalSubscriptionId(
-                    internalSubscriptionId,
-                    cit->first.id(),
-                    cit->first.correlationId());
+            queue->registerInternalSubscriptionId(internalSubscriptionId,
+                                                  cit->first.id(),
+                                                  cit->first.correlationId());
         }
         return context;  // RETURN
     }
@@ -5314,10 +5310,9 @@ BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
         streamParams.consumerPriority()      = options.consumerPriority();
         streamParams.consumerPriorityCount() = 1;
 
-        queue->registerInternalSubscriptionId(
-                queue->subQueueId(),
-                queue->subQueueId(),
-                bmqt::CorrelationId());
+        queue->registerInternalSubscriptionId(queue->subQueueId(),
+                                              queue->subQueueId(),
+                                              bmqt::CorrelationId());
     }
 
     return context;
@@ -6140,7 +6135,7 @@ void BrokerSession::onConfigureQueueResponse(
                              res == bmqt::GenericResult::e_NOT_CONNECTED ||
                              res == bmqt::GenericResult::e_NOT_SUPPORTED);
 
-            (void) res;
+            (void)res;
             BALL_LOG_INFO << "Ignore cancelled request: "
                           << context->request();
             return;  // RETURN

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.h
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.h
@@ -852,6 +852,9 @@ class BrokerSession BSLS_CPP11_FINAL {
     // retransmission timeout provided by
     // the broker
 
+    unsigned int d_nextInternalSubscriptionId;
+    // Assists generating unique ids for Configure requests.
+
   private:
     // NOT IMPLEMENTED
     BrokerSession(const BrokerSession&);

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -501,7 +501,7 @@ class Event {
     /// underlying raw event is of type ACK, PUT or PUSH.
     void addCorrelationId(const bmqt::CorrelationId& correlationId,
                           unsigned int               subscriptionHandleId =
-                              bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID);
+                              bmqt::SubscriptionHandle::k_INVALID_HANDLE_ID);
 
     /// Insert the specified `queue` to the queues and the specified
     /// `corrId` to the list of correlationIds associated with this event.

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -797,9 +797,8 @@ inline bmqp::PutEventBuilder* Event::putEventBuilder()
     return &(d_putEventBuilderBuffer.object());
 }
 
-inline void Event::addCorrelationId(
-        const bmqt::CorrelationId& correlationId,
-        unsigned int               subscriptionHandleId)
+inline void Event::addCorrelationId(const bmqt::CorrelationId& correlationId,
+                                    unsigned int subscriptionHandleId)
 {
     // TODO: when ACK event is created locally we have to fill d_correlationIds
     //       before the raw ACK 'bmqp::Event' is created and may be used to
@@ -812,9 +811,7 @@ inline void Event::addCorrelationId(
     // BSLS_ASSERT_SAFE(d_rawEvent.isAckEvent());
 
     d_correlationIds.push_back(
-            bsl::make_pair(
-                    correlationId,
-                    subscriptionHandleId));
+        bsl::make_pair(correlationId, subscriptionHandleId));
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -471,7 +471,7 @@ class Event {
     /// undefined unless 0 <= 'position' < numCorrrelationIds(), and event's
     /// type() is MESSAGEEVENT, 'messageEventMode()' is READ and the
     /// underlying raw event is of type PUSH.
-    const unsigned int subscriptionId(int position) const;
+    unsigned int subscriptionId(int position) const;
 
     // MANIPULATORS
 
@@ -500,7 +500,7 @@ class Event {
     /// event's type() is MESSAGEEVENT, 'messageEventMode()' is READ and the
     /// underlying raw event is of type ACK, PUT or PUSH.
     void addCorrelationId(const bmqt::CorrelationId& correlationId,
-                          unsigned int               subscriptionId =
+                          unsigned int               subscriptionHandleId =
                               bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID);
 
     /// Insert the specified `queue` to the queues and the specified
@@ -746,7 +746,7 @@ inline const bmqt::CorrelationId& Event::correlationId(int position) const
     return d_correlationIds[position].first;
 }
 
-inline const unsigned int Event::subscriptionId(int position) const
+inline unsigned int Event::subscriptionId(int position) const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(type() == EventType::e_MESSAGE);
@@ -797,8 +797,9 @@ inline bmqp::PutEventBuilder* Event::putEventBuilder()
     return &(d_putEventBuilderBuffer.object());
 }
 
-inline void Event::addCorrelationId(const bmqt::CorrelationId& correlationId,
-                                    unsigned int               subscriptionId)
+inline void Event::addCorrelationId(
+        const bmqt::CorrelationId& correlationId,
+        unsigned int               subscriptionHandleId)
 {
     // TODO: when ACK event is created locally we have to fill d_correlationIds
     //       before the raw ACK 'bmqp::Event' is created and may be used to
@@ -810,7 +811,10 @@ inline void Event::addCorrelationId(const bmqt::CorrelationId& correlationId,
     // BSLS_ASSERT_SAFE(messageEventMode() == MessageEventMode::e_READ);
     // BSLS_ASSERT_SAFE(d_rawEvent.isAckEvent());
 
-    d_correlationIds.push_back(bsl::make_pair(correlationId, subscriptionId));
+    d_correlationIds.push_back(
+            bsl::make_pair(
+                    correlationId,
+                    subscriptionHandleId));
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
@@ -341,13 +341,16 @@ void MessageDumper::dumpPushEvent(bsl::ostream& out, const bmqp::Event& event)
         unsigned int        subscriptionId;
         bmqp::RdaInfo       rdaInfo;
         bmqt::CorrelationId correlationId;
+        unsigned int        subscriptionHandle;
 
         iter.extractQueueInfo(&qId, &subscriptionId, &rdaInfo);
 
         QueueManager::QueueSp queue =
-            d_queueManager_p->lookupQueueBySubscriptionId(&correlationId,
-                                                          qId,
-                                                          subscriptionId);
+            d_queueManager_p->lookupQueueBySubscriptionId(
+                    &correlationId,
+                    &subscriptionHandle,
+                    qId,
+                    subscriptionId);
         BSLS_ASSERT_SAFE(queue);
 
         out << "PUSH Message #" << ++msgNum << ": "

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
@@ -346,11 +346,10 @@ void MessageDumper::dumpPushEvent(bsl::ostream& out, const bmqp::Event& event)
         iter.extractQueueInfo(&qId, &subscriptionId, &rdaInfo);
 
         QueueManager::QueueSp queue =
-            d_queueManager_p->lookupQueueBySubscriptionId(
-                    &correlationId,
-                    &subscriptionHandle,
-                    qId,
-                    subscriptionId);
+            d_queueManager_p->lookupQueueBySubscriptionId(&correlationId,
+                                                          &subscriptionHandle,
+                                                          qId,
+                                                          subscriptionId);
         BSLS_ASSERT_SAFE(queue);
 
         out << "PUSH Message #" << ++msgNum << ": "

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
@@ -341,15 +341,16 @@ void MessageDumper::dumpPushEvent(bsl::ostream& out, const bmqp::Event& event)
         unsigned int        subscriptionId;
         bmqp::RdaInfo       rdaInfo;
         bmqt::CorrelationId correlationId;
-        unsigned int        subscriptionHandle;
+        unsigned int        subscriptionHandleId;
 
         iter.extractQueueInfo(&qId, &subscriptionId, &rdaInfo);
 
         QueueManager::QueueSp queue =
-            d_queueManager_p->lookupQueueBySubscriptionId(&correlationId,
-                                                          &subscriptionHandle,
-                                                          qId,
-                                                          subscriptionId);
+            d_queueManager_p->lookupQueueBySubscriptionId(
+                &correlationId,
+                &subscriptionHandleId,
+                qId,
+                subscriptionId);
         BSLS_ASSERT_SAFE(queue);
 
         out << "PUSH Message #" << ++msgNum << ": "

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -545,12 +545,16 @@ void Tester::registerSubscription(const bslstl::StringRef&   uri,
                                   unsigned int               subscriptionId,
                                   const bmqt::CorrelationId& correlationId)
 {
-    const bmqimp::QueueManager::QueueSp& queue = d_queueManager.lookupQueue(
-        uri);
+    const bmqimp::QueueManager::QueueSp& queue =
+            d_queueManager.lookupQueue(
+                    uri);
 
     BSLS_ASSERT_SAFE(queue);
 
-    d_queueManager.registerSubscription(queue, subscriptionId, correlationId);
+    queue->registerInternalSubscriptionId(
+            subscriptionId,
+            subscriptionId,
+            correlationId);
 }
 
 void Tester::updateSubscriptions(const bslstl::StringRef&              uri,

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -545,16 +545,14 @@ void Tester::registerSubscription(const bslstl::StringRef&   uri,
                                   unsigned int               subscriptionId,
                                   const bmqt::CorrelationId& correlationId)
 {
-    const bmqimp::QueueManager::QueueSp& queue =
-            d_queueManager.lookupQueue(
-                    uri);
+    const bmqimp::QueueManager::QueueSp& queue = d_queueManager.lookupQueue(
+        uri);
 
     BSLS_ASSERT_SAFE(queue);
 
-    queue->registerInternalSubscriptionId(
-            subscriptionId,
-            subscriptionId,
-            correlationId);
+    queue->registerInternalSubscriptionId(subscriptionId,
+                                          subscriptionId,
+                                          correlationId);
 }
 
 void Tester::updateSubscriptions(const bslstl::StringRef&              uri,

--- a/src/groups/bmq/bmqimp/bmqimp_queue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.cpp
@@ -325,6 +325,7 @@ Queue::Queue(bslma::Allocator* allocator)
 , d_schemaLearner(allocator)
 , d_schemaLearnerContext(d_schemaLearner.createContext())
 , d_config(allocator)
+, d_registeredInternalSubscriptionIds(allocator)
 {
     d_handleParameters.uri()   = "";
     d_handleParameters.flags() = bmqt::QueueFlagsUtil::empty();

--- a/src/groups/bmq/bmqimp/bmqimp_queue.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.h
@@ -174,8 +174,8 @@ struct QueueStatsUtil {
 class Queue {
   public:
     // PUBLIC TYPES
-    typedef bsl::pair<unsigned int, bmqt::CorrelationId>    SubscriptionHandle;
-        // Not using private 'bmqt::SubscriptionHandle' ctor
+    typedef bsl::pair<unsigned int, bmqt::CorrelationId> SubscriptionHandle;
+    // Not using private 'bmqt::SubscriptionHandle' ctor
 
   private:
     // DATA
@@ -262,11 +262,11 @@ class Queue {
     bmqp_ctrlmsg::StreamParameters d_config;
 
     bsl::unordered_map<unsigned int, SubscriptionHandle>
-                                d_registeredInternalSubscriptionIds;
-        // This keeps SubscriptionHandle (id and CorrelationId) for Configure
-        // response processing.
-        // Supporting multiple concurrent Configure requests.
-        // TODO: This should go into ConfigureRequest context.
+        d_registeredInternalSubscriptionIds;
+    // This keeps SubscriptionHandle (id and CorrelationId) for Configure
+    // response processing.
+    // Supporting multiple concurrent Configure requests.
+    // TODO: This should go into ConfigureRequest context.
 
   private:
     // NOT IMPLEMENTED
@@ -337,19 +337,19 @@ class Queue {
     /// reinitialize the state before a new start).
     void clearStatContext();
 
-    void registerInternalSubscriptionId(
-            unsigned int                internalSubscriptionId,
-            unsigned int                subscriptionHandleId,
-            const bmqt::CorrelationId&  correlationId);
-        // Keep the specified 'subscriptionHandleId' and 'correlationId'
-        // associated with the specified 'internalSubscriptionId' between
-        // Configure request and Configure response (until
-        // 'extractSubscriptionHandle').
+    void
+    registerInternalSubscriptionId(unsigned int internalSubscriptionId,
+                                   unsigned int subscriptionHandleId,
+                                   const bmqt::CorrelationId& correlationId);
+    // Keep the specified 'subscriptionHandleId' and 'correlationId'
+    // associated with the specified 'internalSubscriptionId' between
+    // Configure request and Configure response (until
+    // 'extractSubscriptionHandle').
 
-    SubscriptionHandle extractSubscriptionHandle(
-            unsigned int internalSubscriptionId);
-        // Lookup, copy, erase, and return the copy of what was registered
-        // by 'registerInternalSubscriptionId'.
+    SubscriptionHandle
+    extractSubscriptionHandle(unsigned int internalSubscriptionId);
+    // Lookup, copy, erase, and return the copy of what was registered
+    // by 'registerInternalSubscriptionId'.
 
     // ACCESSORS
 
@@ -554,26 +554,24 @@ inline Queue& Queue::setConfig(const bmqp_ctrlmsg::StreamParameters& value)
     return *this;
 }
 
-inline
-void Queue::registerInternalSubscriptionId(
-        unsigned int                internalSubscriptionId,
-        unsigned int                subscriptionHandleId,
-        const bmqt::CorrelationId&  correlationId)
+inline void
+Queue::registerInternalSubscriptionId(unsigned int internalSubscriptionId,
+                                      unsigned int subscriptionHandleId,
+                                      const bmqt::CorrelationId& correlationId)
 {
     d_registeredInternalSubscriptionIds.emplace(
-            internalSubscriptionId,
-            SubscriptionHandle(subscriptionHandleId, correlationId));
+        internalSubscriptionId,
+        SubscriptionHandle(subscriptionHandleId, correlationId));
 }
 
-inline
-Queue::SubscriptionHandle
+inline Queue::SubscriptionHandle
 Queue::extractSubscriptionHandle(unsigned int internalSubscriptionId)
 {
-    bsl::unordered_map<unsigned int, SubscriptionHandle>::const_iterator
-    cit = d_registeredInternalSubscriptionIds.find(internalSubscriptionId);
+    bsl::unordered_map<unsigned int, SubscriptionHandle>::const_iterator cit =
+        d_registeredInternalSubscriptionIds.find(internalSubscriptionId);
 
     if (cit == d_registeredInternalSubscriptionIds.end()) {
-        return {internalSubscriptionId, bmqt::CorrelationId()};       // RETURN
+        return {internalSubscriptionId, bmqt::CorrelationId()};  // RETURN
     }
 
     SubscriptionHandle result(cit->second);

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -66,10 +66,10 @@ QueueManager::lookupQueueLocked(const bmqp::QueueId& queueId) const
 }
 
 QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionIdLocked(
-        bmqt::CorrelationId *correlationId,
-        unsigned int        *subscriptionHandleId,
-        int                  qId,
-        unsigned int         internalSubscriptionId) const
+    bmqt::CorrelationId* correlationId,
+    unsigned int*        subscriptionHandleId,
+    int                  qId,
+    unsigned int         internalSubscriptionId) const
 {
     // PRECONDITIONS
     // d_queuesLock locked
@@ -87,8 +87,8 @@ QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionIdLocked(
     // lookup by 'subscriptionId'
     SubscriptionId id(qId, internalSubscriptionId);
 
-    QueuesBySubscriptions::const_iterator cit =
-            d_queuesBySubscriptionIds.find(id);
+    QueuesBySubscriptions::const_iterator cit = d_queuesBySubscriptionIds.find(
+        id);
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
             cit == d_queuesBySubscriptionIds.end())) {
@@ -98,8 +98,8 @@ QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionIdLocked(
 
     BSLS_ASSERT_SAFE(cit->second.d_queue);
 
-    *subscriptionHandleId   = cit->second.d_subscriptionHandle.first;
-    *correlationId          = cit->second.d_subscriptionHandle.second;
+    *subscriptionHandleId = cit->second.d_subscriptionHandle.first;
+    *correlationId        = cit->second.d_subscriptionHandle.second;
 
     return cit->second.d_queue;
 }
@@ -289,10 +289,9 @@ void QueueManager::resetState()
 }
 
 const QueueManager::QueueSp
-QueueManager::observePushEvent(
-        bmqt::CorrelationId             *correlationId,
-        unsigned int                    *subscriptionHandle,
-        const bmqp::EventUtilQueueInfo&  info)
+QueueManager::observePushEvent(bmqt::CorrelationId* correlationId,
+                               unsigned int*        subscriptionHandle,
+                               const bmqp::EventUtilQueueInfo& info)
 {
     // Update stats
     const QueueSp queue = lookupQueueBySubscriptionIdLocked(
@@ -497,8 +496,8 @@ void QueueManager::resetSubStreamCount(const bsl::string& canonicalUri)
 }
 
 void QueueManager::updateSubscriptions(
-    const bsl::shared_ptr<Queue>&            queue,
-    const bmqp_ctrlmsg::StreamParameters&    config)
+    const bsl::shared_ptr<Queue>&         queue,
+    const bmqp_ctrlmsg::StreamParameters& config)
 {
     BSLS_ASSERT_SAFE(queue);
 
@@ -506,28 +505,19 @@ void QueueManager::updateSubscriptions(
 
     for (size_t i = 0; i < previous.subscriptions().size(); ++i) {
         unsigned int internalSubscriptionId =
-                previous.subscriptions()[i].sId();
+            previous.subscriptions()[i].sId();
 
-        SubscriptionId id(
-                queue->id(),
-                internalSubscriptionId);
+        SubscriptionId id(queue->id(), internalSubscriptionId);
 
         d_queuesBySubscriptionIds.erase(id);
     }
 
     for (size_t i = 0; i < config.subscriptions().size(); ++i) {
+        unsigned int internalSubscriptionId = config.subscriptions()[i].sId();
 
-        unsigned int internalSubscriptionId =
-                config.subscriptions()[i].sId();
-
-        d_queuesBySubscriptionIds.insert(
-                bsl::make_pair(
-                        SubscriptionId(
-                                queue->id(),
-                                internalSubscriptionId),
-                        QueueBySubscription(
-                                internalSubscriptionId,
-                                queue)));
+        d_queuesBySubscriptionIds.insert(bsl::make_pair(
+            SubscriptionId(queue->id(), internalSubscriptionId),
+            QueueBySubscription(internalSubscriptionId, queue)));
     }
 }
 

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -290,13 +290,13 @@ void QueueManager::resetState()
 
 const QueueManager::QueueSp
 QueueManager::observePushEvent(bmqt::CorrelationId* correlationId,
-                               unsigned int*        subscriptionHandle,
+                               unsigned int*        subscriptionHandleId,
                                const bmqp::EventUtilQueueInfo& info)
 {
     // Update stats
     const QueueSp queue = lookupQueueBySubscriptionIdLocked(
         correlationId,
-        subscriptionHandle,
+        subscriptionHandleId,
         info.d_header.queueId(),
         info.d_subscriptionId);
 

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
@@ -311,7 +311,7 @@ class QueueManager {
                     const bmqp::PushMessageIterator& iterator);
 
     const QueueSp observePushEvent(bmqt::CorrelationId* correlationId,
-                                   unsigned int*        subscriptionHandle,
+                                   unsigned int*        subscriptionHandleId,
                                    const bmqp::EventUtilQueueInfo& info);
 
     /// Update stats for the queue(s) corresponding to the messages pointed
@@ -352,7 +352,7 @@ class QueueManager {
     /// `correlationId`, and return a shared pointer to the Queue object (if
     /// found), or an empty shared pointer (if not found).
     QueueSp lookupQueueBySubscriptionId(bmqt::CorrelationId* correlationId,
-                                        unsigned int* subscriptionHandle,
+                                        unsigned int* subscriptionHandleId,
                                         int           queueId,
                                         unsigned int  subscriptionId) const;
 
@@ -438,14 +438,14 @@ QueueManager::lookupQueue(const bmqp::QueueId& queueId) const
 
 inline QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionId(
     bmqt::CorrelationId* correlationId,
-    unsigned int*        subscriptionHandle,
+    unsigned int*        subscriptionHandleId,
     int                  queueId,
     unsigned int         internalSubscriptionId) const
 {
     bsls::SpinLockGuard guard(&d_queuesLock);  // d_queuesLock LOCKED
 
     return lookupQueueBySubscriptionIdLocked(correlationId,
-                                             subscriptionHandle,
+                                             subscriptionHandleId,
                                              queueId,
                                              internalSubscriptionId);
 }

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
@@ -151,7 +151,7 @@ class QueueManager {
   public:
     // TYPES
 
-    typedef bsl::shared_ptr<Queue> QueueSp;
+    typedef bsl::shared_ptr<Queue>                       QueueSp;
     typedef bsl::pair<unsigned int, bmqt::CorrelationId> SubscriptionUandle;
 
     struct QueueBySubscription {
@@ -161,9 +161,8 @@ class QueueManager {
         // The Subscription correlationId as
         // specified in the configure request.
 
-        QueueBySubscription(
-                unsigned int                     internalSubscriptionId,
-                const bsl::shared_ptr<Queue>&     queue);
+        QueueBySubscription(unsigned int internalSubscriptionId,
+                            const bsl::shared_ptr<Queue>& queue);
     };
 
     /// Subscription id -> {Queue, Subscription correlationId}
@@ -247,11 +246,10 @@ class QueueManager {
     /// successful lookup Load the Subscription correlationId into the
     /// specified `correlationId`.
     QueueSp
-    lookupQueueBySubscriptionIdLocked(
-            bmqt::CorrelationId *correlationId,
-            unsigned int        *subscriptionHandleId,
-            int                  qid,
-            unsigned int         innerSubscriptionId) const;
+    lookupQueueBySubscriptionIdLocked(bmqt::CorrelationId* correlationId,
+                                      unsigned int* subscriptionHandleId,
+                                      int           qid,
+                                      unsigned int  innerSubscriptionId) const;
 
   public:
     // TRAITS
@@ -312,10 +310,9 @@ class QueueManager {
                     bool* hasMessageWithMultipleSubQueueIds,
                     const bmqp::PushMessageIterator& iterator);
 
-    const QueueSp observePushEvent(
-            bmqt::CorrelationId             *correlationId,
-            unsigned int                    *subscriptionHandle,
-            const bmqp::EventUtilQueueInfo&  info);
+    const QueueSp observePushEvent(bmqt::CorrelationId* correlationId,
+                                   unsigned int*        subscriptionHandle,
+                                   const bmqp::EventUtilQueueInfo& info);
 
     /// Update stats for the queue(s) corresponding to the messages pointed
     /// to by the specified `iterator` and populate the specified
@@ -343,9 +340,8 @@ class QueueManager {
     /// object.
     void resetSubStreamCount(const bsl::string& canonicalUri);
 
-    void updateSubscriptions(
-            const bsl::shared_ptr<Queue>&            queue,
-            const bmqp_ctrlmsg::StreamParameters&     config);
+    void updateSubscriptions(const bsl::shared_ptr<Queue>&         queue,
+                             const bmqp_ctrlmsg::StreamParameters& config);
 
     // ACCESSORS
     QueueSp lookupQueue(const bmqt::Uri& uri) const;
@@ -355,11 +351,10 @@ class QueueManager {
     /// Lookup the queue with the specified `queueId`, or `uri`, or
     /// `correlationId`, and return a shared pointer to the Queue object (if
     /// found), or an empty shared pointer (if not found).
-    QueueSp lookupQueueBySubscriptionId(
-            bmqt::CorrelationId* correlationId,
-            unsigned int        *subscriptionHandle,
-            int                  queueId,
-            unsigned int subscriptionId) const;
+    QueueSp lookupQueueBySubscriptionId(bmqt::CorrelationId* correlationId,
+                                        unsigned int* subscriptionHandle,
+                                        int           queueId,
+                                        unsigned int  subscriptionId) const;
 
     // TBD: Temporary method to enable refactoring of 'BrokerSession'.
     //      Specifically, reopen logic in 'BrokerSession::processPacket'.
@@ -386,11 +381,11 @@ class QueueManager {
 // ----------------------------------------
 
 inline QueueManager::QueueBySubscription::QueueBySubscription(
-        unsigned int                     internalSubscriptionId,
-        const bsl::shared_ptr<Queue>&     queue)
+    unsigned int                  internalSubscriptionId,
+    const bsl::shared_ptr<Queue>& queue)
 : d_queue(queue)
 , d_subscriptionHandle(
-        queue->extractSubscriptionHandle(internalSubscriptionId))
+      queue->extractSubscriptionHandle(internalSubscriptionId))
 {
     // NOTHING
 }
@@ -441,20 +436,18 @@ QueueManager::lookupQueue(const bmqp::QueueId& queueId) const
     return lookupQueueLocked(queueId);
 }
 
-inline QueueManager::QueueSp
-QueueManager::lookupQueueBySubscriptionId(
-        bmqt::CorrelationId* correlationId,
-        unsigned int        *subscriptionHandle,
-        int                  queueId,
-        unsigned int         internalSubscriptionId) const
+inline QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionId(
+    bmqt::CorrelationId* correlationId,
+    unsigned int*        subscriptionHandle,
+    int                  queueId,
+    unsigned int         internalSubscriptionId) const
 {
     bsls::SpinLockGuard guard(&d_queuesLock);  // d_queuesLock LOCKED
 
-    return lookupQueueBySubscriptionIdLocked(
-            correlationId,
-            subscriptionHandle,
-            queueId,
-            internalSubscriptionId);
+    return lookupQueueBySubscriptionIdLocked(correlationId,
+                                             subscriptionHandle,
+                                             queueId,
+                                             internalSubscriptionId);
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_optionsview.h
+++ b/src/groups/bmq/bmqp/bmqp_optionsview.h
@@ -347,7 +347,7 @@ inline OptionsView::Iterator::Iterator(const OptionsView* optionsView,
                                        const unsigned int offset)
 : d_optionsView_p(optionsView)
 , d_offset(offset)
-, d_value(static_cast<const bmqp::OptionType::Enum>(d_offset))
+, d_value(static_cast<bmqp::OptionType::Enum>(d_offset))
 {
 }
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -411,6 +411,7 @@ struct Protocol {
     // RemainingDeliveryAttempts counter value.
 
     static const unsigned int k_DEFAULT_SUBSCRIPTION_ID = 0;
+    // Internal unique id in Configure request
 
     // CLASS METHODS
 

--- a/src/groups/bmq/bmqt/bmqt_subscription.cpp
+++ b/src/groups/bmq/bmqt/bmqt_subscription.cpp
@@ -43,7 +43,7 @@ const int Subscription::k_DEFAULT_CONSUMER_PRIORITY        = 0;
 
 unsigned int SubscriptionHandle::nextId()
 {
-    static bsls::AtomicUint s_id = 0;
+    static bsls::AtomicUint s_id = k_INVALID_HANDLE_ID;
 
     return ++s_id;
 }

--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -64,6 +64,10 @@ class SubscriptionHandle {
     friend class bmqa::MessageImpl;
     friend class bmqa::MessageIterator;
 
+  public:
+    static const unsigned int k_INVALID_HANDLE_ID = 0;
+    // Initial (invalid) value for 'bmqt::SubscriptionHandle::d_id'
+
   private:
     // PRIVATE DATA
     unsigned int d_id;
@@ -281,7 +285,7 @@ bsl::ostream& operator<<(bsl::ostream& stream, const Subscription& rhs);
 // ----------------------
 
 inline SubscriptionHandle::SubscriptionHandle()
-: d_id(0)
+: d_id(k_INVALID_HANDLE_ID)
 , d_correlationId()
 {
     // NOTHING

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -535,10 +535,12 @@ QueueHandle::QueueHandle(
     d_throttledDroppedPutMessages.initialize(
         1,
         5 * bdlt::TimeUnitRatio::k_NS_PER_S);
-    d_throttledSubscriptionInfo.initialize(
-        1,
-        5 * bdlt::TimeUnitRatio::k_NS_PER_S);
     // One maximum log per 5 seconds
+
+    d_throttledSubscriptionInfo.initialize(
+        10,
+        5 * bdlt::TimeUnitRatio::k_NS_PER_S);
+    // Ten per 5 seconds
 
     setHandleParameters(handleParameters);
 }


### PR DESCRIPTION
Issue number of the reported bug or feature request: #133

2 Subscription Ids is not enough; we need 3.

In the order of increasing uniqueness:
1. `CorrelationId` - user provided.
2. `SubscriptionHandle` - uniquely identifies a Subscription in `QueueOptions`.  But if reused for different App in the same queue, creates the issue
3.  New unique id generated for each Subscription for each Configure request.

The existing logic involved storing request context associated with subscriptions (like, `CorrelationId`) until response arrives which makes the context effective.  The logic is slightly refactored.

Ideally, the context belongs to `BrokerSession::RequestManagerType::RequestSp` but that calls for a bigger refactoring of the SDK.
