### PR TITLE
Add checks to pointer arguments in m_bmqtool_inpututil

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_inpututil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.cpp
@@ -52,6 +52,9 @@ void InputUtil::preprocessInput(bsl::string*                     verb,
                                 const bsl::string&               input,
                                 bsl::unordered_set<bsl::string>* keys)
 {
+    BSLS_ASSERT_SAFE(verb);
+    BSLS_ASSERT_SAFE(output);
+    BSLS_ASSERT_SAFE(keys);
     mwcu::MemOutStream oss;
 
     bool isKey = true, isFirstKey = true, isVerb = true;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #81*

**Describe your changes**
Added `BSLS_ASSERT_SAFE` guards to check whether the pointer is null or not.

**Testing performed**
Build passes, not sure if any testing is required.
