### PR TITLE
[DO NOT MERGE] CMakeLists.txt: Find benchmark and zlib outside of vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,12 +26,12 @@ if(DEFINED VCPKG_TOOLCHAIN)
   # vcpkg exports most other targets under a different name than what BdeBuildSystem uses to find
   # targets. Because of this, if we detect that we're using vcpkg to provide targets, we alias them to the
   # pkg-config style names BdeBuildSystem is trying to use.
-  find_package(benchmark CONFIG REQUIRED)
-  find_package(ZLIB REQUIRED)
-
-  add_library(benchmark ALIAS benchmark::benchmark)
-  add_library(zlib ALIAS ZLIB::ZLIB)
 endif()
+find_package(benchmark CONFIG REQUIRED)
+find_package(ZLIB REQUIRED)
+
+add_library(benchmark ALIAS benchmark::benchmark)
+add_library(zlib ALIAS ZLIB::ZLIB)
 
 # -----------------------------------------------------------------------------
 #                                INITIALIZATION


### PR DESCRIPTION
This fixes the `ld: cannot find -lbenchmark` error when building unit tests as reported by @jll63 and our internal CI. However, I am not too confident about merging this PR, because I do not understand the significance of the `if(DEFINED VCPKG_TOOLCHAIN)` block.