### PR TITLE
Protect use of `e_INVALID_MSG_GROUP_ID` in mqbnet

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -687,7 +687,9 @@ Channel::writeImmediate(bool*                                     isConsumed,
             }
             *isConsumed = false;
         } break;
+#ifdef BMQ_ENABLE_MSG_GROUPID
         case bmqt::EventBuilderResult::e_INVALID_MSG_GROUP_ID:
+#endif
         case bmqt::EventBuilderResult::e_PAYLOAD_EMPTY:
         case bmqt::EventBuilderResult::e_MISSING_CORRELATION_ID:
         case bmqt::EventBuilderResult::e_QUEUE_READONLY:


### PR DESCRIPTION
The `e_INVALID_MSG_GROUP_ID` feature is currently in development, and its availability is controlled by the temporary
`BMQ_ENABLE_MSG_GROUPID` preprocessor macro.  Most uses of `e_INVALID_MSG_GROUP_ID` are protected by checking whether this macro is defined, but in the `mqbnet_channel` component, there is a single use that was not protected.

This bug likely went unnoticed because the default developer build defines `BMQ_ENABLE_MSG_GROUPID`, and our release builds build each target separately, with `BMQ_ENABLE_MSG_GROUPID` off for only our release of `libbmq`, not the `mqb` package group.  However, if a user builds BlazingMQ all at once without `BMQ_ENABLE_MSG_GROUPID` enabled, BlazingMQ fails to compile.

This patch guards the use of `e_INVALID_MSG_GROUP_ID` within `mqbnet_channel` using the `BMQ_ENABLE_MSG_GROUPID` macro.  Any prior builds that successfully compiled must have had this macro set for `e_INVALID_MSG_GROUP_ID` to have been defined, so this patch only affects the method of building described above.
