### PR TITLE
docs: Remove references to Python SDK shortly being open sourced

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ themselves from each other by using a message queue to facilitate
 communication.
 
 BlazingMQ's back-end (message brokers) has been implemented in C++, and client
-libraries are available in C++, Java, and Python (the Python SDK will be
-published shortly as open source too!).
+libraries are available in C++, Java, and Python.
 
 BlazingMQ is an actively developed project and has been battle-tested in
 production at Bloomberg for 8+ years.

--- a/docs/docs/introduction/overview.md
+++ b/docs/docs/introduction/overview.md
@@ -32,12 +32,12 @@ themselves from each other by using a message queue to facilitate communication.
 Within Bloomberg, the BlazingMQ framework processes billions of messages and
 terabytes of data every day and is used in production by thousands of applications.
 
-BlazingMQ client libraries are available in C++, Java and Python (the Python SDK
-will be published shortly as open source). Within Bloomberg, client applications and
-BlazingMQ clusters both run in a variety of environments, and BlazingMQ attempts to
-provide a consistent user experience across heterogeneous deployments. In
-general, BlazingMQ clusters can be hosted anywhere and do not depend on any
-other Bloomberg-specific or open source frameworks.
+BlazingMQ client libraries are available in C++, Java and Python. Within
+Bloomberg, client applications and BlazingMQ clusters both run in a variety of
+environments, and BlazingMQ attempts to provide a consistent user experience
+across heterogeneous deployments. In general, BlazingMQ clusters can be hosted
+anywhere and do not depend on any other Bloomberg-specific or open source
+frameworks.
 
 ---
 

--- a/docs/docs/introduction/roadmap.md
+++ b/docs/docs/introduction/roadmap.md
@@ -19,14 +19,6 @@ BlazingMQ, please reach out to us!
 
 ## Short-Term
 
-### Python Client Library
-{: .no_toc }
-
-BlazingMQ has a full-fledged Python client library which was not published as
-open source in the initial OSS release. This library will be published once
-any enterprise dependencies have been removed from it, and CI,
-packaging, and release workflow have been updated to be suitable for OSS.
-
 ### Testing Suites
 {: .no_toc }
 


### PR DESCRIPTION
As the BlazingMQ Python SDK has now been open sourced, this patch removes any references to the SDK not yet being open sourced in the main BlazingMQ documentation.