### PR TITLE
docs: Teach Jekyll to directly include generated Python docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -47,6 +47,11 @@ exclude:
  # theme test code
    - fixtures/
 
+include:
+   - _static
+   - _modules
+   - _sources
+
 # Set a path/url to a logo that will be displayed instead of the title
 logo: "/assets/images/Asset 2@3x.png"
 favicon_ico: "favicon.ico"


### PR DESCRIPTION
The previous patch tried to do this with a `.nojekyll` file, but this file only works when placed in the root of the GitHub pages directory, and serves to turn off any Jekyll generation for the entire site.  We do want Jekyll to generate most of our site for us, but we don’t want it to ignore directories that the Python documentation generator Sphinx creates for us which begin with underscores.  This patch reverts the `.nojekyll` attempt, and instead modifies the Jekyll configuration to explicitly include these directories.

**Testing performed**
Unlike the previous patch, which could not be tested locally, as it used technology specific to GitHub pages, this patch was tested with a local version of Jekyll.  It may still not work, if the GitHub pages version of Jekyll differs here.