### PR TITLE
docs: Update `SessionOptions` accessors’ and manipulators’ docs

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -263,13 +263,21 @@ class SessionOptions {
     /// minutes.
     SessionOptions& setStatsDumpInterval(const bsls::TimeInterval& value);
 
+    /// Set the timeout for connecting to the broker to the specified `value`.
     SessionOptions& setConnectTimeout(const bsls::TimeInterval& value);
+
+    /// Set the timeout for disconnecting from the broker to the specified
+    /// `value`.
     SessionOptions& setDisconnectTimeout(const bsls::TimeInterval& value);
+
+    /// Set the timeout for opening a queue to the specified `value`.
     SessionOptions& setOpenQueueTimeout(const bsls::TimeInterval& value);
+
+    /// Set the timeout for configuring or deconfiguring a queue to the
+    /// specified `value`.
     SessionOptions& setConfigureQueueTimeout(const bsls::TimeInterval& value);
 
-    /// Set the timeout for operations of the corresponding type to the
-    /// specified `value`.
+    /// Set the timeout for closing a queue to the specified `value`.
     SessionOptions& setCloseQueueTimeout(const bsls::TimeInterval& value);
 
     /// Set a `HostHealthMonitor` object that will notify the session when
@@ -319,12 +327,19 @@ class SessionOptions {
     /// Get the stats dump interval.
     const bsls::TimeInterval& statsDumpInterval() const;
 
+    /// Get the timeout for connecting to the broker.
     const bsls::TimeInterval& connectTimeout() const;
+
+    /// Get the timeout for disconnecting from the broker.
     const bsls::TimeInterval& disconnectTimeout() const;
+
+    /// Get the timeout for opening a queue.
     const bsls::TimeInterval& openQueueTimeout() const;
+
+    /// Get the timeout for configuring or disconfiguring a queue.
     const bsls::TimeInterval& configureQueueTimeout() const;
 
-    /// Get the timeout for the operations of the corresponding type.
+    /// Get the timeout for closing a queue.
     const bsls::TimeInterval& closeQueueTimeout() const;
 
     const bsl::shared_ptr<bmqpi::HostHealthMonitor>& hostHealthMonitor() const;


### PR DESCRIPTION
When the BlazingMQ documentation was converted from BDE style to the more standard Doxygen style, documentation comments were moved from below the declarations they documented to above.  Several timeout-related accessors and manipulators in `bmqt::SessionOptions`, though, were documented as a group with a single documentation comment; our automatic conversion script resulted in only the last of the accessors or manipulators receiving the documentation comment, rather than grouping all accessors and manipulators with one documentation comment.

This patch applies individual documentation comments to each undocumented accessor and manipulator.  This results in the simplest, most consistent documentation style, at the expense of some extra verbiage compared to the original documentation style.

We are unable to test these changes to the docs without our ongoing work to directly build the documentation using Doxygen.