### PR TITLE
re-insert queue tracking if needed

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -906,41 +906,48 @@ void ClusterQueueHelper::processPendingContexts(
 
 void ClusterQueueHelper::assignUpstreamSubqueueId(OpenQueueContext* context)
 {
-    // If needed, generate upstream subQueueId
-    if (context->d_upstreamSubQueueId !=
-        bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID) {
-        return;  // RETURN
-    }
-
     QueueLiveState&   info  = context->d_queueContext_p->d_liveQInfo;
     const bsl::string appId = bmqp::QueueUtil::extractAppId(
         context->d_handleParameters);
     StreamsMap::const_iterator it = info.d_subQueueIds.findByAppIdSafe(appId);
-    unsigned int               upstreamSubId;
 
-    if (it == info.d_subQueueIds.end()) {
-        bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> subQueueIdInfo =
-            context->d_handleParameters.subIdInfo();
+    // If needed, generate upstream subQueueId
+    if (context->d_upstreamSubQueueId ==
+        bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID) {
+        unsigned int upstreamSubId;
 
-        if (appId == bmqp::ProtocolUtil::k_DEFAULT_APP_ID) {
-            upstreamSubId = bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID;
+        if (it == info.d_subQueueIds.end()) {
+            bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> subQueueIdInfo =
+                context->d_handleParameters.subIdInfo();
+
+            if (appId == bmqp::ProtocolUtil::k_DEFAULT_APP_ID) {
+                upstreamSubId = bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID;
+            }
+            else {
+                upstreamSubId                  = getNextSubQueueId(context);
+                subQueueIdInfo.value().subId() = upstreamSubId;
+            }
+            info.d_subQueueIds.insert(
+                appId,
+                upstreamSubId,
+                SubQueueContext(context->d_queueContext_p->uri(),
+                                subQueueIdInfo,
+                                d_allocator_p));
         }
         else {
-            upstreamSubId                  = getNextSubQueueId(context);
-            subQueueIdInfo.value().subId() = upstreamSubId;
+            upstreamSubId = it->subId();
         }
+
+        context->d_upstreamSubQueueId = upstreamSubId;
+    }
+    else if (it == info.d_subQueueIds.end()) {
         info.d_subQueueIds.insert(
             appId,
-            upstreamSubId,
+            context->d_upstreamSubQueueId,
             SubQueueContext(context->d_queueContext_p->uri(),
-                            subQueueIdInfo,
+                            context->d_handleParameters.subIdInfo(),
                             d_allocator_p));
     }
-    else {
-        upstreamSubId = it->subId();
-    }
-
-    context->d_upstreamSubQueueId = upstreamSubId;
 }
 
 void ClusterQueueHelper::processOpenQueueRequest(


### PR DESCRIPTION
The following sequence:

1. Queue  has connected clients
2. OpenQueue request receives a response `[ category = E_REFUSED code = -11 message = "self node is stopping" ]`
3. As the result, the OpenQueue goes into pending contexts collection
4. All existing clients close the queue
5.  As the result, the internal QueueInfo tracking (created upon `upstreamSubQueueId` assignment) gets erased
6.  The state restores (new Leader) and the queue processes pending contexts and sends OpenQueue request.
7. Upon request sending, the queue wants to merge new counters with the existing ones from the tracking, but the tracking is gone

... leads to assertion.

Proposed solution is to re-insert the tracking if it is missing (as if just received the pending OpenQueue request) 