### PR TITLE
docs: Include Sphinx JS for Python SDK docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -51,6 +51,7 @@ include:
    - _static
    - _modules
    - _sources
+   - _sphinx_javascript_frameworks_compat.js  # Required for the Python SDK API documentation
 
 # Set a path/url to a logo that will be displayed instead of the title
 logo: "/assets/images/Asset 2@3x.png"


### PR DESCRIPTION
When running a search within the Python SDK docs, the synopsis for each match is a file not found error message.  The root cause of this is that the Sphinx Javascript file `_static/_sphinx_javascript_frameworks_compat.js` does not seem to be copied by GitHub Pages’ Jekyll processor.  This is likely due to the fact that its filename begins with an underscore, which causes Jekyll to treat it as a special file, not to be copied literally.  We saw this problem generally before the fix in commit 37bf5a9, as the `_static` directory was not being included.

This patch adds an explicit include for the Sphinx Javascript file, teaching GitHub Pages to include it in its output verbatim.

*Issue number of the reported bug or feature request: #162*

See also https://github.com/bloomberg/blazingmq-sdk-python/issues/11