### PR TITLE
Fix: handle other selection types in comparator [173726948]

### DIFF
--- a/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
@@ -51,7 +51,8 @@ struct SortPurgeQueueResultByBytesDesc {
     bool operator()(const PurgeQueueResult& lhs,
                     const PurgeQueueResult& rhs) const
     {
-        return (lhs.queue().numBytesPurged() > rhs.queue().numBytesPurged());
+        return (lhs.isQueueValue() ? lhs.queue().numBytesPurged() : 0) >
+               (rhs.isQueueValue() ? rhs.queue().numBytesPurged() : 0);
     }
 };
 


### PR DESCRIPTION
We use comparator here:
https://github.com/bloomberg/blazingmq/blob/2b68c904082885d4718088f55601a07bfdb3aef3/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp#L297

And this functor works only for `Queue` selection, and doesn't work for `Error` selection.
https://github.com/bloomberg/blazingmq/blob/2b68c904082885d4718088f55601a07bfdb3aef3/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp#L50-L56
