### PR TITLE
Build ntf-core without `-Werror`

### DIFF
--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -69,7 +69,11 @@ fi
 if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     # Build and install NTF
     pushd "${DIR_THIRDPARTY}/ntf-core"
-    ./configure --prefix "${DIR_INSTALL}" --output "${DIR_BUILD}/ntf"
+    ./configure --prefix "${DIR_INSTALL}" \
+                --output "${DIR_BUILD}/ntf" \
+                --without-warnings-as-errors \
+                --without-usage-examples \
+                --without-applications
     make -j 16
     make install
     popd

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -118,7 +118,11 @@ fi
 if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     # Build and install NTF
     pushd "${DIR_THIRDPARTY}/ntf-core"
-    ./configure --prefix "${DIR_INSTALL}" --output "${DIR_BUILD}/ntf"
+    ./configure --prefix "${DIR_INSTALL}" \
+                --output "${DIR_BUILD}/ntf" \
+                --without-warnings-as-errors \
+                --without-usage-examples \
+                --without-applications
     make -j 16
     make install
     popd


### PR DESCRIPTION
Occasional changes to ntf-core result in build errors, because we build ntf-core with warnings as errors.  This patch copies the relevant changes from the Python SDK repository to avoid this, as well as to build fewer unnecessary parts of ntf-core.