### PR TITLE
fix: mix of strong and weak consistencies

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1043,7 +1043,7 @@ void StorageManager::recoveredQueuesCbImpl(
         mqbs::ReplicatedStorage* rs = storageMapIt->second;
         BSLS_ASSERT_SAFE(rs);
 
-        const bool isStrongConsistency = !rs->hasReceipt(bmqt::MessageGUID());
+        const bool isStrongConsistency = rs->isStrongConsistency();
 
         if (mqbs::RecordType::e_QUEUE_OP != fsIt.type()) {
             // It's one of MESSAGE/CONFIRM/DELETION records, which means it

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -516,6 +516,8 @@ class DataStoreRecordHandle {
 
     /// Return the Primary LeaseId which created the record.
     unsigned int primaryLeaseId() const;
+
+    bsls::Types::Uint64 sequenceNum() const;
 };
 
 // FREE OPERATORS
@@ -1162,6 +1164,12 @@ inline unsigned int DataStoreRecordHandle::primaryLeaseId() const
 {
     BSLS_ASSERT_SAFE(isValid());
     return d_iterator->first.d_primaryLeaseId;
+}
+
+inline bsls::Types::Uint64 DataStoreRecordHandle::sequenceNum() const
+{
+    BSLS_ASSERT_SAFE(isValid());
+    return d_iterator->first.d_sequenceNum;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -501,6 +501,8 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
 
     virtual const RecordHandles&
     queueOpRecordHandles() const BSLS_KEYWORD_OVERRIDE;
+
+    virtual bool isStrongConsistency() const BSLS_KEYWORD_OVERRIDE;
 };
 
 // ===============================
@@ -748,6 +750,11 @@ inline const ReplicatedStorage::RecordHandles&
 FileBackedStorage::queueOpRecordHandles() const
 {
     return d_queueOpRecordHandles;
+}
+
+inline bool FileBackedStorage::isStrongConsistency() const
+{
+    return !d_hasReceipts;
 }
 
 inline int FileBackedStorage::numVirtualStorages() const

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5125,8 +5125,7 @@ FileStore::FileStore(const DataStoreConfig&  config,
 , d_unreceipted(d_allocators.get("UnreceiptedRecords"))
 , d_replicationFactor(replicationFactor)
 , d_nodes(allocator)
-, d_lastStrongConsistencySequenceNum(0)
-, d_lastStrongConsistencyPrimaryLeaseId(0)
+, d_lastRecoveredStrongConsistency()
 , d_fileSets(allocator)
 , d_cluster_p(cluster)
 , d_miscWorkThreadPool_p(miscWorkThreadPool)
@@ -6525,14 +6524,15 @@ void FileStore::setPrimary(mqbnet::ClusterNode* primaryNode,
         d_config.scheduler()->cancelEvent(
             &d_partitionHighwatermarkEventHandle);
 
-        if (d_lastStrongConsistencyPrimaryLeaseId == d_primaryLeaseId) {
+        if (d_lastRecoveredStrongConsistency.d_primaryLeaseId ==
+            d_primaryLeaseId) {
             BALL_LOG_INFO << partitionDesc() << "Issuing Implicit Receipt ["
                           << "primaryLeaseId = " << d_primaryLeaseId
                           << ", d_sequenceNum = " << d_sequenceNum << "].";
 
             issueReceipt(primaryNode,
-                         d_lastStrongConsistencyPrimaryLeaseId,
-                         d_lastStrongConsistencySequenceNum);
+                         d_lastRecoveredStrongConsistency.d_primaryLeaseId,
+                         d_lastRecoveredStrongConsistency.d_sequenceNum);
         }
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2498,11 +2498,6 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             record.d_messagePropertiesInfo      = bmqp::MessagePropertiesInfo(
                 *dataHeader);
 
-            if (d_lastRecoveredMessage < key) {
-                // This will be used as Implicit Receipt
-                d_lastRecoveredMessage = key;
-            }
-
             // Update in-memory record mapping.
             d_records.rinsert(bsl::make_pair(key, record));
 
@@ -5130,6 +5125,8 @@ FileStore::FileStore(const DataStoreConfig&  config,
 , d_unreceipted(d_allocators.get("UnreceiptedRecords"))
 , d_replicationFactor(replicationFactor)
 , d_nodes(allocator)
+, d_lastStrongConsistencySequenceNum(0)
+, d_lastStrongConsistencyPrimaryLeaseId(0)
 , d_fileSets(allocator)
 , d_cluster_p(cluster)
 , d_miscWorkThreadPool_p(miscWorkThreadPool)
@@ -6528,14 +6525,14 @@ void FileStore::setPrimary(mqbnet::ClusterNode* primaryNode,
         d_config.scheduler()->cancelEvent(
             &d_partitionHighwatermarkEventHandle);
 
-        if (d_lastRecoveredMessage.d_primaryLeaseId == d_primaryLeaseId) {
+        if (d_lastStrongConsistencyPrimaryLeaseId == d_primaryLeaseId) {
             BALL_LOG_INFO << partitionDesc() << "Issuing Implicit Receipt ["
                           << "primaryLeaseId = " << d_primaryLeaseId
                           << ", d_sequenceNum = " << d_sequenceNum << "].";
 
             issueReceipt(primaryNode,
-                         d_lastRecoveredMessage.d_primaryLeaseId,
-                         d_lastRecoveredMessage.d_sequenceNum);
+                         d_lastStrongConsistencyPrimaryLeaseId,
+                         d_lastStrongConsistencySequenceNum);
         }
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -329,8 +329,7 @@ class FileStore : public DataStore {
 
     NodeReceiptContexts d_nodes;
 
-    bsls::Types::Uint64 d_lastStrongConsistencySequenceNum;
-    unsigned int        d_lastStrongConsistencyPrimaryLeaseId;
+    DataStoreRecordKey d_lastRecoveredStrongConsistency;
 
     FileSets d_fileSets;
     // List of file sets.  File set at
@@ -1183,8 +1182,8 @@ inline void
 FileStore::setLastStrongConsistency(unsigned int        primaryLeaseId,
                                     bsls::Types::Uint64 sequenceNum)
 {
-    d_lastStrongConsistencyPrimaryLeaseId = primaryLeaseId;
-    d_lastStrongConsistencySequenceNum    = sequenceNum;
+    d_lastRecoveredStrongConsistency.d_primaryLeaseId = primaryLeaseId;
+    d_lastRecoveredStrongConsistency.d_sequenceNum    = sequenceNum;
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -329,7 +329,8 @@ class FileStore : public DataStore {
 
     NodeReceiptContexts d_nodes;
 
-    DataStoreRecordKey d_lastRecoveredMessage;
+    bsls::Types::Uint64 d_lastStrongConsistencySequenceNum;
+    unsigned int        d_lastStrongConsistencyPrimaryLeaseId;
 
     FileSets d_fileSets;
     // List of file sets.  File set at
@@ -898,6 +899,10 @@ class FileStore : public DataStore {
     /// set this to true during testing.
     void setIgnoreCrc32c(bool value);
 
+    // This will be used as Implicit Receipt
+    void setLastStrongConsistency(unsigned int        primaryLeaseId,
+                                  bsls::Types::Uint64 sequenceNum);
+
     /// Load into the specified `storages` the list of queue storages for
     /// which all filters from the specified `filters` are returning true.
     void getStorages(StorageList*          storages,
@@ -1172,6 +1177,14 @@ inline bool FileStore::inDispatcherThread() const
 inline void FileStore::setIgnoreCrc32c(bool value)
 {
     d_ignoreCrc32c = value;
+}
+
+inline void
+FileStore::setLastStrongConsistency(unsigned int        primaryLeaseId,
+                                    bsls::Types::Uint64 sequenceNum)
+{
+    d_lastStrongConsistencyPrimaryLeaseId = primaryLeaseId;
+    d_lastStrongConsistencySequenceNum    = sequenceNum;
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -584,6 +584,11 @@ InMemoryStorage::queueOpRecordHandles() const
     return d_queueOpRecordHandles;
 }
 
+bool InMemoryStorage::isStrongConsistency() const
+{
+    return false;
+}
+
 // -----------------------------
 // class InMemoryStorageIterator
 // -----------------------------

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -517,6 +517,8 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
 
     virtual const RecordHandles&
     queueOpRecordHandles() const BSLS_KEYWORD_OVERRIDE;
+
+    virtual bool isStrongConsistency() const BSLS_KEYWORD_OVERRIDE;
 };
 
 // =============================
@@ -807,7 +809,7 @@ inline bool InMemoryStorage::hasVirtualStorage(const bsl::string& appId,
     return d_virtualStorageCatalog.hasVirtualStorage(appId, appKey);
 }
 
-inline bool InMemoryStorage::hasReceipt(const bmqt::MessageGUID& msgGUID) const
+inline bool InMemoryStorage::hasReceipt(const bmqt::MessageGUID&) const
 {
     return true;
 }

--- a/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
@@ -100,6 +100,9 @@ class ReplicatedStorage : public mqbi::Storage {
     /// Return a non-modifiable list of handles of all QUEUEOP records
     /// associated with this storage.
     virtual const RecordHandles& queueOpRecordHandles() const = 0;
+
+    // Return 'true' if the storage is of the strong consistency
+    virtual bool isStrongConsistency() const = 0;
 };
 
 // ============================================================================


### PR DESCRIPTION
When a partition hosts both weak and strong consistencies and there are recovered messages and the last recovered messages is of weak consistency, replica can issue implicit receipt for the weak consistency GUID.  Primary will ignore that receipt because the collection of unreceipted messages is hashtable, not a map (for performance reasons).  (Primary will process next ones).

Solution is to make sure implicit receipt is for the last strong consistency GUID.

This fix needs manual merge into the future FSM flow.
