### PR TITLE
Add clang format control for cpp11 features

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -155,7 +155,7 @@ jobs:
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
-          clang-format-version: '14'
+          clang-format-version: '15'
           check-path: ${{ matrix.path }}
 
   shellcheck:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ CMakeUserPresets.json
 /.vscode/
 /include/
 /lib/
+*.bak

--- a/src/applications/bmqbrkr/bmqbrkrscm_versiontag.h
+++ b/src/applications/bmqbrkr/bmqbrkrscm_versiontag.h
@@ -57,7 +57,7 @@
 #define BMQBRKR_VERSION_PATCH 99
 // BMQBRKR patch level
 
-#define BMQBRKR_MAKE_VERSION(major, minor) ((major)*10000 + (minor)*100)
+#define BMQBRKR_MAKE_VERSION(major, minor) ((major) * 10000 + (minor) * 100)
 // Construct a composite version number in the range [ 0 .. 999900 ] from
 // the specified 'major' and 'minor' version numbers.  The resulting value,
 // when expressed as a 6-digit decimal string, has "00" as the two
@@ -73,7 +73,7 @@
 // and 'minor' are integral values in the range '[ 0 .. 99 ]'.
 
 #define BMQBRKR_MAKE_EXT_VERSION(major, minor, patch)                         \
-    ((major)*10000 + (minor)*100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 // Similar to BMQBRKR_MAKE_VERSION(), but include the patch number as well.
 
 #define BMQBRKR_VERSION                                                       \

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -959,14 +959,14 @@ MockSession::MockSession(const bmqt::SessionOptions& options,
                                     bdlf::PlaceHolders::_2,
                                     bdlf::PlaceHolders::_3))
 , d_lastQueueId(0)
-, d_corrIdContainer_sp(new (*bslma::Default::allocator(allocator))
+, d_corrIdContainer_sp(new(*bslma::Default::allocator(allocator))
                            bmqimp::MessageCorrelationIdContainer(
                                bslma::Default::allocator(allocator)),
                        bslma::Default::allocator(allocator))
 , d_postedEvents(bslma::Default::allocator(allocator))
 , d_rootStatContext(mwcst::StatContextConfiguration("MockSession", allocator),
                     allocator)
-, d_queuesStats_sp(new (*bslma::Default::allocator(allocator))
+, d_queuesStats_sp(new(*bslma::Default::allocator(allocator))
                        bmqimp::Stat(bslma::Default::allocator(allocator)),
                    bslma::Default::allocator(allocator))
 , d_sessionOptions(options, allocator)
@@ -1002,14 +1002,14 @@ MockSession::MockSession(bslma::ManagedPtr<SessionEventHandler> eventHandler,
                                     bdlf::PlaceHolders::_2,
                                     bdlf::PlaceHolders::_3))
 , d_lastQueueId(0)
-, d_corrIdContainer_sp(new (*bslma::Default::allocator(allocator))
+, d_corrIdContainer_sp(new(*bslma::Default::allocator(allocator))
                            bmqimp::MessageCorrelationIdContainer(
                                bslma::Default::allocator(allocator)),
                        bslma::Default::allocator(allocator))
 , d_postedEvents(bslma::Default::allocator(allocator))
 , d_rootStatContext(mwcst::StatContextConfiguration("MockSession", allocator),
                     allocator)
-, d_queuesStats_sp(new (*bslma::Default::allocator(allocator))
+, d_queuesStats_sp(new(*bslma::Default::allocator(allocator))
                        bmqimp::Stat(bslma::Default::allocator(allocator)),
                    bslma::Default::allocator(allocator))
 , d_sessionOptions(options, allocator)

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -68,8 +68,7 @@ using namespace bsl;
 
 /// Mapping class.  Will be partially specialized below.
 template <typename T>
-struct ResultRegistry {
-};
+struct ResultRegistry {};
 
 /// Partial specialization for mapping to `bmqa::OpenQueueStatus`.
 template <>

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -1350,7 +1350,7 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
     typedef QueueState    S;
     typedef QueueFsmEvent E;
     QueueStateTransition  table[] = {
-         // current state           event              new state
+        // current state           event              new state
         {S::e_CLOSED, E::e_OPEN_CMD, S::e_OPENING_OPN},
         //
         {S::e_OPENING_OPN, E::e_RESP_OK, S::e_OPENING_CFG},

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
@@ -302,7 +302,7 @@ static void test3_multithreadUseIP()
     // (it's unable to complete in 90 seconds).
     const int k_NUM_GUIDS = 500000;  // 500k
 #else
-    const int                k_NUM_GUIDS = 1000000;   // 1M
+    const int k_NUM_GUIDS = 1000000;  // 1M
 #endif
 
     bslmt::ThreadGroup threadGroup(s_allocator_p);
@@ -377,7 +377,7 @@ static void test4_multithreadUseHostname()
     // (it's unable to complete in 90 seconds).
     const int k_NUM_GUIDS = 500000;  // 500k
 #else
-    const int                k_NUM_GUIDS = 1000000;   // 1M
+    const int k_NUM_GUIDS = 1000000;  // 1M
 #endif
 
     bslmt::ThreadGroup threadGroup(s_allocator_p);

--- a/src/groups/bmq/bmqp/bmqp_queueid.cpp
+++ b/src/groups/bmq/bmqp/bmqp_queueid.cpp
@@ -30,8 +30,7 @@ namespace bsl {
 // need to have 'is_fundamental' trait.
 
 template <>
-struct is_fundamental<BloombergLP::bmqp::QueueId::QueueIdInt> : true_type {
-};
+struct is_fundamental<BloombergLP::bmqp::QueueId::QueueIdInt> : true_type {};
 
 template <>
 struct is_fundamental<BloombergLP::bmqp::QueueId::SubQueueIdInt> : true_type {

--- a/src/groups/bmq/bmqscm/bmqscm_versiontag.h
+++ b/src/groups/bmq/bmqscm/bmqscm_versiontag.h
@@ -56,7 +56,7 @@
 #define BMQ_VERSION_PATCH 99
 // BlazingMQ patch level
 
-#define BMQ_MAKE_VERSION(major, minor) ((major)*10000 + (minor)*100)
+#define BMQ_MAKE_VERSION(major, minor) ((major) * 10000 + (minor) * 100)
 // Construct a composite version number in the range [ 0 .. 999900 ] from
 // the specified 'major' and 'minor' version numbers.  The resulting value,
 // when expressed as a 6-digit decimal string, has "00" as the two
@@ -72,7 +72,7 @@
 // and 'minor' are integral values in the range '[ 0 .. 99 ]'.
 
 #define BMQ_MAKE_EXT_VERSION(major, minor, patch)                             \
-    ((major)*10000 + (minor)*100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 // Similar to BMQ_MAKE_VERSION(), but include the patch number as well.
 
 #define BMQ_VERSION BMQ_MAKE_VERSION(BMQ_VERSION_MAJOR, BMQ_VERSION_MINOR)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -576,7 +576,7 @@ ClusterOrchestrator::ClusterOrchestrator(
 , d_stateManager_mp(
       clusterConfig.clusterAttributes().isFSMWorkflow()
           ? static_cast<mqbi::ClusterStateManager*>(
-                new (*d_allocator_p) mqbc::ClusterStateManager(
+                new(*d_allocator_p) mqbc::ClusterStateManager(
                     clusterConfig,
                     d_cluster_p,
                     d_clusterData_p,
@@ -595,7 +595,7 @@ ClusterOrchestrator::ClusterOrchestrator(
                     k_WATCHDOG_TIMEOUT_DURATION,
                     d_allocators.get("ClusterStateManager")))
           : static_cast<mqbi::ClusterStateManager*>(
-                new (*d_allocator_p) ClusterStateManager(
+                new(*d_allocator_p) ClusterStateManager(
                     clusterConfig,
                     d_cluster_p,
                     d_clusterData_p,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1955,7 +1955,7 @@ bool ClusterQueueHelper::createQueue(
                   << context.d_handleParameters << "]";
 
     mqbi::Cluster::OpenQueueConfirmationCookie confirmationCookie(
-        new (*d_allocator_p) mqbi::QueueHandle*(0),
+        new (*d_allocator_p) mqbi::QueueHandle * (0),
         bdlf::BindUtil::bind(
             &ClusterQueueHelper::onOpenQueueConfirmationCookieReleased,
             this,

--- a/src/groups/mqb/mqbblp/mqbblp_messagegroupidmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_messagegroupidmanager.cpp
@@ -624,7 +624,7 @@ MessageGroupIdManager::MessageGroupIdManager(const Time&       timeout,
 , d_timeout(timeout)
 , d_maxMsgGroupIds(maxMsgGroupIds)
 , d_rebalance(rebalance)
-, d_index(new (*allocator) Index(allocator), allocator)
+, d_index(new(*allocator) Index(allocator), allocator)
 {
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -81,7 +81,7 @@ struct ClientContext {
 
 ClientContext::ClientContext()
 : d_dispatcherClient(s_allocator_p)
-, d_requesterContext_sp(new (*s_allocator_p)
+, d_requesterContext_sp(new(*s_allocator_p)
                             mqbi::QueueHandleRequesterContext(s_allocator_p),
                         s_allocator_p)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -805,7 +805,7 @@ QueueEngineUtil_AppState::QueueEngineUtil_AppState(
     const mqbu::StorageKey&                  appKey,
     bslma::Allocator*                        allocator)
 : d_storageIter_mp(iterator)
-, d_routing_sp(new (*allocator) Routers::AppContext(queueContext, allocator),
+, d_routing_sp(new(*allocator) Routers::AppContext(queueContext, allocator),
                allocator)
 , d_redeliveryList(allocator)
 , d_putAsideList(allocator)

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -663,7 +663,7 @@ inline QueueHandle::Downstream::Downstream(const bsl::string& appId,
                                            bslma::Allocator* allocator_p)
 : d_appId(appId)
 , d_upstreamSubQueueId(upstreamSubQueueId)
-, d_data(new (*allocator_p)
+, d_data(new(*allocator_p)
              mqbi::QueueHandle::UnconfirmedMessageInfoMap(allocator_p),
          allocator_p)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
@@ -122,7 +122,7 @@ void QueueHandleCatalog::queueHandleDeleter(mqbi::QueueHandle* handle)
 QueueHandleCatalog::QueueHandleCatalog(mqbi::Queue*      queue,
                                        bslma::Allocator* allocator)
 : d_queue_p(queue)
-, d_handleFactory_mp(new (*allocator) DefaultHandleFactory(), allocator)
+, d_handleFactory_mp(new(*allocator) DefaultHandleFactory(), allocator)
 , d_handles(allocator)
 , d_allocator_p(allocator)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
@@ -525,8 +525,8 @@ QueueSessionManager::QueueSessionManager(
 , d_domainFactory_p(domainFactory)
 , d_allocator_p(allocator)
 , d_shutdownInProgress(false)
-, d_validator_sp(new (*allocator) mwcu::AtomicValidator(), allocator)
-, d_requesterContext_sp(new (*allocator)
+, d_validator_sp(new(*allocator) mwcu::AtomicValidator(), allocator)
+, d_requesterContext_sp(new(*allocator)
                             mqbi::QueueHandleRequesterContext(allocator),
                         allocator)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -832,7 +832,7 @@ inline Routers::QueueRoutingContext::QueueRoutingContext(
 : d_expressions(allocator)
 , d_nextSubscriptionId(0)
 , d_groupIds(allocator)
-, d_preader(new (*allocator) MessagePropertiesReader(schemaLearner, allocator),
+, d_preader(new(*allocator) MessagePropertiesReader(schemaLearner, allocator),
             allocator)
 , d_evaluationContext(0, allocator)
 , d_allocator_p(allocator)

--- a/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
@@ -76,7 +76,7 @@ struct TestStorage {
                 allocator)
     , d_iterator(d_storage.getIterator(mqbu::StorageKey()))
     , d_bufferFactory(32, allocator)
-    , d_queue_sp(new (*allocator) mqbmock::Queue(0, allocator), allocator)
+    , d_queue_sp(new(*allocator) mqbmock::Queue(0, allocator), allocator)
     , d_allocator_p(allocator)
 
     {

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
@@ -42,7 +42,7 @@ ClusterNodeSession::ClusterNodeSession(
 , d_clusterNode_p(netNode)
 , d_peerInstanceId(0)  // There is no invalid value for this field
 , d_queueHandleRequesterContext_sp(
-      new (*allocator) mqbi::QueueHandleRequesterContext(allocator),
+      new(*allocator) mqbi::QueueHandleRequesterContext(allocator),
       allocator)
 , d_nodeStatus(bmqp_ctrlmsg::NodeStatus::E_UNAVAILABLE)  // See note in ctor
 , d_statContext_sp()

--- a/src/groups/mqb/mqbscm/mqbscm_versiontag.h
+++ b/src/groups/mqb/mqbscm/mqbscm_versiontag.h
@@ -56,7 +56,7 @@
 #define MQB_VERSION_PATCH 99
 // MQB patch level
 
-#define MQB_MAKE_VERSION(major, minor) ((major)*10000 + (minor)*100)
+#define MQB_MAKE_VERSION(major, minor) ((major) * 10000 + (minor) * 100)
 // Construct a composite version number in the range [ 0 .. 999900 ] from
 // the specified 'major' and 'minor' version numbers.  The resulting value,
 // when expressed as a 6-digit decimal string, has "00" as the two
@@ -72,7 +72,7 @@
 // and 'minor' are integral values in the range '[ 0 .. 99 ]'.
 
 #define MQB_MAKE_EXT_VERSION(major, minor, patch)                             \
-    ((major)*10000 + (minor)*100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 // Similar to MQB_MAKE_VERSION(), but include the patch number as well.
 
 #define MQB_VERSION MQB_MAKE_VERSION(MQB_VERSION_MAJOR, MQB_VERSION_MINOR)

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
@@ -187,7 +187,7 @@ static void test2_multithread()
     // (it's unable to complete in 90 seconds).
     const int k_NUM_GUIDS = 500000;  // 500k
 #else
-    const int                k_NUM_GUIDS = 1000000;   // 1M
+    const int k_NUM_GUIDS = 1000000;  // 1M
 #endif
 
     bslmt::ThreadGroup threadGroup(s_allocator_p);

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -215,7 +215,7 @@ static void test3_insert()
     const int k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const int k_NUM_ELEMENTS = 100 * 1000;   // 100K
+    const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #endif
 
     // Insert 1M elements

--- a/src/groups/mwc/mwcc/mwcc_twokeyhashmap.h
+++ b/src/groups/mwc/mwcc/mwcc_twokeyhashmap.h
@@ -1038,7 +1038,7 @@ inline TwoKeyHashMap<K1, K2, VALUE, H1, H2>::TwoKeyHashMap(
           H2(),
           typename K2Map::key_equal(),
           basicAllocator)
-, d_nodeAllocator(new (*allocator()) bdlma::Pool(sizeof(Node), allocator()),
+, d_nodeAllocator(new(*allocator()) bdlma::Pool(sizeof(Node), allocator()),
                   allocator())
 {
     // POSTCONDITIONS
@@ -1057,7 +1057,7 @@ inline TwoKeyHashMap<K1, K2, VALUE, H1, H2>::TwoKeyHashMap(
           H2(),
           typename K2Map::key_equal(),
           basicAllocator)
-, d_nodeAllocator(new (*allocator()) bdlma::Pool(sizeof(Node), allocator()),
+, d_nodeAllocator(new(*allocator()) bdlma::Pool(sizeof(Node), allocator()),
                   allocator())
 {
     // POSTCONDITIONS
@@ -1077,7 +1077,7 @@ inline TwoKeyHashMap<K1, K2, VALUE, H1, H2>::TwoKeyHashMap(
           hash2,
           typename K2Map::key_equal(),
           basicAllocator)
-, d_nodeAllocator(new (*allocator()) bdlma::Pool(sizeof(Node), allocator()),
+, d_nodeAllocator(new(*allocator()) bdlma::Pool(sizeof(Node), allocator()),
                   allocator())
 {
     // POSTCONDITIONS
@@ -1096,7 +1096,7 @@ inline TwoKeyHashMap<K1, K2, VALUE, H1, H2>::TwoKeyHashMap(
           original.d_k2Map.hash_function(),
           original.d_k2Map.key_eq(),
           basicAllocator)
-, d_nodeAllocator(new (*allocator()) bdlma::Pool(sizeof(Node), allocator()),
+, d_nodeAllocator(new(*allocator()) bdlma::Pool(sizeof(Node), allocator()),
                   allocator())
 {
     // free memory on failure
@@ -1129,7 +1129,7 @@ inline TwoKeyHashMap<K1, K2, VALUE, H1, H2>::TwoKeyHashMap(
           H2(),
           typename K2Map::key_equal(),
           basicAllocator)
-, d_nodeAllocator(new (*allocator()) bdlma::Pool(sizeof(Node), allocator()),
+, d_nodeAllocator(new(*allocator()) bdlma::Pool(sizeof(Node), allocator()),
                   allocator())
 {
     if (allocator() == bslmf::MovableRefUtil::access(original).allocator()) {

--- a/src/groups/mwc/mwcex/mwcex_bindutil.h
+++ b/src/groups/mwc/mwcex/mwcex_bindutil.h
@@ -152,14 +152,18 @@
 #include <bsls_assert.h>
 #include <bsls_compilerfeatures.h>
 
+// clang-format off
+
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 29 05:10:11 2022
+// Generated on Fri Jan  5 16:18:32 2024
 // Command line: sim_cpp11_features.pl mwcex_bindutil.h
-#define COMPILING_MWCEX_BINDUTIL_H
-#include <mwcex_bindutil_cpp03.h>
-#undef COMPILING_MWCEX_BINDUTIL_H
+# define COMPILING_MWCEX_BINDUTIL_H
+# include <mwcex_bindutil_cpp03.h>
+# undef COMPILING_MWCEX_BINDUTIL_H
 #else
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcex {
@@ -168,7 +172,9 @@ namespace mwcex {
 // struct BindUtil_DummyNullaryFunction
 // ====================================
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+// clang-format on
 
 /// Provides a dummy nullary function object which result type is the same
 /// as the result type of the specified `FUNCTION` when invoked with
@@ -255,7 +261,9 @@ class BindUtil_BindWrapper {
     typename ExecutionUtil::ExecuteResult<POLICY, FUNCTION>::Type
     operator()() const;
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+    // clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
+    // clang-format on
 
     /// Call `ExecutionUtil::execute(p, bsl::move(f2))` and return the
     /// result of that operation, where `p` is the contained execution
@@ -373,7 +381,9 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()() const
     return ExecutionUtil::execute(d_policy, d_function.object());
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
+// clang-format on
 template <class POLICY, class FUNCTION>
 template <class ARG1, class... ARGS>
 inline typename ExecutionUtil::ExecuteResult<
@@ -420,6 +430,10 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+// clang-format off
+
+#endif // End C++11 code
+
+// clang-format on
 
 #endif

--- a/src/groups/mwc/mwcex/mwcex_bindutil_cpp03.cpp
+++ b/src/groups/mwc/mwcex/mwcex_bindutil_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2019-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:47:32 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_bindutil.cpp
 
 #define INCLUDED_MWCEX_BINDUTIL_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCEX_BINDUTIL_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 94c00eba0023da381e39f10494dc2702cd370a07287ed615df4d209f7f42e919

--- a/src/groups/mwc/mwcex/mwcex_bindutil_cpp03.h
+++ b/src/groups/mwc/mwcex/mwcex_bindutil_cpp03.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2019-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,10 +36,12 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jul 13 12:01:40 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_bindutil.h
 
 #ifdef COMPILING_MWCEX_BINDUTIL_H
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcex {
@@ -48,6 +50,7 @@ namespace mwcex {
 // struct BindUtil_DummyNullaryFunction
 // ====================================
 
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcex_bindutil.h
@@ -57,59 +60,52 @@ namespace mwcex {
 #ifndef MWCEX_BINDUTIL_VARIADIC_LIMIT_A
 #define MWCEX_BINDUTIL_VARIADIC_LIMIT_A MWCEX_BINDUTIL_VARIADIC_LIMIT
 #endif
+
 template <class FUNCTION
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
-          ,
-          class ARGS_0 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_0 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
-          ,
-          class ARGS_1 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_1 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-          ,
-          class ARGS_2 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_2 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-          ,
-          class ARGS_3 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_3 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-          ,
-          class ARGS_4 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_4 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-          ,
-          class ARGS_5 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_5 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-          ,
-          class ARGS_6 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_6 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-          ,
-          class ARGS_7 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_7 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class ARGS_8 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_8 = BSLS_COMPILERFEATURES_NILT
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class = BSLS_COMPILERFEATURES_NILT>
+        , class = BSLS_COMPILERFEATURES_NILT>
 struct BindUtil_DummyNullaryFunction;
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 template <class FUNCTION>
 struct BindUtil_DummyNullaryFunction<FUNCTION> {
+
     typedef typename bsl::invoke_result<FUNCTION>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -118,193 +114,205 @@ struct BindUtil_DummyNullaryFunction<FUNCTION> {
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 template <class FUNCTION, class ARGS_1>
 struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1> {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS_1>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-template <class FUNCTION, class ARGS_1, class ARGS_2>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-template <class FUNCTION, class ARGS_1, class ARGS_2, class ARGS_3>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2, ARGS_3> {
-    typedef typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3>::type
-        ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4>::
-            type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5> {
-    typedef typename bsl::
-        invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4, ARGS_5>::type
-            ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_A >= 9
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8,
-                                     ARGS_9> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8,
-                                        ARGS_9>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8,
+                                               ARGS_9> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8,
+                                                  ARGS_9>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -313,9 +321,12 @@ struct BindUtil_DummyNullaryFunction<FUNCTION,
 #else
 // The generated code below is a workaround for the absence of perfect
 // forwarding in some compilers.
+
 template <class FUNCTION, class... ARGS>
 struct BindUtil_DummyNullaryFunction {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS...>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -327,16 +338,15 @@ struct BindUtil_DummyNullaryFunction {
 // class BindUtil_BindWrapper
 // ==========================
 
+/// Provides a callable bind wrapper containing an execution policy and a
+/// function object bound to the invocation of `ExecutionUtil::execute`.
+///
+/// `POLICY` must be an execution policy type (see `mwcex_executionpolicy`).
+///
+/// `FUNCTION` must meet the requirements of Destructible as specified in
+/// the C++ standard.
 template <class POLICY, class FUNCTION>
 class BindUtil_BindWrapper {
-    // Provides a callable bind wrapper containing an execution policy and a
-    // function object bound to the invocation of 'ExecutionUtil::execute'.
-    //
-    // 'POLICY' must be an execution policy type (see 'mwcex_executionpolicy').
-    //
-    // 'FUNCTION' must meet the requirements of Destructible as specified in
-    // the C++ standard.
-
   private:
     // PRIVATE DATA
     POLICY d_policy;
@@ -345,50 +355,53 @@ class BindUtil_BindWrapper {
 
   public:
     // CREATORS
+
+    /// Create a `BindUtil_BindWrapper` object containing an execution
+    /// policy of type `POLICY` direct-non-list-initialized with
+    /// `bsl::forward<POLICY_PARAM>(policy)` and a function object of type
+    /// `FUNCTION` direct-non-list-initialized with
+    /// `bsl::forward<FUNCTION_PARAM>(function)`. Specify an `allocator`
+    /// used to supply memory.
+    ///
+    /// `POLICY` must be constructible from
+    /// `bsl::forward<POLICY_PARAM>(policy)`.
+    ///
+    /// `FUNCTION` must be constructible from
+    /// `bsl::forward<FUNCTION_PARAM>(function)`.
     template <class POLICY_PARAM, class FUNCTION_PARAM>
     BindUtil_BindWrapper(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY_PARAM)
                              policy,
                          BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION_PARAM)
                              function,
                          bslma::Allocator* allocator);
-    // Create a 'BindUtil_BindWrapper' object containing an execution
-    // policy of type 'POLICY' direct-non-list-initialized with
-    // 'bsl::forward<POLICY_PARAM>(policy)' and a function object of type
-    // 'FUNCTION' direct-non-list-initialized with
-    // 'bsl::forward<FUNCTION_PARAM>(function)'. Specify an 'allocator'
-    // used to supply memory.
-    //
-    // 'POLICY' must be constructible from
-    // 'bsl::forward<POLICY_PARAM>(policy)'.
-    //
-    // 'FUNCTION' must be constructible from
-    // 'bsl::forward<FUNCTION_PARAM>(function)'.
 
+    /// Create a `BindUtil_BindWrapper` object having the same state as the
+    /// specified `original` object. Optionally specify an `allocator` used
+    /// to supply memory. If `allocator` is 0, the default memory allocator
+    /// is used.
     BindUtil_BindWrapper(const BindUtil_BindWrapper& original,
                          bslma::Allocator*           allocator = 0);
-    // Create a 'BindUtil_BindWrapper' object having the same state as the
-    // specified 'original' object. Optionally specify an 'allocator' used
-    // to supply memory. If 'allocator' is 0, the default memory allocator
-    // is used.
 
+    /// Create a `BindUtil_BindWrapper` object having the same state as the
+    /// specified `original` object, leaving `original` in an unspecified
+    /// state. Optionally specify an `allocator` used to supply memory. If
+    /// `allocator` is 0, the default memory allocator is used.
     BindUtil_BindWrapper(bslmf::MovableRef<BindUtil_BindWrapper> original,
                          bslma::Allocator* allocator = 0);
-    // Create a 'BindUtil_BindWrapper' object having the same state as the
-    // specified 'original' object, leaving 'original' in an unspecified
-    // state. Optionally specify an 'allocator' used to supply memory. If
-    // 'allocator' is 0, the default memory allocator is used.
 
   public:
     // ACCESSORS
+
+    /// Call `ExecutionUtil::execute(p, f)` and return the result of that
+    /// operation, where `p` is the contained execution policy and `f` is
+    /// the contained function object.
+    ///
+    /// Given an object `f` of type `FUNCTION`, `f()` shall be a valid
+    /// expression.
     typename ExecutionUtil::ExecuteResult<POLICY, FUNCTION>::Type
     operator()() const;
-    // Call 'ExecutionUtil::execute(p, f)' and return the result of that
-    // operation, where 'p' is the contained execution policy and 'f' is
-    // the contained function object.
-    //
-    // Given an object 'f' of type 'FUNCTION', 'f()' shall be a valid
-    // expression.
 
+    // clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcex_bindutil.h
@@ -398,13 +411,15 @@ class BindUtil_BindWrapper {
 #ifndef MWCEX_BINDUTIL_VARIADIC_LIMIT_B
 #define MWCEX_BINDUTIL_VARIADIC_LIMIT_B MWCEX_BINDUTIL_VARIADIC_LIMIT
 #endif
+
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 0
     template <class ARG1>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-    operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type
+        operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 0
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
@@ -420,7 +435,8 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
-    template <class ARG1, class ARGS_1, class ARGS_2>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -434,7 +450,9 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
-    template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -450,11 +468,10 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -472,12 +489,11 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -497,13 +513,12 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -525,14 +540,13 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -556,15 +570,14 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -590,8 +603,9 @@ class BindUtil_BindWrapper {
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+
     template <class ARG1, class... ARGS>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -614,37 +628,37 @@ class BindUtil_BindWrapper {
 // struct BindUtil
 // ===============
 
+/// Provides a namespace for utility functions to bind functors to execution
+/// functions.
 struct BindUtil {
-    // Provides a namespace for utility functions to bind functors to execution
-    // functions.
-
     // CLASS METHODS
+
+    /// Return a callable object of unspecified type containing an execution
+    /// policy `p` of type `bsl::decay_t<POLICY>` direct-non-list-
+    /// initialized with `bsl::forward<POLICY>(policy)` and a function
+    /// object `f` of type `bsl::decay_t<FUNCTION>` direct-non-list-
+    /// initialized with `bsl::forward<FUNCTION>(function)`, such that:
+    /// * When called with no arguments, performs
+    ///:  `ExecutionUtil::execute(p, f)` and returns the result of that
+    ///:  operation.
+    /// * When called with 1 or more arguments `args...` of type `ARGS...`,
+    ///   performs `ExecutionUtil::execute(p, bsl::move(f2))` and return
+    ///   the result of that operation, where `f1` is the result of
+    ///   `DECAY_COPY(f)` evaluated in the calling thread, `args1...` is
+    ///   the result of `DECAY_COPY(args)...` evaluated in the calling
+    ///   thread, and `f2` is a function object of unspecified type that,
+    ///   when called as `f2()`, performs `return f1(args1...)`.
+    ///
+    /// `POLICY` must be an execution policy type (see
+    /// `mwcex_executionpolicy`).
+    ///
+    /// `bsl::decay_t<FUNCTION>` must meet the requirements of Destructible
+    /// and MoveConstructible as specified in the C++ standard.
     template <class POLICY, class FUNCTION>
     static BindUtil_BindWrapper<typename bsl::decay<POLICY>::type,
                                 typename bsl::decay<FUNCTION>::type>
         bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
                     BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) function);
-    // Return a callable object of unspecified type containing an execution
-    // policy 'p' of type 'bsl::decay_t<POLICY>' direct-non-list-
-    // initialized with 'bsl::forward<POLICY>(policy)' and a function
-    // object 'f' of type 'bsl::decay_t<FUNCTION>' direct-non-list-
-    // initialized with 'bsl::forward<FUNCTION>(function)', such that:
-    //: o When called with no arguments, performs
-    //:  'ExecutionUtil::execute(p, f)' and returns the result of that
-    //:  operation.
-    //: o When called with 1 or more arguments 'args...' of type 'ARGS...',
-    //:   performs 'ExecutionUtil::execute(p, bsl::move(f2))' and return
-    //:   the result of that operation, where 'f1' is the result of
-    //:   'DECAY_COPY(f)' evaluated in the calling thread, 'args1...' is
-    //:   the result of 'DECAY_COPY(args)...' evaluated in the calling
-    //:   thread, and 'f2' is a function object of unspecified type that,
-    //:   when called as 'f2()', performs 'return f1(args1...)'.
-    //
-    // 'POLICY' must be an execution policy type (see
-    // 'mwcex_executionpolicy').
-    //
-    // 'bsl::decay_t<FUNCTION>' must meet the requirements of Destructible
-    // and MoveConstructible as specified in the C++ standard.
 };
 
 // ============================================================================
@@ -700,6 +714,7 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()() const
     return ExecutionUtil::execute(d_policy, d_function.object());
 }
 
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcex_bindutil.h
@@ -717,18 +732,19 @@ inline typename ExecutionUtil::ExecuteResult<
     BindUtil_DummyNullaryFunction<FUNCTION,
                                   typename bsl::decay<ARG1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-        ResultType;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type ResultType;
 
-    return ExecutionUtil::execute(
-        d_policy,
-        bdlf::BindUtil::bindR<ResultType>(d_function.object(),
-                                          bslmf::Util::forward<ARG1>(arg1)));
+    return ExecutionUtil::execute(d_policy,
+                                  bdlf::BindUtil::bindR<ResultType>(
+                                      d_function.object(),
+                                      bslmf::Util::forward<ARG1>(arg1)));
 }
 #endif  // MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 0
 
@@ -741,8 +757,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS_1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -761,7 +778,8 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 2
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -769,9 +787,10 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_1>::type,
                                   typename bsl::decay<ARGS_2>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -792,7 +811,9 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 3
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -801,10 +822,11 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_2>::type,
                                   typename bsl::decay<ARGS_3>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -827,7 +849,10 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 4
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -837,11 +862,12 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_3>::type,
                                   typename bsl::decay<ARGS_4>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -866,12 +892,11 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 5
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -882,12 +907,13 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_4>::type,
                                   typename bsl::decay<ARGS_5>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -914,13 +940,12 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 6
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -932,13 +957,14 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_5>::type,
                                   typename bsl::decay<ARGS_6>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -967,14 +993,13 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 7
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -987,14 +1012,15 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_6>::type,
                                   typename bsl::decay<ARGS_7>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1025,15 +1051,14 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if MWCEX_BINDUTIL_VARIADIC_LIMIT_C >= 8
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -1047,15 +1072,16 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_7>::type,
                                   typename bsl::decay<ARGS_8>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1097,8 +1123,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS>::type...> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                                BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1137,24 +1164,14 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_MWCEX_BINDUTIL_H)
-#error Not valid except when included from mwcex_bindutil.h
-#endif  // ! defined(COMPILING_MWCEX_BINDUTIL_H)
+// clang-format off
 
-#endif  // ! defined(INCLUDED_MWCEX_BINDUTIL_CPP03)
+#else // if ! defined(DEFINED_MWCEX_BINDUTIL_H)
+# error Not valid except when included from mwcex_bindutil.h
+#endif // ! defined(COMPILING_MWCEX_BINDUTIL_H)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+#endif // ! defined(INCLUDED_MWCEX_BINDUTIL_CPP03)
+
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 0cdd31f538164385c8cf944af781c29b9e691aea7901cf36d84391b752bed7b9
+

--- a/src/groups/mwc/mwcex/mwcex_executionproperty.h
+++ b/src/groups/mwc/mwcex/mwcex_executionproperty.h
@@ -55,8 +55,7 @@ struct ExecutionProperty {
     /// Provides a tag type defining the Two-Way direction property and the
     /// result type of the execution function.
     template <class R>
-    struct TwoWayR {
-    };
+    struct TwoWayR {};
 
     enum Blocking {
         // Provides a enumeration type defining the blocking behavior property.

--- a/src/groups/mwc/mwcex/mwcex_executionutil.h
+++ b/src/groups/mwc/mwcex/mwcex_executionutil.h
@@ -206,8 +206,7 @@ class ExecutionPolicy;
 /// Provides a metafunction that determines, at compile time, the type
 /// returned by `mwcex::ExecutionUtil::execute`.
 template <class POLICY, class FUNCTION>
-struct ExecutionUtil_ExecuteResult {
-};
+struct ExecutionUtil_ExecuteResult {};
 
 /// Provides a specialization of `ExecutionUtil_ExecuteResult` for One-Way
 /// policies.
@@ -253,8 +252,7 @@ struct ExecutionUtil_ExecuteResult<
 /// Provides a metafunction that determines, at compile time, the type
 /// returned by `mwcex::ExecutionUtil::thenExecute`.
 template <class POLICY, class FUTURE, class FUNCTION>
-struct ExecutionUtil_ThenExecuteResult {
-};
+struct ExecutionUtil_ThenExecuteResult {};
 
 /// Provides a specialization of `ExecutionUtil_ThenExecuteResult` for
 /// One-Way policies.
@@ -1866,7 +1864,7 @@ ExecutionUtil::execute(
 #else
     typedef
         typename bsl::invoke_result<typename bsl::decay<FUNCTION>::type>::type
-                                                                 Result;
+            Result;
 #endif
 
     return execute(policy.template twoWayR<Result>(),

--- a/src/groups/mwc/mwcex/mwcex_executortraits.h
+++ b/src/groups/mwc/mwcex/mwcex_executortraits.h
@@ -63,16 +63,14 @@ namespace mwcex {
 /// Provides a metafunction to detect if an executor has a proper `dispatch`
 /// member function.
 template <class EXECUTOR, class FUNCTION, class = void>
-struct ExecutorTraits_CanDispatch : bsl::false_type {
-};
+struct ExecutorTraits_CanDispatch : bsl::false_type {};
 
 template <class EXECUTOR, class FUNCTION>
 struct ExecutorTraits_CanDispatch<
     EXECUTOR,
     FUNCTION,
     bsl::void_t<decltype(bsl::declval<const EXECUTOR&>().dispatch(
-        bsl::declval<FUNCTION>()))> > : bsl::true_type {
-};
+        bsl::declval<FUNCTION>()))> > : bsl::true_type {};
 #else
 
 template <class EXECUTOR, class FUNCTION>
@@ -91,14 +89,11 @@ struct ExecutorTraits_CanDispatch {
     typedef bslmf::MovableRef<bsl::function<void()> > JobRef;
 
     template <class U, void (U::*)(Job) const>
-    struct Test1 {
-    };
+    struct Test1 {};
     template <class U, void (U::*)(const Job&) const>
-    struct Test2 {
-    };
+    struct Test2 {};
     template <class U, void (U::*)(JobRef) const>
-    struct Test3 {
-    };
+    struct Test3 {};
 
     // CLASS METHODS
     template <class U>

--- a/src/groups/mwc/mwcex/mwcex_future.h
+++ b/src/groups/mwc/mwcex/mwcex_future.h
@@ -148,14 +148,18 @@
 #include <bsls_systemtime.h>
 #include <bsls_timeinterval.h>
 
+// clang-format off
+
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 29 04:17:13 2022
+// Generated on Fri Jan  5 17:21:17 2024
 // Command line: sim_cpp11_features.pl mwcex_future.h
-#define COMPILING_MWCEX_FUTURE_H
-#include <mwcex_future_cpp03.h>
-#undef COMPILING_MWCEX_FUTURE_H
+# define COMPILING_MWCEX_FUTURE_H
+# include <mwcex_future_cpp03.h>
+# undef COMPILING_MWCEX_FUTURE_H
 #else
+
+// clang-format on
 
 namespace BloombergLP {
 
@@ -295,8 +299,7 @@ class Future_Callback {
     /// Provides a tag type to specify the type of the async result accepted
     /// by the callback,
     template <class R>
-    struct AsyncResultTypeTag {
-    };
+    struct AsyncResultTypeTag {};
 
   private:
     // PRIVATE TYPES
@@ -855,14 +858,14 @@ class FutureSharedState {
 
     typedef typename bsl::remove_const<R>::type ValueType;
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
-    typedef bsl::exception_ptr                  ExceptionPtrType;
+    typedef bsl::exception_ptr ExceptionPtrType;
 #endif
-    typedef Future_Exception                    ExceptionObjType;
+    typedef Future_Exception ExceptionObjType;
 
     /// Shared state result. May contain a value, an exception pointer
     /// (C++11 only), or an exception object.
     union Result {
-        bsls::ObjectBuffer<ValueType>        d_value;
+        bsls::ObjectBuffer<ValueType> d_value;
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
         bsls::ObjectBuffer<ExceptionPtrType> d_exceptionPtr;
 #endif
@@ -953,7 +956,9 @@ class FutureSharedState {
     /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+    // clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+    // clang-format on
 
     /// Atomically initialize the stored value as if by direct-non-list-
     /// initializing an object of type `R` with 'bsl::forward<ARGS>(
@@ -1663,7 +1668,9 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
     emplaceValue(bslmf::MovableRefUtil::move(value));
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+// clang-format on
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(ARGS&&... args)
@@ -1900,6 +1907,10 @@ inline void mwcex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+// clang-format off
+
+#endif // End C++11 code
+
+// clang-format on
 
 #endif

--- a/src/groups/mwc/mwcex/mwcex_future_cpp03.cpp
+++ b/src/groups/mwc/mwcex/mwcex_future_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2018-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:51:54 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_future.cpp
 
 #define INCLUDED_MWCEX_FUTURE_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCEX_FUTURE_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: c09f883982393fc1cca73b80e4ca29a8fa6993b248d23cb0249ede5af9b4db54

--- a/src/groups/mwc/mwcex/mwcex_future_cpp03.h
+++ b/src/groups/mwc/mwcex/mwcex_future_cpp03.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2018-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,17 +36,14 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 29 04:17:13 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_future.h
 
 #ifdef COMPILING_MWCEX_FUTURE_H
 
-namespace BloombergLP {
+// clang-format on
 
-// FORWARD DECLARATION
-namespace bslma {
-class Allocator;
-}
+namespace BloombergLP {
 
 namespace mwcex {
 
@@ -59,36 +56,36 @@ class FutureSharedState;
 // class Future_Exception
 // ======================
 
+/// Provides a polymorphic exception wrapper that can hold and emit any type
+/// of exception.
 class Future_Exception {
-    // Provides a polymorphic exception wrapper that can hold and emit any type
-    // of exception.
-
   private:
     // PRIVATE TYPES
-    class TargetBase {
-        // Provides an interface used to implement the type erasure technique.
-        // When creating a polymorphic exception with a target of type 'E', an
-        // instance of derived class template 'Target<E>' is instantiated and
-        // stored via a pointer to its base class (this one). Then, calls to
-        // 'mwcex::Future_Exception's public methods are forwarded to this
-        // class.
 
+    /// Provides an interface used to implement the type erasure technique.
+    /// When creating a polymorphic exception with a target of type `E`, an
+    /// instance of derived class template `Target<E>` is instantiated and
+    /// stored via a pointer to its base class (this one). Then, calls to
+    /// `mwcex::Future_Exception`s public methods are forwarded to this
+    /// class.
+    class TargetBase {
       public:
         // CREATORS
+
+        /// Destroy this object and the contained exception target with it.
         virtual ~TargetBase();
-        // Destroy this object and the contained exception target with it.
 
       public:
         // ACCESSORS
+
+        /// Throw a copy of the contained exception object.
         BSLS_ANNOTATION_NORETURN virtual void emit() const = 0;
-        // Throw a copy of the contained exception object.
     };
 
+    /// Provides an implementation of the `TargetBase` interface containing
+    /// the exception target.
     template <class EXCEPTION>
     class Target : public TargetBase {
-        // Provides an implementation of the 'TargetBase' interface containing
-        // the exception target.
-
       private:
         // PRIVATE DATA
         bslalg::ConstructorProxy<EXCEPTION> d_exception;
@@ -100,36 +97,39 @@ class Future_Exception {
 
       public:
         // CREATORS
+
+        /// Create a `Target` object containing an exception target of type
+        /// `EXCEPTION` direct-non-list-initialized by
+        /// `bsl::forward<EXCEPTION_PARAM>(exception)`. Specify an
+        /// `allocator` used to supply memory.
         template <class EXCEPTION_PARAM>
         Target(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION_PARAM) exception,
                bslma::Allocator* allocator);
-        // Create a 'Target' object containing an exception target of type
-        // 'EXCEPTION' direct-non-list-initialized by
-        // 'bsl::forward<EXCEPTION_PARAM>(exception)'. Specify an
-        // 'allocator' used to supply memory.
 
       public:
         // ACCESSORS
+
+        /// Implements `TargetBase::emit`.
         BSLS_ANNOTATION_NORETURN void emit() const BSLS_KEYWORD_OVERRIDE;
-        // Implements 'TargetBase::emit'.
     };
 
   private:
     // PRIVATE TYPES
-    struct Dummy {
-        // Provides a "small" dummy object which size is used to calculate the
-        // size of the on-stack buffer used for optimization.
 
+    /// Provides a "small" dummy object which size is used to calculate the
+    /// size of the on-stack buffer used for optimization.
+    struct Dummy {
         void* d_padding[3];
     };
 
   private:
     // PRIVATE DATA
-    mwcu::ObjectPlaceHolder<sizeof(Target<Dummy>)> d_target;
+
     // Uses an on-stack buffer to allocate memory for "small" objects, and
     // falls back to requesting memory from the the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
+    mwcu::ObjectPlaceHolder<sizeof(Target<Dummy>)> d_target;
 
   private:
     // NOT IMPLEMENTED
@@ -138,19 +138,20 @@ class Future_Exception {
 
   public:
     // CREATORS
+
+    /// Create a `Future_Exception` object containing an exception target
+    /// of type `bsl::decay_t<EXCEPTION>` direct-non-list-initialized by
+    /// `bsl::forward<EXCEPTION>(exception)`. Specify an `allocator` used to
+    /// supply memory.
+    ///
+    /// `bsl::decay_t<EXCEPTION>` must meet the requirements of Destructible
+    /// and CopyConstructible as specified in the C++ standard.
     template <class EXCEPTION>
     Future_Exception(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION) exception,
                      bslma::Allocator* allocator);
-    // Create a 'Future_Exception' object containing an exception target
-    // of type 'bsl::decay_t<EXCEPTION>' direct-non-list-initialized by
-    // 'bsl::forward<EXCEPTION>(exception)'. Specify an 'allocator' used to
-    // supply memory.
-    //
-    // 'bsl::decay_t<EXCEPTION>' must meet the requirements of Destructible
-    // and CopyConstructible as specified in the C++ standard.
 
+    /// Destroy this object and the contained exception target with it.
     ~Future_Exception();
-    // Destroy this object and the contained exception target with it.
 
   public:
     // ACCESSORS
@@ -172,45 +173,45 @@ class Future_Exception {
 // class Future_Callback
 // =====================
 
+/// Provides a polymorphic callback wrapper with small buffer optimization.
 class Future_Callback {
-    // Provides a polymorphic callback wrapper with small buffer optimization.
-
   public:
     // TYPES
+
+    /// Provides a tag type to specify the type of the async result accepted
+    /// by the callback,
     template <class R>
-    struct AsyncResultTypeTag {
-        // Provides a tag type to specify the type of the async result accepted
-        // by the callback,
-    };
+    struct AsyncResultTypeTag {};
 
   private:
     // PRIVATE TYPES
-    class TargetBase {
-        // Provides an interface used to implement the type erasure technique.
-        // When creating a polymorphic wrapper with an async result type 'R'
-        // and a callback of type 'F', an instance of derived class template
-        // 'Target<R, F>' is instantiated and stored via a pointer to its base
-        // class (this one). Then, calls to 'mwcex::Future_Callback's public
-        // methods are forwarded to this class.
 
+    /// Provides an interface used to implement the type erasure technique.
+    /// When creating a polymorphic wrapper with an async result type `R`
+    /// and a callback of type `F`, an instance of derived class template
+    /// `Target<R, F>` is instantiated and stored via a pointer to its base
+    /// class (this one). Then, calls to `mwcex::Future_Callback`s public
+    /// methods are forwarded to this class.
+    class TargetBase {
       public:
         // CREATORS
+
+        /// Destroy this object and the contained function object with it.
         virtual ~TargetBase();
-        // Destroy this object and the contained function object with it.
 
       public:
         // MANIPULATORS
+
+        /// Perform `bsl::move(f)(FutureResult<R>((S*)sharedState))`, where
+        /// `f` is the contained function object, `R` the type of the async
+        /// result, and `S` is `Future<R>::SharedStateType`.
         virtual void invoke(void* sharedState) = 0;
-        // Perform 'bsl::move(f)(FutureResult<R>((S*)sharedState))', where
-        // 'f' is the contained function object, 'R' the type of the async
-        // result, and 'S' is 'Future<R>::SharedStateType'.
     };
 
+    /// Provides an implementation of the `TargetBase` interface containing
+    /// the function object.
     template <class R, class FUNCTION>
     class Target : public TargetBase {
-        // Provides an implementation of the 'TargetBase' interface containing
-        // the function object.
-
       private:
         // PRIVATE DATA
         bslalg::ConstructorProxy<FUNCTION> d_function;
@@ -222,36 +223,39 @@ class Future_Callback {
 
       public:
         // CREATORS
+
+        /// Create a `Target` object containing a function object of type
+        /// `FUNCTION` direct-non-list-initialized by
+        /// `bsl::forward<FUNCTION_PARAM>(function)`. Specify an `allocator`
+        /// used to supply memory.
         template <class FUNCTION_PARAM>
         Target(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION_PARAM) function,
                bslma::Allocator* allocator);
-        // Create a 'Target' object containing a function object of type
-        // 'FUNCTION' direct-non-list-initialized by
-        // 'bsl::forward<FUNCTION_PARAM>(function)'. Specify an 'allocator'
-        // used to supply memory.
 
       public:
         // MANIPULATORS
+
+        /// Implements `TargetBase::invoke`.
         void invoke(void* sharedState) BSLS_KEYWORD_OVERRIDE;
-        // Implements 'TargetBase::invoke'.
     };
 
   private:
     // PRIVATE TYPES
-    struct Dummy {
-        // Provides a "small" dummy object which size is used to calculate the
-        // size of the on-stack buffer used for optimization.
 
+    /// Provides a "small" dummy object which size is used to calculate the
+    /// size of the on-stack buffer used for optimization.
+    struct Dummy {
         void* d_padding[3];
     };
 
   private:
     // PRIVATE DATA
-    mwcu::ObjectPlaceHolder<sizeof(Target<void, Dummy>)> d_target;
+
     // Uses an on-stack buffer to allocate memory for "small" objects, and
     // falls back to requesting memory from the the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
+    mwcu::ObjectPlaceHolder<sizeof(Target<void, Dummy>)> d_target;
 
   private:
     // NOT IMPLEMENTED
@@ -260,30 +264,32 @@ class Future_Callback {
 
   public:
     // CREATORS
+
+    /// Create a `Future_Callback` object containing a function object of
+    /// type `FUNCTION` direct-non-list-initialized by
+    /// `bsl::forward<FUNCTION_PARAM>(function)`. Specify an `allocator`
+    /// used to supply memory.
+    ///
+    /// `bsl::decay_t<FUNCTION>` must meet the requirements of Destructible
+    /// and MoveConstructible as specified in the C++ standard. Given an
+    /// object `f` of type `bsl::decay_t<FUNCTION>`,
+    /// `f(bsl::declval<FutureResult<R>>())` shall be a valid
+    /// expression.
     template <class R, class FUNCTION>
     Future_Callback(AsyncResultTypeTag<R>,
                     BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) function,
                     bslma::Allocator* allocator);
-    // Create a 'Future_Callback' object containing a function object of
-    // type 'FUNCTION' direct-non-list-initialized by
-    // 'bsl::forward<FUNCTION_PARAM>(function)'. Specify an 'allocator'
-    // used to supply memory.
-    //
-    // 'bsl::decay_t<FUNCTION>' must meet the requirements of Destructible
-    // and MoveConstructible as specified in the C++ standard. Given an
-    // object 'f' of type 'bsl::decay_t<FUNCTION>',
-    // 'f(bsl::declval<FutureResult<R>>())' shall be a valid
-    // expression.
 
+    /// Destroy this object and the contained function object with it.
     ~Future_Callback();
-    // Destroy this object and the contained function object with it.
 
   public:
     // MANIPULATORS
+
+    /// Perform `bsl::move(f)(FutureResult<R>((S*)sharedState))`, where `f`
+    /// is the contained function object, `R` is the type of the async
+    /// result, and `S` is `Future<R>::SharedStateType`.
     void invoke(void* sharedState);
-    // Perform 'bsl::move(f)(FutureResult<R>((S*)sharedState))', where 'f'
-    // is the contained function object, 'R' is the type of the async
-    // result, and 'S' is 'Future<R>::SharedStateType'.
 
   public:
     // TRAITS
@@ -294,10 +300,9 @@ class Future_Callback {
 // struct FutureStatus
 // ===================
 
+/// Specifies state of a future as returned by `waitFor` and `waitUntil`
+/// functions of `mwcex::Future` and `mwcex::FutureSharedState`.
 struct FutureStatus {
-    // Specifies state of a future as returned by 'waitFor' and 'waitUntil'
-    // functions of 'mwcex::Future' and 'mwcex::FutureSharedState'.
-
     enum Enum {
         e_READY  // the shared state is ready
         ,
@@ -309,18 +314,18 @@ struct FutureStatus {
 // class Future
 // ============
 
+/// Provides a mechanism to access the result of an asynchronous operation.
+///
+/// `R` must meet the requirements of Destructible as specified in the C++
+/// standard.
 template <class R>
 class Future {
-    // Provides a mechanism to access the result of an asynchronous operation.
-    //
-    // 'R' must meet the requirements of Destructible as specified in the C++
-    // standard.
-
   public:
     // TYPES
+
+    /// Defines the type of the shared state accepted by the future
+    /// constructor.
     typedef FutureSharedState<R> SharedStateType;
-    // Defines the type of the shared state accepted by the future
-    // constructor.
 
   protected:
     // PROTECTED DATA
@@ -335,109 +340,91 @@ class Future {
 
   public:
     // CREATORS
-    Future() BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'Future' object having no shared state.
 
+    /// Create a `Future` object having no shared state.
+    Future() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Create a `Future` object having the specified `sharedState`.
     explicit Future(const bsl::shared_ptr<SharedStateType>& sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'Future' object having the specified 'sharedState'.
-
-    //! Future(const Future& original) noexcept = default;
-    // Create a 'Future' object that refers to and assumes management of
-    // the same shared state (if any) as the specified 'original' object.
-
-    //! Future(Future&& original) noexcept      = default;
-    // Create a 'Future' object that refers to and assumes management of
-    // the same shared state (if any) as the specified 'original' object,
-    // and reset 'original' to a default-constructed state.
-
-    //! ~Future() = default;
-    // Destroy this object. Release the underlying shared state, if any.
 
   public:
     // MANIPULATORS
-    //! Future& operator=(const Future& rhs) noexcept = default;
-    // Make this future refer to and assume management of the same shared
-    // state (if any) as the specified 'rhs' future. Return '*this'.
 
-    //! Future& operator=(Future&& rhs) noexcept      = default;
-    // Make this future refer to and assume management of the same shared
-    // state (if any) as the specified 'rhs' future, and reset 'rhs' to a
-    // default-constructed state. Return '*this'.
-
+    /// If `isReady()` is `true`, call 'DECAY_COPY(bsl::forward<FUNCTION>(
+    /// callback))(FutureResult<R>(*this))'. Otherwise, store the specified
+    /// `callback` as if by direct-non-list-initializing an object `f` of
+    /// type `bsl::decay_t<FUNCTION>` with 'bsl::forward<FUNCTION>(
+    /// callback)` to be invoked as `bsl::move(f)(FutureResult<R>(*this))'
+    /// as soon as the shared state becomes ready. Effectively calls
+    /// `whenReady` on the underlying shared state. The behavior is
+    /// undefined if a callback is already attached to the shared state, or
+    /// if the future has no shared state.
+    ///
+    /// Throws any exception thrown by the selected constructor of
+    /// `bsl::decay_t<FUNCTION>`, any exception thrown by 'DECAY_COPY(
+    /// bsl::forward<FUNCTION>(callback))(FutureResult<R>(*this))', or
+    /// `bsl::bad_alloc` if memory allocation fails. If an exception is
+    /// thrown, this function has no effect.
+    ///
+    /// Note that, unless otherwise specified, it is safe to invoke any
+    /// function on `*this` from the context of the attached callback.
+    ///
+    /// `bsl::decay_t<FUNCTION>` must meet the requirements of Destructible
+    /// and MoveConstructible as specified in the C++ standard. Given an
+    /// object `f` of type `bsl::decay_t<FUNCTION>`,
+    /// `f(bsl::declval<FutureResult<R>>())` shall be a valid expression.
     template <class FUNCTION>
     void whenReady(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) callback);
-    // If 'isReady()' is 'true', call 'DECAY_COPY(bsl::forward<FUNCTION>(
-    // callback))(FutureResult<R>(*this))'. Otherwise, store the specified
-    // 'callback' as if by direct-non-list-initializing an object 'f' of
-    // type 'bsl::decay_t<FUNCTION>' with 'bsl::forward<FUNCTION>(
-    // callback)' to be invoked as 'bsl::move(f)(FutureResult<R>(*this))'
-    // as soon as the shared state becomes ready. Effectively calls
-    // 'whenReady' on the underlying shared state. The behavior is
-    // undefined if a callback is already attached to the shared state, or
-    // if the future has no shared state.
-    //
-    // Throws any exception thrown by the selected constructor of
-    // 'bsl::decay_t<FUNCTION>', any exception thrown by 'DECAY_COPY(
-    // bsl::forward<FUNCTION>(callback))(FutureResult<R>(*this))', or
-    // 'bsl::bad_alloc' if memory allocation fails. If an exception is
-    // thrown, this function has no effect.
-    //
-    // Note that, unless otherwise specified, it is safe to invoke any
-    // function on '*this' from the context of the attached callback.
-    //
-    // 'bsl::decay_t<FUNCTION>' must meet the requirements of Destructible
-    // and MoveConstructible as specified in the C++ standard. Given an
-    // object 'f' of type 'bsl::decay_t<FUNCTION>',
-    // 'f(bsl::declval<FutureResult<R>>())' shall be a valid expression.
 
+    /// Swap the contents of `*this` and `other`.
     void swap(Future& other) BSLS_KEYWORD_NOEXCEPT;
-    // Swap the contents of '*this' and 'other'.
 
   public:
     // ACCESSORS
+
+    /// Return `true` if the future has a shared state, and `false`
+    /// otherwise.
     bool isValid() const BSLS_KEYWORD_NOEXCEPT;
-    // Return 'true' if the future has a shared state, and 'false'
-    // otherwise.
 
+    /// Return `true` if the shared state is ready, and `false` otherwise.
+    /// Effectively calls `isReady` on the underlying shared state. The
+    /// behavior is undefined unless the future has a shared state.
     bool isReady() const BSLS_KEYWORD_NOEXCEPT;
-    // Return 'true' if the shared state is ready, and 'false' otherwise.
-    // Effectively calls 'isReady' on the underlying shared state. The
-    // behavior is undefined unless the future has a shared state.
 
+    /// Block the calling thread until the shared state is ready. Then,
+    /// return the contained value or throw the contained exception.
+    /// Effectively calls `get` on the underlying shared state. The
+    /// behavior is undefined unless the future has a shared state.
     R&       get();
     const R& get() const;
-    // Block the calling thread until the shared state is ready. Then,
-    // return the contained value or throw the contained exception.
-    // Effectively calls 'get' on the underlying shared state. The
-    // behavior is undefined unless the future has a shared state.
 
+    /// Block the calling thread until the shared state is ready.
+    /// Effectively calls `wait` on the underlying shared state. The
+    /// behavior is undefined unless the future has a shared state.
     void wait() const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state is ready.
-    // Effectively calls 'wait' on the underlying shared state. The
-    // behavior is undefined unless the future has a shared state.
 
+    /// Block the calling thread until the shared state becomes ready or the
+    /// specified `duration` time has elapsed, whichever comes first. The
+    /// `duration` is an offset from the current point in time, which is
+    /// determined by the clock indicated at the construction of the
+    /// underlying shared state. Return a value identifying the state of the
+    /// result. Effectively calls `waitFor` on the underlying shared
+    /// state. The behavior is undefined unless the future has a shared
+    /// state.
     FutureStatus::Enum
     waitFor(const bsls::TimeInterval& duration) const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state becomes ready or the
-    // specified 'duration' time has elapsed, whichever comes first. The
-    // 'duration' is an offset from the current point in time, which is
-    // determined by the clock indicated at the construction of the
-    // underlying shared state. Return a value identifying the state of the
-    // result. Effectively calls 'waitFor' on the underlying shared
-    // state. The behavior is undefined unless the future has a shared
-    // state.
 
+    /// Block the calling thread until the shared state becomes ready or
+    /// until the specified `timeout`, whichever comes first. The `timeout`
+    /// is an absolute time represented as an interval from some epoch,
+    /// which is determined by the clock indicated at the construction of
+    /// the underlying shared state. Return a value identifying the state
+    /// of the result. Effectively calls `waitUntil` on the underlying
+    /// shared state. The behavior is undefined unless the future has a
+    /// shared state.
     FutureStatus::Enum
     waitUntil(const bsls::TimeInterval& timeout) const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state becomes ready or
-    // until the specified 'timeout', whichever comes first. The 'timeout'
-    // is an absolute time represented as an interval from some epoch,
-    // which is determined by the clock indicated at the construction of
-    // the underlying shared state. Return a value identifying the state
-    // of the result. Effectively calls 'waitUntil' on the underlying
-    // shared state. The behavior is undefined unless the future has a
-    // shared state.
 
   public:
     // TRAITS
@@ -448,15 +435,15 @@ class Future {
 // class Future<void>
 // ==================
 
+/// Provides a specialization of `Future` for `void` result type.
 template <>
 class Future<void> : private Future<bslmf::Nil> {
-    // Provides a specialization of 'Future' for 'void' result type.
-
   public:
     // TYPES
+
+    /// Defines the type of the shared state accepted by the future
+    /// constructor.
     typedef FutureSharedState<bslmf::Nil> SharedStateType;
-    // Defines the type of the shared state accepted by the future
-    // constructor.
 
   private:
     // PRIVATE TYPES
@@ -468,62 +455,50 @@ class Future<void> : private Future<bslmf::Nil> {
 
   public:
     // CREATORS
-    Future() BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    Future() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Same as for the non-specialized class template.
     explicit Future(const bsl::shared_ptr<SharedStateType>& sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! Future(const Future& original) noexcept = default;
-    // Same as for the non-specialized class template.
-
-    //! Future(Future&& original) noexcept      = default;
-    // Same as for the non-specialized class template.
-
-    //! ~Future() = default;
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    //! Future& operator=(const Future& rhs) noexcept = default;
-    // Same as for the non-specialized class template.
 
-    //! Future& operator=(Future&& rhs) noexcept      = default;
-    // Same as for the non-specialized class template.
-
+    /// Same as for the non-specialized class template.
     template <class FUNCTION>
     void whenReady(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) callback);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(Future& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
+
+    /// Same as for the non-specialized class template.
     bool isValid() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     bool isReady() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Block the calling thread until the shared state is ready. Then, if
+    /// the shared state contains an exception, throw the contained
+    /// exception. Effectively calls `get` on the underlying shared
+    /// state. The behavior is undefined unless the future has a shared
+    /// state.
     void get() const;
-    // Block the calling thread until the shared state is ready. Then, if
-    // the shared state contains an exception, throw the contained
-    // exception. Effectively calls 'get' on the underlying shared
-    // state. The behavior is undefined unless the future has a shared
-    // state.
 
+    /// Same as for the non-specialized class template.
     void wait() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     FutureStatus::Enum
     waitFor(const bsls::TimeInterval& duration) const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     FutureStatus::Enum
     waitUntil(const bsls::TimeInterval& timeout) const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // TRAITS
@@ -534,15 +509,15 @@ class Future<void> : private Future<bslmf::Nil> {
 // class Future<R&>
 // ================
 
+/// Provides a specialization of `Future` for reference result types.
 template <class R>
 class Future<R&> : private Future<bsl::reference_wrapper<R> > {
-    // Provides a specialization of 'Future' for reference result types.
-
   public:
     // TYPES
+
+    /// Defines the type of the shared state accepted by the future
+    /// constructor.
     typedef FutureSharedState<bsl::reference_wrapper<R> > SharedStateType;
-    // Defines the type of the shared state accepted by the future
-    // constructor.
 
   private:
     // PRIVATE TYPES
@@ -554,61 +529,49 @@ class Future<R&> : private Future<bsl::reference_wrapper<R> > {
 
   public:
     // CREATORS
-    Future() BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    Future() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Same as for the non-specialized class template.
     explicit Future(const bsl::shared_ptr<SharedStateType>& sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! Future(const Future& original) noexcept = default;
-    // Same as for the non-specialized class template.
-
-    //! Future(Future&& original) noexcept      = default;
-    // Same as for the non-specialized class template.
-
-    //! ~Future() = default;
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    //! Future& operator=(const Future& rhs) noexcept = default;
-    // Same as for the non-specialized class template.
 
-    //! Future& operator=(Future&& rhs) noexcept      = default;
-    // Same as for the non-specialized class template.
-
+    /// Same as for the non-specialized class template.
     template <class FUNCTION>
     void whenReady(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) callback);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(Future& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
+
+    /// Same as for the non-specialized class template.
     bool isValid() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     bool isReady() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Block the calling thread until the shared state is ready. Then,
+    /// return the contained reference or throw the contained exception.
+    /// Effectively calls `get` on the underlying shared state. The
+    /// behavior is undefined unless the future has a shared state.
     R& get() const;
-    // Block the calling thread until the shared state is ready. Then,
-    // return the contained reference or throw the contained exception.
-    // Effectively calls 'get' on the underlying shared state. The
-    // behavior is undefined unless the future has a shared state.
 
+    /// Same as for the non-specialized class template.
     void wait() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     FutureStatus::Enum
     waitFor(const bsls::TimeInterval& duration) const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     FutureStatus::Enum
     waitUntil(const bsls::TimeInterval& timeout) const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // TRAITS
@@ -619,59 +582,49 @@ class Future<R&> : private Future<bsl::reference_wrapper<R> > {
 // class FutureResult
 // ==================
 
+/// Provides a mechanism to access the result of an asynchronous operation
+/// that is already established. Objects of this type are passed as
+/// parameters to notification callbacks.
+///
+/// `R` must meet the requirements of Destructible as specified in the C++
+/// standard.
 template <class R>
 class FutureResult {
-    // Provides a mechanism to access the result of an asynchronous operation
-    // that is already established. Objects of this type are passed as
-    // parameters to notification callbacks.
-    //
-    // 'R' must meet the requirements of Destructible as specified in the C++
-    // standard.
-
   private:
     // PRIVATE DATA
     typename Future<R>::SharedStateType* d_sharedState_p;
 
   public:
+    /// Create a `FutureResult` object having the same shared state as the
+    /// specified `future`. The behavior is undefined unless
+    /// `future.isValid()` and `future.isReady()` are `true`.
+    ///
+    /// Note that no copy of the specified `future` is stored in this
+    /// object, meaning that the reference counting for the shared state
+    /// is not affected.
     explicit FutureResult(const Future<R>& future) BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'FutureResult' object having the same shared state as the
-    // specified 'future'. The behavior is undefined unless
-    // 'future.isValid()' and 'future.isReady()' are 'true'.
-    //
-    // Note that no copy of the specified 'future' is stored in this
-    // object, meaning that the reference counting for the shared state
-    // is not affected.
 
+    /// Create a `FutureResult` object having the specified `sharedState`.
+    /// The behavior is undefined unless `sharedState->isReady()` is `true`.
     explicit FutureResult(typename Future<R>::SharedStateType* sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'FutureResult' object having the specified 'sharedState'.
-    // The behavior is undefined unless 'sharedState->isReady()' is 'true'.
 
-    //! FutureResult(const FutureResult& original) noexcept = default;
-    //! FutureResult(FutureResult&& original)      noexcept = default;
-    // Create a 'FutureResult' object that refers to the same shared state
-    // as the specified 'original' object.
-
+    /// Swap the contents of `*this` and `other`.
     void swap(FutureResult& other) BSLS_KEYWORD_NOEXCEPT;
-    // Swap the contents of '*this' and 'other'.
 
   public:
     // MANIPULATORS
-    //! FutureResult& operator=(const FutureResult& rhs) noexcept = default;
-    //! FutureResult& operator=(FutureResult&& rhs)      noexcept = default;
-    // Make this future result refer to the same shared state as the
-    // specified 'rhs' object. Return '*this'.
-
   public:
     // ACCESSORS
+
+    /// Perform `return get();`.
     operator R&();
     operator const R&() const;
-    // Perform 'return get();'.
 
+    /// Return the contained value or throw the contained exception.
+    /// Effectively calls `get` on the underlying shared state.
     R&       get();
     const R& get() const;
-    // Return the contained value or throw the contained exception.
-    // Effectively calls 'get' on the underlying shared state.
 
   public:
     // TRAITS
@@ -682,41 +635,35 @@ class FutureResult {
 // class FutureResult<void>
 // ========================
 
+/// Provides a specialization of `FutureResult` for `void` result type.
 template <>
 class FutureResult<void> {
-    // Provides a specialization of 'FutureResult' for 'void' result type.
-
   private:
     // PRIVATE DATA
     Future<void>::SharedStateType* d_sharedState_p;
 
   public:
     // CREATORS
-    explicit FutureResult(const Future<void>& future) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    explicit FutureResult(const Future<void>& future) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Same as for the non-specialized class template.
     explicit FutureResult(Future<void>::SharedStateType* sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! FutureResult(const FutureResult& original) noexcept = default;
-    //! FutureResult(FutureResult&& original)      noexcept = default;
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    //! FutureResult& operator=(const FutureResult& rhs) noexcept = default;
-    //! FutureResult& operator=(FutureResult&& rhs)      noexcept = default;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(FutureResult& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
+
+    /// If the shared state contains an exception, throw the contained
+    /// exception. Effectively calls `get` on the underlying shared state.
     void get() const;
-    // If the shared state contains an exception, throw the contained
-    // exception. Effectively calls 'get' on the underlying shared state.
 
   public:
     // TRAITS
@@ -727,44 +674,38 @@ class FutureResult<void> {
 // class FutureResult<R&>
 // ======================
 
+/// Provides a specialization of `FutureResult` for reference result types.
 template <class R>
 class FutureResult<R&> {
-    // Provides a specialization of 'FutureResult' for reference result types.
-
   private:
     // PRIVATE DATA
     typename Future<R&>::SharedStateType* d_sharedState_p;
 
   public:
     // CREATORS
-    explicit FutureResult(const Future<R&>& future) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    explicit FutureResult(const Future<R&>& future) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Same as for the non-specialized class template.
     explicit FutureResult(typename Future<R&>::SharedStateType* sharedState)
         BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! FutureResult(const FutureResult& original) noexcept = default;
-    //! FutureResult(FutureResult&& original)      noexcept = default;
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    //! FutureResult& operator=(const FutureResult& rhs) noexcept = default;
-    //! FutureResult& operator=(FutureResult&& rhs)      noexcept = default;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(FutureResult& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
-    operator R&() const;
-    // Perform 'return get();'.
 
+    /// Perform `return get();`.
+    operator R&() const;
+
+    /// Return the contained reference or throw the contained exception.
+    /// Effectively calls `get` on the underlying shared state.
     R& get() const;
-    // Return the contained reference or throw the contained exception.
-    // Effectively calls 'get' on the underlying shared state.
 
   public:
     // TRAITS
@@ -775,14 +716,13 @@ class FutureResult<R&> {
 // class FutureSharedState
 // =======================
 
+/// Provides a shared state that stores the result of an asynchronous
+/// operation.
+///
+/// `R` must meet the requirements of Destructible as specified in the C++
+/// standard.
 template <class R>
 class FutureSharedState {
-    // Provides a shared state that stores the result of an asynchronous
-    // operation.
-    //
-    // 'R' must meet the requirements of Destructible as specified in the C++
-    // standard.
-
   private:
     // PRIVATE TYPES
     enum State {
@@ -804,10 +744,9 @@ class FutureSharedState {
 #endif
     typedef Future_Exception ExceptionObjType;
 
+    /// Shared state result. May contain a value, an exception pointer
+    /// (C++11 only), or an exception object.
     union Result {
-        // Shared state result. May contain a value, an exception pointer
-        // (C++11 only), or an exception object.
-
         bsls::ObjectBuffer<ValueType> d_value;
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
         bsls::ObjectBuffer<ExceptionPtrType> d_exceptionPtr;
@@ -833,9 +772,10 @@ class FutureSharedState {
 
   private:
     // PRIVATE MANIPULATORS
+
+    /// If a callback is attached to the shared state, invoke, and then
+    /// destroy it.
     void invokeAndDestroyCallback();
-    // If a callback is attached to the shared state, invoke, and then
-    // destroy it.
 
   private:
     // NOT IMPLEMENTED
@@ -847,56 +787,58 @@ class FutureSharedState {
     // CREATORS
     explicit FutureSharedState(bslma::Allocator* basicAllocator = 0);
 
+    /// Create a `FutureSharedState` object. Optionally specify a
+    /// `clockType` indicating the type of the system clock against which
+    /// the `bsls::TimeInterval` timeouts passed to `waitFor` and
+    /// `waitUntil` methods are to be interpreted. If `clockType` is not
+    /// specified, the monotonic system clock is used. Optionally specify a
+    /// `basicAllocator` used to supply memory. If `basicAllocator` is not
+    /// specified, the currently installed default allocator is used.
     explicit FutureSharedState(bsls::SystemClockType::Enum clockType,
                                bslma::Allocator*           basicAllocator = 0);
-    // Create a 'FutureSharedState' object. Optionally specify a
-    // 'clockType' indicating the type of the system clock against which
-    // the 'bsls::TimeInterval' timeouts passed to 'waitFor' and
-    // 'waitUntil' methods are to be interpreted. If 'clockType' is not
-    // specified, the monotonic system clock is used. Optionally specify a
-    // 'basicAllocator' used to supply memory. If 'basicAllocator' is not
-    // specified, the currently installed default allocator is used.
 
+    /// Destroy this object. Destroy any contained value, exception pointer,
+    /// exception object or callback. The behavior is undefined if this
+    /// function is invoked from the context of a callback attached to this
+    /// shared state.
     ~FutureSharedState();
-    // Destroy this object. Destroy any contained value, exception pointer,
-    // exception object or callback. The behavior is undefined if this
-    // function is invoked from the context of a callback attached to this
-    // shared state.
 
   public:
     // MANIPULATORS
+
+    /// Atomically initialize the stored value as if by direct-non-list-
+    /// initializing an object of type `R` with `value` and make the state
+    /// ready. If a callback is attached to the shared state, invoke, and
+    /// then destroy it. The behavior is undefined if the shared state is
+    /// ready.
+    ///
+    /// Throws any exception thrown by the selected constructor of `R`, or
+    /// any exception thrown by the attached callback. If an exception is
+    /// thrown by `R`s constructor, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored value stays
+    /// initialized and the callback is destroyed.
+    ///
+    /// `R` must meet the requirements of CopyConstructible as specified in
+    /// the C++ standard.
     void setValue(const R& value);
-    // Atomically initialize the stored value as if by direct-non-list-
-    // initializing an object of type 'R' with 'value' and make the state
-    // ready. If a callback is attached to the shared state, invoke, and
-    // then destroy it. The behavior is undefined if the shared state is
-    // ready.
-    //
-    // Throws any exception thrown by the selected constructor of 'R', or
-    // any exception thrown by the attached callback. If an exception is
-    // thrown by 'R's constructor, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored value stays
-    // initialized and the callback is destroyed.
-    //
-    // 'R' must meet the requirements of CopyConstructible as specified in
-    // the C++ standard.
 
+    /// Atomically initialize the stored value as if by direct-non-list-
+    /// initializing an object of type `R` with bsl::move(value)' and make
+    /// the state ready. If a callback is attached to the shared state,
+    /// invoke, and then destroy it. The behavior is undefined if the shared
+    /// state is ready.
+    ///
+    /// Throws any exception thrown by the selected constructor of `R`, or
+    /// any exception thrown by the attached callback. If an exception is
+    /// thrown by `R`s constructor, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored value stays
+    /// initialized and the callback is destroyed.
+    ///
+    /// `R` must meet the requirements of MoveConstructible as specified in
+    /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
-    // Atomically initialize the stored value as if by direct-non-list-
-    // initializing an object of type 'R' with bsl::move(value)' and make
-    // the state ready. If a callback is attached to the shared state,
-    // invoke, and then destroy it. The behavior is undefined if the shared
-    // state is ready.
-    //
-    // Throws any exception thrown by the selected constructor of 'R', or
-    // any exception thrown by the attached callback. If an exception is
-    // thrown by 'R's constructor, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored value stays
-    // initialized and the callback is destroyed.
-    //
-    // 'R' must meet the requirements of MoveConstructible as specified in
-    // the C++ standard.
 
+    // clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcex_future.h
@@ -906,6 +848,7 @@ class FutureSharedState {
 #ifndef MWCEX_FUTURE_VARIADIC_LIMIT_A
 #define MWCEX_FUTURE_VARIADIC_LIMIT_A MWCEX_FUTURE_VARIADIC_LIMIT
 #endif
+
 #if MWCEX_FUTURE_VARIADIC_LIMIT_A >= 0
     void emplaceValue();
 #endif  // MWCEX_FUTURE_VARIADIC_LIMIT_A >= 0
@@ -916,20 +859,26 @@ class FutureSharedState {
 #endif  // MWCEX_FUTURE_VARIADIC_LIMIT_A >= 1
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // MWCEX_FUTURE_VARIADIC_LIMIT_A >= 2
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // MWCEX_FUTURE_VARIADIC_LIMIT_A >= 3
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -1022,105 +971,107 @@ class FutureSharedState {
 #endif  // MWCEX_FUTURE_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
 #endif
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
+    /// Atomically store the specified `exception` pointer into the shared
+    /// state and make the state ready. If a callback is attached to the
+    /// shared state, invoke, and then destroy it. The behavior is undefined
+    /// if the shared state is ready.
+    ///
+    /// Throws any exception thrown by the attached callback. If an
+    /// exception is thrown, the stored exception stays initialized and the
+    /// callback is destroyed.
     void setException(bsl::exception_ptr exception);
-    // Atomically store the specified 'exception' pointer into the shared
-    // state and make the state ready. If a callback is attached to the
-    // shared state, invoke, and then destroy it. The behavior is undefined
-    // if the shared state is ready.
-    //
-    // Throws any exception thrown by the attached callback. If an
-    // exception is thrown, the stored exception stays initialized and the
-    // callback is destroyed.
 #endif
 
+    /// Atomically initialize the stored exception object as if by direct-
+    /// non-list-initializing an object of type `bsl::decay_t<EXCEPTION>`
+    /// with `bsl::forward<EXCEPTION>(EXCEPTION)` and make the state ready.
+    /// If a callback is attached to the shared state, invoke, and then
+    /// destroy it. The behavior is undefined if the shared state is ready.
+    ///
+    /// Throws any exception thrown by the selected constructor of
+    /// `bsl::decay_t<EXCEPTION>`, any exception thrown by the attached
+    /// callback, or `bsl::bad_alloc` if memory allocation fails. If an
+    /// exception is thrown by `bsl::decay_t<EXCEPTION>`s constructor or due
+    /// to memory allocation failure, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored exception
+    /// stays initialized and the callback is destroyed.
+    ///
+    /// `bsl::decay_t<EXCEPTION>` must meet the requirements of Destructible
+    /// and CopyConstructible as specified in the C++ standard.
     template <class EXCEPTION>
     void setException(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION) exception);
-    // Atomically initialize the stored exception object as if by direct-
-    // non-list-initializing an object of type 'bsl::decay_t<EXCEPTION>'
-    // with 'bsl::forward<EXCEPTION>(EXCEPTION)' and make the state ready.
-    // If a callback is attached to the shared state, invoke, and then
-    // destroy it. The behavior is undefined if the shared state is ready.
-    //
-    // Throws any exception thrown by the selected constructor of
-    // 'bsl::decay_t<EXCEPTION>', any exception thrown by the attached
-    // callback, or 'bsl::bad_alloc' if memory allocation fails. If an
-    // exception is thrown by 'bsl::decay_t<EXCEPTION>'s constructor or due
-    // to memory allocation failure, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored exception
-    // stays initialized and the callback is destroyed.
-    //
-    // 'bsl::decay_t<EXCEPTION>' must meet the requirements of Destructible
-    // and CopyConstructible as specified in the C++ standard.
 
+    /// If `isReady()` is `true`, call 'DECAY_COPY(bsl::forward<FUNCTION>(
+    /// callback))(FutureResult<R_T>(this))'. Otherwise, store the specified
+    /// `callback` as if by direct-non-list-initializing an object `f` of
+    /// type `bsl::decay_t<FUNCTION>` with 'bsl::forward<FUNCTION>(
+    /// callback)` to be invoked as `bsl::move(f)(FutureResult<R_T>(this))'
+    /// as soon as the shared state becomes ready. The behavior is undefined
+    /// if a callback is already attached to this shared state.
+    ///
+    /// Throws any exception thrown by the selected constructor of
+    /// `bsl::decay_t<FUNCTION>`, any exception thrown by 'DECAY_COPY(
+    /// bsl::forward<FUNCTION>(callback))(FutureResult<R_T>(this))', or
+    /// `bsl::bad_alloc` if memory allocation fails. If an exception is
+    /// thrown, this function has no effect.
+    ///
+    /// Note that, unless otherwise specified, it is safe to invoke any
+    /// function on `*this` from the context of the attached callback.
+    ///
+    /// `bsl::decay_t<FUNCTION>` must meet the requirements of Destructible
+    /// and MoveConstructible as specified in the C++ standard. Given an
+    /// object `f` of type `bsl::decay_t<FUNCTION>`,
+    /// `f(bsl::declval<FutureResult<R_T>>())` shall be a valid expression.
     template <class R_T, class FUNCTION>
     void whenReady(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) callback);
-    // If 'isReady()' is 'true', call 'DECAY_COPY(bsl::forward<FUNCTION>(
-    // callback))(FutureResult<R_T>(this))'. Otherwise, store the specified
-    // 'callback' as if by direct-non-list-initializing an object 'f' of
-    // type 'bsl::decay_t<FUNCTION>' with 'bsl::forward<FUNCTION>(
-    // callback)' to be invoked as 'bsl::move(f)(FutureResult<R_T>(this))'
-    // as soon as the shared state becomes ready. The behavior is undefined
-    // if a callback is already attached to this shared state.
-    //
-    // Throws any exception thrown by the selected constructor of
-    // 'bsl::decay_t<FUNCTION>', any exception thrown by 'DECAY_COPY(
-    // bsl::forward<FUNCTION>(callback))(FutureResult<R_T>(this))', or
-    // 'bsl::bad_alloc' if memory allocation fails. If an exception is
-    // thrown, this function has no effect.
-    //
-    // Note that, unless otherwise specified, it is safe to invoke any
-    // function on '*this' from the context of the attached callback.
-    //
-    // 'bsl::decay_t<FUNCTION>' must meet the requirements of Destructible
-    // and MoveConstructible as specified in the C++ standard. Given an
-    // object 'f' of type 'bsl::decay_t<FUNCTION>',
-    // 'f(bsl::declval<FutureResult<R_T>>())' shall be a valid expression.
 
   public:
     // ACCESSORS
-    bool isReady() const BSLS_KEYWORD_NOEXCEPT;
-    // Return 'true' if the shared state is ready, and 'false' otherwise.
 
+    /// Return `true` if the shared state is ready, and `false` otherwise.
+    bool isReady() const BSLS_KEYWORD_NOEXCEPT;
+
+    /// Block the calling thread until the shared state is ready. Then, if
+    /// the state contains a value, return a reference to the contained
+    /// value. Otherwise, if the state contains an exception, throw the
+    /// contained exception.
     R&       get();
     const R& get() const;
-    // Block the calling thread until the shared state is ready. Then, if
-    // the state contains a value, return a reference to the contained
-    // value. Otherwise, if the state contains an exception, throw the
-    // contained exception.
 
+    /// Block the calling thread until the shared state is ready.
     void wait() const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state is ready.
 
+    /// Block the calling thread until the shared state becomes ready or the
+    /// specified `duration` time has elapsed, whichever comes first. The
+    /// `duration` is an offset from the current point in time, which is
+    /// determined by the clock indicated at construction. Return a value
+    /// identifying the state of the result.
     FutureStatus::Enum
     waitFor(const bsls::TimeInterval& duration) const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state becomes ready or the
-    // specified 'duration' time has elapsed, whichever comes first. The
-    // 'duration' is an offset from the current point in time, which is
-    // determined by the clock indicated at construction. Return a value
-    // identifying the state of the result.
 
+    /// Block the calling thread until the shared state becomes ready or
+    /// until the specified `timeout`, whichever comes first. The `timeout`
+    /// is an absolute time represented as an interval from some epoch,
+    /// which is determined by the clock indicated at construction. Return a
+    /// value identifying the state of the result.
     FutureStatus::Enum
     waitUntil(const bsls::TimeInterval& timeout) const BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until the shared state becomes ready or
-    // until the specified 'timeout', whichever comes first. The 'timeout'
-    // is an absolute time represented as an interval from some epoch,
-    // which is determined by the clock indicated at construction. Return a
-    // value identifying the state of the result.
 
+    /// Return the system clock type used by this object for timed
+    /// operations.
     bsls::SystemClockType::Enum clockType() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the system clock type used by this object for timed
-    // operations.
 
+    /// Return the allocator used by this object to supply memory.
     bslma::Allocator* allocator() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the allocator used by this object to supply memory.
 
   public:
     // TRAITS
@@ -1129,13 +1080,14 @@ class FutureSharedState {
 };
 
 // FREE OPERATORS
+
+/// Swap the contents of `lhs` and `rhs`.
 template <class R>
 void swap(Future<R>& lhs, Future<R>& rhs) BSLS_KEYWORD_NOEXCEPT;
-// Swap the contents of 'lhs' and 'rhs'.
 
+/// Swap the contents of `lhs` and `rhs`.
 template <class R>
 void swap(FutureResult<R>& lhs, FutureResult<R>& rhs) BSLS_KEYWORD_NOEXCEPT;
-// Swap the contents of 'lhs' and 'rhs'.
 
 // ============================================================================
 //                           INLINE DEFINITIONS
@@ -1718,6 +1670,7 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
     emplaceValue(bslmf::MovableRefUtil::move(value));
 }
 
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcex_future.h
@@ -1729,7 +1682,8 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
 #endif
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 0
 template <class R>
-inline void FutureSharedState<R>::emplaceValue()
+inline void FutureSharedState<R>::emplaceValue(
+                               )
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1753,9 +1707,8 @@ inline void FutureSharedState<R>::emplaceValue()
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 1
 template <class R>
 template <class ARGS_1>
-inline void
-FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                       args_1)
+inline void FutureSharedState<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1779,10 +1732,11 @@ FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 2
 template <class R>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1807,11 +1761,13 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 3
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1837,12 +1793,15 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 4
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1869,13 +1828,17 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if MWCEX_FUTURE_VARIADIC_LIMIT_B >= 5
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1910,12 +1873,12 @@ template <class ARGS_1,
           class ARGS_5,
           class ARGS_6>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1952,13 +1915,13 @@ template <class ARGS_1,
           class ARGS_6,
           class ARGS_7>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1997,14 +1960,14 @@ template <class ARGS_1,
           class ARGS_7,
           class ARGS_8>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2045,15 +2008,15 @@ template <class ARGS_1,
           class ARGS_8,
           class ARGS_9>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2089,7 +2052,7 @@ inline void FutureSharedState<R>::emplaceValue(
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2323,24 +2286,14 @@ inline void mwcex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_MWCEX_FUTURE_H)
-#error Not valid except when included from mwcex_future.h
-#endif  // ! defined(COMPILING_MWCEX_FUTURE_H)
+// clang-format off
 
-#endif  // ! defined(INCLUDED_MWCEX_FUTURE_CPP03)
+#else // if ! defined(DEFINED_MWCEX_FUTURE_H)
+# error Not valid except when included from mwcex_future.h
+#endif // ! defined(COMPILING_MWCEX_FUTURE_H)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+#endif // ! defined(INCLUDED_MWCEX_FUTURE_CPP03)
+
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: f4619c8fa5459ba0b0731830fb9331dea1a57eb72a62a86ecf2c12660b1f7512
+

--- a/src/groups/mwc/mwcex/mwcex_promise.h
+++ b/src/groups/mwc/mwcex/mwcex_promise.h
@@ -92,7 +92,7 @@
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 29 04:19:38 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_promise.h
 #define COMPILING_MWCEX_PROMISE_H
 #include <mwcex_promise_cpp03.h>

--- a/src/groups/mwc/mwcex/mwcex_promise_cpp03.cpp
+++ b/src/groups/mwc/mwcex/mwcex_promise_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2018-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:52:21 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_promise.cpp
 
 #define INCLUDED_MWCEX_PROMISE_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCEX_PROMISE_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 0c82bc211291d24143697cf064af00db4a50ee5adabf49ecf5b3b72a057cb929

--- a/src/groups/mwc/mwcex/mwcex_promise_cpp03.h
+++ b/src/groups/mwc/mwcex/mwcex_promise_cpp03.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2018-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,17 +36,12 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 29 04:19:38 2022
+// Generated on Mon Jan 22 16:59:02 2024
 // Command line: sim_cpp11_features.pl mwcex_promise.h
 
 #ifdef COMPILING_MWCEX_PROMISE_H
 
 namespace BloombergLP {
-
-// FORWARD DECLARATION
-namespace bslma {
-class Allocator;
-}
 
 namespace mwcex {
 
@@ -54,15 +49,14 @@ namespace mwcex {
 // class Promise
 // =============
 
+/// Provides a mechanism to store a value or an exception that is later
+/// acquired asynchronously via a `mwcex::Future` object created by the
+/// `mwcex::Promise` object.
+///
+/// `R` must meet the requirements of Destructible as specified in the C++
+/// standard.
 template <class R>
 class Promise {
-    // Provides a mechanism to store a value or an exception that is later
-    // acquired asynchronously via a 'mwcex::Future' object created by the
-    // 'mwcex::Promise' object.
-    //
-    // 'R' must meet the requirements of Destructible as specified in the C++
-    // standard.
-
   private:
     // PRIVATE TYPES
     typedef typename Future<R>::SharedStateType SharedStateType;
@@ -82,69 +76,71 @@ class Promise {
 
   public:
     // CREATORS
-    explicit Promise(bslma::Allocator* basicAllocator = 0);
-    // Create a 'Promise' object holding a shared state of type
-    // 'mwcex::Future<R>::SharedStateType' initialized with the specified
-    // 'basicAllocator'.
 
+    /// Create a `Promise` object holding a shared state of type
+    /// `mwcex::Future<R>::SharedStateType` initialized with the specified
+    /// `basicAllocator`.
+    explicit Promise(bslma::Allocator* basicAllocator = 0);
+
+    /// Create a `Promise` object holding a shared state of type
+    /// `mwcex::Future<R>::SharedStateType` initialized with the specified
+    /// `clockType` and `basicAllocator`.
     explicit Promise(bsls::SystemClockType::Enum clockType,
                      bslma::Allocator*           basicAllocator = 0);
-    // Create a 'Promise' object holding a shared state of type
-    // 'mwcex::Future<R>::SharedStateType' initialized with the specified
-    // 'clockType' and 'basicAllocator'.
 
+    /// Create a `Promise` object that refers to and assumes management of
+    /// the same shared state (if any) as the specified `original` object,
+    /// and leave `original` having no shared state.
     Promise(bslmf::MovableRef<Promise> original) BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'Promise' object that refers to and assumes management of
-    // the same shared state (if any) as the specified 'original' object,
-    // and leave 'original' having no shared state.
 
+    /// Destroy this object. If `*this` has a shared state and the shared
+    /// state is not ready, store a `mwcex::PromiseBroken` exception object
+    /// into the shared state and make the state ready, then release the
+    /// underlying shared state.
     ~Promise();
-    // Destroy this object. If '*this' has a shared state and the shared
-    // state is not ready, store a 'mwcex::PromiseBroken' exception object
-    // into the shared state and make the state ready, then release the
-    // underlying shared state.
 
   public:
     // MANIPULATORS
+
+    /// Make this promise refer to and assume management of the same shared
+    /// state (if any) as the specified `rhs` promise, and leave `rhs`
+    /// having no shared state. Return `*this`.
     Promise& operator=(bslmf::MovableRef<Promise> rhs) BSLS_KEYWORD_NOEXCEPT;
-    // Make this promise refer to and assume management of the same shared
-    // state (if any) as the specified 'rhs' promise, and leave 'rhs'
-    // having no shared state. Return '*this'.
 
+    /// Atomically store the specified `value` into the shared state as if
+    /// by direct-non-list-initializing an object of type `R` with `value`
+    /// and make the state ready. If a callback is attached to the shared
+    /// state, invoke, and then destroy it. Effectively calls `setValue`
+    /// on the underlying shared state. The behavior is undefined if the
+    /// shared state is ready or if the promise has no shared state.
+    ///
+    /// Throws any exception thrown by the selected constructor of `R`, or
+    /// any exception thrown by the attached callback. If an exception is
+    /// thrown by `R`s constructor, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored value stays
+    /// initialized and the callback is destroyed.
+    ///
+    /// `R` must meet the requirements of CopyConstructible as specified in
+    /// the C++ standard.
     void setValue(const R& value);
-    // Atomically store the specified 'value' into the shared state as if
-    // by direct-non-list-initializing an object of type 'R' with 'value'
-    // and make the state ready. If a callback is attached to the shared
-    // state, invoke, and then destroy it. Effectively calls 'setValue'
-    // on the underlying shared state. The behavior is undefined if the
-    // shared state is ready or if the promise has no shared state.
-    //
-    // Throws any exception thrown by the selected constructor of 'R', or
-    // any exception thrown by the attached callback. If an exception is
-    // thrown by 'R's constructor, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored value stays
-    // initialized and the callback is destroyed.
-    //
-    // 'R' must meet the requirements of CopyConstructible as specified in
-    // the C++ standard.
 
+    /// Atomically store the specified `value` into the shared state as if
+    /// by direct-non-list-initializing an object of type `R` with
+    /// `bsl::move(value)` and make the state ready. If a callback is
+    /// attached to the shared state, invoke, and then destroy it.
+    /// Effectively calls `setValue` on the underlying shared state. The
+    /// behavior is undefined if the shared state is ready or if the promise
+    /// has no shared state.
+    ///
+    /// Throws any exception thrown by the selected constructor of `R`, or
+    /// any exception thrown by the attached callback. If an exception is
+    /// thrown by `R`s constructor, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored value stays
+    /// initialized and the callback is destroyed.
+    ///
+    /// `R` must meet the requirements of MoveConstructible as specified in
+    /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
-    // Atomically store the specified 'value' into the shared state as if
-    // by direct-non-list-initializing an object of type 'R' with
-    // 'bsl::move(value)' and make the state ready. If a callback is
-    // attached to the shared state, invoke, and then destroy it.
-    // Effectively calls 'setValue' on the underlying shared state. The
-    // behavior is undefined if the shared state is ready or if the promise
-    // has no shared state.
-    //
-    // Throws any exception thrown by the selected constructor of 'R', or
-    // any exception thrown by the attached callback. If an exception is
-    // thrown by 'R's constructor, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored value stays
-    // initialized and the callback is destroyed.
-    //
-    // 'R' must meet the requirements of MoveConstructible as specified in
-    // the C++ standard.
 
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
@@ -155,6 +151,7 @@ class Promise {
 #ifndef MWCEX_PROMISE_VARIADIC_LIMIT_A
 #define MWCEX_PROMISE_VARIADIC_LIMIT_A MWCEX_PROMISE_VARIADIC_LIMIT
 #endif
+
 #if MWCEX_PROMISE_VARIADIC_LIMIT_A >= 0
     void emplaceValue();
 #endif  // MWCEX_PROMISE_VARIADIC_LIMIT_A >= 0
@@ -273,55 +270,57 @@ class Promise {
 #else
     // The generated code below is a workaround for the absence of perfect
     // forwarding in some compilers.
+
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
 #endif
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
+    /// Atomically store the specified `exception` pointer into the shared
+    /// state and make the state ready. If a callback is attached to the
+    /// shared state, invoke, and then destroy it. Effectively calls
+    /// `setException` on the underlying shared state. The behavior is
+    /// undefined if the shared state is ready or if the promise has no
+    /// shared state.
+    ///
+    /// Throws any exception thrown by the attached callback. If an
+    /// exception is thrown, the stored exception stays initialized and the
+    /// callback is destroyed.
     void setException(bsl::exception_ptr exception);
-    // Atomically store the specified 'exception' pointer into the shared
-    // state and make the state ready. If a callback is attached to the
-    // shared state, invoke, and then destroy it. Effectively calls
-    // 'setException' on the underlying shared state. The behavior is
-    // undefined if the shared state is ready or if the promise has no
-    // shared state.
-    //
-    // Throws any exception thrown by the attached callback. If an
-    // exception is thrown, the stored exception stays initialized and the
-    // callback is destroyed.
 #endif
 
+    /// Atomically store the specified `exception` object into the shared
+    /// state as if by direct-non-list-initializing an object of type
+    /// `bsl::decay_t<EXCEPTION>` with `bsl::forward<EXCEPTION>(EXCEPTION)`
+    /// and make the state ready. If a callback is attached to the shared
+    /// state, invoke, and then destroy it. Effectively calls
+    /// `setException` on the underlying shared state. The behavior is
+    /// undefined if the shared state is ready or if the promise has no
+    /// shared state.
+    ///
+    /// Throws any exception thrown by the selected constructor of
+    /// `bsl::decay_t<EXCEPTION>`, any exception thrown by the attached
+    /// callback, or `bsl::bad_alloc` if memory allocation fails. If an
+    /// exception is thrown by `bsl::decay_t<EXCEPTION>`s constructor or due
+    /// to memory allocation failure, this function has no effect. If an
+    /// exception is thrown by the attached callback, the stored exception
+    /// stays initialized and the callback is destroyed.
+    ///
+    /// `bsl::decay_t<EXCEPTION>` must meet the requirements of Destructible
+    /// and CopyConstructible as specified in the C++ standard.
     template <class EXCEPTION>
     void setException(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION) exception);
-    // Atomically store the specified 'exception' object into the shared
-    // state as if by direct-non-list-initializing an object of type
-    // 'bsl::decay_t<EXCEPTION>' with 'bsl::forward<EXCEPTION>(EXCEPTION)'
-    // and make the state ready. If a callback is attached to the shared
-    // state, invoke, and then destroy it. Effectively calls
-    // 'setException' on the underlying shared state. The behavior is
-    // undefined if the shared state is ready or if the promise has no
-    // shared state.
-    //
-    // Throws any exception thrown by the selected constructor of
-    // 'bsl::decay_t<EXCEPTION>', any exception thrown by the attached
-    // callback, or 'bsl::bad_alloc' if memory allocation fails. If an
-    // exception is thrown by 'bsl::decay_t<EXCEPTION>'s constructor or due
-    // to memory allocation failure, this function has no effect. If an
-    // exception is thrown by the attached callback, the stored exception
-    // stays initialized and the callback is destroyed.
-    //
-    // 'bsl::decay_t<EXCEPTION>' must meet the requirements of Destructible
-    // and CopyConstructible as specified in the C++ standard.
 
+    /// Swap the contents of `*this` and `other`.
     void swap(Promise& other) BSLS_KEYWORD_NOEXCEPT;
-    // Swap the contents of '*this' and 'other'.
 
   public:
     // ACCESSORS
+
+    /// Return a future associated with the shared state owned by `*this`.
+    /// The behavior is undefined unless the promise has a shared state.
     Future<R> future() const BSLS_KEYWORD_NOEXCEPT;
-    // Return a future associated with the shared state owned by '*this'.
-    // The behavior is undefined unless the promise has a shared state.
 
   public:
     // TRAITS
@@ -333,10 +332,9 @@ class Promise {
 // class Promise<void>
 // ===================
 
+/// Provides a specialization of `Promise` for `void` result type.
 template <>
 class Promise<void> : private Promise<bslmf::Nil> {
-    // Provides a specialization of 'Promise' for 'void' result type.
-
   private:
     // PRIVATE TYPES
     typedef Promise<bslmf::Nil> Impl;
@@ -348,51 +346,51 @@ class Promise<void> : private Promise<bslmf::Nil> {
 
   public:
     // CREATORS
-    explicit Promise(bslma::Allocator* basicAllocator = 0);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    explicit Promise(bslma::Allocator* basicAllocator = 0);
+
+    /// Same as for the non-specialized class template.
     explicit Promise(bsls::SystemClockType::Enum clockType,
                      bslma::Allocator*           basicAllocator = 0);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     Promise(bslmf::MovableRef<Promise> original) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! ~Promise();
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    Promise& operator=(bslmf::MovableRef<Promise> rhs) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    Promise& operator=(bslmf::MovableRef<Promise> rhs) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Atomically make the shared state ready. If a callback is attached to
+    /// the shared state, invoke, and then destroy it. Effectively calls
+    /// `setValue` on the underlying shared state. The behavior is
+    /// undefined if the shared state is ready or if the promise has no
+    /// shared state.
+    ///
+    /// Throws any exception thrown by the attached callback. If an
+    /// exception is thrown, the stored value stays initialized and the
+    /// callback is destroyed.
     void setValue();
-    // Atomically make the shared state ready. If a callback is attached to
-    // the shared state, invoke, and then destroy it. Effectively calls
-    // 'setValue' on the underlying shared state. The behavior is
-    // undefined if the shared state is ready or if the promise has no
-    // shared state.
-    //
-    // Throws any exception thrown by the attached callback. If an
-    // exception is thrown, the stored value stays initialized and the
-    // callback is destroyed.
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
+    /// Same as for the non-specialized class template.
     void setException(bsl::exception_ptr exception);
-    // Same as for the non-specialized class template.
 #endif
 
+    /// Same as for the non-specialized class template.
     template <class EXCEPTION>
     void setException(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION) exception);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(Promise& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
+
+    /// Same as for the non-specialized class template.
     Future<void> future() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // TRAITS
@@ -404,10 +402,9 @@ class Promise<void> : private Promise<bslmf::Nil> {
 // class Promise<R&>
 // =================
 
+/// Provides a specialization of `Promise` for reference result types.
 template <class R>
 class Promise<R&> : private Promise<bsl::reference_wrapper<R> > {
-    // Provides a specialization of 'Promise' for reference result types.
-
   private:
     // PRIVATE TYPES
     typedef Promise<bsl::reference_wrapper<R> > Impl;
@@ -419,52 +416,52 @@ class Promise<R&> : private Promise<bsl::reference_wrapper<R> > {
 
   public:
     // CREATORS
-    explicit Promise(bslma::Allocator* basicAllocator = 0);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    explicit Promise(bslma::Allocator* basicAllocator = 0);
+
+    /// Same as for the non-specialized class template.
     explicit Promise(bsls::SystemClockType::Enum clockType,
                      bslma::Allocator*           basicAllocator = 0);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     Promise(bslmf::MovableRef<Promise> original) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
-
-    //! ~Promise();
-    // Same as for the non-specialized class template.
 
   public:
     // MANIPULATORS
-    Promise& operator=(bslmf::MovableRef<Promise> rhs) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
+    Promise& operator=(bslmf::MovableRef<Promise> rhs) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Atomically store the specified `value` reference into the shared
+    /// state and make the state ready. If a callback is attached to the
+    /// shared state, invoke, and then destroy it. Effectively calls
+    /// `setValue` on the underlying shared state. The behavior is
+    /// undefined if the shared state is ready or if the promise has no
+    /// shared state.
+    ///
+    /// Throws any exception thrown by the attached callback. If an
+    /// exception is thrown, the stored reference stays initialized and the
+    /// callback is destroyed.
     void setValue(R& value);
-    // Atomically store the specified 'value' reference into the shared
-    // state and make the state ready. If a callback is attached to the
-    // shared state, invoke, and then destroy it. Effectively calls
-    // 'setValue' on the underlying shared state. The behavior is
-    // undefined if the shared state is ready or if the promise has no
-    // shared state.
-    //
-    // Throws any exception thrown by the attached callback. If an
-    // exception is thrown, the stored reference stays initialized and the
-    // callback is destroyed.
 
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
+    /// Same as for the non-specialized class template.
     void setException(bsl::exception_ptr exception);
-    // Same as for the non-specialized class template.
 #endif
 
+    /// Same as for the non-specialized class template.
     template <class EXCEPTION>
     void setException(BSLS_COMPILERFEATURES_FORWARD_REF(EXCEPTION) exception);
-    // Same as for the non-specialized class template.
 
+    /// Same as for the non-specialized class template.
     void swap(Promise& other) BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // ACCESSORS
+
+    /// Same as for the non-specialized class template.
     Future<R&> future() const BSLS_KEYWORD_NOEXCEPT;
-    // Same as for the non-specialized class template.
 
   public:
     // TRAITS
@@ -476,25 +473,27 @@ class Promise<R&> : private Promise<bsl::reference_wrapper<R> > {
 // class PromiseBroken
 // ===================
 
+/// Provide an exception class to indicate a promise was broken.
 class PromiseBroken : public bsl::exception {
-    // Provide an exception class to indicate a promise was broken.
-
   public:
     // CREATORS
+
+    /// Create a `PromiseBroken` object.
     PromiseBroken() BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'PromiseBroken' object.
 
   public:
     // ACCESSORS
+
+    /// Return a pointer to the string literal "PromiseBroken", with a
+    /// storage duration of the lifetime of the program.
     const char* what() const BSLS_EXCEPTION_WHAT_NOTHROW BSLS_KEYWORD_OVERRIDE;
-    // Return a pointer to the string literal "PromiseBroken", with a
-    // storage duration of the lifetime of the program.
 };
 
 // FREE OPERATORS
+
+/// Swap the contents of `lhs` and `rhs`.
 template <class R>
 void swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT;
-// Swap the contents of 'lhs' and 'rhs'.
 
 // ============================================================================
 //                           INLINE DEFINITIONS
@@ -1011,18 +1010,5 @@ inline void mwcex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 
 #endif  // ! defined(INCLUDED_MWCEX_PROMISE_CPP03)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 7fbcbfd7e0165f0f11da630e4b42b42648eb19ce489e6f584fb1b3abd7a299f2

--- a/src/groups/mwc/mwcscm/mwcscm_versiontag.h
+++ b/src/groups/mwc/mwcscm/mwcscm_versiontag.h
@@ -56,7 +56,7 @@
 #define MWC_VERSION_PATCH 99
 // MWC patch level
 
-#define MWC_MAKE_VERSION(major, minor) ((major)*10000 + (minor)*100)
+#define MWC_MAKE_VERSION(major, minor) ((major) * 10000 + (minor) * 100)
 // Construct a composite version number in the range [ 0 .. 999900 ] from
 // the specified 'major' and 'minor' version numbers.  The resulting value,
 // when expressed as a 6-digit decimal string, has "00" as the two
@@ -72,7 +72,7 @@
 // and 'minor' are integral values in the range '[ 0 .. 99 ]'.
 
 #define MWC_MAKE_EXT_VERSION(major, minor, patch)                             \
-    ((major)*10000 + (minor)*100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 // Similar to MWC_MAKE_VERSION(), but include the patch number as well.
 
 #define MWC_VERSION MWC_MAKE_VERSION(MWC_VERSION_MAJOR, MWC_VERSION_MINOR)

--- a/src/groups/mwc/mwcst/mwcst_statcontext.h
+++ b/src/groups/mwc/mwcst/mwcst_statcontext.h
@@ -1049,8 +1049,8 @@ class StatContextIterator {
     // ACCESSORS
     const StatContext* operator->() const;
     const StatContext& operator*() const;
-                       operator const StatContext*() const;
-                       operator bool() const;
+    operator const StatContext*() const;
+    operator bool() const;
 };
 
 // ============================================================================

--- a/src/groups/mwc/mwctst/mwctst_testhelper.h
+++ b/src/groups/mwc/mwctst/mwctst_testhelper.h
@@ -621,7 +621,7 @@
     balst::StackTraceTestAllocator _stTestAlloc;                                \
     _stTestAlloc.setName("test");                                               \
                                                                                 \
-    if ((F)&mwctst::TestHelper::e_USE_STACKTRACE_ALLOCATOR) {                   \
+    if ((F) & mwctst::TestHelper::e_USE_STACKTRACE_ALLOCATOR) {                 \
         s_allocator_p = &_stTestAlloc;                                          \
     }                                                                           \
     else {                                                                      \

--- a/src/groups/mwc/mwcu/mwcu_noop.h
+++ b/src/groups/mwc/mwcu/mwcu_noop.h
@@ -34,14 +34,18 @@
 #include <bsls_compilerfeatures.h>
 #include <bsls_keyword.h>
 
+// clang-format off
+
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 29 04:03:13 2022
+// Generated on Fri Jan  5 17:20:31 2024
 // Command line: sim_cpp11_features.pl mwcu_noop.h
-#define COMPILING_MWCU_NOOP_H
-#include <mwcu_noop_cpp03.h>
-#undef COMPILING_MWCU_NOOP_H
+# define COMPILING_MWCU_NOOP_H
+# include <mwcu_noop_cpp03.h>
+# undef COMPILING_MWCU_NOOP_H
 #else
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcu {
@@ -60,7 +64,9 @@ class NoOp {
 
   public:
     // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+    // clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+    // clang-format on
 
     /// Do nothing.
     template <class... ARGS>
@@ -82,7 +88,9 @@ class NoOp {
 // ----------
 
 // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+// clang-format on
 template <class... ARGS>
 inline void NoOp::operator()(const ARGS&...) const BSLS_KEYWORD_NOEXCEPT
 {
@@ -93,6 +101,10 @@ inline void NoOp::operator()(const ARGS&...) const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+// clang-format off
+
+#endif // End C++11 code
+
+// clang-format on
 
 #endif

--- a/src/groups/mwc/mwcu/mwcu_noop_cpp03.cpp
+++ b/src/groups/mwc/mwcu/mwcu_noop_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:56:02 2022
+// Generated on Mon Jan 22 16:58:55 2024
 // Command line: sim_cpp11_features.pl mwcu_noop.cpp
 
 #define INCLUDED_MWCU_NOOP_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCU_NOOP_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 052996dd9c3184d1b65d62274312b4f440825b7107dc5be7bfc177cfbe21ee96

--- a/src/groups/mwc/mwcu/mwcu_noop_cpp03.h
+++ b/src/groups/mwc/mwcu/mwcu_noop_cpp03.h
@@ -36,10 +36,12 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 29 04:03:13 2022
+// Generated on Mon Jan 22 16:58:55 2024
 // Command line: sim_cpp11_features.pl mwcu_noop.h
 
 #ifdef COMPILING_MWCU_NOOP_H
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcu {
@@ -48,16 +50,17 @@ namespace mwcu {
 // class NoOp
 // ==========
 
+/// A no-op functor.
 class NoOp {
-    // A no-op functor.
-
   public:
     // TYPES
+
+    /// Defines the result type of the call operator.
     typedef void ResultType;
-    // Defines the result type of the call operator.
 
   public:
     // ACCESSORS
+    // clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_noop.h
@@ -67,6 +70,7 @@ class NoOp {
 #ifndef MWCU_NOOP_VARIADIC_LIMIT_A
 #define MWCU_NOOP_VARIADIC_LIMIT_A MWCU_NOOP_VARIADIC_LIMIT
 #endif
+
 #if MWCU_NOOP_VARIADIC_LIMIT_A >= 0
     void operator()() const BSLS_KEYWORD_NOEXCEPT;
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_A >= 0
@@ -77,19 +81,26 @@ class NoOp {
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_A >= 1
 
 #if MWCU_NOOP_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
-    void operator()(const ARGS_1&, const ARGS_2&) const BSLS_KEYWORD_NOEXCEPT;
+    template <class ARGS_1,
+              class ARGS_2>
+    void operator()(const ARGS_1&,
+                    const ARGS_2&) const BSLS_KEYWORD_NOEXCEPT;
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_A >= 2
 
 #if MWCU_NOOP_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void operator()(const ARGS_1&,
                     const ARGS_2&,
                     const ARGS_3&) const BSLS_KEYWORD_NOEXCEPT;
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_A >= 3
 
 #if MWCU_NOOP_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void operator()(const ARGS_1&,
                     const ARGS_2&,
                     const ARGS_3&,
@@ -182,8 +193,9 @@ class NoOp {
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+
     template <class... ARGS>
     void operator()(const ARGS&...) const BSLS_KEYWORD_NOEXCEPT;
 
@@ -204,6 +216,7 @@ class NoOp {
 // ----------
 
 // ACCESSORS
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_noop.h
@@ -227,7 +240,8 @@ inline void NoOp::operator()(const ARGS_1&) const BSLS_KEYWORD_NOEXCEPT
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_B >= 1
 
 #if MWCU_NOOP_VARIADIC_LIMIT_B >= 2
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void NoOp::operator()(const ARGS_1&,
                              const ARGS_2&) const BSLS_KEYWORD_NOEXCEPT
 {
@@ -235,7 +249,9 @@ inline void NoOp::operator()(const ARGS_1&,
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_B >= 2
 
 #if MWCU_NOOP_VARIADIC_LIMIT_B >= 3
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void NoOp::operator()(const ARGS_1&,
                              const ARGS_2&,
                              const ARGS_3&) const BSLS_KEYWORD_NOEXCEPT
@@ -244,7 +260,10 @@ inline void NoOp::operator()(const ARGS_1&,
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_B >= 3
 
 #if MWCU_NOOP_VARIADIC_LIMIT_B >= 4
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void NoOp::operator()(const ARGS_1&,
                              const ARGS_2&,
                              const ARGS_3&,
@@ -254,7 +273,11 @@ inline void NoOp::operator()(const ARGS_1&,
 #endif  // MWCU_NOOP_VARIADIC_LIMIT_B >= 4
 
 #if MWCU_NOOP_VARIADIC_LIMIT_B >= 5
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void NoOp::operator()(const ARGS_1&,
                              const ARGS_2&,
                              const ARGS_3&,
@@ -357,24 +380,14 @@ inline void NoOp::operator()(const ARGS&...) const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_MWCU_NOOP_H)
-#error Not valid except when included from mwcu_noop.h
-#endif  // ! defined(COMPILING_MWCU_NOOP_H)
+// clang-format off
 
-#endif  // ! defined(INCLUDED_MWCU_NOOP_CPP03)
+#else // if ! defined(DEFINED_MWCU_NOOP_H)
+# error Not valid except when included from mwcu_noop.h
+#endif // ! defined(COMPILING_MWCU_NOOP_H)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+#endif // ! defined(INCLUDED_MWCU_NOOP_CPP03)
+
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 4648afff07d071044bfde573ba13195b1f68ddb124d77bad9ab5c9dc587c626e
+

--- a/src/groups/mwc/mwcu/mwcu_objectplaceholder.h
+++ b/src/groups/mwc/mwcu/mwcu_objectplaceholder.h
@@ -45,14 +45,18 @@
 #include <bsls_keyword.h>
 #include <bsls_performancehint.h>
 
+// clang-format off
+
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 29 04:09:58 2022
+// Generated on Fri Jan  5 17:19:16 2024
 // Command line: sim_cpp11_features.pl mwcu_objectplaceholder.h
-#define COMPILING_MWCU_OBJECTPLACEHOLDER_H
-#include <mwcu_objectplaceholder_cpp03.h>
-#undef COMPILING_MWCU_OBJECTPLACEHOLDER_H
+# define COMPILING_MWCU_OBJECTPLACEHOLDER_H
+# include <mwcu_objectplaceholder_cpp03.h>
+# undef COMPILING_MWCU_OBJECTPLACEHOLDER_H
 #else
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcu {
@@ -191,7 +195,9 @@ class ObjectPlaceHolder {
 
   public:
     // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+    // clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+    // clang-format on
 
     /// Initialize this placeholder with an object of the specified `TYPE`
     /// constructed from the specified `args` arguments.  Specify an
@@ -387,7 +393,9 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 }
 
 // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+// clang-format on
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
@@ -470,6 +478,10 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+// clang-format off
+
+#endif // End C++11 code
+
+// clang-format on
 
 #endif

--- a/src/groups/mwc/mwcu/mwcu_objectplaceholder_cpp03.cpp
+++ b/src/groups/mwc/mwcu/mwcu_objectplaceholder_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2021-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:53:36 2022
+// Generated on Mon Jan 22 16:58:55 2024
 // Command line: sim_cpp11_features.pl mwcu_objectplaceholder.cpp
 
 #define INCLUDED_MWCU_OBJECTPLACEHOLDER_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCU_OBJECTPLACEHOLDER_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 0e3a342427e90e93f75dbde327e6c1ad2186003ab5d7fdcaa53ca19f1920aab8

--- a/src/groups/mwc/mwcu/mwcu_objectplaceholder_cpp03.h
+++ b/src/groups/mwc/mwcu/mwcu_objectplaceholder_cpp03.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2021-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,10 +36,12 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 29 04:11:12 2022
+// Generated on Mon Jan 22 16:58:55 2024
 // Command line: sim_cpp11_features.pl mwcu_objectplaceholder.h
 
 #ifdef COMPILING_MWCU_OBJECTPLACEHOLDER_H
+
+// clang-format on
 
 namespace BloombergLP {
 namespace mwcu {
@@ -48,40 +50,40 @@ namespace mwcu {
 // class ObjectPlaceHolder_ObjectGuard
 // ===================================
 
+/// A guard to deallocate an object in case of exception.
 template <class PLACEHOLDER>
 class ObjectPlaceHolder_ObjectGuard {
-    // A guard to deallocate an object in case of exception.
-
   private:
     // PRIVATE DATA
     PLACEHOLDER* d_placeholder_p;
 
   public:
     // CREATORS
+
+    /// Create a `ObjectPlaceHolder_ObjectGuard` object initialized with
+    /// the specified `placeholder`.
     explicit ObjectPlaceHolder_ObjectGuard(PLACEHOLDER* placeholder)
         BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'ObjectPlaceHolder_ObjectGuard' object initialized with
-    // the specified 'placeholder'.
 
+    /// Destroy this object.  Deallocate the object unless the guard was
+    /// released.
     ~ObjectPlaceHolder_ObjectGuard();
-    // Destroy this object.  Deallocate the object unless the guard was
-    // released.
 
   public:
     // MANIPULATORS
+
+    /// Release this guard.
     void release() BSLS_KEYWORD_NOEXCEPT;
-    // Release this guard.
 };
 
 // =======================
 // class ObjectPlaceHolder
 // =======================
 
+/// A placeholder for any object with a local buffer of (at least) the
+/// specified `SIZE`.
 template <size_t SIZE>
 class ObjectPlaceHolder {
-    // A placeholder for any object with a local buffer of (at least) the
-    // specified 'SIZE'.
-
   private:
     // PRIVATE TYPES
     enum State {
@@ -94,67 +96,71 @@ class ObjectPlaceHolder {
         e_FULL_EXT = 2  // The placeholder contains an external object.
     };
 
+    /// An aligned buffer large enough to hold two pointers - the allocator
+    /// pointer and the object pointer.
     typedef bsls::AlignedBuffer<(
         SIZE > (sizeof(void*) * 2) ? SIZE : (sizeof(void*) * 2))>
         Buffer;
-    // An aligned buffer large enough to hold two pointers - the allocator
-    // pointer and the object pointer.
 
+    /// A guard to deallocate an object in case of exception.
     typedef ObjectPlaceHolder_ObjectGuard<ObjectPlaceHolder<SIZE> >
         ObjectGuard;
-    // A guard to deallocate an object in case of exception.
 
     // FRIENDS
     friend class ObjectPlaceHolder_ObjectGuard<ObjectPlaceHolder<SIZE> >;
 
   private:
     // PRIVATE CLASS DATA
-    static const size_t k_BUFFER_SIZE = sizeof(Buffer);
+
     // The effective buffer size.
+    static const size_t k_BUFFER_SIZE = sizeof(Buffer);
 
   private:
     // PRIVATE DATA
-    Buffer d_buffer;
+
     // Unless the placeholder is empty, contains either a pair of pointers
     // - the allocator pointer and the object pointer, or the object itself.
+    Buffer d_buffer;
 
-    char d_state;
-    // Placeholder state. Use 'char' instead of 'State' to reduce memory
+    // Placeholder state. Use `char` instead of `State` to reduce memory
     // footprint.
+    char d_state;
 
   private:
     // PRIVATE MANIPULATORS
+
+    /// Store the specified `allocator` used to allocate the contained
+    /// external object into the local buffer.
     void storeAllocator(bslma::Allocator* allocator) BSLS_KEYWORD_NOEXCEPT;
-    // Store the specified 'allocator' used to allocate the contained
-    // external object into the local buffer.
 
+    /// Save the specified `address` of the contained external object into
+    /// the local buffer.
     void storeObjectAddress(void* address) BSLS_KEYWORD_NOEXCEPT;
-    // Save the specified 'address' of the contained external object into
-    // the local buffer.
 
+    /// Return the address of a contiguous block of memory large enough to
+    /// accommodate an object of the specified `TYPE`.  If the allocation
+    /// request exceeds the local buffer capacity, use memory obtained
+    /// from the specified `allocator`.  On exception, this function has no
+    /// effect.  The behavior is undefined if memory was already allocated,
+    /// and has not already been released.
     template <class TYPE>
     TYPE* allocateObject(bslma::Allocator* allocator);
-    // Return the address of a contiguous block of memory large enough to
-    // accommodate an object of the specified 'TYPE'.  If the allocation
-    // request exceeds the local buffer capacity, use memory obtained
-    // from the specified 'allocator'.  On exception, this function has no
-    // effect.  The behavior is undefined if memory was already allocated,
-    // and has not already been released.
 
+    /// Release memory allocated during the last successful call to
+    /// `allocateObject`.  The behavior is undefined if no memory was
+    /// allocated, or if the memory has already been released.
     void deallocateObject() BSLS_KEYWORD_NOEXCEPT;
-    // Release memory allocated during the last successful call to
-    // 'allocateObject'.  The behavior is undefined if no memory was
-    // allocated, or if the memory has already been released.
 
   private:
     // PRIVATE ACCESSORS
-    bslma::Allocator* loadAllocator() const BSLS_KEYWORD_NOEXCEPT;
-    // Load the allocator used to allocate the contained object from the
-    // local buffer, and return it.
 
+    /// Load the allocator used to allocate the contained object from the
+    /// local buffer, and return it.
+    bslma::Allocator* loadAllocator() const BSLS_KEYWORD_NOEXCEPT;
+
+    /// Load the address of the contained object from the local buffer, and
+    /// return it.
     void* loadObjectAddress() const BSLS_KEYWORD_NOEXCEPT;
-    // Load the address of the contained object from the local buffer, and
-    // return it.
 
   private:
     // NOT IMPLEMENTED
@@ -164,15 +170,17 @@ class ObjectPlaceHolder {
 
   public:
     // CREATORS
-    ObjectPlaceHolder() BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'ObjectPlaceHolder' object containing nothing.
 
+    /// Create a `ObjectPlaceHolder` object containing nothing.
+    ObjectPlaceHolder() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Destroy this object.  The behavior is undefined unless the
+    /// placeholder is empty.
     ~ObjectPlaceHolder();
-    // Destroy this object.  The behavior is undefined unless the
-    // placeholder is empty.
 
   public:
     // MANIPULATORS
+    // clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_objectplaceholder.h
@@ -180,9 +188,9 @@ class ObjectPlaceHolder {
 #define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A
-#define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A                               \
-    MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
+
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 0
     template <class TYPE>
     void createObject(bslma::Allocator* allocator);
@@ -191,171 +199,171 @@ class ObjectPlaceHolder {
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
     template <class TYPE, class ARGS_1>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
-    template <class TYPE, class ARGS_1, class ARGS_2>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
-    template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8,
-              class ARGS_9>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
 #endif  // MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+
     template <class TYPE, class... ARGS>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
 #endif
 
+    /// Destroy the object of the specified `TYPE` contained in this
+    /// placeholder, leaving the placeholder empty.  The behavior is
+    /// undefined unless the placeholder contains an object of the specified
+    /// `TYPE`.
+    ///
+    /// Note that `TYPE` does not necessarily has to be the same as the
+    /// original type specified on object creation, as long as `TYPE` is
+    /// polymorphic and is the base class of the original type.
     template <class TYPE>
     void deleteObject() BSLS_KEYWORD_NOEXCEPT;
-    // Destroy the object of the specified 'TYPE' contained in this
-    // placeholder, leaving the placeholder empty.  The behavior is
-    // undefined unless the placeholder contains an object of the specified
-    // 'TYPE'.
-    //
-    // Note that 'TYPE' does not necessarily has to be the same as the
-    // original type specified on object creation, as long as 'TYPE' is
-    // polymorphic and is the base class of the original type.
 
   public:
     // ACCESSORS
     template <class TYPE>
     TYPE* object() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Return a pointer to the contained object of the specified `TYPE`,
+    /// or 0 if the placeholder is empty.  The behavior is undefined unless
+    /// the placeholder is empty, or contains an object of the specified
+    /// `TYPE`.
+    ///
+    /// Note that `TYPE` does not necessarily has to be the same as the
+    /// original type specified on object creation, as long as `TYPE` is
+    /// polymorphic and is the base class of the original type.
     template <class TYPE>
     const TYPE* object() const BSLS_KEYWORD_NOEXCEPT;
-    // Return a pointer to the contained object of the specified 'TYPE',
-    // or 0 if the placeholder is empty.  The behavior is undefined unless
-    // the placeholder is empty, or contains an object of the specified
-    // 'TYPE'.
-    //
-    // Note that 'TYPE' does not necessarily has to be the same as the
-    // original type specified on object creation, as long as 'TYPE' is
-    // polymorphic and is the base class of the original type.
 
-    void*       objectAddress() BSLS_KEYWORD_NOEXCEPT;
+    void* objectAddress() BSLS_KEYWORD_NOEXCEPT;
+
+    /// Return the address of the contained object, or 0 if the placeholder
+    /// is empty.
     const void* objectAddress() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the address of the contained object, or 0 if the placeholder
-    // is empty.
 };
 
 // ============================================================================
@@ -507,6 +515,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 }
 
 // MANIPULATORS
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_objectplaceholder.h
@@ -514,8 +523,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 #define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B
-#define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B                               \
-    MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 0
@@ -529,7 +537,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(object, allocator);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator);
 
     objectGuard.release();
 }
@@ -538,10 +547,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 1
 template <size_t SIZE>
 template <class TYPE, class ARGS_1>
-inline void
-ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
-                                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                          args_1)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -549,10 +556,10 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1));
 
     objectGuard.release();
 }
@@ -560,11 +567,11 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 2
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -572,11 +579,12 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2));
 
     objectGuard.release();
 }
@@ -584,12 +592,13 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 3
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -597,12 +606,14 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3));
 
     objectGuard.release();
 }
@@ -610,13 +621,15 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 4
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -624,13 +637,16 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4));
 
     objectGuard.release();
 }
@@ -638,19 +654,17 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 5
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -658,14 +672,18 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5));
 
     objectGuard.release();
 }
@@ -673,21 +691,19 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 6
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -695,15 +711,20 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6));
 
     objectGuard.release();
 }
@@ -711,23 +732,21 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 7
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -735,16 +754,22 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7));
 
     objectGuard.release();
 }
@@ -752,25 +777,23 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 8
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -778,17 +801,24 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8));
 
     objectGuard.release();
 }
@@ -796,27 +826,25 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if MWCU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 9
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8,
+                      class ARGS_9>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -824,18 +852,26 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_9, args_9));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_9,
+                                          args_9));
 
     objectGuard.release();
 }
@@ -847,20 +883,19 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
 
-    TYPE* object = allocateObject<TYPE>(allocator);
+    TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                           BSLS_COMPILERFEATURES_FORWARD(ARGS,
+                                           args)...);
 
     objectGuard.release();
 }
@@ -925,24 +960,14 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_MWCU_OBJECTPLACEHOLDER_H)
-#error Not valid except when included from mwcu_objectplaceholder.h
-#endif  // ! defined(COMPILING_MWCU_OBJECTPLACEHOLDER_H)
+// clang-format off
 
-#endif  // ! defined(INCLUDED_MWCU_OBJECTPLACEHOLDER_CPP03)
+#else // if ! defined(DEFINED_MWCU_OBJECTPLACEHOLDER_H)
+# error Not valid except when included from mwcu_objectplaceholder.h
+#endif // ! defined(COMPILING_MWCU_OBJECTPLACEHOLDER_H)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+#endif // ! defined(INCLUDED_MWCU_OBJECTPLACEHOLDER_CPP03)
+
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 28732c70a0a16496bb160e3ef245f575c95b1fa0212e534286bc1720fd5b6acc
+

--- a/src/groups/mwc/mwcu/mwcu_operationchain.h
+++ b/src/groups/mwc/mwcu/mwcu_operationchain.h
@@ -191,14 +191,18 @@
 #include <bsl_type_traits.h>
 #endif
 
+// clang-format off
+
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // Include version that can be compiled with C++03
-// Generated on Tue Jun 28 12:18:48 2022
+// Generated on Fri Jan  5 17:14:30 2024
 // Command line: sim_cpp11_features.pl mwcu_operationchain.h
-#define COMPILING_MWCU_OPERATIONCHAIN_H
-#include <mwcu_operationchain_cpp03.h>
-#undef COMPILING_MWCU_OPERATIONCHAIN_H
+# define COMPILING_MWCU_OPERATIONCHAIN_H
+# include <mwcu_operationchain_cpp03.h>
+# undef COMPILING_MWCU_OPERATIONCHAIN_H
 #else
+
+// clang-format on
 
 namespace BloombergLP {
 
@@ -302,7 +306,9 @@ class OperationChain_CompletionCallbackWrapper {
 
   public:
     // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+    // clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+    // clang-format on
 
     /// Invoke the associated completion callback with the specified `args`
     /// arguments and notify the associated operation chain. Propagate any
@@ -803,7 +809,9 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 }
 
 // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+// clang-format off
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
+// clang-format on
 template <class CO_CALLBACK>
 template <class... ARGS>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
@@ -1018,6 +1026,10 @@ inline void mwcu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+// clang-format off
+
+#endif // End C++11 code
+
+// clang-format on
 
 #endif

--- a/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.cpp
+++ b/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2021-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 06:32:40 2022
+// Generated on Mon Jan 22 16:58:55 2024
 // Command line: sim_cpp11_features.pl mwcu_operationchain.cpp
 
 #define INCLUDED_MWCU_OPERATIONCHAIN_CPP03  // Disable inclusion
@@ -30,18 +30,5 @@
 
 #endif  // defined(COMPILING_MWCU_OPERATIONCHAIN_CPP)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 6adcbfe96999ba790e9848de43366b7d44c4921d9381a900eae07fba05b1f531

--- a/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.h
+++ b/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2021-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,20 +36,18 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Tue Jun 28 12:27:23 2022
+// Generated on Mon Jan 22 16:58:54 2024
 // Command line: sim_cpp11_features.pl mwcu_operationchain.h
 
 #ifdef COMPILING_MWCU_OPERATIONCHAIN_H
 
-namespace BloombergLP {
+// clang-format on
 
-// FORWARD DECLARATION
-namespace bslma {
-class Allocator;
-}
+namespace BloombergLP {
 
 namespace mwcu {
 
+// FORWARD DECLARATION
 class OperationChain;
 class OperationChainLink;
 class OperationChain_Job;
@@ -58,6 +56,13 @@ class OperationChain_Job;
 // struct OperationChain_IsCompletionCallbackCompatible
 // ====================================================
 
+/// A metafunction returning whether or not the specified `TYPE` satisfies
+/// requirements for a completion callback. To satisfy those requirements
+/// `TYPE` must meet the requirements of Destructible and MoveConstructible
+/// as specified in the C++ standard.
+///
+/// Note that unless compiled with C++17 support, this metafunction always
+/// returns `true`.
 template <class TYPE>
 struct OperationChain_IsCompletionCallbackCompatible
 #if __cplusplus >= 201703L
@@ -69,19 +74,21 @@ struct OperationChain_IsCompletionCallbackCompatible
 : bsl::integral_constant<bool, true>
 #endif
 {
-    // A metafunction returning whether or not the specified 'TYPE' satisfies
-    // requirements for a completion callback. To satisfy those requirements
-    // 'TYPE' must meet the requirements of Destructible and MoveConstructible
-    // as specified in the C++ standard.
-    //
-    // Note that unless compiled with C++17 support, this metafunction always
-    // returns 'true'.
 };
 
 // ===================================================
 // struct OperationChain_IsOperationCallbackCompatible
 // ===================================================
 
+/// A metafunction returning whether or not the specified `TYPE` satisfies
+/// requirements for a operation callback. To satisfy those requirements
+/// `TYPE` must meet the requirements of Destructible and MoveConstructible
+/// as specified in the C++ standard, as well as be Invocable with a single
+/// parameter that is a functor object of unspecified type taking an
+/// arbitrary number of template arguments.
+///
+/// Note that unless compiled with C++17 support, this metafunction always
+/// returns `true`.
 template <class TYPE>
 struct OperationChain_IsOperationCallbackCompatible
 #if __cplusplus >= 201703L
@@ -95,34 +102,25 @@ struct OperationChain_IsOperationCallbackCompatible
 : bsl::integral_constant<bool, true>
 #endif
 {
-    // A metafunction returning whether or not the specified 'TYPE' satisfies
-    // requirements for a operation callback. To satisfy those requirements
-    // 'TYPE' must meet the requirements of Destructible and MoveConstructible
-    // as specified in the C++ standard, as well as be Invocable with a single
-    // parameter that is a functor object of unspecified type taking an
-    // arbitrary number of template arguments.
-    //
-    // Note that unless compiled with C++17 support, this metafunction always
-    // returns 'true'.
 };
 
 // ==============================================
 // class OperationChain_CompletionCallbackWrapper
 // ==============================================
 
+/// A wrapper around a completion callback object that invokes the callback
+/// and notifies the operation chain.
 template <class CO_CALLBACK>
 class OperationChain_CompletionCallbackWrapper {
-    // A wrapper around a completion callback object that invokes the callback
-    // and notifies the operation chain.
-
     // PRECONDITIONS
     BSLMF_ASSERT(
         OperationChain_IsCompletionCallbackCompatible<CO_CALLBACK>::value);
 
   public:
     // TYPES
+
+    /// Defines the result type of the call operator.
     typedef void ResultType;
-    // Defines the result type of the call operator.
 
     typedef bsl::list<OperationChain_Job>::iterator JobHandle;
 
@@ -136,16 +134,18 @@ class OperationChain_CompletionCallbackWrapper {
 
   public:
     // CREATORS
+
+    /// Create a `OperationChain_CompletionCallbackWrapper` object having
+    /// the associated operation `chain`, `jobHandle` and `coCallback`
+    /// completion callback.
     OperationChain_CompletionCallbackWrapper(OperationChain* chain,
                                              JobHandle       jobHandle,
                                              CO_CALLBACK*    coCallback)
         BSLS_KEYWORD_NOEXCEPT;
-    // Create a 'OperationChain_CompletionCallbackWrapper' object having
-    // the associated operation 'chain', 'jobHandle' and 'coCallback'
-    // completion callback.
 
   public:
     // ACCESSORS
+    // clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_operationchain.h
@@ -155,6 +155,7 @@ class OperationChain_CompletionCallbackWrapper {
 #ifndef MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A
 #define MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A MWCU_OPERATIONCHAIN_VARIADIC_LIMIT
 #endif
+
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 0
     void operator()() const;
 #endif  // MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 0
@@ -165,20 +166,26 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 1
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const;
 #endif  // MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const;
 #endif  // MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -271,8 +278,9 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
+
     template <class... ARGS>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const;
 // }}} END GENERATED CODE
@@ -287,36 +295,36 @@ class OperationChain_CompletionCallbackWrapper {
 // class OperationChain_Job
 // ========================
 
+/// A job representing an async operation to be executed and accounted for.
 class OperationChain_Job {
-    // A job representing an async operation to be executed and accounted for.
-
   public:
     // TYPES
     typedef bsl::list<OperationChain_Job>::iterator JobHandle;
 
   private:
     // PRIVATE TYPES
-    class TargetBase {
-        // An interface used to implement the type erasure technique.
 
+    /// An interface used to implement the type erasure technique.
+    class TargetBase {
       public:
         // CREATORS
+
+        /// Destroy this object and the contained callback objects with it.
         virtual ~TargetBase();
-        // Destroy this object and the contained callback objects with it.
 
       public:
         // MANIPULATORS
+
+        /// Start executing the associated async operation bound to the
+        /// contained operation callback. On completion, invoke the
+        /// contained completion callback and notify the specified operation
+        /// `chain`.
         virtual void execute(OperationChain* chain, JobHandle jobHandle) = 0;
-        // Start executing the associated async operation bound to the
-        // contained operation callback. On completion, invoke the
-        // contained completion callback and notify the specified operation
-        // 'chain'.
     };
 
+    /// Provides an implementation of the `TargetBase` interface.
     template <class OP_CALLBACK, class CO_CALLBACK>
     class Target : public TargetBase {
-        // Provides an implementation of the 'TargetBase' interface.
-
         // PRECONDITIONS
         BSLMF_ASSERT(
             OperationChain_IsOperationCallbackCompatible<OP_CALLBACK>::value);
@@ -335,40 +343,42 @@ class OperationChain_Job {
 
       public:
         // CREATORS
+
+        /// Create a `Target` object containing the specified `opCallback`
+        /// operation callback and `coCallback` completion callback. Specify
+        /// an `allocator` used to supply memory.
         template <class OP_CALLBACK_ARG, class CO_CALLBACK_ARG>
         Target(BSLS_COMPILERFEATURES_FORWARD_REF(OP_CALLBACK_ARG) opCallback,
                BSLS_COMPILERFEATURES_FORWARD_REF(CO_CALLBACK_ARG) coCallback,
                bslma::Allocator* allocator);
-        // Create a 'Target' object containing the specified 'opCallback'
-        // operation callback and 'coCallback' completion callback. Specify
-        // an 'allocator' used to supply memory.
 
       public:
         // MANIPULATORS
+
+        /// Implements `TargetBase::execute`.
         void execute(OperationChain* chain,
                      JobHandle       jobHandle) BSLS_KEYWORD_OVERRIDE;
-        // Implements 'TargetBase::execute'.
     };
 
+    /// A "small" dummy functor used to help calculate the size of the
+    /// on-stack buffer.
     struct Dummy : public mwcu::NoOp {
-        // A "small" dummy functor used to help calculate the size of the
-        // on-stack buffer.
-
         void* d_padding[5];
     };
 
   private:
     // PRIVATE DATA
-    unsigned d_id;
+
     // Job ID, used to tell the number of jobs in a link. This value is
     // unique per link, starts with 1, and is incremented with each new
     // job inserted into a link.
+    unsigned d_id;
 
-    mwcu::ObjectPlaceHolder<sizeof(Target<Dummy, Dummy>)> d_target;
     // Uses an on-stack buffer to allocate memory for "small" objects, and
     // falls back to requesting memory from the the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
+    mwcu::ObjectPlaceHolder<sizeof(Target<Dummy, Dummy>)> d_target;
 
   private:
     // NOT IMPLEMENTED
@@ -378,6 +388,18 @@ class OperationChain_Job {
 
   public:
     // CREATORS
+
+    /// Create a `OperationChain_Job` object having the specified `id` and
+    /// containing the specified `opCallback` operation callback and
+    /// `coCallback` completion callback. Specify an `allocator` used to
+    /// supply memory.
+    ///
+    /// `bsl::decay_t<OP_CALLBACK>` and `bsl::decay_t<CO_CALLBACK>` must
+    /// meet the requirements of Destructible and MoveConstructible as
+    /// specified in the C++ standard. Given an object `f1` of type
+    /// `bsl::decay_t<OP_CALLBACK>&&`, `f1(f2)` shall be a valid
+    /// expression, where `f2` is a function object of unspecified type
+    /// callable with the same arguments as `bsl::decay_t<CO_CALLBACK>&&`.
     template <class OP_CALLBACK, class CO_CALLBACK>
     explicit OperationChain_Job(unsigned id,
                                 BSLS_COMPILERFEATURES_FORWARD_REF(OP_CALLBACK)
@@ -385,33 +407,24 @@ class OperationChain_Job {
                                 BSLS_COMPILERFEATURES_FORWARD_REF(CO_CALLBACK)
                                     coCallback,
                                 bslma::Allocator* allocator);
-    // Create a 'OperationChain_Job' object having the specified 'id' and
-    // containing the specified 'opCallback' operation callback and
-    // 'coCallback' completion callback. Specify an 'allocator' used to
-    // supply memory.
-    //
-    // 'bsl::decay_t<OP_CALLBACK>' and 'bsl::decay_t<CO_CALLBACK>' must
-    // meet the requirements of Destructible and MoveConstructible as
-    // specified in the C++ standard. Given an object 'f1' of type
-    // 'bsl::decay_t<OP_CALLBACK>&&', 'f1(f2)' shall be a valid
-    // expression, where 'f2' is a function object of unspecified type
-    // callable with the same arguments as 'bsl::decay_t<CO_CALLBACK>&&'.
 
+    /// Destroy this object and the contained callback objects with it.
     ~OperationChain_Job();
-    // Destroy this object and the contained callback objects with it.
 
   public:
     // MANIPULATORS
+
+    /// Start executing the associated async operation bound to the
+    /// contained operation callback. On completion, invoke the contained
+    /// completion callback and notify the specified operation `chain` using
+    /// the specified `jobHandle`.
     void execute(OperationChain* chain, JobHandle jobHandle) BSLS_NOTHROW_SPEC;
-    // Start executing the associated async operation bound to the
-    // contained operation callback. On completion, invoke the contained
-    // completion callback and notify the specified operation 'chain' using
-    // the specified 'jobHandle'.
 
   public:
     // ACCESSORS
+
+    /// Return the ID of this job.
     unsigned id() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the ID of this job.
 
   public:
     // TRAITS
@@ -423,9 +436,8 @@ class OperationChain_Job {
 // class OperationChain
 // ====================
 
+/// A mechanism to serialize execution of async operations.
 class OperationChain {
-    // A mechanism to serialize execution of async operations.
-
   public:
     // TYPES
     typedef OperationChainLink Link;
@@ -440,23 +452,24 @@ class OperationChain {
 
   private:
     // PRIVATE DATA
-    mutable bslmt::Mutex d_mutex;
+
     // Used for general thread-safety.
+    mutable bslmt::Mutex d_mutex;
 
-    mutable bslmt::Condition d_condition;
     // Used to synchronize with completion of async operations.
+    mutable bslmt::Condition d_condition;
 
-    bool d_isStarted;
     // Whether or not this operation chain is started.
+    bool d_isStarted;
 
-    unsigned d_numLinks;
     // The number of links in this operation chain.
+    unsigned d_numLinks;
 
-    unsigned d_numJobsRunning;
     // The number of jobs currently executing.
+    unsigned d_numJobsRunning;
 
-    JobList d_jobList;
     // Jobs executing async operations.
+    JobList d_jobList;
 
     // FRIENDS
     template <class>
@@ -464,12 +477,13 @@ class OperationChain {
 
   private:
     // PRIVATE MANIPULATORS
-    void onOperationCompleted(JobHandle handle) BSLS_KEYWORD_NOEXCEPT;
-    // Callback invoked to notify this operation chain an async
-    // operation identified by the specified 'handle' has completed.
 
+    /// Callback invoked to notify this operation chain an async
+    /// operation identified by the specified `handle` has completed.
+    void onOperationCompleted(JobHandle handle) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Execute all operations in the first link of this operation chain.
     void run() BSLS_KEYWORD_NOEXCEPT;
-    // Execute all operations in the first link of this operation chain.
 
   private:
     // NOT IMPLEMENTED
@@ -478,82 +492,101 @@ class OperationChain {
 
   public:
     // CREATORS
+
+    /// Create a `OperationChain` object. Optionally specify a
+    /// `createStarted` flag used to create the chain in a started state. If
+    /// the flag is not specified or its value is `false`, create the chain
+    /// in a stopped state. Optionally specify a `basicAllocator` used to
+    /// supply memory. If `basicAllocator` is 0, the default memory
+    /// allocator is used.
     explicit OperationChain(bslma::Allocator* basicAllocator = 0);
     explicit OperationChain(bool              createStarted,
                             bslma::Allocator* basicAllocator = 0);
-    // Create a 'OperationChain' object. Optionally specify a
-    // 'createStarted' flag used to create the chain in a started state. If
-    // the flag is not specified or its value is 'false', create the chain
-    // in a stopped state. Optionally specify a 'basicAllocator' used to
-    // supply memory. If 'basicAllocator' is 0, the default memory
-    // allocator is used.
 
+    /// Destroy this object. Call `stop()` followed by `join()`. Destroy all
+    /// operation and completion callback objects left in the chain, if any.
     ~OperationChain();
-    // Destroy this object. Call 'stop()' followed by 'join()'. Destroy all
-    // operation and completion callback objects left in the chain, if any.
 
   public:
     // MANIPULATORS
+
+    /// Start executing operations in this operation chain. If the chain is
+    /// already started, this function has no effect.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
     void start();
-    // Start executing operations in this operation chain. If the chain is
-    // already started, this function has no effect.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
 
+    /// Stop executing operations in this operation chain without blocking
+    /// the calling thread pending completion of any currently executing
+    /// operation. If the chain is already stopped, this function has no
+    /// effect.
     void stop() BSLS_KEYWORD_NOEXCEPT;
-    // Stop executing operations in this operation chain without blocking
-    // the calling thread pending completion of any currently executing
-    // operation. If the chain is already stopped, this function has no
-    // effect.
 
+    /// Block the calling thread until there is no operations executing
+    /// in this operation chain. If there is no operations currently
+    /// executing, return immediately.
     void join() BSLS_KEYWORD_NOEXCEPT;
-    // Block the calling thread until there is no operations executing
-    // in this operation chain. If there is no operations currently
-    // executing, return immediately.
 
+    /// Append the specified `link` to this operation chain. If the chain is
+    /// started and the appended `link` is the first one in the chain,
+    /// execute all operations in the appended `link` immediately. If the
+    /// appended `link` is empty, this function has no effect. After this
+    /// operation completes, `link` is left empty. The behavior is undefined
+    /// unless `link` uses the same allocator as this object.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
     void append(Link* link);
     void append(bslmf::MovableRef<Link> link);
-    // Append the specified 'link' to this operation chain. If the chain is
-    // started and the appended 'link' is the first one in the chain,
-    // execute all operations in the appended 'link' immediately. If the
-    // appended 'link' is empty, this function has no effect. After this
-    // operation completes, 'link' is left empty. The behavior is undefined
-    // unless 'link' uses the same allocator as this object.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
 
 #ifdef BSLS_COMPILERFEATURES_SUPPORT_GENERALIZED_INITIALIZERS
+    /// Append all links from the specified `links` list to this operation
+    /// chain in the order they appear in the list. If the chain is started
+    /// and the first appended link is the first one in the chain, execute
+    /// all operations in the first appended link immediately. If the
+    /// `links` list is empty, this function has no effect. If the `links`
+    /// list contains empty links, ignore them. After this operation
+    /// completes, all links in the `links` list are left empty. The
+    /// behavior is undefined unless all links in the `links` list use the
+    /// same allocator as this object.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
     void append(bsl::initializer_list<Link*> links);
-    // Append all links from the specified 'links' list to this operation
-    // chain in the order they appear in the list. If the chain is started
-    // and the first appended link is the first one in the chain, execute
-    // all operations in the first appended link immediately. If the
-    // 'links' list is empty, this function has no effect. If the 'links'
-    // list contains empty links, ignore them. After this operation
-    // completes, all links in the 'links' list are left empty. The
-    // behavior is undefined unless all links in the 'links' list use the
-    // same allocator as this object.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
 #endif
 
+    /// Append the specified `count` number of links from the specified
+    /// `links` array to this operation chain in the order they appear in
+    /// the array. If the chain is started and the first appended link is
+    /// the first one in the chain, execute all operations in the first
+    /// appended link immediately. If `count` is 0, this function has no
+    /// effect. If the `links` array contains empty links, ignore them.
+    /// After this operation completes, all links in the `links` array are
+    /// left empty. The behavior is undefined unless all links in the
+    /// `links` array use the same allocator as this object.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
     void append(Link* const* links, size_t count);
-    // Append the specified 'count' number of links from the specified
-    // 'links' array to this operation chain in the order they appear in
-    // the array. If the chain is started and the first appended link is
-    // the first one in the chain, execute all operations in the first
-    // appended link immediately. If 'count' is 0, this function has no
-    // effect. If the 'links' array contains empty links, ignore them.
-    // After this operation completes, all links in the 'links' array are
-    // left empty. The behavior is undefined unless all links in the
-    // 'links' array use the same allocator as this object.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
 
+    /// Append a link containing a single operation represented by the
+    /// specified `opCallback` operation callback and the optionally
+    /// specified `coCallback` completion callback to this operation chain.
+    /// If no completion callback is specified, use `mwcu::NoOp`. If the
+    /// chain is started and the appended link is the first one in the
+    /// chain, execute the single operation in the appended link
+    /// immediately.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
+    ///
+    /// `bsl::decay_t<OP_CALLBACK>` and `bsl::decay_t<CO_CALLBACK>` must
+    /// meet the requirements of Destructible and MoveConstructible as
+    /// specified in the C++ standard. Given an object `f1` of type
+    /// `bsl::decay_t<OP_CALLBACK>&&`, `f1(f2)` shall be a valid
+    /// expression, where `f2` is a function object of unspecified type
+    /// callable with the same arguments as `bsl::decay_t<CO_CALLBACK>&&`.
     template <class OP_CALLBACK>
     void appendInplace(BSLS_COMPILERFEATURES_FORWARD_REF(OP_CALLBACK)
                            opCallback);
@@ -562,70 +595,55 @@ class OperationChain {
                            opCallback,
                        BSLS_COMPILERFEATURES_FORWARD_REF(CO_CALLBACK)
                            coCallback);
-    // Append a link containing a single operation represented by the
-    // specified 'opCallback' operation callback and the optionally
-    // specified 'coCallback' completion callback to this operation chain.
-    // If no completion callback is specified, use 'mwcu::NoOp'. If the
-    // chain is started and the appended link is the first one in the
-    // chain, execute the single operation in the appended link
-    // immediately.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
-    //
-    // 'bsl::decay_t<OP_CALLBACK>' and 'bsl::decay_t<CO_CALLBACK>' must
-    // meet the requirements of Destructible and MoveConstructible as
-    // specified in the C++ standard. Given an object 'f1' of type
-    // 'bsl::decay_t<OP_CALLBACK>&&', 'f1(f2)' shall be a valid
-    // expression, where 'f2' is a function object of unspecified type
-    // callable with the same arguments as 'bsl::decay_t<CO_CALLBACK>&&'.
 
     int popBack() BSLS_KEYWORD_NOEXCEPT;
-    int popBack(Link* link) BSLS_KEYWORD_NOEXCEPT;
-    // Extract and remove the last link from this operation chain and load
-    // it into the optionally specified 'link'. Return 0 on success, and a
-    // non-zero value if the link can not be extracted, either because the
-    // chain is empty, or because operations in the extracted link are
-    // currently executing. On failure, this function has no effect and the
-    // contents of 'link' are unmodified. The behavior is undefined unless
-    // 'link' uses that same allocator as this object.
 
+    /// Extract and remove the last link from this operation chain and load
+    /// it into the optionally specified `link`. Return 0 on success, and a
+    /// non-zero value if the link can not be extracted, either because the
+    /// chain is empty, or because operations in the extracted link are
+    /// currently executing. On failure, this function has no effect and the
+    /// contents of `link` are unmodified. The behavior is undefined unless
+    /// `link` uses that same allocator as this object.
+    int popBack(Link* link) BSLS_KEYWORD_NOEXCEPT;
+
+    /// Remove all links from this operation chain. If operations in this
+    /// chain are currently executing, do not remove the first link. Return
+    /// the number of operations removed. If this chain is empty, this
+    /// function has no effect and 0 is returned.
     size_t removeAll() BSLS_KEYWORD_NOEXCEPT;
-    // Remove all links from this operation chain. If operations in this
-    // chain are currently executing, do not remove the first link. Return
-    // the number of operations removed. If this chain is empty, this
-    // function has no effect and 0 is returned.
 
   public:
     // ACCESSORS
+
+    /// Return `true` if this operation chain is started, and `false`
+    /// otherwise. Note that a stopped chain can still be executing
+    /// operations.
     bool isStarted() const BSLS_KEYWORD_NOEXCEPT;
-    // Return 'true' if this operation chain is started, and 'false'
-    // otherwise. Note that a stopped chain can still be executing
-    // operations.
 
+    /// Return `true` if this operation chain is currently executing at
+    /// least one operation, and `false` otherwise.
     bool isRunning() const BSLS_KEYWORD_NOEXCEPT;
-    // Return 'true' if this operation chain is currently executing at
-    // least one operation, and 'false' otherwise.
 
+    /// Return the number of links in this operation chain. A value of 0
+    /// means the chain is empty.
     size_t numLinks() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the number of links in this operation chain. A value of 0
-    // means the chain is empty.
 
+    /// Return the number of operations in this operation chain, including
+    /// those that are currently executing (if any). A value of 0 means the
+    /// chain is empty.
     size_t numOperations() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the number of operations in this operation chain, including
-    // those that are currently executing (if any). A value of 0 means the
-    // chain is empty.
 
+    /// Return the number of operations in this operation chain that are not
+    /// currently executing.
     size_t numOperationsPending() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the number of operations in this operation chain that are not
-    // currently executing.
 
+    /// Return the number of operations in this operation chain that are
+    /// currently executing.
     size_t numOperationsExecuting() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the number of operations in this operation chain that are
-    // currently executing.
 
+    /// Return the allocator used by this operation chain to supply memory.
     bslma::Allocator* allocator() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the allocator used by this operation chain to supply memory.
 
   public:
     // TRAITS
@@ -636,9 +654,8 @@ class OperationChain {
 // class OperationChainLink
 // ========================
 
+/// A representation of a link in the operation chain.
 class OperationChainLink {
-    // A representation of a link in the operation chain.
-
   private:
     // PRIVATE TYPES
     typedef OperationChain_Job Job;
@@ -647,8 +664,9 @@ class OperationChainLink {
 
   private:
     // PRIVATE DATA
-    JobList d_jobList;
+
     // Jobs executing async operations.
+    JobList d_jobList;
 
     // FRIENDS
     friend class OperationChain;
@@ -661,64 +679,67 @@ class OperationChainLink {
 
   public:
     // CREATORS
-    explicit OperationChainLink(bslma::Allocator* basicAllocator = 0);
-    // Create a 'OperationChainLink' object initialized empty. Optionally
-    // specify a 'basicAllocator' used to supply memory. If
-    // 'basicAllocator' is 0, the default memory allocator is used.
 
+    /// Create a `OperationChainLink` object initialized empty. Optionally
+    /// specify a `basicAllocator` used to supply memory. If
+    /// `basicAllocator` is 0, the default memory allocator is used.
+    explicit OperationChainLink(bslma::Allocator* basicAllocator = 0);
+
+    /// Create a `OperationChainLink` object having the same value as the
+    /// specified `original` object by moving the contents of `original` to
+    /// the new link. The allocator associated with `original` is propagated
+    /// for use in the newly-created link. `original` is left empty.
     OperationChainLink(bslmf::MovableRef<OperationChainLink> original);
-    // Create a 'OperationChainLink' object having the same value as the
-    // specified 'original' object by moving the contents of 'original' to
-    // the new link. The allocator associated with 'original' is propagated
-    // for use in the newly-created link. 'original' is left empty.
 
   public:
     // MANIPULATORS
+
+    /// Assign to this object the value of the specified `rhs` object and
+    /// return a reference providing modifiable access to this object. The
+    /// contents of `rhs` are moved to this link. `rhs` is left empty. The
+    /// behavior is undefined unless `rhs` uses that same allocator as this
+    /// object.
     OperationChainLink&
     operator=(bslmf::MovableRef<OperationChainLink> rhs) BSLS_KEYWORD_NOEXCEPT;
-    // Assign to this object the value of the specified 'rhs' object and
-    // return a reference providing modifiable access to this object. The
-    // contents of 'rhs' are moved to this link. 'rhs' is left empty. The
-    // behavior is undefined unless 'rhs' uses that same allocator as this
-    // object.
 
+    /// Insert an operation into this link. Specify a `opCallback` operation
+    /// callback initiating the operation. Optionally specify a `coCallback`
+    /// completion callback to be passed to the operation callback as a
+    /// parameter. If no completion callback is specified, use `mwcu::NoOp`.
+    ///
+    /// This function meets the strong exception guarantee. If an exception
+    /// is thrown, this function has no effect.
+    ///
+    /// `bsl::decay_t<OP_CALLBACK>` and `bsl::decay_t<CO_CALLBACK>` must
+    /// meet the requirements of Destructible and MoveConstructible as
+    /// specified in the C++ standard. Given an object `f1` of type
+    /// `bsl::decay_t<OP_CALLBACK>&&`, `f1(f2)` shall be a valid
+    /// expression, where `f2` is a function object of unspecified type
+    /// callable with the same arguments as `bsl::decay_t<CO_CALLBACK>&&`.
     template <class OP_CALLBACK>
     void insert(BSLS_COMPILERFEATURES_FORWARD_REF(OP_CALLBACK) opCallback);
     template <class OP_CALLBACK, class CO_CALLBACK>
     void insert(BSLS_COMPILERFEATURES_FORWARD_REF(OP_CALLBACK) opCallback,
                 BSLS_COMPILERFEATURES_FORWARD_REF(CO_CALLBACK) coCallback);
-    // Insert an operation into this link. Specify a 'opCallback' operation
-    // callback initiating the operation. Optionally specify a 'coCallback'
-    // completion callback to be passed to the operation callback as a
-    // parameter. If no completion callback is specified, use 'mwcu::NoOp'.
-    //
-    // This function meets the strong exception guarantee. If an exception
-    // is thrown, this function has no effect.
-    //
-    // 'bsl::decay_t<OP_CALLBACK>' and 'bsl::decay_t<CO_CALLBACK>' must
-    // meet the requirements of Destructible and MoveConstructible as
-    // specified in the C++ standard. Given an object 'f1' of type
-    // 'bsl::decay_t<OP_CALLBACK>&&', 'f1(f2)' shall be a valid
-    // expression, where 'f2' is a function object of unspecified type
-    // callable with the same arguments as 'bsl::decay_t<CO_CALLBACK>&&'.
 
+    /// Remove all operations in this link, if any. Return the number of
+    /// operations removed.
     size_t removeAll() BSLS_KEYWORD_NOEXCEPT;
-    // Remove all operations in this link, if any. Return the number of
-    // operations removed.
 
+    /// Swap the contents of this object and the specified `other` object.
+    /// The behavior is undefined unless `other` uses that same allocator
+    /// as this object.
     void swap(OperationChainLink& other) BSLS_KEYWORD_NOEXCEPT;
-    // Swap the contents of this object and the specified 'other' object.
-    // The behavior is undefined unless 'other' uses that same allocator
-    // as this object.
 
   public:
     // ACCESSORS
-    size_t numOperations() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the number of operations in this link. A value of 0 means the
-    // link is empty.
 
+    /// Return the number of operations in this link. A value of 0 means the
+    /// link is empty.
+    size_t numOperations() const BSLS_KEYWORD_NOEXCEPT;
+
+    /// Return the allocator used by this link to supply memory.
     bslma::Allocator* allocator() const BSLS_KEYWORD_NOEXCEPT;
-    // Return the allocator used by this link to supply memory.
 
   public:
     // TRAITS
@@ -727,10 +748,11 @@ class OperationChainLink {
 };
 
 // FREE OPERATORS
+
+/// Swap the contents of `lhs` and `rhs`. The behavior is undefined unless
+/// `lhs` and `rhs` use the same allocator.
 void swap(OperationChainLink& lhs,
           OperationChainLink& rhs) BSLS_KEYWORD_NOEXCEPT;
-// Swap the contents of 'lhs' and 'rhs'. The behavior is undefined unless
-// 'lhs' and 'rhs' use the same allocator.
 
 // ============================================================================
 //                            INLINE DEFINITIONS
@@ -756,6 +778,7 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 }
 
 // ACCESSORS
+// clang-format off
 #if BSLS_COMPILERFEATURES_SIMULATE_VARIADIC_TEMPLATES
 // {{{ BEGIN GENERATED CODE
 // Command line: sim_cpp11_features.pl mwcu_operationchain.h
@@ -768,11 +791,11 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 0
 template <class CO_CALLBACK>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
-
-) const
+    ) const
 {
     try {
-        bslmf::Util::moveIfSupported((*d_coCallback_p))();
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            );
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -804,15 +827,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 2
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -825,17 +849,19 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 3
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -848,7 +874,10 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 4
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -856,11 +885,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -873,7 +902,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if MWCU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 5
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -882,12 +915,12 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -915,13 +948,13 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -951,14 +984,14 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -990,15 +1023,15 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1032,16 +1065,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8),
-                               bslmf::Util::forward<ARGS_9>(args_9));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8),
+            bslmf::Util::forward<ARGS_9>(args_9));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1267,24 +1300,14 @@ inline void mwcu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_MWCU_OPERATIONCHAIN_H)
-#error Not valid except when included from mwcu_operationchain.h
-#endif  // ! defined(COMPILING_MWCU_OPERATIONCHAIN_H)
+// clang-format off
 
-#endif  // ! defined(INCLUDED_MWCU_OPERATIONCHAIN_CPP03)
+#else // if ! defined(DEFINED_MWCU_OPERATIONCHAIN_H)
+# error Not valid except when included from mwcu_operationchain.h
+#endif // ! defined(COMPILING_MWCU_OPERATIONCHAIN_H)
 
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------
+#endif // ! defined(INCLUDED_MWCU_OPERATIONCHAIN_CPP03)
+
+// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
+// SOURCE-SHA: 4f31981d3c4df7fb1874f528745e3a965d7f04191813ce651325e5d743462536
+

--- a/src/groups/mwc/mwcu/mwcu_tlsbool.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_tlsbool.t.cpp
@@ -158,8 +158,8 @@ static void test2_isValid()
     catch (int) {
     };
 
-        // Test isValid and default values.  There is a limit of
-        // PTHREAD_KEYS_MAX (1024 on Linux) keys that can be created.
+    // Test isValid and default values.  There is a limit of
+    // PTHREAD_KEYS_MAX (1024 on Linux) keys that can be created.
 
 #if !defined PTHREAD_KEYS_MAX
     // Somehow, some platforms (e.g., SunOs) don't define that variable so skip

--- a/src/groups/mwc/mwcu/mwcu_weakmemfn.h
+++ b/src/groups/mwc/mwcu/mwcu_weakmemfn.h
@@ -203,8 +203,7 @@ class WeakMemFnResult;
 /// that its call signature is compatible with the specified return type
 /// `RET` and the specified argument types `ARGS`.
 template <class WEAKMEMFN, class RET, class ARGS>
-struct WeakMemFn_Invocable {
-};
+struct WeakMemFn_Invocable {};
 
 /// Provides a specialization of `WeakMemFn_Invocable` for a non-void return
 /// types and 0 argument types.
@@ -619,8 +618,7 @@ struct WeakMemFn_Invocable<
 /// with the specified return type `RET` and the specified argument types
 /// `ARGS`.
 template <class WEAKMEMFN, class RET, class ARGS>
-struct WeakMemFnInstance_Invocable {
-};
+struct WeakMemFnInstance_Invocable {};
 
 /// Provides a specialization of `WeakMemFnInstance_Invocable` for 0
 /// argument types.

--- a/src/plugins/bmqprometheus/bmqprometheus_versiontag.h
+++ b/src/plugins/bmqprometheus/bmqprometheus_versiontag.h
@@ -69,11 +69,11 @@
 /// integral constant.  Also note that the patch version number is
 /// intentionally not included.  The behavior is undefined unless 'major'
 /// and 'minor' are integral values in the range '[ 0 .. 99 ]'.
-#define PROMETHEUS_MAKE_VERSION(major, minor) ((major)*10000 + (minor)*100)
+#define PROMETHEUS_MAKE_VERSION(major, minor) ((major) * 10000 + (minor) * 100)
 
 /// Similar to PROMETHEUS_MAKE_VERSION(), but include patch number as well.
 #define PROMETHEUS_MAKE_EXT_VERSION(major, minor, patch)                      \
-    ((major)*10000 + (minor)*100 + (patch))
+    ((major) * 10000 + (minor) * 100 + (patch))
 
 /// Construct a composite version number in the range [ 0 .. 999900 ] from
 /// the specified 'PROMETHEUS_VERSION_MAJOR' and 'PROMETHEUS_VERSION_MINOR'


### PR DESCRIPTION
These changes minimize the amount of changes coming from the files supporting a simulating C++11, eliminating all discrepancies except the license header. Future versions of sim_cpp11_features.pl should address this issue.