### PR TITLE
Protect static initialization in SubscriptionHandle

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_subscription.cpp
+++ b/src/groups/bmq/bmqt/bmqt_subscription.cpp
@@ -22,6 +22,7 @@
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
+#include <bslmt_once.h>
 #include <bsls_annotation.h>
 
 namespace BloombergLP {
@@ -43,9 +44,16 @@ const int Subscription::k_DEFAULT_CONSUMER_PRIORITY        = 0;
 
 unsigned int SubscriptionHandle::nextId()
 {
-    static bsls::AtomicUint s_id = k_INVALID_HANDLE_ID;
+    static bsls::AtomicUint* s_id = 0;
 
-    return ++s_id;
+    BSLMT_ONCE_DO
+    {
+        s_id = new bsls::AtomicUint(k_INVALID_HANDLE_ID);
+        // Heap allocate it to prevent 'exit-time-destructor needed' compiler
+        // warning.  Causes valgrind-reported memory leak.
+    }
+
+    return ++(*s_id);
 }
 
 }  // close package namespace


### PR DESCRIPTION
Fix:#141
Before this fix is applied, creating multiple SubscriptionHandles at the same time from different threads just after the app starts may have led to duplication of SubscriptionHandle's Ids.