### PR TITLE
Treat non-zero time intervals correctly in Session::nextEvent

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -1483,7 +1483,7 @@ Event Session::nextEvent(const bsls::TimeInterval& timeout)
     // If no timeout was specified, use a long timeout to simulate a 'no
     // timeout' behavior
     bsls::TimeInterval time = timeout;
-    if (time.totalMicroseconds() == 0) {
+    if (time == bsls::TimeInterval()) {
         time.addDays(365);
     }
 


### PR DESCRIPTION
Before this fix timer intervals less than 1 us was treated as a null-interval which led to (almost) infinite waiting for `bmqa::Session::nextEvent()` to return an event.

Fix:#142