### PR TITLE
CI: Update GitHub Actions to use Node.js 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     name: "Check if BlazingMQ can build, and pass unit and integration tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up dependencies
         run: |
           sudo apt-get update
@@ -75,7 +75,7 @@ jobs:
             --tb line                           \
             --reruns=3                          \
             -n 4 -v
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             build/blazingmq
@@ -88,8 +88,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_and_test
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache/@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache/@v4
         with:
           path: |
             build/blazingmq
@@ -155,7 +155,7 @@ jobs:
     name: "Documentation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up dependencies
         run: |
           sudo apt-get update
@@ -172,7 +172,7 @@ jobs:
         path:
           - 'src'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run clang-format style check for C/C++/Protobuf programs.
         uses: jidicula/clang-format-action@v4.11.0
         with:
@@ -183,7 +183,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
 
@@ -191,7 +191,7 @@ jobs:
     name: "Check whether docker single-node and cluster workflows build correctly."
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Docker Single-Node Workflow
         run: docker compose -f docker/single-node/docker-compose.yaml up --build -d
       - name: Docker Cluster Workflow


### PR DESCRIPTION
Our CI has been admonishing us to use more recent versions of certain GitHub Actions, like `actions/checkout`, which are built on Node.js version 20 instead of the older Node.js version 16.  This transition is documented [here][actions-transition].

This patch updates the actions we can to ones that are built on Node.js 20:

  - `actions/checkout@v3` → `actions/checkout@v4`
  - `actions/cache@v3`    → `actions/cache@v4`

Although some actions upgrades introduce breaking changes in their behavior, neither of these upgrades change any behavior.  See the changelogs for the [checkout][checkout-changelog] and [cache][cache-changelog] actions to verify this.

Fixes: #193

[actions-transition]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
[checkout-changelog]: https://github.com/actions/checkout/releases/tag/v4.0.0
[cache-changelog]: https://github.com/actions/cache?tab=readme-ov-file#v4