### PR TITLE
configurator: also create storage directories

### DIFF
--- a/src/python/blazingmq/dev/it/process/broker.py
+++ b/src/python/blazingmq/dev/it/process/broker.py
@@ -34,7 +34,6 @@ class Broker(blazingmq.dev.it.process.bmqproc.BMQProcess):
     def __init__(self, config: cfg.Broker, cluster, **kwargs):
         cwd: Path = kwargs["cwd"]
         (cwd / "bmqbrkr.ctl").unlink(missing_ok=True)
-        cwd.joinpath("storage", "archive").mkdir(parents=True)
         super().__init__(
             config.name,
             ["bin/bmqbrkr.tsk", "etc"],


### PR DESCRIPTION
Improvements to `blazimgmq.dev.configurator`.
* Create the two storage directories.
* Add `Cluster.domain` method, which takes a `Domain` object.