### PR TITLE
Fix: race condition when allocating ports in ITs

### DIFF
--- a/src/python/blazingmq/dev/reserveport.py
+++ b/src/python/blazingmq/dev/reserveport.py
@@ -105,11 +105,11 @@ def tcp_address(address: str, port: int) -> TcpAddress:
 def reserve_port() -> typing.Iterator[TcpAddress]:
     """Return a TCP address with a reserved port for 'bind'ing."""
 
-    sock = socket.socket()
-    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    sock.bind(("0.0.0.0", 0))
-    sockname = sock.getsockname()
+    with socket.socket() as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("0.0.0.0", 0))
+        sockname = sock.getsockname()
+    
+        address = tcp_address(sockname[0], sockname[1])
 
-    yield tcp_address(sockname[0], sockname[1])
-
-    sock.close()
+    yield address


### PR DESCRIPTION
On a very fast machine, we launch broker faster than probe socket connection is closed. Because of this, broker is not able to listen to the specified port:

```
PANIC: PANIC [STARTUP] (1): Failed to start application [rc: 91, error: Failed listening to port '50834' for TCPSessionFactory 'localhost' [rc: 1]]
BMQBRKR~@~08FEB2024_18:11:33.718~@~8080399424~@~ERROR~@~bmqbrkr.m.cpp:754~@~PANIC [STARTUP] (1): Failed to start application [rc: 91, error: Failed listening to port '50834' for TCPSessionFactory 'localhost' [rc: 1]]
```