### PR TITLE
build: Do not link against `libfl`

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -22,7 +22,6 @@
             "inherits": "base",
             "cacheVariables": {
                 "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
-                "FL_LIBRARY": "/opt/homebrew/opt/flex/lib/libfl.a",
                 "FLEX_INCLUDE_DIR": "/opt/homebrew/opt/flex/include"
             }
         },
@@ -33,7 +32,6 @@
             "inherits": "base",
             "cacheVariables": {
                 "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
-                "FL_LIBRARY": "/usr/local/lib/opt/flex/lib/libfl.a",
                 "FLEX_INCLUDE_DIR": "/usr/local/lib/opt/flex/include"
             }
         },

--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -76,12 +76,9 @@ target_sources(bmqeval-iface
                ${FLEX_SimpleEvaluatorScanner_OUTPUTS})
 
 target_include_directories(bmqeval-iface PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${FLEX_INCLUDE_DIRS})
-if(NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-  target_link_libraries(bmq PUBLIC "${FLEX_LIBRARIES}")
-endif()
 
 target_include_directories(bmqeval_simpleevaluator.t
                            PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
-target_link_libraries(bmqeval_simpleevaluator.t PUBLIC bmq "${FLEX_LIBRARIES}" benchmark)
+target_link_libraries(bmqeval_simpleevaluator.t PUBLIC bmq benchmark)
 


### PR DESCRIPTION
BlazingMQ uses `flex` to generate lexing code that aids during parsing and evaluating subscription expressions.  This tool has two parts: a binary, `flex` which reads in the `bmqeval_simpleevaluatorscanner.l` file and produces C++ source code that does lexical analysis on subscription expressions; and a library, variously `libfl.a`, `libfl.so`, or `libfl.dylib`, which contains supporting code.  We crucially need the former to make use of `flex`, but it does not seem that we need the latter.  In fact, linking against a shared object version of `libfl` fails.

`libfl` exports two functions that code generated by `flex` can make use of, `main` and `yywrap`.  These are default implementations of these two functions that users can override as needed.

    $ nm /opt/homebrew/Cellar/flex/2.6.4_2/lib/libfl.2.dylib
                     U _exit
    0000000000003f7c T _main
                     U _yylex
    0000000000003f90 T _yywrap

In BlazingMQ, our generated lexer is a class, `SimpleEvaluatorScanner`, rather than a binary with an entrypoint `main`, so we do not make use of `flex`’s default `main` implementation.  We also do not make use of `yywrap`, which allows lexing multiple input files in one go, instead [explicitly turning it off][yywrap].  It would seem we have no need to link against this library, then.  In fact, [we never link against `libfl` on Darwin systems][darwin], further showing that we do not depend on this library and do not need to link against it.

Furthermore, if we accidentally link to a shared object version of `libfl`, our build will fail.  All versions of `libfl`, shared or static, have an undefined reference to a generated `yylex` function, usually produced by `flex`, which is used in the default implementations of `main` or `yywrap`.  However, BlazingMQ uses `flex` to [generate a class `SimpleEvaluatorScanner`][class] rather than a function `yylex`, so there is nothing to resolve the symbol that `libfl`’s default implementations expect.  This has not been a problem for us for two reasons:

  1. Our Ubuntu-based build systems always link against the static library version of `libfl`, packaged in `libfl-dev`.  Linking against the static library will never expose this issue, for the following reason.  When linking against the `libfl.a` archive, the linker has no need to pull in `main` or `yywrap`, so it never encounters the undefined reference to `yylex`.  In fact, nothing from `libfl` needs to be linked in at all.

  2. Our Darwin-based build systems never link against `libfl` at all.  Darwin by default would choose to link against the shared object version of `libfl` if we let it.  The undefined reference issue crops up when linking an executable with a shared object, because the linker cannot prove that the executable will notcall the shared object’s `main` or `yywrap` implementations dynamically (via, say, `dlsym`).  It acts conservatively, requiring the undefined reference to `yylex` to be resolved.  To solve this, we remove any link dependency on `libfl` on Darwin.

In the first case, we are explictly requesting a link dependency which accidentally has no effect, and in the second case, we are correctly not requesting the unnecessary link dependency.

Issue #201, though, exposes this unhappy equilibrium by attempting to link to the shared object version of `libfl` on a Fedora system.  This fails in exactly the way we would expect Darwin builds to fail.

This patch removes all link-time dependencies on `libfl` in any of its forms
across the codebase.  BlazingMQ still need the binary `flex` during builds,
though, as well as the header files from `libfl-dev`, so this patch keeps the
existing build dependencies.  By merging this patch, we will furthermore remove
the special case we needed for Darwin machines.

[darwin]: https://github.com/bloomberg/blazingmq/blame/e888fcdef8a6d825d2d08bbd3c0d8549d3537905/src/groups/bmq/CMakeLists.txt#L79
[yywrap]: https://github.com/bloomberg/blazingmq/blob/e888fcdef8a6d825d2d08bbd3c0d8549d3537905/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l#L17
[class]: https://github.com/bloomberg/blazingmq/blob/e888fcdef8a6d825d2d08bbd3c0d8549d3537905/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l#L19
