### PR TITLE
Feat[MQB]: Support listening on multiple ports

### DIFF
--- a/src/groups/mqb/mqbcfg/doc/mqbcfg.txt
+++ b/src/groups/mqb/mqbcfg/doc/mqbcfg.txt
@@ -10,11 +10,12 @@ broker, as well as the generated corresponding messages component.
 
 /Hierarchical Synopsis
 /---------------------
- The 'mqbcfg' package currently has 2 components having 2 level of physical
+ The 'mqbcfg' package currently has 3 components having 2 levels of physical
  dependency.  The list below shows the hierarchical ordering of the components.
 ..
   1. mqbcfg_messages
   2. mqbcfg_brokerconfig
+  2. mqbcfg_tcpinterfaceconfigvalidator
 ..
 
 /Component Synopsis
@@ -23,3 +24,5 @@ broker, as well as the generated corresponding messages component.
 :      BMQBroker generated configuration messages.
 : 'mqbcfg_brokerconfig'
 :      Provide global access to broker configuration.
+: 'mqbcfg_tcpinterfaceconfigvalidator'
+:      Provide validation logic for `appConfig/networkInterfaces/tcpInterface/listeners` in the broker configuration.

--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -233,6 +233,10 @@
   <complexType name='TcpInterfaceConfig'>
     <annotation>
       <documentation>
+        name.................:
+            The name of the TCP session manager.
+        port.................:
+            (Deprecated) The port to receive connections.
         lowWatermark.........:
         highWatermark........:
             Watermarks used for channels with a client or proxy.
@@ -243,6 +247,9 @@
         heartbeatIntervalMs..:
             How often (in milliseconds) to check if the channel received data,
             and emit heartbeat.  0 to globally disable.
+        listeners:
+            A list of listener interfaces to receive TCP connections from. When non-empty
+            this option overrides the listener specified by port.
       </documentation>
     </annotation>
     <sequence>
@@ -255,6 +262,24 @@
       <element name='nodeLowWatermark'    type='long' default='1024'/>
       <element name='nodeHighWatermark'   type='long' default='2048'/>
       <element name='heartbeatIntervalMs' type='int' default='3000'/>
+      <element name='listeners'           type='tns:TcpInterfaceListener' minOccurs='0' maxOccurs='unbounded'/>
+   </sequence>
+  </complexType>
+
+  <complexType name='TcpInterfaceListener'>
+    <annotation>
+      <documentation>
+      This type describes the information needed for the broker to open a TCP listener.
+
+      name.................:
+        A name to associate this listener to.
+      port.................:
+        The port this listener will accept connections on.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name='name'                type='string'/>
+      <element name='port'                type='int'/>
     </sequence>
   </complexType>
 

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 // mqbcfg_messages.cpp            *DO NOT EDIT*            @generated -*-C++-*-
 
 #include <mqbcfg_messages.h>
@@ -2261,25 +2260,15 @@ bsl::ostream& TcpClusterNodeConnection::print(bsl::ostream& stream,
     return stream;
 }
 
-// ------------------------
-// class TcpInterfaceConfig
-// ------------------------
+// --------------------------
+// class TcpInterfaceListener
+// --------------------------
 
 // CONSTANTS
 
-const char TcpInterfaceConfig::CLASS_NAME[] = "TcpInterfaceConfig";
+const char TcpInterfaceListener::CLASS_NAME[] = "TcpInterfaceListener";
 
-const int TcpInterfaceConfig::DEFAULT_INITIALIZER_MAX_CONNECTIONS = 10000;
-
-const bsls::Types::Int64
-    TcpInterfaceConfig::DEFAULT_INITIALIZER_NODE_LOW_WATERMARK = 1024;
-
-const bsls::Types::Int64
-    TcpInterfaceConfig::DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK = 2048;
-
-const int TcpInterfaceConfig::DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS = 3000;
-
-const bdlat_AttributeInfo TcpInterfaceConfig::ATTRIBUTE_INFO_ARRAY[] = {
+const bdlat_AttributeInfo TcpInterfaceListener::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_NAME,
      "name",
      sizeof("name") - 1,
@@ -2289,51 +2278,16 @@ const bdlat_AttributeInfo TcpInterfaceConfig::ATTRIBUTE_INFO_ARRAY[] = {
      "port",
      sizeof("port") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_IO_THREADS,
-     "ioThreads",
-     sizeof("ioThreads") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_MAX_CONNECTIONS,
-     "maxConnections",
-     sizeof("maxConnections") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_LOW_WATERMARK,
-     "lowWatermark",
-     sizeof("lowWatermark") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_HIGH_WATERMARK,
-     "highWatermark",
-     sizeof("highWatermark") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_NODE_LOW_WATERMARK,
-     "nodeLowWatermark",
-     sizeof("nodeLowWatermark") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_NODE_HIGH_WATERMARK,
-     "nodeHighWatermark",
-     sizeof("nodeHighWatermark") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS,
-     "heartbeatIntervalMs",
-     sizeof("heartbeatIntervalMs") - 1,
-     "",
      bdlat_FormattingMode::e_DEC}};
 
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-TcpInterfaceConfig::lookupAttributeInfo(const char* name, int nameLength)
+TcpInterfaceListener::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 9; ++i) {
+    for (int i = 0; i < 2; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
-            TcpInterfaceConfig::ATTRIBUTE_INFO_ARRAY[i];
+            TcpInterfaceListener::ATTRIBUTE_INFO_ARRAY[i];
 
         if (nameLength == attributeInfo.d_nameLength &&
             0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
@@ -2344,107 +2298,59 @@ TcpInterfaceConfig::lookupAttributeInfo(const char* name, int nameLength)
     return 0;
 }
 
-const bdlat_AttributeInfo* TcpInterfaceConfig::lookupAttributeInfo(int id)
+const bdlat_AttributeInfo* TcpInterfaceListener::lookupAttributeInfo(int id)
 {
     switch (id) {
     case ATTRIBUTE_ID_NAME: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME];
     case ATTRIBUTE_ID_PORT: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT];
-    case ATTRIBUTE_ID_IO_THREADS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS];
-    case ATTRIBUTE_ID_MAX_CONNECTIONS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS];
-    case ATTRIBUTE_ID_LOW_WATERMARK:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK];
-    case ATTRIBUTE_ID_HIGH_WATERMARK:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK];
-    case ATTRIBUTE_ID_NODE_LOW_WATERMARK:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK];
-    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK];
-    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS];
     default: return 0;
     }
 }
 
 // CREATORS
 
-TcpInterfaceConfig::TcpInterfaceConfig(bslma::Allocator* basicAllocator)
-: d_lowWatermark()
-, d_highWatermark()
-, d_nodeLowWatermark(DEFAULT_INITIALIZER_NODE_LOW_WATERMARK)
-, d_nodeHighWatermark(DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK)
-, d_name(basicAllocator)
+TcpInterfaceListener::TcpInterfaceListener(bslma::Allocator* basicAllocator)
+: d_name(basicAllocator)
 , d_port()
-, d_ioThreads()
-, d_maxConnections(DEFAULT_INITIALIZER_MAX_CONNECTIONS)
-, d_heartbeatIntervalMs(DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS)
 {
 }
 
-TcpInterfaceConfig::TcpInterfaceConfig(const TcpInterfaceConfig& original,
-                                       bslma::Allocator* basicAllocator)
-: d_lowWatermark(original.d_lowWatermark)
-, d_highWatermark(original.d_highWatermark)
-, d_nodeLowWatermark(original.d_nodeLowWatermark)
-, d_nodeHighWatermark(original.d_nodeHighWatermark)
-, d_name(original.d_name, basicAllocator)
+TcpInterfaceListener::TcpInterfaceListener(
+    const TcpInterfaceListener& original,
+    bslma::Allocator*           basicAllocator)
+: d_name(original.d_name, basicAllocator)
 , d_port(original.d_port)
-, d_ioThreads(original.d_ioThreads)
-, d_maxConnections(original.d_maxConnections)
-, d_heartbeatIntervalMs(original.d_heartbeatIntervalMs)
 {
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-TcpInterfaceConfig::TcpInterfaceConfig(TcpInterfaceConfig&& original) noexcept
-: d_lowWatermark(bsl::move(original.d_lowWatermark)),
-  d_highWatermark(bsl::move(original.d_highWatermark)),
-  d_nodeLowWatermark(bsl::move(original.d_nodeLowWatermark)),
-  d_nodeHighWatermark(bsl::move(original.d_nodeHighWatermark)),
-  d_name(bsl::move(original.d_name)),
-  d_port(bsl::move(original.d_port)),
-  d_ioThreads(bsl::move(original.d_ioThreads)),
-  d_maxConnections(bsl::move(original.d_maxConnections)),
-  d_heartbeatIntervalMs(bsl::move(original.d_heartbeatIntervalMs))
+TcpInterfaceListener::TcpInterfaceListener(TcpInterfaceListener&& original)
+    noexcept : d_name(bsl::move(original.d_name)),
+               d_port(bsl::move(original.d_port))
 {
 }
 
-TcpInterfaceConfig::TcpInterfaceConfig(TcpInterfaceConfig&& original,
-                                       bslma::Allocator*    basicAllocator)
-: d_lowWatermark(bsl::move(original.d_lowWatermark))
-, d_highWatermark(bsl::move(original.d_highWatermark))
-, d_nodeLowWatermark(bsl::move(original.d_nodeLowWatermark))
-, d_nodeHighWatermark(bsl::move(original.d_nodeHighWatermark))
-, d_name(bsl::move(original.d_name), basicAllocator)
+TcpInterfaceListener::TcpInterfaceListener(TcpInterfaceListener&& original,
+                                           bslma::Allocator* basicAllocator)
+: d_name(bsl::move(original.d_name), basicAllocator)
 , d_port(bsl::move(original.d_port))
-, d_ioThreads(bsl::move(original.d_ioThreads))
-, d_maxConnections(bsl::move(original.d_maxConnections))
-, d_heartbeatIntervalMs(bsl::move(original.d_heartbeatIntervalMs))
 {
 }
 #endif
 
-TcpInterfaceConfig::~TcpInterfaceConfig()
+TcpInterfaceListener::~TcpInterfaceListener()
 {
 }
 
 // MANIPULATORS
 
-TcpInterfaceConfig&
-TcpInterfaceConfig::operator=(const TcpInterfaceConfig& rhs)
+TcpInterfaceListener&
+TcpInterfaceListener::operator=(const TcpInterfaceListener& rhs)
 {
     if (this != &rhs) {
-        d_name                = rhs.d_name;
-        d_port                = rhs.d_port;
-        d_ioThreads           = rhs.d_ioThreads;
-        d_maxConnections      = rhs.d_maxConnections;
-        d_lowWatermark        = rhs.d_lowWatermark;
-        d_highWatermark       = rhs.d_highWatermark;
-        d_nodeLowWatermark    = rhs.d_nodeLowWatermark;
-        d_nodeHighWatermark   = rhs.d_nodeHighWatermark;
-        d_heartbeatIntervalMs = rhs.d_heartbeatIntervalMs;
+        d_name = rhs.d_name;
+        d_port = rhs.d_port;
     }
 
     return *this;
@@ -2452,54 +2358,34 @@ TcpInterfaceConfig::operator=(const TcpInterfaceConfig& rhs)
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-TcpInterfaceConfig& TcpInterfaceConfig::operator=(TcpInterfaceConfig&& rhs)
+TcpInterfaceListener&
+TcpInterfaceListener::operator=(TcpInterfaceListener&& rhs)
 {
     if (this != &rhs) {
-        d_name                = bsl::move(rhs.d_name);
-        d_port                = bsl::move(rhs.d_port);
-        d_ioThreads           = bsl::move(rhs.d_ioThreads);
-        d_maxConnections      = bsl::move(rhs.d_maxConnections);
-        d_lowWatermark        = bsl::move(rhs.d_lowWatermark);
-        d_highWatermark       = bsl::move(rhs.d_highWatermark);
-        d_nodeLowWatermark    = bsl::move(rhs.d_nodeLowWatermark);
-        d_nodeHighWatermark   = bsl::move(rhs.d_nodeHighWatermark);
-        d_heartbeatIntervalMs = bsl::move(rhs.d_heartbeatIntervalMs);
+        d_name = bsl::move(rhs.d_name);
+        d_port = bsl::move(rhs.d_port);
     }
 
     return *this;
 }
 #endif
 
-void TcpInterfaceConfig::reset()
+void TcpInterfaceListener::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_name);
     bdlat_ValueTypeFunctions::reset(&d_port);
-    bdlat_ValueTypeFunctions::reset(&d_ioThreads);
-    d_maxConnections = DEFAULT_INITIALIZER_MAX_CONNECTIONS;
-    bdlat_ValueTypeFunctions::reset(&d_lowWatermark);
-    bdlat_ValueTypeFunctions::reset(&d_highWatermark);
-    d_nodeLowWatermark    = DEFAULT_INITIALIZER_NODE_LOW_WATERMARK;
-    d_nodeHighWatermark   = DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK;
-    d_heartbeatIntervalMs = DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS;
 }
 
 // ACCESSORS
 
-bsl::ostream& TcpInterfaceConfig::print(bsl::ostream& stream,
-                                        int           level,
-                                        int           spacesPerLevel) const
+bsl::ostream& TcpInterfaceListener::print(bsl::ostream& stream,
+                                          int           level,
+                                          int           spacesPerLevel) const
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("name", this->name());
     printer.printAttribute("port", this->port());
-    printer.printAttribute("ioThreads", this->ioThreads());
-    printer.printAttribute("maxConnections", this->maxConnections());
-    printer.printAttribute("lowWatermark", this->lowWatermark());
-    printer.printAttribute("highWatermark", this->highWatermark());
-    printer.printAttribute("nodeLowWatermark", this->nodeLowWatermark());
-    printer.printAttribute("nodeHighWatermark", this->nodeHighWatermark());
-    printer.printAttribute("heartbeatIntervalMs", this->heartbeatIntervalMs());
     printer.end();
     return stream;
 }
@@ -3227,135 +3113,6 @@ LogController::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     return stream;
 }
 
-// -----------------------
-// class NetworkInterfaces
-// -----------------------
-
-// CONSTANTS
-
-const char NetworkInterfaces::CLASS_NAME[] = "NetworkInterfaces";
-
-const bdlat_AttributeInfo NetworkInterfaces::ATTRIBUTE_INFO_ARRAY[] = {
-    {ATTRIBUTE_ID_HEARTBEATS,
-     "heartbeats",
-     sizeof("heartbeats") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT},
-    {ATTRIBUTE_ID_TCP_INTERFACE,
-     "tcpInterface",
-     sizeof("tcpInterface") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT}};
-
-// CLASS METHODS
-
-const bdlat_AttributeInfo*
-NetworkInterfaces::lookupAttributeInfo(const char* name, int nameLength)
-{
-    for (int i = 0; i < 2; ++i) {
-        const bdlat_AttributeInfo& attributeInfo =
-            NetworkInterfaces::ATTRIBUTE_INFO_ARRAY[i];
-
-        if (nameLength == attributeInfo.d_nameLength &&
-            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
-            return &attributeInfo;
-        }
-    }
-
-    return 0;
-}
-
-const bdlat_AttributeInfo* NetworkInterfaces::lookupAttributeInfo(int id)
-{
-    switch (id) {
-    case ATTRIBUTE_ID_HEARTBEATS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS];
-    case ATTRIBUTE_ID_TCP_INTERFACE:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE];
-    default: return 0;
-    }
-}
-
-// CREATORS
-
-NetworkInterfaces::NetworkInterfaces(bslma::Allocator* basicAllocator)
-: d_tcpInterface(basicAllocator)
-, d_heartbeats()
-{
-}
-
-NetworkInterfaces::NetworkInterfaces(const NetworkInterfaces& original,
-                                     bslma::Allocator*        basicAllocator)
-: d_tcpInterface(original.d_tcpInterface, basicAllocator)
-, d_heartbeats(original.d_heartbeats)
-{
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-NetworkInterfaces::NetworkInterfaces(NetworkInterfaces&& original) noexcept
-: d_tcpInterface(bsl::move(original.d_tcpInterface)),
-  d_heartbeats(bsl::move(original.d_heartbeats))
-{
-}
-
-NetworkInterfaces::NetworkInterfaces(NetworkInterfaces&& original,
-                                     bslma::Allocator*   basicAllocator)
-: d_tcpInterface(bsl::move(original.d_tcpInterface), basicAllocator)
-, d_heartbeats(bsl::move(original.d_heartbeats))
-{
-}
-#endif
-
-NetworkInterfaces::~NetworkInterfaces()
-{
-}
-
-// MANIPULATORS
-
-NetworkInterfaces& NetworkInterfaces::operator=(const NetworkInterfaces& rhs)
-{
-    if (this != &rhs) {
-        d_heartbeats   = rhs.d_heartbeats;
-        d_tcpInterface = rhs.d_tcpInterface;
-    }
-
-    return *this;
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-NetworkInterfaces& NetworkInterfaces::operator=(NetworkInterfaces&& rhs)
-{
-    if (this != &rhs) {
-        d_heartbeats   = bsl::move(rhs.d_heartbeats);
-        d_tcpInterface = bsl::move(rhs.d_tcpInterface);
-    }
-
-    return *this;
-}
-#endif
-
-void NetworkInterfaces::reset()
-{
-    bdlat_ValueTypeFunctions::reset(&d_heartbeats);
-    bdlat_ValueTypeFunctions::reset(&d_tcpInterface);
-}
-
-// ACCESSORS
-
-bsl::ostream& NetworkInterfaces::print(bsl::ostream& stream,
-                                       int           level,
-                                       int           spacesPerLevel) const
-{
-    bslim::Printer printer(&stream, level, spacesPerLevel);
-    printer.start();
-    printer.printAttribute("heartbeats", this->heartbeats());
-    printer.printAttribute("tcpInterface", this->tcpInterface());
-    printer.end();
-    return stream;
-}
-
 // ---------------------
 // class PartitionConfig
 // ---------------------
@@ -3784,6 +3541,264 @@ bsl::ostream& StatPluginConfigPrometheus::print(bsl::ostream& stream,
     return stream;
 }
 
+// ------------------------
+// class TcpInterfaceConfig
+// ------------------------
+
+// CONSTANTS
+
+const char TcpInterfaceConfig::CLASS_NAME[] = "TcpInterfaceConfig";
+
+const int TcpInterfaceConfig::DEFAULT_INITIALIZER_MAX_CONNECTIONS = 10000;
+
+const bsls::Types::Int64
+    TcpInterfaceConfig::DEFAULT_INITIALIZER_NODE_LOW_WATERMARK = 1024;
+
+const bsls::Types::Int64
+    TcpInterfaceConfig::DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK = 2048;
+
+const int TcpInterfaceConfig::DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS = 3000;
+
+const bdlat_AttributeInfo TcpInterfaceConfig::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_NAME,
+     "name",
+     sizeof("name") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_PORT,
+     "port",
+     sizeof("port") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_IO_THREADS,
+     "ioThreads",
+     sizeof("ioThreads") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_MAX_CONNECTIONS,
+     "maxConnections",
+     sizeof("maxConnections") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_LOW_WATERMARK,
+     "lowWatermark",
+     sizeof("lowWatermark") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_HIGH_WATERMARK,
+     "highWatermark",
+     sizeof("highWatermark") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_NODE_LOW_WATERMARK,
+     "nodeLowWatermark",
+     sizeof("nodeLowWatermark") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_NODE_HIGH_WATERMARK,
+     "nodeHighWatermark",
+     sizeof("nodeHighWatermark") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS,
+     "heartbeatIntervalMs",
+     sizeof("heartbeatIntervalMs") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_LISTENERS,
+     "listeners",
+     sizeof("listeners") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo*
+TcpInterfaceConfig::lookupAttributeInfo(const char* name, int nameLength)
+{
+    for (int i = 0; i < 10; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            TcpInterfaceConfig::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo* TcpInterfaceConfig::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME];
+    case ATTRIBUTE_ID_PORT: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT];
+    case ATTRIBUTE_ID_IO_THREADS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS];
+    case ATTRIBUTE_ID_MAX_CONNECTIONS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS];
+    case ATTRIBUTE_ID_LOW_WATERMARK:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK];
+    case ATTRIBUTE_ID_HIGH_WATERMARK:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK];
+    case ATTRIBUTE_ID_NODE_LOW_WATERMARK:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK];
+    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK];
+    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS];
+    case ATTRIBUTE_ID_LISTENERS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LISTENERS];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+TcpInterfaceConfig::TcpInterfaceConfig(bslma::Allocator* basicAllocator)
+: d_lowWatermark()
+, d_highWatermark()
+, d_nodeLowWatermark(DEFAULT_INITIALIZER_NODE_LOW_WATERMARK)
+, d_nodeHighWatermark(DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK)
+, d_listeners(basicAllocator)
+, d_name(basicAllocator)
+, d_port()
+, d_ioThreads()
+, d_maxConnections(DEFAULT_INITIALIZER_MAX_CONNECTIONS)
+, d_heartbeatIntervalMs(DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS)
+{
+}
+
+TcpInterfaceConfig::TcpInterfaceConfig(const TcpInterfaceConfig& original,
+                                       bslma::Allocator* basicAllocator)
+: d_lowWatermark(original.d_lowWatermark)
+, d_highWatermark(original.d_highWatermark)
+, d_nodeLowWatermark(original.d_nodeLowWatermark)
+, d_nodeHighWatermark(original.d_nodeHighWatermark)
+, d_listeners(original.d_listeners, basicAllocator)
+, d_name(original.d_name, basicAllocator)
+, d_port(original.d_port)
+, d_ioThreads(original.d_ioThreads)
+, d_maxConnections(original.d_maxConnections)
+, d_heartbeatIntervalMs(original.d_heartbeatIntervalMs)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+TcpInterfaceConfig::TcpInterfaceConfig(TcpInterfaceConfig&& original) noexcept
+: d_lowWatermark(bsl::move(original.d_lowWatermark)),
+  d_highWatermark(bsl::move(original.d_highWatermark)),
+  d_nodeLowWatermark(bsl::move(original.d_nodeLowWatermark)),
+  d_nodeHighWatermark(bsl::move(original.d_nodeHighWatermark)),
+  d_listeners(bsl::move(original.d_listeners)),
+  d_name(bsl::move(original.d_name)),
+  d_port(bsl::move(original.d_port)),
+  d_ioThreads(bsl::move(original.d_ioThreads)),
+  d_maxConnections(bsl::move(original.d_maxConnections)),
+  d_heartbeatIntervalMs(bsl::move(original.d_heartbeatIntervalMs))
+{
+}
+
+TcpInterfaceConfig::TcpInterfaceConfig(TcpInterfaceConfig&& original,
+                                       bslma::Allocator*    basicAllocator)
+: d_lowWatermark(bsl::move(original.d_lowWatermark))
+, d_highWatermark(bsl::move(original.d_highWatermark))
+, d_nodeLowWatermark(bsl::move(original.d_nodeLowWatermark))
+, d_nodeHighWatermark(bsl::move(original.d_nodeHighWatermark))
+, d_listeners(bsl::move(original.d_listeners), basicAllocator)
+, d_name(bsl::move(original.d_name), basicAllocator)
+, d_port(bsl::move(original.d_port))
+, d_ioThreads(bsl::move(original.d_ioThreads))
+, d_maxConnections(bsl::move(original.d_maxConnections))
+, d_heartbeatIntervalMs(bsl::move(original.d_heartbeatIntervalMs))
+{
+}
+#endif
+
+TcpInterfaceConfig::~TcpInterfaceConfig()
+{
+}
+
+// MANIPULATORS
+
+TcpInterfaceConfig&
+TcpInterfaceConfig::operator=(const TcpInterfaceConfig& rhs)
+{
+    if (this != &rhs) {
+        d_name                = rhs.d_name;
+        d_port                = rhs.d_port;
+        d_ioThreads           = rhs.d_ioThreads;
+        d_maxConnections      = rhs.d_maxConnections;
+        d_lowWatermark        = rhs.d_lowWatermark;
+        d_highWatermark       = rhs.d_highWatermark;
+        d_nodeLowWatermark    = rhs.d_nodeLowWatermark;
+        d_nodeHighWatermark   = rhs.d_nodeHighWatermark;
+        d_heartbeatIntervalMs = rhs.d_heartbeatIntervalMs;
+        d_listeners           = rhs.d_listeners;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+TcpInterfaceConfig& TcpInterfaceConfig::operator=(TcpInterfaceConfig&& rhs)
+{
+    if (this != &rhs) {
+        d_name                = bsl::move(rhs.d_name);
+        d_port                = bsl::move(rhs.d_port);
+        d_ioThreads           = bsl::move(rhs.d_ioThreads);
+        d_maxConnections      = bsl::move(rhs.d_maxConnections);
+        d_lowWatermark        = bsl::move(rhs.d_lowWatermark);
+        d_highWatermark       = bsl::move(rhs.d_highWatermark);
+        d_nodeLowWatermark    = bsl::move(rhs.d_nodeLowWatermark);
+        d_nodeHighWatermark   = bsl::move(rhs.d_nodeHighWatermark);
+        d_heartbeatIntervalMs = bsl::move(rhs.d_heartbeatIntervalMs);
+        d_listeners           = bsl::move(rhs.d_listeners);
+    }
+
+    return *this;
+}
+#endif
+
+void TcpInterfaceConfig::reset()
+{
+    bdlat_ValueTypeFunctions::reset(&d_name);
+    bdlat_ValueTypeFunctions::reset(&d_port);
+    bdlat_ValueTypeFunctions::reset(&d_ioThreads);
+    d_maxConnections = DEFAULT_INITIALIZER_MAX_CONNECTIONS;
+    bdlat_ValueTypeFunctions::reset(&d_lowWatermark);
+    bdlat_ValueTypeFunctions::reset(&d_highWatermark);
+    d_nodeLowWatermark    = DEFAULT_INITIALIZER_NODE_LOW_WATERMARK;
+    d_nodeHighWatermark   = DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK;
+    d_heartbeatIntervalMs = DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS;
+    bdlat_ValueTypeFunctions::reset(&d_listeners);
+}
+
+// ACCESSORS
+
+bsl::ostream& TcpInterfaceConfig::print(bsl::ostream& stream,
+                                        int           level,
+                                        int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("name", this->name());
+    printer.printAttribute("port", this->port());
+    printer.printAttribute("ioThreads", this->ioThreads());
+    printer.printAttribute("maxConnections", this->maxConnections());
+    printer.printAttribute("lowWatermark", this->lowWatermark());
+    printer.printAttribute("highWatermark", this->highWatermark());
+    printer.printAttribute("nodeLowWatermark", this->nodeLowWatermark());
+    printer.printAttribute("nodeHighWatermark", this->nodeHighWatermark());
+    printer.printAttribute("heartbeatIntervalMs", this->heartbeatIntervalMs());
+    printer.printAttribute("listeners", this->listeners());
+    printer.end();
+    return stream;
+}
+
 // -----------------
 // class ClusterNode
 // -----------------
@@ -4021,6 +4036,135 @@ bsl::ostream& DispatcherConfig::print(bsl::ostream& stream,
     printer.printAttribute("sessions", this->sessions());
     printer.printAttribute("queues", this->queues());
     printer.printAttribute("clusters", this->clusters());
+    printer.end();
+    return stream;
+}
+
+// -----------------------
+// class NetworkInterfaces
+// -----------------------
+
+// CONSTANTS
+
+const char NetworkInterfaces::CLASS_NAME[] = "NetworkInterfaces";
+
+const bdlat_AttributeInfo NetworkInterfaces::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_HEARTBEATS,
+     "heartbeats",
+     sizeof("heartbeats") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT},
+    {ATTRIBUTE_ID_TCP_INTERFACE,
+     "tcpInterface",
+     sizeof("tcpInterface") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo*
+NetworkInterfaces::lookupAttributeInfo(const char* name, int nameLength)
+{
+    for (int i = 0; i < 2; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            NetworkInterfaces::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo* NetworkInterfaces::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_HEARTBEATS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS];
+    case ATTRIBUTE_ID_TCP_INTERFACE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+NetworkInterfaces::NetworkInterfaces(bslma::Allocator* basicAllocator)
+: d_tcpInterface(basicAllocator)
+, d_heartbeats()
+{
+}
+
+NetworkInterfaces::NetworkInterfaces(const NetworkInterfaces& original,
+                                     bslma::Allocator*        basicAllocator)
+: d_tcpInterface(original.d_tcpInterface, basicAllocator)
+, d_heartbeats(original.d_heartbeats)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+NetworkInterfaces::NetworkInterfaces(NetworkInterfaces&& original) noexcept
+: d_tcpInterface(bsl::move(original.d_tcpInterface)),
+  d_heartbeats(bsl::move(original.d_heartbeats))
+{
+}
+
+NetworkInterfaces::NetworkInterfaces(NetworkInterfaces&& original,
+                                     bslma::Allocator*   basicAllocator)
+: d_tcpInterface(bsl::move(original.d_tcpInterface), basicAllocator)
+, d_heartbeats(bsl::move(original.d_heartbeats))
+{
+}
+#endif
+
+NetworkInterfaces::~NetworkInterfaces()
+{
+}
+
+// MANIPULATORS
+
+NetworkInterfaces& NetworkInterfaces::operator=(const NetworkInterfaces& rhs)
+{
+    if (this != &rhs) {
+        d_heartbeats   = rhs.d_heartbeats;
+        d_tcpInterface = rhs.d_tcpInterface;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+NetworkInterfaces& NetworkInterfaces::operator=(NetworkInterfaces&& rhs)
+{
+    if (this != &rhs) {
+        d_heartbeats   = bsl::move(rhs.d_heartbeats);
+        d_tcpInterface = bsl::move(rhs.d_tcpInterface);
+    }
+
+    return *this;
+}
+#endif
+
+void NetworkInterfaces::reset()
+{
+    bdlat_ValueTypeFunctions::reset(&d_heartbeats);
+    bdlat_ValueTypeFunctions::reset(&d_tcpInterface);
+}
+
+// ACCESSORS
+
+bsl::ostream& NetworkInterfaces::print(bsl::ostream& stream,
+                                       int           level,
+                                       int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("heartbeats", this->heartbeats());
+    printer.printAttribute("tcpInterface", this->tcpInterface());
     printer.end();
     return stream;
 }
@@ -5823,13 +5967,6 @@ Configuration::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY @BLP_BAS_CODEGEN_VERSION@
+// GENERATED BY BLP_BAS_CODEGEN_2024.07.18
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd
-// ----------------------------------------------------------------------------
-// NOTICE:
-//      Copyright 2024 Bloomberg Finance L.P. All rights reserved.
-//      Property of Bloomberg Finance L.P. (BFLP)
-//      This software is made available solely pursuant to the
-//      terms of a BFLP license agreement which governs its use.
-// ------------------------------- END-OF-FILE --------------------------------

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 // mqbcfg_messages.h             *DO NOT EDIT*             @generated -*-C++-*-
 #ifndef INCLUDED_MQBCFG_MESSAGES
 #define INCLUDED_MQBCFG_MESSAGES
@@ -102,7 +101,7 @@ namespace mqbcfg {
 class TcpClusterNodeConnection;
 }
 namespace mqbcfg {
-class TcpInterfaceConfig;
+class TcpInterfaceListener;
 }
 namespace mqbcfg {
 class VirtualClusterInformation;
@@ -117,19 +116,22 @@ namespace mqbcfg {
 class LogController;
 }
 namespace mqbcfg {
-class NetworkInterfaces;
-}
-namespace mqbcfg {
 class PartitionConfig;
 }
 namespace mqbcfg {
 class StatPluginConfigPrometheus;
 }
 namespace mqbcfg {
+class TcpInterfaceConfig;
+}
+namespace mqbcfg {
 class ClusterNode;
 }
 namespace mqbcfg {
 class DispatcherConfig;
+}
+namespace mqbcfg {
+class NetworkInterfaces;
 }
 namespace mqbcfg {
 class ReversedClusterConnection;
@@ -4020,73 +4022,31 @@ BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
 
 namespace mqbcfg {
 
-// ========================
-// class TcpInterfaceConfig
-// ========================
+// ==========================
+// class TcpInterfaceListener
+// ==========================
 
-class TcpInterfaceConfig {
-    // lowWatermark.........: highWatermark........: Watermarks used for
-    // channels with a client or proxy.  nodeLowWatermark.....:
-    // nodeHighWatermark....: Reduced watermarks for communication between
-    // cluster nodes where BlazingMQ maintains its own cache.
-    // heartbeatIntervalMs..: How often (in milliseconds) to check if the
-    // channel received data, and emit heartbeat.  0 to globally disable.
+class TcpInterfaceListener {
+    // This type describes the information needed for the broker to open a TCP
+    // listener.
+    // name.................: A name to associate this listener to.
+    // port.................: The port this listener will accept connections
+    // on.
 
     // INSTANCE DATA
-    bsls::Types::Int64 d_lowWatermark;
-    bsls::Types::Int64 d_highWatermark;
-    bsls::Types::Int64 d_nodeLowWatermark;
-    bsls::Types::Int64 d_nodeHighWatermark;
-    bsl::string        d_name;
-    int                d_port;
-    int                d_ioThreads;
-    int                d_maxConnections;
-    int                d_heartbeatIntervalMs;
-
-    // PRIVATE ACCESSORS
-    template <typename t_HASH_ALGORITHM>
-    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
-
-    bool isEqualTo(const TcpInterfaceConfig& rhs) const;
+    bsl::string d_name;
+    int         d_port;
 
   public:
     // TYPES
-    enum {
-        ATTRIBUTE_ID_NAME                  = 0,
-        ATTRIBUTE_ID_PORT                  = 1,
-        ATTRIBUTE_ID_IO_THREADS            = 2,
-        ATTRIBUTE_ID_MAX_CONNECTIONS       = 3,
-        ATTRIBUTE_ID_LOW_WATERMARK         = 4,
-        ATTRIBUTE_ID_HIGH_WATERMARK        = 5,
-        ATTRIBUTE_ID_NODE_LOW_WATERMARK    = 6,
-        ATTRIBUTE_ID_NODE_HIGH_WATERMARK   = 7,
-        ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS = 8
-    };
+    enum { ATTRIBUTE_ID_NAME = 0, ATTRIBUTE_ID_PORT = 1 };
 
-    enum { NUM_ATTRIBUTES = 9 };
+    enum { NUM_ATTRIBUTES = 2 };
 
-    enum {
-        ATTRIBUTE_INDEX_NAME                  = 0,
-        ATTRIBUTE_INDEX_PORT                  = 1,
-        ATTRIBUTE_INDEX_IO_THREADS            = 2,
-        ATTRIBUTE_INDEX_MAX_CONNECTIONS       = 3,
-        ATTRIBUTE_INDEX_LOW_WATERMARK         = 4,
-        ATTRIBUTE_INDEX_HIGH_WATERMARK        = 5,
-        ATTRIBUTE_INDEX_NODE_LOW_WATERMARK    = 6,
-        ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK   = 7,
-        ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS = 8
-    };
+    enum { ATTRIBUTE_INDEX_NAME = 0, ATTRIBUTE_INDEX_PORT = 1 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
-
-    static const int DEFAULT_INITIALIZER_MAX_CONNECTIONS;
-
-    static const bsls::Types::Int64 DEFAULT_INITIALIZER_NODE_LOW_WATERMARK;
-
-    static const bsls::Types::Int64 DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK;
-
-    static const int DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS;
 
     static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
 
@@ -4103,29 +4063,29 @@ class TcpInterfaceConfig {
     // exists, and 0 otherwise.
 
     // CREATORS
-    explicit TcpInterfaceConfig(bslma::Allocator* basicAllocator = 0);
-    // Create an object of type 'TcpInterfaceConfig' having the default
+    explicit TcpInterfaceListener(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'TcpInterfaceListener' having the default
     // value.  Use the optionally specified 'basicAllocator' to supply
     // memory.  If 'basicAllocator' is 0, the currently installed default
     // allocator is used.
 
-    TcpInterfaceConfig(const TcpInterfaceConfig& original,
-                       bslma::Allocator*         basicAllocator = 0);
-    // Create an object of type 'TcpInterfaceConfig' having the value of
+    TcpInterfaceListener(const TcpInterfaceListener& original,
+                         bslma::Allocator*           basicAllocator = 0);
+    // Create an object of type 'TcpInterfaceListener' having the value of
     // the specified 'original' object.  Use the optionally specified
     // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
     // currently installed default allocator is used.
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    TcpInterfaceConfig(TcpInterfaceConfig&& original) noexcept;
-    // Create an object of type 'TcpInterfaceConfig' having the value of
+    TcpInterfaceListener(TcpInterfaceListener&& original) noexcept;
+    // Create an object of type 'TcpInterfaceListener' having the value of
     // the specified 'original' object.  After performing this action, the
     // 'original' object will be left in a valid, but unspecified state.
 
-    TcpInterfaceConfig(TcpInterfaceConfig&& original,
-                       bslma::Allocator*    basicAllocator);
-    // Create an object of type 'TcpInterfaceConfig' having the value of
+    TcpInterfaceListener(TcpInterfaceListener&& original,
+                         bslma::Allocator*      basicAllocator);
+    // Create an object of type 'TcpInterfaceListener' having the value of
     // the specified 'original' object.  After performing this action, the
     // 'original' object will be left in a valid, but unspecified state.
     // Use the optionally specified 'basicAllocator' to supply memory.  If
@@ -4133,16 +4093,16 @@ class TcpInterfaceConfig {
     // used.
 #endif
 
-    ~TcpInterfaceConfig();
+    ~TcpInterfaceListener();
     // Destroy this object.
 
     // MANIPULATORS
-    TcpInterfaceConfig& operator=(const TcpInterfaceConfig& rhs);
+    TcpInterfaceListener& operator=(const TcpInterfaceListener& rhs);
     // Assign to this object the value of the specified 'rhs' object.
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    TcpInterfaceConfig& operator=(TcpInterfaceConfig&& rhs);
+    TcpInterfaceListener& operator=(TcpInterfaceListener&& rhs);
     // Assign to this object the value of the specified 'rhs' object.
     // After performing this action, the 'rhs' object will be left in a
     // valid, but unspecified state.
@@ -4188,34 +4148,6 @@ class TcpInterfaceConfig {
     int& port();
     // Return a reference to the modifiable "Port" attribute of this
     // object.
-
-    int& ioThreads();
-    // Return a reference to the modifiable "IoThreads" attribute of this
-    // object.
-
-    int& maxConnections();
-    // Return a reference to the modifiable "MaxConnections" attribute of
-    // this object.
-
-    bsls::Types::Int64& lowWatermark();
-    // Return a reference to the modifiable "LowWatermark" attribute of
-    // this object.
-
-    bsls::Types::Int64& highWatermark();
-    // Return a reference to the modifiable "HighWatermark" attribute of
-    // this object.
-
-    bsls::Types::Int64& nodeLowWatermark();
-    // Return a reference to the modifiable "NodeLowWatermark" attribute of
-    // this object.
-
-    bsls::Types::Int64& nodeHighWatermark();
-    // Return a reference to the modifiable "NodeHighWatermark" attribute
-    // of this object.
-
-    int& heartbeatIntervalMs();
-    // Return a reference to the modifiable "HeartbeatIntervalMs" attribute
-    // of this object.
 
     // ACCESSORS
     bsl::ostream&
@@ -4267,48 +4199,25 @@ class TcpInterfaceConfig {
     int port() const;
     // Return the value of the "Port" attribute of this object.
 
-    int ioThreads() const;
-    // Return the value of the "IoThreads" attribute of this object.
-
-    int maxConnections() const;
-    // Return the value of the "MaxConnections" attribute of this object.
-
-    bsls::Types::Int64 lowWatermark() const;
-    // Return the value of the "LowWatermark" attribute of this object.
-
-    bsls::Types::Int64 highWatermark() const;
-    // Return the value of the "HighWatermark" attribute of this object.
-
-    bsls::Types::Int64 nodeLowWatermark() const;
-    // Return the value of the "NodeLowWatermark" attribute of this object.
-
-    bsls::Types::Int64 nodeHighWatermark() const;
-    // Return the value of the "NodeHighWatermark" attribute of this
-    // object.
-
-    int heartbeatIntervalMs() const;
-    // Return the value of the "HeartbeatIntervalMs" attribute of this
-    // object.
-
     // HIDDEN FRIENDS
-    friend bool operator==(const TcpInterfaceConfig& lhs,
-                           const TcpInterfaceConfig& rhs)
+    friend bool operator==(const TcpInterfaceListener& lhs,
+                           const TcpInterfaceListener& rhs)
     // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.isEqualTo(rhs);
+        return lhs.name() == rhs.name() && lhs.port() == rhs.port();
     }
 
-    friend bool operator!=(const TcpInterfaceConfig& lhs,
-                           const TcpInterfaceConfig& rhs)
+    friend bool operator!=(const TcpInterfaceListener& lhs,
+                           const TcpInterfaceListener& rhs)
     // Returns '!(lhs == rhs)'
     {
         return !(lhs == rhs);
     }
 
-    friend bsl::ostream& operator<<(bsl::ostream&             stream,
-                                    const TcpInterfaceConfig& rhs)
+    friend bsl::ostream& operator<<(bsl::ostream&               stream,
+                                    const TcpInterfaceListener& rhs)
     // Format the specified 'rhs' to the specified output 'stream' and
     // return a reference to the modifiable 'stream'.
     {
@@ -4316,14 +4225,16 @@ class TcpInterfaceConfig {
     }
 
     template <typename t_HASH_ALGORITHM>
-    friend void hashAppend(t_HASH_ALGORITHM&         hashAlg,
-                           const TcpInterfaceConfig& object)
+    friend void hashAppend(t_HASH_ALGORITHM&           hashAlg,
+                           const TcpInterfaceListener& object)
     // Pass the specified 'object' to the specified 'hashAlg'.  This
     // function integrates with the 'bslh' modular hashing system and
     // effectively provides a 'bsl::hash' specialization for
-    // 'TcpInterfaceConfig'.
+    // 'TcpInterfaceListener'.
     {
-        object.hashAppendImpl(hashAlg);
+        using bslh::hashAppend;
+        hashAppend(hashAlg, object.name());
+        hashAppend(hashAlg, object.port());
     }
 };
 
@@ -4332,7 +4243,7 @@ class TcpInterfaceConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::TcpInterfaceConfig)
+    mqbcfg::TcpInterfaceListener)
 
 namespace mqbcfg {
 
@@ -5286,227 +5197,6 @@ BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
 
 namespace mqbcfg {
 
-// =======================
-// class NetworkInterfaces
-// =======================
-
-class NetworkInterfaces {
-    // INSTANCE DATA
-    bdlb::NullableValue<TcpInterfaceConfig> d_tcpInterface;
-    Heartbeat                               d_heartbeats;
-
-  public:
-    // TYPES
-    enum { ATTRIBUTE_ID_HEARTBEATS = 0, ATTRIBUTE_ID_TCP_INTERFACE = 1 };
-
-    enum { NUM_ATTRIBUTES = 2 };
-
-    enum { ATTRIBUTE_INDEX_HEARTBEATS = 0, ATTRIBUTE_INDEX_TCP_INTERFACE = 1 };
-
-    // CONSTANTS
-    static const char CLASS_NAME[];
-
-    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
-
-  public:
-    // CLASS METHODS
-    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
-    // Return attribute information for the attribute indicated by the
-    // specified 'id' if the attribute exists, and 0 otherwise.
-
-    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
-                                                          int nameLength);
-    // Return attribute information for the attribute indicated by the
-    // specified 'name' of the specified 'nameLength' if the attribute
-    // exists, and 0 otherwise.
-
-    // CREATORS
-    explicit NetworkInterfaces(bslma::Allocator* basicAllocator = 0);
-    // Create an object of type 'NetworkInterfaces' having the default
-    // value.  Use the optionally specified 'basicAllocator' to supply
-    // memory.  If 'basicAllocator' is 0, the currently installed default
-    // allocator is used.
-
-    NetworkInterfaces(const NetworkInterfaces& original,
-                      bslma::Allocator*        basicAllocator = 0);
-    // Create an object of type 'NetworkInterfaces' having the value of the
-    // specified 'original' object.  Use the optionally specified
-    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
-    // currently installed default allocator is used.
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    NetworkInterfaces(NetworkInterfaces&& original) noexcept;
-    // Create an object of type 'NetworkInterfaces' having the value of the
-    // specified 'original' object.  After performing this action, the
-    // 'original' object will be left in a valid, but unspecified state.
-
-    NetworkInterfaces(NetworkInterfaces&& original,
-                      bslma::Allocator*   basicAllocator);
-    // Create an object of type 'NetworkInterfaces' having the value of the
-    // specified 'original' object.  After performing this action, the
-    // 'original' object will be left in a valid, but unspecified state.
-    // Use the optionally specified 'basicAllocator' to supply memory.  If
-    // 'basicAllocator' is 0, the currently installed default allocator is
-    // used.
-#endif
-
-    ~NetworkInterfaces();
-    // Destroy this object.
-
-    // MANIPULATORS
-    NetworkInterfaces& operator=(const NetworkInterfaces& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    NetworkInterfaces& operator=(NetworkInterfaces&& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-    // After performing this action, the 'rhs' object will be left in a
-    // valid, but unspecified state.
-#endif
-
-    void reset();
-    // Reset this object to the default value (i.e., its value upon
-    // default construction).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttributes(t_MANIPULATOR& manipulator);
-    // Invoke the specified 'manipulator' sequentially on the address of
-    // each (modifiable) attribute of this object, supplying 'manipulator'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'manipulator' (i.e., the invocation that
-    // terminated the sequence).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'id',
-    // supplying 'manipulator' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'manipulator' if 'id' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator,
-                            const char*    name,
-                            int            nameLength);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'name' of the
-    // specified 'nameLength', supplying 'manipulator' with the
-    // corresponding attribute information structure.  Return the value
-    // returned from the invocation of 'manipulator' if 'name' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    Heartbeat& heartbeats();
-    // Return a reference to the modifiable "Heartbeats" attribute of this
-    // object.
-
-    bdlb::NullableValue<TcpInterfaceConfig>& tcpInterface();
-    // Return a reference to the modifiable "TcpInterface" attribute of
-    // this object.
-
-    // ACCESSORS
-    bsl::ostream&
-    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
-    // Format this object to the specified output 'stream' at the
-    // optionally specified indentation 'level' and return a reference to
-    // the modifiable 'stream'.  If 'level' is specified, optionally
-    // specify 'spacesPerLevel', the number of spaces per indentation level
-    // for this and all of its nested objects.  Each line is indented by
-    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    // negative, suppress indentation of the first line.  If
-    // 'spacesPerLevel' is negative, suppress line breaks and format the
-    // entire output on one line.  If 'stream' is initially invalid, this
-    // operation has no effect.  Note that a trailing newline is provided
-    // in multiline mode only.
-
-    template <typename t_ACCESSOR>
-    int accessAttributes(t_ACCESSOR& accessor) const;
-    // Invoke the specified 'accessor' sequentially on each
-    // (non-modifiable) attribute of this object, supplying 'accessor'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'accessor' (i.e., the invocation that terminated
-    // the sequence).
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor, int id) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'id', supplying 'accessor'
-    // with the corresponding attribute information structure.  Return the
-    // value returned from the invocation of 'accessor' if 'id' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor,
-                        const char* name,
-                        int         nameLength) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'name' of the specified
-    // 'nameLength', supplying 'accessor' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'accessor' if 'name' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    const Heartbeat& heartbeats() const;
-    // Return a reference offering non-modifiable access to the
-    // "Heartbeats" attribute of this object.
-
-    const bdlb::NullableValue<TcpInterfaceConfig>& tcpInterface() const;
-    // Return a reference offering non-modifiable access to the
-    // "TcpInterface" attribute of this object.
-
-    // HIDDEN FRIENDS
-    friend bool operator==(const NetworkInterfaces& lhs,
-                           const NetworkInterfaces& rhs)
-    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
-    // have the same value, and 'false' otherwise.  Two attribute objects
-    // have the same value if each respective attribute has the same value.
-    {
-        return lhs.heartbeats() == rhs.heartbeats() &&
-               lhs.tcpInterface() == rhs.tcpInterface();
-    }
-
-    friend bool operator!=(const NetworkInterfaces& lhs,
-                           const NetworkInterfaces& rhs)
-    // Returns '!(lhs == rhs)'
-    {
-        return !(lhs == rhs);
-    }
-
-    friend bsl::ostream& operator<<(bsl::ostream&            stream,
-                                    const NetworkInterfaces& rhs)
-    // Format the specified 'rhs' to the specified output 'stream' and
-    // return a reference to the modifiable 'stream'.
-    {
-        return rhs.print(stream, 0, -1);
-    }
-
-    template <typename t_HASH_ALGORITHM>
-    friend void hashAppend(t_HASH_ALGORITHM&        hashAlg,
-                           const NetworkInterfaces& object)
-    // Pass the specified 'object' to the specified 'hashAlg'.  This
-    // function integrates with the 'bslh' modular hashing system and
-    // effectively provides a 'bsl::hash' specialization for
-    // 'NetworkInterfaces'.
-    {
-        using bslh::hashAppend;
-        hashAppend(hashAlg, object.heartbeats());
-        hashAppend(hashAlg, object.tcpInterface());
-    }
-};
-
-}  // close package namespace
-
-// TRAITS
-
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::NetworkInterfaces)
-
-namespace mqbcfg {
-
 // =====================
 // class PartitionConfig
 // =====================
@@ -6098,6 +5788,338 @@ BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
 
 namespace mqbcfg {
 
+// ========================
+// class TcpInterfaceConfig
+// ========================
+
+class TcpInterfaceConfig {
+    // name.................: The name of the TCP session manager.
+    // port.................: (Deprecated) The port to receive connections.
+    // lowWatermark.........: highWatermark........: Watermarks used for
+    // channels with a client or proxy.  nodeLowWatermark.....:
+    // nodeHighWatermark....: Reduced watermarks for communication between
+    // cluster nodes where BlazingMQ maintains its own cache.
+    // heartbeatIntervalMs..: How often (in milliseconds) to check if the
+    // channel received data, and emit heartbeat.  0 to globally disable.
+    // listeners: A list of listener interfaces to receive TCP connections
+    // from.  When non-empty this option overrides the listener specified by
+    // port.
+
+    // INSTANCE DATA
+    bsls::Types::Int64                d_lowWatermark;
+    bsls::Types::Int64                d_highWatermark;
+    bsls::Types::Int64                d_nodeLowWatermark;
+    bsls::Types::Int64                d_nodeHighWatermark;
+    bsl::vector<TcpInterfaceListener> d_listeners;
+    bsl::string                       d_name;
+    int                               d_port;
+    int                               d_ioThreads;
+    int                               d_maxConnections;
+    int                               d_heartbeatIntervalMs;
+
+    // PRIVATE ACCESSORS
+    template <typename t_HASH_ALGORITHM>
+    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
+
+    bool isEqualTo(const TcpInterfaceConfig& rhs) const;
+
+  public:
+    // TYPES
+    enum {
+        ATTRIBUTE_ID_NAME                  = 0,
+        ATTRIBUTE_ID_PORT                  = 1,
+        ATTRIBUTE_ID_IO_THREADS            = 2,
+        ATTRIBUTE_ID_MAX_CONNECTIONS       = 3,
+        ATTRIBUTE_ID_LOW_WATERMARK         = 4,
+        ATTRIBUTE_ID_HIGH_WATERMARK        = 5,
+        ATTRIBUTE_ID_NODE_LOW_WATERMARK    = 6,
+        ATTRIBUTE_ID_NODE_HIGH_WATERMARK   = 7,
+        ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS = 8,
+        ATTRIBUTE_ID_LISTENERS             = 9
+    };
+
+    enum { NUM_ATTRIBUTES = 10 };
+
+    enum {
+        ATTRIBUTE_INDEX_NAME                  = 0,
+        ATTRIBUTE_INDEX_PORT                  = 1,
+        ATTRIBUTE_INDEX_IO_THREADS            = 2,
+        ATTRIBUTE_INDEX_MAX_CONNECTIONS       = 3,
+        ATTRIBUTE_INDEX_LOW_WATERMARK         = 4,
+        ATTRIBUTE_INDEX_HIGH_WATERMARK        = 5,
+        ATTRIBUTE_INDEX_NODE_LOW_WATERMARK    = 6,
+        ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK   = 7,
+        ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS = 8,
+        ATTRIBUTE_INDEX_LISTENERS             = 9
+    };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const int DEFAULT_INITIALIZER_MAX_CONNECTIONS;
+
+    static const bsls::Types::Int64 DEFAULT_INITIALIZER_NODE_LOW_WATERMARK;
+
+    static const bsls::Types::Int64 DEFAULT_INITIALIZER_NODE_HIGH_WATERMARK;
+
+    static const int DEFAULT_INITIALIZER_HEARTBEAT_INTERVAL_MS;
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit TcpInterfaceConfig(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'TcpInterfaceConfig' having the default
+    // value.  Use the optionally specified 'basicAllocator' to supply
+    // memory.  If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+
+    TcpInterfaceConfig(const TcpInterfaceConfig& original,
+                       bslma::Allocator*         basicAllocator = 0);
+    // Create an object of type 'TcpInterfaceConfig' having the value of
+    // the specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    TcpInterfaceConfig(TcpInterfaceConfig&& original) noexcept;
+    // Create an object of type 'TcpInterfaceConfig' having the value of
+    // the specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+
+    TcpInterfaceConfig(TcpInterfaceConfig&& original,
+                       bslma::Allocator*    basicAllocator);
+    // Create an object of type 'TcpInterfaceConfig' having the value of
+    // the specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+    // Use the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+#endif
+
+    ~TcpInterfaceConfig();
+    // Destroy this object.
+
+    // MANIPULATORS
+    TcpInterfaceConfig& operator=(const TcpInterfaceConfig& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    TcpInterfaceConfig& operator=(TcpInterfaceConfig&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    bsl::string& name();
+    // Return a reference to the modifiable "Name" attribute of this
+    // object.
+
+    int& port();
+    // Return a reference to the modifiable "Port" attribute of this
+    // object.
+
+    int& ioThreads();
+    // Return a reference to the modifiable "IoThreads" attribute of this
+    // object.
+
+    int& maxConnections();
+    // Return a reference to the modifiable "MaxConnections" attribute of
+    // this object.
+
+    bsls::Types::Int64& lowWatermark();
+    // Return a reference to the modifiable "LowWatermark" attribute of
+    // this object.
+
+    bsls::Types::Int64& highWatermark();
+    // Return a reference to the modifiable "HighWatermark" attribute of
+    // this object.
+
+    bsls::Types::Int64& nodeLowWatermark();
+    // Return a reference to the modifiable "NodeLowWatermark" attribute of
+    // this object.
+
+    bsls::Types::Int64& nodeHighWatermark();
+    // Return a reference to the modifiable "NodeHighWatermark" attribute
+    // of this object.
+
+    int& heartbeatIntervalMs();
+    // Return a reference to the modifiable "HeartbeatIntervalMs" attribute
+    // of this object.
+
+    bsl::vector<TcpInterfaceListener>& listeners();
+    // Return a reference to the modifiable "Listeners" attribute of this
+    // object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    const bsl::string& name() const;
+    // Return a reference offering non-modifiable access to the "Name"
+    // attribute of this object.
+
+    int port() const;
+    // Return the value of the "Port" attribute of this object.
+
+    int ioThreads() const;
+    // Return the value of the "IoThreads" attribute of this object.
+
+    int maxConnections() const;
+    // Return the value of the "MaxConnections" attribute of this object.
+
+    bsls::Types::Int64 lowWatermark() const;
+    // Return the value of the "LowWatermark" attribute of this object.
+
+    bsls::Types::Int64 highWatermark() const;
+    // Return the value of the "HighWatermark" attribute of this object.
+
+    bsls::Types::Int64 nodeLowWatermark() const;
+    // Return the value of the "NodeLowWatermark" attribute of this object.
+
+    bsls::Types::Int64 nodeHighWatermark() const;
+    // Return the value of the "NodeHighWatermark" attribute of this
+    // object.
+
+    int heartbeatIntervalMs() const;
+    // Return the value of the "HeartbeatIntervalMs" attribute of this
+    // object.
+
+    const bsl::vector<TcpInterfaceListener>& listeners() const;
+    // Return a reference offering non-modifiable access to the "Listeners"
+    // attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const TcpInterfaceConfig& lhs,
+                           const TcpInterfaceConfig& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.isEqualTo(rhs);
+    }
+
+    friend bool operator!=(const TcpInterfaceConfig& lhs,
+                           const TcpInterfaceConfig& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream&             stream,
+                                    const TcpInterfaceConfig& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM&         hashAlg,
+                           const TcpInterfaceConfig& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for
+    // 'TcpInterfaceConfig'.
+    {
+        object.hashAppendImpl(hashAlg);
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    mqbcfg::TcpInterfaceConfig)
+
+namespace mqbcfg {
+
 // =================
 // class ClusterNode
 // =================
@@ -6546,6 +6568,227 @@ class DispatcherConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::DispatcherConfig)
+
+namespace mqbcfg {
+
+// =======================
+// class NetworkInterfaces
+// =======================
+
+class NetworkInterfaces {
+    // INSTANCE DATA
+    bdlb::NullableValue<TcpInterfaceConfig> d_tcpInterface;
+    Heartbeat                               d_heartbeats;
+
+  public:
+    // TYPES
+    enum { ATTRIBUTE_ID_HEARTBEATS = 0, ATTRIBUTE_ID_TCP_INTERFACE = 1 };
+
+    enum { NUM_ATTRIBUTES = 2 };
+
+    enum { ATTRIBUTE_INDEX_HEARTBEATS = 0, ATTRIBUTE_INDEX_TCP_INTERFACE = 1 };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit NetworkInterfaces(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'NetworkInterfaces' having the default
+    // value.  Use the optionally specified 'basicAllocator' to supply
+    // memory.  If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+
+    NetworkInterfaces(const NetworkInterfaces& original,
+                      bslma::Allocator*        basicAllocator = 0);
+    // Create an object of type 'NetworkInterfaces' having the value of the
+    // specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    NetworkInterfaces(NetworkInterfaces&& original) noexcept;
+    // Create an object of type 'NetworkInterfaces' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+
+    NetworkInterfaces(NetworkInterfaces&& original,
+                      bslma::Allocator*   basicAllocator);
+    // Create an object of type 'NetworkInterfaces' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+    // Use the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+#endif
+
+    ~NetworkInterfaces();
+    // Destroy this object.
+
+    // MANIPULATORS
+    NetworkInterfaces& operator=(const NetworkInterfaces& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    NetworkInterfaces& operator=(NetworkInterfaces&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    Heartbeat& heartbeats();
+    // Return a reference to the modifiable "Heartbeats" attribute of this
+    // object.
+
+    bdlb::NullableValue<TcpInterfaceConfig>& tcpInterface();
+    // Return a reference to the modifiable "TcpInterface" attribute of
+    // this object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    const Heartbeat& heartbeats() const;
+    // Return a reference offering non-modifiable access to the
+    // "Heartbeats" attribute of this object.
+
+    const bdlb::NullableValue<TcpInterfaceConfig>& tcpInterface() const;
+    // Return a reference offering non-modifiable access to the
+    // "TcpInterface" attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const NetworkInterfaces& lhs,
+                           const NetworkInterfaces& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.heartbeats() == rhs.heartbeats() &&
+               lhs.tcpInterface() == rhs.tcpInterface();
+    }
+
+    friend bool operator!=(const NetworkInterfaces& lhs,
+                           const NetworkInterfaces& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream&            stream,
+                                    const NetworkInterfaces& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM&        hashAlg,
+                           const NetworkInterfaces& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for
+    // 'NetworkInterfaces'.
+    {
+        using bslh::hashAppend;
+        hashAppend(hashAlg, object.heartbeats());
+        hashAppend(hashAlg, object.tcpInterface());
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    mqbcfg::NetworkInterfaces)
 
 namespace mqbcfg {
 
@@ -12717,42 +12960,14 @@ inline const bsl::string& TcpClusterNodeConnection::endpoint() const
     return d_endpoint;
 }
 
-// ------------------------
-// class TcpInterfaceConfig
-// ------------------------
-
-// PRIVATE ACCESSORS
-template <typename t_HASH_ALGORITHM>
-void TcpInterfaceConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
-{
-    using bslh::hashAppend;
-    hashAppend(hashAlgorithm, this->name());
-    hashAppend(hashAlgorithm, this->port());
-    hashAppend(hashAlgorithm, this->ioThreads());
-    hashAppend(hashAlgorithm, this->maxConnections());
-    hashAppend(hashAlgorithm, this->lowWatermark());
-    hashAppend(hashAlgorithm, this->highWatermark());
-    hashAppend(hashAlgorithm, this->nodeLowWatermark());
-    hashAppend(hashAlgorithm, this->nodeHighWatermark());
-    hashAppend(hashAlgorithm, this->heartbeatIntervalMs());
-}
-
-inline bool TcpInterfaceConfig::isEqualTo(const TcpInterfaceConfig& rhs) const
-{
-    return this->name() == rhs.name() && this->port() == rhs.port() &&
-           this->ioThreads() == rhs.ioThreads() &&
-           this->maxConnections() == rhs.maxConnections() &&
-           this->lowWatermark() == rhs.lowWatermark() &&
-           this->highWatermark() == rhs.highWatermark() &&
-           this->nodeLowWatermark() == rhs.nodeLowWatermark() &&
-           this->nodeHighWatermark() == rhs.nodeHighWatermark() &&
-           this->heartbeatIntervalMs() == rhs.heartbeatIntervalMs();
-}
+// --------------------------
+// class TcpInterfaceListener
+// --------------------------
 
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int TcpInterfaceConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+int TcpInterfaceListener::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
     int ret;
 
@@ -12766,56 +12981,12 @@ int TcpInterfaceConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
-    ret = manipulator(&d_ioThreads,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_maxConnections,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_lowWatermark,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_highWatermark,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(
-        &d_nodeLowWatermark,
-        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(
-        &d_nodeHighWatermark,
-        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(
-        &d_heartbeatIntervalMs,
-        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
-    if (ret) {
-        return ret;
-    }
-
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+int TcpInterfaceListener::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                              int            id)
 {
     enum { NOT_FOUND = -1 };
 
@@ -12828,48 +12999,14 @@ int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
         return manipulator(&d_port,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
     }
-    case ATTRIBUTE_ID_IO_THREADS: {
-        return manipulator(&d_ioThreads,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
-    }
-    case ATTRIBUTE_ID_MAX_CONNECTIONS: {
-        return manipulator(
-            &d_maxConnections,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
-    }
-    case ATTRIBUTE_ID_LOW_WATERMARK: {
-        return manipulator(
-            &d_lowWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_HIGH_WATERMARK: {
-        return manipulator(
-            &d_highWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_NODE_LOW_WATERMARK: {
-        return manipulator(
-            &d_nodeLowWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK: {
-        return manipulator(
-            &d_nodeHighWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS: {
-        return manipulator(
-            &d_heartbeatIntervalMs,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
-    }
     default: return NOT_FOUND;
     }
 }
 
 template <typename t_MANIPULATOR>
-int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                            const char*    name,
-                                            int            nameLength)
+int TcpInterfaceListener::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                              const char*    name,
+                                              int            nameLength)
 {
     enum { NOT_FOUND = -1 };
 
@@ -12882,54 +13019,19 @@ int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
     return manipulateAttribute(manipulator, attributeInfo->d_id);
 }
 
-inline bsl::string& TcpInterfaceConfig::name()
+inline bsl::string& TcpInterfaceListener::name()
 {
     return d_name;
 }
 
-inline int& TcpInterfaceConfig::port()
+inline int& TcpInterfaceListener::port()
 {
     return d_port;
 }
 
-inline int& TcpInterfaceConfig::ioThreads()
-{
-    return d_ioThreads;
-}
-
-inline int& TcpInterfaceConfig::maxConnections()
-{
-    return d_maxConnections;
-}
-
-inline bsls::Types::Int64& TcpInterfaceConfig::lowWatermark()
-{
-    return d_lowWatermark;
-}
-
-inline bsls::Types::Int64& TcpInterfaceConfig::highWatermark()
-{
-    return d_highWatermark;
-}
-
-inline bsls::Types::Int64& TcpInterfaceConfig::nodeLowWatermark()
-{
-    return d_nodeLowWatermark;
-}
-
-inline bsls::Types::Int64& TcpInterfaceConfig::nodeHighWatermark()
-{
-    return d_nodeHighWatermark;
-}
-
-inline int& TcpInterfaceConfig::heartbeatIntervalMs()
-{
-    return d_heartbeatIntervalMs;
-}
-
 // ACCESSORS
 template <typename t_ACCESSOR>
-int TcpInterfaceConfig::accessAttributes(t_ACCESSOR& accessor) const
+int TcpInterfaceListener::accessAttributes(t_ACCESSOR& accessor) const
 {
     int ret;
 
@@ -12943,54 +13045,11 @@ int TcpInterfaceConfig::accessAttributes(t_ACCESSOR& accessor) const
         return ret;
     }
 
-    ret = accessor(d_ioThreads,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_maxConnections,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_lowWatermark,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_highWatermark,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_nodeLowWatermark,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_nodeHighWatermark,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(
-        d_heartbeatIntervalMs,
-        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
-    if (ret) {
-        return ret;
-    }
-
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
+int TcpInterfaceListener::accessAttribute(t_ACCESSOR& accessor, int id) const
 {
     enum { NOT_FOUND = -1 };
 
@@ -13001,45 +13060,14 @@ int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PORT: {
         return accessor(d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
     }
-    case ATTRIBUTE_ID_IO_THREADS: {
-        return accessor(d_ioThreads,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
-    }
-    case ATTRIBUTE_ID_MAX_CONNECTIONS: {
-        return accessor(d_maxConnections,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
-    }
-    case ATTRIBUTE_ID_LOW_WATERMARK: {
-        return accessor(d_lowWatermark,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_HIGH_WATERMARK: {
-        return accessor(d_highWatermark,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_NODE_LOW_WATERMARK: {
-        return accessor(
-            d_nodeLowWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK: {
-        return accessor(
-            d_nodeHighWatermark,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
-    }
-    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS: {
-        return accessor(
-            d_heartbeatIntervalMs,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
-    }
     default: return NOT_FOUND;
     }
 }
 
 template <typename t_ACCESSOR>
-int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor,
-                                        const char* name,
-                                        int         nameLength) const
+int TcpInterfaceListener::accessAttribute(t_ACCESSOR& accessor,
+                                          const char* name,
+                                          int         nameLength) const
 {
     enum { NOT_FOUND = -1 };
 
@@ -13052,49 +13080,14 @@ int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor,
     return accessAttribute(accessor, attributeInfo->d_id);
 }
 
-inline const bsl::string& TcpInterfaceConfig::name() const
+inline const bsl::string& TcpInterfaceListener::name() const
 {
     return d_name;
 }
 
-inline int TcpInterfaceConfig::port() const
+inline int TcpInterfaceListener::port() const
 {
     return d_port;
-}
-
-inline int TcpInterfaceConfig::ioThreads() const
-{
-    return d_ioThreads;
-}
-
-inline int TcpInterfaceConfig::maxConnections() const
-{
-    return d_maxConnections;
-}
-
-inline bsls::Types::Int64 TcpInterfaceConfig::lowWatermark() const
-{
-    return d_lowWatermark;
-}
-
-inline bsls::Types::Int64 TcpInterfaceConfig::highWatermark() const
-{
-    return d_highWatermark;
-}
-
-inline bsls::Types::Int64 TcpInterfaceConfig::nodeLowWatermark() const
-{
-    return d_nodeLowWatermark;
-}
-
-inline bsls::Types::Int64 TcpInterfaceConfig::nodeHighWatermark() const
-{
-    return d_nodeHighWatermark;
-}
-
-inline int TcpInterfaceConfig::heartbeatIntervalMs() const
-{
-    return d_heartbeatIntervalMs;
 }
 
 // -------------------------------
@@ -13899,144 +13892,6 @@ inline const SyslogConfig& LogController::syslog() const
     return d_syslog;
 }
 
-// -----------------------
-// class NetworkInterfaces
-// -----------------------
-
-// CLASS METHODS
-// MANIPULATORS
-template <typename t_MANIPULATOR>
-int NetworkInterfaces::manipulateAttributes(t_MANIPULATOR& manipulator)
-{
-    int ret;
-
-    ret = manipulator(&d_heartbeats,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_tcpInterface,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
-}
-
-template <typename t_MANIPULATOR>
-int NetworkInterfaces::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
-{
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_HEARTBEATS: {
-        return manipulator(&d_heartbeats,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
-    }
-    case ATTRIBUTE_ID_TCP_INTERFACE: {
-        return manipulator(
-            &d_tcpInterface,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_MANIPULATOR>
-int NetworkInterfaces::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                           const char*    name,
-                                           int            nameLength)
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return manipulateAttribute(manipulator, attributeInfo->d_id);
-}
-
-inline Heartbeat& NetworkInterfaces::heartbeats()
-{
-    return d_heartbeats;
-}
-
-inline bdlb::NullableValue<TcpInterfaceConfig>&
-NetworkInterfaces::tcpInterface()
-{
-    return d_tcpInterface;
-}
-
-// ACCESSORS
-template <typename t_ACCESSOR>
-int NetworkInterfaces::accessAttributes(t_ACCESSOR& accessor) const
-{
-    int ret;
-
-    ret = accessor(d_heartbeats,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_tcpInterface,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
-}
-
-template <typename t_ACCESSOR>
-int NetworkInterfaces::accessAttribute(t_ACCESSOR& accessor, int id) const
-{
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_HEARTBEATS: {
-        return accessor(d_heartbeats,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
-    }
-    case ATTRIBUTE_ID_TCP_INTERFACE: {
-        return accessor(d_tcpInterface,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_ACCESSOR>
-int NetworkInterfaces::accessAttribute(t_ACCESSOR& accessor,
-                                       const char* name,
-                                       int         nameLength) const
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return accessAttribute(accessor, attributeInfo->d_id);
-}
-
-inline const Heartbeat& NetworkInterfaces::heartbeats() const
-{
-    return d_heartbeats;
-}
-
-inline const bdlb::NullableValue<TcpInterfaceConfig>&
-NetworkInterfaces::tcpInterface() const
-{
-    return d_tcpInterface;
-}
-
 // ---------------------
 // class PartitionConfig
 // ---------------------
@@ -14664,6 +14519,419 @@ inline int StatPluginConfigPrometheus::port() const
     return d_port;
 }
 
+// ------------------------
+// class TcpInterfaceConfig
+// ------------------------
+
+// PRIVATE ACCESSORS
+template <typename t_HASH_ALGORITHM>
+void TcpInterfaceConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
+{
+    using bslh::hashAppend;
+    hashAppend(hashAlgorithm, this->name());
+    hashAppend(hashAlgorithm, this->port());
+    hashAppend(hashAlgorithm, this->ioThreads());
+    hashAppend(hashAlgorithm, this->maxConnections());
+    hashAppend(hashAlgorithm, this->lowWatermark());
+    hashAppend(hashAlgorithm, this->highWatermark());
+    hashAppend(hashAlgorithm, this->nodeLowWatermark());
+    hashAppend(hashAlgorithm, this->nodeHighWatermark());
+    hashAppend(hashAlgorithm, this->heartbeatIntervalMs());
+    hashAppend(hashAlgorithm, this->listeners());
+}
+
+inline bool TcpInterfaceConfig::isEqualTo(const TcpInterfaceConfig& rhs) const
+{
+    return this->name() == rhs.name() && this->port() == rhs.port() &&
+           this->ioThreads() == rhs.ioThreads() &&
+           this->maxConnections() == rhs.maxConnections() &&
+           this->lowWatermark() == rhs.lowWatermark() &&
+           this->highWatermark() == rhs.highWatermark() &&
+           this->nodeLowWatermark() == rhs.nodeLowWatermark() &&
+           this->nodeHighWatermark() == rhs.nodeHighWatermark() &&
+           this->heartbeatIntervalMs() == rhs.heartbeatIntervalMs() &&
+           this->listeners() == rhs.listeners();
+}
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int TcpInterfaceConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(&d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_ioThreads,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_maxConnections,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_lowWatermark,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_highWatermark,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(
+        &d_nodeLowWatermark,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(
+        &d_nodeHighWatermark,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(
+        &d_heartbeatIntervalMs,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_listeners,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LISTENERS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: {
+        return manipulator(&d_name,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    }
+    case ATTRIBUTE_ID_PORT: {
+        return manipulator(&d_port,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    }
+    case ATTRIBUTE_ID_IO_THREADS: {
+        return manipulator(&d_ioThreads,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
+    }
+    case ATTRIBUTE_ID_MAX_CONNECTIONS: {
+        return manipulator(
+            &d_maxConnections,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
+    }
+    case ATTRIBUTE_ID_LOW_WATERMARK: {
+        return manipulator(
+            &d_lowWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_HIGH_WATERMARK: {
+        return manipulator(
+            &d_highWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_NODE_LOW_WATERMARK: {
+        return manipulator(
+            &d_nodeLowWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK: {
+        return manipulator(
+            &d_nodeHighWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS: {
+        return manipulator(
+            &d_heartbeatIntervalMs,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
+    }
+    case ATTRIBUTE_ID_LISTENERS: {
+        return manipulator(&d_listeners,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LISTENERS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int TcpInterfaceConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                            const char*    name,
+                                            int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline bsl::string& TcpInterfaceConfig::name()
+{
+    return d_name;
+}
+
+inline int& TcpInterfaceConfig::port()
+{
+    return d_port;
+}
+
+inline int& TcpInterfaceConfig::ioThreads()
+{
+    return d_ioThreads;
+}
+
+inline int& TcpInterfaceConfig::maxConnections()
+{
+    return d_maxConnections;
+}
+
+inline bsls::Types::Int64& TcpInterfaceConfig::lowWatermark()
+{
+    return d_lowWatermark;
+}
+
+inline bsls::Types::Int64& TcpInterfaceConfig::highWatermark()
+{
+    return d_highWatermark;
+}
+
+inline bsls::Types::Int64& TcpInterfaceConfig::nodeLowWatermark()
+{
+    return d_nodeLowWatermark;
+}
+
+inline bsls::Types::Int64& TcpInterfaceConfig::nodeHighWatermark()
+{
+    return d_nodeHighWatermark;
+}
+
+inline int& TcpInterfaceConfig::heartbeatIntervalMs()
+{
+    return d_heartbeatIntervalMs;
+}
+
+inline bsl::vector<TcpInterfaceListener>& TcpInterfaceConfig::listeners()
+{
+    return d_listeners;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int TcpInterfaceConfig::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_ioThreads,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_maxConnections,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_lowWatermark,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_highWatermark,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_nodeLowWatermark,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_nodeHighWatermark,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(
+        d_heartbeatIntervalMs,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_listeners,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LISTENERS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: {
+        return accessor(d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    }
+    case ATTRIBUTE_ID_PORT: {
+        return accessor(d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    }
+    case ATTRIBUTE_ID_IO_THREADS: {
+        return accessor(d_ioThreads,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_IO_THREADS]);
+    }
+    case ATTRIBUTE_ID_MAX_CONNECTIONS: {
+        return accessor(d_maxConnections,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_CONNECTIONS]);
+    }
+    case ATTRIBUTE_ID_LOW_WATERMARK: {
+        return accessor(d_lowWatermark,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LOW_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_HIGH_WATERMARK: {
+        return accessor(d_highWatermark,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HIGH_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_NODE_LOW_WATERMARK: {
+        return accessor(
+            d_nodeLowWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_LOW_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_NODE_HIGH_WATERMARK: {
+        return accessor(
+            d_nodeHighWatermark,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NODE_HIGH_WATERMARK]);
+    }
+    case ATTRIBUTE_ID_HEARTBEAT_INTERVAL_MS: {
+        return accessor(
+            d_heartbeatIntervalMs,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEAT_INTERVAL_MS]);
+    }
+    case ATTRIBUTE_ID_LISTENERS: {
+        return accessor(d_listeners,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LISTENERS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int TcpInterfaceConfig::accessAttribute(t_ACCESSOR& accessor,
+                                        const char* name,
+                                        int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline const bsl::string& TcpInterfaceConfig::name() const
+{
+    return d_name;
+}
+
+inline int TcpInterfaceConfig::port() const
+{
+    return d_port;
+}
+
+inline int TcpInterfaceConfig::ioThreads() const
+{
+    return d_ioThreads;
+}
+
+inline int TcpInterfaceConfig::maxConnections() const
+{
+    return d_maxConnections;
+}
+
+inline bsls::Types::Int64 TcpInterfaceConfig::lowWatermark() const
+{
+    return d_lowWatermark;
+}
+
+inline bsls::Types::Int64 TcpInterfaceConfig::highWatermark() const
+{
+    return d_highWatermark;
+}
+
+inline bsls::Types::Int64 TcpInterfaceConfig::nodeLowWatermark() const
+{
+    return d_nodeLowWatermark;
+}
+
+inline bsls::Types::Int64 TcpInterfaceConfig::nodeHighWatermark() const
+{
+    return d_nodeHighWatermark;
+}
+
+inline int TcpInterfaceConfig::heartbeatIntervalMs() const
+{
+    return d_heartbeatIntervalMs;
+}
+
+inline const bsl::vector<TcpInterfaceListener>&
+TcpInterfaceConfig::listeners() const
+{
+    return d_listeners;
+}
+
 // -----------------
 // class ClusterNode
 // -----------------
@@ -15039,6 +15307,144 @@ inline const DispatcherProcessorConfig& DispatcherConfig::queues() const
 inline const DispatcherProcessorConfig& DispatcherConfig::clusters() const
 {
     return d_clusters;
+}
+
+// -----------------------
+// class NetworkInterfaces
+// -----------------------
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int NetworkInterfaces::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(&d_heartbeats,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_tcpInterface,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int NetworkInterfaces::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_HEARTBEATS: {
+        return manipulator(&d_heartbeats,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
+    }
+    case ATTRIBUTE_ID_TCP_INTERFACE: {
+        return manipulator(
+            &d_tcpInterface,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int NetworkInterfaces::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                           const char*    name,
+                                           int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline Heartbeat& NetworkInterfaces::heartbeats()
+{
+    return d_heartbeats;
+}
+
+inline bdlb::NullableValue<TcpInterfaceConfig>&
+NetworkInterfaces::tcpInterface()
+{
+    return d_tcpInterface;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int NetworkInterfaces::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(d_heartbeats,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_tcpInterface,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int NetworkInterfaces::accessAttribute(t_ACCESSOR& accessor, int id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_HEARTBEATS: {
+        return accessor(d_heartbeats,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_HEARTBEATS]);
+    }
+    case ATTRIBUTE_ID_TCP_INTERFACE: {
+        return accessor(d_tcpInterface,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TCP_INTERFACE]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int NetworkInterfaces::accessAttribute(t_ACCESSOR& accessor,
+                                       const char* name,
+                                       int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline const Heartbeat& NetworkInterfaces::heartbeats() const
+{
+    return d_heartbeats;
+}
+
+inline const bdlb::NullableValue<TcpInterfaceConfig>&
+NetworkInterfaces::tcpInterface() const
+{
+    return d_tcpInterface;
 }
 
 // -------------------------------
@@ -17688,6 +18094,6 @@ inline const AppConfig& Configuration::appConfig() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY @BLP_BAS_CODEGEN_VERSION@
+// GENERATED BY BLP_BAS_CODEGEN_2024.07.18
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.cpp
@@ -1,0 +1,109 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// mqbcfg_tcpinterfaceconfigvalidator.cpp
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(mqbcfg_tcpinterfaceconfigvalidator_h, "$Id$ $CSID$")
+
+#include <mqbcfg_tcpinterfaceconfigvalidator.h>
+
+#include <ball_log.h>
+#include <bsl_algorithm.h>
+#include <bsl_functional.h>
+#include <bsl_type_traits.h>
+#include <bsl_vector.h>
+
+namespace BloombergLP {
+namespace mqbcfg {
+
+namespace {
+
+const char LOG_CATEGORY[] = "MQBCFG.TCPINTERFACECONFIGVALIDATOR";
+BALL_LOG_SET_NAMESPACE_CATEGORY(LOG_CATEGORY)
+
+/// @brief Transform the range that elements in the range [`begin`, `end`) and
+/// then check if the result contains unique items.
+template <typename It, typename F>
+bool uniqueWith(It begin, It end, F f)
+{
+    typedef typename bsl::iterator_traits<It>::reference    Reference;
+    typedef typename bsl::invoke_result<F, Reference>::type Result;
+    bsl::vector<Result>                                     sorted;
+    sorted.reserve(bsl::distance(begin, end));
+
+    bsl::transform(begin, end, bsl::back_inserter(sorted), f);
+    bsl::sort(sorted.begin(), sorted.end());
+    typename bsl::vector<Result>::iterator newEnd = bsl::unique(sorted.begin(),
+                                                                sorted.end());
+    return sorted.end() == newEnd;
+}
+
+}  // close unnamed namespace
+
+// PRIVATE STATIC FUNCTIONS
+int TcpInterfaceConfigValidator::port(
+    const mqbcfg::TcpInterfaceListener& listener)
+{
+    return listener.port();
+}
+
+bsl::string_view
+TcpInterfaceConfigValidator::name(const mqbcfg::TcpInterfaceListener& listener)
+{
+    return listener.name();
+}
+
+bool TcpInterfaceConfigValidator::isValidPort(
+    const mqbcfg::TcpInterfaceListener& listener)
+{
+    return 0 <= listener.port() && listener.port() <= 65535;
+}
+
+TcpInterfaceConfigValidator::ErrorCode TcpInterfaceConfigValidator::operator()(
+    const mqbcfg::TcpInterfaceConfig& config) const
+{
+    if (config.listeners().empty()) {
+        return k_OK;
+    }
+
+    bsl::vector<mqbcfg::TcpInterfaceListener>::const_iterator
+        first = config.listeners().cbegin(),
+        last  = config.listeners().cend();
+    // The names of each network interface is unique
+    if (!uniqueWith(first, last, TcpInterfaceConfigValidator::name)) {
+        BALL_LOG_ERROR << "TCP interface validation failed: Multiple "
+                          "interfaces with the same name";
+        return k_DUPLICATE_NAME;
+    }
+
+    // The ports of each network interface is unqiue
+    if (!uniqueWith(first, last, TcpInterfaceConfigValidator::port)) {
+        BALL_LOG_ERROR << "TCP interface validation failed: Multiple "
+                          "interfaces using the same port";
+        return k_DUPLICATE_PORT;
+    }
+
+    // Ports passed are possible port values
+    if (!bsl::all_of(first, last, TcpInterfaceConfigValidator::isValidPort)) {
+        BALL_LOG_ERROR << "TCP interface validation failed: Invalid port "
+                          "specified";
+        return k_PORT_RANGE;
+    }
+
+    return k_OK;
+}
+
+}  // close namespace mqbcfg
+}  // close namespace BloombergLP

--- a/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.h
@@ -1,0 +1,85 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// mqbcfg_tcpinterfaceconfigvalidator.h
+#ifndef INCLUDED_MQBCFG_TCPINTERFACECONFIGVALIDATOR
+#define INCLUDED_MQBCFG_TCPINTERFACECONFIGVALIDATOR
+
+#include <bsls_ident.h>
+BSLS_IDENT_RCSID(mqbcfg_tcpinterfaceconfigvalidator_h, "$Id$ $CSID$")
+BSLS_IDENT_PRAGMA_ONCE
+
+#include <mqbcfg_messages.h>
+
+#include <ball_log.h>
+
+/// PURPOSE: This component provdies a class to validate TcpInterfaceConfig
+/// settings in the broker config.
+///
+/// CLASSES:
+///  mqbcfg::TcpInterfaceConfigValidator: A predicate object that validates the
+///  TCP interfaces in the broker config
+///
+/// DESCRIPTION:
+
+namespace BloombergLP {
+namespace mqbcfg {
+
+/// @brief This class is a functor that validates the
+/// `appConfig/networkInterfaces/tcpInterface/listeners` property of the broker
+/// config.
+class TcpInterfaceConfigValidator {
+  private:
+    // PRIVATE STATIC FUNCTIONS
+    static int port(const mqbcfg::TcpInterfaceListener& listener);
+
+    static bsl::string_view name(const mqbcfg::TcpInterfaceListener& listener);
+
+    static bool isValidPort(const mqbcfg::TcpInterfaceListener& listener);
+
+  public:
+    // TYPES
+    /// Codes to indicate the reason for a validation failure.
+    enum ErrorCode {
+        /// Indicates a config is valid. Guaranteed to equal zero.
+        k_OK = 0,
+        /// Indicates there were multiple interfaces with the same name.
+        k_DUPLICATE_NAME = -1,
+        /// Indicates there were multiple interfaces using the same ports.
+        k_DUPLICATE_PORT = -2,
+        /// Indicates a port number was passed outside of the valid port range.
+        k_PORT_RANGE = -3
+    };
+
+    // ACCESSORS
+
+    /// @brief Validate the TCP interface configuration.
+    ///
+    /// The TCP interface configuration is invalid unless:
+    /// 1. The names of each network interface is unique
+    /// 2. The ports of each network interface is unqiue
+    /// 3. Ports passed are possible port values
+    ///
+    /// @returns An error code indicating success (`k_OK`) or a non-zero code
+    /// indicating the cause of failure.
+    ErrorCode operator()(const mqbcfg::TcpInterfaceConfig& config) const;
+};
+
+// ============================================================================
+//                          INLINE FUNCTION DEFINITIONS
+// ============================================================================
+
+}  // close namespace mqbcfg
+}  // close namespace BloombergLP
+#endif

--- a/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.t.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.t.cpp
@@ -1,0 +1,125 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbcfg_tcpinterfaceconfigvalidator.t.cpp                           -*-C++-*-
+#include <mqbcfg_tcpinterfaceconfigvalidator.h>
+
+// MQB
+#include <mqbcfg_messages.h>
+
+// BMQ
+#include <bmqtst_testhelper.h>
+
+// BDE
+#include <bsl_cstdlib.h>
+#include <bsl_iostream.h>
+#include <bsls_asserttest.h>
+
+using namespace BloombergLP;
+
+struct TcpInterfaceConfigValidatorTest : bmqtst::Test {};
+
+TEST_F(TcpInterfaceConfigValidatorTest, breathingTest)
+{
+    ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK, 0);
+}
+
+TEST_F(TcpInterfaceConfigValidatorTest, emptyConfigIsValid)
+{
+    mqbcfg::TcpInterfaceConfigValidator validator;
+    mqbcfg::TcpInterfaceConfig          config;
+
+    ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK, validator(config));
+}
+
+TEST_F(TcpInterfaceConfigValidatorTest, nonUniqueNamesAreInvalid)
+{
+    mqbcfg::TcpInterfaceConfigValidator validator;
+    mqbcfg::TcpInterfaceConfig          config;
+
+    {
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.name() = "Test";
+    }
+
+    {
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.name() = "Test";
+    }
+
+    ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_NAME,
+              validator(config));
+}
+
+TEST_F(TcpInterfaceConfigValidatorTest, nonUniquePortsAreInvalid)
+{
+    mqbcfg::TcpInterfaceConfigValidator validator;
+    mqbcfg::TcpInterfaceConfig          config;
+
+    {
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.name() = "listener0";
+        listener.port() = 8000;
+    }
+
+    {
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.name() = "listener1";
+        listener.port() = 8000;
+    }
+
+    ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_PORT,
+              validator(config));
+}
+
+TEST_F(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
+{
+    mqbcfg::TcpInterfaceConfigValidator validator;
+
+    {
+        mqbcfg::TcpInterfaceConfig    config;
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.port() = 0x10000;
+        ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
+                  validator(config));
+    }
+
+    {
+        mqbcfg::TcpInterfaceConfig    config;
+        mqbcfg::TcpInterfaceListener& listener =
+            config.listeners().emplace_back();
+        listener.port() = -1;
+        ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
+                  validator(config));
+    }
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    bmqtst::runTest(_testCase);
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
+}

--- a/src/groups/mqb/mqbcfg/package/mqbcfg.mem
+++ b/src/groups/mqb/mqbcfg/package/mqbcfg.mem
@@ -1,2 +1,3 @@
 mqbcfg_brokerconfig
 mqbcfg_messages
+mqbcfg_tcpinterfaceconfigvalidator

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -22,6 +22,7 @@
 
 // MQB
 #include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
 #include <mqbnet_cluster.h>
 #include <mqbnet_clusterimp.h>
 #include <mqbnet_session.h>
@@ -389,6 +390,9 @@ int TransportManager::start(bsl::ostream& errorDescription)
 
     // Create and start the TCPInterface, if any
     const mqbcfg::AppConfig& brkrCfg = mqbcfg::BrokerConfig::get();
+
+    // If the new network interfaces exist, use them. Otherwise, fall back to
+    // the old network interface config.
     if (!brkrCfg.networkInterfaces().tcpInterface().isNull()) {
         rc = createAndStartTcpInterface(
             errorDescription,

--- a/src/python/blazingmq/dev/it/process/broker.py
+++ b/src/python/blazingmq/dev/it/process/broker.py
@@ -28,6 +28,12 @@ import os
 from pathlib import Path
 import signal
 
+from typing import Optional, TypeVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from blazingmq.dev.it.cluster import Cluster
+
 from blazingmq.dev.it.process import proc
 import blazingmq.dev.it.process.bmqproc
 import blazingmq.dev.it.testconstants as tc
@@ -46,7 +52,17 @@ def open_non_blocking(path, flags):
 
 
 class Broker(blazingmq.dev.it.process.bmqproc.BMQProcess):
-    def __init__(self, config: cfg.Broker, cluster, **kwargs):
+    Self = TypeVar("Self", bound="Broker")
+
+    config: cfg.Broker
+    cluster: "Cluster"
+    cluster_name: str
+    _pid: Optional[int]
+    _auto_id: itertools.count
+    last_known_leader: Optional[Self]
+    last_known_active: Optional[str]
+
+    def __init__(self, config: cfg.Broker, cluster: "Cluster", **kwargs):
         cwd: Path = kwargs["cwd"]
         (cwd / "bmqbrkr.ctl").unlink(missing_ok=True)
         super().__init__(

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -652,6 +652,27 @@ class TweakFactory:
 
                     heartbeat_interval_ms = HeartbeatIntervalMs()
 
+                    class Listeners(metaclass=TweakMetaclass):
+                        class Name(metaclass=TweakMetaclass):
+
+                            def __call__(
+                                self, value: typing.Union[str, NoneType]
+                            ) -> Callable: ...
+
+                        name = Name()
+
+                        class Port(metaclass=TweakMetaclass):
+
+                            def __call__(
+                                self, value: typing.Union[int, NoneType]
+                            ) -> Callable: ...
+
+                        port = Port()
+
+                        def __call__(self, value: None) -> Callable: ...
+
+                    listeners = Listeners()
+
                     def __call__(
                         self,
                         value: typing.Union[

--- a/src/python/blazingmq/dev/it/util.py
+++ b/src/python/blazingmq/dev/it/util.py
@@ -26,6 +26,12 @@ import random
 import string
 import time
 
+from typing import List, Generic, TypeVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from blazingmq.dev.it.process.client import Client
+
 
 def random_string(len):
     letters = string.ascii_lowercase
@@ -114,7 +120,7 @@ class Queue:
     action is to close the queue (if it has not yet been explicitly closed).
     """
 
-    def __init__(self, client, uri, flags, **kw):
+    def __init__(self, client: "Client", uri: str, flags: List[str], **kw):
         """Open the queue specified by 'uri' via the specified 'client, using the
         specified 'flags'.
         """
@@ -139,7 +145,7 @@ class Queue:
     def list(self, *args, **kwargs):
         return self.client.list(self.uri, *args, **kwargs)
 
-    def confirm(self, *args, **kwargs):
+    def confirm(self, *args, **kwargs) -> int | None:
         return self.client.confirm(self.uri, *args, **kwargs)
 
     def configure(self, *args, **kwargs):
@@ -151,7 +157,10 @@ class Queue:
         return rc
 
 
-class ListContextManager(list):
+_T = TypeVar("_T")
+
+
+class ListContextManager(list[_T]):
     def __enter__(self):
         return self
 

--- a/src/python/blazingmq/schemas/mqbcfg.py
+++ b/src/python/blazingmq/schemas/mqbcfg.py
@@ -971,18 +971,14 @@ class TcpClusterNodeConnection:
 
 
 @dataclass
-class TcpInterfaceConfig:
-    """lowWatermark.........:
+class TcpInterfaceListener:
+    """This type describes the information needed for the broker to open a TCP
+    listener.
 
-    highWatermark........:
-    Watermarks used for channels with a client or proxy.
-    nodeLowWatermark.....:
-    nodeHighWatermark....:
-    Reduced watermarks for communication between cluster nodes where
-    BlazingMQ maintains its own cache.
-    heartbeatIntervalMs..:
-    How often (in milliseconds) to check if the channel received data,
-    and emit heartbeat.  0 to globally disable.
+    name.................:
+    A name to associate this listener to.
+    port.................:
+    The port this listener will accept connections on.
     """
 
     name: Optional[str] = field(
@@ -996,69 +992,6 @@ class TcpInterfaceConfig:
     port: Optional[int] = field(
         default=None,
         metadata={
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    io_threads: Optional[int] = field(
-        default=None,
-        metadata={
-            "name": "ioThreads",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    max_connections: int = field(
-        default=10000,
-        metadata={
-            "name": "maxConnections",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    low_watermark: Optional[int] = field(
-        default=None,
-        metadata={
-            "name": "lowWatermark",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    high_watermark: Optional[int] = field(
-        default=None,
-        metadata={
-            "name": "highWatermark",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    node_low_watermark: int = field(
-        default=1024,
-        metadata={
-            "name": "nodeLowWatermark",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    node_high_watermark: int = field(
-        default=2048,
-        metadata={
-            "name": "nodeHighWatermark",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    heartbeat_interval_ms: int = field(
-        default=3000,
-        metadata={
-            "name": "heartbeatIntervalMs",
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,
@@ -1227,26 +1160,6 @@ class LogController:
 
 
 @dataclass
-class NetworkInterfaces:
-    heartbeats: Optional[Heartbeat] = field(
-        default=None,
-        metadata={
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    tcp_interface: Optional[TcpInterfaceConfig] = field(
-        default=None,
-        metadata={
-            "name": "tcpInterface",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-        },
-    )
-
-
-@dataclass
 class PartitionConfig:
     """Type representing the configuration for the storage layer of a cluster.
 
@@ -1396,6 +1309,116 @@ class StatPluginConfigPrometheus:
 
 
 @dataclass
+class TcpInterfaceConfig:
+    """name.................:
+
+    The name of the TCP session manager.
+    port.................:
+    (Deprecated) The port to receive connections.
+    lowWatermark.........:
+    highWatermark........:
+    Watermarks used for channels with a client or proxy.
+    nodeLowWatermark.....:
+    nodeHighWatermark....:
+    Reduced watermarks for communication between cluster nodes where
+    BlazingMQ maintains its own cache.
+    heartbeatIntervalMs..:
+    How often (in milliseconds) to check if the channel received data,
+    and emit heartbeat.  0 to globally disable.
+    listeners:
+    A list of listener interfaces to receive TCP connections from. When non-empty
+    this option overrides the listener specified by port.
+    """
+
+    name: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    port: Optional[int] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    io_threads: Optional[int] = field(
+        default=None,
+        metadata={
+            "name": "ioThreads",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    max_connections: int = field(
+        default=10000,
+        metadata={
+            "name": "maxConnections",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    low_watermark: Optional[int] = field(
+        default=None,
+        metadata={
+            "name": "lowWatermark",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    high_watermark: Optional[int] = field(
+        default=None,
+        metadata={
+            "name": "highWatermark",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    node_low_watermark: int = field(
+        default=1024,
+        metadata={
+            "name": "nodeLowWatermark",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    node_high_watermark: int = field(
+        default=2048,
+        metadata={
+            "name": "nodeHighWatermark",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    heartbeat_interval_ms: int = field(
+        default=3000,
+        metadata={
+            "name": "heartbeatIntervalMs",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    listeners: List[TcpInterfaceListener] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+        },
+    )
+
+
+@dataclass
 class ClusterNode:
     """Type representing the configuration of a node in a cluster.
 
@@ -1466,6 +1489,26 @@ class DispatcherConfig:
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,
+        },
+    )
+
+
+@dataclass
+class NetworkInterfaces:
+    heartbeats: Optional[Heartbeat] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    tcp_interface: Optional[TcpInterfaceConfig] = field(
+        default=None,
+        metadata={
+            "name": "tcpInterface",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
         },
     )
 
@@ -1793,7 +1836,7 @@ class StatsConfig:
 
 @dataclass
 class AppConfig:
-    """Top level typ for the broker's configuration.
+    """Top level type for the broker's configuration.
 
     brokerInstanceName...: name of the broker instance
     brokerVersion........: version of the broker


### PR DESCRIPTION
This extends the broker config to support listening to connections on multiple ports. This lays the groundwork for future extensions that will be added to `TcpInterfaceListener`. The broker will behave the same without the listener config, but with the listeners added the broker will open new listen operations for each one, ignoring the `port` field in the `networkInterfaces`. We also added an extra component for validating these new configs.