### PR TITLE
Fix potential sync issue

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -110,7 +110,7 @@ class Application : public bmqa::SessionEventHandler {
     bdlmt::EventScheduler d_scheduler;
     // Used to schedule stat snapshots
 
-    bool d_isConnected;
+    bsls::AtomicBool d_isConnected;
     // Are we connected to bmqbrkr?  (to
     // know whether to dump stats/publish
     // message or not)


### PR DESCRIPTION
The d_isConnected flag in bmqtool's Application class was declared just bool, while it was accessed from different threads, which could lead to a synchronization issues. Making it atomic bool should fix this issue.
