### PR TITLE
Fix 'Wconversion' warns: static casting doubles

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -250,7 +250,7 @@ class Application {
     /// of this `Application`.
     const bmqt::SessionOptions& sessionOptions() const;
 
-    /// Return `true` if the the application is started, `false` otherwise.
+    /// Return `true` if the application is started, `false` otherwise.
     bool isStarted() const;
 
     // MANIPULATORS

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -2590,7 +2590,7 @@ void TestSession::verifyCloseQueueResult(
     ASSERT(waitForQueueState(queue, state));
 
     if (state == bmqimp::QueueState::e_CLOSED) {
-        // Verify that the queue is removed from the the active queue list
+        // Verify that the queue is removed from the active queue list
         ASSERT(waitForQueueRemoved(queue));
     }
     ASSERT_EQ(queue->isValid(), false);

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -332,7 +332,7 @@ class Event {
     Event& configureAsMessageEvent(const bmqp::Event& rawEvent);
 
     /// Configure this instance as a message event in write mode with the
-    /// the specified `bufferFactory` to allocate blob buffers when needed.
+    /// specified `bufferFactory` to allocate blob buffers when needed.
     /// Behavior is undefined unless `bufferFactory` points to a valid blob
     /// buffer factory.  Also change the type of this Event to be
     /// `MESSAGEEVENT`, and type of message event mode to `WRITE`.

--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -67,7 +67,7 @@ struct ZLib {
 
     // CLASS METHODS
 
-    /// Return a buffer sufficient to hold the the specified number of
+    /// Return a buffer sufficient to hold the specified number of
     /// `items`, each having the specified `size`, using the specified
     /// `opaque` casted to a `bslma::Allocator *` to supply memory.
     static void*

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -1873,8 +1873,7 @@ struct AckMessage {
     //                  message
     //  MessageGUID...: MessageGUID associated to this message by the broker
     //  QueueId.......: Id of the queue (as advertised during open queue by the
-    //                  the producer of the Put event this Ack is a response
-    //                  of)
+    //                  producer of the Put event this Ack is a response of)
     //..
 
   private:
@@ -3378,7 +3377,7 @@ struct MessagePropertiesInfo {
     MessagePropertiesInfo(const MessagePropertiesInfo& other);
 
     /// Construct object indicating MessageProperties presence as the
-    /// the specified `isPresent` with Schema id as the specified `schemaId`
+    /// specified `isPresent` with Schema id as the specified `schemaId`
     /// and the specified `isRecycled`.
     MessagePropertiesInfo(bool         isPresent,
                           SchemaIdType schemaId,

--- a/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
@@ -1105,7 +1105,7 @@ static void test3_flagUtils()
 
             int flags = 0;
 
-            // 1. Check that the the flag is not 'isSet'.
+            // 1. Check that the flag is not 'isSet'.
             ASSERT(!bmqp::PutHeaderFlagUtil::isSet(flags, test.d_value));
 
             // 2. Set the flag.  Verify that it is set, and that no other
@@ -1170,7 +1170,7 @@ static void test3_flagUtils()
 
             int flags = 0;
 
-            // 1. Check that the the flag is not 'isSet'.
+            // 1. Check that the flag is not 'isSet'.
             ASSERT(!bmqp::PushHeaderFlagUtil::isSet(flags, test.d_value));
 
             // 2. Set the flag.  Verify that it is set, and that no other
@@ -1236,7 +1236,7 @@ static void test3_flagUtils()
 
             int flags = 0;
 
-            // 1. Check that the the flag is not 'isSet'.
+            // 1. Check that the flag is not 'isSet'.
             ASSERT(!bmqp::StorageHeaderFlagUtil::isSet(flags, test.d_value));
 
             // 2. Set the flag.  Verify that it is set, and that no other flag

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.t.cpp
@@ -908,7 +908,7 @@ static void test1_breathingTest()
 //     decompress flag is set to true. The iterator has messages which
 //     have not been compressed.
 //   - Create a valid iterator which allows decompression i.e. the
-//     the decompress flag is set to true. The iterator has messages which
+//     decompress flag is set to true. The iterator has messages which
 //     have been compressed using ZLIB compression algorithm.
 //
 // Testing:

--- a/src/groups/bmq/bmqp/bmqp_putmessageiterator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_putmessageiterator.t.cpp
@@ -66,7 +66,7 @@ static void test1_breathingTest()
 //     decompress flag is set to true. The iterator has messages which
 //     have not been compressed.
 //   - Create a valid iterator which allows decompression i.e. the
-//     the decompress flag is set to true. The iterator has messages which
+//     decompress flag is set to true. The iterator has messages which
 //     have been compressed using ZLIB compression algorithm.
 //
 // Testing:

--- a/src/groups/bmq/bmqt/bmqt_version.h
+++ b/src/groups/bmq/bmqt/bmqt_version.h
@@ -112,11 +112,11 @@ class Version {
 bsl::ostream& operator<<(bsl::ostream& stream, const Version& rhs);
 
 /// Return `true` if the object in the specified `lhs` represents the same
-/// version as the the one in the specified `rhs`, return false otherwise.
+/// version as the one in the specified `rhs`, return false otherwise.
 bool operator==(const Version& lhs, const Version& rhs);
 
 /// Return `true` if the object in the specified `lhs` represents a
-/// different version than the the one in the specified `rhs`, return false
+/// different version than the one in the specified `rhs`, return false
 /// otherwise.
 bool operator!=(const Version& lhs, const Version& rhs);
 

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -497,7 +497,7 @@ class MyMockQueueHandle : public mqbmock::QueueHandle {
 
     // ACCESSORS
 
-    /// Returns the the captured messages.
+    /// Returns the captured messages.
     const bsl::vector<Post>& postedMessages() const
     {
         return d_postedMessages;

--- a/src/groups/mqb/mqbc/mqbc_recoveryutil.h
+++ b/src/groups/mqb/mqbc/mqbc_recoveryutil.h
@@ -130,7 +130,7 @@ struct RecoveryUtil {
         mqbs::JournalFileIterator&                   journalIt);
 
     /// This function operates on the record currently being pointed by the
-    /// the specified `journalIt`. It uses the specified `dataFd` if the
+    /// specified `journalIt`. It uses the specified `dataFd` if the
     /// record is a data record, the specified `qlistFd` if the record is
     /// a qlist record and the specified `fsmWorkflow` value is false. It
     /// populates the specified `storageMsgType`, `payloadRecordBase` and

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -389,7 +389,7 @@ class Storage {
     virtual bslma::ManagedPtr<StorageIterator>
     getIterator(const mqbu::StorageKey& appKey) = 0;
 
-    /// Load into the the specified `out` an iterator for items stored in
+    /// Load into the specified `out` an iterator for items stored in
     /// the virtual storage identified by the specified `appKey`, initially
     /// pointing to the item associated with the specified `msgGUID`.
     /// Return zero on success, and a non-zero code if `msgGUID` was not

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -396,7 +396,7 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     virtual bslma::ManagedPtr<mqbi::StorageIterator>
     getIterator(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
-    /// Load into the the specified `out` an iterator for items stored in
+    /// Load into the specified `out` an iterator for items stored in
     /// the virtual storage identified by the specified `appKey`, initially
     /// pointing to the item associated with the specified `msgGUID`.
     /// Return zero on success, and a non-zero code if `msgGUID` was not

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7083,7 +7083,7 @@ void FileStore::flush()
     // 'gcHistory' attempts to iterate all old items. If there are more of them
     // than the batchSize (1000), it returns 'true'.  In this case, re-enable
     // flush client to call it again next Idle time.
-    // If it returns 'false', there is no immediate work.  Wait for the the
+    // If it returns 'false', there is no immediate work.  Wait for the
     // next k_GC_MESSAGES_INTERVAL_SECONDS.
 
     if (haveMore || haveMoreHistory) {

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -290,7 +290,7 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     virtual bslma::ManagedPtr<mqbi::StorageIterator>
     getIterator(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
-    /// Load into the the specified `out` an iterator for items stored in
+    /// Load into the specified `out` an iterator for items stored in
     /// the virtual storage identified by the specified `appKey`, initially
     /// pointing to the item associated with the specified `msgGUID`.
     /// Return zero on success, and a non-zero code if `msgGUID` was not

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.h
@@ -306,7 +306,7 @@ class VirtualStorage : public mqbi::Storage {
     bslma::ManagedPtr<mqbi::StorageIterator>
     getIterator(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
-    /// Load into the the specified `out` an iterator for items stored in
+    /// Load into the specified `out` an iterator for items stored in
     /// the virtual storage identified by the specified `appKey`, initially
     /// pointing to the item associated with the specified `msgGUID`.
     /// Return zero on success, and a non-zero code if `msgGUID` was not

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -126,7 +126,7 @@ class VirtualStorageCatalog {
     bslma::ManagedPtr<mqbi::StorageIterator>
     getIterator(const mqbu::StorageKey& appKey);
 
-    /// Load into the the specified `out` an iterator for items stored in
+    /// Load into the specified `out` an iterator for items stored in
     /// the virtual storage identified by the specified `appKey`, initially
     /// pointing to the item associated with the specified `msgGUID`.
     /// Return zero on success, and a non-zero code if `msgGUID` was not

--- a/src/groups/mwc/mwcex/mwcex_future.h
+++ b/src/groups/mwc/mwcex/mwcex_future.h
@@ -240,7 +240,7 @@ class Future_Exception {
     // PRIVATE DATA
 
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
     mwcu::ObjectPlaceHolder<sizeof(Target<Dummy>)> d_target;
@@ -367,7 +367,7 @@ class Future_Callback {
     // PRIVATE DATA
 
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
     mwcu::ObjectPlaceHolder<sizeof(Target<void, Dummy>)> d_target;

--- a/src/groups/mwc/mwcex/mwcex_future.t.cpp
+++ b/src/groups/mwc/mwcex/mwcex_future.t.cpp
@@ -1144,7 +1144,7 @@ static void test12_future_creators()
 //
 //   2. Construct a non-specialized future object with a shared state.
 //      Check that the future is valid and has acquired the ownership of
-//      the shared state. Then destroy the future and check the the shared
+//      the shared state. Then destroy the future and check the shared
 //      state ownership has been released.
 //
 //   3. Default-construct a void-specialized future object. Check the
@@ -1152,7 +1152,7 @@ static void test12_future_creators()
 //
 //   4. Construct a void-specialized future object with a shared state.
 //      Check that the future is valid and has acquired the ownership of
-//      the shared state. Then destroy the future and check the the shared
+//      the shared state. Then destroy the future and check the shared
 //      state ownership has been released.
 //
 //   5. Default-construct a reference-specialized future object. Check the
@@ -1161,7 +1161,7 @@ static void test12_future_creators()
 //   6. Construct a reference-specialized future object with a shared
 //      state. Check that the future is valid and has acquired the
 //      ownership of the shared state. Then destroy the future and check
-//      the the shared state ownership has been released.
+//      the shared state ownership has been released.
 //
 // Testing:
 //   'mwcex::Future's constructors

--- a/src/groups/mwc/mwcex/mwcex_future_cpp03.h
+++ b/src/groups/mwc/mwcex/mwcex_future_cpp03.h
@@ -127,7 +127,7 @@ class Future_Exception {
     // PRIVATE DATA
     mwcu::ObjectPlaceHolder<sizeof(Target<Dummy>)> d_target;
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
 
@@ -249,7 +249,7 @@ class Future_Callback {
     // PRIVATE DATA
     mwcu::ObjectPlaceHolder<sizeof(Target<void, Dummy>)> d_target;
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
 

--- a/src/groups/mwc/mwcex/mwcex_job.h
+++ b/src/groups/mwc/mwcex/mwcex_job.h
@@ -135,7 +135,7 @@ class Job {
     // PRIVATE DATA
 
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
     mwcu::ObjectPlaceHolder<sizeof(Job_Target<Dummy>)> d_target;

--- a/src/groups/mwc/mwcex/mwcex_sequentialcontext.h
+++ b/src/groups/mwc/mwcex/mwcex_sequentialcontext.h
@@ -242,7 +242,7 @@ class SequentialContext {
     /// Return the number of outstanding jobs for this execution context,
     /// that is defined as the number of function objects that have been
     /// added to the context via its associated executor, but not yet
-    /// invoked, plus the the number of function objects that are currently
+    /// invoked, plus the number of function objects that are currently
     /// being invoked within the context, which is either 0 or 1.
     size_t outstandingJobs() const BSLS_KEYWORD_NOEXCEPT;
 

--- a/src/groups/mwc/mwcex/mwcex_strand.h
+++ b/src/groups/mwc/mwcex/mwcex_strand.h
@@ -224,7 +224,7 @@ class Strand {
     /// Return the number of outstanding jobs for this execution context,
     /// that is defined as the number of functors that have been added to
     /// the strand via its associated executor, but not yet invoked, plus
-    /// the the number of functors that are currently being invoked within
+    /// the number of functors that are currently being invoked within
     /// the strand, which is either 0 or 1.
     size_t outstandingJobs() const BSLS_KEYWORD_NOEXCEPT;
 

--- a/src/groups/mwc/mwcst/mwcst_statcontext.h
+++ b/src/groups/mwc/mwcst/mwcst_statcontext.h
@@ -135,7 +135,7 @@
 // update the values of the 'mwcstm::StatContextUpdate' to represent the value
 // changes in that snapshot.  This update may then be applied to another
 // 'StatContext', which will add or remove subcontexts and update its values
-// based on the the update.  Since the update component is serializable, this
+// based on the update.  Since the update component is serializable, this
 // context can reside in another process.
 //
 // 'StatContext' additionally provides a way to generate a complete
@@ -151,7 +151,7 @@
 // track of:
 //: o The number of messages and bytes sent and received via the interface,
 //    since the beginning;
-//: o The the number of messages per second and bytes per second sent and
+//: o The number of messages per second and bytes per second sent and
 //    received over the last 10 seconds.
 // So basically we need 4 metrics for input and the same 4 metrics for
 // output.
@@ -451,7 +451,7 @@
 //..
 // Now lets record some data points.
 //..
-//  int memInUse = 50000;    // size of the the allocator in bytes
+//  int memInUse = 50000;    // size of the allocator in bytes
 //  context.setValue(0, memInUse);
 //
 //  memInUse = 1500;

--- a/src/groups/mwc/mwcst/mwcst_statcontext.t.cpp
+++ b/src/groups/mwc/mwcst/mwcst_statcontext.t.cpp
@@ -199,7 +199,7 @@ static void usageExample(bsl::ostream& stream, bslma::Allocator* allocator)
     // track of:
     // - The number of messages and bytes sent and received via the interface,
     //   since the beginning;
-    // - The the number of messages per second and bytes per second sent and
+    // - The number of messages per second and bytes per second sent and
     //   received over the last 10 seconds.
     // So basically we need 4 metrics for input and the same 4 metrics for
     // output.
@@ -622,7 +622,7 @@ static void subcontextUsageExample(bsl::ostream&     stream,
             .value("Memory", numSnapshots));
 
     // Now lets record some data points.
-    int memInUse = 50000;  // size of the the allocator in bytes
+    int memInUse = 50000;  // size of the allocator in bytes
     context.setValue(0, memInUse);
 
     memInUse = 1500;
@@ -668,7 +668,7 @@ static void subcontextUsageExampleUpdate(bsl::ostream&     stream,
         mwcst::StatContextConfiguration("Interface Allocator")
             .value("Memory", numSnapshots));
 
-    int memInUse = 50000;  // size of the the allocator in bytes
+    int memInUse = 50000;  // size of the allocator in bytes
     context.setValue(0, memInUse);
 
     memInUse = 1500;

--- a/src/groups/mwc/mwcst/mwcst_statvalue.h
+++ b/src/groups/mwc/mwcst/mwcst_statvalue.h
@@ -214,7 +214,7 @@ class StatValue {
         /// A continuous value logically represents a curve that is moved
         /// with `adjustValue` and `setValue`.  When adding two continuous
         /// StatValues, imagine them being stacked into a single continuous
-        /// value.  For example the max of the added value will the the sum
+        /// value.  For example the max of the added value will the sum
         /// of the maxes of the values being added.
         DMCST_CONTINUOUS,
 

--- a/src/groups/mwc/mwcst/mwcst_statvalue.h
+++ b/src/groups/mwc/mwcst/mwcst_statvalue.h
@@ -214,7 +214,7 @@ class StatValue {
         /// A continuous value logically represents a curve that is moved
         /// with `adjustValue` and `setValue`.  When adding two continuous
         /// StatValues, imagine them being stacked into a single continuous
-        /// value.  For example the max of the added value will the sum
+        /// value.  For example the max of the added value will be the sum
         /// of the maxes of the values being added.
         DMCST_CONTINUOUS,
 

--- a/src/groups/mwc/mwcu/mwcu_blob.h
+++ b/src/groups/mwc/mwcu/mwcu_blob.h
@@ -132,7 +132,7 @@ class BlobSection {
     /// Return a modifiable reference to the start position.
     BlobPosition& start();
 
-    /// Return a modifiable reference to the the end position.
+    /// Return a modifiable reference to the end position.
     BlobPosition& end();
 
     // ACCESSORS

--- a/src/groups/mwc/mwcu/mwcu_operationchain.h
+++ b/src/groups/mwc/mwcu/mwcu_operationchain.h
@@ -31,7 +31,7 @@
 // called a "link". A link can contain one or more operations executing in
 // parallel. Links are indexed and ordered, such that the first link has index
 // 0, operations in the link 'N' starts executing after the completion of all
-// operations in the the link 'N - 1', and operations in link 0 starts
+// operations in the link 'N - 1', and operations in link 0 starts
 // executing as soon as the chain is started. After all operations in link 0
 // are executed, the link is removed from the chain and the next link in line
 // becomes link 0.
@@ -400,7 +400,7 @@ class OperationChain_Job {
     unsigned d_id;
 
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
     mwcu::ObjectPlaceHolder<sizeof(Target<Dummy, Dummy>)> d_target;

--- a/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.h
+++ b/src/groups/mwc/mwcu/mwcu_operationchain_cpp03.h
@@ -366,7 +366,7 @@ class OperationChain_Job {
 
     mwcu::ObjectPlaceHolder<sizeof(Target<Dummy, Dummy>)> d_target;
     // Uses an on-stack buffer to allocate memory for "small" objects, and
-    // falls back to requesting memory from the the supplied allocator if
+    // falls back to requesting memory from the supplied allocator if
     // the buffer is not large enough. Note that the size of the on-stack
     // buffer is an arbitrary value.
 

--- a/src/groups/mwc/mwcu/mwcu_printutil.cpp
+++ b/src/groups/mwc/mwcu/mwcu_printutil.cpp
@@ -183,7 +183,8 @@ prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision)
     if (precision == 0 || unit == 0) {
         // When no decimal part is required, we round up the value and print it
         bsls::Types::Int64 quot = lround(
-            static_cast<double>(bytes) / bsl::pow(1024., static_cast<double>(unit)));
+            static_cast<double>(bytes) /
+            bsl::pow(1024., static_cast<double>(unit)));
         if (quot == 1024 && unit != k_UNITS_COUNT - 1) {
             // This is a special case when the round up leads to the next unit
             quot = 1;
@@ -281,7 +282,8 @@ bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
         // precision digits
         const bsls::Types::Int64 quot      = timeNs / div;
         const long               remainder = lround(
-            (static_cast<double>(timeNs - quot * div) / static_cast<double>(div)) *
+            (static_cast<double>(timeNs - quot * div) /
+             static_cast<double>(div)) *
             bsl::pow(10., static_cast<double>(precision)));
         temp << quot << "." << bsl::setw(precision) << bsl::setfill('0')
              << remainder;

--- a/src/groups/mwc/mwcu/mwcu_printutil.cpp
+++ b/src/groups/mwc/mwcu/mwcu_printutil.cpp
@@ -183,7 +183,7 @@ prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision)
     if (precision == 0 || unit == 0) {
         // When no decimal part is required, we round up the value and print it
         bsls::Types::Int64 quot = lround(
-            bytes / bsl::pow(1024., static_cast<double>(unit)));
+            static_cast<double>(bytes) / bsl::pow(1024., static_cast<double>(unit)));
         if (quot == 1024 && unit != k_UNITS_COUNT - 1) {
             // This is a special case when the round up leads to the next unit
             quot = 1;
@@ -272,7 +272,7 @@ bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
     // Compute and print the quotient and remainder
     if (precision == 0 || unitIdx == 0) {
         // When no decimal part is required, we round up the value and print it
-        const bsls::Types::Int64 quot = lround(timeNs /
+        const bsls::Types::Int64 quot = lround(static_cast<double>(timeNs) /
                                                static_cast<double>(div));
         temp << quot;
     }
@@ -281,7 +281,7 @@ bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
         // precision digits
         const bsls::Types::Int64 quot      = timeNs / div;
         const long               remainder = lround(
-            (static_cast<double>(timeNs - quot * div) / div) *
+            (static_cast<double>(timeNs - quot * div) / static_cast<double>(div)) *
             bsl::pow(10., static_cast<double>(precision)));
         temp << quot << "." << bsl::setw(precision) << bsl::setfill('0')
              << remainder;

--- a/src/groups/mwc/mwcu/mwcu_sharedresource.h
+++ b/src/groups/mwc/mwcu/mwcu_sharedresource.h
@@ -153,7 +153,7 @@
 //  void
 //  MyService::asyncDoStuff()
 //  {
-//      // acquire the shared resource and bind to the the async operation
+//      // acquire the shared resource and bind to the async operation
 //      d_threadPool_p->enqueueJob(bdlf::BindUtil::bind(&MyService::doStuff,
 //                                                      d_self.acquire()));
 //  }
@@ -178,7 +178,7 @@
 //  void
 //  MyService::asyncDoStuff()
 //  {
-//      // acquire the shared resource and bind to the the async operation
+//      // acquire the shared resource and bind to the async operation
 //      d_threadPool_p->enqueueJob(mwcu::WeakMemFnUtil::weakMemFn(
 //                                                      &MyService::doStuff,
 //                                                      d_self.acquireWeak()));

--- a/src/groups/mwc/mwcu/mwcu_sharedresource.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_sharedresource.t.cpp
@@ -102,7 +102,7 @@ void MyService::doStuff()
 
 void MyService::asyncDoStuff()
 {
-    // acquire the shared resource and bind to the the async operation
+    // acquire the shared resource and bind to the async operation
     d_threadPool_p->enqueueJob(
         mwcu::WeakMemFnUtil::weakMemFn(&MyService::doStuff,
                                        d_self.acquireWeak()));

--- a/src/groups/mwc/mwcu/mwcu_throttledaction.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_throttledaction.t.cpp
@@ -278,7 +278,7 @@ static void test3_throttleWithDefaultReset()
     mwcu::ThrottledActionParams obj(k_INTERVAL_MS, k_MAX_COUNT_PER_INTERVAL);
 
     // 1. Do a 'MWCU_THROTTLEDACTION_THROTTLE' up to and including the
-    //    the maximum number of times (within the specified time interval)
+    //    maximum number of times (within the specified time interval)
     //    and ensure that the specified 'ACTION' was executed exactly the
     //      maximum number of times and the default reset function was not
     //      called.


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This is a small `good first issue` contribution to fix -Wconversion warnings that pollutes the build log.

This particular PR deals with the following warnings:

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:186:13: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  186 |             bytes / bsl::pow(1024., static_cast<double>(unit)));
```

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:275:48: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  275 |         const bsls::Types::Int64 quot = lround(timeNs /
```

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:284:57: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  284 |             (static_cast<double>(timeNs - quot * div) / div) *
```

**Testing performed**
N/A

**Additional context**
Converting from `BloombergLP::bsls::Types::Int64` (a 64-bit integer) to `double` (a 64-bit floating-point) can potentially lead to a loss of precision, but it depends on the size of the integer value used in this context. The division involving another `double` should already result in similar loss of precision though, so this may be fine. Please check this before merging.