### PR TITLE
Fix 'Wconversion' warns: static casting doubles

### DIFF
--- a/src/groups/mwc/mwcu/mwcu_printutil.cpp
+++ b/src/groups/mwc/mwcu/mwcu_printutil.cpp
@@ -183,7 +183,8 @@ prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision)
     if (precision == 0 || unit == 0) {
         // When no decimal part is required, we round up the value and print it
         bsls::Types::Int64 quot = lround(
-            bytes / bsl::pow(1024., static_cast<double>(unit)));
+            static_cast<double>(bytes) /
+            bsl::pow(1024., static_cast<double>(unit)));
         if (quot == 1024 && unit != k_UNITS_COUNT - 1) {
             // This is a special case when the round up leads to the next unit
             quot = 1;
@@ -272,7 +273,7 @@ bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
     // Compute and print the quotient and remainder
     if (precision == 0 || unitIdx == 0) {
         // When no decimal part is required, we round up the value and print it
-        const bsls::Types::Int64 quot = lround(timeNs /
+        const bsls::Types::Int64 quot = lround(static_cast<double>(timeNs) /
                                                static_cast<double>(div));
         temp << quot;
     }
@@ -281,7 +282,8 @@ bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
         // precision digits
         const bsls::Types::Int64 quot      = timeNs / div;
         const long               remainder = lround(
-            (static_cast<double>(timeNs - quot * div) / div) *
+            (static_cast<double>(timeNs - quot * div) /
+             static_cast<double>(div)) *
             bsl::pow(10., static_cast<double>(precision)));
         temp << quot << "." << bsl::setw(precision) << bsl::setfill('0')
              << remainder;


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This is a small `good first issue` contribution to fix -Wconversion warnings that pollutes the build log.
Formatted the updates with clang-format.

This particular PR deals with the following warnings:

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:186:13: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  186 |             bytes / bsl::pow(1024., static_cast<double>(unit)));
```

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:275:48: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  275 |         const bsls::Types::Int64 quot = lround(timeNs /
```

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcu/mwcu_printutil.cpp:284:57: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘double’ may change value [-Wconversion]
  284 |             (static_cast<double>(timeNs - quot * div) / div) *
```

**Testing performed**
N/A

**Additional context**
Converting from `BloombergLP::bsls::Types::Int64` (a 64-bit integer) to `double` (a 64-bit floating-point) can potentially lead to a loss of precision, but it depends on the size of the integer value used in this context. The division involving another `double` should already result in similar loss of precision though, so this may be fine. Please check this before merging.