### PR TITLE
Revert "Gracefully terminate bmqtool in auto mode"

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -1046,7 +1046,14 @@ void Application::producerThread()
         }
     }
 
-    d_shutdownSemaphore_p->post();
+    // Finished posting messages in auto mode?
+    // If shutDownGrace is set, signal to the main thread to exit.
+    if (d_parameters_p->mode() == ParametersMode::e_AUTO &&
+        d_parameters_p->shutdownGrace() != 0) {
+        // We do not need to sleep the grace period, since it is done
+        // by the main thread, in the stop() function.
+        d_shutdownSemaphore_p->post();
+    }
 }
 
 // CLASS METHODS


### PR DESCRIPTION
Reverts bloomberg/blazingmq#208

Few notes
1.  Running the tool infinitely is not a problem for IT: a test can call `producer.force_stop()`
2.  Exiting producer too soon (right after posting last PUT) can be a problem for IT because BMQ simply NACKs unacknowledged PUTs (if a test exercises  failover before ACKs) as soon as producer disconnects.  For this reason, producer (or a test) needs to "wait" before producer exits.  How long?  IT relies on external factors as the synchronization point at which it can call `producer.force_stop()`.
3. There is `eventHandler` thread in producer that reads incoming ACKs.  See `Application::onMessageEvent` (and `Application::autoReadShutdown`) 
4.  If we do not want an infinite run, we specify `shutdownGrace`, and auto producer exits after waiting this constant time.
5. For IT, `shutdownGrace` is `0`

We can change this, but we need to address 2. 


