### PR TITLE
ConfigureStream unconditionally

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -276,9 +276,7 @@ bool waitRealTime(bslmt::TimedSemaphore* sem)
 
 bool isConfigure(const bmqp_ctrlmsg::ControlMessage& request)
 {
-    return bmqscm::Version::versionAsInt() == bmqp::Protocol::k_DEV_VERSION
-               ? request.choice().isConfigureStreamValue()
-               : request.choice().isConfigureQueueStreamValue();
+    return request.choice().isConfigureStreamValue();
 }
 
 void makeResponse(bmqp_ctrlmsg::ControlMessage*       response,

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2584,9 +2584,11 @@ int main(int argc, char* argv[])
         mwcsys::Time::initialize(s_allocator_p);
 
         mqbcfg::AppConfig brokerConfig(s_allocator_p);
-        brokerConfig.brokerVersion() = 999999;  // required for test case 8
-                                                // to convert msg properties
-                                                // from v1 to v2
+
+        // Assuming brokerConfig.messagePropertiesV2().MessagePropertiesV2()
+        // .advertiseV2Support() == true by default.
+        //
+        // Required for test case 8 to convert msg properties from v1 to v2
         mqbcfg::BrokerConfig::set(brokerConfig);
 
         bsl::shared_ptr<mwcst::StatContext> statContext =


### PR DESCRIPTION
Retire `ConfigureQueueStream`
SDK sends `ConfigureStream` unconditionally.  This must be in accord with broker's MessageProperties V2 and configureStream configurations.