### PR TITLE
blazingmq.util.logging: store switch value in args namespace

### DIFF
--- a/src/python/blazingmq/util/logging.py
+++ b/src/python/blazingmq/util/logging.py
@@ -108,6 +108,7 @@ class Action(argparse.Action):
     """
 
     def __call__(self, parser, namespace, level_spec, option_string=None):
+        setattr(namespace, self.dest, level_spec)
         levels = normalize_log_levels(level_spec)
         logging.basicConfig(level=levels[0])
         apply_normalized_log_levels(levels)


### PR DESCRIPTION
Make `bmq.util.logging.Action` store the value. Even though the action sets the log levels appropriately, this change makes it possible to detect whether the switch was specified.