### PR TITLE
Avoid flushList upon initiateShutdown

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -854,6 +854,8 @@ void ClientSession::initiateShutdownDispatched(
         return;  // RETURN
     }
 
+    flush();  // Flush any pending messages
+
     // Wait for tearDown.
     d_shutdownCallback = callback;
 
@@ -2813,7 +2815,10 @@ void ClientSession::initiateShutdown(const ShutdownCb&         callback,
                              this,
                              callback,
                              timeout),
-        this);
+        this,
+        mqbi::DispatcherEventType::e_DISPATCHER);
+    // Use 'mqbi::DispatcherEventType::e_DISPATCHER' to avoid (re)enabling
+    // 'd_flushList'
 }
 
 void ClientSession::invalidate()


### PR DESCRIPTION
The existing code takes precautions to avoid adding `ClientSession` to the `d_flushList` when `tearDown`.
But `ClientSession::initiateShutdown` can be called twice (by multiple clusters/proxies) and the second call while detecting the state, re-enables `d_flushList`.

The solution could be to make sure `initiateShutdown` does not re-enable `d_flushList`.