### PR TITLE
Fix macro redefinition warnings, add bmqstoragetool.td target

### DIFF
--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -194,6 +194,13 @@ function(bmq_add_application_test target)
       add_custom_target(${target}.t)
     endif()
     add_dependencies(${target}.t ${lib_target}.t)
+
+    if(_COMPAT)
+      if (NOT TARGET ${target}.td)
+        add_custom_target(${target}.td)
+      endif()
+      add_dependencies(${target}.td ${lib_target}.t)
+    endif()
   endif()
 
   if (${lib_target}_TEST_TARGETS)
@@ -203,16 +210,6 @@ function(bmq_add_application_test target)
   set(td_manifest)
 
   if(${lib_target}_TEST_TARGETS)
-
-    if(NOT TARGET ${lib_target}.t)
-      add_custom_target(${lib_target}.t)      
-      if(_COMPAT)
-        add_custom_target(${lib_target}.td)
-      endif()
-    endif()
-
-    add_dependencies(${lib_target}.t ${${lib_target}_TEST_TARGETS})
-
     if(_COMPAT)
       foreach(test_target ${${lib_target}_TEST_TARGETS})
         string(REPLACE ".t" "" component ${test_target})

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
@@ -51,6 +51,15 @@
 
 // GMOCK
 #include <gmock/gmock.h>
+// Undefine macroses from gtest.h which are defined in mwctst_testhelper.h
+#undef ASSERT_EQ
+#undef ASSERT_NE
+#undef ASSERT_LT
+#undef ASSERT_LE
+#undef ASSERT_GT
+#undef ASSERT_GE
+#undef TEST_F
+#undef TEST
 
 // TEST DRIVER
 #include <mwctst_testhelper.h>


### PR DESCRIPTION
- Fixed `gtest.h` macro redefinition warnings;
- Added `make` target `bmqstoragetool.td` for consistency;
