### PR TITLE
fix: do not use defaultSubQueueInfoArray()

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
@@ -67,10 +67,6 @@ bsls::ObjectBuffer<bdlbb::Blob> g_heartbeatRspBlob;
 /// heartbeat response and an empty blob.
 bsls::ObjectBuffer<bdlbb::Blob> g_emptyBlob;
 
-/// A static SubQueueInfoArray prefilled with the default subQueueId and an
-/// unlimited RDA counter.
-bsls::ObjectBuffer<Protocol::SubQueueInfosArray> g_defaultSubQueueInfoArray;
-
 /// Integer to keep track of the number of calls to `initialize` for the
 /// `ProtocolUtil`.  If the value is non-zero, then it has already been
 /// initialized, otherwise it can be initialized.  Each call to `initialize`
@@ -168,13 +164,6 @@ void ProtocolUtil::initialize(bslma::Allocator* allocator)
 
     // Create empty blob
     new (g_emptyBlob.buffer()) bdlbb::Blob(alloc);
-
-    // Populate the default subQueueInfo array with the default subQueueId and
-    // an unlimited RDA counter
-    new (g_defaultSubQueueInfoArray.buffer()) Protocol::SubQueueInfosArray(
-        1,
-        SubQueueInfo(Protocol::k_DEFAULT_SUBSCRIPTION_ID),
-        alloc);
 }
 
 void ProtocolUtil::shutdown()
@@ -187,12 +176,6 @@ void ProtocolUtil::shutdown()
     if (--g_initialized != 0) {
         return;  // RETURN
     }
-
-    g_defaultSubQueueInfoArray.object()
-        .mwcc::Array<SubQueueInfo, 16>::Array::~Array();
-    // Above expression, particularly the 'Array::' before '~Array()' is
-    // required if passing '-Wpedantic' flag in our build, which is what we
-    // are doing when building with clang.
 
     g_heartbeatRspBlob.object().bdlbb::Blob::~Blob();
     g_heartbeatReqBlob.object().bdlbb::Blob::~Blob();
@@ -337,14 +320,6 @@ void ProtocolUtil::binaryToHex(char*       buffer,
         buffer[index]     = k_INT_TO_HEX_TABLE[ch >> 4];
         buffer[index + 1] = k_INT_TO_HEX_TABLE[ch & 0xF];
     }
-}
-
-const Protocol::SubQueueInfosArray& ProtocolUtil::defaultSubQueueInfoArray()
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(g_initialized && "Not initialized");
-
-    return g_defaultSubQueueInfoArray.object();
 }
 
 int ProtocolUtil::ackResultToCode(bmqt::AckResult::Enum value)

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -376,13 +376,6 @@ struct ProtocolUtil {
 
     /// Protocol miscellaneous
     ///----------------------
-
-    /// Return a reference not offering modifiable access to the statically
-    /// created default SubQueueInfoArray (a SubQueueInfosArray containing
-    /// the default subQueueId and an unlimited RDA counter).  The behavior
-    /// is undefined unless `initialize` has been called.
-    static const Protocol::SubQueueInfosArray& defaultSubQueueInfoArray();
-
     static int ackResultToCode(bmqt::AckResult::Enum value);
 
     /// Convert the specified `value` between an `AckResult` enum value

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
@@ -528,52 +528,7 @@ static void test6_heartbeatAndEmptyBlobs()
     bmqp::ProtocolUtil::shutdown();
 }
 
-static void test7_defaultSubQueueInfoArray()
-// ------------------------------------------------------------------------
-// DEFAULT SUBQUEUEINFO ARRAY
-//
-// Concerns:
-//   1. If 'initialize' has not been called, unable to obtain the default
-//      SubQueueInfoArray.
-//   2. After 'initialize' has been called, should be able to obtain a
-//      reference not offering modifiable access to the statically created
-//      default SubQueueInfoArray containing one element: The default
-//      subQueueId with an unlimited RDA counter.
-//
-// Plan:
-//   1. Assert failure of calling 'defaultSubQueueInfoArray' without prior
-//      call to 'initialize'.
-//   2. Initialize the 'ProtocolUtil' and verify obtaining the default
-//      SubQueueInfoArray.
-//
-// Testing:
-//   defaultSubQueueInfoArray
-//   ----------------------------------------------------------------------
-{
-    mwctst::TestHelper::printTestName("DEFAULT SUBQUEUEINFOARRAY");
-
-    // 1. If 'initialize' has not been called, unable to obtain the default
-    //    SubQueueInfoArray.
-    ASSERT_SAFE_FAIL(bmqp::ProtocolUtil::defaultSubQueueInfoArray());
-
-    // 2. After 'initialize' has been called, should be able to obtain a
-    //    reference not offering modifiable access to the statically created
-    //    default SubQueueInfoArray containing one element: The default
-    //    subQueueId with an unlimited RDA counter.
-    bmqp::ProtocolUtil::initialize(s_allocator_p);
-
-    ASSERT_SAFE_PASS(bmqp::ProtocolUtil::defaultSubQueueInfoArray());
-
-    const bmqp::Protocol::SubQueueInfosArray& subQueueInfoArray =
-        bmqp::ProtocolUtil::defaultSubQueueInfoArray();
-    ASSERT_EQ(subQueueInfoArray.size(), 1U);
-    ASSERT_EQ(subQueueInfoArray[0].id(), bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID);
-    ASSERT_EQ(subQueueInfoArray[0].rdaInfo().isUnlimited(), true);
-
-    bmqp::ProtocolUtil::shutdown();
-}
-
-static void test8_ackResultToCode()
+static void test7_ackResultToCode()
 // ------------------------------------------------------------------------
 // ACK RESULT TO CODE
 //
@@ -621,7 +576,7 @@ static void test8_ackResultToCode()
     }
 }
 
-static void test9_ackResultFromCode()
+static void test8_ackResultFromCode()
 // ------------------------------------------------------------------------
 // ACK RESULT FROM CODE
 //
@@ -665,7 +620,7 @@ static void test9_ackResultFromCode()
     }
 }
 
-static void test10_loadFieldValues()
+static void test9_loadFieldValues()
 // ------------------------------------------------------------------------
 // LOAD FIELD VALUES
 //
@@ -802,7 +757,7 @@ static void encodeDecodeHelper(E encodingType)
     ASSERT_EQ(decodedClusterMessage, clusterMessage);
 }
 
-static void test11_encodeDecodeMessage()
+static void test10_encodeDecodeMessage()
 // ------------------------------------------------------------------------
 // ENCODE DECODE MESSAGE
 //
@@ -868,7 +823,7 @@ static void populateBlob(bdlbb::Blob* blob, int atLeastLen)
     }
 }
 
-static void test12_parseMessageProperties()
+static void test11_parseMessageProperties()
 // ------------------------------------------------------------------------
 // TESTS PARSING AS IT IS USED IN QueueEngineUtil::logRejectMessage
 //
@@ -953,12 +908,11 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 12: test12_parseMessageProperties(); break;
-    case 11: test11_encodeDecodeMessage(); break;
-    case 10: test10_loadFieldValues(); break;
-    case 9: test9_ackResultFromCode(); break;
-    case 8: test8_ackResultToCode(); break;
-    case 7: test7_defaultSubQueueInfoArray(); break;
+    case 11: test11_parseMessageProperties(); break;
+    case 10: test10_encodeDecodeMessage(); break;
+    case 9: test9_loadFieldValues(); break;
+    case 8: test8_ackResultFromCode(); break;
+    case 7: test7_ackResultToCode(); break;
     case 6: test6_heartbeatAndEmptyBlobs(); break;
     case 5: test5_paddingBlob(); break;
     case 4: test4_paddingChar(); break;

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -1022,7 +1022,10 @@ bool QueueEngineUtil_AppState::visitBroadcast(
         message->guid(),
         message->attributes(),
         "",  // msgGroupId
-        bmqp::ProtocolUtil::defaultSubQueueInfoArray());
+        bmqp::Protocol::SubQueueInfosArray(
+            1,
+            bmqp::SubQueueInfo(subscription->d_downstreamSubscriptionId)));
+
     return false;
 }
 


### PR DESCRIPTION
Any broadcast PUSH for now needs real subscription id.  Cannot use `defaultSubQueueInfoArray()`, it will cause `#CLIENT_INVALID_PUSH` or `Assertion failed: cit != d_subscriptions.end()`