### PR TITLE
CI: remove python packages installation from macos build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,8 +133,6 @@ jobs:
             bison \
             flex \
             google-benchmark
-          python3 -m pip install --upgrade pip
-          pip install -r ${{ github.workspace }}/src/python/requirements.txt
       - name: Build BlazingMQ
         run: bin/build-darwin.sh
 


### PR DESCRIPTION
Workaround for the latest CI crash, we don't actually need pip packages for macos workflow