### PR TITLE
Fix: data type consistency and Wconv catch

### DIFF
--- a/src/groups/mwc/mwcc/mwcc_array.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_array.t.cpp
@@ -397,11 +397,11 @@ static void test1_breathingTest()
             ObjType obj1(s_allocator_p);
             ObjType obj2(s_allocator_p);
 
-            for (size_t i = 0; i < 50; ++i) {
+            for (int i = 0; i < 50; ++i) {
                 obj1.push_back(TestType("a", s_allocator_p));
             }
 
-            for (size_t i = 0; i < 100; ++i) {
+            for (int i = 0; i < 100; ++i) {
                 obj2.push_back(TestType("b", s_allocator_p));
             }
 
@@ -416,11 +416,11 @@ static void test1_breathingTest()
             ObjType obj1(s_allocator_p);
             ObjType obj2(s_allocator_p);
 
-            for (size_t i = 0; i < 50; ++i) {
+            for (int i = 0; i < 50; ++i) {
                 obj1.push_back(TestType("a", s_allocator_p));
             }
 
-            for (size_t i = 0; i < 100; ++i) {
+            for (int i = 0; i < 100; ++i) {
                 obj2.push_back(TestType("b", s_allocator_p));
             }
 
@@ -434,7 +434,7 @@ static void test1_breathingTest()
         {
             ObjType* obj = new (*s_allocator_p) ObjType(s_allocator_p);
 
-            for (size_t i = 0; i < 50; ++i) {
+            for (int i = 0; i < 50; ++i) {
                 obj->push_back(TestType("a", s_allocator_p));
             }
 
@@ -629,12 +629,12 @@ static void test6_assign()
     bslma::TestAllocator ta("testAlloc");
 
     ObjType obj(&ta);
-    for (size_t i = 0; i < k_STATIC_LEN + 5; ++i) {
+    for (int i = 0; i < k_STATIC_LEN + 5; ++i) {
         obj.push_back(TestType(i, s_allocator_p));
     }
 
     bsl::vector<TestType> srcVec(s_allocator_p);
-    for (size_t i = 0; i < 2 * k_STATIC_LEN; ++i) {
+    for (int i = 0; i < 2 * k_STATIC_LEN; ++i) {
         srcVec.push_back(TestType(10 * i, s_allocator_p));
     }
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This PR deals with some ‘size_t‘ and ‘int‘ data type inconsistencies. Between lines 400-437, I fixed the data types to ‘int‘ from ‘size_t‘ to keep consistent with the previous loops in the file.

This PR also catches with the following -Wconversion warnings that pollutes the build logs:

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_array.t.cpp:633:32: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  633 |         obj.push_back(TestType(i, s_allocator_p));
      |                                ^
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_array.t.cpp:638:38: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  638 |         srcVec.push_back(TestType(10 * i, s_allocator_p));
      |                                   ~~~^~~
``` 
      
**Testing performed**
N/A

**Additional context**
An alternative naive fix to the logs would have been casting the first parameters in TestType as an ‘int‘ instead of making the changing the for loops to be of data type ‘int‘ instead of ‘size_t‘. However, k_STATIC_LEN is defined to be ‘const int <unnamed>::k_STATIC_LEN = 10‘, and most of the for loops in the context use ‘int‘ if they aren't explicitly bounded by or referring to an obj size.

Note that lines 400-437 look hardcoded. Please comment to let me know if I should use or define a local ‘k_NB_ITEMS‘ or some other sort of constant(s) instead of having 50, 100, 150, 200, etc, and I can add this to the PR if needed.