### PR TITLE
protect ClientSession::initiateShutdownDispatched

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -2811,10 +2811,11 @@ void ClientSession::initiateShutdown(const ShutdownCb&         callback,
     BALL_LOG_INFO << description() << ": initiateShutdown";
 
     dispatcher()->execute(
-        bdlf::BindUtil::bind(&ClientSession::initiateShutdownDispatched,
-                             this,
-                             callback,
-                             timeout),
+        bdlf::BindUtil::bind(
+            bdlf::MemFnUtil::memFn(&ClientSession::initiateShutdownDispatched,
+                                   d_self.acquire()),
+            callback,
+            timeout),
         this,
         mqbi::DispatcherEventType::e_DISPATCHER);
     // Use 'mqbi::DispatcherEventType::e_DISPATCHER' to avoid (re)enabling


### PR DESCRIPTION
When calling `ClientSession::initiateShutdown` multiple times (as in the multi-cluster environment), the first call can result in the session destruction _after_ subsequent call(s) schedule `ClientSession::initiateShutdownDispatched`. The latter results in a seqfault.
As a solution, bind `shared_ptr<ClientSession>` to the `ClientSession::initiateShutdownDispatched`.