### PR TITLE
CI: reduce cache size

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,6 @@ jobs:
           find . -name "*.o" -type f -delete
           find . -name "*.a" -type f -delete
           find . -name "*.t.tsk" -type f -delete
-          du -h -a
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,9 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cmake --build build/blazingmq --parallel 8 --target all all.t
+      - name: Clean-up build directories before caching
+        run: |
+          find . -name "*.o" -type f -delete
       - uses: actions/cache@v4
         with:
           path: |
@@ -70,6 +73,7 @@ jobs:
         with:
           path: |
             build/blazingmq
+            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Run Python Unit Tests
@@ -96,6 +100,7 @@ jobs:
         with:
           path: |
             build/blazingmq
+            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Run Integration Tests
@@ -144,6 +149,7 @@ jobs:
         with:
           path: |
             build/blazingmq
+            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Set up plugins dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
       - name: Clean-up build directories before caching
         run: |
           find . -name "*.o" -type f -delete
+          find . -name "*.a" -type f -delete
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,6 @@ jobs:
         with:
           path: |
             build/blazingmq
-            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Run Python Unit Tests
@@ -97,7 +96,6 @@ jobs:
         with:
           path: |
             build/blazingmq
-            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Run Integration Tests
@@ -146,7 +144,6 @@ jobs:
         with:
           path: |
             build/blazingmq
-            deps
             /opt/bb/include
           key: cache-${{ github.sha }}
       - name: Set up plugins dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
         run: |
           find . -name "*.o" -type f -delete
           find . -name "*.a" -type f -delete
+          du -h
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           find . -name "*.o" -type f -delete
           find . -name "*.a" -type f -delete
-          du -h
+          du -h -a
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,10 +52,15 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cmake --build build/blazingmq --parallel 8 --target all all.t
+      - name: Run C++ Unit Tests
+        run: |
+          cd ${{ github.workspace }}/build/blazingmq
+          ctest -E mwcsys_executil.t --output-on-failure
       - name: Clean-up build directories before caching
         run: |
           find . -name "*.o" -type f -delete
           find . -name "*.a" -type f -delete
+          find . -name "*.t.tsk" -type f -delete
           du -h -a
       - uses: actions/cache@v4
         with:
@@ -87,10 +92,6 @@ jobs:
           src/python/bin/schemagen
           src/python/bin/tweakgen
           pytest src/python
-      - name: Run C++ Unit Tests
-        run: |
-          cd ${{ github.workspace }}/build/blazingmq
-          ctest -E mwcsys_executil.t --output-on-failure
 
   integration_tests_ubuntu:
     name: BlazingMQ integration tests


### PR DESCRIPTION
The current size of a cache entry is 1.9 GB, with GH limits of 10 GB we have a problem with parallel PRs.

From my research:
300MB of cache is used by object files (`*.o`)
400MB of cache is used by built static libraries (`*.a`)
1000MB of cache is used by built unit test drivers (`*.t.tsk`)

This PR adds cleanup step to remove all these files before caching. Since we need test drivers for unit tests, I placed unit tests validation before the cleanup step.

The plot twist here is that a cache doesn't speed up plugins build. You can see that enabling plugins build causes most (all?) files rebuild.

The final size of a cache decreased by 10x: 1.9GB -> 190MB