### PR TITLE
Fix -Wextra-semi warnings

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.h
@@ -43,9 +43,9 @@ class CommandProcessor {
     // CREATORS
 
     /// Default constructor.
-    CommandProcessor(){};
+    CommandProcessor() {}
 
-    virtual ~CommandProcessor(){};
+    virtual ~CommandProcessor() {}
 
     // MANIPULATORS
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
@@ -54,7 +54,7 @@ class FileManager {
     virtual mqbs::JournalFileIterator* journalFileIterator() = 0;
     virtual mqbs::DataFileIterator*    dataFileIterator()    = 0;
 
-    virtual ~FileManager(){};
+    virtual ~FileManager() {}
 };
 
 class FileManagerImpl : public FileManager {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -86,7 +86,7 @@ class SearchResult {
     // CREATORS
 
     /// Destructor
-    virtual ~SearchResult(){};
+    virtual ~SearchResult() {}
 
     // MANIPULATORS
 

--- a/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.h
+++ b/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.h
@@ -79,7 +79,7 @@ class PrometheusStatExporter {
 
     virtual ~PrometheusStatExporter() = default;
 
-    virtual void onData(){};
+    virtual void onData() {}
     virtual int  start() = 0;
     virtual void stop()  = 0;
 };


### PR DESCRIPTION
**Describe your changes**
This PR fixes some compiler warnings for trailing semicolons on function defs: `warning: extra ';' after member function definition [-Wextra-semi]`