### PR TITLE
Fix: mwcc monitoredqueue and orderedhashmap Wconv warnings

### DIFF
--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue.h
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue.h
@@ -590,7 +590,7 @@ template <class QUEUE, class QUEUE_TRAITS>
 inline int MonitoredQueue<QUEUE, QUEUE_TRAITS>::pushBack(
     bslmf::MovableRef<ElementType> value)
 {
-    const int currentQueueLen = numElements();
+    const int currentQueueLen = static_cast<int>(numElements());
     if (currentQueueLen + 1 >= capacity()) {
         // We've filled the queue.  Alarm
         if (!Traits::isPushBackDisabled(d_queue) &&

--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue.h
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue.h
@@ -590,7 +590,7 @@ template <class QUEUE, class QUEUE_TRAITS>
 inline int MonitoredQueue<QUEUE, QUEUE_TRAITS>::pushBack(
     bslmf::MovableRef<ElementType> value)
 {
-    const int currentQueueLen = static_cast<int>(numElements());
+    const bsls::Types::Int64 currentQueueLen = numElements();
     if (currentQueueLen + 1 >= capacity()) {
         // We've filled the queue.  Alarm
         if (!Traits::isPushBackDisabled(d_queue) &&

--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
@@ -110,8 +110,7 @@ static void performanceTestPusher(int                        iterations,
 static void printProcessedItems(int numItems, bsls::Types::Int64 elapsedTime)
 {
     const double numSeconds = static_cast<double>(elapsedTime) / 1000000000LL;
-    const bsls::Types::Int64 itemsPerSec = static_cast<bsls::Types::Int64>(
-        numItems / numSeconds);
+    const bsls::Types::Int64 itemsPerSec = numItems / numSeconds;
 
     bsl::cout << "Processed " << numItems << " items in "
               << mwcu::PrintUtil::prettyTimeInterval(elapsedTime) << ". "

--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
@@ -110,7 +110,8 @@ static void performanceTestPusher(int                        iterations,
 static void printProcessedItems(int numItems, bsls::Types::Int64 elapsedTime)
 {
     const double numSeconds = static_cast<double>(elapsedTime) / 1000000000LL;
-    const bsls::Types::Int64 itemsPerSec = numItems / numSeconds;
+    const bsls::Types::Int64 itemsPerSec = static_cast<bsls::Types::Int64>(
+        numItems / numSeconds);
 
     bsl::cout << "Processed " << numItems << " items in "
               << mwcu::PrintUtil::prettyTimeInterval(elapsedTime) << ". "

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
@@ -1386,7 +1386,7 @@ OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::erase(const_iterator position)
     iterator nextPosition(position.d_link_p->nextInList());
     Node*    nodeToErase = static_cast<Node*>(position.d_link_p);
 
-    int count = erase(get_key(nodeToErase->value()));
+    size_t count = erase(get_key(nodeToErase->value()));
     BSLS_ASSERT(1 == count && "Invalid iterator provided");
     static_cast<void>(count);  // suppress compiler warning
     return nextPosition;

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -215,7 +215,7 @@ static void test3_insert()
     const int k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const int k_NUM_ELEMENTS = 100 * 1000;   // 100K
+    const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #endif
 
     // Insert 1M elements
@@ -826,7 +826,7 @@ static void test14_localIterator()
 
     const size_t bucketCount = map.bucket_count();
 
-    int key         = bucketCount / 2;
+    int key         = static_cast<int>(bucketCount / 2);
     int originalKey = key;
 
     map.insert(bsl::make_pair(key, key * key));
@@ -853,7 +853,7 @@ static void test14_localIterator()
     // Add keys such that they all map to same bucket in the table, while
     // ensuring that table is not rehashed.
     for (unsigned int i = 0; i < (bucketCount - 2); ++i) {
-        key += bucketCount;
+        key += static_cast<int>(bucketCount);
         map.insert(bsl::make_pair(key, key * key));
     }
 
@@ -861,7 +861,8 @@ static void test14_localIterator()
     localEndIt = map.end(bucket);
 
     key = originalKey;
-    for (; localIt != localEndIt; ++localIt, key += bucketCount) {
+    for (; localIt != localEndIt;
+         ++localIt, key += static_cast<int>(bucketCount)) {
         ASSERT_EQ(localIt->first, key);
         ASSERT_EQ(localIt->second, key * key);
     }
@@ -1115,7 +1116,7 @@ testN1_insertPerformanceOrdered_GoogleBenchmark(benchmark::State& state)
         // OrderedHashMap
         typedef mwcc::OrderedHashMap<int, int> MyMapType;
 
-        MyMapType map(state.range(0), s_allocator_p);
+        MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
         for (auto _ : state) {
             for (int i = 0; i < state.range(0); ++i) {
                 map.insert(bsl::make_pair(i, i));
@@ -1190,7 +1191,7 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
     // This case can be used to profile the component.
 
     typedef mwcc::OrderedHashMap<int, int> MyMapType;
-    MyMapType                              map(state.range(0), s_allocator_p);
+    MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
 
     // Insert elements.
     for (auto _ : state) {

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -215,7 +215,7 @@ static void test3_insert()
     const int k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
+    const int k_NUM_ELEMENTS = 100 * 1000;   // 100K
 #endif
 
     // Insert 1M elements
@@ -861,8 +861,7 @@ static void test14_localIterator()
     localEndIt = map.end(bucket);
 
     key = originalKey;
-    for (; localIt != localEndIt;
-         ++localIt, key += static_cast<int>(bucketCount)) {
+    for (; localIt != localEndIt; ++localIt, key += static_cast<int>(bucketCount)) {
         ASSERT_EQ(localIt->first, key);
         ASSERT_EQ(localIt->second, key * key);
     }
@@ -1191,7 +1190,7 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
     // This case can be used to profile the component.
 
     typedef mwcc::OrderedHashMap<int, int> MyMapType;
-    MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
+    MyMapType                              map(static_cast<int>(state.range(0)), s_allocator_p);
 
     // Insert elements.
     for (auto _ : state) {

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -60,23 +60,23 @@ class IdentityHasher {
   public:
     IdentityHasher() {}
 
-    size_t operator()(int x) const { return x; }
+    size_t operator()(size_t x) const { return x; }
 };
 
 struct TestKeyType {
     // CLASS LEVEL DATA
-    static int s_numDeletions;
+    static size_t s_numDeletions;
 
     // DATA
-    int d_a;
+    size_t d_a;
 
     // CREATORS
-    TestKeyType(int a) { d_a = a; }
+    TestKeyType(size_t a) { d_a = a; }
 
     ~TestKeyType() { s_numDeletions += 1; }
 };
 
-int TestKeyType::s_numDeletions(0);
+size_t TestKeyType::s_numDeletions(0);
 
 // FREE FUNCTIONS
 bool operator==(const TestKeyType& lhs, const TestKeyType& rhs)
@@ -93,18 +93,18 @@ void hashAppend(HASH_ALGORITHM& hashAlgo, const TestKeyType& key)
 
 struct TestValueType {
     // CLASS LEVEL DATA
-    static int s_numDeletions;
+    static size_t s_numDeletions;
 
     // DATA
-    int d_b;
+    size_t d_b;
 
     // CREATORS
-    TestValueType(int b) { d_b = b; }
+    TestValueType(size_t b) { d_b = b; }
 
     ~TestValueType() { s_numDeletions += 1; }
 };
 
-int TestValueType::s_numDeletions(0);
+size_t TestValueType::s_numDeletions(0);
 
 }  // close unnamed namespace
 
@@ -121,7 +121,7 @@ static void test1_breathingTest()
     mwctst::TestHelper::printTestName("BREATHING TEST");
 
     // Breathing test
-    typedef mwcc::OrderedHashMap<int, bsl::string> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, bsl::string> MyMapType;
     typedef MyMapType::iterator                    IterType;
     typedef MyMapType::const_iterator              ConstIterType;
 
@@ -204,7 +204,7 @@ static void test3_insert()
 {
     mwctst::TestHelper::printTestName("INSERT");
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
@@ -212,14 +212,14 @@ static void test3_insert()
     MyMapType map(s_allocator_p);
 
 #ifdef BSLS_PLATFORM_OS_LINUX
-    const int k_NUM_ELEMENTS = 1000 * 1000;  // 1M
+    const size_t k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const int k_NUM_ELEMENTS = 100 * 1000;   // 100K
+    const size_t k_NUM_ELEMENTS = 100 * 1000;   // 100K
 #endif
 
     // Insert 1M elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i + 1));
         ASSERT_EQ_D(i, true, rc.second);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -228,12 +228,12 @@ static void test3_insert()
         ASSERT_EQ_D(i, true, 1.5 >= map.load_factor());
     }
 
-    ASSERT_EQ(map.size(), static_cast<unsigned int>(k_NUM_ELEMENTS));
+    ASSERT_EQ(map.size(), k_NUM_ELEMENTS);
 
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = 0;
+        size_t              i    = 0;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -245,7 +245,7 @@ static void test3_insert()
     // Reverse iterate using --(end()) and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = k_NUM_ELEMENTS - 1;
+        size_t              i    = k_NUM_ELEMENTS - 1;
         ConstIterType    cit  = --(cmap.end());  // last element
         for (; cit != cmap.begin(); --cit) {
             ASSERT_EQ_D(i, true, i > 0);
@@ -276,13 +276,13 @@ static void test4_rinsert()
 
 #ifdef BSLS_PLATFORM_OS_AIX
     // Avoid timeout on AIX
-    const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
+    const size_t k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #else
-    const int k_NUM_ELEMENTS = 1000 * 1000;  // 1M
+    const size_t k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #endif
 
     // Insert 1M elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.rinsert(bsl::make_pair(i, i + 1));
         ASSERT_EQ_D(i, true, rc.second);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -291,12 +291,12 @@ static void test4_rinsert()
         ASSERT_EQ_D(i, true, 1.5 >= map.load_factor());
     }
 
-    ASSERT_EQ(map.size(), static_cast<unsigned int>(k_NUM_ELEMENTS));
+    ASSERT_EQ(map.size(), k_NUM_ELEMENTS);
 
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = k_NUM_ELEMENTS - 1;
+        size_t              i    = k_NUM_ELEMENTS - 1;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, i, cit->first);
             ASSERT_EQ_D(i, (i + 1), cit->second);
@@ -307,7 +307,7 @@ static void test4_rinsert()
     // Reverse iterate using --(end()) and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = 0;
+        size_t              i    = 0;
         ConstIterType    cit  = --(cmap.end());  // last element
         for (; cit != cmap.begin(); --cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
@@ -329,18 +329,18 @@ static void test5_insertEraseInsert()
     mwctst::TestHelper::printTestName("INSERT ERASE INSERT");
 
     // insert/erase/insert test
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
     MyMapType map(s_allocator_p);
 
-    const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
-    const int k_STEP         = 10;
+    const size_t k_NUM_ELEMENTS = 100 * 1000;  // 100K
+    const size_t k_STEP         = 10;
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i + 1));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -351,7 +351,7 @@ static void test5_insertEraseInsert()
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = 0;
+        size_t              i    = 0;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -361,19 +361,19 @@ static void test5_insertEraseInsert()
     }
 
     // Erase few elements
-    for (int i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
         ASSERT_EQ_D(i, 1U, map.erase(i));
     }
 
     // Find erased elements
-    for (int i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
         ASSERT_EQ_D(i, true, map.end() == map.find(i));
     }
 
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        int              i    = 1;
+        size_t              i    = 1;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -386,7 +386,7 @@ static void test5_insertEraseInsert()
     }
 
     // Insert elements which were erased earlier
-    for (int i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; i += k_STEP) {
         RcType rc = map.insert(bsl::make_pair(i, i + 1));
         ASSERT_EQ_D(i, true, rc.second);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -397,7 +397,7 @@ static void test5_insertEraseInsert()
     // Iterate and confirm
     {
         IterType it = map.begin();
-        int      i  = 1;
+        size_t      i  = 1;
 
         // Iterate over original elements
         for (; it != map.end(); ++it) {
@@ -450,10 +450,10 @@ static void test6_clear()
     ASSERT_EQ(0U, map.size());
     ASSERT_EQ(true, map.load_factor() == 0.0);
 
-    const int k_NUM_ELEMENTS = 100;
+    const size_t k_NUM_ELEMENTS = 100;
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i + 1));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -463,7 +463,7 @@ static void test6_clear()
 
     ASSERT_EQ(false, map.empty());
     ASSERT_EQ(true, map.begin() != map.end());
-    ASSERT_EQ(static_cast<unsigned int>(k_NUM_ELEMENTS), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS, map.size());
 
     map.clear();
     ASSERT_EQ(true, map.empty());
@@ -485,11 +485,11 @@ static void test7_erase()
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 100;
+    const size_t k_NUM_ELEMENTS = 100;
     MyMapType map(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -522,18 +522,18 @@ static void test8_eraseClear()
     typedef MyMapType::iterator                              IterType;
     typedef bsl::pair<IterType, bool>                        RcType;
 
-    const int k_NUM_ELEMENTS = 100;
+    const size_t k_NUM_ELEMENTS = 100;
     MyMapType map(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(
             bsl::make_pair(TestKeyType(i), TestValueType(i)));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
     }
 
-    ASSERT_EQ(static_cast<size_t>(k_NUM_ELEMENTS), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS, map.size());
 
     // Reset static counters
     TestKeyType::s_numDeletions   = 0;
@@ -560,22 +560,22 @@ static void test9_insertFailure()
     mwctst::TestHelper::printTestName("INSERT FAILURE");
 
     // insert (key, value) already present in the container
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 100000;
+    const size_t k_NUM_ELEMENTS = 100000;
     MyMapType map(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, true, rc.second);
         ASSERT_EQ_D(i, true, rc.first != map.end());
     }
 
     // insert same keys again
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, false);
         ASSERT_EQ_D(i, true, rc.first == map.find(i));
@@ -593,15 +593,15 @@ static void test10_erasureIterator()
     mwctst::TestHelper::printTestName("ERASURE ITERATOR");
     // Use iterator returned by erase(const_iterator)
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 10000;
+    const size_t k_NUM_ELEMENTS = 10000;
     MyMapType map(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -617,7 +617,7 @@ static void test10_erasureIterator()
     ASSERT_EQ(true, it != map.end());
     ASSERT_EQ(true, it == map.find(9001));
 
-    int i = 9001;
+    size_t i = 9001;
     for (; it != map.end(); ++it) {
         ASSERT_EQ_D(i, i, it->first);
         ++i;
@@ -639,17 +639,17 @@ static void test11_copyConstructor()
     // Copy construct object 2 from object 1.
     // Assert that object 2 has same elements etc.
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 10000;
+    const size_t k_NUM_ELEMENTS = 10000;
 
     MyMapType* m1p = new (*s_allocator_p) MyMapType(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = m1p->insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != m1p->end());
@@ -658,7 +658,7 @@ static void test11_copyConstructor()
     MyMapType m2(*m1p, s_allocator_p);
 
     // Iterate and confirm
-    int i = 0;
+    size_t i = 0;
     for (ConstIterType cit = m2.begin(); cit != m2.end(); ++cit) {
         ASSERT_EQ_D(i, cit->first, i);
         ASSERT_EQ_D(i, cit->second, i);
@@ -692,17 +692,17 @@ static void test12_assignmentOperator()
     // object 2 = object 1
     // Assert that object 2 has same elements as object 1 etc.
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 10000;
+    const size_t k_NUM_ELEMENTS = 10000;
 
     MyMapType* m1p = new (*s_allocator_p) MyMapType(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = m1p->insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != m1p->end());
@@ -711,7 +711,7 @@ static void test12_assignmentOperator()
     MyMapType m2(s_allocator_p);
 
     // Insert elements
-    for (int i = k_NUM_ELEMENTS; i > 0; --i) {
+    for (size_t i = k_NUM_ELEMENTS; i > 0; --i) {
         RcType rc = m2.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != m2.end());
@@ -720,7 +720,7 @@ static void test12_assignmentOperator()
     m2 = *m1p;
 
     // Iterate and confirm
-    int i = 0;
+    size_t i = 0;
     for (ConstIterType cit = m2.begin(); cit != m2.end(); ++cit) {
         ASSERT_EQ_D(i, cit->first, i);
         ASSERT_EQ_D(i, cit->second, i);
@@ -762,7 +762,7 @@ static void test13_previousEndIterator()
     IterType      endIt  = map.end();
     ConstIterType endCit = cmap.end();
 
-    int                       i  = 0;
+    size_t                       i  = 0;
     bsl::pair<IterType, bool> rc = map.insert(bsl::make_pair(i, i * i));
 
     ASSERT_EQ(true, rc.first == endIt);
@@ -817,7 +817,7 @@ static void test14_localIterator()
     // of the hash table, we specify such keys such that they will all map
     // to the same bucket in the table.
 
-    typedef mwcc::OrderedHashMap<int, int, IdentityHasher> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t, IdentityHasher> MyMapType;
     typedef MyMapType::local_iterator                      LocalIterType;
     typedef MyMapType::const_local_iterator                ConstLocalIterType;
 
@@ -826,8 +826,8 @@ static void test14_localIterator()
 
     const size_t bucketCount = map.bucket_count();
 
-    int key         = static_cast<int>(bucketCount / 2);
-    int originalKey = key;
+    size_t key         = bucketCount / 2;
+    size_t originalKey = key;
 
     map.insert(bsl::make_pair(key, key * key));
 
@@ -852,8 +852,8 @@ static void test14_localIterator()
 
     // Add keys such that they all map to same bucket in the table, while
     // ensuring that table is not rehashed.
-    for (unsigned int i = 0; i < (bucketCount - 2); ++i) {
-        key += static_cast<int>(bucketCount);
+    for (size_t i = 0; i < (bucketCount - 2); ++i) {
+        key += bucketCount;
         map.insert(bsl::make_pair(key, key * key));
     }
 
@@ -862,7 +862,7 @@ static void test14_localIterator()
 
     key = originalKey;
     for (; localIt != localEndIt;
-         ++localIt, key += static_cast<int>(bucketCount)) {
+         ++localIt, key += bucketCount) {
         ASSERT_EQ(localIt->first, key);
         ASSERT_EQ(localIt->second, key * key);
     }
@@ -889,16 +889,16 @@ static void test15_eraseRange()
     mwctst::TestHelper::printTestName("ERASE RANGE");
 
     // erase
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef MyMapType::const_iterator      ConstIterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
-    const int k_NUM_ELEMENTS = 100;
+    const size_t k_NUM_ELEMENTS = 100;
     MyMapType map(s_allocator_p);
 
     // Insert elements
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         RcType rc = map.insert(bsl::make_pair(i, i));
         ASSERT_EQ_D(i, rc.second, true);
         ASSERT_EQ_D(i, true, rc.first != map.end());
@@ -906,23 +906,23 @@ static void test15_eraseRange()
         ASSERT_EQ_D(i, i, rc.first->second);
     }
 
-    ASSERT_EQ(size_t(k_NUM_ELEMENTS), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS, map.size());
 
     ASSERT(map.erase(map.begin(), map.begin()) == map.begin());
-    ASSERT_EQ(size_t(k_NUM_ELEMENTS), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS, map.size());
 
     ASSERT(map.erase(map.end(), map.end()) == map.end());
-    ASSERT_EQ(size_t(k_NUM_ELEMENTS), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS, map.size());
 
     ConstIterType second = ++map.begin();
     ASSERT(map.erase(map.begin(), second) == second);
     ASSERT(map.begin() == second);
-    ASSERT_EQ(size_t(k_NUM_ELEMENTS - 1), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS - 1, map.size());
     ASSERT_EQ_D(1, 1, map.begin()->first);
     ASSERT_EQ_D(1, 1, map.begin()->second);
 
     ASSERT(map.erase(--map.end(), map.end()) == map.end());
-    ASSERT_EQ(size_t(k_NUM_ELEMENTS - 2), map.size());
+    ASSERT_EQ(k_NUM_ELEMENTS - 2, map.size());
     ASSERT_EQ_D(k_NUM_ELEMENTS - 2, k_NUM_ELEMENTS - 2, (--map.end())->first);
     ASSERT_EQ_D(k_NUM_ELEMENTS - 2, k_NUM_ELEMENTS - 2, (--map.end())->second);
 
@@ -942,17 +942,17 @@ static void testN1_insertPerformanceOrdered()
     mwctst::TestHelper::printTestName("INSERT PERFORMANCE");
 
     // Performance comparison of insert() with bsl::unordered_map
-    const int          k_NUM_ELEMENTS = 5000000;
+    const size_t          k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 ohmTime;
 
     {
         // OrderedHashMap
-        typedef mwcc::OrderedHashMap<int, int> MyMapType;
+        typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
 
         MyMapType map(k_NUM_ELEMENTS, s_allocator_p);
 
         bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
-        for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             map.insert(bsl::make_pair(i, i));
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
@@ -970,17 +970,17 @@ static void testN1_insertPerformanceUnordered()
     mwctst::TestHelper::printTestName("INSERT PERFORMANCE");
 
     // Performance comparison of insert() with bsl::unordered_map
-    const int          k_NUM_ELEMENTS = 5000000;
+    const size_t          k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 umTime;
     {
         // bsl::unordered_map
-        typedef bsl::unordered_map<int, int> MyMapType;
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
 
         MyMapType map(s_allocator_p);
         map.reserve(k_NUM_ELEMENTS);
 
         bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
-        for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             map.insert(bsl::make_pair(i, i));
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
@@ -1000,16 +1000,16 @@ BSLA_MAYBE_UNUSED static void testN2_erasePerformanceOrdered()
 
     // Insert elements, iterate and erase while iterating
 
-    const int          k_NUM_ELEMENTS = 5000000;
+    const size_t          k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 ohmTime;
     {
-        typedef mwcc::OrderedHashMap<int, int> MyMapType;
+        typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
         typedef MyMapType::iterator            IterType;
         typedef bsl::pair<IterType, bool>      RcType;
 
         MyMapType map(s_allocator_p);
         // Insert 1M elements
-        for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             ASSERT_EQ_D(i, i, rc.first->first);
             ASSERT_EQ_D(i, i, rc.first->second);
@@ -1038,16 +1038,16 @@ BSLA_MAYBE_UNUSED static void testN2_erasePerformanceUnordered()
 
     // Insert elements, iterate and erase while iterating
 
-    const int          k_NUM_ELEMENTS = 5000000;
+    const size_t          k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 umTime;
     {
-        typedef bsl::unordered_map<int, int> MyMapType;
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
         typedef MyMapType::iterator          IterType;
         typedef bsl::pair<IterType, bool>    RcType;
 
         MyMapType map(s_allocator_p);
         // Insert 1M elements
-        for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             ASSERT_EQ_D(i, i, rc.first->first);
             ASSERT_EQ_D(i, i, rc.first->second);
@@ -1074,13 +1074,13 @@ BSLA_MAYBE_UNUSED static void testN3_profile()
 
     // A simple snippet which inserts elements in the ordered hash map.
     // This case can be used to profile the component.
-    const int k_NUM_ELEMENTS = 5000000;
+    const size_t k_NUM_ELEMENTS = 5000000;
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     MyMapType                              map(k_NUM_ELEMENTS, s_allocator_p);
 
     // Insert elements.
-    for (int i = 0; i < k_NUM_ELEMENTS; ++i) {
+    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
         map.insert(bsl::make_pair(i, i));
     }
 }
@@ -1096,10 +1096,10 @@ testN1_insertPerformanceUnordered_GoogleBenchmark(benchmark::State& state)
     // Performance comparison of insert() with bsl::unordered_map
     {
         // UnorderedMap
-        typedef bsl::unordered_map<int, int> MyMapType;
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
         MyMapType map(state.range(0), s_allocator_p);
         for (auto _ : state) {
-            for (int i = 0; i < state.range(0); ++i) {
+            for (size_t i = 0; i < state.range(0); ++i) {
                 map.insert(bsl::make_pair(i, i));
             }
         }
@@ -1114,11 +1114,11 @@ testN1_insertPerformanceOrdered_GoogleBenchmark(benchmark::State& state)
     // Performance comparison of insert() with bsl::unordered_map
     {
         // OrderedHashMap
-        typedef mwcc::OrderedHashMap<int, int> MyMapType;
+        typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
 
-        MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
+        MyMapType map(state.range(0), s_allocator_p);
         for (auto _ : state) {
-            for (int i = 0; i < state.range(0); ++i) {
+            for (size_t i = 0; i < state.range(0); ++i) {
                 map.insert(bsl::make_pair(i, i));
             }
         }
@@ -1129,14 +1129,14 @@ static void
 testN2_erasePerformanceUnordered_GoogleBenchmark(benchmark::State& state)
 {
     // Unordered Map Erase Performance Test
-    typedef bsl::unordered_map<int, int> MyMapType;
+    typedef bsl::unordered_map<size_t, size_t> MyMapType;
     typedef MyMapType::iterator          IterType;
     typedef bsl::pair<IterType, bool>    RcType;
 
     MyMapType map(s_allocator_p);
     for (auto _ : state) {
         state.PauseTiming();
-        for (int i = 0; i < state.range(0); ++i) {
+        for (size_t i = 0; i < state.range(0); ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             ASSERT_EQ_D(i, i, rc.first->first);
             ASSERT_EQ_D(i, i, rc.first->second);
@@ -1158,7 +1158,7 @@ testN2_erasePerformanceOrdered_GoogleBenchmark(benchmark::State& state)
     // Performance comparison of erase() with bsl::unordered_map
 
     // Insert elements, iterate and erase while iterating
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
     typedef MyMapType::iterator            IterType;
     typedef bsl::pair<IterType, bool>      RcType;
 
@@ -1166,7 +1166,7 @@ testN2_erasePerformanceOrdered_GoogleBenchmark(benchmark::State& state)
     // Insert 1M elements
     for (auto _ : state) {
         state.PauseTiming();
-        for (int i = 0; i < state.range(0); ++i) {
+        for (size_t i = 0; i < state.range(0); ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             ASSERT_EQ_D(i, i, rc.first->first);
             ASSERT_EQ_D(i, i, rc.first->second);
@@ -1190,12 +1190,12 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
     // A simple snippet which inserts elements in the ordered hash map.
     // This case can be used to profile the component.
 
-    typedef mwcc::OrderedHashMap<int, int> MyMapType;
-    MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
+    typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
+    MyMapType map(state.range(0), s_allocator_p);
 
     // Insert elements.
     for (auto _ : state) {
-        for (int i = 0; i < state.range(0); ++i) {
+        for (size_t i = 0; i < state.range(0); ++i) {
             map.insert(bsl::make_pair(i, i));
         }
     }

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -122,8 +122,8 @@ static void test1_breathingTest()
 
     // Breathing test
     typedef mwcc::OrderedHashMap<size_t, bsl::string> MyMapType;
-    typedef MyMapType::iterator                    IterType;
-    typedef MyMapType::const_iterator              ConstIterType;
+    typedef MyMapType::iterator                       IterType;
+    typedef MyMapType::const_iterator                 ConstIterType;
 
     const bsl::string s("foo", s_allocator_p);
 
@@ -205,9 +205,9 @@ static void test3_insert()
     mwctst::TestHelper::printTestName("INSERT");
 
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef MyMapType::const_iterator      ConstIterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef MyMapType::const_iterator            ConstIterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     MyMapType map(s_allocator_p);
 
@@ -215,7 +215,7 @@ static void test3_insert()
     const size_t k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const size_t k_NUM_ELEMENTS = 100 * 1000;   // 100K
+    const size_t k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #endif
 
     // Insert 1M elements
@@ -233,7 +233,7 @@ static void test3_insert()
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = 0;
+        size_t           i    = 0;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -245,7 +245,7 @@ static void test3_insert()
     // Reverse iterate using --(end()) and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = k_NUM_ELEMENTS - 1;
+        size_t           i    = k_NUM_ELEMENTS - 1;
         ConstIterType    cit  = --(cmap.end());  // last element
         for (; cit != cmap.begin(); --cit) {
             ASSERT_EQ_D(i, true, i > 0);
@@ -296,7 +296,7 @@ static void test4_rinsert()
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = k_NUM_ELEMENTS - 1;
+        size_t           i    = k_NUM_ELEMENTS - 1;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, i, cit->first);
             ASSERT_EQ_D(i, (i + 1), cit->second);
@@ -307,7 +307,7 @@ static void test4_rinsert()
     // Reverse iterate using --(end()) and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = 0;
+        size_t           i    = 0;
         ConstIterType    cit  = --(cmap.end());  // last element
         for (; cit != cmap.begin(); --cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
@@ -330,9 +330,9 @@ static void test5_insertEraseInsert()
 
     // insert/erase/insert test
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef MyMapType::const_iterator      ConstIterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef MyMapType::const_iterator            ConstIterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     MyMapType map(s_allocator_p);
 
@@ -351,7 +351,7 @@ static void test5_insertEraseInsert()
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = 0;
+        size_t           i    = 0;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -373,7 +373,7 @@ static void test5_insertEraseInsert()
     // Iterate and confirm
     {
         const MyMapType& cmap = map;
-        size_t              i    = 1;
+        size_t           i    = 1;
         for (ConstIterType cit = cmap.begin(); cit != cmap.end(); ++cit) {
             ASSERT_EQ_D(i, true, i < k_NUM_ELEMENTS);
             ASSERT_EQ_D(i, i, cit->first);
@@ -397,7 +397,7 @@ static void test5_insertEraseInsert()
     // Iterate and confirm
     {
         IterType it = map.begin();
-        size_t      i  = 1;
+        size_t   i  = 1;
 
         // Iterate over original elements
         for (; it != map.end(); ++it) {
@@ -486,7 +486,7 @@ static void test7_erase()
     typedef bsl::pair<IterType, bool>      RcType;
 
     const size_t k_NUM_ELEMENTS = 100;
-    MyMapType map(s_allocator_p);
+    MyMapType    map(s_allocator_p);
 
     // Insert elements
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -523,7 +523,7 @@ static void test8_eraseClear()
     typedef bsl::pair<IterType, bool>                        RcType;
 
     const size_t k_NUM_ELEMENTS = 100;
-    MyMapType map(s_allocator_p);
+    MyMapType    map(s_allocator_p);
 
     // Insert elements
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -561,11 +561,11 @@ static void test9_insertFailure()
 
     // insert (key, value) already present in the container
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     const size_t k_NUM_ELEMENTS = 100000;
-    MyMapType map(s_allocator_p);
+    MyMapType    map(s_allocator_p);
 
     // Insert elements
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -594,11 +594,11 @@ static void test10_erasureIterator()
     // Use iterator returned by erase(const_iterator)
 
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     const size_t k_NUM_ELEMENTS = 10000;
-    MyMapType map(s_allocator_p);
+    MyMapType    map(s_allocator_p);
 
     // Insert elements
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -640,9 +640,9 @@ static void test11_copyConstructor()
     // Assert that object 2 has same elements etc.
 
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef MyMapType::const_iterator      ConstIterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef MyMapType::const_iterator            ConstIterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     const size_t k_NUM_ELEMENTS = 10000;
 
@@ -693,9 +693,9 @@ static void test12_assignmentOperator()
     // Assert that object 2 has same elements as object 1 etc.
 
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef MyMapType::const_iterator      ConstIterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef MyMapType::const_iterator            ConstIterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     const size_t k_NUM_ELEMENTS = 10000;
 
@@ -762,7 +762,7 @@ static void test13_previousEndIterator()
     IterType      endIt  = map.end();
     ConstIterType endCit = cmap.end();
 
-    size_t                       i  = 0;
+    size_t                    i  = 0;
     bsl::pair<IterType, bool> rc = map.insert(bsl::make_pair(i, i * i));
 
     ASSERT_EQ(true, rc.first == endIt);
@@ -818,8 +818,8 @@ static void test14_localIterator()
     // to the same bucket in the table.
 
     typedef mwcc::OrderedHashMap<size_t, size_t, IdentityHasher> MyMapType;
-    typedef MyMapType::local_iterator                      LocalIterType;
-    typedef MyMapType::const_local_iterator                ConstLocalIterType;
+    typedef MyMapType::local_iterator                            LocalIterType;
+    typedef MyMapType::const_local_iterator ConstLocalIterType;
 
     MyMapType        map(s_allocator_p);
     const MyMapType& cmap = map;
@@ -861,8 +861,7 @@ static void test14_localIterator()
     localEndIt = map.end(bucket);
 
     key = originalKey;
-    for (; localIt != localEndIt;
-         ++localIt, key += bucketCount) {
+    for (; localIt != localEndIt; ++localIt, key += bucketCount) {
         ASSERT_EQ(localIt->first, key);
         ASSERT_EQ(localIt->second, key * key);
     }
@@ -890,12 +889,12 @@ static void test15_eraseRange()
 
     // erase
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef MyMapType::const_iterator      ConstIterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef MyMapType::const_iterator            ConstIterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     const size_t k_NUM_ELEMENTS = 100;
-    MyMapType map(s_allocator_p);
+    MyMapType    map(s_allocator_p);
 
     // Insert elements
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -942,7 +941,7 @@ static void testN1_insertPerformanceOrdered()
     mwctst::TestHelper::printTestName("INSERT PERFORMANCE");
 
     // Performance comparison of insert() with bsl::unordered_map
-    const size_t          k_NUM_ELEMENTS = 5000000;
+    const size_t       k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 ohmTime;
 
     {
@@ -970,7 +969,7 @@ static void testN1_insertPerformanceUnordered()
     mwctst::TestHelper::printTestName("INSERT PERFORMANCE");
 
     // Performance comparison of insert() with bsl::unordered_map
-    const size_t          k_NUM_ELEMENTS = 5000000;
+    const size_t       k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 umTime;
     {
         // bsl::unordered_map
@@ -1000,12 +999,12 @@ BSLA_MAYBE_UNUSED static void testN2_erasePerformanceOrdered()
 
     // Insert elements, iterate and erase while iterating
 
-    const size_t          k_NUM_ELEMENTS = 5000000;
+    const size_t       k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 ohmTime;
     {
         typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-        typedef MyMapType::iterator            IterType;
-        typedef bsl::pair<IterType, bool>      RcType;
+        typedef MyMapType::iterator                  IterType;
+        typedef bsl::pair<IterType, bool>            RcType;
 
         MyMapType map(s_allocator_p);
         // Insert 1M elements
@@ -1038,12 +1037,12 @@ BSLA_MAYBE_UNUSED static void testN2_erasePerformanceUnordered()
 
     // Insert elements, iterate and erase while iterating
 
-    const size_t          k_NUM_ELEMENTS = 5000000;
+    const size_t       k_NUM_ELEMENTS = 5000000;
     bsls::Types::Int64 umTime;
     {
         typedef bsl::unordered_map<size_t, size_t> MyMapType;
-        typedef MyMapType::iterator          IterType;
-        typedef bsl::pair<IterType, bool>    RcType;
+        typedef MyMapType::iterator                IterType;
+        typedef bsl::pair<IterType, bool>          RcType;
 
         MyMapType map(s_allocator_p);
         // Insert 1M elements
@@ -1077,7 +1076,7 @@ BSLA_MAYBE_UNUSED static void testN3_profile()
     const size_t k_NUM_ELEMENTS = 5000000;
 
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    MyMapType                              map(k_NUM_ELEMENTS, s_allocator_p);
+    MyMapType map(k_NUM_ELEMENTS, s_allocator_p);
 
     // Insert elements.
     for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
@@ -1130,8 +1129,8 @@ testN2_erasePerformanceUnordered_GoogleBenchmark(benchmark::State& state)
 {
     // Unordered Map Erase Performance Test
     typedef bsl::unordered_map<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator          IterType;
-    typedef bsl::pair<IterType, bool>    RcType;
+    typedef MyMapType::iterator                IterType;
+    typedef bsl::pair<IterType, bool>          RcType;
 
     MyMapType map(s_allocator_p);
     for (auto _ : state) {
@@ -1159,8 +1158,8 @@ testN2_erasePerformanceOrdered_GoogleBenchmark(benchmark::State& state)
 
     // Insert elements, iterate and erase while iterating
     typedef mwcc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator            IterType;
-    typedef bsl::pair<IterType, bool>      RcType;
+    typedef MyMapType::iterator                  IterType;
+    typedef bsl::pair<IterType, bool>            RcType;
 
     MyMapType map(s_allocator_p);
     // Insert 1M elements

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -861,7 +861,8 @@ static void test14_localIterator()
     localEndIt = map.end(bucket);
 
     key = originalKey;
-    for (; localIt != localEndIt; ++localIt, key += static_cast<int>(bucketCount)) {
+    for (; localIt != localEndIt;
+         ++localIt, key += static_cast<int>(bucketCount)) {
         ASSERT_EQ(localIt->first, key);
         ASSERT_EQ(localIt->second, key * key);
     }
@@ -1190,7 +1191,7 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
     // This case can be used to profile the component.
 
     typedef mwcc::OrderedHashMap<int, int> MyMapType;
-    MyMapType                              map(static_cast<int>(state.range(0)), s_allocator_p);
+    MyMapType map(static_cast<int>(state.range(0)), s_allocator_p);
 
     // Insert elements.
     for (auto _ : state) {

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -215,7 +215,7 @@ static void test3_insert()
     const size_t k_NUM_ELEMENTS = 1000 * 1000;  // 1M
 #else
     // Avoid timeout on AIX and Solaris
-    const size_t k_NUM_ELEMENTS = 100 * 1000;  // 100K
+    const size_t k_NUM_ELEMENTS = 100 * 1000;   // 100K
 #endif
 
     // Insert 1M elements


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This PR deals with more ‘size_t‘ and ‘int‘ data type inconsistencies, through casting, adjusting data types, etc. It also catches the following -Wconversion warnings that pollutes the build logs:

```
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_monitoredqueue.h:593:44: warning: conversion from ‘BloombergLP::bsls::Types::Int64’ {aka ‘long long int’} to ‘int’ may change value [-Wconversion]
  593 |     const int currentQueueLen = numElements();
      |                                 ~~~~~~~~~~~^~
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.h:1389:22: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 1389 |     int count = erase(get_key(nodeToErase->value()));
      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp:864:50: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
  864 |     for (; localIt != localEndIt; ++localIt, key += bucketCount) {
      |                                              ~~~~^~~~~~~~~~~~~~
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp: In function ‘void testN1_insertPerformanceOrdered_GoogleBenchmark(benchmark::State&)’:
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp:1118:34: warning: conversion from ‘int64_t’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
 1118 |         MyMapType map(state.range(0), s_allocator_p);
      |                       ~~~~~~~~~~~^~~
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp: In function ‘void testN3_profile_GoogleBenchmark(benchmark::State&)’:
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp:1193:59: warning: conversion from ‘int64_t’ {aka ‘long int’} to ‘int’ may change value [-Wconversion]
 1193 |     MyMapType                              map(state.range(0), s_allocator_p);
      |                                                ~~~~~~~~~~~^~~
``` 

**Additional context**
There is another separate issue I found with 'reserveCapacity', where it takes in ‘size_t’ values like ’d_bucketArraySize’ or ’d_numElements’ indicating errors similar to the captured log below:

``` 
/home/runner/work/blazingmq/blazingmq/src/groups/mwc/mwcc/mwcc_orderedhashmap.h:1197:58: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 1197 |             d_nodePool.reserveCapacity(d_bucketArraySize - d_numElements);
      |                                        ~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
``` 

However, when I observe 'reserveCapacity', the function signature seems to expect ‘size_t’ rather than ’int’ as a parameter. Please see ’mwcu_memoutstream.h’

Perhaps the issue is caused by the fact that 'reserveCapacity' in ’mwcu_memoutstream.h’ expects 'bsl::size_t' as a parameter instead of ‘size_t’? Should I adjust ’reserveCapacity’ to try to remedy this, and if so, any ideas/feedback on how to fix this case for ’reserveCapacity’?

Also, fixing this one issue seems to fix/clean at least 100 warns/errors logs in BlazingMQ Build!