### PR TITLE
Implement batch posting in CLI mode

### DIFF
--- a/src/applications/bmqtool/README.md
+++ b/src/applications/bmqtool/README.md
@@ -115,9 +115,9 @@ opened regularly (without specifying a mode).  To run the `bmqtool`, you invoke
 | `open`    | `uri=string [async=true] [maxUnconfirmedMessages=N) (maxUnconfirmedByes=M)` | Open a connection with the queue at the given `uri`. |
 | `close`   | `uri=string [async=true]` | Close connection with the queue at the given `uri`. |
 | `post`    | `uri=string payload=string [, ...] [async=true]` | Post a message (the `payload`) to the queue at the given `uri`. |
+| `batch-post` | `uri=string payload=string [, ...] (msgSize=S) (eventSize=N) (eventsCount=M) (postInterval=P) (postRate=R)` | Post `M` events containing `N` messages containing provided `payload` or auto-generated and containing `S` bytes each to the queue at the given `uri` at a rate of `R/P` (where `P` is expressed in ms). `M=0` means endless posting. |
 | `list`    | N/A            | List the messages that have yet to be ACKed by the tool.     |
 | `confirm` | `guid=string`  | Confirm (ACK) the message matching the given GUID.           |
-| `batch-post` | `uri=string payload=string [, ...] (eventSize=N) (eventsCount=M) (postInterval=P) (postRate=R)` | Post M messages to the queue at the given `uri`. |  
 | `help`    | N/A            | Show the help dialog.                                        |
 | `bye`     | N/A            | Exit the tool.                                               |
 | `quit`    | N/A            | Exit the tool.                                               |

--- a/src/applications/bmqtool/README.md
+++ b/src/applications/bmqtool/README.md
@@ -117,6 +117,7 @@ opened regularly (without specifying a mode).  To run the `bmqtool`, you invoke
 | `post`    | `uri=string payload=string [, ...] [async=true]` | Post a message (the `payload`) to the queue at the given `uri`. |
 | `list`    | N/A            | List the messages that have yet to be ACKed by the tool.     |
 | `confirm` | `guid=string`  | Confirm (ACK) the message matching the given GUID.           |
+| `batch-post` | `uri=string payload=string [, ...] (eventSize=N) (eventsCount=M) (postInterval=P) (postRate=R)` | Post M messages to the queue at the given `uri`. |  
 | `help`    | N/A            | Show the help dialog.                                        |
 | `bye`     | N/A            | Exit the tool.                                               |
 | `quit`    | N/A            | Exit the tool.                                               |

--- a/src/applications/bmqtool/bmqtoolcmd.xsd
+++ b/src/applications/bmqtool/bmqtoolcmd.xsd
@@ -17,6 +17,7 @@
       <element name='post'           type='tns:PostCommand'/>
       <element name='list'           type='tns:ListCommand'/>
       <element name='confirm'        type='tns:ConfirmCommand'/>
+      <element name='batch-post'     type='tns:BatchPostCommand'/>
 
       <!-- Commands specific to e_STORAGE mode -->
       <element name='openStorage'        type='tns:OpenStorageCommand'/>
@@ -106,6 +107,19 @@
       <element name='guid' type='string'/>
     </sequence>
   </complexType>
+
+  <complexType name='BatchPostCommand'>
+    <sequence>
+      <element name='uri'                      type='string'/>
+      <element name='payload'                  type='string'  maxOccurs='unbounded'/>
+      <element name='msgSize'                  type='int'     default="1024"/>
+      <element name='eventSize'                type='long'    default="1"/>
+      <element name='eventsCount'              type='long'    default="0"/>
+      <element name='postInterval'             type='int'     default="1000"/>
+      <element name='postRate'                 type='int'     default="1"/>
+    </sequence>
+  </complexType>
+
 
   <!-- Commands specific to e_STORAGE mode -->
   <complexType name='OpenStorageCommand'>

--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -44,6 +44,7 @@
 #include <mwctsk_consoleobserver.h>
 
 // BDE
+#include "m_bmqtool_poster.h"
 #include <ball_multiplexobserver.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_pooledblobbufferfactory.h>
@@ -77,17 +78,6 @@ class Application : public bmqa::SessionEventHandler {
     // TYPES
     typedef bslma::ManagedPtr<mwcst::StatContext> StatContextMP;
 
-    /// This structure holds context created by `bmqa::Session`.
-    /// It must be destructed before the `d_session_mp`.
-    struct SessionContext {
-        bmqa::QueueId d_queueId;
-
-        bmqa::MessageEventBuilder d_eventBuilder;
-        // Message event builder.
-
-        SessionContext(bslma::Allocator* d_allocator);
-    };
-
     // DATA
     bslma::Allocator* d_allocator_p;
     // Held, not owned
@@ -103,6 +93,9 @@ class Application : public bmqa::SessionEventHandler {
     bslmt::ThreadUtil::Handle d_runningThread;
     // Handle on the running thread
     // (producer mode)
+
+    bmqa::QueueId d_queueId;
+    // Queue to send/receive messages
 
     StatContextMP d_statContext_mp;
     // StatContext for msg/event stats
@@ -123,26 +116,8 @@ class Application : public bmqa::SessionEventHandler {
 
     mwctsk::ConsoleObserver d_consoleObserver;
 
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
-    // Buffer factory for the payload of the
-    // published message
-
-    bdlbb::PooledBlobBufferFactory d_timeBufferFactory;
-    // Small buffer factory for the first
-    // blob of the published message, to
-    // hold the timestamp information
-
-    bdlbb::Blob d_blob;
-    // Blob to post
-
-    bslma::ManagedPtr<SessionContext> d_sessionContext_mp;
-
     bslma::ManagedPtr<bmqa::Session> d_session_mp;
     // Session with the BlazingMQ broker.
-
-    int d_msgUntilNextTimestamp;
-    // Number of messages remaining to send
-    // until stamping one with latency.
 
     Interactive d_interactive;
 

--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -75,6 +75,10 @@ namespace m_bmqtool {
 /// Main application class for `bmqtool`.
 class Application : public bmqa::SessionEventHandler {
   private:
+    // CLASS METHODS
+    static mwcst::StatContext createStatContext(int historySize,
+                                                bslma::Allocator* allocator);
+
     // TYPES
     typedef bslma::ManagedPtr<mwcst::StatContext> StatContextMP;
 
@@ -97,7 +101,7 @@ class Application : public bmqa::SessionEventHandler {
     bmqa::QueueId d_queueId;
     // Queue to send/receive messages
 
-    StatContextMP d_statContext_mp;
+    mwcst::StatContext d_statContext;
     // StatContext for msg/event stats
 
     bdlmt::EventScheduler d_scheduler;
@@ -119,13 +123,17 @@ class Application : public bmqa::SessionEventHandler {
     bslma::ManagedPtr<bmqa::Session> d_session_mp;
     // Session with the BlazingMQ broker.
 
-    Interactive d_interactive;
-
     StorageInspector d_storageInspector;
 
     FileLogger d_fileLogger;
     // Logger to use in case events logging
     // to file has been enabled.
+
+    Poster d_poster;
+    // A factory for posting series of messages.
+
+    Interactive d_interactive;
+    // CLI handler.
 
     bsl::list<bsls::Types::Int64> d_latencies;
     // List of all message latencies (in

--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -76,7 +76,7 @@ namespace m_bmqtool {
 class Application : public bmqa::SessionEventHandler {
   private:
     // CLASS METHODS
-    static mwcst::StatContext createStatContext(int historySize,
+    static mwcst::StatContext createStatContext(int               historySize,
                                                 bslma::Allocator* allocator);
 
     // TYPES

--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -29,6 +29,7 @@
 #include <m_bmqtool_filelogger.h>
 #include <m_bmqtool_interactive.h>
 #include <m_bmqtool_messages.h>
+#include <m_bmqtool_poster.h>
 #include <m_bmqtool_storageinspector.h>
 
 // MQB
@@ -44,7 +45,6 @@
 #include <mwctsk_consoleobserver.h>
 
 // BDE
-#include "m_bmqtool_poster.h"
 #include <ball_multiplexobserver.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_pooledblobbufferfactory.h>

--- a/src/applications/bmqtool/m_bmqtool_interactive.cpp
+++ b/src/applications/bmqtool/m_bmqtool_interactive.cpp
@@ -715,8 +715,6 @@ void Interactive::processCommand(const BatchPostCommand& command)
     parameters.setEventSize(command.eventSize());
     parameters.setPostInterval(command.postInterval());
     parameters.setMsgSize(command.msgSize());
-    parameters.setQueueFlags(bmqt::QueueFlags::e_ACK |
-                             bmqt::QueueFlags::e_WRITE);
 
     // Lookup the Queue by URI
     bmqa::QueueId queueId;
@@ -724,6 +722,7 @@ void Interactive::processCommand(const BatchPostCommand& command)
         BALL_LOG_ERROR << "unknown queue '" << command.uri() << "'";
         return;  // RETURN
     }
+    parameters.setQueueFlags(queueId.flags());
 
     bslmt::Turnstile turnstile(1000.0);
     if (parameters.postInterval() != 0) {

--- a/src/applications/bmqtool/m_bmqtool_interactive.cpp
+++ b/src/applications/bmqtool/m_bmqtool_interactive.cpp
@@ -153,8 +153,8 @@ void Interactive::printHelp()
         << "parameter 'messageProperties' is optional" << bsl::endl
         << bsl::endl
         << "  batch-post uri=\"bmq://bmq.test.persistent.priority/qqq\" "
-           "payload=[\"sample message\"] eventsCount=300 postRate=10 "
-           "postInterval=5000"
+           "payload=[\"sample message\"] eventsCount=300 postInterval=5000 "
+           "postRate=10"
         << bsl::endl
         << "    - 'batch-post' command requires 'uri' argument, "
            "all the rest are optional"
@@ -805,6 +805,10 @@ Interactive::Interactive(Parameters*       parameters,
 , d_poster_p(poster)
 , d_allocator_p(allocator)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(parameters);
+    BSLS_ASSERT_SAFE(poster);
+
     bdls::ProcessUtil::getProcessName(&d_producerIdProperty);  // ignore rc
 
     bsl::ostringstream pidStr;

--- a/src/applications/bmqtool/m_bmqtool_interactive.cpp
+++ b/src/applications/bmqtool/m_bmqtool_interactive.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 Bloomberg Finance L.P.
+// Copyright 2014-2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,6 +19,7 @@
 // BMQTOOL
 #include <m_bmqtool_inpututil.h>
 #include <m_bmqtool_parameters.h>
+#include <m_bmqtool_poster.h>
 
 // BMQ
 #include <bmqa_event.h>
@@ -41,8 +42,8 @@
 #include <bdls_processutil.h>
 #include <bdlt_currenttime.h>
 #include <bsl_iostream.h>
-#include <bsl_utility.h>
 #include <bslmt_lockguard.h>
+#include <bslmt_turnstile.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
@@ -117,6 +118,9 @@ void Interactive::printHelp()
         << "    (messageProperties=[{\"name\": \"\", \"value\": \"\", "
            "\"type\": \"\"}])"
         << bsl::endl
+        << "  batch-post uri=\"\" payload=[\"\",\"\"] (msgSize=u) "
+           "(eventSize=v) (eventsCount=w) (postInterval=x) (postRate=y)"
+        << bsl::endl
         << "  list (uri=\"\")" << bsl::endl
         << "  confirm uri=\"\" guid=\"\" "
         << "('*' for all, '+/-n' for oldest/latest 'n')" << bsl::endl
@@ -147,6 +151,13 @@ void Interactive::printHelp()
         << bsl::endl
         << "    - 'post' command requires 'uri' and 'payload' arguments, "
         << "parameter 'messageProperties' is optional" << bsl::endl
+        << bsl::endl
+        << "  batch-post uri=\"bmq://bmq.test.persistent.priority/qqq\" "
+           "payload=[\"sample message\"] eventsCount=300 postRate=10 "
+           "postInterval=5000" << bsl::endl
+        << "    - 'batch-post' command requires 'uri' argument, "
+           "all the rest are optional"
+        << bsl::endl
         << bsl::endl;
 }
 
@@ -695,6 +706,42 @@ void Interactive::processCommand(const ListCommand& command)
     }
 }
 
+void Interactive::processCommand(const BatchPostCommand& command)
+{
+    Parameters parameters(d_allocator_p);
+    parameters.setEventsCount(command.eventsCount());
+    parameters.setPostRate(command.postRate());
+    parameters.setEventSize(command.eventSize());
+    parameters.setPostInterval(command.postInterval());
+    parameters.setMsgSize(command.msgSize());
+    parameters.setQueueFlags(bmqt::QueueFlags::e_ACK |
+                             bmqt::QueueFlags::e_WRITE);
+
+    // Lookup the Queue by URI
+    bmqa::QueueId queueId;
+    if (d_session_p->getQueueId(&queueId, command.uri()) != 0) {
+        BALL_LOG_ERROR << "unknown queue '" << command.uri() << "'";
+        return;  // RETURN
+    }
+
+    bslmt::Turnstile turnstile(1000.0);
+    if (parameters.postInterval() != 0) {
+        turnstile.reset(1000.0 / parameters.postInterval());
+    }
+
+    PostingContext postingContext =
+        d_poster_p->createPostingContext(d_session_p, &parameters, queueId);
+
+    while (postingContext.pendingPost()) {
+        postingContext.postNext();
+        if (parameters.postInterval() != 0 && postingContext.pendingPost()) {
+            turnstile.waitTurn();
+        }
+    }
+
+    BALL_LOG_INFO << "All messages have been posted";
+}
+
 Interactive::UriEntryPtr
 Interactive::createUriEntry(const bsl::string&          uri,
                             Interactive::UriEntryStatus status)
@@ -746,13 +793,16 @@ void Interactive::eventHandlerThread()
     BALL_LOG_INFO << "EventHandlerThread terminated";
 }
 
-Interactive::Interactive(Parameters* parameters, bslma::Allocator* allocator)
+Interactive::Interactive(Parameters*       parameters,
+                         Poster*           poster,
+                         bslma::Allocator* allocator)
 : d_session_p(0)
 , d_sessionEventHandler_p(0)
 , d_parameters_p(parameters)
 , d_uris(allocator)
 , d_eventHandlerThreads(allocator)
 , d_producerIdProperty("** NONE **", allocator)
+, d_poster_p(poster)
 , d_allocator_p(allocator)
 {
     bdls::ProcessUtil::getProcessName(&d_producerIdProperty);  // ignore rc
@@ -857,6 +907,12 @@ int Interactive::mainLoop()
             }
             else if (verb == "confirm") {
                 ConfirmCommand command;
+                if (InputUtil::parseCommand(&command, &error, jsonInput)) {
+                    processCommand(command);
+                }
+            }
+            else if (verb == "batch-post") {
+                BatchPostCommand command;
                 if (InputUtil::parseCommand(&command, &error, jsonInput)) {
                     processCommand(command);
                 }

--- a/src/applications/bmqtool/m_bmqtool_interactive.cpp
+++ b/src/applications/bmqtool/m_bmqtool_interactive.cpp
@@ -154,7 +154,8 @@ void Interactive::printHelp()
         << bsl::endl
         << "  batch-post uri=\"bmq://bmq.test.persistent.priority/qqq\" "
            "payload=[\"sample message\"] eventsCount=300 postRate=10 "
-           "postInterval=5000" << bsl::endl
+           "postInterval=5000"
+        << bsl::endl
         << "    - 'batch-post' command requires 'uri' argument, "
            "all the rest are optional"
         << bsl::endl

--- a/src/applications/bmqtool/m_bmqtool_interactive.h
+++ b/src/applications/bmqtool/m_bmqtool_interactive.h
@@ -170,8 +170,8 @@ class Interactive {
 
     /// Constructor using the specified `parameters`, 'poster',
     /// and `allocator`.
-    Interactive(Parameters* parameters,
-                Poster* poster,
+    Interactive(Parameters*       parameters,
+                Poster*           poster,
                 bslma::Allocator* allocator);
 
     // MANIPULATORS

--- a/src/applications/bmqtool/m_bmqtool_interactive.h
+++ b/src/applications/bmqtool/m_bmqtool_interactive.h
@@ -27,6 +27,7 @@
 
 // BMQTOOL
 #include <m_bmqtool_messages.h>
+#include <m_bmqtool_poster.h>
 
 // BMQ
 #include <bmqa_closequeuestatus.h>
@@ -128,8 +129,13 @@ class Interactive {
     // interactive mode.  Note that this string is
     // of the format '/path/to/this/bmqtool:<PID>'.
 
+    Poster* d_poster_p;
+    // A factory for posting series of messages.
+    // Held, not owned
+
     bslma::Allocator* d_allocator_p;
     // Held, not owned
+
   private:
     // PRIVATE MANIPULATORS
     void printHelp();
@@ -143,6 +149,7 @@ class Interactive {
     void processCommand(const PostCommand& command, bool hasMPs);
     void processCommand(const ConfirmCommand& command);
     void processCommand(const ListCommand& command);
+    void processCommand(const BatchPostCommand& command);
 
     /// Create and insert an entry keyed on the specified `uri` into the map
     /// of full uri to unconfirmed messages contained in this object.  The
@@ -161,8 +168,11 @@ class Interactive {
   public:
     // CREATORS
 
-    /// Constructor using the specified `parameters` and `allocator`.
-    Interactive(Parameters* parameters, bslma::Allocator* allocator);
+    /// Constructor using the specified `parameters`, 'poster',
+    /// and `allocator`.
+    Interactive(Parameters* parameters,
+                Poster* poster,
+                bslma::Allocator* allocator);
 
     // MANIPULATORS
 

--- a/src/applications/bmqtool/m_bmqtool_messages.cpp
+++ b/src/applications/bmqtool/m_bmqtool_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 Bloomberg Finance L.P.
+// Copyright 2014-2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,220 @@
 
 namespace BloombergLP {
 namespace m_bmqtool {
+
+// ----------------------
+// class BatchPostCommand
+// ----------------------
+
+// CONSTANTS
+
+const char BatchPostCommand::CLASS_NAME[] = "BatchPostCommand";
+
+const int BatchPostCommand::DEFAULT_INITIALIZER_MSG_SIZE = 1024;
+
+const bsls::Types::Int64 BatchPostCommand::DEFAULT_INITIALIZER_EVENT_SIZE = 1;
+
+const bsls::Types::Int64 BatchPostCommand::DEFAULT_INITIALIZER_EVENTS_COUNT =
+    0;
+
+const int BatchPostCommand::DEFAULT_INITIALIZER_POST_INTERVAL = 1000;
+
+const int BatchPostCommand::DEFAULT_INITIALIZER_POST_RATE = 1;
+
+const bdlat_AttributeInfo BatchPostCommand::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_URI,
+     "uri",
+     sizeof("uri") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_PAYLOAD,
+     "payload",
+     sizeof("payload") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_MSG_SIZE,
+     "msgSize",
+     sizeof("msgSize") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_EVENT_SIZE,
+     "eventSize",
+     sizeof("eventSize") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_EVENTS_COUNT,
+     "eventsCount",
+     sizeof("eventsCount") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_POST_INTERVAL,
+     "postInterval",
+     sizeof("postInterval") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_POST_RATE,
+     "postRate",
+     sizeof("postRate") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo*
+BatchPostCommand::lookupAttributeInfo(const char* name, int nameLength)
+{
+    for (int i = 0; i < 7; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            BatchPostCommand::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo* BatchPostCommand::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_URI: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_URI];
+    case ATTRIBUTE_ID_PAYLOAD:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PAYLOAD];
+    case ATTRIBUTE_ID_MSG_SIZE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MSG_SIZE];
+    case ATTRIBUTE_ID_EVENT_SIZE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENT_SIZE];
+    case ATTRIBUTE_ID_EVENTS_COUNT:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENTS_COUNT];
+    case ATTRIBUTE_ID_POST_INTERVAL:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_INTERVAL];
+    case ATTRIBUTE_ID_POST_RATE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_RATE];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+BatchPostCommand::BatchPostCommand(bslma::Allocator* basicAllocator)
+: d_eventSize(DEFAULT_INITIALIZER_EVENT_SIZE)
+, d_eventsCount(DEFAULT_INITIALIZER_EVENTS_COUNT)
+, d_payload(basicAllocator)
+, d_uri(basicAllocator)
+, d_msgSize(DEFAULT_INITIALIZER_MSG_SIZE)
+, d_postInterval(DEFAULT_INITIALIZER_POST_INTERVAL)
+, d_postRate(DEFAULT_INITIALIZER_POST_RATE)
+{
+}
+
+BatchPostCommand::BatchPostCommand(const BatchPostCommand& original,
+                                   bslma::Allocator*       basicAllocator)
+: d_eventSize(original.d_eventSize)
+, d_eventsCount(original.d_eventsCount)
+, d_payload(original.d_payload, basicAllocator)
+, d_uri(original.d_uri, basicAllocator)
+, d_msgSize(original.d_msgSize)
+, d_postInterval(original.d_postInterval)
+, d_postRate(original.d_postRate)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+BatchPostCommand::BatchPostCommand(BatchPostCommand&& original) noexcept
+: d_eventSize(bsl::move(original.d_eventSize)),
+  d_eventsCount(bsl::move(original.d_eventsCount)),
+  d_payload(bsl::move(original.d_payload)),
+  d_uri(bsl::move(original.d_uri)),
+  d_msgSize(bsl::move(original.d_msgSize)),
+  d_postInterval(bsl::move(original.d_postInterval)),
+  d_postRate(bsl::move(original.d_postRate))
+{
+}
+
+BatchPostCommand::BatchPostCommand(BatchPostCommand&& original,
+                                   bslma::Allocator*  basicAllocator)
+: d_eventSize(bsl::move(original.d_eventSize))
+, d_eventsCount(bsl::move(original.d_eventsCount))
+, d_payload(bsl::move(original.d_payload), basicAllocator)
+, d_uri(bsl::move(original.d_uri), basicAllocator)
+, d_msgSize(bsl::move(original.d_msgSize))
+, d_postInterval(bsl::move(original.d_postInterval))
+, d_postRate(bsl::move(original.d_postRate))
+{
+}
+#endif
+
+BatchPostCommand::~BatchPostCommand()
+{
+}
+
+// MANIPULATORS
+
+BatchPostCommand& BatchPostCommand::operator=(const BatchPostCommand& rhs)
+{
+    if (this != &rhs) {
+        d_uri          = rhs.d_uri;
+        d_payload      = rhs.d_payload;
+        d_msgSize      = rhs.d_msgSize;
+        d_eventSize    = rhs.d_eventSize;
+        d_eventsCount  = rhs.d_eventsCount;
+        d_postInterval = rhs.d_postInterval;
+        d_postRate     = rhs.d_postRate;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+BatchPostCommand& BatchPostCommand::operator=(BatchPostCommand&& rhs)
+{
+    if (this != &rhs) {
+        d_uri          = bsl::move(rhs.d_uri);
+        d_payload      = bsl::move(rhs.d_payload);
+        d_msgSize      = bsl::move(rhs.d_msgSize);
+        d_eventSize    = bsl::move(rhs.d_eventSize);
+        d_eventsCount  = bsl::move(rhs.d_eventsCount);
+        d_postInterval = bsl::move(rhs.d_postInterval);
+        d_postRate     = bsl::move(rhs.d_postRate);
+    }
+
+    return *this;
+}
+#endif
+
+void BatchPostCommand::reset()
+{
+    bdlat_ValueTypeFunctions::reset(&d_uri);
+    bdlat_ValueTypeFunctions::reset(&d_payload);
+    d_msgSize      = DEFAULT_INITIALIZER_MSG_SIZE;
+    d_eventSize    = DEFAULT_INITIALIZER_EVENT_SIZE;
+    d_eventsCount  = DEFAULT_INITIALIZER_EVENTS_COUNT;
+    d_postInterval = DEFAULT_INITIALIZER_POST_INTERVAL;
+    d_postRate     = DEFAULT_INITIALIZER_POST_RATE;
+}
+
+// ACCESSORS
+
+bsl::ostream& BatchPostCommand::print(bsl::ostream& stream,
+                                      int           level,
+                                      int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("uri", this->uri());
+    printer.printAttribute("payload", this->payload());
+    printer.printAttribute("msgSize", this->msgSize());
+    printer.printAttribute("eventSize", this->eventSize());
+    printer.printAttribute("eventsCount", this->eventsCount());
+    printer.printAttribute("postInterval", this->postInterval());
+    printer.printAttribute("postRate", this->postRate());
+    printer.end();
+    return stream;
+}
 
 // -----------------------
 // class CloseQueueCommand
@@ -4875,6 +5089,11 @@ const bdlat_SelectionInfo Command::SELECTION_INFO_ARRAY[] = {
      sizeof("confirm") - 1,
      "",
      bdlat_FormattingMode::e_DEFAULT},
+    {SELECTION_ID_BATCH_POST,
+     "batch-post",
+     sizeof("batch-post") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT},
     {SELECTION_ID_OPEN_STORAGE,
      "openStorage",
      sizeof("openStorage") - 1,
@@ -4921,7 +5140,7 @@ const bdlat_SelectionInfo Command::SELECTION_INFO_ARRAY[] = {
 const bdlat_SelectionInfo* Command::lookupSelectionInfo(const char* name,
                                                         int         nameLength)
 {
-    for (int i = 0; i < 16; ++i) {
+    for (int i = 0; i < 17; ++i) {
         const bdlat_SelectionInfo& selectionInfo =
             Command::SELECTION_INFO_ARRAY[i];
 
@@ -4950,6 +5169,8 @@ const bdlat_SelectionInfo* Command::lookupSelectionInfo(int id)
     case SELECTION_ID_LIST: return &SELECTION_INFO_ARRAY[SELECTION_INDEX_LIST];
     case SELECTION_ID_CONFIRM:
         return &SELECTION_INFO_ARRAY[SELECTION_INDEX_CONFIRM];
+    case SELECTION_ID_BATCH_POST:
+        return &SELECTION_INFO_ARRAY[SELECTION_INDEX_BATCH_POST];
     case SELECTION_ID_OPEN_STORAGE:
         return &SELECTION_INFO_ARRAY[SELECTION_INDEX_OPEN_STORAGE];
     case SELECTION_ID_CLOSE_STORAGE:
@@ -5006,6 +5227,10 @@ Command::Command(const Command& original, bslma::Allocator* basicAllocator)
     case SELECTION_ID_CONFIRM: {
         new (d_confirm.buffer())
             ConfirmCommand(original.d_confirm.object(), d_allocator_p);
+    } break;
+    case SELECTION_ID_BATCH_POST: {
+        new (d_batchPost.buffer())
+            BatchPostCommand(original.d_batchPost.object(), d_allocator_p);
     } break;
     case SELECTION_ID_OPEN_STORAGE: {
         new (d_openStorage.buffer())
@@ -5082,6 +5307,11 @@ Command::Command(Command&& original) noexcept
         new (d_confirm.buffer())
             ConfirmCommand(bsl::move(original.d_confirm.object()),
                            d_allocator_p);
+    } break;
+    case SELECTION_ID_BATCH_POST: {
+        new (d_batchPost.buffer())
+            BatchPostCommand(bsl::move(original.d_batchPost.object()),
+                             d_allocator_p);
     } break;
     case SELECTION_ID_OPEN_STORAGE: {
         new (d_openStorage.buffer())
@@ -5161,6 +5391,11 @@ Command::Command(Command&& original, bslma::Allocator* basicAllocator)
             ConfirmCommand(bsl::move(original.d_confirm.object()),
                            d_allocator_p);
     } break;
+    case SELECTION_ID_BATCH_POST: {
+        new (d_batchPost.buffer())
+            BatchPostCommand(bsl::move(original.d_batchPost.object()),
+                             d_allocator_p);
+    } break;
     case SELECTION_ID_OPEN_STORAGE: {
         new (d_openStorage.buffer())
             OpenStorageCommand(bsl::move(original.d_openStorage.object()),
@@ -5230,6 +5465,9 @@ Command& Command::operator=(const Command& rhs)
         case SELECTION_ID_CONFIRM: {
             makeConfirm(rhs.d_confirm.object());
         } break;
+        case SELECTION_ID_BATCH_POST: {
+            makeBatchPost(rhs.d_batchPost.object());
+        } break;
         case SELECTION_ID_OPEN_STORAGE: {
             makeOpenStorage(rhs.d_openStorage.object());
         } break;
@@ -5293,6 +5531,9 @@ Command& Command::operator=(Command&& rhs)
         case SELECTION_ID_CONFIRM: {
             makeConfirm(bsl::move(rhs.d_confirm.object()));
         } break;
+        case SELECTION_ID_BATCH_POST: {
+            makeBatchPost(bsl::move(rhs.d_batchPost.object()));
+        } break;
         case SELECTION_ID_OPEN_STORAGE: {
             makeOpenStorage(bsl::move(rhs.d_openStorage.object()));
         } break;
@@ -5354,6 +5595,9 @@ void Command::reset()
     case SELECTION_ID_CONFIRM: {
         d_confirm.object().~ConfirmCommand();
     } break;
+    case SELECTION_ID_BATCH_POST: {
+        d_batchPost.object().~BatchPostCommand();
+    } break;
     case SELECTION_ID_OPEN_STORAGE: {
         d_openStorage.object().~OpenStorageCommand();
     } break;
@@ -5410,6 +5654,9 @@ int Command::makeSelection(int selectionId)
     } break;
     case SELECTION_ID_CONFIRM: {
         makeConfirm();
+    } break;
+    case SELECTION_ID_BATCH_POST: {
+        makeBatchPost();
     } break;
     case SELECTION_ID_OPEN_STORAGE: {
         makeOpenStorage();
@@ -5821,6 +6068,52 @@ ConfirmCommand& Command::makeConfirm(ConfirmCommand&& value)
 }
 #endif
 
+BatchPostCommand& Command::makeBatchPost()
+{
+    if (SELECTION_ID_BATCH_POST == d_selectionId) {
+        bdlat_ValueTypeFunctions::reset(&d_batchPost.object());
+    }
+    else {
+        reset();
+        new (d_batchPost.buffer()) BatchPostCommand(d_allocator_p);
+        d_selectionId = SELECTION_ID_BATCH_POST;
+    }
+
+    return d_batchPost.object();
+}
+
+BatchPostCommand& Command::makeBatchPost(const BatchPostCommand& value)
+{
+    if (SELECTION_ID_BATCH_POST == d_selectionId) {
+        d_batchPost.object() = value;
+    }
+    else {
+        reset();
+        new (d_batchPost.buffer()) BatchPostCommand(value, d_allocator_p);
+        d_selectionId = SELECTION_ID_BATCH_POST;
+    }
+
+    return d_batchPost.object();
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+BatchPostCommand& Command::makeBatchPost(BatchPostCommand&& value)
+{
+    if (SELECTION_ID_BATCH_POST == d_selectionId) {
+        d_batchPost.object() = bsl::move(value);
+    }
+    else {
+        reset();
+        new (d_batchPost.buffer())
+            BatchPostCommand(bsl::move(value), d_allocator_p);
+        d_selectionId = SELECTION_ID_BATCH_POST;
+    }
+
+    return d_batchPost.object();
+}
+#endif
+
 OpenStorageCommand& Command::makeOpenStorage()
 {
     if (SELECTION_ID_OPEN_STORAGE == d_selectionId) {
@@ -6217,6 +6510,9 @@ Command::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     case SELECTION_ID_CONFIRM: {
         printer.printAttribute("confirm", d_confirm.object());
     } break;
+    case SELECTION_ID_BATCH_POST: {
+        printer.printAttribute("batchPost", d_batchPost.object());
+    } break;
     case SELECTION_ID_OPEN_STORAGE: {
         printer.printAttribute("openStorage", d_openStorage.object());
     } break;
@@ -6266,6 +6562,8 @@ const char* Command::selectionName() const
         return SELECTION_INFO_ARRAY[SELECTION_INDEX_LIST].name();
     case SELECTION_ID_CONFIRM:
         return SELECTION_INFO_ARRAY[SELECTION_INDEX_CONFIRM].name();
+    case SELECTION_ID_BATCH_POST:
+        return SELECTION_INFO_ARRAY[SELECTION_INDEX_BATCH_POST].name();
     case SELECTION_ID_OPEN_STORAGE:
         return SELECTION_INFO_ARRAY[SELECTION_INDEX_OPEN_STORAGE].name();
     case SELECTION_ID_CLOSE_STORAGE:

--- a/src/applications/bmqtool/m_bmqtool_messages.h
+++ b/src/applications/bmqtool/m_bmqtool_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 Bloomberg Finance L.P.
+// Copyright 2014-2024 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +56,9 @@ namespace bslma {
 class Allocator;
 }
 
+namespace m_bmqtool {
+class BatchPostCommand;
+}
 namespace m_bmqtool {
 class CloseQueueCommand;
 }
@@ -125,6 +128,295 @@ class PostCommand;
 namespace m_bmqtool {
 class Command;
 }
+namespace m_bmqtool {
+
+// ======================
+// class BatchPostCommand
+// ======================
+
+class BatchPostCommand {
+    // INSTANCE DATA
+    bsls::Types::Int64       d_eventSize;
+    bsls::Types::Int64       d_eventsCount;
+    bsl::vector<bsl::string> d_payload;
+    bsl::string              d_uri;
+    int                      d_msgSize;
+    int                      d_postInterval;
+    int                      d_postRate;
+
+    // PRIVATE ACCESSORS
+    template <typename t_HASH_ALGORITHM>
+    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
+
+    bool isEqualTo(const BatchPostCommand& rhs) const;
+
+  public:
+    // TYPES
+    enum {
+        ATTRIBUTE_ID_URI           = 0,
+        ATTRIBUTE_ID_PAYLOAD       = 1,
+        ATTRIBUTE_ID_MSG_SIZE      = 2,
+        ATTRIBUTE_ID_EVENT_SIZE    = 3,
+        ATTRIBUTE_ID_EVENTS_COUNT  = 4,
+        ATTRIBUTE_ID_POST_INTERVAL = 5,
+        ATTRIBUTE_ID_POST_RATE     = 6
+    };
+
+    enum { NUM_ATTRIBUTES = 7 };
+
+    enum {
+        ATTRIBUTE_INDEX_URI           = 0,
+        ATTRIBUTE_INDEX_PAYLOAD       = 1,
+        ATTRIBUTE_INDEX_MSG_SIZE      = 2,
+        ATTRIBUTE_INDEX_EVENT_SIZE    = 3,
+        ATTRIBUTE_INDEX_EVENTS_COUNT  = 4,
+        ATTRIBUTE_INDEX_POST_INTERVAL = 5,
+        ATTRIBUTE_INDEX_POST_RATE     = 6
+    };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const int DEFAULT_INITIALIZER_MSG_SIZE;
+
+    static const bsls::Types::Int64 DEFAULT_INITIALIZER_EVENT_SIZE;
+
+    static const bsls::Types::Int64 DEFAULT_INITIALIZER_EVENTS_COUNT;
+
+    static const int DEFAULT_INITIALIZER_POST_INTERVAL;
+
+    static const int DEFAULT_INITIALIZER_POST_RATE;
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit BatchPostCommand(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'BatchPostCommand' having the default
+    // value.  Use the optionally specified 'basicAllocator' to supply
+    // memory.  If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+
+    BatchPostCommand(const BatchPostCommand& original,
+                     bslma::Allocator*       basicAllocator = 0);
+    // Create an object of type 'BatchPostCommand' having the value of the
+    // specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    BatchPostCommand(BatchPostCommand&& original) noexcept;
+    // Create an object of type 'BatchPostCommand' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+
+    BatchPostCommand(BatchPostCommand&& original,
+                     bslma::Allocator*  basicAllocator);
+    // Create an object of type 'BatchPostCommand' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+    // Use the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+#endif
+
+    ~BatchPostCommand();
+    // Destroy this object.
+
+    // MANIPULATORS
+    BatchPostCommand& operator=(const BatchPostCommand& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    BatchPostCommand& operator=(BatchPostCommand&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    bsl::string& uri();
+    // Return a reference to the modifiable "Uri" attribute of this object.
+
+    bsl::vector<bsl::string>& payload();
+    // Return a reference to the modifiable "Payload" attribute of this
+    // object.
+
+    int& msgSize();
+    // Return a reference to the modifiable "MsgSize" attribute of this
+    // object.
+
+    bsls::Types::Int64& eventSize();
+    // Return a reference to the modifiable "EventSize" attribute of this
+    // object.
+
+    bsls::Types::Int64& eventsCount();
+    // Return a reference to the modifiable "EventsCount" attribute of this
+    // object.
+
+    int& postInterval();
+    // Return a reference to the modifiable "PostInterval" attribute of
+    // this object.
+
+    int& postRate();
+    // Return a reference to the modifiable "PostRate" attribute of this
+    // object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    const bsl::string& uri() const;
+    // Return a reference offering non-modifiable access to the "Uri"
+    // attribute of this object.
+
+    const bsl::vector<bsl::string>& payload() const;
+    // Return a reference offering non-modifiable access to the "Payload"
+    // attribute of this object.
+
+    int msgSize() const;
+    // Return the value of the "MsgSize" attribute of this object.
+
+    bsls::Types::Int64 eventSize() const;
+    // Return the value of the "EventSize" attribute of this object.
+
+    bsls::Types::Int64 eventsCount() const;
+    // Return the value of the "EventsCount" attribute of this object.
+
+    int postInterval() const;
+    // Return the value of the "PostInterval" attribute of this object.
+
+    int postRate() const;
+    // Return the value of the "PostRate" attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const BatchPostCommand& lhs,
+                           const BatchPostCommand& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.isEqualTo(rhs);
+    }
+
+    friend bool operator!=(const BatchPostCommand& lhs,
+                           const BatchPostCommand& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream&           stream,
+                                    const BatchPostCommand& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM&       hashAlg,
+                           const BatchPostCommand& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for
+    // 'BatchPostCommand'.
+    {
+        object.hashAppendImpl(hashAlg);
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    m_bmqtool::BatchPostCommand)
+
 namespace m_bmqtool {
 
 // =======================
@@ -5676,6 +5968,7 @@ class Command {
         bsls::ObjectBuffer<PostCommand>           d_post;
         bsls::ObjectBuffer<ListCommand>           d_list;
         bsls::ObjectBuffer<ConfirmCommand>        d_confirm;
+        bsls::ObjectBuffer<BatchPostCommand>      d_batchPost;
         bsls::ObjectBuffer<OpenStorageCommand>    d_openStorage;
         bsls::ObjectBuffer<CloseStorageCommand>   d_closeStorage;
         bsls::ObjectBuffer<MetadataCommand>       d_metadata;
@@ -5708,17 +6001,18 @@ class Command {
         SELECTION_ID_POST            = 5,
         SELECTION_ID_LIST            = 6,
         SELECTION_ID_CONFIRM         = 7,
-        SELECTION_ID_OPEN_STORAGE    = 8,
-        SELECTION_ID_CLOSE_STORAGE   = 9,
-        SELECTION_ID_METADATA        = 10,
-        SELECTION_ID_LIST_QUEUES     = 11,
-        SELECTION_ID_DUMP_QUEUE      = 12,
-        SELECTION_ID_DATA            = 13,
-        SELECTION_ID_QLIST           = 14,
-        SELECTION_ID_JOURNAL         = 15
+        SELECTION_ID_BATCH_POST      = 8,
+        SELECTION_ID_OPEN_STORAGE    = 9,
+        SELECTION_ID_CLOSE_STORAGE   = 10,
+        SELECTION_ID_METADATA        = 11,
+        SELECTION_ID_LIST_QUEUES     = 12,
+        SELECTION_ID_DUMP_QUEUE      = 13,
+        SELECTION_ID_DATA            = 14,
+        SELECTION_ID_QLIST           = 15,
+        SELECTION_ID_JOURNAL         = 16
     };
 
-    enum { NUM_SELECTIONS = 16 };
+    enum { NUM_SELECTIONS = 17 };
 
     enum {
         SELECTION_INDEX_START           = 0,
@@ -5729,14 +6023,15 @@ class Command {
         SELECTION_INDEX_POST            = 5,
         SELECTION_INDEX_LIST            = 6,
         SELECTION_INDEX_CONFIRM         = 7,
-        SELECTION_INDEX_OPEN_STORAGE    = 8,
-        SELECTION_INDEX_CLOSE_STORAGE   = 9,
-        SELECTION_INDEX_METADATA        = 10,
-        SELECTION_INDEX_LIST_QUEUES     = 11,
-        SELECTION_INDEX_DUMP_QUEUE      = 12,
-        SELECTION_INDEX_DATA            = 13,
-        SELECTION_INDEX_QLIST           = 14,
-        SELECTION_INDEX_JOURNAL         = 15
+        SELECTION_INDEX_BATCH_POST      = 8,
+        SELECTION_INDEX_OPEN_STORAGE    = 9,
+        SELECTION_INDEX_CLOSE_STORAGE   = 10,
+        SELECTION_INDEX_METADATA        = 11,
+        SELECTION_INDEX_LIST_QUEUES     = 12,
+        SELECTION_INDEX_DUMP_QUEUE      = 13,
+        SELECTION_INDEX_DATA            = 14,
+        SELECTION_INDEX_QLIST           = 15,
+        SELECTION_INDEX_JOURNAL         = 16
     };
 
     // CONSTANTS
@@ -5895,6 +6190,16 @@ class Command {
     // specify the 'value' of the "Confirm".  If 'value' is not specified,
     // the default "Confirm" value is used.
 
+    BatchPostCommand& makeBatchPost();
+    BatchPostCommand& makeBatchPost(const BatchPostCommand& value);
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    BatchPostCommand& makeBatchPost(BatchPostCommand&& value);
+#endif
+    // Set the value of this object to be a "BatchPost" value.  Optionally
+    // specify the 'value' of the "BatchPost".  If 'value' is not
+    // specified, the default "BatchPost" value is used.
+
     OpenStorageCommand& makeOpenStorage();
     OpenStorageCommand& makeOpenStorage(const OpenStorageCommand& value);
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
@@ -6024,6 +6329,11 @@ class Command {
     // object if "Confirm" is the current selection.  The behavior is
     // undefined unless "Confirm" is the selection of this object.
 
+    BatchPostCommand& batchPost();
+    // Return a reference to the modifiable "BatchPost" selection of this
+    // object if "BatchPost" is the current selection.  The behavior is
+    // undefined unless "BatchPost" is the selection of this object.
+
     OpenStorageCommand& openStorage();
     // Return a reference to the modifiable "OpenStorage" selection of this
     // object if "OpenStorage" is the current selection.  The behavior is
@@ -6132,6 +6442,11 @@ class Command {
     // object if "Confirm" is the current selection.  The behavior is
     // undefined unless "Confirm" is the selection of this object.
 
+    const BatchPostCommand& batchPost() const;
+    // Return a reference to the non-modifiable "BatchPost" selection of
+    // this object if "BatchPost" is the current selection.  The behavior
+    // is undefined unless "BatchPost" is the selection of this object.
+
     const OpenStorageCommand& openStorage() const;
     // Return a reference to the non-modifiable "OpenStorage" selection of
     // this object if "OpenStorage" is the current selection.  The behavior
@@ -6204,6 +6519,10 @@ class Command {
     bool isConfirmValue() const;
     // Return 'true' if the value of this object is a "Confirm" value, and
     // return 'false' otherwise.
+
+    bool isBatchPostValue() const;
+    // Return 'true' if the value of this object is a "BatchPost" value,
+    // and return 'false' otherwise.
 
     bool isOpenStorageValue() const;
     // Return 'true' if the value of this object is a "OpenStorage" value,
@@ -6290,6 +6609,310 @@ BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(m_bmqtool::Command)
 //=============================================================================
 
 namespace m_bmqtool {
+
+// ----------------------
+// class BatchPostCommand
+// ----------------------
+
+// PRIVATE ACCESSORS
+template <typename t_HASH_ALGORITHM>
+void BatchPostCommand::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
+{
+    using bslh::hashAppend;
+    hashAppend(hashAlgorithm, this->uri());
+    hashAppend(hashAlgorithm, this->payload());
+    hashAppend(hashAlgorithm, this->msgSize());
+    hashAppend(hashAlgorithm, this->eventSize());
+    hashAppend(hashAlgorithm, this->eventsCount());
+    hashAppend(hashAlgorithm, this->postInterval());
+    hashAppend(hashAlgorithm, this->postRate());
+}
+
+inline bool BatchPostCommand::isEqualTo(const BatchPostCommand& rhs) const
+{
+    return this->uri() == rhs.uri() && this->payload() == rhs.payload() &&
+           this->msgSize() == rhs.msgSize() &&
+           this->eventSize() == rhs.eventSize() &&
+           this->eventsCount() == rhs.eventsCount() &&
+           this->postInterval() == rhs.postInterval() &&
+           this->postRate() == rhs.postRate();
+}
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int BatchPostCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(&d_uri, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_URI]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_payload,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PAYLOAD]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_msgSize,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MSG_SIZE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_eventSize,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENT_SIZE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_eventsCount,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENTS_COUNT]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_postInterval,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_INTERVAL]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_postRate,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_RATE]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int BatchPostCommand::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_URI: {
+        return manipulator(&d_uri, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_URI]);
+    }
+    case ATTRIBUTE_ID_PAYLOAD: {
+        return manipulator(&d_payload,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PAYLOAD]);
+    }
+    case ATTRIBUTE_ID_MSG_SIZE: {
+        return manipulator(&d_msgSize,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MSG_SIZE]);
+    }
+    case ATTRIBUTE_ID_EVENT_SIZE: {
+        return manipulator(&d_eventSize,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENT_SIZE]);
+    }
+    case ATTRIBUTE_ID_EVENTS_COUNT: {
+        return manipulator(&d_eventsCount,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENTS_COUNT]);
+    }
+    case ATTRIBUTE_ID_POST_INTERVAL: {
+        return manipulator(
+            &d_postInterval,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_INTERVAL]);
+    }
+    case ATTRIBUTE_ID_POST_RATE: {
+        return manipulator(&d_postRate,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_RATE]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int BatchPostCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                          const char*    name,
+                                          int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline bsl::string& BatchPostCommand::uri()
+{
+    return d_uri;
+}
+
+inline bsl::vector<bsl::string>& BatchPostCommand::payload()
+{
+    return d_payload;
+}
+
+inline int& BatchPostCommand::msgSize()
+{
+    return d_msgSize;
+}
+
+inline bsls::Types::Int64& BatchPostCommand::eventSize()
+{
+    return d_eventSize;
+}
+
+inline bsls::Types::Int64& BatchPostCommand::eventsCount()
+{
+    return d_eventsCount;
+}
+
+inline int& BatchPostCommand::postInterval()
+{
+    return d_postInterval;
+}
+
+inline int& BatchPostCommand::postRate()
+{
+    return d_postRate;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int BatchPostCommand::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(d_uri, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_URI]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_payload, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PAYLOAD]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_msgSize, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MSG_SIZE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_eventSize,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENT_SIZE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_eventsCount,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENTS_COUNT]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_postInterval,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_INTERVAL]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_postRate,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_RATE]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int BatchPostCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_URI: {
+        return accessor(d_uri, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_URI]);
+    }
+    case ATTRIBUTE_ID_PAYLOAD: {
+        return accessor(d_payload,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PAYLOAD]);
+    }
+    case ATTRIBUTE_ID_MSG_SIZE: {
+        return accessor(d_msgSize,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MSG_SIZE]);
+    }
+    case ATTRIBUTE_ID_EVENT_SIZE: {
+        return accessor(d_eventSize,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENT_SIZE]);
+    }
+    case ATTRIBUTE_ID_EVENTS_COUNT: {
+        return accessor(d_eventsCount,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_EVENTS_COUNT]);
+    }
+    case ATTRIBUTE_ID_POST_INTERVAL: {
+        return accessor(d_postInterval,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_INTERVAL]);
+    }
+    case ATTRIBUTE_ID_POST_RATE: {
+        return accessor(d_postRate,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_POST_RATE]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int BatchPostCommand::accessAttribute(t_ACCESSOR& accessor,
+                                      const char* name,
+                                      int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline const bsl::string& BatchPostCommand::uri() const
+{
+    return d_uri;
+}
+
+inline const bsl::vector<bsl::string>& BatchPostCommand::payload() const
+{
+    return d_payload;
+}
+
+inline int BatchPostCommand::msgSize() const
+{
+    return d_msgSize;
+}
+
+inline bsls::Types::Int64 BatchPostCommand::eventSize() const
+{
+    return d_eventSize;
+}
+
+inline bsls::Types::Int64 BatchPostCommand::eventsCount() const
+{
+    return d_eventsCount;
+}
+
+inline int BatchPostCommand::postInterval() const
+{
+    return d_postInterval;
+}
+
+inline int BatchPostCommand::postRate() const
+{
+    return d_postRate;
+}
 
 // -----------------------
 // class CloseQueueCommand
@@ -10776,6 +11399,9 @@ void Command::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
     case Class::SELECTION_ID_CONFIRM:
         hashAppend(hashAlgorithm, this->confirm());
         break;
+    case Class::SELECTION_ID_BATCH_POST:
+        hashAppend(hashAlgorithm, this->batchPost());
+        break;
     case Class::SELECTION_ID_OPEN_STORAGE:
         hashAppend(hashAlgorithm, this->openStorage());
         break;
@@ -10821,6 +11447,8 @@ inline bool Command::isEqualTo(const Command& rhs) const
         case Class::SELECTION_ID_LIST: return this->list() == rhs.list();
         case Class::SELECTION_ID_CONFIRM:
             return this->confirm() == rhs.confirm();
+        case Class::SELECTION_ID_BATCH_POST:
+            return this->batchPost() == rhs.batchPost();
         case Class::SELECTION_ID_OPEN_STORAGE:
             return this->openStorage() == rhs.openStorage();
         case Class::SELECTION_ID_CLOSE_STORAGE:
@@ -10887,6 +11515,9 @@ int Command::manipulateSelection(t_MANIPULATOR& manipulator)
     case Command::SELECTION_ID_CONFIRM:
         return manipulator(&d_confirm.object(),
                            SELECTION_INFO_ARRAY[SELECTION_INDEX_CONFIRM]);
+    case Command::SELECTION_ID_BATCH_POST:
+        return manipulator(&d_batchPost.object(),
+                           SELECTION_INFO_ARRAY[SELECTION_INDEX_BATCH_POST]);
     case Command::SELECTION_ID_OPEN_STORAGE:
         return manipulator(&d_openStorage.object(),
                            SELECTION_INFO_ARRAY[SELECTION_INDEX_OPEN_STORAGE]);
@@ -10964,6 +11595,12 @@ inline ConfirmCommand& Command::confirm()
 {
     BSLS_ASSERT(SELECTION_ID_CONFIRM == d_selectionId);
     return d_confirm.object();
+}
+
+inline BatchPostCommand& Command::batchPost()
+{
+    BSLS_ASSERT(SELECTION_ID_BATCH_POST == d_selectionId);
+    return d_batchPost.object();
 }
 
 inline OpenStorageCommand& Command::openStorage()
@@ -11048,6 +11685,9 @@ int Command::accessSelection(t_ACCESSOR& accessor) const
     case SELECTION_ID_CONFIRM:
         return accessor(d_confirm.object(),
                         SELECTION_INFO_ARRAY[SELECTION_INDEX_CONFIRM]);
+    case SELECTION_ID_BATCH_POST:
+        return accessor(d_batchPost.object(),
+                        SELECTION_INFO_ARRAY[SELECTION_INDEX_BATCH_POST]);
     case SELECTION_ID_OPEN_STORAGE:
         return accessor(d_openStorage.object(),
                         SELECTION_INFO_ARRAY[SELECTION_INDEX_OPEN_STORAGE]);
@@ -11122,6 +11762,12 @@ inline const ConfirmCommand& Command::confirm() const
 {
     BSLS_ASSERT(SELECTION_ID_CONFIRM == d_selectionId);
     return d_confirm.object();
+}
+
+inline const BatchPostCommand& Command::batchPost() const
+{
+    BSLS_ASSERT(SELECTION_ID_BATCH_POST == d_selectionId);
+    return d_batchPost.object();
 }
 
 inline const OpenStorageCommand& Command::openStorage() const
@@ -11210,6 +11856,11 @@ inline bool Command::isListValue() const
 inline bool Command::isConfirmValue() const
 {
     return SELECTION_ID_CONFIRM == d_selectionId;
+}
+
+inline bool Command::isBatchPostValue() const
+{
+    return SELECTION_ID_BATCH_POST == d_selectionId;
 }
 
 inline bool Command::isOpenStorageValue() const

--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -1,15 +1,32 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
 //
-// Created by syuzvinsky on 3/7/24.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// m_bmqtool_poster.cpp                                               -*-C++-*-
+
+// BMQTOOL
+#include <m_bmqtool_statutil.h>
 #include <m_bmqtool_inpututil.h>
+#include <m_bmqtool_poster.h>
+
+// BMQ
+#include <bmqimp_event.h>
+#include <bmqt_queueflags.h>
+
+// BDE
 #include <ball_log.h>
 #include <bdlbb_blobutil.h>
-#include <bdlt_currenttime.h>
-#include <bmqt_queueflags.h>
-#include <bsls_timeutil.h>
-#include <m_bmqtool_poster.h>
-#include <bmqimp_event.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
@@ -18,55 +35,33 @@ namespace {
 
 BALL_LOG_SET_NAMESPACE_CATEGORY("BMQTOOL.POSTER");
 
-// How often (in ms) should a message be stamped with the latency: because
-// computing the current time is expensive, we will only insert the timestamp
-// inside a sample subset of the messages (1 every 'k_LATENCY_INTERVAL_MS'
-// time), as computed by the configured frequency of message publishing.
-const int k_LATENCY_INTERVAL_MS = 5;
-
-// Return the current time -in nanoseconds- using either the system time or the
-// performance timer (depending on the value of the specified 'resolutionTimer'
-bsls::Types::Int64 getNowAsNs(ParametersLatency::Value resolutionTimer)
-{
-    if (resolutionTimer == ParametersLatency::e_EPOCH) {
-        bsls::TimeInterval now = bdlt::CurrentTime::now();
-        return now.totalNanoseconds();  // RETURN
-    }
-    else if (resolutionTimer == ParametersLatency::e_HIRES) {
-        return bsls::TimeUtil::getTimer();  // RETURN
-    }
-    else {
-        BSLS_ASSERT_OPT(false && "Unsupported latency mode");
-    }
-
-    return 0;
 }
 
-}
-
-Poster::Poster(
-    bmqa::Session* session,
-    Parameters* parameters,
-    FileLogger* fileLogger,
-    const bmqa::QueueId& queueId,
-    bslma::Allocator* allocator)
-    : d_allocator_p(allocator)
-    , d_parameters_p(parameters)
-    , d_session_p(session)
-    , d_fileLogger(fileLogger)
-    , d_remainingEvents(0)
-    , d_numMessagesPosted(0)
-    , d_msgUntilNextTimestamp(0)
-    , d_bufferFactory(4096, d_allocator_p)
-    , d_timeBufferFactory(sizeof(bdlb::BigEndianInt64), d_allocator_p)
-    , d_blob(&d_bufferFactory, d_allocator_p)
-    , d_queueId(queueId, d_allocator_p)
-    , d_properties(d_allocator_p)
+PostingContext::PostingContext(
+    bmqa::Session*                  session,
+    Parameters*                     parameters,
+    const bmqa::QueueId&            queueId,
+    FileLogger*                     fileLogger,
+    mwcst::StatContext*             statContext,
+    bdlbb::PooledBlobBufferFactory* bufferFactory,
+    bdlbb::PooledBlobBufferFactory* timeBufferFactory,
+    bslma::Allocator*               allocator)
+: d_allocator_p(allocator)
+, d_timeBufferFactory_p(timeBufferFactory)
+, d_parameters_p(parameters)
+, d_session_p(session)
+, d_fileLogger(fileLogger)
+, d_statContext_p(statContext)
+, d_remainingEvents(d_parameters_p->eventsCount())
+, d_numMessagesPosted(0)
+, d_msgUntilNextTimestamp(0)
+, d_blob(bufferFactory, d_allocator_p)
+, d_queueId(queueId, d_allocator_p)
+, d_properties(d_allocator_p)
 {
     BSLS_ASSERT_SAFE(session);
     BSLS_ASSERT_SAFE(parameters);
-
-    d_remainingEvents = d_parameters_p->eventsCount();
+    BSLS_ASSERT_SAFE(d_queueId.isValid());
 
     InputUtil::populateProperties(&d_properties,
                                   d_parameters_p->messageProperties());
@@ -80,7 +75,7 @@ Poster::Poster(
             // first blob of 8 bytes that will be swapped out at every
             // post with a new timestamp value.
             bdlbb::BlobBuffer latencyBuffer;
-            d_timeBufferFactory.allocate(&latencyBuffer);
+            d_timeBufferFactory_p->allocate(&latencyBuffer);
             latencyBuffer.setSize(sizeof(bdlb::BigEndianInt64));
             bdlb::BigEndianInt64 zero = bdlb::BigEndianInt64::make(0);
             bsl::memcpy(latencyBuffer.buffer().get(),
@@ -99,24 +94,19 @@ Poster::Poster(
     }
 }
 
-bool Poster::pendingPost() const
+bool PostingContext::pendingPost() const
 {
     // eventsCount() == 0 means endless posting,
     // otherwise check if remainingEvents is positive
     return d_parameters_p->eventsCount() == 0 || d_remainingEvents > 0;
 }
 
-bsl::pair<size_t, size_t> Poster::postNext()
+void PostingContext::postNext()
 {
-    BSLS_ASSERT_SAFE(d_session_mp);
     BSLS_ASSERT_SAFE(pendingPost());
-    BSLS_ASSERT_SAFE(d_queueId.isValid());
 
     bmqa::MessageEventBuilder eventBuilder;
     d_session_p->loadMessageEventBuilder(&eventBuilder);
-
-    int postedEventsSize = 0;
-    int postedMessagesSize = 0;
 
     for (int evtId = 0;
          evtId < d_parameters_p->postRate() && pendingPost();
@@ -129,9 +119,8 @@ bsl::pair<size_t, size_t> Poster::postNext()
             break;  // BREAK
         }
 
-        postedMessagesSize = 0;
         eventBuilder.reset();
-        for (int msgId = 0; msgId < d_parameters_p->eventSize();
+        for (bsl::uint64_t msgId = 0; msgId < d_parameters_p->eventSize();
              ++msgId, ++d_numMessagesPosted) {
             bmqa::Message& msg    = eventBuilder.startMessage();
             int            length = 0;
@@ -162,7 +151,7 @@ bsl::pair<size_t, size_t> Poster::postNext()
                     else {
                         // Insert the timestamp
                         timeNs = bdlb::BigEndianInt64::make(
-                            getNowAsNs(d_parameters_p->latency()));
+                            StatUtil::getNowAsNs(d_parameters_p->latency()));
 
                         // Update the number of messages until next
                         // timestamp:
@@ -171,12 +160,11 @@ bsl::pair<size_t, size_t> Poster::postNext()
                                           1000 /
                                           d_parameters_p->postInterval();
                         d_msgUntilNextTimestamp = nbMsgPerSec *
-                                                  k_LATENCY_INTERVAL_MS /
-                                                  1000;
+                            k_LATENCY_INTERVAL_MS / 1000;
                     }
 
                     bdlbb::BlobBuffer buffer;
-                    d_timeBufferFactory.allocate(&buffer);
+                    d_timeBufferFactory_p->allocate(&buffer);
                     buffer.setSize(sizeof(bdlb::BigEndianInt64));
                     bsl::memcpy(buffer.buffer().get(),
                                 &timeNs,
@@ -198,7 +186,7 @@ bsl::pair<size_t, size_t> Poster::postNext()
                                << "]";
                 continue;  // CONTINUE
             }
-            postedMessagesSize += length;
+            d_statContext_p->adjustValue(k_STAT_MSG, length);
         }
 
         // Now publish the event
@@ -206,7 +194,7 @@ bsl::pair<size_t, size_t> Poster::postNext()
             eventBuilder.messageEvent();
 
         // Write PUTs to log file before posting
-        if (d_fileLogger->isOpen()) {
+        if (d_fileLogger && d_fileLogger->isOpen()) {
             bmqa::MessageIterator it = messageEvent.messageIterator();
             while (it.nextMessage()) {
                 const bmqa::Message& message = it.message();
@@ -226,15 +214,44 @@ bsl::pair<size_t, size_t> Poster::postNext()
         const bsl::shared_ptr<bmqimp::Event>& eventImpl =
             reinterpret_cast<const bsl::shared_ptr<bmqimp::Event>&>(
                 messageEvent);
-        postedEventsSize += eventImpl->rawEvent().blob()->length();
+        d_statContext_p->adjustValue(k_STAT_EVT,
+                                     eventImpl->rawEvent().blob()->length());
 
         if (d_parameters_p->eventsCount() > 0) {
             --d_remainingEvents;
         }
     }
-
-    return bsl::make_pair(postedEventsSize, postedMessagesSize);
 }
+
+Poster::Poster(FileLogger*         fileLogger,
+               mwcst::StatContext* statContext,
+               bslma::Allocator*   allocator)
+: d_allocator_p(allocator)
+, d_bufferFactory(4096, d_allocator_p)
+, d_timeBufferFactory(sizeof(bdlb::BigEndianInt64), d_allocator_p)
+, d_statContext(statContext)
+, d_fileLogger(fileLogger)
+{
+    BSLS_ASSERT_SAFE(fileLogger);
+    BSLS_ASSERT_SAFE(statContext);
+    BSLS_ASSERT_SAFE(allocator);
+}
+
+PostingContext Poster::createPostingContext(
+    bmqa::Session* session,
+    Parameters* parameters,
+    const bmqa::QueueId& queueId)
+{
+    return PostingContext(session,
+                          parameters,
+                          queueId,
+                          d_fileLogger,
+                          d_statContext,
+                          &d_bufferFactory,
+                          &d_timeBufferFactory,
+                          d_allocator_p);
+}
+
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -16,9 +16,9 @@
 // m_bmqtool_poster.cpp                                               -*-C++-*-
 
 // BMQTOOL
-#include <m_bmqtool_statutil.h>
 #include <m_bmqtool_inpututil.h>
 #include <m_bmqtool_poster.h>
+#include <m_bmqtool_statutil.h>
 
 // BMQ
 #include <bmqimp_event.h>
@@ -78,9 +78,7 @@ PostingContext::PostingContext(
             d_timeBufferFactory_p->allocate(&latencyBuffer);
             latencyBuffer.setSize(sizeof(bdlb::BigEndianInt64));
             bdlb::BigEndianInt64 zero = bdlb::BigEndianInt64::make(0);
-            bsl::memcpy(latencyBuffer.buffer().get(),
-                        &zero,
-                        sizeof(zero));
+            bsl::memcpy(latencyBuffer.buffer().get(), &zero, sizeof(zero));
             d_blob.appendDataBuffer(latencyBuffer);
             msgPayloadSize -= sizeof(bdlb::BigEndianInt64);
         }
@@ -108,8 +106,7 @@ void PostingContext::postNext()
     bmqa::MessageEventBuilder eventBuilder;
     d_session_p->loadMessageEventBuilder(&eventBuilder);
 
-    for (int evtId = 0;
-         evtId < d_parameters_p->postRate() && pendingPost();
+    for (int evtId = 0; evtId < d_parameters_p->postRate() && pendingPost();
          ++evtId) {
         if (d_parameters_p->eventSize() == 0) {
             // To get nice stats chart with round numbers in bench mode, we
@@ -126,7 +123,7 @@ void PostingContext::postNext()
             int            length = 0;
 
             // Set a correlationId if queue is open in ACK mode
-            if  (bmqt::QueueFlagsUtil::isAck(d_parameters_p->queueFlags())) {
+            if (bmqt::QueueFlagsUtil::isAck(d_parameters_p->queueFlags())) {
                 msg.setCorrelationId(bmqt::CorrelationId::autoValue());
             }
 
@@ -156,11 +153,10 @@ void PostingContext::postNext()
                         // Update the number of messages until next
                         // timestamp:
                         int nbMsgPerSec = d_parameters_p->eventSize() *
-                                          d_parameters_p->postRate() *
-                                          1000 /
+                                          d_parameters_p->postRate() * 1000 /
                                           d_parameters_p->postInterval();
                         d_msgUntilNextTimestamp = nbMsgPerSec *
-                            k_LATENCY_INTERVAL_MS / 1000;
+                                                  k_LATENCY_INTERVAL_MS / 1000;
                     }
 
                     bdlbb::BlobBuffer buffer;
@@ -182,16 +178,14 @@ void PostingContext::postNext()
             bmqt::EventBuilderResult::Enum rc = eventBuilder.packMessage(
                 d_queueId);
             if (rc != 0) {
-                BALL_LOG_ERROR << "Failed to pack message [rc: " << rc
-                               << "]";
+                BALL_LOG_ERROR << "Failed to pack message [rc: " << rc << "]";
                 continue;  // CONTINUE
             }
             d_statContext_p->adjustValue(k_STAT_MSG, length);
         }
 
         // Now publish the event
-        const bmqa::MessageEvent& messageEvent =
-            eventBuilder.messageEvent();
+        const bmqa::MessageEvent& messageEvent = eventBuilder.messageEvent();
 
         // Write PUTs to log file before posting
         if (d_fileLogger && d_fileLogger->isOpen()) {
@@ -205,9 +199,8 @@ void PostingContext::postNext()
         int rc = d_session_p->post(messageEvent);
 
         if (rc != 0) {
-            BALL_LOG_ERROR
-                << "Failed to post: " << bmqt::PostResult::Enum(rc) << " ("
-                << rc << ")";
+            BALL_LOG_ERROR << "Failed to post: " << bmqt::PostResult::Enum(rc)
+                           << " (" << rc << ")";
             continue;  // CONTINUE
         }
 
@@ -237,10 +230,9 @@ Poster::Poster(FileLogger*         fileLogger,
     BSLS_ASSERT_SAFE(allocator);
 }
 
-PostingContext Poster::createPostingContext(
-    bmqa::Session* session,
-    Parameters* parameters,
-    const bmqa::QueueId& queueId)
+PostingContext Poster::createPostingContext(bmqa::Session*       session,
+                                            Parameters*          parameters,
+                                            const bmqa::QueueId& queueId)
 {
     return PostingContext(session,
                           parameters,
@@ -251,7 +243,6 @@ PostingContext Poster::createPostingContext(
                           &d_timeBufferFactory,
                           d_allocator_p);
 }
-
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -1,0 +1,240 @@
+//
+// Created by syuzvinsky on 3/7/24.
+//
+
+#include <m_bmqtool_inpututil.h>
+#include <ball_log.h>
+#include <bdlbb_blobutil.h>
+#include <bdlt_currenttime.h>
+#include <bmqt_queueflags.h>
+#include <bsls_timeutil.h>
+#include <m_bmqtool_poster.h>
+#include <bmqimp_event.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+namespace {
+
+BALL_LOG_SET_NAMESPACE_CATEGORY("BMQTOOL.POSTER");
+
+// How often (in ms) should a message be stamped with the latency: because
+// computing the current time is expensive, we will only insert the timestamp
+// inside a sample subset of the messages (1 every 'k_LATENCY_INTERVAL_MS'
+// time), as computed by the configured frequency of message publishing.
+const int k_LATENCY_INTERVAL_MS = 5;
+
+// Return the current time -in nanoseconds- using either the system time or the
+// performance timer (depending on the value of the specified 'resolutionTimer'
+bsls::Types::Int64 getNowAsNs(ParametersLatency::Value resolutionTimer)
+{
+    if (resolutionTimer == ParametersLatency::e_EPOCH) {
+        bsls::TimeInterval now = bdlt::CurrentTime::now();
+        return now.totalNanoseconds();  // RETURN
+    }
+    else if (resolutionTimer == ParametersLatency::e_HIRES) {
+        return bsls::TimeUtil::getTimer();  // RETURN
+    }
+    else {
+        BSLS_ASSERT_OPT(false && "Unsupported latency mode");
+    }
+
+    return 0;
+}
+
+}
+
+Poster::Poster(
+    bmqa::Session* session,
+    Parameters* parameters,
+    FileLogger* fileLogger,
+    const bmqa::QueueId& queueId,
+    bslma::Allocator* allocator)
+    : d_allocator_p(allocator)
+    , d_parameters_p(parameters)
+    , d_session_p(session)
+    , d_fileLogger(fileLogger)
+    , d_remainingEvents(0)
+    , d_numMessagesPosted(0)
+    , d_msgUntilNextTimestamp(0)
+    , d_bufferFactory(4096, d_allocator_p)
+    , d_timeBufferFactory(sizeof(bdlb::BigEndianInt64), d_allocator_p)
+    , d_blob(&d_bufferFactory, d_allocator_p)
+    , d_queueId(queueId, d_allocator_p)
+    , d_properties(d_allocator_p)
+{
+    BSLS_ASSERT_SAFE(session);
+    BSLS_ASSERT_SAFE(parameters);
+
+    d_remainingEvents = d_parameters_p->eventsCount();
+
+    InputUtil::populateProperties(&d_properties,
+                                  d_parameters_p->messageProperties());
+
+    // Prepare the blob that we will post over and over again
+    if (d_parameters_p->sequentialMessagePattern().empty()) {
+        int msgPayloadSize = d_parameters_p->msgSize();
+
+        if (d_parameters_p->latency() != ParametersLatency::e_NONE) {
+            // To optimize, if asked to insert latency, we put in a
+            // first blob of 8 bytes that will be swapped out at every
+            // post with a new timestamp value.
+            bdlbb::BlobBuffer latencyBuffer;
+            d_timeBufferFactory.allocate(&latencyBuffer);
+            latencyBuffer.setSize(sizeof(bdlb::BigEndianInt64));
+            bdlb::BigEndianInt64 zero = bdlb::BigEndianInt64::make(0);
+            bsl::memcpy(latencyBuffer.buffer().get(),
+                        &zero,
+                        sizeof(zero));
+            d_blob.appendDataBuffer(latencyBuffer);
+            msgPayloadSize -= sizeof(bdlb::BigEndianInt64);
+        }
+
+        // Initialize a buffer of the right published size, with
+        // alphabet's letters
+        for (int i = 0; i < msgPayloadSize; ++i) {
+            char c = static_cast<char>('A' + i % 26);
+            bdlbb::BlobUtil::append(&d_blob, &c, 1);
+        }
+    }
+}
+
+bool Poster::pendingPost() const
+{
+    // eventsCount() == 0 means endless posting,
+    // otherwise check if remainingEvents is positive
+    return d_parameters_p->eventsCount() == 0 || d_remainingEvents > 0;
+}
+
+bsl::pair<size_t, size_t> Poster::postNext()
+{
+    BSLS_ASSERT_SAFE(d_session_mp);
+    BSLS_ASSERT_SAFE(pendingPost());
+    BSLS_ASSERT_SAFE(d_queueId.isValid());
+
+    bmqa::MessageEventBuilder eventBuilder;
+    d_session_p->loadMessageEventBuilder(&eventBuilder);
+
+    int postedEventsSize = 0;
+    int postedMessagesSize = 0;
+
+    for (int evtId = 0;
+         evtId < d_parameters_p->postRate() && pendingPost();
+         ++evtId) {
+        if (d_parameters_p->eventSize() == 0) {
+            // To get nice stats chart with round numbers in bench mode, we
+            // usually start with eventSize == 0; however posting Events
+            // with 0 message in them cause an assert or an error to spew,
+            // so just avoid it.
+            break;  // BREAK
+        }
+
+        postedMessagesSize = 0;
+        eventBuilder.reset();
+        for (int msgId = 0; msgId < d_parameters_p->eventSize();
+             ++msgId, ++d_numMessagesPosted) {
+            bmqa::Message& msg    = eventBuilder.startMessage();
+            int            length = 0;
+
+            // Set a correlationId if queue is open in ACK mode
+            if  (bmqt::QueueFlagsUtil::isAck(d_parameters_p->queueFlags())) {
+                msg.setCorrelationId(bmqt::CorrelationId::autoValue());
+            }
+
+            if (!d_parameters_p->sequentialMessagePattern().empty()) {
+                char buffer[128];
+                length = snprintf(
+                    buffer,
+                    sizeof(buffer),
+                    d_parameters_p->sequentialMessagePattern().c_str(),
+                    d_numMessagesPosted);
+                msg.setDataRef(buffer, length);
+            }
+            else {
+                // Insert latency if required...
+                if (d_parameters_p->latency() != ParametersLatency::e_NONE) {
+                    bdlb::BigEndianInt64 timeNs;
+
+                    if (d_msgUntilNextTimestamp != 0) {
+                        --d_msgUntilNextTimestamp;
+                        timeNs = bdlb::BigEndianInt64::make(0);
+                    }
+                    else {
+                        // Insert the timestamp
+                        timeNs = bdlb::BigEndianInt64::make(
+                            getNowAsNs(d_parameters_p->latency()));
+
+                        // Update the number of messages until next
+                        // timestamp:
+                        int nbMsgPerSec = d_parameters_p->eventSize() *
+                                          d_parameters_p->postRate() *
+                                          1000 /
+                                          d_parameters_p->postInterval();
+                        d_msgUntilNextTimestamp = nbMsgPerSec *
+                                                  k_LATENCY_INTERVAL_MS /
+                                                  1000;
+                    }
+
+                    bdlbb::BlobBuffer buffer;
+                    d_timeBufferFactory.allocate(&buffer);
+                    buffer.setSize(sizeof(bdlb::BigEndianInt64));
+                    bsl::memcpy(buffer.buffer().get(),
+                                &timeNs,
+                                sizeof(timeNs));
+                    d_blob.swapBufferRaw(0, &buffer);
+                }
+                msg.setDataRef(&d_blob);
+
+                length = d_blob.length();
+            }
+
+            if (d_properties.numProperties()) {
+                msg.setPropertiesRef(&d_properties);
+            }
+            bmqt::EventBuilderResult::Enum rc = eventBuilder.packMessage(
+                d_queueId);
+            if (rc != 0) {
+                BALL_LOG_ERROR << "Failed to pack message [rc: " << rc
+                               << "]";
+                continue;  // CONTINUE
+            }
+            postedMessagesSize += length;
+        }
+
+        // Now publish the event
+        const bmqa::MessageEvent& messageEvent =
+            eventBuilder.messageEvent();
+
+        // Write PUTs to log file before posting
+        if (d_fileLogger->isOpen()) {
+            bmqa::MessageIterator it = messageEvent.messageIterator();
+            while (it.nextMessage()) {
+                const bmqa::Message& message = it.message();
+                d_fileLogger->writePutMessage(message);
+            }
+        }
+
+        int rc = d_session_p->post(messageEvent);
+
+        if (rc != 0) {
+            BALL_LOG_ERROR
+                << "Failed to post: " << bmqt::PostResult::Enum(rc) << " ("
+                << rc << ")";
+            continue;  // CONTINUE
+        }
+
+        const bsl::shared_ptr<bmqimp::Event>& eventImpl =
+            reinterpret_cast<const bsl::shared_ptr<bmqimp::Event>&>(
+                messageEvent);
+        postedEventsSize += eventImpl->rawEvent().blob()->length();
+
+        if (d_parameters_p->eventsCount() > 0) {
+            --d_remainingEvents;
+        }
+    }
+
+    return bsl::make_pair(postedEventsSize, postedMessagesSize);
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -219,7 +219,7 @@ void PostingContext::postNext()
 Poster::Poster(FileLogger*         fileLogger,
                mwcst::StatContext* statContext,
                bslma::Allocator*   allocator)
-: d_allocator_p(allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
 , d_bufferFactory(4096, d_allocator_p)
 , d_timeBufferFactory(sizeof(bdlb::BigEndianInt64), d_allocator_p)
 , d_statContext(statContext)

--- a/src/applications/bmqtool/m_bmqtool_poster.h
+++ b/src/applications/bmqtool/m_bmqtool_poster.h
@@ -1,36 +1,139 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
 //
-// Created by syuzvinsky on 3/7/24.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// m_bmqtool_poster.h                                                 -*-C++-*-
 #ifndef INCLUDED_M_BMQTOOL_POSTER
 #define INCLUDED_M_BMQTOOL_POSTER
 
-#include "m_bmqtool_filelogger.h"
-#include <bdlbb_pooledblobbufferfactory.h>
+//@PURPOSE: Helper classes for posting series of messages.
+//
+//@CLASSES:
+//
+//  m_bmqtool::PostingContext: A class to hold a context of a single series
+//  of messages to be posted.
+//  m_bmqtool::Poster: A factory-semantic class to hold everything needed for
+//  posting and ease creating posting contexts: buffers,
+//  a logger, an allocator etc.
+//
+//@DESCRIPTION: 'm_bmqtool_poster' contains classes that abstract the mechanism
+// of posting series of messages.
+
+// BMQTOOL
+#include <m_bmqtool_filelogger.h>
+#include <m_bmqtool_parameters.h>
+
+// BMQ
 #include <bmqa_messageproperties.h>
 #include <bmqa_session.h>
+#include <mwcst_statcontext.h>
+
+// BDE
+#include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_string.h>
-#include <m_bmqtool_parameters.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
 
-class Poster {
+// ====================
+// class PostingContext
+// ====================
+
+/// A class to hold a context of a single series of messages to be posted.
+class PostingContext {
   private:
+    // DATA
     bslma::Allocator* d_allocator_p;
-    // Held, not owned
+    // Held, not owned.
+
+    bdlbb::PooledBlobBufferFactory* d_timeBufferFactory_p;
+    // Small buffer factory for the first
+    // blob of the published message, used to
+    // hold the timestamp information.
 
     Parameters* d_parameters_p;
+    // Parameters of posting.
 
     bmqa::Session* d_session_p;
-    // A session to post messages. Held, not owned
+    // A session to post messages.
+    // Held, not owned.
 
     FileLogger* d_fileLogger;
+    // Where to log posted messages.
+    // Held, not owned.
+
+    mwcst::StatContext* d_statContext_p;
+    // StatContext for msg/event stats.
     // Held, not owned
 
     int d_remainingEvents;
+    // How many events are still left for posting.
+
     int d_numMessagesPosted;
+    // How many events have already been posted.
+
     int d_msgUntilNextTimestamp;
+    // In how many events the next timestamp will be posted.
+
+    bdlbb::Blob d_blob;
+    // Blob to post
+
+    bmqa::QueueId d_queueId;
+    // Queue ID for posting
+
+    bmqa::MessageProperties d_properties;
+    // Properties that will be added to a posted message
+
+  public:
+    // CREATORS
+
+    PostingContext(bmqa::Session*                  session,
+                   Parameters*                     parameters,
+                   const bmqa::QueueId&            queueId,
+                   FileLogger*                     fileLogger,
+                   mwcst::StatContext*             statContext,
+                   bdlbb::PooledBlobBufferFactory* bufferFactory,
+                   bdlbb::PooledBlobBufferFactory* timeBufferFactory,
+                   bslma::Allocator*               allocator);
+
+    // MANIPULATORS
+
+    /// Post next message. The behavior is undefined unless pendingPost()
+    /// is true.
+    void postNext();
+
+    // ACCESSORS
+
+    /// Return true is there is at least one message which should be posted.
+    bool pendingPost() const;
+
+  private:
+    PostingContext(const PostingContext&);
+    PostingContext& operator=(const PostingContext&);
+};
+
+
+// ============
+// class Poster
+// ============
+
+// A factory-semantic class to hold everything needed for posting
+// and ease creating posting contexts: buffers, a logger, an allocator etc.
+class Poster {
+    // DATA
+    bslma::Allocator* d_allocator_p;
+    // Held, not owned
 
     bdlbb::PooledBlobBufferFactory d_bufferFactory;
     // Buffer factory for the payload of the
@@ -41,23 +144,31 @@ class Poster {
     // blob of the published message, to
     // hold the timestamp information
 
-    bdlbb::Blob d_blob;
-    // Blob to post
+    mwcst::StatContext* d_statContext;
+    // StatContext for msg/event stats.
+    // Held, not owned
 
-    bmqa::QueueId d_queueId;
-
-    bmqa::MessageProperties d_properties;
+    FileLogger* d_fileLogger;
+    // Logger to use in case events logging
+    // to file has been enabled.
+    // Held, not owned
 
   public:
-    Poster(bmqa::Session* session,
-           Parameters* parameters,
-           FileLogger* fileLogger,
-           const bmqa::QueueId& queueId,
-           bslma::Allocator* allocator);
+    // CREATORS
+    Poster(FileLogger*         fileLogger,
+           mwcst::StatContext* statContext,
+           bslma::Allocator*   allocator);
 
-    bool pendingPost() const;
-    bsl::pair<size_t, size_t> postNext();
+    // MANIPULATORS
+    PostingContext createPostingContext(bmqa::Session*       session,
+                                        Parameters*          parameters,
+                                        const bmqa::QueueId& queueId);
+
+  private:
+    Poster(const Poster&);
+    Poster& operator=(const Poster&);
 };
+
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_poster.h
+++ b/src/applications/bmqtool/m_bmqtool_poster.h
@@ -123,7 +123,6 @@ class PostingContext {
     PostingContext& operator=(const PostingContext&);
 };
 
-
 // ============
 // class Poster
 // ============
@@ -168,7 +167,6 @@ class Poster {
     Poster(const Poster&);
     Poster& operator=(const Poster&);
 };
-
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_poster.h
+++ b/src/applications/bmqtool/m_bmqtool_poster.h
@@ -1,0 +1,65 @@
+//
+// Created by syuzvinsky on 3/7/24.
+//
+
+#ifndef INCLUDED_M_BMQTOOL_POSTER
+#define INCLUDED_M_BMQTOOL_POSTER
+
+#include "m_bmqtool_filelogger.h"
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bmqa_messageproperties.h>
+#include <bmqa_session.h>
+#include <bsl_string.h>
+#include <m_bmqtool_parameters.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+class Poster {
+  private:
+    bslma::Allocator* d_allocator_p;
+    // Held, not owned
+
+    Parameters* d_parameters_p;
+
+    bmqa::Session* d_session_p;
+    // A session to post messages. Held, not owned
+
+    FileLogger* d_fileLogger;
+    // Held, not owned
+
+    int d_remainingEvents;
+    int d_numMessagesPosted;
+    int d_msgUntilNextTimestamp;
+
+    bdlbb::PooledBlobBufferFactory d_bufferFactory;
+    // Buffer factory for the payload of the
+    // published message
+
+    bdlbb::PooledBlobBufferFactory d_timeBufferFactory;
+    // Small buffer factory for the first
+    // blob of the published message, to
+    // hold the timestamp information
+
+    bdlbb::Blob d_blob;
+    // Blob to post
+
+    bmqa::QueueId d_queueId;
+
+    bmqa::MessageProperties d_properties;
+
+  public:
+    Poster(bmqa::Session* session,
+           Parameters* parameters,
+           FileLogger* fileLogger,
+           const bmqa::QueueId& queueId,
+           bslma::Allocator* allocator);
+
+    bool pendingPost() const;
+    bsl::pair<size_t, size_t> postNext();
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif  // INCLUDED_M_BMQTOOL_POSTER

--- a/src/applications/bmqtool/m_bmqtool_statutil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_statutil.cpp
@@ -46,7 +46,7 @@ StatUtil::getNowAsNs(ParametersLatency::Value resolutionTimer)
 
 bsls::Types::Int64
 StatUtil::computePercentile(const bsl::vector<bsls::Types::Int64>& data,
-                            double k)
+                            double                                 k)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!data.empty());

--- a/src/applications/bmqtool/m_bmqtool_statutil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_statutil.cpp
@@ -1,0 +1,71 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// m_bmqtool_statutil.cpp                                             -*-C++-*-
+
+// BMQTOOL
+#include <m_bmqtool_parameters.h>
+#include <m_bmqtool_statutil.h>
+
+// BDE
+#include <bdlt_currenttime.h>
+#include <bsls_timeutil.h>
+#include <bsls_types.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+bsls::Types::Int64
+StatUtil::getNowAsNs(ParametersLatency::Value resolutionTimer)
+{
+    if (resolutionTimer == ParametersLatency::e_EPOCH) {
+        bsls::TimeInterval now = bdlt::CurrentTime::now();
+        return now.totalNanoseconds();  // RETURN
+    }
+    else if (resolutionTimer == ParametersLatency::e_HIRES) {
+        return bsls::TimeUtil::getTimer();  // RETURN
+    }
+    else {
+        BSLS_ASSERT_OPT(false && "Unsupported latency mode");
+    }
+
+    return 0;
+}
+
+bsls::Types::Int64
+StatUtil::computePercentile(const bsl::vector<bsls::Types::Int64>& data,
+                            double k)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!data.empty());
+
+    // Special case (useless, but just to be complete)
+    if (bsl::abs(k) < bsl::numeric_limits<double>::epsilon()) {
+        return data[0];  // RETURN
+    }
+
+    const int    index     = bsl::floor(k * data.size() / 100.0);
+    const double remainder = bsl::fmod(k * data.size(), 100.0);
+
+    if (bsl::abs(remainder) < bsl::numeric_limits<double>::epsilon()) {
+        return data[index - 1];  // RETURN
+    }
+    else {
+        return (data[index - 1] + data[index]) / 2;  // RETURN
+    }
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_statutil.h
+++ b/src/applications/bmqtool/m_bmqtool_statutil.h
@@ -51,16 +51,14 @@ const int k_STAT_DUMP_INTERVAL = 1;
 const int k_LATENCY_INTERVAL_MS = 5;
 
 struct StatUtil {
-
     /// Return the current time -in nanoseconds- using either the system time
     /// or the performance timer (depending on the value of the specified
     /// 'resolutionTimer'
     static bsls::Types::Int64
     getNowAsNs(ParametersLatency::Value resolutionTimer);
 
-    /// Compute the `k`th percentile value of the specified `data` (data must be
-    /// sorted).
-    /// Formula:
+    /// Compute the `k`th percentile value of the specified `data` (data must
+    /// be sorted). Formula:
     ///  - compute the index (k percent * data size)
     ///  - if index is not a whole number, round up to nearest whole number and
     ///    return value at that index

--- a/src/applications/bmqtool/m_bmqtool_statutil.h
+++ b/src/applications/bmqtool/m_bmqtool_statutil.h
@@ -1,0 +1,76 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// m_bmqtool_statutil.h                                               -*-C++-*-
+
+#ifndef INCLUDED_M_BMQTOOL_STATUTIL
+#define INCLUDED_M_BMQTOOL_STATUTIL
+
+//@PURPOSE: Provide utility routines as well as some constants for statics
+// calculations.
+//
+//@CLASSES:
+//  m_bmqtool::StatUtil: Statics calculation routines.
+//
+//@DESCRIPTION: 'm_bmqtool::StatUtil' provides utility routines for statistics
+// calculation.
+
+// BMQTOOL
+#include <m_bmqtool_parameters.h>
+
+// BDe
+#include <bsls_types.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+// Index of stats in the stat context
+const int k_STAT_MSG = 0;  // Message
+const int k_STAT_EVT = 1;  // Event
+const int k_STAT_LAT = 2;  // Message Latency
+
+// Dump stats every 1 second
+const int k_STAT_DUMP_INTERVAL = 1;
+
+// How often (in ms) should a message be stamped with the latency: because
+// computing the current time is expensive, we will only insert the timestamp
+// inside a sample subset of the messages (1 every 'k_LATENCY_INTERVAL_MS'
+// time), as computed by the configured frequency of message publishing.
+const int k_LATENCY_INTERVAL_MS = 5;
+
+struct StatUtil {
+
+    /// Return the current time -in nanoseconds- using either the system time
+    /// or the performance timer (depending on the value of the specified
+    /// 'resolutionTimer'
+    static bsls::Types::Int64
+    getNowAsNs(ParametersLatency::Value resolutionTimer);
+
+    /// Compute the `k`th percentile value of the specified `data` (data must be
+    /// sorted).
+    /// Formula:
+    ///  - compute the index (k percent * data size)
+    ///  - if index is not a whole number, round up to nearest whole number and
+    ///    return value at that index
+    ///  - if index it not a whole number, compute the average of the data at
+    ///    index and index + 1
+    static bsls::Types::Int64
+    computePercentile(const bsl::vector<bsls::Types::Int64>& data, double k);
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif  // INCLUDED_M_BMQTOOL_STATUTIL

--- a/src/applications/bmqtool/package/bmqtool.mem
+++ b/src/applications/bmqtool/package/bmqtool.mem
@@ -5,3 +5,4 @@ m_bmqtool_interactive
 m_bmqtool_storageinspector
 m_bmqtool_messages
 m_bmqtool_parameters
+m_bmqtool_poster

--- a/src/applications/bmqtool/package/bmqtool.mem
+++ b/src/applications/bmqtool/package/bmqtool.mem
@@ -6,3 +6,4 @@ m_bmqtool_storageinspector
 m_bmqtool_messages
 m_bmqtool_parameters
 m_bmqtool_poster
+m_bmqtool_statutil


### PR DESCRIPTION
Adding `batch-post` CLI command to initiate posting series of messages. The posting code was taken from `Application` class and put into a separate class `PostingContext`. This class is now used in both interactive and automatic modes.