### PR TITLE
Admin interface stops responding if purge invalid appid

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -41,7 +41,9 @@
 
 // BDE
 #include <bdlb_print.h>
+#include <bdlb_scopeexit.h>
 #include <bdlb_stringrefutil.h>
+#include <bdlf_bind.h>
 #include <bdlf_memfn.h>
 #include <bdlma_localsequentialallocator.h>
 #include <bdls_filesystemutil.h>
@@ -82,6 +84,14 @@ class AppIdMatcher {
         return d_expectedAppId == appIdKeyPair.first;
     }
 };
+
+/// Post on the optionally specified `semaphore`.
+void optionalSemaphorePost(bslmt::Semaphore* semaphore)
+{
+    if (semaphore) {
+        semaphore->post();
+    }
+}
 
 }  // close unnamed namespace
 
@@ -3579,6 +3589,10 @@ void StorageUtil::purgeQueueDispatched(
     BSLS_ASSERT_SAFE(fileStore->config().partitionId() ==
                      storage->partitionId());
 
+    // RAII to ensure we will post on the semaphore no matter how we return
+    bdlb::ScopeExitAny semaphorePost(
+        bdlf::BindUtil::bind(&optionalSemaphorePost, purgeFinishedSemaphore));
+
     if (!fileStore->primaryNode()) {
         mwcu::MemOutStream errorMsg;
         errorMsg << "Not purging queue '" << storage->queueUri() << "' "
@@ -3648,10 +3662,6 @@ void StorageUtil::purgeQueueDispatched(
     queueDetails.appKey()            = appKeyStr.str();
     queueDetails.numMessagesPurged() = numMsgs;
     queueDetails.numBytesPurged()    = numBytes;
-
-    if (purgeFinishedSemaphore) {
-        purgeFinishedSemaphore->post();
-    }
 }
 
 int StorageUtil::processCommand(mqbcmd::StorageResult*     result,


### PR DESCRIPTION
**Describe your changes**
Currently, if try to purge invalid appid, admin interface stops responding and broker cannot be stopped unless sending `SIGKILL`.
The reason is that corresponding semaphore is not posted (same for unset store primary node, purging on non-primary node and `#QUEUE_PURGE_FAILURE`):
https://github.com/bloomberg/blazingmq/blob/397bdc895f52a8725fb4f6aaf9c9ce263d3e605e/src/groups/mqb/mqbc/mqbc_storageutil.cpp#L3619 

Proposed solution is to use `ScopeExitAny` to ensure semaphore is posted on corresponding method exit. 

**Testing performed**
Did manual testing (covered invalid appid and non-primary purging):
```sh
22APR2024_18:43:07.516 (6202060800) INFO bmqbrkr.m.cpp:329 Command 'CMD DOMAINS DOMAIN bmq.test.persistent.fanout QUEUE hello PURGE foo1' processed successfully in 1.07 ms:
Purged 0 message(s) for a total of 0  B from 1 queue(s):
    NumBytes     NumMsgs      AppKey             AppId  QueueName
Errors encountered:
Specified appId 'foo1' not found in the storage of queue 'bmq://bmq.test.persistent.fanout/hello'.
```
```sh
22APR2024_18:38:51.820 (6130692096) INFO bmqbrkr.m.cpp:329 Command 'CMD DOMAINS DOMAIN bmq.test.persistent.fanout QUEUE hello PURGE foo' processed successfully in 2.17 ms:
Purged 0 message(s) for a total of 0  B from 1 queue(s):
    NumBytes     NumMsgs      AppKey             AppId  QueueName
Errors encountered:
Not purging queue 'bmq://bmq.test.persistent.fanout/hello'  with primary node: [lusus, 4][reason: queue is NOT local]
```
