### PR TITLE
Remove unused and incompatible C++11 thread header

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -55,7 +55,6 @@
 #include <bdlf_placeholder.h>
 #include <bdlt_timeunitratio.h>
 #include <bsl_numeric.h>
-#include <bsl_thread.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>


### PR DESCRIPTION
This is a C++11 and up header which we don't allow, and was caught by our internal CI checks. Fortunately it doesn't appear to be getting used, so we're just removing it.
