### PR TITLE
Fix: set correct partitionId on storage summary

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7213,6 +7213,10 @@ void FileStore::getStorages(StorageList*          storages,
 
 void FileStore::loadSummary(mqbcmd::FileStore* fileStore) const
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(fileStore);
+
+    fileStore->partitionId() = d_config.partitionId();
     if (!isOpen()) {
         fileStore->state() = mqbcmd::FileStoreState::CLOSED;
         return;  // RETURN
@@ -7223,8 +7227,7 @@ void FileStore::loadSummary(mqbcmd::FileStore* fileStore) const
         return;  // RETURN
     }
 
-    fileStore->partitionId() = d_config.partitionId();
-    fileStore->state()       = mqbcmd::FileStoreState::OPEN;
+    fileStore->state() = mqbcmd::FileStoreState::OPEN;
     FileStorePrintUtil::loadSummary(&fileStore->summary(),
                                     d_primaryNode_p,
                                     d_primaryLeaseId,


### PR DESCRIPTION
**Problem**: when storage is not open, we print default `partitionId [0]`

```
   Storage Summary:
    ----------------
        Storage location: ........................


    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.
    PartitionId [0]: NOT OPEN.RECOVERY
```

Note that `FileStore` is always constructed with valid existing config object, even if this `FileStore` is not opened yet: https://github.com/bloomberg/blazingmq/blob/26937669e16bd8819657ae6bf9cfd2598e02fd03/src/groups/mqb/mqbs/mqbs_filestore.cpp#L5108