### PR TITLE
Remove horizontal rules from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ This repository contains BlazingMQ message broker, BlazingMQ C++ client library
 and a BlazingMQ command line tool, while BlazingMQ Java client library can be
 found in [this](https://github.com/bloomberg/blazingmq-sdk-java) repository.
 
----
 
 ## Menu
 
@@ -61,14 +60,12 @@ found in [this](https://github.com/bloomberg/blazingmq-sdk-java) repository.
 - [Code of Conduct](#code-of-conduct)
 - [Security Vulnerability Reporting](#security-vulnerability-reporting)
 
----
 
 ## Documentation
 
 Comprehensive documentation about BlazingMQ can be found
 [here](https://bloomberg.github.io/blazingmq).
 
----
 
 ## Quick Start
 
@@ -81,7 +78,6 @@ In the
 article, readers can learn about some intermediate and advanced features of
 BlazingMQ and see them in action.
 
----
 
 ## Building
 
@@ -111,7 +107,6 @@ cmake --build cmake.bld
 
 For a list of presets, please look at the `*-vcpkg` configurations in [`CMakePresets.json`](./CMakePresets.json).
 
----
 
 ## Installation
 
@@ -119,7 +114,6 @@ For a list of presets, please look at the `*-vcpkg` configurations in [`CMakePre
 article describes the steps for installing a BlazingMQ cluster in a set of Docker
 containers, along with a recommended set of configurations.
 
----
 
 ## Contributions
 
@@ -133,13 +127,11 @@ Before sending a [Pull Request](../../pulls), please make sure you have read
 our [Contribution
 Guidelines](https://github.com/bloomberg/.github/blob/main/CONTRIBUTING.md).
 
----
 
 ## License
 
 BlazingMQ is Apache 2.0 licensed, as found in the [LICENSE](LICENSE) file.
 
----
 
 ## Code of Conduct
 
@@ -148,7 +140,6 @@ Conduct](https://github.com/bloomberg/.github/blob/main/CODE_OF_CONDUCT.md).
 If you have any concerns about the Code, or behavior which you have experienced
 in the project, please contact us at opensource@bloomberg.net.
 
----
 
 ## Security Vulnerability Reporting
 
@@ -159,5 +150,3 @@ the suspected issue and any methods you've found to reproduce it.
 Please do NOT open an issue in the GitHub repository, as we'd prefer to keep
 vulnerability reports private until we've had an opportunity to review and
 address them.
-
----


### PR DESCRIPTION
This cleans up the formatting of the headers in the README. For some reason, we had a whole bunch of horizontal rules which clutter up the sections.