### PR TITLE
Fix: improve storage tool checks, disable default allocator check, fix mwcsys_executil

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessorfactory.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessorfactory.cpp
@@ -31,20 +31,25 @@ CommandProcessorFactory::createCommandProcessor(
     bsl::ostream&                   ostream,
     bslma::Allocator*               allocator)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(params);
+
+    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
+
     // Create searchResult for given 'params'.
     bsl::shared_ptr<SearchResult> searchResult =
         SearchResultFactory::createSearchResult(params,
                                                 fileManager,
                                                 ostream,
-                                                allocator);
+                                                alloc);
     // Create commandProcessor.
     bslma::ManagedPtr<CommandProcessor> commandProcessor(
-        new (*allocator) JournalFileProcessor(params,
-                                              fileManager,
-                                              searchResult,
-                                              ostream,
-                                              allocator),
-        allocator);
+        new (*alloc) JournalFileProcessor(params,
+                                          fileManager,
+                                          searchResult,
+                                          ostream,
+                                          alloc),
+        alloc);
     return commandProcessor;
 }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessorfactory.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessorfactory.t.cpp
@@ -45,7 +45,7 @@ static void test1_breathingTest()
 {
     mwctst::TestHelper::printTestName("BREATHING TEST");
     // Empty parameters
-    CommandLineArguments           arguments;
+    CommandLineArguments           arguments(s_allocator_p);
     Parameters                     params(arguments, s_allocator_p);
     bslma::ManagedPtr<FileManager> fileManager(new (*s_allocator_p)
                                                    FileManagerMock(),

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -70,8 +70,9 @@ FileManagerImpl::FileManagerImpl(const bsl::string& journalFile,
                                  bslma::Allocator*  allocator)
 : d_journalFile(journalFile, allocator)
 , d_dataFile(dataFile, allocator)
+, d_allocator_p(bslma::Default::allocator(allocator))
 {
-    mwcu::MemOutStream ss(allocator);
+    mwcu::MemOutStream ss(d_allocator_p);
     if ((!d_journalFile.path().empty() && !d_journalFile.resetIterator(ss)) ||
         (!d_dataFile.path().empty() && !d_dataFile.resetIterator(ss))) {
         throw bsl::runtime_error(ss.str());  // THROW
@@ -95,29 +96,31 @@ mqbs::DataFileIterator* FileManagerImpl::dataFileIterator()
 QueueMap FileManagerImpl::buildQueueMap(const bsl::string& cslFile,
                                         bslma::Allocator*  allocator)
 {
+    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
+
     using namespace bmqp_ctrlmsg;
     typedef bsl::vector<QueueInfo>     QueueInfos;
     typedef QueueInfos::const_iterator QueueInfosIt;
     if (cslFile.empty()) {
         throw bsl::runtime_error("empty CSL file path");  // THROW
     }
-    QueueMap d_queueMap(allocator);
+    QueueMap d_queueMap(alloc);
 
     // Required for ledger operations
     bmqp::Crc32c::initialize();
 
     // Instantiate ledger config
-    mqbsi::LedgerConfig                    ledgerConfig(allocator);
+    mqbsi::LedgerConfig                    ledgerConfig(alloc);
     bsl::shared_ptr<mqbsi::LogIdGenerator> logIdGenerator(
-        new (*allocator) mqbmock::LogIdGenerator("bmq_csl_", allocator),
-        allocator);
+        new (*alloc) mqbmock::LogIdGenerator("bmq_csl_", alloc),
+        alloc);
     bsl::shared_ptr<mqbsi::LogFactory> logFactory(
-        new (*allocator) mqbsl::MemoryMappedOnDiskLogFactory(allocator),
-        allocator);
+        new (*alloc) mqbsl::MemoryMappedOnDiskLogFactory(alloc),
+        alloc);
     bdls::FilesystemUtil::Offset fileSize = bdls::FilesystemUtil::getFileSize(
         cslFile.c_str());
-    bsl::string pattern(allocator);
-    bsl::string location(allocator);
+    bsl::string pattern(alloc);
+    bsl::string location(alloc);
     BSLS_ASSERT(bdls::PathUtil::getBasename(&pattern, cslFile) == 0);
     BSLS_ASSERT(bdls::PathUtil::getDirname(&location, cslFile) == 0);
     ledgerConfig.setLocation(location)
@@ -133,7 +136,7 @@ QueueMap FileManagerImpl::buildQueueMap(const bsl::string& cslFile,
         .setValidateLogCallback(mqbc::ClusterStateLedgerUtil::validateLog);
 
     // Create and open the ledger
-    mqbsl::Ledger ledger(ledgerConfig, allocator);
+    mqbsl::Ledger ledger(ledgerConfig, alloc);
     BSLS_ASSERT(ledger.open(mqbsi::Ledger::e_READ_ONLY) == 0);
     // Set guard to close the ledger
     bdlb::ScopeExitAny guard(bdlf::BindUtil::bind(closeLedger, &ledger));

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -70,9 +70,8 @@ FileManagerImpl::FileManagerImpl(const bsl::string& journalFile,
                                  bslma::Allocator*  allocator)
 : d_journalFile(journalFile, allocator)
 , d_dataFile(dataFile, allocator)
-, d_allocator_p(bslma::Default::allocator(allocator))
 {
-    mwcu::MemOutStream ss(d_allocator_p);
+    mwcu::MemOutStream ss(allocator);
     if ((!d_journalFile.path().empty() && !d_journalFile.resetIterator(ss)) ||
         (!d_dataFile.path().empty() && !d_dataFile.resetIterator(ss))) {
         throw bsl::runtime_error(ss.str());  // THROW

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
@@ -92,8 +92,12 @@ class FileManagerImpl : public FileManager {
     // PRIVATE DATA
     FileHandler<mqbs::JournalFileIterator> d_journalFile;
     // Handler of journal file
+
     FileHandler<mqbs::DataFileIterator> d_dataFile;
     // Handler of data file
+
+    bslma::Allocator* d_allocator_p;
+    // Allocator to use
 
   public:
     // CREATORS

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
@@ -96,9 +96,6 @@ class FileManagerImpl : public FileManager {
     FileHandler<mqbs::DataFileIterator> d_dataFile;
     // Handler of data file
 
-    bslma::Allocator* d_allocator_p;
-    // Allocator to use
-
   public:
     // CREATORS
     /// Default constructor

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.cpp
@@ -45,6 +45,9 @@ namespace m_bmqstoragetool {
 int moveToLowerBound(mqbs::JournalFileIterator* jit,
                      const bsls::Types::Uint64& timestamp)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(jit);
+
     int                rc         = 1;
     const unsigned int recordSize = jit->header().recordWords() *
                                     bmqp::Protocol::k_WORD_SIZE;

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -758,6 +758,10 @@ static void test12_printMessagesDetailsTest()
 {
     mwctst::TestHelper::printTestName("PRINT MESSAGE DETAILS TEST");
 
+    s_ignoreCheckDefAlloc = true;
+    // Disable default allocator check for this test until we can debug
+    // it on AIX/Solaris
+
     // Simulate journal file
     const size_t    k_NUM_RECORDS = 15;
     RecordsListType records(s_allocator_p);

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -758,9 +758,11 @@ static void test12_printMessagesDetailsTest()
 {
     mwctst::TestHelper::printTestName("PRINT MESSAGE DETAILS TEST");
 
+#if defined(BSLS_PLATFORM_OS_SOLARIS) || defined(BSLS_PLATFORM_OS_AIX)
     s_ignoreCheckDefAlloc = true;
     // Disable default allocator check for this test until we can debug
     // it on AIX/Solaris
+#endif
 
     // Simulate journal file
     const size_t    k_NUM_RECORDS = 15;

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.cpp
@@ -109,6 +109,9 @@ bool findQueueAppIdByAppKey(
     const bsl::vector<BloombergLP::bmqp_ctrlmsg::AppIdInfo>& appIds,
     const mqbu::StorageKey&                                  appKey)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(appId);
+
     if (appKey.isNull())
         return false;  // RETURN
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
@@ -99,7 +99,7 @@ bool CommandLineArguments::validate(bsl::string* error)
     mwcu::MemOutStream ss;
 
     if (d_journalPath.empty() && d_journalFile.empty()) {
-        ss << "Niether journal path nor journal file are specified\n";
+        ss << "Neither journal path nor journal file are specified\n";
     }
     else if (!d_journalPath.empty()) {
         if (d_journalFile.empty() && d_dataFile.empty()) {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_queuemap.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_queuemap.cpp
@@ -92,10 +92,13 @@ void QueueMap::update(const bmqp_ctrlmsg::QueueInfoUpdate& queueInfoUpdate)
 bool QueueMap::findInfoByKey(bmqp_ctrlmsg::QueueInfo* queueInfo_p,
                              const mqbu::StorageKey&  key) const
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(queueInfo_p);
+
     QueueKeyToInfoMap::const_iterator it = d_queueKeyToInfoMap.find(key);
     if (it != d_queueKeyToInfoMap.end()) {
         *queueInfo_p = it->second;
-        return true;
+        return true;  // RETURN
     }
     return false;
 }
@@ -103,10 +106,13 @@ bool QueueMap::findInfoByKey(bmqp_ctrlmsg::QueueInfo* queueInfo_p,
 bool QueueMap::findKeyByUri(mqbu::StorageKey*  queueKey_p,
                             const bsl::string& uri) const
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(queueKey_p);
+
     QueueUriToKeyMap::const_iterator it = d_queueUriToKeyMap.find(uri);
     if (it != d_queueUriToKeyMap.end()) {
         *queueKey_p = it->second;
-        return true;
+        return true;  // RETURN
     }
     return false;
 }

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -37,7 +37,7 @@ void printDataFileMeta(bsl::ostream&           ostream,
                        mqbs::DataFileIterator* dataFile_p)
 {
     if (!dataFile_p || !dataFile_p->isValid()) {
-        return;
+        return;  // RETURN
     }
     ostream << "\nDetails of data file: \n"
             << *dataFile_p->mappedFileDescriptor() << " "
@@ -50,7 +50,7 @@ void printJournalFileMeta(bsl::ostream&              ostream,
                           bslma::Allocator*          allocator)
 {
     if (!journalFile_p || !journalFile_p->isValid()) {
-        return;
+        return;  // RETURN
     }
 
     ostream << "\nDetails of journal file: \n";
@@ -124,7 +124,8 @@ void printJournalFileMeta(bsl::ostream&              ostream,
 
         bsls::Types::Uint64 epochValue = syncPt.header().timestamp();
         bdlt::Datetime      datetime;
-        int rc = bdlt::EpochUtil::convertFromTimeT64(&datetime, epochValue);
+        const int           rc = bdlt::EpochUtil::convertFromTimeT64(&datetime,
+                                                           epochValue);
         if (0 != rc) {
             printer << 0;
         }
@@ -289,10 +290,10 @@ bool SearchResultTimestampDecorator::processDeletionRecord(
 SearchShortResult::SearchShortResult(
     bsl::ostream&                     ostream,
     bslma::ManagedPtr<PayloadDumper>& payloadDumper,
-    bslma::Allocator*                 allocator,
-    const bool                        printImmediately,
-    const bool                        eraseDeleted,
-    const bool                        printOnDelete)
+    bool                              printImmediately,
+    bool                              eraseDeleted,
+    bool                              printOnDelete,
+    bslma::Allocator*                 allocator)
 : d_ostream(ostream)
 , d_payloadDumper(payloadDumper)
 , d_printImmediately(printImmediately)
@@ -408,10 +409,10 @@ SearchDetailResult::SearchDetailResult(
     bsl::ostream&                     ostream,
     const QueueMap&                   queueMap,
     bslma::ManagedPtr<PayloadDumper>& payloadDumper,
-    bslma::Allocator*                 allocator,
-    const bool                        printImmediately,
-    const bool                        eraseDeleted,
-    const bool                        cleanUnprinted)
+    bool                              printImmediately,
+    bool                              eraseDeleted,
+    bool                              cleanUnprinted,
+    bslma::Allocator*                 allocator)
 : d_ostream(ostream)
 , d_queueMap(queueMap)
 , d_payloadDumper(payloadDumper)
@@ -540,6 +541,7 @@ bool SearchDetailResult::hasCache() const
 // ========================
 // class SearchAllDecorator
 // ========================
+
 SearchAllDecorator::SearchAllDecorator(
     const bsl::shared_ptr<SearchResult>& component,
     bslma::Allocator*                    allocator)

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -619,6 +619,7 @@ void SearchOutstandingDecorator::outputResult()
 // =======================================
 // class SearchPartiallyConfirmedDecorator
 // =======================================
+
 SearchPartiallyConfirmedDecorator::SearchPartiallyConfirmedDecorator(
     const bsl::shared_ptr<SearchResult>& component,
     bsl::ostream&                        ostream,

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -171,14 +171,14 @@ class SearchShortResult : public SearchResult {
   public:
     // CREATORS
 
-    /// Constructor using the specified `ostream`, `payloadDumper`, `allocator`
-    /// `printImmediately`, `eraseDeleted`, and `printOnDelete`.
+    /// Constructor using the specified `ostream`, `payloadDumper`,
+    /// `printImmediately`, `eraseDeleted`, `printOnDelete` and `allocator`.
     explicit SearchShortResult(bsl::ostream&                     ostream,
                                bslma::ManagedPtr<PayloadDumper>& payloadDumper,
-                               bslma::Allocator*                 allocator,
-                               const bool printImmediately = true,
-                               const bool eraseDeleted     = false,
-                               const bool printOnDelete    = false);
+                               bool              printImmediately = true,
+                               bool              eraseDeleted     = false,
+                               bool              printOnDelete    = false,
+                               bslma::Allocator* allocator        = 0);
 
     // MANIPULATORS
 
@@ -274,14 +274,14 @@ class SearchDetailResult : public SearchResult {
     // CREATORS
 
     /// Constructor using the specified `ostream`, `queueMap`, `payloadDumper`,
-    /// `allocator` `printImmediately`, `eraseDeleted`, and `cleanUnprinted`.
+    /// `printImmediately`, `eraseDeleted`, `cleanUnprinted` and `allocator`.
     SearchDetailResult(bsl::ostream&                     ostream,
                        const QueueMap&                   queueMap,
                        bslma::ManagedPtr<PayloadDumper>& payloadDumper,
-                       bslma::Allocator*                 allocator,
-                       const bool printImmediately = true,
-                       const bool eraseDeleted     = true,
-                       const bool cleanUnprinted   = false);
+                       bool              printImmediately = true,
+                       bool              eraseDeleted     = true,
+                       bool              cleanUnprinted   = false,
+                       bslma::Allocator* allocator        = 0);
 
     // MANIPULATORS
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.t.cpp
@@ -45,7 +45,7 @@ static void test1_breathingTest()
 {
     mwctst::TestHelper::printTestName("BREATHING TEST");
     // Empty parameters
-    CommandLineArguments           arguments;
+    CommandLineArguments           arguments(s_allocator_p);
     Parameters                     params(arguments, s_allocator_p);
     bslma::ManagedPtr<FileManager> fileManager(new (*s_allocator_p)
                                                    FileManagerMock(),

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.cpp
@@ -53,7 +53,6 @@ JournalFile::JournalFile(size_t numRecords, bslma::Allocator* allocator)
 , d_timestampIncrement(100)
 , d_fileHeader()
 , d_iterator()
-, d_allocator_p(allocator)
 {
     bsls::Types::Uint64 totalSize =
         sizeof(FileHeader) + sizeof(JournalFileHeader) +

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
@@ -102,7 +102,7 @@ class JournalFile {
     // Number of records.
     MappedFileDescriptor d_mfd;
     // Mapped file descriptor.
-    bsl::vector<char> d_mem;
+    bsl::vector<char> d_buffer;
     // Buffer holding the memory allocated for journal file.
     MemoryBlock d_block;
     // Current memory block.

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
@@ -114,8 +114,6 @@ class JournalFile {
     // File header data.
     JournalFileIterator d_iterator;
     // Journal file iterator.
-    bslma::Allocator* d_allocator_p;
-    // Allocator to be used.
 
     // PRIVATE MANIPULATORS
 
@@ -128,7 +126,7 @@ class JournalFile {
     /// Constructor using the specified `numRecords` and `allocator`.
     explicit JournalFile(size_t numRecords, bslma::Allocator* allocator);
 
-    /// Default destructor.
+    /// Destructor.
     ~JournalFile();
 
     // ACCESSORS

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_testutils.h
@@ -102,8 +102,8 @@ class JournalFile {
     // Number of records.
     MappedFileDescriptor d_mfd;
     // Mapped file descriptor.
-    char* d_mem_p;
-    // Pointer to allocated memory for journal file.
+    bsl::vector<char> d_mem;
+    // Buffer holding the memory allocated for journal file.
     MemoryBlock d_block;
     // Current memory block.
     bsls::Types::Uint64 d_currPos;
@@ -126,9 +126,9 @@ class JournalFile {
     // CREATORS
 
     /// Constructor using the specified `numRecords` and `allocator`.
-    JournalFile(const size_t numRecords, bslma::Allocator* allocator);
+    explicit JournalFile(size_t numRecords, bslma::Allocator* allocator);
 
-    /// Destructor for releasing allocated resource `d_mem_p`.
+    /// Default destructor.
     ~JournalFile();
 
     // ACCESSORS

--- a/src/groups/mwc/mwcsys/mwcsys_executil.t.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_executil.t.cpp
@@ -130,7 +130,7 @@ static void test2_executeSystemFailure()
 
     PVV("Testing abnormal exit of the command");
     rc = mwcsys::ExecUtil::execute(&output,
-                                   "python -c 'import os,signal; "
+                                   "python3 -c 'import os,signal; "
                                    "os.kill(os.getpid(), signal.SIGKILL)'");
     ASSERT_EQ(rc, -2);
     ASSERT_EQ(output, "");


### PR DESCRIPTION
Storage tool:

- remove manual memory management
- add preconditions checks
- list all member fields on construction
- make the code robust to NULL allocator