### PR TITLE
Fix: improve logging on cluster create attempt, cleanup

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -274,6 +274,7 @@ static int getConfig(bsl::ostream&      errorDescription,
                          << "[file: " << configFilename << "]";
         return rc_GENERATION_FAILED;  // RETURN
     }
+    configStream.close();
 
     // ----------------------------------
     // 2. JSON parse the config to object

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -1289,8 +1289,8 @@ void ClientSession::openQueueCb(
         response.choice().makeStatus(status);
 
         BALL_LOG_WARN << "#CLIENT_OPENQUEUE_FAILURE " << description()
-                      << ": Error while opening queue: [reason: '" << status
-                      << "', request: " << handleParamsCtrlMsg << "]";
+                      << ": Error while opening queue: [reason: " << status
+                      << ", request: " << handleParamsCtrlMsg << "]";
     }
     else {
         bmqp_ctrlmsg::OpenQueueResponse& res =

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -108,9 +108,7 @@ void Cluster::startDispatched(bsl::ostream* errorDescription, int* rc)
         rc_SUCCESS             = 0,
         rc_STATE_MGR_FAILURE   = -1,
         rc_MISC_FAILURE        = -2,
-        rc_STORAGE_MGR_FAILURE = -3,
-        rc_QUEUE_HELPER        = -4,
-        rc_STATE_MONITOR       = -5
+        rc_STORAGE_MGR_FAILURE = -3
     };
 
     *rc = d_clusterOrchestrator.start(*errorDescription);
@@ -207,13 +205,7 @@ void Cluster::startDispatched(bsl::ostream* errorDescription, int* rc)
         return;  // RETURN
     }
 
-    *rc = d_clusterOrchestrator.queueHelper().initialize(*errorDescription);
-    if (*rc != 0) {
-        d_storageManager_mp->stop();
-        d_clusterOrchestrator.stop();
-        *rc = *rc * 10 + rc_QUEUE_HELPER;
-        return;  // RETURN
-    }
+    d_clusterOrchestrator.queueHelper().initialize();
 
     d_clusterOrchestrator.setStorageManager(d_storageManager_mp.get());
     d_clusterOrchestrator.queueHelper().setStorageManager(
@@ -249,14 +241,7 @@ void Cluster::startDispatched(bsl::ostream* errorDescription, int* rc)
     // Ready to read.
     netCluster->enableRead();
 
-    *rc = d_clusterMonitor.start(*errorDescription);
-    if (*rc != 0) {
-        d_clusterOrchestrator.queueHelper().teardown();
-        d_storageManager_mp->stop();
-        d_clusterOrchestrator.stop();
-        *rc = *rc * 10 + rc_STATE_MONITOR;
-        return;  // RETURN
-    }
+    d_clusterMonitor.start();
     d_clusterMonitor.registerObserver(this);
 
     // Start a recurring clock for summary print

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -198,6 +198,8 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
 
         if (proxyDefinitionIter ==
             d_clustersDefinition.proxyClusters().end()) {
+            errorDescription << "Fetch proxy definition failed for cluster: '"
+                             << name << "'";
             return rc_FETCH_DEFINITION_FAILED;  // RETURN
         }
 
@@ -257,6 +259,10 @@ int ClusterCatalog::startCluster(bsl::ostream&  errorDescription,
     // contention on the IO (which potentially could lead to negotiation time
     // out), we don't want (and don't have) to start the Cluster under the
     // mutex locked.
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(cluster);
+
     int rc = cluster->start(errorDescription);
 
     if (rc != 0) {
@@ -419,6 +425,7 @@ int ClusterCatalog::loadBrokerClusterConfig(bsl::ostream& errorDescription)
         return rc_CONFIG_READ_ERROR * 10 +
                rc_BROKER_CLUSTER_CONFIG_LOADFAILURE;  // RETURN
     }
+    configStream.close();
 
     // 2. Decode the JSON stream
     baljsn::Decoder            decoder;
@@ -605,6 +612,9 @@ ClusterCatalog::getCluster(bsl::shared_ptr<mqbi::Cluster>* out,
     // NOTE: The 'out' should maybe be returned as a shared_ptr with a custom
     //       deleter, so that the cluster can be destroyed once no longer used
     //       (with eventually a small TTL).
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(out);
 
     bmqp_ctrlmsg::Status status;
     status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -111,7 +111,7 @@ void ClusterProxy::generateNack(bmqt::AckResult::Enum               status,
                        << putHeader.messageGUID() << "], rc: " << rc << ".";);
 }
 
-void ClusterProxy::startDispatched(bsl::ostream* errorDescription, int* rc)
+void ClusterProxy::startDispatched()
 {
     // executed by the *DISPATCHER* thread
 
@@ -120,22 +120,15 @@ void ClusterProxy::startDispatched(bsl::ostream* errorDescription, int* rc)
     BSLS_ASSERT_SAFE(!d_isStarted &&
                      "start() can only be called once on this object");
 
-    enum { rc_SUCCESS = 0, rc_ACTIVE_NODE_MANAGER = -1, rc_QUEUE_HELPER = -2 };
-
-    *rc = d_queueHelper.initialize(*errorDescription);
-    if (*rc != 0) {
-        *rc = (*rc * 10) + rc_QUEUE_HELPER;
-        return;  // RETURN
-    }
+    d_queueHelper.initialize();
 
     d_clusterData.membership().netCluster()->registerObserver(this);
 
     // Start the monitor
-    d_clusterMonitor.start(*errorDescription);
+    d_clusterMonitor.start();
     d_clusterMonitor.registerObserver(this);
 
     d_isStarted = true;
-    *rc         = rc_SUCCESS;
 
     // Because the 'cluster' was already created, it may already had some
     // sessions up before we registered ourself as observer.  So scan all nodes
@@ -1103,17 +1096,14 @@ ClusterProxy::~ClusterProxy()
 
 // MANIPULATORS
 //   (virtual: mqbi::Cluster)
-int ClusterProxy::start(bsl::ostream& errorDescription)
+int ClusterProxy::start(BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
 {
-    int rc;
     dispatcher()->execute(bdlf::BindUtil::bind(&ClusterProxy::startDispatched,
-                                               this,
-                                               &errorDescription,
-                                               &rc),
+                                               this),
                           this);
     dispatcher()->synchronize(this);
 
-    return rc;
+    return 0;
 }
 
 void ClusterProxy::initiateShutdown(const VoidFunctor& callback)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -258,10 +258,8 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
   private:
     // PRIVATE MANIPULATORS
 
-    /// Start the `Cluster` and populate the specified `rc` with the result
-    /// of the operation, 0 on success and non-zero otherwise populating the
-    /// specified `errorDescription` with the reason of the error.
-    void startDispatched(bsl::ostream* errorDescription, int* rc);
+    /// Start the `Cluster`.
+    void startDispatched();
 
     /// Initiate the shutdown of the cluster.  The specified `callback` will
     /// be called when the shutdown is completed.  This routine is invoked

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -4514,8 +4514,7 @@ ClusterQueueHelper::~ClusterQueueHelper()
     // NOTHING: Interface
 }
 
-int ClusterQueueHelper::initialize(
-    BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
+void ClusterQueueHelper::initialize()
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -4526,8 +4525,6 @@ int ClusterQueueHelper::initialize(
     d_clusterData_p->membership().registerObserver(this);
     d_clusterData_p->electorInfo().registerObserver(this);
     d_clusterState_p->registerObserver(this);
-
-    return 0;
 }
 
 void ClusterQueueHelper::teardown()
@@ -4537,6 +4534,7 @@ void ClusterQueueHelper::teardown()
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
     d_clusterState_p->unregisterObserver(this);
     d_clusterData_p->electorInfo().unregisterObserver(this);
     d_clusterData_p->membership().unregisterObserver(this);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -1016,10 +1016,8 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
 
     // MANIPULATORS
 
-    /// Initialize this object and return 0 on success or a non-zero value
-    /// otherwise, populating the specified `errorDescription` with a
-    /// description of the error.
-    int initialize(bsl::ostream& errorDescription);
+    /// Initialize this object.
+    void initialize();
 
     /// Paired operation of the `initialize()`, undo any action that was
     /// performed during `initialize` and restore that object to a default

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.cpp
@@ -450,8 +450,7 @@ ClusterStateMonitor::~ClusterStateMonitor()
     stop();
 }
 
-int ClusterStateMonitor::start(
-    BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
+void ClusterStateMonitor::start()
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!d_isStarted && "Already started");
@@ -509,8 +508,6 @@ int ClusterStateMonitor::start(
 
     // Cluster is in an un-healthy state (default value of d_isHealthy)
     d_clusterData_p->stats().setHealthStatus(d_isHealthy);
-
-    return 0;
 }
 
 void ClusterStateMonitor::registerObserver(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.h
@@ -279,7 +279,7 @@ class ClusterStateMonitor {
     // MANIPULATORS
 
     /// Start the monitor.
-    int start(bsl::ostream& errorDescription);
+    void start();
 
     /// Register the specified `observer` to be notified of threshold state
     /// notifications.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
@@ -295,7 +295,7 @@ static void test1_breathingTest()
     mwcu::MemOutStream dummy;
 
     helper.d_cluster_mp->start(dummy);
-    monitor.start(dummy);
+    monitor.start();
 
     // False by default
     ASSERT_EQ(monitor.isHealthy(), false);
@@ -361,7 +361,7 @@ static void test2_checkAlarmsWithResetTest()
     mwcu::MemOutStream dummy;
 
     helper.d_cluster_mp->start(dummy);
-    monitor.start(dummy);
+    monitor.start();
 
     // False by default
     ASSERT_EQ(monitor.isHealthy(), false);
@@ -589,7 +589,7 @@ static void test3_alwaysInvalidStateTest()
     ASSERT_EQ(monitor.isHealthy(), false);
 
     helper.d_cluster_mp->start(dummy);
-    monitor.start(dummy);
+    monitor.start();
 
     // T: 30
     // - 1 leader passive notification

--- a/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
@@ -113,8 +113,8 @@ void QueueSessionManager::onDomainQualifiedCb(
         // Failed to qualify domain..
         BALL_LOG_WARN << "#CLIENT_OPENQUEUE_FAILURE "
                       << d_dispatcherClient_p->description()
-                      << ": Error while qualifying domain: " << status
-                      << ", request: " << request;
+                      << ": Error while qualifying domain: [reason: " << status
+                      << ", request: " << request << "]";
 
         // Send an error from the client dispatcher thread
         dispatchErrorCallback(errorCallback,
@@ -195,7 +195,8 @@ void QueueSessionManager::onDomainOpenCb(
         // Failed to open domain
         BALL_LOG_WARN << "#CLIENT_OPENQUEUE_FAILURE "
                       << d_dispatcherClient_p->description()
-                      << ": Error while opening domain: " << status;
+                      << ": Error while opening domain: [reason: " << status
+                      << ", request: " << request << "]";
 
         // Send an error from the client dispatcher thread.
         dispatchErrorCallback(errorCallback,

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -488,6 +488,9 @@ int TransportManager::createCluster(
     ConnectionMode                          connectionMode,
     bslma::ManagedPtr<void>*                userData)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(out);
+
     enum RcEnum {
         // Value for the various RC error categories
         rc_SUCCESS           = 0,


### PR DESCRIPTION
Following the internal ticket 175315279
Changes:
- Improve logging when no cluster found in the cluster catalog
- More precondition checks
- Remove `int` return code and `bsl::ostream &errorDescription` argument from `ClusterQueueHelper::initialize`, `ClusterStateMonitor::start` and `ClusterProxy::startDispatched` since these methods are trivial and in fact cannot return non-zero error code
- Early close `ifstream`s when we already read everything