### PR TITLE
Improve clarity in error message

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_queue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.cpp
@@ -342,8 +342,9 @@ Queue::Queue(bslma::Allocator* allocator)
 void Queue::registerStatContext(mwcst::StatContext* parentStatContext)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_uri.isValid() &&
-                     "Can not call registerStatContext on an empty queue");
+    BSLS_ASSERT_SAFE(
+        d_uri.isValid() &&
+        "Cannot call registerStatContext on an invalid queue URI");
     // This method should only be called on a valid queue, with an URI
     BSLS_ASSERT_SAFE(d_stats_mp == 0 && "Stats already initialized");
     BSLS_ASSERT_SAFE(d_state == static_cast<int>(QueueState::e_OPENED) &&


### PR DESCRIPTION
The wording of "cannot call ... on an empty queue" makes it sound like this function errored (or failed a contract in this case) because the queue data structure was empty, whereas the meaning here is actually "on an empty queue **URI string**". For clarity's sake, we'll just say what we mean: the queue's URI is invalid, so this function is out of contract.