### PR TITLE
tsanup.txt: Suppress bdlma::ConcurrentPool::deleteObject

### DIFF
--- a/etc/tsansup.txt
+++ b/etc/tsansup.txt
@@ -7,6 +7,7 @@ race:BloombergLP::bdlcc::ObjectPool<*>::getObject
 race:BloombergLP::bdlcc::ObjectPool<*>::releaseObject
 race:BloombergLP::bdlma::ConcurrentPool::deallocate
 race:BloombergLP::bdlma::ConcurrentPool::allocate
+race:BloombergLP::bdlma::ConcurrentPool::deleteObject
 
 # Similar to above, there is a lengthy comment in bcema_Pool::allocate which
 # attempts to explain why there is no race.


### PR DESCRIPTION
As discussed, this race condition is a false alarm.