### PR TITLE
Lookup by appId

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -61,13 +61,13 @@ VirtualStorageCatalog::put(const bmqt::MessageGUID& msgGUID,
                            const mqbu::StorageKey&  appKey)
 {
     if (!appKey.isNull()) {
-        VirtualStoragesIter it = d_virtualStorages.find(appKey);
+        VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
         BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
 
-        return it->second->put(msgGUID,
-                               msgSize,
-                               rdaInfo,
-                               subScriptionId);  // RETURN
+        return it->value()->put(msgGUID,
+                                msgSize,
+                                rdaInfo,
+                                subScriptionId);  // RETURN
     }
 
     // Add guid to all virtual storages.
@@ -75,7 +75,7 @@ VirtualStorageCatalog::put(const bmqt::MessageGUID& msgGUID,
     for (VirtualStoragesIter it = d_virtualStorages.begin();
          it != d_virtualStorages.end();
          ++it) {
-        it->second->put(msgGUID, msgSize, rdaInfo, subScriptionId);
+        it->value()->put(msgGUID, msgSize, rdaInfo, subScriptionId);
     }
 
     return mqbi::StorageResult::e_SUCCESS;  // RETURN
@@ -87,9 +87,9 @@ VirtualStorageCatalog::getIterator(const mqbu::StorageKey& appKey)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesIter it = d_virtualStorages.find(appKey);
+    VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
-    return it->second->getIterator(appKey);
+    return it->value()->getIterator(appKey);
 }
 
 mqbi::StorageResult::Enum VirtualStorageCatalog::getIterator(
@@ -100,9 +100,9 @@ mqbi::StorageResult::Enum VirtualStorageCatalog::getIterator(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesIter it = d_virtualStorages.find(appKey);
+    VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
-    return it->second->getIterator(out, appKey, msgGUID);
+    return it->value()->getIterator(out, appKey, msgGUID);
 }
 
 mqbi::StorageResult::Enum
@@ -110,16 +110,16 @@ VirtualStorageCatalog::remove(const bmqt::MessageGUID& msgGUID,
                               const mqbu::StorageKey&  appKey)
 {
     if (!appKey.isNull()) {
-        VirtualStoragesIter it = d_virtualStorages.find(appKey);
+        VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
         BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
-        return it->second->remove(msgGUID);  // RETURN
+        return it->value()->remove(msgGUID);  // RETURN
     }
 
     // Remove guid from all virtual storages.
     for (VirtualStoragesIter it = d_virtualStorages.begin();
          it != d_virtualStorages.end();
          ++it) {
-        it->second->remove(msgGUID);  // ignore rc
+        it->value()->remove(msgGUID);  // ignore rc
     }
 
     return mqbi::StorageResult::e_SUCCESS;
@@ -129,16 +129,16 @@ mqbi::StorageResult::Enum
 VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
 {
     if (!appKey.isNull()) {
-        VirtualStoragesIter it = d_virtualStorages.find(appKey);
+        VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
         BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
-        return it->second->removeAll(appKey);  // RETURN
+        return it->value()->removeAll(appKey);  // RETURN
     }
 
     // Clear all virtual storages.
     for (VirtualStoragesIter it = d_virtualStorages.begin();
          it != d_virtualStorages.end();
          ++it) {
-        it->second->removeAll(it->first);  // ignore rc
+        it->value()->removeAll(it->key2());  // ignore rc
     }
 
     return mqbi::StorageResult::e_SUCCESS;
@@ -152,9 +152,9 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
     BSLS_ASSERT_SAFE(!appId.empty());
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesConstIter cit = d_virtualStorages.find(appKey);
+    VirtualStoragesConstIter cit = d_virtualStorages.findByKey2(appKey);
     if (cit != d_virtualStorages.end()) {
-        const VirtualStorage* vs = cit->second.get();
+        const VirtualStorage* vs = cit->value().get();
         BSLS_ASSERT_SAFE(!vs->appKey().isNull());
 
         errorDescription << "Virtual storage exists with same appKey. "
@@ -170,7 +170,7 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
                       appId,
                       appKey,
                       d_allocator_p);
-    d_virtualStorages.insert(bsl::make_pair(appKey, vsp));
+    d_virtualStorages.insert(appId, appKey, vsp);
 
     return 0;
 }
@@ -184,7 +184,7 @@ bool VirtualStorageCatalog::removeVirtualStorage(
         return true;  // RETURN
     }
 
-    VirtualStoragesConstIter it = d_virtualStorages.find(appKey);
+    VirtualStoragesConstIter it = d_virtualStorages.findByKey2(appKey);
     if (it != d_virtualStorages.end()) {
         d_virtualStorages.erase(it);
         return true;  // RETURN
@@ -199,9 +199,9 @@ VirtualStorageCatalog::virtualStorage(const mqbu::StorageKey& appKey)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesIter it = d_virtualStorages.find(appKey);
+    VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
-    return it->second.get();
+    return it->value().get();
 }
 
 void VirtualStorageCatalog::autoConfirm(const bmqt::MessageGUID& msgGUID,
@@ -210,10 +210,10 @@ void VirtualStorageCatalog::autoConfirm(const bmqt::MessageGUID& msgGUID,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesIter it = d_virtualStorages.find(appKey);
+    VirtualStoragesIter it = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
 
-    it->second->autoConfirm(msgGUID);
+    it->value()->autoConfirm(msgGUID);
 }
 
 // ACCESSORS
@@ -223,12 +223,12 @@ bool VirtualStorageCatalog::hasVirtualStorage(const mqbu::StorageKey& appKey,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    VirtualStoragesConstIter cit   = d_virtualStorages.find(appKey);
+    VirtualStoragesConstIter cit   = d_virtualStorages.findByKey2(appKey);
     const bool               hasVs = (cit != d_virtualStorages.end());
 
     if (appId) {
         if (hasVs) {
-            *appId = cit->second->appId();
+            *appId = cit->value()->appId();
             return true;  // RETURN
         }
 
@@ -244,22 +244,19 @@ bool VirtualStorageCatalog::hasVirtualStorage(const bsl::string& appId,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!appId.empty());
 
-    for (VirtualStoragesConstIter it = d_virtualStorages.begin();
-         it != d_virtualStorages.end();
-         ++it) {
-        if (it->second->appId() == appId) {
-            if (appKey) {
-                *appKey = it->first;
-            }
-            return true;  // RETURN
-        }
-    }
+    VirtualStoragesConstIter cit   = d_virtualStorages.findByKey1(appId);
+    const bool               hasVs = (cit != d_virtualStorages.end());
 
     if (appKey) {
+        if (hasVs) {
+            *appKey = cit->key2();
+            return true;  // RETURN
+        }
+
         *appKey = mqbu::StorageKey::k_NULL_KEY;
     }
 
-    return false;
+    return hasVs;
 }
 
 bool VirtualStorageCatalog::hasMessage(const bmqt::MessageGUID& msgGUID) const
@@ -267,7 +264,7 @@ bool VirtualStorageCatalog::hasMessage(const bmqt::MessageGUID& msgGUID) const
     for (VirtualStoragesConstIter it = d_virtualStorages.begin();
          it != d_virtualStorages.end();
          ++it) {
-        if (it->second->hasMessage(msgGUID)) {
+        if (it->value()->hasMessage(msgGUID)) {
             return true;  // RETURN
         }
     }
@@ -284,9 +281,8 @@ void VirtualStorageCatalog::loadVirtualStorageDetails(
     for (VirtualStoragesConstIter cit = d_virtualStorages.begin();
          cit != d_virtualStorages.end();
          ++cit) {
-        BSLS_ASSERT_SAFE(cit->first == cit->second->appKey());
-        buffer->push_back(
-            bsl::make_pair(cit->second->appId(), cit->second->appKey()));
+        BSLS_ASSERT_SAFE(cit->key2() == cit->value()->appKey());
+        buffer->push_back(bsl::make_pair(cit->key1(), cit->key2()));
     }
 }
 

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -71,14 +71,18 @@ VirtualStorageCatalog::put(const bmqt::MessageGUID& msgGUID,
     }
 
     // Add guid to all virtual storages.
-
+    mqbi::StorageResult::Enum lastRc = mqbi::StorageResult::e_SUCCESS;
     for (VirtualStoragesIter it = d_virtualStorages.begin();
          it != d_virtualStorages.end();
          ++it) {
-        it->value()->put(msgGUID, msgSize, rdaInfo, subScriptionId);
+        mqbi::StorageResult::Enum rc =
+            it->value()->put(msgGUID, msgSize, rdaInfo, subScriptionId);
+        if (rc != mqbi::StorageResult::e_SUCCESS) {
+            lastRc = rc;
+        }
     }
 
-    return mqbi::StorageResult::e_SUCCESS;  // RETURN
+    return lastRc;  // RETURN
 }
 
 bslma::ManagedPtr<mqbi::StorageIterator>

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -60,7 +60,7 @@ class VirtualStorageCatalog {
     // PRIVATE TYPES
     typedef bsl::shared_ptr<VirtualStorage> VirtualStorageSp;
 
-    /// appKey -> virtualStorage
+    /// Any(appId, appKey) -> virtualStorage
     typedef mwcc::
         TwoKeyHashMap<bsl::string, mqbu::StorageKey, VirtualStorageSp>
             VirtualStorages;

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -31,6 +31,9 @@
 #include <mqbs_virtualstorage.h>
 #include <mqbu_storagekey.h>
 
+// MWC
+#include <mwcc_twokeyhashmap.h>
+
 // BMQ
 #include <bmqt_messageguid.h>
 
@@ -58,8 +61,9 @@ class VirtualStorageCatalog {
     typedef bsl::shared_ptr<VirtualStorage> VirtualStorageSp;
 
     /// appKey -> virtualStorage
-    typedef bsl::unordered_map<mqbu::StorageKey, VirtualStorageSp>
-        VirtualStorages;
+    typedef mwcc::
+        TwoKeyHashMap<bsl::string, mqbu::StorageKey, VirtualStorageSp>
+            VirtualStorages;
 
     typedef VirtualStorages::iterator VirtualStoragesIter;
 
@@ -234,17 +238,17 @@ inline int VirtualStorageCatalog::numVirtualStorages() const
 inline bsls::Types::Int64
 VirtualStorageCatalog::numMessages(const mqbu::StorageKey& appKey) const
 {
-    VirtualStoragesConstIter cit = d_virtualStorages.find(appKey);
+    VirtualStoragesConstIter cit = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(cit != d_virtualStorages.end());
-    return cit->second->numMessages(appKey);
+    return cit->value()->numMessages(appKey);
 }
 
 inline bsls::Types::Int64
 VirtualStorageCatalog::numBytes(const mqbu::StorageKey& appKey) const
 {
-    VirtualStoragesConstIter cit = d_virtualStorages.find(appKey);
+    VirtualStoragesConstIter cit = d_virtualStorages.findByKey2(appKey);
     BSLS_ASSERT_SAFE(cit != d_virtualStorages.end());
-    return cit->second->numBytes(appKey);
+    return cit->value()->numBytes(appKey);
 }
 
 }  // close package namespace


### PR DESCRIPTION
Avoid iteration in `VirtualStorageCatalog::hasVirtualStorage(const bsl::string& appId` by switching to `TwoKeyHashMap`
Preparatory step for Reliable Broadcast