### PR TITLE
Out-of-order PUSH

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
@@ -234,7 +234,7 @@ void populateBlob(bdlbb::Blob*                        blob,
     const int               queueId = 123;
     const bmqt::MessageGUID guid;
 
-    ph.setFlags(bmqp::PushHeaderFlags::e_UNUSED3)
+    ph.setFlags(bmqp::PushHeaderFlags::e_OUT_OF_ORDER)
         .setOptionsWords(optionsWords)
         .setHeaderWords(sizeof(bmqp::PushHeader) / bmqp::Protocol::k_WORD_SIZE)
         .setQueueId(queueId)
@@ -334,7 +334,7 @@ void populatePackedBlob(bdlbb::Blob*                     blob,
     const int               queueId = 123;
     const bmqt::MessageGUID guid;
 
-    ph.setFlags(bmqp::PushHeaderFlags::e_UNUSED3)
+    ph.setFlags(bmqp::PushHeaderFlags::e_OUT_OF_ORDER)
         .setOptionsWords(optionsWords)
         .setHeaderWords(sizeof(bmqp::PushHeader) / bmqp::Protocol::k_WORD_SIZE)
         .setQueueId(queueId)

--- a/src/groups/bmq/bmqp/bmqp_protocol.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.cpp
@@ -617,7 +617,7 @@ const char* PushHeaderFlags::toAscii(PushHeaderFlags::Enum value)
     switch (value) {
         CASE(IMPLICIT_PAYLOAD)
         CASE(MESSAGE_PROPERTIES)
-        CASE(UNUSED3)
+        CASE(OUT_OF_ORDER)
         CASE(UNUSED4)
     default: return "(* UNKNOWN *)";
     }
@@ -638,7 +638,7 @@ bool PushHeaderFlags::fromAscii(PushHeaderFlags::Enum*   out,
 
     CHECKVALUE(IMPLICIT_PAYLOAD)
     CHECKVALUE(MESSAGE_PROPERTIES)
-    CHECKVALUE(UNUSED3)
+    CHECKVALUE(OUT_OF_ORDER)
     CHECKVALUE(UNUSED4)
 
     // Invalid string
@@ -653,8 +653,7 @@ bool PushHeaderFlags::fromAscii(PushHeaderFlags::Enum*   out,
 
 bool PushHeaderFlagUtil::isValid(bsl::ostream& errorDescription, int flags)
 {
-    if (isSet(flags, PushHeaderFlags::e_UNUSED3) ||
-        isSet(flags, PushHeaderFlags::e_UNUSED4)) {
+    if (isSet(flags, PushHeaderFlags::e_UNUSED4)) {
         errorDescription << "UNUSED flags are invalid.";
         return false;  // RETURN
     }
@@ -675,7 +674,7 @@ bsl::ostream& PushHeaderFlagUtil::prettyPrint(bsl::ostream& stream, int flags)
 
     CHECKVALUE(IMPLICIT_PAYLOAD)
     CHECKVALUE(MESSAGE_PROPERTIES)
-    CHECKVALUE(UNUSED3)
+    CHECKVALUE(OUT_OF_ORDER)
     CHECKVALUE(UNUSED4)
 
     return stream;

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -2188,7 +2188,7 @@ struct PushHeaderFlags {
     enum Enum {
         e_IMPLICIT_PAYLOAD   = (1 << 0),
         e_MESSAGE_PROPERTIES = (1 << 1),
-        e_UNUSED3            = (1 << 2),
+        e_OUT_OF_ORDER       = (1 << 2),
         e_UNUSED4            = (1 << 3)
     };
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
@@ -1160,7 +1160,7 @@ static void test3_flagUtils()
             bool                        d_isValid;
         } k_DATA[] = {{L_, bmqp::PushHeaderFlags::e_IMPLICIT_PAYLOAD, true},
                       {L_, bmqp::PushHeaderFlags::e_MESSAGE_PROPERTIES, true},
-                      {L_, bmqp::PushHeaderFlags::e_UNUSED3, false},
+                      {L_, bmqp::PushHeaderFlags::e_OUT_OF_ORDER, true},
                       {L_, bmqp::PushHeaderFlags::e_UNUSED4, false}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
@@ -1471,7 +1471,7 @@ static void test4_enumPrint()
             {L_,
              bmqp::PushHeaderFlags::e_MESSAGE_PROPERTIES,
              "MESSAGE_PROPERTIES"},
-            {L_, bmqp::PushHeaderFlags::e_UNUSED3, "UNUSED3"},
+            {L_, bmqp::PushHeaderFlags::e_OUT_OF_ORDER, "OUT_OF_ORDER"},
             {L_, bmqp::PushHeaderFlags::e_UNUSED4, "UNUSED4"},
             {L_, -1, "(* UNKNOWN *)"}};
 
@@ -1600,7 +1600,7 @@ static void test5_enumIsomorphism()
     // Enum PushHeaderFlags
     TEST_ISOMORPHISM(PushHeaderFlags, IMPLICIT_PAYLOAD)
     TEST_ISOMORPHISM(PushHeaderFlags, MESSAGE_PROPERTIES)
-    TEST_ISOMORPHISM(PushHeaderFlags, UNUSED3)
+    TEST_ISOMORPHISM(PushHeaderFlags, OUT_OF_ORDER)
     TEST_ISOMORPHISM(PushHeaderFlags, UNUSED4)
 
     // Enum StorageHeaderFlags
@@ -1658,12 +1658,13 @@ static void test6_enumFromString()
     PV("Testing PushHeaderFlagUtil toString method");
     int expectedFlags = bmqp::PushHeaderFlags::e_IMPLICIT_PAYLOAD |
                         bmqp::PushHeaderFlags::e_MESSAGE_PROPERTIES |
-                        bmqp::PushHeaderFlags::e_UNUSED3 |
+                        bmqp::PushHeaderFlags::e_OUT_OF_ORDER |
                         bmqp::PushHeaderFlags::e_UNUSED4;
-    bsl::string corrStr("IMPLICIT_PAYLOAD,MESSAGE_PROPERTIES,UNUSED3,UNUSED4",
-                        s_allocator_p);
+    bsl::string corrStr(
+        "IMPLICIT_PAYLOAD,MESSAGE_PROPERTIES,OUT_OF_ORDER,UNUSED4",
+        s_allocator_p);
     bsl::string incorrStr(
-        "IMPLICIT_PAYLOAD,MESSAGE_PROPERTIES,UNUSED3,INVLD1,INVLD2",
+        "IMPLICIT_PAYLOAD,MESSAGE_PROPERTIES,OUT_OF_ORDER,INVLD1,INVLD2",
         s_allocator_p);
     bsl::string errOutput("Invalid flag(s) 'INVLD1','INVLD2'", s_allocator_p);
     enumFromStringHelper<bmqp::PushHeaderFlagUtil>(expectedFlags,

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -1947,10 +1947,18 @@ void ClientSession::onPushEvent(const mqbi::DispatcherPushEvent& event)
     }
 
     if (convertingRc == 0) {
+        int flags = 0;
+
+        if (event.isOutOfOrderPush()) {
+            bmqp::PushHeaderFlagUtil::setFlag(
+                &flags,
+                bmqp::PushHeaderFlags::e_OUT_OF_ORDER);
+        }
+
         d_state.d_pushBuilder.packMessage(*blob,
                                           event.queueId(),
                                           event.guid(),
-                                          0,
+                                          flags,
                                           cat,
                                           pushProperties);
 

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2155,7 +2155,8 @@ static void test11_initiateShutdown()
                                                   guid,
                                                   messageAttributes,
                                                   msgGroupId,
-                                                  subQueueInfos);
+                                                  subQueueInfos,
+                                                  false);
 
         // Verify there are unconfirmed messages in the handle
         ASSERT_EQ(1, tb.d_domain.d_queueHandle->countUnconfirmed());
@@ -2209,7 +2210,8 @@ static void test11_initiateShutdown()
                                                   guid,
                                                   messageAttributes,
                                                   msgGroupId,
-                                                  subQueueInfos);
+                                                  subQueueInfos,
+                                                  false);
 
         // Verify there are unconfirmed messages in the handle
         ASSERT_EQ(1, tb.d_domain.d_queueHandle->countUnconfirmed());
@@ -2274,7 +2276,8 @@ static void test11_initiateShutdown()
                                                       guid,
                                                       messageAttributes,
                                                       msgGroupId,
-                                                      subQueueInfos);
+                                                      subQueueInfos,
+                                                      false);
             guids.push_back(guid);
         }
         // Verify there are unconfirmed messages in the handle

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -466,7 +466,10 @@ void ClusterProxy::onPushEvent(const mqbi::DispatcherPushEvent& event)
                              appDataSp,
                              optionsSp,
                              logic,
-                             iter.header().compressionAlgorithmType());
+                             iter.header().compressionAlgorithmType(),
+                             bmqp::PushHeaderFlagUtil::isSet(
+                                 iter.header().flags(),
+                                 bmqp::PushHeaderFlags::e_OUT_OF_ORDER));
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -750,7 +750,7 @@ void Queue::onPushMessage(
     const bsl::shared_ptr<bdlbb::Blob>&  options,
     const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
     bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
-    bool                                 isReplayPush)
+    bool                                 isOutOfOrder)
 {
     // executed by the *CLUSTER* dispatcher thread
 
@@ -775,7 +775,7 @@ void Queue::onPushMessage(
         .setGuid(msgGUID)
         .setMessagePropertiesInfo(messagePropertiesInfo)
         .setCompressionAlgorithmType(compressionAlgorithmType)
-        .setOutOfOrderPush(isReplayPush);
+        .setOutOfOrderPush(isOutOfOrder);
 
     dispatcher()->dispatchEvent(dispEvent, this);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -749,7 +749,8 @@ void Queue::onPushMessage(
     const bsl::shared_ptr<bdlbb::Blob>&  appData,
     const bsl::shared_ptr<bdlbb::Blob>&  options,
     const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-    bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType)
+    bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+    bool                                 isReplayPush)
 {
     // executed by the *CLUSTER* dispatcher thread
 
@@ -773,7 +774,8 @@ void Queue::onPushMessage(
         .setOptions(options)
         .setGuid(msgGUID)
         .setMessagePropertiesInfo(messagePropertiesInfo)
-        .setCompressionAlgorithmType(compressionAlgorithmType);
+        .setCompressionAlgorithmType(compressionAlgorithmType)
+        .setOutOfOrderPush(isReplayPush);
 
     dispatcher()->dispatchEvent(dispEvent, this);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -270,8 +270,8 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
         const bsl::shared_ptr<bdlbb::Blob>&  appData,
         const bsl::shared_ptr<bdlbb::Blob>&  options,
         const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType)
-        BSLS_KEYWORD_OVERRIDE;
+        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+        bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
     /// Confirm the message with the specified `msgGUID` for the specified
     /// `upstreamSubQueueId` stream of the queue on behalf of the client

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -430,13 +430,13 @@ struct QueueEngineUtil_AppState {
                            mqbi::Storage&          storage,
                            const bsl::string&      appId);
 
-    /// Try to deliver to the next available consumer message having
-    /// specified `appData`, `options`, `guid`, `attributes` and `rdaInfo`.
-    /// Return true if the message was successfully delivered, or false if
-    /// all consumers were busy and no one could handle the message.  The
-    /// algorithm will try to deliver to highest priority consumers in a
-    /// round-robin manner, respecting their `readCount`.  Behavior is
-    /// undefined unless `appData` is non-null.
+    /// Try to deliver to the next available consumer the specified 'message'.
+    /// If poisonous message handling requires a delay in the delivery, iterate
+    /// all highest priority consumers, load the lowest delay into the
+    /// specified 'delay' and return 'e_DELAY.  If no delay is required, try to
+    /// send the 'message' to a highest priority consumer with matching
+    /// subscription.  Return corresponding result: 'e_SUCCESS',
+    /// 'e_NO_SUBSCRIPTION', 'e_NO_CAPACITY'. or 'e_NO_CAPACITY_ALL'.
     Routers::Result tryDeliverOneMessage(bsls::TimeInterval*          delay,
                                          const mqbi::StorageIterator* message,
                                          bool isOutOfOrder);

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -438,7 +438,8 @@ struct QueueEngineUtil_AppState {
     /// round-robin manner, respecting their `readCount`.  Behavior is
     /// undefined unless `appData` is non-null.
     Routers::Result tryDeliverOneMessage(bsls::TimeInterval*          delay,
-                                         const mqbi::StorageIterator* message);
+                                         const mqbi::StorageIterator* message,
+                                         bool isOutOfOrder);
 
     /// Broadcast to all available consumers, the message having specified
     /// `appData`, `options`, `guid` and `attributes`.  Behavior is

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -477,7 +477,8 @@ void QueueHandle::deliverMessageImpl(
     const bmqt::MessageGUID&                  msgGUID,
     const mqbi::StorageMessageAttributes&     attributes,
     const bmqp::Protocol::MsgGroupId&         msgGroupId,
-    const bmqp::Protocol::SubQueueInfosArray& subQueueInfos)
+    const bmqp::Protocol::SubQueueInfosArray& subQueueInfos,
+    bool                                      isOutOfOrder)
 {
     // executed by the *QUEUE_DISPATCHER* thread
 
@@ -505,7 +506,8 @@ void QueueHandle::deliverMessageImpl(
             attributes.messagePropertiesInfo()))
         .setSubQueueInfos(subQueueInfos)
         .setMsgGroupId(msgGroupId)
-        .setCompressionAlgorithmType(attributes.compressionAlgorithmType());
+        .setCompressionAlgorithmType(attributes.compressionAlgorithmType())
+        .setOutOfOrderPush(isOutOfOrder);
 
     if (message) {
         event->setBlob(message);
@@ -793,7 +795,8 @@ void QueueHandle::deliverMessageNoTrack(
                        msgGUID,
                        attributes,
                        msgGroupId,
-                       subQueueInfos);
+                       subQueueInfos,
+                       false);
 }
 
 void QueueHandle::deliverMessage(
@@ -801,7 +804,8 @@ void QueueHandle::deliverMessage(
     const bmqt::MessageGUID&                  msgGUID,
     const mqbi::StorageMessageAttributes&     attributes,
     const bmqp::Protocol::MsgGroupId&         msgGroupId,
-    const bmqp::Protocol::SubQueueInfosArray& subscriptions)
+    const bmqp::Protocol::SubQueueInfosArray& subscriptions,
+    bool                                      isOutOfOrder)
 {
     // executed by the *QUEUE_DISPATCHER* thread
 
@@ -913,7 +917,8 @@ void QueueHandle::deliverMessage(
                        msgGUID,
                        attributes,
                        msgGroupId,
-                       targetSubscriptions);
+                       targetSubscriptions,
+                       isOutOfOrder);
 }
 
 void QueueHandle::postMessage(const bmqp::PutHeader&              putHeader,

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -241,11 +241,11 @@ class QueueHandle : public mqbi::QueueHandle {
     void clearClientDispatched(bool hasLostClient);
 
     /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgSize`, `msgGUID`, `attributes` and `msgGroupId` for
-    /// the specified `subQueueInfos` streams of the queue.  The behavior is
-    /// undefined unless the queueHandle can send a message at this time for
-    /// all of the `subQueueInfos` streams (see 'canDeliver(unsigned int
-    /// subQueueId)' for more information).
+    /// specified `msgSize`, `msgGUID`, `attributes`, `isOutOfOrder`, and
+    /// `msgGroupId` for the specified `subQueueInfos` streams of the queue.
+    /// The behavior is undefined unless the queueHandle can send a message at
+    /// this time for all of the `subQueueInfos` streams (see
+    /// 'canDeliver(unsigned int subQueueId)' for more information).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void
@@ -367,11 +367,11 @@ class QueueHandle : public mqbi::QueueHandle {
     // optimizations.
 
     /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subscriptions` of the queue.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time for each of the
-    /// corresponding subStreams(see `canDeliver(unsigned int subQueueId)`
-    /// for more information).
+    /// specified `msgSize`, `msgGUID`, `attributes`, `isOutOfOrder`, and
+    /// `msgGroupId` for the specified `subQueueInfos` streams of the queue.
+    /// The behavior is undefined unless the queueHandle can send a message at
+    /// this time for all of the `subQueueInfos` streams (see
+    /// 'canDeliver(unsigned int subQueueId)' for more information).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -248,13 +248,14 @@ class QueueHandle : public mqbi::QueueHandle {
     /// subQueueId)' for more information).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void deliverMessageImpl(
-        const bsl::shared_ptr<bdlbb::Blob>&       message,
-        const int                                 msgSize,
-        const bmqt::MessageGUID&                  msgGUID,
-        const mqbi::StorageMessageAttributes&     attributes,
-        const bmqp::Protocol::MsgGroupId&         msgGroupId,
-        const bmqp::Protocol::SubQueueInfosArray& subQueueInfos);
+    void
+    deliverMessageImpl(const bsl::shared_ptr<bdlbb::Blob>&       message,
+                       const int                                 msgSize,
+                       const bmqt::MessageGUID&                  msgGUID,
+                       const mqbi::StorageMessageAttributes&     attributes,
+                       const bmqp::Protocol::MsgGroupId&         msgGroupId,
+                       const bmqp::Protocol::SubQueueInfosArray& subQueueInfos,
+                       bool                                      isOutOfOrder);
 
     void makeSubStream(const bsl::string& appId,
                        unsigned int       downstreamSubQueueId,
@@ -378,8 +379,8 @@ class QueueHandle : public mqbi::QueueHandle {
                    const bmqt::MessageGUID&                  msgGUID,
                    const mqbi::StorageMessageAttributes&     attributes,
                    const bmqp::Protocol::MsgGroupId&         msgGroupId,
-                   const bmqp::Protocol::SubQueueInfosArray& subscriptions)
-        BSLS_KEYWORD_OVERRIDE;
+                   const bmqp::Protocol::SubQueueInfosArray& subscriptions,
+                   bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
     /// Called by the `Queue` to deliver the specified `message` with the
     /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -338,7 +338,7 @@ void RemoteQueue::pushMessage(
     const bsl::shared_ptr<bdlbb::Blob>&  options,
     const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
     bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
-    bool                                 isReplayPush)
+    bool                                 isOutOfOrder)
 {
     // executed by the *QUEUE DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -337,7 +337,8 @@ void RemoteQueue::pushMessage(
     const bsl::shared_ptr<bdlbb::Blob>&  appData,
     const bsl::shared_ptr<bdlbb::Blob>&  options,
     const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-    bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType)
+    bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+    bool                                 isReplayPush)
 {
     // executed by the *QUEUE DISPATCHER* thread
 
@@ -823,7 +824,8 @@ void RemoteQueue::onDispatcherEvent(const mqbi::DispatcherEvent& event)
                     realEvent->blob(),
                     realEvent->options(),
                     realEvent->messagePropertiesInfo(),
-                    realEvent->compressionAlgorithmType());
+                    realEvent->compressionAlgorithmType(),
+                    realEvent->isOutOfOrderPush());
     } break;
     case mqbi::DispatcherEventType::e_PUT: {
         const mqbi::DispatcherPutEvent* realEvent = event.asPutEvent();

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -318,7 +318,8 @@ class RemoteQueue {
                 const bsl::shared_ptr<bdlbb::Blob>&  appData,
                 const bsl::shared_ptr<bdlbb::Blob>&  options,
                 const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-                bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType);
+                bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+                bool                                 isReplayPush);
 
     SubStreamContext& subStreamContext(unsigned int upstreamSubQueueId);
 

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -319,7 +319,7 @@ class RemoteQueue {
                 const bsl::shared_ptr<bdlbb::Blob>&  options,
                 const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
                 bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
-                bool                                 isReplayPush);
+                bool                                 isOutOfOrder);
 
     SubStreamContext& subStreamContext(unsigned int upstreamSubQueueId);
 

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.h
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.h
@@ -685,8 +685,8 @@ class DispatcherPushEvent {
     virtual bmqt::CompressionAlgorithmType::Enum
     compressionAlgorithmType() const = 0;
 
-    /// Return 'true' if the associated PUSH message is a Replay (not the first
-    /// delivery attempt) or put-aside (no matching subscription).
+    /// Return 'true' if the associated PUSH message is Out-of-Order - not the
+    /// first delivery attempt or put-aside (no matching subscription).
     virtual bool isOutOfOrderPush() const = 0;
 };
 

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.h
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.h
@@ -684,6 +684,10 @@ class DispatcherPushEvent {
     /// event is compressed.
     virtual bmqt::CompressionAlgorithmType::Enum
     compressionAlgorithmType() const = 0;
+
+    /// Return 'true' if the associated PUSH message is a Replay (not the first
+    /// delivery attempt) or put-aside (no matching subscription).
+    virtual bool isOutOfOrderPush() const = 0;
 };
 
 // ========================
@@ -997,6 +1001,8 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
 
     bmqt::CompressionAlgorithmType::Enum d_compressionAlgorithmType;
 
+    bool d_isOutOfOrder;
+
     bsls::Types::Uint64 d_genCount;
 
     bsl::shared_ptr<mwcu::AtomicState> d_state;
@@ -1048,6 +1054,7 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
     messagePropertiesInfo() const BSLS_KEYWORD_OVERRIDE;
     bmqt::CompressionAlgorithmType::Enum
                         compressionAlgorithmType() const BSLS_KEYWORD_OVERRIDE;
+    bool                isOutOfOrderPush() const BSLS_KEYWORD_OVERRIDE;
     bsls::Types::Uint64 genCount() const BSLS_KEYWORD_OVERRIDE;
     // Return the value of the corresponding member.  Refer to the various
     // DispatcherEvent view interfaces for more specific information.
@@ -1086,6 +1093,10 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
     /// reference offering modifiable access to this object.
     DispatcherEvent&
     setCompressionAlgorithmType(bmqt::CompressionAlgorithmType::Enum value);
+
+    /// Set the corresponding member to the specified `value` and return a
+    /// reference offering modifiable access to this object.
+    DispatcherEvent& setOutOfOrderPush(bool value);
 
     /// PUT messages carry `genCount`; if there is a mismatch between PUT
     /// `genCount` and current upstream 'genCount, then the PUT message gets
@@ -1299,6 +1310,7 @@ inline DispatcherEvent::DispatcherEvent(bslma::Allocator* allocator)
 , d_msgGroupId(allocator)
 , d_messagePropertiesInfo()
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
+, d_isOutOfOrder(false)
 , d_genCount(0)
 {
     // NOTHING
@@ -1401,6 +1413,11 @@ inline bmqt::CompressionAlgorithmType::Enum
 DispatcherEvent::compressionAlgorithmType() const
 {
     return d_compressionAlgorithmType;
+}
+
+inline bool DispatcherEvent::isOutOfOrderPush() const
+{
+    return d_isOutOfOrder;
 }
 
 inline bsls::Types::Uint64 DispatcherEvent::genCount() const
@@ -1563,6 +1580,12 @@ inline DispatcherEvent& DispatcherEvent::setCompressionAlgorithmType(
     return *this;
 }
 
+inline DispatcherEvent& DispatcherEvent::setOutOfOrderPush(bool value)
+{
+    d_isOutOfOrder = value;
+    return *this;
+}
+
 inline DispatcherEvent& DispatcherEvent::setGenCount(unsigned int genCount)
 {
     d_genCount = genCount;
@@ -1598,6 +1621,7 @@ inline void DispatcherEvent::reset()
     d_msgGroupId.clear();
     d_messagePropertiesInfo    = bmqp::MessagePropertiesInfo();
     d_compressionAlgorithmType = bmqt::CompressionAlgorithmType::e_NONE;
+    d_isOutOfOrder             = false;
     d_genCount                 = 0;
     d_state.reset();
 }

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -565,12 +565,13 @@ class QueueHandle {
     /// for more information).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    virtual void deliverMessage(
-        const bsl::shared_ptr<bdlbb::Blob>&       message,
-        const bmqt::MessageGUID&                  msgGUID,
-        const StorageMessageAttributes&           attributes,
-        const bmqp::Protocol::MsgGroupId&         msgGroupId,
-        const bmqp::Protocol::SubQueueInfosArray& subscriptions) = 0;
+    virtual void
+    deliverMessage(const bsl::shared_ptr<bdlbb::Blob>&       message,
+                   const bmqt::MessageGUID&                  msgGUID,
+                   const StorageMessageAttributes&           attributes,
+                   const bmqp::Protocol::MsgGroupId&         msgGroupId,
+                   const bmqp::Protocol::SubQueueInfosArray& subscriptions,
+                   bool                                      isOutOfOrder) = 0;
 
     /// Called by the `Queue` to deliver the specified `message` with the
     /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
@@ -811,7 +812,8 @@ class Queue : public DispatcherClient {
         const bsl::shared_ptr<bdlbb::Blob>&  appData,
         const bsl::shared_ptr<bdlbb::Blob>&  options,
         const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType) = 0;
+        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+        bool                                 isOutOfOrder) = 0;
 
     /// Confirm the message with the specified `msgGUID` for the specified
     /// `upstreamSubQueueId` stream of the queue on behalf of the client

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -258,7 +258,8 @@ void Queue::onPushMessage(
     BSLS_ANNOTATION_UNUSED const bmqp::MessagePropertiesInfo&
                                  hasMessageProperties,
     BSLS_ANNOTATION_UNUSED       bmqt::CompressionAlgorithmType::Enum
-                                 compressionAlgorithmType)
+                                 compressionAlgorithmType,
+    BSLS_ANNOTATION_UNUSED bool  isOutOfOrder)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -258,8 +258,8 @@ class Queue : public mqbi::Queue {
         const bsl::shared_ptr<bdlbb::Blob>&  appData,
         const bsl::shared_ptr<bdlbb::Blob>&  options,
         const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
-        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType)
-        BSLS_KEYWORD_OVERRIDE;
+        bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
+        bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
     /// Confirm the message with the specified `msgGUID` for the specified
     /// `upstreamSubQueueId` stream of the queue on behalf of the client

--- a/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
@@ -282,7 +282,8 @@ void QueueHandle::deliverMessage(
     const bmqt::MessageGUID&            msgGUID,
     BSLS_ANNOTATION_UNUSED const mqbi::StorageMessageAttributes& attributes,
     BSLS_ANNOTATION_UNUSED const bmqp::Protocol::MsgGroupId& msgGroupId,
-    const bmqp::Protocol::SubQueueInfosArray&                subscriptions)
+    const bmqp::Protocol::SubQueueInfosArray&                subscriptions,
+    BSLS_ANNOTATION_UNUSED bool                              isOutOfOrder)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(
@@ -317,7 +318,12 @@ void QueueHandle::deliverMessageNoTrack(
     const bmqp::Protocol::SubQueueInfosArray& subscriptions)
 {
     // Delegate, from a simplified mock perspective.
-    deliverMessage(message, msgGUID, attributes, msgGroupId, subscriptions);
+    deliverMessage(message,
+                   msgGUID,
+                   attributes,
+                   msgGroupId,
+                   subscriptions,
+                   false);
 }
 
 void QueueHandle::configure(

--- a/src/groups/mqb/mqbmock/mqbmock_queuehandle.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queuehandle.h
@@ -326,8 +326,8 @@ class QueueHandle : public mqbi::QueueHandle {
                    const bmqt::MessageGUID&                  msgGUID,
                    const mqbi::StorageMessageAttributes&     attributes,
                    const bmqp::Protocol::MsgGroupId&         msgGroupId,
-                   const bmqp::Protocol::SubQueueInfosArray& subscriptions)
-        BSLS_KEYWORD_OVERRIDE;
+                   const bmqp::Protocol::SubQueueInfosArray& subscriptions,
+                   bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
     /// Called by the `Queue` to deliver the specified `message` with the
     /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified


### PR DESCRIPTION
Preparing for the Reliable Broadcast

To get rid of the second VSC in Replica and Proxy (`RelayQueueEngine::d_subStreamMessages_p`):
-  introduce OOO Push
- add OOO to RDL _and_ the (only) VSC in the storage
        
Today, proxy and replica add PUSH to both storage and the additional VSC
If we add a special treatment for OOO Push, then just the storage is enough for in-order PUSH
In-order guarantees first time delivery.
    
The next step would be to refactor VSC to rely on order and to batch Apps