### PR TITLE
[DO NOT MERGE] Remove `MWC_INTERNAL_USAGE` from CMake

### DIFF
--- a/etc/cmake/BMQPlugins.cmake
+++ b/etc/cmake/BMQPlugins.cmake
@@ -31,9 +31,6 @@ function(bmq_add_plugin name)
     # Declare the plugin library.
     add_library(${name} MODULE ${${name}_SOURCE_FILES})
 
-    # Give plugins access to MWC.
-    target_compile_definitions(${name} PRIVATE "MWC_INTERNAL_USAGE")
-
     # Add './' to #include-paths.
     target_include_directories(${name} BEFORE PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR})

--- a/etc/cmake/TargetBMQStyleUor.cmake
+++ b/etc/cmake/TargetBMQStyleUor.cmake
@@ -57,7 +57,6 @@ function(target_bmq_style_uor TARGET)
   target_bmq_default_compiler_flags(${TARGET})
 
   add_library(${TARGET}-flags INTERFACE IMPORTED)
-  target_compile_definitions(${TARGET}-flags INTERFACE "MWC_INTERNAL_USAGE")
 
   bbs_setup_target_uor(${TARGET}
     SKIP_TESTS

--- a/src/applications/bmqbrkr/CMakeLists.txt
+++ b/src/applications/bmqbrkr/CMakeLists.txt
@@ -93,7 +93,6 @@ if(BMQ_TARGET_BMQBRKR_NEEDED)
   bbs_read_metadata(PACKAGE bmqbrkr)
 
   add_executable(bmqbrkr ${bmqbrkr_MAIN_SOURCE} ${bmqbrkr_SOURCE_FILES})
-  target_compile_definitions(bmqbrkr PRIVATE "MWC_INTERNAL_USAGE")
   target_include_directories(bmqbrkr
     BEFORE PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/applications/bmqstoragetool/CMakeLists.txt
+++ b/src/applications/bmqstoragetool/CMakeLists.txt
@@ -7,8 +7,6 @@ endif()
 
 add_executable(bmqstoragetool)
 
-target_compile_definitions(bmqstoragetool PRIVATE "MWC_INTERNAL_USAGE")
-
 target_bmq_default_compiler_flags(bmqstoragetool)
 
 set_target_properties(bmqstoragetool

--- a/src/applications/bmqtool/CMakeLists.txt
+++ b/src/applications/bmqtool/CMakeLists.txt
@@ -7,8 +7,6 @@ endif()
 
 add_executable(bmqtool)
 
-target_compile_definitions(bmqtool PRIVATE "MWC_INTERNAL_USAGE")
-
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang")
   # NOTE: The followings are using the 'deprecated' COMPILE_FLAGS property and
   # not COMPILE_OPTIONS because the later doesn't seem to work for a

--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -9,8 +9,6 @@ endif()
 add_library(bmq)
 set_property(TARGET bmq PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-target_compile_definitions(bmq PRIVATE "MWC_INTERNAL_USAGE")
-
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang")
   target_compile_options(bmq PRIVATE "-msse4.2")
 endif()

--- a/src/groups/mqb/CMakeLists.txt
+++ b/src/groups/mqb/CMakeLists.txt
@@ -10,8 +10,6 @@ endif()
 add_library( mqb )
 set_property( TARGET mqb PROPERTY POSITION_INDEPENDENT_CODE ON )
 
-target_compile_definitions( mqb PRIVATE "MWC_INTERNAL_USAGE" )
-
 # Pass build type to a source file so that it can print it in startup banner
 set_property(SOURCE "mqba/mqba_application.cpp"
              APPEND

--- a/src/groups/mwc/CMakeLists.txt
+++ b/src/groups/mwc/CMakeLists.txt
@@ -7,13 +7,6 @@ endif()
 
 add_library(mwc)
 
-target_compile_definitions(mwc PRIVATE "MWC_INTERNAL_USAGE")
-target_compile_definitions(mwc INTERFACE "MWC_INTERNAL_USAGE")
-
-# Adding it to 'interface' so that mwc test drivers can compile; but sadly
-# this makes it so that any target linking about this 'mwc' target will
-# also implicitly inherit from that flag, which is ok since it's privately
-# build, but not ideal.
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang")
   # NOTE: The followings are using the 'deprecated' COMPILE_FLAGS property and
   # not COMPILE_OPTIONS because the later doesn't seem to work for a


### PR DESCRIPTION
This PR is based on #315, and includes those changes in it.  We want that PR to go in first, we'll hold off on this PR until we've released those changes in libmwc and are sure users have time to switch to that version.  Then, we'll rebase this PR so we just get the second of the two patches.