### PR TITLE
FSM mode: Fix error related to missing virtual storage [175227886]

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -1590,7 +1590,6 @@ void ClusterStateManager::processQueueAssignmentAdvisory(
         const mqbu::StorageKey         queueKey(
             mqbu::StorageKey::BinaryRepresentation(),
             queueInfo.key().data());
-        BSLS_ASSERT_SAFE(queueInfo.appIds().empty());
 
         bool                    queueAlreadyAssigned = false;
         const DomainStatesCIter domCit = d_state_p->domainStates().find(

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -786,8 +786,7 @@ void ClusterUtil::populateQueueAssignmentAdvisory(
     ClusterState*                          clusterState,
     ClusterData*                           clusterData,
     const bmqt::Uri&                       uri,
-    const mqbi::Domain*                    domain,
-    bool                                   isCSLMode)
+    const mqbi::Domain*                    domain)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(advisory);
@@ -810,10 +809,8 @@ void ClusterUtil::populateQueueAssignmentAdvisory(
                                           uri.asString());
     key->loadBinary(&queueInfo.key());
 
-    if (isCSLMode) {
-        // Generate appIds and appKeys
-        populateAppIdInfos(&queueInfo.appIds(), domain->config().mode());
-    }
+    // Generate appIds and appKeys
+    populateAppIdInfos(&queueInfo.appIds(), domain->config().mode());
 
     BALL_LOG_INFO << clusterData->identity().description()
                   << ": Populated QueueAssignmentAdvisory: " << *advisory;
@@ -1007,16 +1004,12 @@ ClusterUtil::assignQueue(ClusterState*           clusterState,
                                     clusterState,
                                     clusterData,
                                     uri,
-                                    domIt->second->domain(),
-                                    cluster->isCSLModeEnabled());
+                                    domIt->second->domain());
     if (cluster->isCSLModeEnabled()) {
         // In CSL mode, we delay the insertion to queueKeys until
         // 'onQueueAssigned' observer callback.
 
         clusterState->queueKeys().erase(key);
-    }
-    else {
-        BSLS_ASSERT_SAFE(queueAdvisory.queues().back().appIds().empty());
     }
 
     // Apply 'queueAssignmentAdvisory' to CSL

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -203,17 +203,15 @@ struct ClusterUtil {
 
     /// Populate the specified `advisory` with information describing a
     /// queue assignment of the specified `uri` living in the specified
-    /// `domain`, using the specified `clusterState`, `clusterData` and
-    /// `isCSLMode` flag.  Load into the specified `key` the unique queue
-    /// key generated.
+    /// `domain`, using the specified `clusterState`, `clusterData`.  Load into
+    /// the specified `key` the unique queue key generated.
     static void populateQueueAssignmentAdvisory(
         bmqp_ctrlmsg::QueueAssignmentAdvisory* advisory,
         mqbu::StorageKey*                      key,
         ClusterState*                          clusterState,
         ClusterData*                           clusterData,
         const bmqt::Uri&                       uri,
-        const mqbi::Domain*                    domain,
-        bool                                   isCSLMode);
+        const mqbi::Domain*                    domain);
 
     /// Populate the specified `advisory` with information describing a
     /// queue unassignment of the specified `uri` having the specified `key`


### PR DESCRIPTION
When we tested switching cluster from non-FSM to FSM mode, we see errors such as `*.mqbblp.rootqueueengine mqbblp_rootqueueengine.cpp:398 #QUEUE_STORAGE_NOTFOUND Virtual storage does not exist for AppId 'foo', queue: 'bmq://bmq.test.mmap.fanout/qqq'`. This is because we used to not populate app Id infos in `QueueAssignmentAdviosry` for non-FSM mode; then, when we switch to FSM mode and attempt to recreate storages, we do not see those expected appIds and thus emit above error.

The fix is to always populate app Id infos in `QueueAssignmentAdviosry` regardless of mode.

**Caveat**: This PR does not retroactively change the storage files of any existing BlazingMQ broker. So, we would still run into issue if we restart an existing cluster from non-FSM mode to FSM mode.