### PR TITLE
Refactor: better support for per-appId queue metrics

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -113,14 +113,6 @@ struct QueueEngineUtil {
                 const mqbi::QueueHandleRequesterContext&   clientContext =
                     mqbi::QueueHandleRequesterContext());
 
-    /// Report to the specified `domainStats` the queue-time metric of the
-    /// message having specified `attributes` and `appId`. Note that this
-    /// method must be invoked only at the primary node.
-    static void
-    reportQueueTimeMetric(mqbstat::QueueStatsDomain*            domainStats,
-                          const mqbi::StorageMessageAttributes& attributes,
-                          const bsl::string&                    appId);
-
     /// Return true is the specified `queue` is of the broadcast type.
     static bool isBroadcastMode(const mqbi::Queue* queue);
 

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -408,8 +408,15 @@ mqbu::ResourceUsageMonitorStateTransition::Enum QueueHandle::updateMonitor(
             msgSize);
 
         // Report CONFIRM time only at first hop
+        // Note that we update metric per entire queue and also per `appId`
         if (d_clientContext_sp->isFirstHop()) {
-            d_domainStats_p->reportConfirmTime(timeDelta, appId);
+            d_domainStats_p->onEvent(
+                mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                timeDelta);
+            d_domainStats_p->onEvent(
+                mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                timeDelta,
+                appId);
         }
     }
 

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -229,20 +229,21 @@ class QueueStatsDomain {
     QueueStatsDomain& setWriterCount(int writerCount);
 
     /// Update statistics for the event of the specified `type` and with the
-    /// specified `value` (depending on the `type`, `value` can represent
+    /// specified `value`.  Depending on the `type`, `value` can represent
     /// the number of bytes, a counter, ...
     void onEvent(EventType::Enum type, bsls::Types::Int64 value);
+
+    /// Update statistics for the event of the specified `type` and with the
+    /// specified `value` for the specified `appId`.  Depending on the `type`,
+    /// `value` can represent the number of bytes, a counter, ...
+    void onEvent(EventType::Enum    type,
+                 bsls::Types::Int64 value,
+                 const bsl::string& appId);
 
     /// Force set the stats of the content of the queue to the specified
     /// absolute `messages` and `bytes` values.
     void setQueueContentRaw(bsls::Types::Int64 messages,
                             bsls::Types::Int64 bytes);
-
-    /// Report `confirmation time` metric for the specified `appId`.
-    void reportConfirmTime(bsls::Types::Int64 value, const bsl::string& appId);
-
-    /// Report `queue time` metric for the specified `appId`.
-    void reportQueueTime(bsls::Types::Int64 value, const bsl::string& appId);
 
     /// Update subcontexts in case of domain reconfigure with the given list of
     /// AppIds.


### PR DESCRIPTION
This PR is a preparation PR for introducing per-AppId queue depth metric, it rolls back some changes done in this PR https://github.com/bloomberg/blazingmq/pull/226 and also makes is possible to extend queue metrics more easily with per-AppId metrics.

Changes:
- Fixed metrics reporting duplication
- Simplified `QueueEngineUtil` interface by removing `reportQueueTimeMetric` which is used only locally
- Simplified `QueueStatsDomain` interface by removing complex functions `reportConfirmTime`, `reportQueueTime`, and introduce the second flavour of `onEvent` which expects `appId` parameter to report parameters to the nested SubContext
- So now we have both `onEvent(type,value)` to report global queue metrics and `onEvent(type,value,appId)` to report metrics specific for `appId`

As a result, it is easy to extend `onEvent(type,value,appId)` to log more per-AppId metrics.