### PR TITLE
MQB: structured stats support, out of order stats snapshot

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -551,7 +551,9 @@ int Application::processCommand(const bslstl::StringRef& source,
     }
     else if (command.isStatValue()) {
         mqbcmd::StatResult statResult;
-        d_statController_mp->processCommand(&statResult, command.stat());
+        d_statController_mp->processCommand(&statResult,
+                                            command.stat(),
+                                            commandWithOptions.encoding());
         if (statResult.isErrorValue()) {
             cmdResult.makeError(statResult.error());
         }

--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
@@ -1,0 +1,268 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbstat_jsonprinter.cpp                                            -*-C++-*-
+#include <mqbstat_jsonprinter.h>
+
+#include <mqbscm_version.h>
+
+// MQB
+#include <mqbstat_queuestats.h>
+
+// MWC
+#include <mwcu_memoutstream.h>
+
+// BDE
+#include <ball_log.h>
+#include <bdljsn_json.h>
+#include <bdljsn_jsonutil.h>
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace mqbstat {
+
+namespace {
+
+// ---------------------
+// class JsonPrinterImpl
+// ---------------------
+
+/// The implementation class for JsonPrinter, containing all the cached options
+/// for printing statistics as json.  This implementation exists and is hidden
+/// from the package include for the following reasons:
+/// - Don't want to expose `bdljsn` names and symbols to the outer scope.
+/// - Member fields and functions defined for this implementation are used only
+///   locally, so there is no reason to make it visible.
+class JsonPrinterImpl {
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBSTAT.JSONPRINTERIMPL");
+
+  private:
+    // PRIVATE TYPES
+    typedef bsl::unordered_map<bsl::string, mwcst::StatContext*>
+        StatContextsMap;
+
+    typedef mqbstat::QueueStatsDomain::Stat Stat;
+
+  private:
+    // DATA
+    /// Config to use
+    const mqbcfg::StatsConfig& d_config;
+
+    /// Options for printing a compact json
+    const bdljsn::WriteOptions d_opsCompact;
+
+    /// Options for printing a pretty json
+    const bdljsn::WriteOptions d_opsPretty;
+
+    /// StatContext-s map
+    const StatContextsMap d_contexts;
+
+  private:
+    // NOT IMPLEMENTED
+    JsonPrinterImpl(const JsonPrinterImpl& other) BSLS_CPP11_DELETED;
+    JsonPrinterImpl&
+    operator=(const JsonPrinterImpl& other) BSLS_CPP11_DELETED;
+
+    // ACCESSORS
+
+    /// "domainQueues"
+    /// Populate the specified `bdljsn::JsonObject*` with the values
+    /// from the specified `ctx`.
+    void populateQueueValues(bdljsn::JsonObject*       queueObject,
+                             const mwcst::StatContext& ctx) const;
+    void populateQueueStats(bdljsn::JsonObject*       domainObject,
+                            const mwcst::StatContext& ctx) const;
+    void populateDomainQueueStats(bdljsn::JsonObject*       parent,
+                                  const mwcst::StatContext& ctx) const;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(JsonPrinterImpl, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a new `JsonPrinterImpl` object, using the specified `config`,
+    /// `statContextsMap` and the specified `allocator`.
+    JsonPrinterImpl(const mqbcfg::StatsConfig& config,
+                    const StatContextsMap&     statContextsMap,
+                    bslma::Allocator*          allocator);
+
+    // ACCESSORS
+
+    /// Print the json-encoded stats to the specified `out`.
+    /// If the specified `compact` flag is `true`, the json is printed in a
+    /// compact form, otherwise the json is printed in a pretty form.
+    /// Return `0` on success, and non-zero return code on failure.
+    ///
+    /// THREAD: This method is called in the *StatController scheduler* thread.
+    int printStats(bsl::string* out, bool compact) const;
+};
+
+inline JsonPrinterImpl::JsonPrinterImpl(const mqbcfg::StatsConfig& config,
+                                        const StatContextsMap& statContextsMap,
+                                        bslma::Allocator*      allocator)
+: d_config(config)
+, d_opsCompact(bdljsn::WriteOptions().setSpacesPerLevel(0).setStyle(
+      bdljsn::WriteStyle::e_COMPACT))
+, d_opsPretty(bdljsn::WriteOptions().setSpacesPerLevel(4).setStyle(
+      bdljsn::WriteStyle::e_PRETTY))
+, d_contexts(statContextsMap, allocator)
+{
+}
+
+inline void
+JsonPrinterImpl::populateQueueValues(bdljsn::JsonObject*       queueObject,
+                                     const mwcst::StatContext& ctx) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(queueObject);
+
+    static const bsl::vector<Stat::Enum> defs = {Stat::e_NB_PRODUCER,
+                                                 Stat::e_NB_CONSUMER,
+                                                 Stat::e_PUT_MESSAGES_DELTA,
+                                                 Stat::e_PUT_BYTES_DELTA,
+                                                 Stat::e_PUSH_MESSAGES_DELTA,
+                                                 Stat::e_PUSH_BYTES_DELTA,
+                                                 Stat::e_ACK_DELTA,
+                                                 Stat::e_ACK_TIME_AVG,
+                                                 Stat::e_ACK_TIME_MAX,
+                                                 Stat::e_NACK_DELTA,
+                                                 Stat::e_CONFIRM_DELTA,
+                                                 Stat::e_CONFIRM_TIME_AVG,
+                                                 Stat::e_CONFIRM_TIME_MAX};
+
+    if (ctx.numValues() > 0) {
+        bdljsn::JsonObject& values = (*queueObject)["values"].makeObject();
+
+        for (int i = 0; i < defs.size(); i++) {
+            Stat::Enum d = defs[i];
+
+            const bsls::Types::Int64 value =
+                mqbstat::QueueStatsDomain::getValue(ctx, -1, d);
+
+            values[Stat::toString(d)].makeNumber() = value;
+        }
+    }
+}
+
+inline void
+JsonPrinterImpl::populateQueueStats(bdljsn::JsonObject*       domainObject,
+                                    const mwcst::StatContext& ctx) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(domainObject);
+
+    for (mwcst::StatContextIterator queueIt = ctx.subcontextIterator();
+         queueIt;
+         ++queueIt) {
+        bdljsn::JsonObject& queueObj =
+            (*domainObject)[queueIt->name()].makeObject();
+        populateQueueValues(&queueObj, *queueIt);
+
+        if (queueIt->numSubcontexts() > 0) {
+            bdljsn::JsonObject& appIdsObject = queueObj["appIds"].makeObject();
+
+            // Add metrics per appId, if any
+            for (mwcst::StatContextIterator appIdIt =
+                     queueIt->subcontextIterator();
+                 appIdIt;
+                 ++appIdIt) {
+                // Do not expect another nested StatContext within appId
+                BSLS_ASSERT_SAFE(0 == appIdIt->numSubcontexts());
+
+                populateQueueValues(
+                    &appIdsObject[appIdIt->name()].makeObject(),
+                    *appIdIt);
+            }
+        }
+    }
+}
+
+inline void
+JsonPrinterImpl::populateDomainQueueStats(bdljsn::JsonObject*       parent,
+                                          const mwcst::StatContext& ctx) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(parent);
+
+    bdljsn::JsonObject& nodes = (*parent)["domains"].makeObject();
+    for (mwcst::StatContextIterator domainIt = ctx.subcontextIterator();
+         domainIt;
+         ++domainIt) {
+        populateQueueStats(&nodes[domainIt->name()].makeObject(), *domainIt);
+    }
+}
+
+inline int JsonPrinterImpl::printStats(bsl::string* out, bool compact) const
+{
+    // executed by *StatController scheduler* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(out);
+
+    bdljsn::Json        json;
+    bdljsn::JsonObject& obj = json.makeObject();
+
+    {
+        const mwcst::StatContext& ctx =
+            *d_contexts.find("domainQueues")->second;
+        bdljsn::JsonObject& domainQueuesObj = obj["domainQueues"].makeObject();
+
+        populateDomainQueueStats(&domainQueuesObj, ctx);
+    }
+
+    const bdljsn::WriteOptions& ops = compact ? d_opsCompact : d_opsPretty;
+
+    mwcu::MemOutStream os;
+    const int          rc = bdljsn::JsonUtil::write(os, json, ops);
+    if (0 != rc) {
+        BALL_LOG_ERROR << "failed to encode stats json, rc = " << rc;
+        return rc;  // RETURN
+    }
+    (*out) = os.str();
+    return 0;
+}
+
+}  // close unnamed namespace
+
+// -----------------
+// class JsonPrinter
+// -----------------
+
+JsonPrinter::JsonPrinter(const mqbcfg::StatsConfig& config,
+                         const StatContextsMap&     statContextsMap,
+                         bslma::Allocator*          allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_impl_mp(new (*d_allocator_p)
+                JsonPrinterImpl(config, statContextsMap, d_allocator_p),
+            d_allocator_p)
+{
+}
+
+int JsonPrinter::printStats(bsl::string* out, bool compact) const
+{
+    // executed by *StatController scheduler* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(out);
+    BSLS_ASSERT_SAFE(d_impl_mp);
+
+    return d_impl_mp->printStats(out, compact);
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
@@ -1,0 +1,101 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbstat_jsonprinter.h                                              -*-C++-*-
+#ifndef INCLUDED_MQBSTAT_JSONPRINTER
+#define INCLUDED_MQBSTAT_JSONPRINTER
+
+//@PURPOSE: Provide a mechanism to print statistics as a json
+//
+//@CLASSES:
+//  mqbstat::JsonPrinter: statistics printer to json
+//
+//@DESCRIPTION: 'mqbstat::JsonPrinter' handles the printing of the statistics
+// as a compact or pretty json.  It is responsible solely for printing, so any
+// statistics updates (e.g. making a new snapshot of the used StatContexts)
+// must be done before calling to this component.
+
+// MQB
+#include <mqbcfg_messages.h>
+
+// MWC
+#include <mwcst_statcontext.h>
+
+// BDE
+#include <bsl_string.h>
+#include <bsl_unordered_map.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+
+namespace BloombergLP {
+
+namespace mqbstat {
+
+// FORWARD DECLARATIONS
+namespace {
+class JsonPrinterImpl;
+}  // close unnamed namespace
+
+// =================
+// class JsonPrinter
+// =================
+
+class JsonPrinter {
+  private:
+    // PRIVATE TYPES
+    typedef bsl::unordered_map<bsl::string, mwcst::StatContext*>
+        StatContextsMap;
+
+  private:
+    // DATA
+    /// Allocator to use
+    bslma::Allocator* d_allocator_p;
+
+    /// Managed pointer to the printer implementation.
+    const bslma::ManagedPtr<JsonPrinterImpl> d_impl_mp;
+
+  private:
+    // NOT IMPLEMENTED
+    JsonPrinter(const JsonPrinter& other) BSLS_CPP11_DELETED;
+    JsonPrinter& operator=(const JsonPrinter& other) BSLS_CPP11_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(JsonPrinter, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a new `JsonPrinter` object, using the specified `config`,
+    /// `statContextsMap` and the specified `allocator`.
+    JsonPrinter(const mqbcfg::StatsConfig& config,
+                const StatContextsMap&     statContextsMap,
+                bslma::Allocator*          allocator);
+
+    // ACCESSORS
+
+    /// Print the json-encoded stats to the specified `out`.
+    /// If the specified `compact` flag is `true`, the json is printed in
+    /// compact form, otherwise the json is printed in pretty form.
+    /// Return `0` on success, and non-zero return code on failure.
+    ///
+    /// THREAD: This method is called in the *StatController scheduler* thread.
+    int printStats(bsl::string* out, bool compact) const;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
@@ -17,18 +17,15 @@
 #ifndef INCLUDED_MQBSTAT_JSONPRINTER
 #define INCLUDED_MQBSTAT_JSONPRINTER
 
-//@PURPOSE: Provide a mechanism to print statistics as a json
+//@PURPOSE: Provide a mechanism to print statistics as a JSON
 //
 //@CLASSES:
-//  mqbstat::JsonPrinter: statistics printer to json
+//  mqbstat::JsonPrinter: statistics printer to JSON
 //
 //@DESCRIPTION: 'mqbstat::JsonPrinter' handles the printing of the statistics
-// as a compact or pretty json.  It is responsible solely for printing, so any
+// as a compact or pretty JSON.  It is responsible solely for printing, so any
 // statistics updates (e.g. making a new snapshot of the used StatContexts)
 // must be done before calling to this component.
-
-// MQB
-#include <mqbcfg_messages.h>
 
 // MWC
 #include <mwcst_statcontext.h>
@@ -37,8 +34,6 @@
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bslma_allocator.h>
-#include <bslma_usesbslmaallocator.h>
-#include <bslmf_nestedtraitdeclaration.h>
 
 namespace BloombergLP {
 
@@ -55,17 +50,9 @@ class JsonPrinterImpl;
 
 class JsonPrinter {
   private:
-    // PRIVATE TYPES
-    typedef bsl::unordered_map<bsl::string, mwcst::StatContext*>
-        StatContextsMap;
-
-  private:
     // DATA
-    /// Allocator to use
-    bslma::Allocator* d_allocator_p;
-
     /// Managed pointer to the printer implementation.
-    const bslma::ManagedPtr<JsonPrinterImpl> d_impl_mp;
+    bslma::ManagedPtr<JsonPrinterImpl> d_impl_mp;
 
   private:
     // NOT IMPLEMENTED
@@ -73,22 +60,22 @@ class JsonPrinter {
     JsonPrinter& operator=(const JsonPrinter& other) BSLS_CPP11_DELETED;
 
   public:
-    // TRAITS
-    BSLMF_NESTED_TRAIT_DECLARATION(JsonPrinter, bslma::UsesBslmaAllocator)
+    // PUBLIC TYPES
+    typedef bsl::unordered_map<bsl::string, mwcst::StatContext*>
+        StatContextsMap;
 
     // CREATORS
 
-    /// Create a new `JsonPrinter` object, using the specified `config`,
-    /// `statContextsMap` and the specified `allocator`.
-    JsonPrinter(const mqbcfg::StatsConfig& config,
-                const StatContextsMap&     statContextsMap,
-                bslma::Allocator*          allocator);
+    /// Create a new `JsonPrinter` object, using the specified
+    /// `statContextsMap` and the optionally specified `allocator`.
+    explicit JsonPrinter(const StatContextsMap& statContextsMap,
+                         bslma::Allocator*      allocator = 0);
 
     // ACCESSORS
 
-    /// Print the json-encoded stats to the specified `out`.
-    /// If the specified `compact` flag is `true`, the json is printed in
-    /// compact form, otherwise the json is printed in pretty form.
+    /// Print the JSON-encoded stats to the specified `out`.
+    /// If the specified `compact` flag is `true`, the JSON is printed in
+    /// compact form, otherwise the JSON is printed in pretty form.
     /// Return `0` on success, and non-zero return code on failure.
     ///
     /// THREAD: This method is called in the *StatController scheduler* thread.

--- a/src/groups/mqb/mqbstat/mqbstat_printer.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.cpp
@@ -18,7 +18,6 @@
 
 #include <mqbscm_version.h>
 // MQB
-#include <mqbscm_versiontag.h>
 #include <mqbstat_queuestats.h>
 
 // MWC

--- a/src/groups/mqb/mqbstat/mqbstat_printer.h
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.h
@@ -127,10 +127,10 @@ class Printer {
     /// Create a new `Printer` object, using the specified `config`,
     /// `eventScheduler`, `statContextsMap` and the specified `allocator`
     /// for memory allocation.
-    Printer(const mqbcfg::StatsConfig& config,
-            bdlmt::EventScheduler*     eventScheduler,
-            const StatContextsMap&     statContextsMap,
-            bslma::Allocator*          allocator);
+    explicit Printer(const mqbcfg::StatsConfig& config,
+                     bdlmt::EventScheduler*     eventScheduler,
+                     const StatContextsMap&     statContextsMap,
+                     bslma::Allocator*          allocator);
 
     // MANIPULATORS
 

--- a/src/groups/mqb/mqbstat/mqbstat_printer.h
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.h
@@ -26,7 +26,6 @@
 // It holds the tables and table info providers which can be printed.
 
 // MQB
-
 #include <mqbcfg_messages.h>
 
 // MWC

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -284,6 +284,9 @@ QueueStatsDomain::getValue(const mwcst::StatContext& context,
 {
     // invoked from the SNAPSHOT thread
 
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(snapshotId >= -1);  // do not support other negatives yet
+
     const mwcst::StatValue::SnapshotLocation latestSnapshot(0, 0);
 
 #define OLDEST_SNAPSHOT(STAT)                                                 \

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -138,6 +138,10 @@ class QueueStatsDomain {
             e_NO_SC_MSGS_DELTA,
             e_NO_SC_MSGS_ABS
         };
+
+        /// Return the non-modifiable string description corresponding to
+        /// the specified enumeration `value`.
+        static const char* toString(Stat::Enum value);
     };
 
     struct Role {
@@ -198,7 +202,8 @@ class QueueStatsDomain {
     /// represented by its associated specified `context` as the difference
     /// between the latest snapshot-ed value (i.e., `snapshotId == 0`) and
     /// the value that was recorded at the specified `snapshotId` snapshots
-    /// ago.
+    /// ago.  Any negative `snapshotId` means that the oldest available
+    /// snapshot should be used.
     ///
     /// THREAD: This method can only be invoked from the `snapshot` thread.
     static bsls::Types::Int64 getValue(const mwcst::StatContext& context,

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -202,8 +202,8 @@ class QueueStatsDomain {
     /// represented by its associated specified `context` as the difference
     /// between the latest snapshot-ed value (i.e., `snapshotId == 0`) and
     /// the value that was recorded at the specified `snapshotId` snapshots
-    /// ago.  Any negative `snapshotId` means that the oldest available
-    /// snapshot should be used.
+    /// ago.  The negative `snapshotId == -1` means that the oldest available
+    /// snapshot should be used, while other negative values are not supported.
     ///
     /// THREAD: This method can only be invoked from the `snapshot` thread.
     static bsls::Types::Int64 getValue(const mwcst::StatContext& context,

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -46,6 +46,7 @@
 #include <ball_context.h>
 #include <ball_log.h>
 #include <ball_loggermanager.h>
+#include <ball_logthrottle.h>
 #include <bdlb_scopeexit.h>
 #include <bdlb_string.h>
 #include <bdlb_stringrefutil.h>
@@ -70,6 +71,13 @@ namespace BloombergLP {
 namespace mqbstat {
 
 namespace {
+
+const int k_MAX_INSTANT_MESSAGES = 1;
+// Maximum messages logged with throttling in a short period of time.
+
+const bsls::Types::Int64 k_NS_PER_MESSAGE = 15 *
+                                            bdlt::TimeUnitRatio::k_NS_PER_M;
+// Time interval between messages logged with throttling.
 
 const char k_PUBLISHINTERVAL_SUFFIX[] = ".PUBLISHINTERVAL";
 
@@ -233,26 +241,51 @@ void StatController::initializeStats()
             false)));
 }
 
-void StatController::captureStats(mqbcmd::StatResult* result)
+void StatController::captureStatsAndSemaphorePost(
+    mqbcmd::StatResult*                  result,
+    bslmt::Semaphore*                    semaphore,
+    const mqbcmd::EncodingFormat::Value& encoding)
 {
-    // This must execute in the *SCHEDULER* thread.
+    // executed by the *SCHEDULER* thread
 
     if (d_allocatorsStatContext_p) {
         // When using test allocator, we don't have a stat context
         d_allocatorsStatContext_p->snapshot();
     }
 
-    mwcu::MemOutStream os;
-    d_printer_mp->printStats(os);
-    result->makeStats(os.str());
-}
+    switch (encoding) {
+    case mqbcmd::EncodingFormat::TEXT: {
+        mwcu::MemOutStream os;
+        d_printer_mp->printStats(os);
+        result->makeStats() = os.str();
+    } break;  // BREAK
 
-void StatController::captureStatsAndSemaphorePost(mqbcmd::StatResult* result,
-                                                  bslmt::Semaphore* semaphore)
-{
-    // executed by the *SCHEDULER* thread
+    case mqbcmd::EncodingFormat::JSON_COMPACT: BSLS_ANNOTATION_FALLTHROUGH;
+    case mqbcmd::EncodingFormat::JSON_PRETTY: {
+        // Make an unscheduled snapshot, but do not notify stats consumers
+        // since it's not necessary
+        const bool savedNextSnapshot = snapshot();
+        if (savedNextSnapshot) {
+            const bool compact = (encoding ==
+                                  mqbcmd::EncodingFormat::JSON_COMPACT);
+            const int  rc = d_jsonPrinter_mp->printStats(&result->makeStats(),
+                                                        compact);
+            if (0 != rc) {
+                result->makeError().message() = "Stats print to json failed";
+            }
+        }
+        else {
+            result->makeError().message() =
+                "Cannot save the recent snapshot, trying to make snapshots "
+                "too often";
+        }
+    } break;  // BREAK
 
-    captureStats(result);
+    default: {
+        BSLS_ASSERT(!"invalid enumerator");
+    } break;  // BREAK
+    }
+
     semaphore->post();
 }
 
@@ -482,24 +515,20 @@ void StatController::listTunables(mqbcmd::StatResult* result,
     }
 }
 
-void StatController::snapshot()
+bool StatController::snapshot()
 {
     // executed by the *SCHEDULER* thread
+    const bsls::Types::Int64 now = mwcsys::Time::highResolutionTimer();
 
     // Safeguard against too frequent invocation from the scheduler.
-    const bsls::Types::Int64 now     = mwcsys::Time::highResolutionTimer();
-    const bsls::Types::Int64 nsDelta = now - d_lastSnapshotTime;
-    const bsls::Types::Int64 minDelta =
-        mqbcfg::BrokerConfig::get().stats().snapshotInterval() *
-        bdlt::TimeUnitRatio::k_NS_PER_S / 2;
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(nsDelta < minDelta)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        if (d_lastSnapshotLogLimiter.requestPermission()) {
-            BALL_LOG_INFO << "snapshot invoked too frequently (delta = "
-                          << mwcu::PrintUtil::prettyTimeInterval(nsDelta)
-                          << "), skipping snapshot";
-        }
-        return;  // RETURN
+    if (!d_snapshotThrottle.requestPermission()) {
+        const bsls::Types::Int64 nsDelta = now - d_lastSnapshotTime;
+        BALL_LOGTHROTTLE_WARN(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
+            << "[THROTTLED] Snapshot invoked too frequently (delta = "
+            << mwcu::PrintUtil::prettyTimeInterval(nsDelta)
+            << "), skipping snapshot";
+
+        return false;  // RETURN
     }
 
     d_lastSnapshotTime = now;
@@ -518,21 +547,36 @@ void StatController::snapshot()
     // through snapshot
     d_systemStatMonitor_mp->snapshot();
 
+    // Printer needs to be notified of every snapshot, but has an internal
+    // action counter to know when it's time to print.  Allocator stat context
+    // only has a history size of 2, so we need to snapshot only once, just
+    // before printing.
+    // TODO: adopt this code for `mqbstat::JsonPrinter` when we report
+    //       allocator stats in json
+    const bool willPrint = d_printer_mp->nextSnapshotWillPrint();
+    if (d_allocatorsStatContext_p && willPrint) {
+        d_allocatorsStatContext_p->snapshot();
+    }
+
+    return true;
+}
+
+void StatController::snapshotAndNotify()
+{
+    // executed by the *SCHEDULER* thread
+
+    if (!snapshot()) {
+        // Trying to make snapshots too often
+        return;  // RETURN
+    }
+
     // StatConsumers will report all stats
     bsl::vector<StatConsumerMp>::iterator it = d_statConsumers.begin();
     for (; it != d_statConsumers.end(); ++it) {
         (*it)->onSnapshot();
     }
 
-    // Printer needs to be notified of every snapshot, but has an internal
-    // action counter to know when it's time to print.  Allocator stat context
-    // only has an history size of 2, so we need to snapshot only once, just
-    // before printing.
     const bool willPrint = d_printer_mp->nextSnapshotWillPrint();
-    if (d_allocatorsStatContext_p && willPrint) {
-        d_allocatorsStatContext_p->snapshot();
-    }
-
     d_printer_mp->onSnapshot();
 
     // Finally, perform cleanup of expired stat contexts if we have printed
@@ -612,6 +656,7 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
 : d_allocators(allocator)
 , d_scheduler_mp(0)
 , d_lastSnapshotTime()
+, d_snapshotThrottle()
 , d_allocatorsStatContext_p(allocatorsStatContext)
 , d_statContextsMap(allocator)
 , d_statContextChannelsLocal_mp(0)
@@ -621,6 +666,7 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
 , d_bufferFactory_p(bufferFactory)
 , d_commandProcessorFn(bsl::allocator_arg, allocator, commandProcessor)
 , d_printer_mp(0)
+, d_jsonPrinter_mp(0)
 , d_statConsumers(allocator)
 , d_statConsumerMaxPublishInterval(0)
 , d_eventScheduler_p(eventScheduler)
@@ -630,9 +676,11 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
     BSLS_ASSERT_SAFE(eventScheduler->clockType() ==
                      bsls::SystemClockType::e_MONOTONIC);
 
-    d_lastSnapshotLogLimiter.initialize(1,
-                                        15 * bdlt::TimeUnitRatio::k_NS_PER_M);
-    // Throttling of one maximum alarm per 15 minutes
+    // Have to initialize the throttle with default "allow none" parameters to
+    // avoid possible undefined behaviour according to its usage contract.
+    // The throttle should be reinitialized during 'start()' with normal
+    // values.
+    d_snapshotThrottle.initialize(0, 1);
 }
 
 int StatController::start(bsl::ostream& errorDescription)
@@ -650,6 +698,13 @@ int StatController::start(bsl::ostream& errorDescription)
                       << "[reason: snapshotInterval is <= 0]";
         return 0;  // RETURN
     }
+
+    // Initialize the safeguard throttle against too often snapshots
+    const int k_MAX_SNAPSHOTS_PER_INTERVAL = 4;
+    d_snapshotThrottle.initialize(k_MAX_SNAPSHOTS_PER_INTERVAL,
+                                  brkrCfg.stats().snapshotInterval() *
+                                      bdlt::TimeUnitRatio::k_NS_PER_S /
+                                      k_MAX_SNAPSHOTS_PER_INTERVAL);
 
     // Start the scheduler
     d_scheduler_mp.load(new (*d_allocator_p) bdlmt::TimerEventScheduler(
@@ -784,6 +839,12 @@ int StatController::start(bsl::ostream& errorDescription)
         errorStream.reset();
     }
 
+    // Start the json printer
+    d_jsonPrinter_mp.load(
+        new (*d_allocator_p)
+            JsonPrinter(brkrCfg.stats(), ctxPtrMap, d_allocator_p),
+        d_allocator_p);
+
     // Max value for the stat publish interval must be the minimum history size
     // of all stat contexts.
     d_statConsumerMaxPublishInterval =
@@ -793,7 +854,7 @@ int StatController::start(bsl::ostream& errorDescription)
     // Start the clock
     d_scheduler_mp->startClock(
         bsls::TimeInterval(brkrCfg.stats().snapshotInterval()),
-        bdlf::BindUtil::bind(&StatController::snapshot, this));
+        bdlf::BindUtil::bind(&StatController::snapshotAndNotify, this));
     BALL_LOG_INFO << "Starting statistics  [SnapshotInterval: "
                   << brkrCfg.stats().snapshotInterval() << ", PrintInterval: "
                   << brkrCfg.stats().printer().printInterval() << "]";
@@ -834,6 +895,7 @@ void StatController::stop()
         DESTROY_OBJ((*it), it->name());
     }
     DESTROY_OBJ(d_printer_mp, "Printer");
+    DESTROY_OBJ(d_jsonPrinter_mp, "JsonPrinter");
     DESTROY_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");
     DESTROY_OBJ(d_scheduler_mp, "Scheduler");
 
@@ -852,8 +914,10 @@ void StatController::loadStatContexts(StatContexts* contexts)
     }
 }
 
-int StatController::processCommand(mqbcmd::StatResult*        result,
-                                   const mqbcmd::StatCommand& command)
+int StatController::processCommand(
+    mqbcmd::StatResult*                  result,
+    const mqbcmd::StatCommand&           command,
+    const mqbcmd::EncodingFormat::Value& encoding)
 {
     if (command.isShowValue()) {
         bslmt::Semaphore semaphore;
@@ -862,7 +926,8 @@ int StatController::processCommand(mqbcmd::StatResult*        result,
             bdlf::BindUtil::bind(&StatController::captureStatsAndSemaphorePost,
                                  this,
                                  result,
-                                 &semaphore));
+                                 &semaphore,
+                                 encoding));
         semaphore.wait();
         return 0;  // RETURN
     }

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -230,7 +230,11 @@ class StatController {
     void initializeStats();
 
     /// Capture the stats to the specified `result`' object and post on the
-    /// specified `semaphore` once done.
+    /// specified `semaphore` once done.  The specified `encoding` parameter
+    /// controls whether the result should be in a text format or in a JSON.
+    /// Note that the JSON format is typically used within integration tests
+    /// so we make an out of order stats snapshot when compact or pretty JSON
+    /// encoding is passed.
     void captureStatsAndSemaphorePost(
         mqbcmd::StatResult*                  result,
         bslmt::Semaphore*                    semaphore,
@@ -309,9 +313,10 @@ class StatController {
     /// (allocators, systems, domainQueues, clients, ...).
     void loadStatContexts(StatContexts* contexts);
 
-    /// Process the specified `command`, and write the result to the
-    /// `result`' object.  Return zero on success or a nonzero value
-    /// otherwise.
+    /// Process the specified `command`, and write the result to the `result`
+    /// object.  Return zero on success or a nonzero value otherwise.
+    /// The specified `encoding` parameter controls whether the result should
+    /// be in a text format or in a JSON.
     int processCommand(mqbcmd::StatResult*                  result,
                        const mqbcmd::StatCommand&           command,
                        const mqbcmd::EncodingFormat::Value& encoding);

--- a/src/groups/mqb/mqbstat/package/mqbstat.mem
+++ b/src/groups/mqb/mqbstat/package/mqbstat.mem
@@ -1,6 +1,7 @@
 mqbstat_brokerstats
 mqbstat_clusterstats
 mqbstat_domainstats
+mqbstat_jsonprinter
 mqbstat_printer
 mqbstat_queuestats
 mqbstat_statcontroller

--- a/src/groups/mwc/mwcst/mwcst_statvalue.h
+++ b/src/groups/mwc/mwcst/mwcst_statvalue.h
@@ -339,7 +339,7 @@ class StatValue {
     /// Return the snapshot referred to by the specified `location`.  The
     /// behavior is undefined unless
     /// `location.level() < numLevels()` and
-    /// `location.index() <= historySize(location.level())`
+    /// `location.index() < historySize(location.level())`
     const Snapshot& snapshot(const SnapshotLocation& location) const;
 
     /// Return the minimum value of this StatValue since creation.

--- a/src/integration-tests/test_appids.py
+++ b/src/integration-tests/test_appids.py
@@ -508,7 +508,7 @@ def test_unauthorization(cluster: Cluster):
 
 
 def test_two_consumers_of_unauthorized_app(multi_node: Cluster):
-    """DRQS 167201621: First client open authorized and unauthorized apps;
+    """Ticket 167201621: First client open authorized and unauthorized apps;
     second client opens unauthorized app.
     Then, primary shuts down causing replica to issue wildcard close
     requests to primary.

--- a/src/integration-tests/test_breathing.py
+++ b/src/integration-tests/test_breathing.py
@@ -523,7 +523,7 @@ def test_verify_broadcast(cluster: Cluster):
 def test_verify_redelivery(cluster: Cluster):
     """Drop one consumer having unconfirmed message while there is another
     consumer unable to take the message (due to max_unconfirmed_messages
-    limit).  Then start new consumer and make sure it does not crash (DRQS
+    limit).  Then start new consumer and make sure it does not crash (Ticket
     156808957) and receives that unconfirmed message.
     """
     proxies = cluster.proxy_cycle()

--- a/src/integration-tests/test_graceful_shutdown.py
+++ b/src/integration-tests/test_graceful_shutdown.py
@@ -110,7 +110,7 @@ class TestGracefulShutdown:
 
         assert wait_until(lambda: num_broker_messages() == 3, 3)
 
-        # DRQS 168471730.   Downstream should update its opened subIds upon
+        # Ticket 168471730.   Downstream should update its opened subIds upon
         # closing and not attempt to deconfigure it upon StopRequest
         self.producer.close(tc.URI_FANOUT, block=True)
 
@@ -339,7 +339,7 @@ class TestGracefulShutdown:
     @tweak.cluster.queue_operations.shutdown_timeout_ms(999999)
     def test_active_node_down_stop_requests(self, multi_cluster: Cluster):
         """
-        DRQS 169782591
+        Ticket 169782591
         We have: Consumer -> Proxy -> active_node -> upstream_node.
         Start shutting down active_node (one of cluster.virtual_nodes())
         Because there are unconfirmed, Proxy lingers with StopResponse.

--- a/src/integration-tests/test_queue_close.py
+++ b/src/integration-tests/test_queue_close.py
@@ -52,7 +52,7 @@ def test_close_queue(single_node: Cluster):
 @start_cluster(False)
 def test_close_while_reopening(multi_node: Cluster):
     """
-    DRQS 169125974.  Closing queue while reopen response is pending should
+    Ticket 169125974.  Closing queue while reopen response is pending should
     not result in a dangling handle.
     """
 
@@ -116,7 +116,7 @@ def test_close_while_reopening(multi_node: Cluster):
 
 def test_close_open(multi_node: Cluster):
     """
-    DRQS 169326671.  Close, followed by Open with a different subId.
+    Ticket 169326671.  Close, followed by Open with a different subId.
     """
     proxies = multi_node.proxy_cycle()
     # pick proxy in datacenter opposite to the primary's
@@ -140,7 +140,7 @@ def test_close_open(multi_node: Cluster):
 @tweak.cluster.queue_operations.reopen_retry_interval_ms(1234)
 def test_close_while_retrying_reopen(multi_node: Cluster):
     """
-    DRQS 170043950.  Trigger reopen failure causing proxy to retry on
+    Ticket 170043950.  Trigger reopen failure causing proxy to retry on
     timeout. While waiting, close the queue and make sure, the retry
     accounts for that close.
     """

--- a/src/integration-tests/test_queue_reopen.py
+++ b/src/integration-tests/test_queue_reopen.py
@@ -66,7 +66,7 @@ def test_reopen_empty_queue(multi_node: Cluster):
 
 def test_reopen_substream(multi_node: Cluster):
     """
-    DRQS 169527537.  Make a primary's client reopen the same appId with a
+    Ticket 169527537.  Make a primary's client reopen the same appId with a
     different subId.
     """
 

--- a/src/integration-tests/test_subscriptions.py
+++ b/src/integration-tests/test_subscriptions.py
@@ -1454,7 +1454,7 @@ def test_no_capacity_all_optimization(cluster: Cluster):
     Test: delivery optimization works during routing when all subscriptions
     have no capacity.
 
-    DRQS  171509204
+    Ticket 171509204
 
     - Create 1 producer / 3 consumers: C1, C2, C3.
     - Consumers: max_unconfirmed_messages = 1.
@@ -1557,7 +1557,7 @@ def test_no_capacity_all_fanout(cluster: Cluster):
     Test: delivery optimization encountered with one app does not affect
     other apps.
 
-    DRQS  171509204
+    Ticket 171509204
 
     - Create 1 producer / 2 consumers: C_foo, C_bar.
     - C_foo: max_unconfirmed_messages = 128.

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -535,6 +535,7 @@ class Proto:
                     ),
                 ),
                 stats=mqbcfg.StatsConfig(
+                    app_id_tag_domains=[],
                     plugins=[],
                     snapshot_interval=1,
                     printer=mqbcfg.StatsPrinterConfig(

--- a/src/python/blazingmq/dev/it/data/README.md
+++ b/src/python/blazingmq/dev/it/data/README.md
@@ -1,0 +1,5 @@
+# Integration Tests Additional Data
+
+This directory contains additional data used by integration tests.
+What could be a data:
+- Structs too large to define in ITs scripts, for readability concerns.

--- a/src/python/blazingmq/dev/it/data/__init__.py
+++ b/src/python/blazingmq/dev/it/data/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2024 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/python/blazingmq/dev/it/data/data_metrics.py
+++ b/src/python/blazingmq/dev/it/data/data_metrics.py
@@ -1,0 +1,200 @@
+# Copyright 2024 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Additional data for metrics-related integration tests.
+
+Note: currently these tests are placed in 'test_admin_client.py' tests block, but
+      might be moved to their separate source file if we add more of them.
+
+Note: when the metrics collection evolves, it might be necessary to update
+      the data structures in this source. To do so, it's possible to copy values
+      observed in the debugger for the specific test and paste them as a dictionary,
+      while replacing non-fixed parameters such as time intervals with a
+      condition placeholders (see 'GreaterThan').
+"""
+
+
+from typing import Any
+
+
+class ValueConstraint:
+    """The base class for non-fixed values in a data."""
+
+    def check(self, value: Any) -> bool:
+        """Return 'True' if the specified 'value' satisfy the checked constraint.
+        The caller is responsible for deciding what to do next, e.g. raising an assert.
+        """
+        ...
+
+
+class GreaterThan(ValueConstraint):
+    """This constraint checks if the provided value is greater than the set constraint."""
+
+    def __init__(self, constraint: Any) -> None:
+        self._constraint = constraint
+
+    def check(self, value: Any) -> bool:
+        """Check if the specified 'value' is greater than the stored '_constraint'."""
+        return self._constraint < value
+
+
+TEST_QUEUE_STATS_AFTER_POST = {
+    "appIds": {
+        "bar": {
+            "values": {
+                "queue_confirm_time_max": 0,
+                "queue_confirm_time_avg": 0,
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+        "baz": {
+            "values": {
+                "queue_confirm_time_max": 0,
+                "queue_confirm_time_avg": 0,
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+        "foo": {
+            "values": {
+                "queue_confirm_time_max": 0,
+                "queue_confirm_time_avg": 0,
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+    },
+    "values": {
+        "queue_confirm_time_max": 0,
+        "queue_confirm_time_avg": 0,
+        "queue_nack_msgs": 0,
+        "queue_ack_time_max": GreaterThan(0),
+        "queue_ack_msgs": 32,
+        "queue_confirm_msgs": 0,
+        "queue_push_bytes": 0,
+        "queue_consumers_count": 0,
+        "queue_producers_count": 0,
+        "queue_push_msgs": 0,
+        "queue_ack_time_avg": GreaterThan(0),
+        "queue_put_bytes": 96,
+        "queue_put_msgs": 32,
+    },
+}
+
+TEST_QUEUE_STATS_AFTER_CONFIRM = {
+    "appIds": {
+        "bar": {
+            "values": {
+                "queue_confirm_time_max": GreaterThan(0),
+                "queue_confirm_time_avg": GreaterThan(0),
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+        "baz": {
+            "values": {
+                "queue_confirm_time_max": GreaterThan(0),
+                "queue_confirm_time_avg": GreaterThan(0),
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+        "foo": {
+            "values": {
+                "queue_confirm_time_max": GreaterThan(0),
+                "queue_confirm_time_avg": GreaterThan(0),
+                "queue_nack_msgs": 0,
+                "queue_ack_time_max": 0,
+                "queue_ack_msgs": 0,
+                "queue_confirm_msgs": 0,
+                "queue_push_bytes": 0,
+                "queue_consumers_count": 0,
+                "queue_producers_count": 0,
+                "queue_push_msgs": 0,
+                "queue_ack_time_avg": 0,
+                "queue_put_bytes": 0,
+                "queue_put_msgs": 0,
+            }
+        },
+    },
+    "values": {
+        "queue_confirm_time_max": GreaterThan(0),
+        "queue_confirm_time_avg": GreaterThan(0),
+        "queue_nack_msgs": 0,
+        "queue_ack_time_max": GreaterThan(0),
+        "queue_ack_msgs": 32,
+        "queue_confirm_msgs": 65,
+        "queue_push_bytes": 288,
+        "queue_consumers_count": 3,
+        "queue_producers_count": 0,
+        "queue_push_msgs": 96,
+        "queue_ack_time_avg": GreaterThan(0),
+        "queue_put_bytes": 96,
+        "queue_put_msgs": 32,
+    },
+}
+
+TEST_QUEUE_STATS_TOO_OFTEN_SNAPSHOTS = {
+    "error": {
+        "message": "Cannot save the recent snapshot, trying to make snapshots too often"
+    }
+}

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -157,7 +157,14 @@ class Client(blazingmq.dev.it.process.bmqproc.BMQProcess):
         return res.error_code
 
     def open(
-        self, uri, flags, block=None, succeed=None, no_except=None, timeout=None, **kw
+        self,
+        uri,
+        flags: List[str],
+        block=None,
+        succeed=None,
+        no_except=None,
+        timeout=None,
+        **kw,
     ):
         """
         Open the queue with the specified 'uri' and the specified 'flags'.  If

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -407,6 +407,12 @@ class TweakFactory:
             dispatcher_config = DispatcherConfig()
 
             class Stats(metaclass=TweakMetaclass):
+                class AppIdTagDomains(metaclass=TweakMetaclass):
+                    def __call__(self, value: None) -> Callable:
+                        ...
+
+                app_id_tag_domains = AppIdTagDomains()
+
                 class SnapshotInterval(metaclass=TweakMetaclass):
                     def __call__(self, value: int) -> Callable:
                         ...

--- a/src/python/blazingmq/schemas/mqbcfg.py
+++ b/src/python/blazingmq/schemas/mqbcfg.py
@@ -1776,6 +1776,16 @@ class ClusterProxyDefinition:
 
 @dataclass
 class StatsConfig:
+    app_id_tag_domains: List[str] = field(
+        default_factory=list,
+        metadata={
+            "name": "appIdTagDomains",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "min_occurs": 1,
+            "required": True,
+        },
+    )
     snapshot_interval: int = field(
         default=1,
         metadata={


### PR DESCRIPTION
Changes:
- `mqbstat`: introduce a new component `JsonPrinter` responsible for printing stats from the registered stat context snapshots as a pretty or compact json. This component is used only during admin command processing from the `mqbstat::StatController` scheduler thread.
- `mqbstat::StatController`: split `snapshot()` into 2 separate functions: `snapshot()` (which just makes snapshot but doesn't notify the registered stat consumers) and `snapshotAndNotify()` (which does both). Now we schedule `snapshotAndNotify()` as a periodic event, not the `snapshot()`.
- `mqbstat::StatController`: remove unnecessary `captureStats` and extend `captureStatsAndSemaphorePost` instead. This function supports the old unchanged code path with text stats request (which doesn't make an unscheduled snapshot) and also a new code path to request the json with the recent stats (it makes an out-of-order snapshot).
- `mqbstat::StatController`: rework the too-often snapshot safeguard to use `bslmt::Throttle`.
- `mqbstat::StatController::snapshot`: add a bool return code to notify if the snapshot attempt was successful or the snapshot was throttled due to too often invocations.
- `mqba::Application`: pass the encoding options to the `mqbstat::StatController` on admin command.
- `mqbstat::QueueStats::getValue`: add the ability to access the oldest snapshot by passing a negative `snapshotId`. This makes the API easier and closer to python data containers where you can specify something like `data[-1]` to access the last element even without knowing the exact size of a container.
- `mqbstat::QueueStatsDomain`: add `toString` converter with values synced with the prometheus plugin metric names.
- ITs: add missing broker property `appIdTagDomains` which allows per-appId metrics and regenerate tweaks.
- ITs: add a new integration test `test_stats` which tests per-appId metrics from the broker and also checks the safeguard mechanism.
- Docs: fix comments and documentation, cleanup.