### PR TITLE
CI: build and run C++ UTs in a separate step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get dependencies hash
         id: get-hash
-        run: echo "deps_hash=`cat blazingmq/docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
+        run: echo "deps_hash=`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
       - name: Cache lookup
         uses: actions/cache/restore@v4
         id: cache-lookup
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get dependencies hash
         id: get-hash
-        run: echo "deps_hash=`cat blazingmq/docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
+        run: echo "deps_hash=`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
       - uses: actions/cache/restore@v4
         with:
           path: deps
@@ -102,16 +102,11 @@ jobs:
             -DBDE_BUILD_TARGET_CPP17=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
-          cmake --build build/blazingmq --parallel 8 --target all all.t
-      - name: Run C++ Unit Tests
-        run: |
-          cd ${{ github.workspace }}/build/blazingmq
-          ctest -E mwcsys_executil.t --output-on-failure
+          cmake --build build/blazingmq --parallel 8 --target all
       - name: Clean-up build directories before caching
         run: |
           find . -name "*.o" -type f -delete
           find . -name "*.a" -type f -delete
-          find . -name "*.t.tsk" -type f -delete
       - uses: actions/cache@v4
         with:
           path: |
@@ -120,7 +115,57 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
-  unit_tests_ubuntu:
+  unit_tests_cxx:
+    name: UT [c++]
+    runs-on: ubuntu-latest
+    needs: build_dependencies
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get dependencies hash
+        id: get-hash
+        run: echo "deps_hash=`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
+      - uses: actions/cache/restore@v4
+        with:
+          path: deps
+          key: deps-${{ steps.get-hash.outputs.deps_hash }}
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy build-essential \
+            gdb \
+            curl \
+            python3.10 \
+            python3-pip \
+            cmake \
+            ninja-build \
+            pkg-config \
+            bison \
+            libfl-dev \
+            libbenchmark-dev \
+            libgmock-dev \
+            libz-dev
+      - name: Install cached non packaged dependencies
+        working-directory: deps
+        run: ../docker/build_deps.sh
+      - name: Build BlazingMQ UTs
+        env:
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+        run: |
+          cmake -S . -B build/blazingmq -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBDE_BUILD_TARGET_SAFE=ON \
+            -DBDE_BUILD_TARGET_64=ON \
+            -DBDE_BUILD_TARGET_CPP17=ON \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
+            -DCMAKE_INSTALL_LIBDIR=lib64
+          cmake --build build/blazingmq --parallel 8 --target all.t
+      - name: Run C++ Unit Tests
+        run: |
+          cd ${{ github.workspace }}/build/blazingmq
+          ctest -E mwcsys_executil.t --output-on-failure
+
+  unit_tests_python:
     name: UT [python]
     runs-on: ubuntu-latest
     needs: build_ubuntu
@@ -198,7 +243,6 @@ jobs:
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
           cd src/python
           python3 -m blazingmq.dev.fuzztest --broker-dir ${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr --request ${{ matrix.request }}
-
 
   build_macosx:
     name: Build [macosx_${{ matrix.arch }}]

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -30,7 +30,7 @@ fetch_git() {
 fetch_deps() {
     fetch_git bloomberg bde-tools 4.8.0.0
     fetch_git bloomberg bde 4.8.0.0
-    fetch_git bloomberg ntf-core latest
+    fetch_git bloomberg ntf-core 2.4.2
 }
 
 configure() {


### PR DESCRIPTION
CI:
- Fix incorrect path to file causing hash evaluation error.
- Pin `ntf-core` version in `build-deps.sh` to prevent hash collisions causing `ntf-core` rebuild even on cache hit.
- Extract UTs build from the main broker build step, to speed up the CI. Some later steps are depend only on the broker/tool, so it's not necessary to wait for all UTs to link and run to launch these tests

Future work: extract packages install and project configuration to reusable workflow and reference it instead of copy-pasting the same.