### PR TITLE
Fix weak-vtables compiler warnings

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.cpp
@@ -1,0 +1,32 @@
+// Copyright 2014-2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqstoragetool
+#include <m_bmqstoragetool_commandprocessor.h>
+
+namespace BloombergLP {
+namespace m_bmqstoragetool {
+
+// ----------------------
+// class CommandProcessor
+// ----------------------
+
+CommandProcessor::~CommandProcessor()
+{
+    // NOTHING
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_commandprocessor.h
@@ -45,7 +45,7 @@ class CommandProcessor {
     /// Default constructor.
     CommandProcessor() {}
 
-    virtual ~CommandProcessor() {}
+    virtual ~CommandProcessor();
 
     // MANIPULATORS
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -59,6 +59,15 @@ void closeLedger(mqbsl::Ledger* ledger)
 
 }  // close unnamed namespace
 
+// ==============================
+// class FileManager::FileHandler
+// ==============================
+
+FileManager::~FileManager()
+{
+    // NOTHING
+}
+
 // =====================
 // class FileManagerImpl
 // =====================

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.h
@@ -54,7 +54,7 @@ class FileManager {
     virtual mqbs::JournalFileIterator* journalFileIterator() = 0;
     virtual mqbs::DataFileIterator*    dataFileIterator()    = 0;
 
-    virtual ~FileManager() {}
+    virtual ~FileManager();
 };
 
 class FileManagerImpl : public FileManager {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -180,6 +180,15 @@ void outputFooter(bsl::ostream& ostream, bsl::size_t foundMessagesCount)
 
 }  // close unnamed namespace
 
+// ==================
+// class SearchResult
+// ==================
+
+SearchResult::~SearchResult()
+{
+    // NOTHING
+}
+
 // ===========================
 // class SearchResultDecorator
 // ===========================

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -86,7 +86,7 @@ class SearchResult {
     // CREATORS
 
     /// Destructor
-    virtual ~SearchResult() {}
+    virtual ~SearchResult();
 
     // MANIPULATORS
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -139,6 +139,15 @@ bool SimpleEvaluator::evaluate(EvaluationContext& context) const
     return value.theBoolean();
 }
 
+// ---------------------------------
+// class SimpleEvaluator::Expression
+// ---------------------------------
+
+SimpleEvaluator::Expression::~Expression()
+{
+    // NOTHING
+}
+
 // -------------------------------
 // class SimpleEvaluator::Property
 // -------------------------------

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -140,7 +140,7 @@ class SimpleEvaluator {
     /// derived.
     class Expression {
       public:
-        virtual ~Expression() {}
+        virtual ~Expression();
 
         /// Evaluate a Expression.
         virtual bdld::Datum evaluate(EvaluationContext& context) const = 0;


### PR DESCRIPTION
Moving empty destructors from class definitions into `.cpp` files to fix warnings like:

```
/blazingmq/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h:141:11: warning: 'Expression' has no out-of-line virtual method definitions; its vtable will be emitted in every translation unit [-Wweak-vtables]
    class Expression {
 ```