### PR TITLE
CI: use the latest black formatter version

### DIFF
--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - name: black style check
         run: |
-          sudo apt-get install -y python3.10 python3-pip
+          sudo apt-get install -y python3.12 python3-pip
           pip3 install git+https://github.com/psf/black
           black .
           git diff -q | tee format_diff.txt

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -34,10 +34,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0    
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: black style check
         run: |
-          sudo apt-get install -y python3.12 python3-pip
+          sudo apt-get install -y python3-pip
           pip3 install git+https://github.com/psf/black
           black .
           git diff -q | tee format_diff.txt

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -39,8 +39,6 @@ jobs:
         run: |
           sudo apt install -y python3.10 python3-pip
           pip3 install git+https://github.com/psf/black
-          black --version
           black .
-          cat src/python/blazingmq/dev/it/tweaks/generated.py
           git diff -q | tee format_diff.txt
           if [ -s format_diff.txt ]; then exit 1; fi

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -37,7 +37,9 @@ jobs:
           fetch-depth: 0
       - name: black style check
         run: |
-          sudo apt-get install black
+          sudo apt install -y python3.10 python3-pip
+          pip3 install git+https://github.com/psf/black
+          black --version
           black .
           git diff -q | tee format_diff.txt
           if [ -s format_diff.txt ]; then exit 1; fi

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - name: black style check
         run: |
-          sudo apt install -y python3.10 python3-pip
+          sudo apt-get install -y python3.10 python3-pip
           pip3 install git+https://github.com/psf/black
           black .
           git diff -q | tee format_diff.txt

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -41,5 +41,6 @@ jobs:
           pip3 install git+https://github.com/psf/black
           black --version
           black .
+          cat src/python/blazingmq/dev/it/tweaks/generated.py
           git diff -q | tee format_diff.txt
           if [ -s format_diff.txt ]; then exit 1; fi

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0    
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -40,7 +40,6 @@ jobs:
           python-version: '3.12'
       - name: black style check
         run: |
-          sudo apt-get install -y python3-pip
           pip3 install git+https://github.com/psf/black
           black .
           git diff -q | tee format_diff.txt

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -355,32 +355,28 @@ class Site(abc.ABC):
     configurator: "Configurator"
 
     @abc.abstractmethod
-    def __str__(self) -> str:
-        ...
+    def __str__(self) -> str: ...
 
     @abc.abstractmethod
-    def install(self, from_path: Union[str, Path], to_path: Union[str, Path]) -> None:
-        ...
+    def install(
+        self, from_path: Union[str, Path], to_path: Union[str, Path]
+    ) -> None: ...
 
     @abc.abstractmethod
-    def create_file(self, path: Union[str, Path], content: str, mode=None) -> None:
-        ...
+    def create_file(self, path: Union[str, Path], content: str, mode=None) -> None: ...
 
     @abc.abstractmethod
-    def mkdir(self, path: Union[str, Path]) -> None:
-        ...
+    def mkdir(self, path: Union[str, Path]) -> None: ...
 
     @abc.abstractmethod
-    def rmdir(self, path: Union[str, Path]) -> None:
-        ...
+    def rmdir(self, path: Union[str, Path]) -> None: ...
 
     @abc.abstractmethod
     def create_json_file(
         self,
         path: Union[str, Path],
         content,
-    ) -> None:
-        ...
+    ) -> None: ...
 
 
 def _cluster_definition_partial_prototype(partition_config: mqbcfg.PartitionConfig):

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -98,9 +98,7 @@ class TweakFactory:
                 logging_verbosity = LoggingVerbosity()
 
                 class BslsLogSeverityThreshold(metaclass=TweakMetaclass):
-                    def __call__(
-                        self, value: str
-                    ) -> Callable: ...
+                    def __call__(self, value: str) -> Callable: ...
 
                 bsls_log_severity_threshold = BslsLogSeverityThreshold()
 
@@ -169,65 +167,47 @@ class TweakFactory:
 
         class AppConfig(metaclass=TweakMetaclass):
             class BrokerInstanceName(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[str, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             broker_instance_name = BrokerInstanceName()
 
             class BrokerVersion(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[int, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             broker_version = BrokerVersion()
 
             class ConfigVersion(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[int, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             config_version = ConfigVersion()
 
             class EtcDir(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[str, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             etc_dir = EtcDir()
 
             class HostName(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[str, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_name = HostName()
 
             class HostTags(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[str, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_tags = HostTags()
 
             class HostDataCenter(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[str, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_data_center = HostDataCenter()
 
             class IsRunningOnDev(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[bool, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[bool, NoneType]) -> Callable: ...
 
             is_running_on_dev = IsRunningOnDev()
 
             class LogsObserverMaxSize(metaclass=TweakMetaclass):
-                def __call__(
-                    self, value: typing.Union[int, NoneType]
-                ) -> Callable: ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             logs_observer_max_size = LogsObserverMaxSize()
 
@@ -498,14 +478,12 @@ class TweakFactory:
                     max_age_days = MaxAgeDays()
 
                     class RotateBytes(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     rotate_bytes = RotateBytes()
 
                     class RotateDays(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     rotate_days = RotateDays()
 
@@ -514,42 +492,36 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.StatsPrinterConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 printer = Printer()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbcfg.StatsConfig, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             stats = Stats()
 
             class NetworkInterfaces(metaclass=TweakMetaclass):
                 class Heartbeats(metaclass=TweakMetaclass):
                     class Client(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     client = Client()
 
                     class DownstreamBroker(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     downstream_broker = DownstreamBroker()
 
                     class UpstreamBroker(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     upstream_broker = UpstreamBroker()
 
                     class ClusterPeer(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     cluster_peer = ClusterPeer()
 
@@ -558,8 +530,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.Heartbeat, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 heartbeats = Heartbeats()
 
@@ -567,70 +538,60 @@ class TweakFactory:
                     class Name(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     name = Name()
 
                     class Port(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     port = Port()
 
                     class IoThreads(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     io_threads = IoThreads()
 
                     class MaxConnections(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     max_connections = MaxConnections()
 
                     class LowWatermark(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     low_watermark = LowWatermark()
 
                     class HighWatermark(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     high_watermark = HighWatermark()
 
                     class NodeLowWatermark(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     node_low_watermark = NodeLowWatermark()
 
                     class NodeHighWatermark(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     node_high_watermark = NodeHighWatermark()
 
                     class HeartbeatIntervalMs(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     heartbeat_interval_ms = HeartbeatIntervalMs()
 
                     class UseNtf(metaclass=TweakMetaclass):
-                        def __call__(self, value: bool) -> Callable:
-                            ...
+                        def __call__(self, value: bool) -> Callable: ...
 
                     use_ntf = UseNtf()
 
@@ -639,8 +600,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.TcpInterfaceConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 tcp_interface = TcpInterface()
 
@@ -649,15 +609,15 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.NetworkInterfaces, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             network_interfaces = NetworkInterfaces()
 
             class BmqconfConfig(metaclass=TweakMetaclass):
                 class CacheTtlseconds(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 cache_ttlseconds = CacheTtlseconds()
 
@@ -666,48 +626,41 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.BmqconfConfig, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             bmqconf_config = BmqconfConfig()
 
             class Plugins(metaclass=TweakMetaclass):
                 class Libraries(metaclass=TweakMetaclass):
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 libraries = Libraries()
 
                 class Enabled(metaclass=TweakMetaclass):
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 enabled = Enabled()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbcfg.Plugins, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             plugins = Plugins()
 
             class MessagePropertiesV2(metaclass=TweakMetaclass):
                 class AdvertiseV2Support(metaclass=TweakMetaclass):
-                    def __call__(self, value: bool) -> Callable:
-                        ...
+                    def __call__(self, value: bool) -> Callable: ...
 
                 advertise_v2_support = AdvertiseV2Support()
 
                 class MinCppSdkVersion(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 min_cpp_sdk_version = MinCppSdkVersion()
 
                 class MinJavaSdkVersion(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 min_java_sdk_version = MinJavaSdkVersion()
 
@@ -716,36 +669,31 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.MessagePropertiesV2, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             message_properties_v2 = MessagePropertiesV2()
 
             class ConfigureStream(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             configure_stream = ConfigureStream()
 
             def __call__(
                 self, value: typing.Union[blazingmq.schemas.mqbcfg.AppConfig, NoneType]
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         app_config = AppConfig()
 
     class Domain:
         class Name(metaclass=TweakMetaclass):
-            def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                ...
+            def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
         name = Name()
 
         class Mode(metaclass=TweakMetaclass):
             class Fanout(metaclass=TweakMetaclass):
                 class AppIds(metaclass=TweakMetaclass):
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 app_ids = AppIds()
 
@@ -754,8 +702,7 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbconf.QueueModeFanout, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             fanout = Fanout()
 
@@ -765,8 +712,7 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbconf.QueueModePriority, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             priority = Priority()
 
@@ -776,82 +722,78 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbconf.QueueModeBroadcast, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             broadcast = Broadcast()
 
             def __call__(
                 self, value: typing.Union[blazingmq.schemas.mqbconf.QueueMode, NoneType]
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         mode = Mode()
 
         class Storage(metaclass=TweakMetaclass):
             class DomainLimits(metaclass=TweakMetaclass):
                 class Messages(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 messages = Messages()
 
                 class MessagesWatermarkRatio(metaclass=TweakMetaclass):
-                    def __call__(self, value: decimal.Decimal) -> Callable:
-                        ...
+                    def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 messages_watermark_ratio = MessagesWatermarkRatio()
 
                 class Bytes(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 bytes = Bytes()
 
                 class BytesWatermarkRatio(metaclass=TweakMetaclass):
-                    def __call__(self, value: decimal.Decimal) -> Callable:
-                        ...
+                    def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 bytes_watermark_ratio = BytesWatermarkRatio()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbconf.Limits, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             domain_limits = DomainLimits()
 
             class QueueLimits(metaclass=TweakMetaclass):
                 class Messages(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 messages = Messages()
 
                 class MessagesWatermarkRatio(metaclass=TweakMetaclass):
-                    def __call__(self, value: decimal.Decimal) -> Callable:
-                        ...
+                    def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 messages_watermark_ratio = MessagesWatermarkRatio()
 
                 class Bytes(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 bytes = Bytes()
 
                 class BytesWatermarkRatio(metaclass=TweakMetaclass):
-                    def __call__(self, value: decimal.Decimal) -> Callable:
-                        ...
+                    def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 bytes_watermark_ratio = BytesWatermarkRatio()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbconf.Limits, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             queue_limits = QueueLimits()
 
@@ -862,8 +804,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbconf.InMemoryStorage, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 in_memory = InMemory()
 
@@ -873,16 +814,14 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbconf.FileBackedStorage, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 file_backed = FileBacked()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbconf.Storage, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             config = Config()
 
@@ -891,45 +830,38 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbconf.StorageDefinition, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         storage = Storage()
 
         class MaxConsumers(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         max_consumers = MaxConsumers()
 
         class MaxProducers(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         max_producers = MaxProducers()
 
         class MaxQueues(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         max_queues = MaxQueues()
 
         class MsgGroupIdConfig(metaclass=TweakMetaclass):
             class Rebalance(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             rebalance = Rebalance()
 
             class MaxGroups(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_groups = MaxGroups()
 
             class TtlSeconds(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             ttl_seconds = TtlSeconds()
 
@@ -938,32 +870,27 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbconf.MsgGroupIdConfig, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         msg_group_id_config = MsgGroupIdConfig()
 
         class MaxIdleTime(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         max_idle_time = MaxIdleTime()
 
         class MessageTtl(metaclass=TweakMetaclass):
-            def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                ...
+            def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
         message_ttl = MessageTtl()
 
         class MaxDeliveryAttempts(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         max_delivery_attempts = MaxDeliveryAttempts()
 
         class DeduplicationTimeMs(metaclass=TweakMetaclass):
-            def __call__(self, value: int) -> Callable:
-                ...
+            def __call__(self, value: int) -> Callable: ...
 
         deduplication_time_ms = DeduplicationTimeMs()
 
@@ -974,8 +901,7 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbconf.QueueConsistencyEventual, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             eventual = Eventual()
 
@@ -985,23 +911,20 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbconf.QueueConsistencyStrong, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             strong = Strong()
 
             def __call__(
                 self,
                 value: typing.Union[blazingmq.schemas.mqbconf.Consistency, NoneType],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         consistency = Consistency()
 
         class Subscriptions(metaclass=TweakMetaclass):
             class AppId(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             app_id = AppId()
 
@@ -1009,53 +932,47 @@ class TweakFactory:
                 class Version(metaclass=TweakMetaclass):
                     def __call__(
                         self, value: blazingmq.schemas.mqbconf.ExpressionVersion
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 version = Version()
 
                 class Text(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 text = Text()
 
                 def __call__(
                     self,
                     value: typing.Union[blazingmq.schemas.mqbconf.Expression, NoneType],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             expression = Expression()
 
-            def __call__(self, value: None) -> Callable:
-                ...
+            def __call__(self, value: None) -> Callable: ...
 
         subscriptions = Subscriptions()
 
     class Cluster:
         class Name(metaclass=TweakMetaclass):
-            def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                ...
+            def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
         name = Name()
 
         class Nodes(metaclass=TweakMetaclass):
             class Id(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             id = Id()
 
             class Name(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             name = Name()
 
             class DataCenter(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             data_center = DataCenter()
 
@@ -1064,8 +981,7 @@ class TweakFactory:
                     class Endpoint(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     endpoint = Endpoint()
 
@@ -1074,8 +990,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.TcpClusterNodeConnection, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 tcp = Tcp()
 
@@ -1084,129 +999,108 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.ClusterNodeConnection, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             transport = Transport()
 
-            def __call__(self, value: None) -> Callable:
-                ...
+            def __call__(self, value: None) -> Callable: ...
 
         nodes = Nodes()
 
         class PartitionConfig(metaclass=TweakMetaclass):
             class NumPartitions(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             num_partitions = NumPartitions()
 
             class Location(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             location = Location()
 
             class ArchiveLocation(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             archive_location = ArchiveLocation()
 
             class MaxDataFileSize(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_data_file_size = MaxDataFileSize()
 
             class MaxJournalFileSize(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_journal_file_size = MaxJournalFileSize()
 
             class MaxQlistFileSize(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_qlist_file_size = MaxQlistFileSize()
 
             class Preallocate(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             preallocate = Preallocate()
 
             class MaxArchivedFileSets(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_archived_file_sets = MaxArchivedFileSets()
 
             class PrefaultPages(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             prefault_pages = PrefaultPages()
 
             class FlushAtShutdown(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             flush_at_shutdown = FlushAtShutdown()
 
             class SyncConfig(metaclass=TweakMetaclass):
                 class StartupRecoveryMaxDurationMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 startup_recovery_max_duration_ms = StartupRecoveryMaxDurationMs()
 
                 class MaxAttemptsStorageSync(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 max_attempts_storage_sync = MaxAttemptsStorageSync()
 
                 class StorageSyncReqTimeoutMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 storage_sync_req_timeout_ms = StorageSyncReqTimeoutMs()
 
                 class MasterSyncMaxDurationMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 master_sync_max_duration_ms = MasterSyncMaxDurationMs()
 
                 class PartitionSyncStateReqTimeoutMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_state_req_timeout_ms = PartitionSyncStateReqTimeoutMs()
 
                 class PartitionSyncDataReqTimeoutMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_data_req_timeout_ms = PartitionSyncDataReqTimeoutMs()
 
                 class StartupWaitDurationMs(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 startup_wait_duration_ms = StartupWaitDurationMs()
 
                 class FileChunkSize(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 file_chunk_size = FileChunkSize()
 
                 class PartitionSyncEventSize(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_event_size = PartitionSyncEventSize()
 
@@ -1215,16 +1109,14 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.StorageSyncConfig, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             sync_config = SyncConfig()
 
             def __call__(
                 self,
                 value: typing.Union[blazingmq.schemas.mqbcfg.PartitionConfig, NoneType],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         partition_config = PartitionConfig()
 
@@ -1234,144 +1126,121 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbcfg.MasterAssignmentAlgorithm, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         master_assignment = MasterAssignment()
 
         class Elector(metaclass=TweakMetaclass):
             class InitialWaitTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             initial_wait_timeout_ms = InitialWaitTimeoutMs()
 
             class MaxRandomWaitTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_random_wait_timeout_ms = MaxRandomWaitTimeoutMs()
 
             class ScoutingResultTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             scouting_result_timeout_ms = ScoutingResultTimeoutMs()
 
             class ElectionResultTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             election_result_timeout_ms = ElectionResultTimeoutMs()
 
             class HeartbeatBroadcastPeriodMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             heartbeat_broadcast_period_ms = HeartbeatBroadcastPeriodMs()
 
             class HeartbeatCheckPeriodMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             heartbeat_check_period_ms = HeartbeatCheckPeriodMs()
 
             class HeartbeatMissCount(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             heartbeat_miss_count = HeartbeatMissCount()
 
             class Quorum(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             quorum = Quorum()
 
             class LeaderSyncDelayMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             leader_sync_delay_ms = LeaderSyncDelayMs()
 
             def __call__(
                 self,
                 value: typing.Union[blazingmq.schemas.mqbcfg.ElectorConfig, NoneType],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         elector = Elector()
 
         class QueueOperations(metaclass=TweakMetaclass):
             class OpenTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             open_timeout_ms = OpenTimeoutMs()
 
             class ConfigureTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             configure_timeout_ms = ConfigureTimeoutMs()
 
             class CloseTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             close_timeout_ms = CloseTimeoutMs()
 
             class ReopenTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             reopen_timeout_ms = ReopenTimeoutMs()
 
             class ReopenRetryIntervalMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             reopen_retry_interval_ms = ReopenRetryIntervalMs()
 
             class ReopenMaxAttempts(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             reopen_max_attempts = ReopenMaxAttempts()
 
             class AssignmentTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             assignment_timeout_ms = AssignmentTimeoutMs()
 
             class KeepaliveDurationMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             keepalive_duration_ms = KeepaliveDurationMs()
 
             class ConsumptionMonitorPeriodMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             consumption_monitor_period_ms = ConsumptionMonitorPeriodMs()
 
             class StopTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             stop_timeout_ms = StopTimeoutMs()
 
             class ShutdownTimeoutMs(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             shutdown_timeout_ms = ShutdownTimeoutMs()
 
             class AckWindowSize(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             ack_window_size = AckWindowSize()
 
@@ -1380,21 +1249,18 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbcfg.QueueOperationsConfig, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         queue_operations = QueueOperations()
 
         class ClusterAttributes(metaclass=TweakMetaclass):
             class IsCslmodeEnabled(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             is_cslmode_enabled = IsCslmodeEnabled()
 
             class IsFsmworkflow(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable:
-                    ...
+                def __call__(self, value: bool) -> Callable: ...
 
             is_fsmworkflow = IsFsmworkflow()
 
@@ -1403,57 +1269,48 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbcfg.ClusterAttributes, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         cluster_attributes = ClusterAttributes()
 
         class ClusterMonitorConfig(metaclass=TweakMetaclass):
             class MaxTimeLeader(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_time_leader = MaxTimeLeader()
 
             class MaxTimeMaster(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_time_master = MaxTimeMaster()
 
             class MaxTimeNode(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_time_node = MaxTimeNode()
 
             class MaxTimeFailover(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             max_time_failover = MaxTimeFailover()
 
             class ThresholdLeader(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             threshold_leader = ThresholdLeader()
 
             class ThresholdMaster(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             threshold_master = ThresholdMaster()
 
             class ThresholdNode(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             threshold_node = ThresholdNode()
 
             class ThresholdFailover(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             threshold_failover = ThresholdFailover()
 
@@ -1462,33 +1319,28 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbcfg.ClusterMonitorConfig, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         cluster_monitor_config = ClusterMonitorConfig()
 
         class MessageThrottleConfig(metaclass=TweakMetaclass):
             class LowThreshold(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             low_threshold = LowThreshold()
 
             class HighThreshold(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             high_threshold = HighThreshold()
 
             class LowInterval(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             low_interval = LowInterval()
 
             class HighInterval(metaclass=TweakMetaclass):
-                def __call__(self, value: int) -> Callable:
-                    ...
+                def __call__(self, value: int) -> Callable: ...
 
             high_interval = HighInterval()
 
@@ -1497,8 +1349,7 @@ class TweakFactory:
                 value: typing.Union[
                     blazingmq.schemas.mqbcfg.MessageThrottleConfig, NoneType
                 ],
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         message_throttle_config = MessageThrottleConfig()
 

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -45,100 +45,101 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.AllocatorType, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             allocator_type = AllocatorType()
 
             class AllocationLimit(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             allocation_limit = AllocationLimit()
 
             class LogController(metaclass=TweakMetaclass):
                 class FileName(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 file_name = FileName()
 
                 class FileMaxAgeDays(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 file_max_age_days = FileMaxAgeDays()
 
                 class RotationBytes(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[int, NoneType]
+                    ) -> Callable: ...
 
                 rotation_bytes = RotationBytes()
 
                 class LogfileFormat(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 logfile_format = LogfileFormat()
 
                 class ConsoleFormat(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 console_format = ConsoleFormat()
 
                 class LoggingVerbosity(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 logging_verbosity = LoggingVerbosity()
 
                 class BslsLogSeverityThreshold(metaclass=TweakMetaclass):
-                    def __call__(self, value: str) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: str
+                    ) -> Callable: ...
 
                 bsls_log_severity_threshold = BslsLogSeverityThreshold()
 
                 class ConsoleSeverityThreshold(metaclass=TweakMetaclass):
-                    def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                        ...
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
 
                 console_severity_threshold = ConsoleSeverityThreshold()
 
                 class Categories(metaclass=TweakMetaclass):
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 categories = Categories()
 
                 class Syslog(metaclass=TweakMetaclass):
                     class Enabled(metaclass=TweakMetaclass):
-                        def __call__(self, value: bool) -> Callable:
-                            ...
+                        def __call__(self, value: bool) -> Callable: ...
 
                     enabled = Enabled()
 
                     class AppName(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     app_name = AppName()
 
                     class LogFormat(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     log_format = LogFormat()
 
                     class Verbosity(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     verbosity = Verbosity()
 
@@ -147,8 +148,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.SyslogConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 syslog = Syslog()
 
@@ -157,76 +157,82 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.LogController, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             log_controller = LogController()
 
             def __call__(
                 self, value: typing.Union[blazingmq.schemas.mqbcfg.TaskConfig, NoneType]
-            ) -> Callable:
-                ...
+            ) -> Callable: ...
 
         task_config = TaskConfig()
 
         class AppConfig(metaclass=TweakMetaclass):
             class BrokerInstanceName(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[str, NoneType]
+                ) -> Callable: ...
 
             broker_instance_name = BrokerInstanceName()
 
             class BrokerVersion(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[int, NoneType]
+                ) -> Callable: ...
 
             broker_version = BrokerVersion()
 
             class ConfigVersion(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[int, NoneType]
+                ) -> Callable: ...
 
             config_version = ConfigVersion()
 
             class EtcDir(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[str, NoneType]
+                ) -> Callable: ...
 
             etc_dir = EtcDir()
 
             class HostName(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[str, NoneType]
+                ) -> Callable: ...
 
             host_name = HostName()
 
             class HostTags(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[str, NoneType]
+                ) -> Callable: ...
 
             host_tags = HostTags()
 
             class HostDataCenter(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[str, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[str, NoneType]
+                ) -> Callable: ...
 
             host_data_center = HostDataCenter()
 
             class IsRunningOnDev(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[bool, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[bool, NoneType]
+                ) -> Callable: ...
 
             is_running_on_dev = IsRunningOnDev()
 
             class LogsObserverMaxSize(metaclass=TweakMetaclass):
-                def __call__(self, value: typing.Union[int, NoneType]) -> Callable:
-                    ...
+                def __call__(
+                    self, value: typing.Union[int, NoneType]
+                ) -> Callable: ...
 
             logs_observer_max_size = LogsObserverMaxSize()
 
             class LatencyMonitorDomain(metaclass=TweakMetaclass):
-                def __call__(self, value: str) -> Callable:
-                    ...
+                def __call__(self, value: str) -> Callable: ...
 
             latency_monitor_domain = LatencyMonitorDomain()
 
@@ -235,8 +241,7 @@ class TweakFactory:
                     class NumProcessors(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     num_processors = NumProcessors()
 
@@ -244,24 +249,21 @@ class TweakFactory:
                         class QueueSize(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_high_watermark = QueueSizeHighWatermark()
 
@@ -271,8 +273,7 @@ class TweakFactory:
                                 blazingmq.schemas.mqbcfg.DispatcherProcessorParameters,
                                 NoneType,
                             ],
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     processor_config = ProcessorConfig()
 
@@ -281,8 +282,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.DispatcherProcessorConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 sessions = Sessions()
 
@@ -290,8 +290,7 @@ class TweakFactory:
                     class NumProcessors(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     num_processors = NumProcessors()
 
@@ -299,24 +298,21 @@ class TweakFactory:
                         class QueueSize(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_high_watermark = QueueSizeHighWatermark()
 
@@ -326,8 +322,7 @@ class TweakFactory:
                                 blazingmq.schemas.mqbcfg.DispatcherProcessorParameters,
                                 NoneType,
                             ],
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     processor_config = ProcessorConfig()
 
@@ -336,8 +331,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.DispatcherProcessorConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 queues = Queues()
 
@@ -345,8 +339,7 @@ class TweakFactory:
                     class NumProcessors(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     num_processors = NumProcessors()
 
@@ -354,24 +347,21 @@ class TweakFactory:
                         class QueueSize(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         queue_size_high_watermark = QueueSizeHighWatermark()
 
@@ -381,8 +371,7 @@ class TweakFactory:
                                 blazingmq.schemas.mqbcfg.DispatcherProcessorParameters,
                                 NoneType,
                             ],
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     processor_config = ProcessorConfig()
 
@@ -391,8 +380,7 @@ class TweakFactory:
                         value: typing.Union[
                             blazingmq.schemas.mqbcfg.DispatcherProcessorConfig, NoneType
                         ],
-                    ) -> Callable:
-                        ...
+                    ) -> Callable: ...
 
                 clusters = Clusters()
 
@@ -401,70 +389,59 @@ class TweakFactory:
                     value: typing.Union[
                         blazingmq.schemas.mqbcfg.DispatcherConfig, NoneType
                     ],
-                ) -> Callable:
-                    ...
+                ) -> Callable: ...
 
             dispatcher_config = DispatcherConfig()
 
             class Stats(metaclass=TweakMetaclass):
                 class AppIdTagDomains(metaclass=TweakMetaclass):
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 app_id_tag_domains = AppIdTagDomains()
 
                 class SnapshotInterval(metaclass=TweakMetaclass):
-                    def __call__(self, value: int) -> Callable:
-                        ...
+                    def __call__(self, value: int) -> Callable: ...
 
                 snapshot_interval = SnapshotInterval()
 
                 class Plugins(metaclass=TweakMetaclass):
                     class Name(metaclass=TweakMetaclass):
-                        def __call__(self, value: str) -> Callable:
-                            ...
+                        def __call__(self, value: str) -> Callable: ...
 
                     name = Name()
 
                     class QueueSize(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     queue_size = QueueSize()
 
                     class QueueHighWatermark(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     queue_high_watermark = QueueHighWatermark()
 
                     class QueueLowWatermark(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     queue_low_watermark = QueueLowWatermark()
 
                     class PublishInterval(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     publish_interval = PublishInterval()
 
                     class NamespacePrefix(metaclass=TweakMetaclass):
-                        def __call__(self, value: str) -> Callable:
-                            ...
+                        def __call__(self, value: str) -> Callable: ...
 
                     namespace_prefix = NamespacePrefix()
 
                     class Hosts(metaclass=TweakMetaclass):
-                        def __call__(self, value: None) -> Callable:
-                            ...
+                        def __call__(self, value: None) -> Callable: ...
 
                     hosts = Hosts()
 
                     class InstanceId(metaclass=TweakMetaclass):
-                        def __call__(self, value: str) -> Callable:
-                            ...
+                        def __call__(self, value: str) -> Callable: ...
 
                     instance_id = InstanceId()
 
@@ -472,20 +449,17 @@ class TweakFactory:
                         class Mode(metaclass=TweakMetaclass):
                             def __call__(
                                 self, value: blazingmq.schemas.mqbcfg.ExportMode
-                            ) -> Callable:
-                                ...
+                            ) -> Callable: ...
 
                         mode = Mode()
 
                         class Host(metaclass=TweakMetaclass):
-                            def __call__(self, value: str) -> Callable:
-                                ...
+                            def __call__(self, value: str) -> Callable: ...
 
                         host = Host()
 
                         class Port(metaclass=TweakMetaclass):
-                            def __call__(self, value: int) -> Callable:
-                                ...
+                            def __call__(self, value: int) -> Callable: ...
 
                         port = Port()
 
@@ -495,36 +469,31 @@ class TweakFactory:
                                 blazingmq.schemas.mqbcfg.StatPluginConfigPrometheus,
                                 NoneType,
                             ],
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     prometheus_specific = PrometheusSpecific()
 
-                    def __call__(self, value: None) -> Callable:
-                        ...
+                    def __call__(self, value: None) -> Callable: ...
 
                 plugins = Plugins()
 
                 class Printer(metaclass=TweakMetaclass):
                     class PrintInterval(metaclass=TweakMetaclass):
-                        def __call__(self, value: int) -> Callable:
-                            ...
+                        def __call__(self, value: int) -> Callable: ...
 
                     print_interval = PrintInterval()
 
                     class File(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[str, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     file = File()
 
                     class MaxAgeDays(metaclass=TweakMetaclass):
                         def __call__(
                             self, value: typing.Union[int, NoneType]
-                        ) -> Callable:
-                            ...
+                        ) -> Callable: ...
 
                     max_age_days = MaxAgeDays()
 


### PR DESCRIPTION
The latest `black` formatter enforces one-liners with `...` operator

```
Successfully installed black-24.4.3.dev23+g7e2afc9
```