### PR TITLE
fix: update queue stats on response (not only on request)

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -395,9 +395,7 @@ void Queue::convertToLocalDispatched()
 
 void Queue::updateStats()
 {
-    d_state.stats()
-        .setReaderCount(d_state.handleParameters().readCount())
-        .setWriterCount(d_state.handleParameters().writeCount());
+    d_state.updateStats();
 }
 
 void Queue::listMessagesDispatched(mqbcmd::QueueResult* result,

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -132,6 +132,13 @@ QueueState::subtract(const bmqp_ctrlmsg::QueueHandleParameters& params)
     return mqbi::QueueCounts(it->second.readCount(), it->second.writeCount());
 }
 
+void QueueState::updateStats()
+{
+    stats()
+        .setReaderCount(handleParameters().readCount())
+        .setWriterCount(handleParameters().writeCount());
+}
+
 mqbi::QueueCounts QueueState::consumerAndProducerCounts(
     const bmqp_ctrlmsg::QueueHandleParameters& params) const
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -282,6 +282,9 @@ class QueueState {
     /// Return reference to the structures for the queue engine routing.
     Routers::QueueRoutingContext& routingContext();
 
+    /// Update the stats to the current values in the handleParamaters
+    void updateStats();
+
     // ACCESSORS
 
     /// Return true if the queue has upstream parameters for the specified

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -732,6 +732,8 @@ void RemoteQueue::onHandleReleased(
     BSLS_ASSERT_SAFE(d_state_p->queue()->dispatcher()->inDispatcherThread(
         d_state_p->queue()));
 
+    d_state_p->updateStats();
+
     mqbi::Cluster* cluster = d_state_p->domain()->cluster();
     if (result.hasNoHandleStreamConsumers()) {
         // Lost last reader for the specified subStream for the handle


### PR DESCRIPTION
In the presence of another client, the reported stats are one step behind because they get updated to early - before consumer fully closes.