### PR TITLE
dev: Optimize counting of unconfirmed

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2106,6 +2106,7 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
                                    d_clusterData_p->scheduler(),
                                    d_clusterData_p->miscWorkThreadPool(),
                                    openQueueResponse.routingConfiguration(),
+                                   &d_counterOfUnconfirmed,
                                    d_allocator_p),
         d_allocator_p);
 
@@ -4485,6 +4486,7 @@ ClusterQueueHelper::ClusterQueueHelper(
 , d_numPendingReopenQueueRequests(0)
 , d_primaryNotLeaderAlarmRaised(false)
 , d_stopContexts(allocator)
+, d_counterOfUnconfirmed(0)
 {
     BSLS_ASSERT(
         d_clusterData_p->clusterConfig()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2106,7 +2106,7 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
                                    d_clusterData_p->scheduler(),
                                    d_clusterData_p->miscWorkThreadPool(),
                                    openQueueResponse.routingConfiguration(),
-                                   &d_counterOfUnconfirmed,
+                                   &d_unconfirmedCounter,
                                    d_allocator_p),
         d_allocator_p);
 
@@ -4486,7 +4486,7 @@ ClusterQueueHelper::ClusterQueueHelper(
 , d_numPendingReopenQueueRequests(0)
 , d_primaryNotLeaderAlarmRaised(false)
 , d_stopContexts(allocator)
-, d_counterOfUnconfirmed(0)
+, d_unconfirmedCounter(NULL)
 {
     BSLS_ASSERT(
         d_clusterData_p->clusterConfig()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -486,6 +486,9 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
 
     StopContexts d_stopContexts;
 
+    mqbu::SingleCounter d_counterOfUnconfirmed;
+    // Top level in the hierarchy: Cluster ->> QueueState ->> QueueHandle
+
   private:
     // PRIVATE MANIPULATORS
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -486,8 +486,8 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
 
     StopContexts d_stopContexts;
 
-    mqbu::SingleCounter d_counterOfUnconfirmed;
-    // Top level in the hierarchy: Cluster ->> QueueState ->> QueueHandle
+    mqbu::SingleCounter d_unconfirmedCounter;
+    /// Top level in the hierarchy: Cluster ->> QueueState ->> QueueHandle
 
   private:
     // PRIVATE MANIPULATORS

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -458,11 +458,18 @@ Queue::Queue(const bmqt::Uri&                          uri,
              bdlmt::EventScheduler*                    scheduler,
              bdlmt::FixedThreadPool*                   threadPool,
              const bmqp_ctrlmsg::RoutingConfiguration& routingCfg,
-             mqbu::SingleCounter*                      parent,
+             mqbu::SingleCounter*                      unconfirmedCounter,
              bslma::Allocator*                         allocator)
 : d_allocator_p(allocator)
 , d_schemaLearner(allocator)
-, d_state(this, uri, id, key, partitionId, domain, parent, allocator)
+, d_state(this,
+          uri,
+          id,
+          key,
+          partitionId,
+          domain,
+          unconfirmedCounter,
+          allocator)
 , d_localQueue_mp(0)
 , d_remoteQueue_mp(0)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -458,10 +458,11 @@ Queue::Queue(const bmqt::Uri&                          uri,
              bdlmt::EventScheduler*                    scheduler,
              bdlmt::FixedThreadPool*                   threadPool,
              const bmqp_ctrlmsg::RoutingConfiguration& routingCfg,
+             mqbu::SingleCounter*                      parent,
              bslma::Allocator*                         allocator)
 : d_allocator_p(allocator)
 , d_schemaLearner(allocator)
-, d_state(this, uri, id, key, partitionId, domain, allocator)
+, d_state(this, uri, id, key, partitionId, domain, parent, allocator)
 , d_localQueue_mp(0)
 , d_remoteQueue_mp(0)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -170,7 +170,7 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
           bdlmt::EventScheduler*                    scheduler,
           bdlmt::FixedThreadPool*                   threadPool,
           const bmqp_ctrlmsg::RoutingConfiguration& routingCfg,
-          mqbu::SingleCounter*                      parent,
+          mqbu::SingleCounter*                      unconfirmedCounter,
           bslma::Allocator*                         allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -170,6 +170,7 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
           bdlmt::EventScheduler*                    scheduler,
           bdlmt::FixedThreadPool*                   threadPool,
           const bmqp_ctrlmsg::RoutingConfiguration& routingCfg,
+          mqbu::SingleCounter*                      parent,
           bslma::Allocator*                         allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -151,8 +151,8 @@ Test::Test()
                d_storageKey,
                d_partitionId,
                &d_domain,
-               0,
-               // not counting unconfirmed
+               NULL,
+               // no parent counter of unconfirmed
                s_allocator_p)
 , d_monitor(&d_queueState, s_allocator_p)
 , d_storage(d_queue.uri(),

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -151,6 +151,8 @@ Test::Test()
                d_storageKey,
                d_partitionId,
                &d_domain,
+               0,
+               // not counting unconfirmed
                s_allocator_p)
 , d_monitor(&d_queueState, s_allocator_p)
 , d_storage(d_queue.uri(),

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -502,6 +502,8 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig)
                                                 k_NULL_QUEUE_KEY,
                                                 k_PARTITION_ID,
                                                 d_mockDomain_mp.get(),
+                                                0,
+                                                // not counting Unconfirmed
                                                 d_allocator_p),
                          d_allocator_p);
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -502,8 +502,8 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig)
                                                 k_NULL_QUEUE_KEY,
                                                 k_PARTITION_ID,
                                                 d_mockDomain_mp.get(),
-                                                0,
-                                                // not counting Unconfirmed
+                                                NULL,
+                                                // no parent counter
                                                 d_allocator_p),
                          d_allocator_p);
 

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -206,7 +206,7 @@ class QueueHandle : public mqbi::QueueHandle {
 
     bmqp::SchemaLearner::Context d_schemaLearnerPushContext;
 
-    mqbu::SingleCounter d_counterOfUnconfirmed;
+    mqbu::SingleCounter d_unconfirmedCounter;
     // Count Unconfirmed for (cluster) shutdown
 
     bslma::Allocator* d_allocator_p;
@@ -283,7 +283,7 @@ class QueueHandle : public mqbi::QueueHandle {
                                                            clientContext,
                 mqbstat::QueueStatsDomain*                 domainStats,
                 const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-                mqbu::SingleCounter*                       parent,
+                mqbu::SingleCounter*                       unconfirmedCounter,
                 bslma::Allocator*                          allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -206,6 +206,9 @@ class QueueHandle : public mqbi::QueueHandle {
 
     bmqp::SchemaLearner::Context d_schemaLearnerPushContext;
 
+    mqbu::SingleCounter d_counterOfUnconfirmed;
+    // Count Unconfirmed for (cluster) shutdown
+
     bslma::Allocator* d_allocator_p;
     // Allocator to use.
 
@@ -280,6 +283,7 @@ class QueueHandle : public mqbi::QueueHandle {
                                                            clientContext,
                 mqbstat::QueueStatsDomain*                 domainStats,
                 const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
+                mqbu::SingleCounter*                       parent,
                 bslma::Allocator*                          allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
@@ -65,7 +65,7 @@ class DefaultHandleFactory : public mqbi::QueueHandleFactory {
                                                           clientContext,
                mqbstat::QueueStatsDomain*                 stats,
                const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-               mqbu::SingleCounter*                       parent,
+               mqbu::SingleCounter*                       unconfirmedCounter,
                bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
     // Create a new handle, using the specified 'allocator', for the
     // specified 'queue' as requested by the specified 'clientContext' with
@@ -87,14 +87,14 @@ mqbi::QueueHandle* DefaultHandleFactory::makeHandle(
     const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>& clientContext,
     mqbstat::QueueStatsDomain*                                stats,
     const bmqp_ctrlmsg::QueueHandleParameters&                handleParameters,
-    mqbu::SingleCounter*                                      parent,
-    bslma::Allocator*                                         allocator)
+    mqbu::SingleCounter* unconfirmedCounter,
+    bslma::Allocator*    allocator)
 {
     return new (*allocator) mqbblp::QueueHandle(queue,
                                                 clientContext,
                                                 stats,
                                                 handleParameters,
-                                                parent,
+                                                unconfirmedCounter,
                                                 allocator);
 }
 
@@ -128,7 +128,7 @@ QueueHandleCatalog::QueueHandleCatalog(mqbi::Queue*         queue,
 : d_queue_p(queue)
 , d_handleFactory_mp(new (*allocator) DefaultHandleFactory(), allocator)
 , d_handles(allocator)
-, d_counterOfUnconfirmed_p(counter)
+, d_unconfirmedCounter_p(counter)
 , d_allocator_p(allocator)
 {
     // NOTHING
@@ -177,7 +177,7 @@ mqbi::QueueHandle* QueueHandleCatalog::createHandle(
         clientContext,
         stats,
         canonicalHandleParams,
-        d_counterOfUnconfirmed_p,
+        d_unconfirmedCounter_p,
         d_allocator_p);
     handle->setIsClientClusterMember(clientContext->isClusterMember());
 

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
@@ -146,8 +146,8 @@ class QueueHandleCatalog {
     // 'mutable' because TwoKeyHashMap
     // doesn't expose const operators.
 
-    mqbu::SingleCounter* d_counterOfUnconfirmed_p;
-    // Count Unconfirmed for (cluster) shutdown
+    mqbu::SingleCounter* d_unconfirmedCounter_p;
+    /// Count Unconfirmed for (cluster) shutdown, held, not owned
 
     bslma::Allocator* d_allocator_p;
     // Allocator to use.
@@ -173,7 +173,8 @@ class QueueHandleCatalog {
     // CREATOR
 
     /// Create a new object associated to the specified `queue`.  Use the
-    /// specified `allocator` for any memory allocations.
+    /// specified `allocator` for any memory allocations.  Use the specified
+    /// 'counter' to aggregate the counting of  unconfirmed by each handle.
     QueueHandleCatalog(mqbi::Queue*         queue,
                        mqbu::SingleCounter* counter,
                        bslma::Allocator*    allocator);

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
@@ -30,9 +30,9 @@
 // must be executed by the dispatcher thread of the associated queue.
 
 // MQB
-
 #include <mqbi_queue.h>
 #include <mqbi_storage.h>
+#include <mqbu_resourceusagemonitor.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
@@ -146,6 +146,9 @@ class QueueHandleCatalog {
     // 'mutable' because TwoKeyHashMap
     // doesn't expose const operators.
 
+    mqbu::SingleCounter* d_counterOfUnconfirmed_p;
+    // Count Unconfirmed for (cluster) shutdown
+
     bslma::Allocator* d_allocator_p;
     // Allocator to use.
 
@@ -171,7 +174,9 @@ class QueueHandleCatalog {
 
     /// Create a new object associated to the specified `queue`.  Use the
     /// specified `allocator` for any memory allocations.
-    QueueHandleCatalog(mqbi::Queue* queue, bslma::Allocator* allocator);
+    QueueHandleCatalog(mqbi::Queue*         queue,
+                       mqbu::SingleCounter* counter,
+                       bslma::Allocator*    allocator);
 
     /// Destructor.
     ~QueueHandleCatalog();

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -51,7 +51,7 @@ QueueState::QueueState(mqbi::Queue*            queue,
                        const mqbu::StorageKey& key,
                        int                     partitionId,
                        mqbi::Domain*           domain,
-                       mqbu::SingleCounter*    parent,
+                       mqbu::SingleCounter*    unconfirmedCounter,
                        bslma::Allocator*       allocator)
 : d_queue_p(queue)
 , d_uri(uri, allocator)
@@ -70,8 +70,8 @@ QueueState::QueueState(mqbi::Queue*            queue,
 , d_storage_mp(0)
 , d_stats()
 , d_messageThrottleConfig()
-, d_counterOfUnconfirmed(parent)
-, d_handleCatalog(queue, &d_counterOfUnconfirmed, allocator)
+, d_unconfirmedCounter(unconfirmedCounter)
+, d_handleCatalog(queue, &d_unconfirmedCounter, allocator)
 , d_context(queue->schemaLearner(), allocator)
 , d_subStreams(allocator)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -51,6 +51,7 @@ QueueState::QueueState(mqbi::Queue*            queue,
                        const mqbu::StorageKey& key,
                        int                     partitionId,
                        mqbi::Domain*           domain,
+                       mqbu::SingleCounter*    parent,
                        bslma::Allocator*       allocator)
 : d_queue_p(queue)
 , d_uri(uri, allocator)
@@ -69,7 +70,8 @@ QueueState::QueueState(mqbi::Queue*            queue,
 , d_storage_mp(0)
 , d_stats()
 , d_messageThrottleConfig()
-, d_handleCatalog(queue, allocator)
+, d_counterOfUnconfirmed(parent)
+, d_handleCatalog(queue, &d_counterOfUnconfirmed, allocator)
 , d_context(queue->schemaLearner(), allocator)
 , d_subStreams(allocator)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -182,7 +182,7 @@ class QueueState {
     // The throttling thresholds and delay
     // values for poison messages
 
-    mqbu::SingleCounter d_counterOfUnconfirmed;
+    mqbu::SingleCounter d_unconfirmedCounter;
 
     QueueHandleCatalog d_handleCatalog;
 
@@ -205,14 +205,16 @@ class QueueState {
 
     /// Create a new `QueueState` associated to the specified `queue` and
     /// having the specified `uri`, `id`, `key`, `partitionId` and `domain`.
-    /// Use the specified `allocator` for any memory allocations.
+    /// Use the specified `allocator` for any memory allocations.  Use the
+    /// specified 'unconfirmedCounter' to aggregate the  counting of
+    /// unconfirmed by each queue handle.
     QueueState(mqbi::Queue*            queue,
                const bmqt::Uri&        uri,
                unsigned int            id,
                const mqbu::StorageKey& key,
                int                     partitionId,
                mqbi::Domain*           domain,
-               mqbu::SingleCounter*    parent,
+               mqbu::SingleCounter*    unconfirmedCounter,
                bslma::Allocator*       allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -182,6 +182,8 @@ class QueueState {
     // The throttling thresholds and delay
     // values for poison messages
 
+    mqbu::SingleCounter d_counterOfUnconfirmed;
+
     QueueHandleCatalog d_handleCatalog;
 
     Routers::QueueRoutingContext d_context;
@@ -210,6 +212,7 @@ class QueueState {
                const mqbu::StorageKey& key,
                int                     partitionId,
                mqbi::Domain*           domain,
+               mqbu::SingleCounter*    parent,
                bslma::Allocator*       allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
@@ -289,6 +289,8 @@ TestBench::TestRemoteQueue::TestRemoteQueue(
                d_storageKey,
                1,  // partition
                &theBench.d_domain,
+               0,
+               // not counting unconfirmed
                theBench.d_allocator_p)
 , d_remoteQueue(&d_queueState,
                 timeout,

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
@@ -289,8 +289,8 @@ TestBench::TestRemoteQueue::TestRemoteQueue(
                d_storageKey,
                1,  // partition
                &theBench.d_domain,
-               0,
-               // not counting unconfirmed
+               NULL,
+               // no parent counter of unconfirmed
                theBench.d_allocator_p)
 , d_remoteQueue(&d_queueState,
                 timeout,

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
@@ -142,7 +142,7 @@ int ClusterStateLedgerUtil::validateFileHeader(
     const ClusterStateFileHeader& header,
     const mqbu::StorageKey&       expectedLogId)
 {
-    if (static_cast<const int>(header.protocolVersion()) !=
+    if (static_cast<int>(header.protocolVersion()) !=
         ClusterStateLedgerProtocol::k_VERSION) {
         return ClusterStateLedgerUtilRc::e_INVALID_PROTOCOL_VERSION;  // RETURN
     }

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -965,13 +965,14 @@ class QueueHandleFactory {
     /// Create a new handle, using the specified `allocator`, for the
     /// specified `queue` as requested by the specified `clientContext` with
     /// the specified `parameters`, and associated wit the specified
-    /// `stats`.  Use the specified 'counterOfUnconfirmed'.
+    /// `stats`.  Use the specified 'unconfirmedCounter' to aggregate the
+    /// counting of unconfirmed by each queue handle.
     virtual QueueHandle* makeHandle(
         const bsl::shared_ptr<Queue>&                       queue,
         const bsl::shared_ptr<QueueHandleRequesterContext>& clientContext,
         mqbstat::QueueStatsDomain*                          stats,
         const bmqp_ctrlmsg::QueueHandleParameters&          handleParameters,
-        mqbu::SingleCounter*                                parent,
+        mqbu::SingleCounter*                                unconfirmedCounter,
         bslma::Allocator*                                   allocator) = 0;
 };
 

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -51,6 +51,7 @@
 #include <mqbconfm_messages.h>
 #include <mqbi_dispatcher.h>
 #include <mqbi_storage.h>
+#include <mqbu_resourceusagemonitor.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
@@ -964,12 +965,13 @@ class QueueHandleFactory {
     /// Create a new handle, using the specified `allocator`, for the
     /// specified `queue` as requested by the specified `clientContext` with
     /// the specified `parameters`, and associated wit the specified
-    /// `stats`.
+    /// `stats`.  Use the specified 'counterOfUnconfirmed'.
     virtual QueueHandle* makeHandle(
         const bsl::shared_ptr<Queue>&                       queue,
         const bsl::shared_ptr<QueueHandleRequesterContext>& clientContext,
         mqbstat::QueueStatsDomain*                          stats,
         const bmqp_ctrlmsg::QueueHandleParameters&          handleParameters,
+        mqbu::SingleCounter*                                parent,
         bslma::Allocator*                                   allocator) = 0;
 };
 

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -528,7 +528,8 @@ mqbi::QueueHandle* HandleFactory::makeHandle(
     const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>& clientContext,
     mqbstat::QueueStatsDomain*                                stats,
     const bmqp_ctrlmsg::QueueHandleParameters&                handleParameters,
-    bslma::Allocator*                                         allocator)
+    BSLS_ANNOTATION_UNUSED mqbu::SingleCounter* parent,
+    bslma::Allocator*                           allocator)
 {
     return new (*allocator) mqbmock::QueueHandle(queue,
                                                  clientContext,

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -447,6 +447,7 @@ class HandleFactory : public mqbi::QueueHandleFactory {
                                                           clientContext,
                mqbstat::QueueStatsDomain*                 stats,
                const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
+               mqbu::SingleCounter*                       parent,
                bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
 };
 

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -447,7 +447,7 @@ class HandleFactory : public mqbi::QueueHandleFactory {
                                                           clientContext,
                mqbstat::QueueStatsDomain*                 stats,
                const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-               mqbu::SingleCounter*                       parent,
+               mqbu::SingleCounter*                       unconfirmedCounter,
                bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
 };
 

--- a/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.h
+++ b/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.h
@@ -466,17 +466,27 @@ class ResourceUsageMonitor {
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
 };
 
+// ====================
+// struct SingleCounter
+// ====================
+
 struct SingleCounter {
     /// Thread-safe int value hierarchical tracker
     /// Relies on an owner for creation/destruction
 
-    SingleCounter*  d_parent_p;
-    bsls::AtomicInt d_value;
+    SingleCounter* d_parent_p;
+    /// If not null, gets updated
 
-    SingleCounter(SingleCounter* parent);
+    bsls::AtomicInt64 d_value;
+    /// The value being tracked
 
+    // CREATORS
+    explicit SingleCounter(SingleCounter* parent);
+
+    /// Add the specified `delta` to the value.
     void update(int delta);
 
+    /// Return the value being tracked.
     int value() const;
 };
 
@@ -687,6 +697,9 @@ inline SingleCounter::SingleCounter(SingleCounter* parent)
 inline void SingleCounter::update(int delta)
 {
     d_value += delta;
+
+    BSLS_ASSERT_SAFE(d_value >= 0);
+
     if (d_parent_p) {
         d_parent_p->update(delta);
     }


### PR DESCRIPTION
First step in optimizing shutdown logic.  The goal of which is to avoid iterating subStreams (preparing for Reliable Broadcast).

The `ClusterQueueHelper::d_counterOfUnconfirmed` is all we will need for shutdown in the next step.
All other counters will (gradually) retire.