### PR TITLE
mqba_domainmanager: refactor code into locateOrCreateDomain function

### DIFF
--- a/src/groups/mqb/mqba/mqba_domainmanager.h
+++ b/src/groups/mqb/mqba/mqba_domainmanager.h
@@ -332,6 +332,13 @@ class DomainManager BSLS_CPP11_FINAL : public mqbi::DomainFactory {
     /// specified `errorDescription` otherwise.
     int locateDomain(DomainSp* domain, const bsl::string& domainName);
 
+    /// Load into the specified `domainSp` the domain corresponding to the
+    /// specified `domainName`, if found. If not found then attempt to create
+    /// the domain corresponding to `domainName` and load the result into the
+    /// specified `domainSp`. Retunr 0 on success, or a non-zero return code on
+    /// failure.
+    int locateOrCreateDomain(DomainSp* domain, const bsl::string& domainName);
+
     /// Process the specified `command` and load the result of the command
     /// in the specified `result`.  Return zero on success or a nonzero
     /// value otherwise.

--- a/src/groups/mqb/mqba/mqba_domainmanager.h
+++ b/src/groups/mqb/mqba/mqba_domainmanager.h
@@ -335,7 +335,7 @@ class DomainManager BSLS_CPP11_FINAL : public mqbi::DomainFactory {
     /// Load into the specified `domainSp` the domain corresponding to the
     /// specified `domainName`, if found. If not found then attempt to create
     /// the domain corresponding to `domainName` and load the result into the
-    /// specified `domainSp`. Retunr 0 on success, or a non-zero return code on
+    /// specified `domainSp`. Return 0 on success, or a non-zero return code on
     /// failure.
     int locateOrCreateDomain(DomainSp* domain, const bsl::string& domainName);
 


### PR DESCRIPTION
Refactor code to locate or create a domain into a single function for reusability.

This is particularly useful for #352.