### PR TITLE
Refactor[MWC]: explicit operator= in mwcc containers

### DIFF
--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
@@ -297,7 +297,7 @@ class OrderedHashMap_SequentialIterator {
     // MANIPULATORS
 
     /// Assign to this object the value of the specified `rhs` object.
-    OrderedHashMap_SequentialIterator& operator=(const NcIter&);
+    OrderedHashMap_SequentialIterator& operator=(const NcIter& rhs);
 
     /// Advance this iterator to the next element in the sequential list and
     /// return its new value.  The behavior is undefined unless this

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.h
@@ -296,6 +296,9 @@ class OrderedHashMap_SequentialIterator {
 
     // MANIPULATORS
 
+    /// Assign to this object the value of the specified `rhs` object.
+    OrderedHashMap_SequentialIterator& operator=(const NcIter&);
+
     /// Advance this iterator to the next element in the sequential list and
     /// return its new value.  The behavior is undefined unless this
     /// iterator is in the range `[begin() .. end())` (i.e., the iterator is
@@ -885,6 +888,15 @@ inline OrderedHashMap_SequentialIterator<
 }
 
 // MANIPULATORS
+
+template <class VALUE>
+inline OrderedHashMap_SequentialIterator<VALUE>&
+OrderedHashMap_SequentialIterator<VALUE>::operator=(const NcIter& rhs)
+{
+    d_link_p = rhs.d_link_p;
+    return *this;
+}
+
 template <class VALUE>
 inline OrderedHashMap_SequentialIterator<VALUE>&
 OrderedHashMap_SequentialIterator<VALUE>::operator++()

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmapwithhistory.h
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmapwithhistory.h
@@ -108,6 +108,9 @@ class OrderedHashMapWithHistory_Iterator {
 
     // MANIPULATORS
 
+    /// Assign to this object the value of the specified `rhs` object.
+    OrderedHashMapWithHistory_Iterator& operator=(const NcIter& rhs);
+
     /// Advance this iterator to the next element in the sequential list and
     /// return its new value.  The behavior is undefined unless this
     /// iterator is in the range `[begin() .. end())` (i.e., the iterator is
@@ -386,6 +389,15 @@ inline OrderedHashMapWithHistory_Iterator<
 }
 
 // MANIPULATORS
+
+template <class VALUE>
+inline OrderedHashMapWithHistory_Iterator<VALUE>&
+OrderedHashMapWithHistory_Iterator<VALUE>::operator=(const NcIter& rhs)
+{
+    d_baseIterator = rhs.d_baseIterator;
+    return *this;
+}
+
 template <class VALUE>
 inline OrderedHashMapWithHistory_Iterator<VALUE>&
 OrderedHashMapWithHistory_Iterator<VALUE>::operator++()


### PR DESCRIPTION
Removing the custom copy constructor `OrderedHashMap_SequentialIterator(const NcIter& other);` doesn't work since it produces compilation errors
```
In file included from /blazingmq/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp:17:
In file included from /blazingmq/src/groups/bmq/bmqimp/bmqimp_brokersession.h:37:
In file included from /blazingmq/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.h:39:
/blazingmq/src/groups/bmq/bmqp/bmqp_requestmanager.h:1509:30: error: no viable conversion from 'OrderedHashMap_SequentialIterator<pair<...>>' to 'OrderedHashMap_SequentialIterator<const pair<...>>'
    for (RequestMapConstIter it = requestsCopy.begin();
                             ^    ~~~~~~~~~~~~~~~~~~~~
```

Implemented explicit `operator=` for `OrderedHashMap_SequentialIterator` and `OrderedHashMapWithHistory_Iterator`