### PR TITLE
Remove AIX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 
 ---
 [![OS Linux](https://img.shields.io/badge/OS-Linux-blue)](#)
-[![OS AIX](https://img.shields.io/badge/OS-AIX-blue)](#)
 [![OS Solaris](https://img.shields.io/badge/OS-Solaris-blue)](#)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue)](LICENSE)
 [![C++](https://img.shields.io/badge/C++-blue)](#)

--- a/docs/docs/faqs/faq_general.md
+++ b/docs/docs/faqs/faq_general.md
@@ -9,12 +9,11 @@ nav_order: 2
 
 ## What platforms are supported by BlazingMQ?
 
-BlazingMQ can run on Linux, AIX and Solaris operating systems.  The minimum
+BlazingMQ can run on Linux and Solaris operating systems.  The minimum
 required versions of these operating systems are as follows:
 
 | Operating System | Version |
 | ---------------- | ------- |
-| AIX              | 7.1     |
 | Linux            | 3.10.0  |
 | Solaris          | 5.11    |
 
@@ -33,7 +32,6 @@ version less than the minimum specified version is not supported.
 | GCC            | 7.3     |
 | clang          | 10.0.1  |
 | Solaris Studio | 5.13    |
-| xlc            | 16.1.0  |
 
 BlazingMQ message broker and C++ client library require the C++03 version of
 the C++ language standard, or any version above it.

--- a/etc/cmake/BMQPlugins.cmake
+++ b/etc/cmake/BMQPlugins.cmake
@@ -52,8 +52,6 @@ function(bmq_add_plugin name)
     include(TargetBMQStyleUor)
     target_bmq_default_compiler_flags(${name})
 
-    # Add -bbigtoc on AIX platforms
-    target_link_options(${name} PRIVATE "$<$<PLATFORM_ID:AIX>:$<$<CXX_COMPILER_ID:XL>:-bbigtoc>>")
     bbs_import_target_dependencies(${name} ${${name}_PCDEPS})
 
     # -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/src/applications/bmqbrkr/CMakeLists.txt
+++ b/src/applications/bmqbrkr/CMakeLists.txt
@@ -28,65 +28,12 @@
 # On Linux and SunOS, this is achieved by using some linker flags
 # (-whole-archive, -z allextract, ...), which indicates to the linker that it
 # should keep all symbols from the libraries mentioned after, even if those are
-# not used in the task. On AIX, we must first prelink the libraries .a into an
-# object .o (asking it to keep all symbols with -bexpfull), and then link that
-# .o with the task.
+# not used in the task.
 #
 # By keeping all symbols, the task will be quite bigger than it should be, but
 # that way we guarantee that any symbols used by the plugins will be found.
 # Because of that, depencies of bmqbrkr.tsk must be kept under close watch and
 # to the bare minimum.
-
-macro(_bmq_prelink_aix_modules)
-  # Declare the task with compiler and linker flags
-  # On AIX, we are going to generate a prelink .o file with all static
-  # libraries, that needs to be added to the sources used to build the task
-  # NOTE: When doing a fully fresh build, the .o doesn't yet exist and CMake
-  #       will complain when adding the .o as a source to the broker. This
-  #       file is generated as a PRE_LINK rule, so at this point, just make
-  #       sure it exist.
-  file( WRITE "${CMAKE_CURRENT_BINARY_DIR}/aix_prelink_libs.o" "" )
-  target_sources( bmqbrkr PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/aix_prelink_libs.o" )
-
-  # The AIX equivalent flags are "-bexpfull -bnogc" ${deps} "-bgc" where each
-  # 'deps' is -bkeepfile:<full_path_to_lib.a>, but this doesn't quite seem to
-  # work as expected, so instead we do what is call prelinking, asking the
-  # loader to generate a .o with all the .a
-  if (IS_64BIT)
-    set(_bit_flag "-b64")
-  else()
-    set(_bit_flag "-b32")
-  endif()
-
-  # Generate the link parameters
-  # NOTE: o bmqbrkr_DEPENDS contains all the declared .dep:
-  #         ex 'mqb;bmq;bce;bde;bsl'
-  #       o _ext_libs contains all the external (from the refRoot) libs
-  #       o _prj_libs contains explicit path to all the libs from this project
-  foreach( dep ${bmqbrkr_DEPENDS} )
-    if( TARGET ${dep} )
-      # It's a lib defined in one project, get the path to the output lib
-      # And add the proper includes dirs
-      list( APPEND _prj_libs "$<TARGET_FILE:${dep}>" )
-      get_property( _include_dir TARGET ${dep} PROPERTY INCLUDE_DIRECTORIES )
-      target_include_directories( bmqbrkr BEFORE INTERFACE ${_include_dir} )
-    else()
-      list( APPEND _ext_libs "$<TARGET_FILE:${dep}>" )
-    endif()
-  endforeach()
-
-  set( cmd
-    /bin/ld ${_bit_flag} -r -bbinder:/usr/ccs/bin/bind64
-    "-L${libPath}" -bexpfull -bnogc ${_prj_libs} )
-  foreach( lib ${_ext_libs} )
-    list( APPEND cmd "${lib}" )
-  endforeach()
-  list( APPEND cmd "-o" "${CMAKE_CURRENT_BINARY_DIR}/aix_prelink_libs.o" )
-  add_custom_command( TARGET bmqbrkr
-    PRE_LINK
-    COMMAND ${cmd}
-    COMMENT "Prelinking ..." )
-endmacro()
 
 if(BMQ_TARGET_BMQBRKR_NEEDED)
   # Read dependencies from .dep and resolve them with pkgconfig
@@ -104,12 +51,6 @@ if(BMQ_TARGET_BMQBRKR_NEEDED)
     PROPERTIES OUTPUT_NAME "bmqbrkr.tsk")
   endif()
 
-  # "-btextpsize:64K -bdatapsize:64K" Memory tweaks.  See internal ticket
-  # D46833503
-  target_link_options(bmqbrkr PRIVATE
-    $<$<PLATFORM_ID:AIX>:$<$<CXX_COMPILER_ID:XL>:-btextpsize:64K>>
-    $<$<PLATFORM_ID:AIX>:$<$<CXX_COMPILER_ID:XL>:-bdatapsize:64K>>)
-
   set_target_properties(bmqbrkr
     PROPERTIES ENABLE_EXPORTS ON)
 
@@ -124,9 +65,7 @@ if(BMQ_TARGET_BMQBRKR_NEEDED)
       # (resulting in a runtime linkage failure).
       #
       # Note that Solaris publishes all symbols to the
-      # dynamic symbol table by default, and AIX seems to
-      # do something similar:
-      # https://developer.ibm.com/articles/au-aix-symbol-visibility/
+      # dynamic symbol table by default.
       "-Wl,--whole-archive"
       ${bmqbrkr_DEPENDS}
       "-Wl,--no-whole-archive")
@@ -135,12 +74,6 @@ if(BMQ_TARGET_BMQBRKR_NEEDED)
       "-Wl,--whole-archive"
       ${bmqbrkr_DEPENDS}
       "-Wl,--no-whole-archive")
-  elseif(CMAKE_SYSTEM_NAME MATCHES "AIX")
-    _bmq_prelink_aix_modules()
-    # Keeps old symbol exporting behavior
-    target_link_options(bmqbrkr PRIVATE -bsvr4)
-    target_link_libraries(bmqbrkr PUBLIC
-      ${bmqbrkr_DEPENDS})
   elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
     target_link_libraries(bmqbrkr PRIVATE "-all_load" ${bmqbrkr_DEPENDS})
   endif()

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -875,10 +875,10 @@ static void test12_printMessagesDetailsTest()
 {
     mwctst::TestHelper::printTestName("PRINT MESSAGE DETAILS TEST");
 
-#if defined(BSLS_PLATFORM_OS_SOLARIS) || defined(BSLS_PLATFORM_OS_AIX)
+#if defined(BSLS_PLATFORM_OS_SOLARIS)
     s_ignoreCheckDefAlloc = true;
     // Disable default allocator check for this test until we can debug
-    // it on AIX/Solaris
+    // it on Solaris
 #endif
 
     // Simulate journal file

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -149,7 +149,7 @@ class SimpleEvaluator {
     // Bison generates different code for different available standards:
     // - For C++ >= 11 it generates the 'emplace' with a move constructor, so
     // it's possible to use 'bslma::ManagedPtr'.
-    // - For C++ < 11 (AIX/Solaris) it generates the 'emplace' with a const&
+    // - For C++ < 11 (Solaris) it generates the 'emplace' with a const&
     // copy constructor, but this constructor is deleted for
     // 'bslma::ManagedPtr', so it's impossible to use here. Use
     // 'bsl::shared_ptr' instead.

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l
@@ -40,7 +40,7 @@
 -?[0-9]+ {
 	updatePosition();
 	try {
-	    // There is a problem with parsing Int64 on AIX/Solaris with string
+	    // There is a problem with parsing Int64 on Solaris with string
 	    // streams: fail flag is not set when overflow expected.  'bsl::stoll'
 	    // is used as a workaround.
 	    bsls::Types::Int64 value = bsl::stoll(yytext);

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -116,11 +116,6 @@ ntcCreateInterfaceConfig(const bmqt::SessionOptions& sessionOptions,
 
     config.setThreadName("bmqimp");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    // Set stack size to 1Mb for IBM.
-    config.setThreadStackSize(1024 * 1024);
-#endif
-
     config.setMaxThreads(1);  // there is only one channel used on this
                               // ChannelPool, with the bmqbrkr
     config.setMaxConnections(128);

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
@@ -297,11 +297,7 @@ static void test3_multithreadUseIP()
 
     const int k_NUM_THREADS = 10;
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    // This test case times out on AIX if 'k_NUM_GUIDS' is close to 1 million
-    // (it's unable to complete in 90 seconds).
-    const int k_NUM_GUIDS = 500000;  // 500k
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const int k_NUM_GUIDS = __has_feature(memory_sanitizer) ? 500000    // 500k
                                                             : 1000000;  // 1M
@@ -379,11 +375,7 @@ static void test4_multithreadUseHostname()
 
     const int k_NUM_THREADS = 10;
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    // This test case times out on AIX if 'k_NUM_GUIDS' is close to 1 million
-    // (it's unable to complete in 90 seconds).
-    const int k_NUM_GUIDS = 500000;  // 500k
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const int k_NUM_GUIDS = __has_feature(memory_sanitizer) ? 500000    // 500k
                                                             : 1000000;  // 1M
@@ -562,9 +554,7 @@ static void test6_defaultHashUniqueness()
 
     mwctst::TestHelper::printTestName("DEFAULT HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_GUIDS = 1000000;  // 1M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_GUIDS = __has_feature(memory_sanitizer)
                                                ? 1000000    // 1M
@@ -652,9 +642,7 @@ static void test7_customHashUniqueness()
 
     mwctst::TestHelper::printTestName("CUSTOM HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_GUIDS = 1000000;  // 1M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_GUIDS = __has_feature(memory_sanitizer)
                                                ? 1000000    // 1M

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -176,11 +176,6 @@ ntcCreateInterfaceConfig(const mqbcfg::TcpInterfaceConfig& tcpConfig)
 
     config.setThreadName("mqbnet");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    // Set stack size to 1Mb for IBM.
-    config.setThreadStackSize(1024 * 1024);
-#endif
-
     config.setMinThreads(tcpConfig.ioThreads());
     config.setMaxThreads(tcpConfig.ioThreads());
     config.setMaxConnections(tcpConfig.maxConnections());

--- a/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
@@ -134,9 +134,7 @@ static void test2_defaultHashUniqueness()
 
     mwctst::TestHelper::printTestName("DEFAULT HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_KEYS = 1000000;  // 1M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_KEYS = __has_feature(memory_sanitizer)
                                               ? 1000000    // 1M
@@ -219,9 +217,7 @@ static void test3_customHashUniqueness()
 
     mwctst::TestHelper::printTestName("CUSTOM HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_KEYS = 5000000;  // 5M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_KEYS = __has_feature(memory_sanitizer)
                                               ? 5000000    // 5M

--- a/src/groups/mqb/mqbs/mqbs_filesystemutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filesystemutil.cpp
@@ -252,7 +252,7 @@ void FileSystemUtil::loadFileSystemName(bsl::string* buffer, const char* path)
     loadNameFromFsType(buffer, buf.f_type);
     return;  // RETURN
 
-#elif defined(BSLS_PLATFORM_OS_SOLARIS) || defined(BSLS_PLATFORM_OS_AIX)
+#elif defined(BSLS_PLATFORM_OS_SOLARIS)
 
     struct ::statvfs buf;
     int              rc = ::statvfs(path, &buf);
@@ -627,8 +627,6 @@ int FileSystemUtil::fallocate(int                 fd,
     return rc_SUCCESS;
 
 #else
-    // As of this writing, AIX has no support for fallocate-equivalent
-    // functionality.
     return rc_UNSUPPORTED;
 
 #endif

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
@@ -182,11 +182,7 @@ static void test2_multithread()
 
     const int k_NUM_THREADS = 10;
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    // This test case times out on AIX if 'k_NUM_GUIDS' is close to 1 million
-    // (it's unable to complete in 90 seconds).
-    const int k_NUM_GUIDS = 500000;  // 500k
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const int k_NUM_GUIDS = __has_feature(memory_sanitizer) ? 500000    // 500k
                                                             : 1000000;  // 1M
@@ -318,9 +314,7 @@ static void test4_defaultHashUniqueness()
 
     mwctst::TestHelper::printTestName("DEFAULT HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_GUIDS = 1000000;  // 1M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_GUIDS = __has_feature(memory_sanitizer)
                                                ? 1000000    // 1M
@@ -406,9 +400,7 @@ static void test5_customHashUniqueness()
 
     mwctst::TestHelper::printTestName("CUSTOM HASH UNIQUENESS");
 
-#ifdef BSLS_PLATFORM_OS_AIX
-    const bsls::Types::Int64 k_NUM_GUIDS = 1000000;  // 1M
-#elif defined(__has_feature)
+#if defined(__has_feature)
     // Avoid timeout under MemorySanitizer
     const bsls::Types::Int64 k_NUM_GUIDS = __has_feature(memory_sanitizer)
                                                ? 1000000    // 1M

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -211,8 +211,8 @@ static void test3_insert()
 
     MyMapType map(s_allocator_p);
 
-#if defined(BSLS_PLATFORM_OS_AIX) || defined(BSLS_PLATFORM_OS_SOLARIS)
-    // Avoid timeout on AIX and Solaris
+#if defined(BSLS_PLATFORM_OS_SOLARIS)
+    // Avoid timeout on Solaris
     const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #elif defined(__has_feature)
     // Avoid timeout under MemorySanitizer
@@ -282,8 +282,8 @@ static void test4_rinsert()
 
     MyMapType map(s_allocator_p);
 
-#if defined(BSLS_PLATFORM_OS_AIX) || defined(BSLS_PLATFORM_OS_SOLARIS)
-    // Avoid timeout on AIX and Solaris
+#if defined(BSLS_PLATFORM_OS_SOLARIS)
+    // Avoid timeout on Solaris
     const int k_NUM_ELEMENTS = 100 * 1000;  // 100K
 #elif defined(__has_feature)
     // Avoid timeout under MemorySanitizer

--- a/src/groups/mwc/mwcsys/mwcsys_executil.t.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_executil.t.cpp
@@ -130,8 +130,8 @@ static void test2_executeSystemFailure()
 
     PVV("Testing abnormal exit of the command");
 
-#if defined(BSLS_PLATFORM_OS_SOLARIS) || defined(BSLS_PLATFORM_OS_AIX)
-    // For AIX/Solaris, python2 support is stopped, and alias `python3`
+#if defined(BSLS_PLATFORM_OS_SOLARIS)
+    // For Solaris, python2 support is stopped, and alias `python3`
     // doesn't exist.  The final supported release is 3.8.
     rc = mwcsys::ExecUtil::execute(&output,
                                    "python3.8 -c 'import os,signal; "

--- a/src/groups/mwc/mwcsys/mwcsys_threadutil.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_threadutil.cpp
@@ -49,13 +49,6 @@ const char k_LOG_CATEGORY[] = "MWCSYS.THREADUTIL";
 bslmt::ThreadAttributes ThreadUtil::defaultAttributes()
 {
     bslmt::ThreadAttributes attributes;
-
-#ifdef BSLS_PLATFORM_OS_AIX
-    // AIX default thread stack size is very small, set it to a decent
-    // value.
-    attributes.setStackSize(1024 * 1024);
-#endif
-
     return attributes;
 }
 

--- a/src/groups/mwc/mwcu/mwcu_tlsbool.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_tlsbool.t.cpp
@@ -183,8 +183,7 @@ static void test2_isValid()
     // There is a maximum number of keys that can be created by a process,
     // defined as PTHREAD_KEYS_MAX.  However, it seems that on some platforms,
     // some keys are already used and the full range is therefore not available
-    // to the application (e.g. on AIX PTHREAD_KEYS_MAX is 450, but application
-    // can only create 445 keys, on Darwin limit is 512 but only 509 or 510 are
+    // to the application (e.g. on Darwin limit is 512 but only 509 or 510 are
     // available, ...).  Figure out what that limit is, by creating keys until
     // creation returns failure.
     bsl::vector<bslmt::ThreadUtil::Key> keys(s_allocator_p);
@@ -212,8 +211,8 @@ static void test2_isValid()
     // At this point, we created the max limit number of keys the system can
     // handle, creating any one more should assert, unless providing a default
     // value in the constructor.
-#if !defined(BSLS_PLATFORM_OS_AIX) && !defined(BSLS_PLATFORM_OS_DARWIN)
-    // It doesn't look like AIX or Darwin handle constructor throwing an
+#if !defined(BSLS_PLATFORM_OS_DARWIN)
+    // It doesn't look like Darwin handle constructor throwing an
     // ASSERT, so skip that check on those platforms.
     {
         // Constructor without a value, should assert

--- a/src/integration-tests/test_breathing.py
+++ b/src/integration-tests/test_breathing.py
@@ -348,7 +348,7 @@ def test_verify_fanout(cluster: Cluster):
     )
 
     # testing {client1 open "foo" for read, client2 open "bar" for read,
-    #          client1 open for write} sequence (RDSIBMQ-1008).
+    #          client1 open for write} sequence.
 
     assert (
         fooConsumerAndProducerOnPrimaryProxy.open(


### PR DESCRIPTION
We are dropping AIX support for BlazingMQ internally. As a result, it may be healthy to do a cleanup of the code added to specifically support this platform, as we will have no good way of testing these code paths.