### PR TITLE
Feat[BMQ, MQB, MWC]: performance tune-up [1]

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
@@ -480,7 +480,8 @@ static void test2_flattenExplodesEvent()
 
     // 1st flattened event
     bmqp::Event flattenedEvent1(&(eventInfos[0].d_blob), s_allocator_p);
-    ASSERT_EQ(eventInfos[0].d_ids.size(), size_t(count * numSubQueueIds - 1));
+    ASSERT_EQ(eventInfos[0].d_ids.size(),
+              static_cast<size_t>(count * numSubQueueIds - 1));
 
     flattenedEvent1.loadPushMessageIterator(&msgIterator, true);
     BSLS_ASSERT_OPT(msgIterator.isValid());

--- a/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
@@ -118,9 +118,8 @@ generateSubQueueInfos(bmqp::Protocol::SubQueueInfosArray* subQueueInfos,
 
     subQueueInfos->clear();
 
-    static unsigned int nextSubId = 1;
     for (int i = 0; i < numSubQueueInfos; ++i) {
-        subQueueInfos->push_back(bmqp::SubQueueInfo(nextSubId++));
+        subQueueInfos->push_back(bmqp::SubQueueInfo(i + 1));
     }
 }
 
@@ -159,7 +158,7 @@ static void appendDatum(bsl::vector<Data>*        data,
     BSLS_ASSERT_OPT(payloadLength >= 0);
 
     Data datum(bufferFactory, allocator);
-    datum.d_qid   = generateRandomInteger(1, 200);
+    datum.d_qid   = data->size();
     datum.d_flags = 0;
     // Use the new SubQueueInfo option
     datum.d_isSubQueueInfo = true;
@@ -420,10 +419,11 @@ static void test2_flattenExplodesEvent()
 //
 // Plan:
 //   1) Create an event composed of one message having a payload of size
-//      one third the maximum enforced size and four SubQueueIds.
+//      a little over the quarter of the maximum enforced size and four
+//      SubQueueIds.
 //   2) Flatten the event.
-//   3) Verify that the flattening results in two event blobs, each having
-//      two messages with one SubQueueId each.
+//   3) Verify that the flattening results in two event blobs, first having
+//      15 messages and the second 1 with one SubQueueId each.
 //
 // Testing:
 //   Flattening an event having a message with more than one SubQueueId
@@ -444,13 +444,21 @@ static void test2_flattenExplodesEvent()
     // 1) Event composed of one message having a payload of size one third the
     //    maximum enforced size and four SubQueueIds.
     // Msg1
-    payloadLength  = bmqp::EventHeader::k_MAX_SIZE_SOFT / 3;
+    payloadLength  = bmqp::PushHeader::k_MAX_PAYLOAD_SIZE_SOFT / 2;
     numSubQueueIds = 4;
-    appendDatum(&data,
-                numSubQueueIds,
-                payloadLength,
-                &bufferFactory,
-                s_allocator_p);
+
+    int count = 0;
+    int total = 0;
+
+    while (total < bmqp::EventHeader::k_MAX_SIZE_SOFT / 4) {
+        appendDatum(&data,
+                    numSubQueueIds,
+                    payloadLength,
+                    &bufferFactory,
+                    s_allocator_p);
+        total += data[count].d_payload.length();
+        ++count;
+    }
 
     // Create event
     appendMessages(&pushEventBuilder, data);
@@ -468,12 +476,11 @@ static void test2_flattenExplodesEvent()
     // 3) Verify that the flattening results in two event blobs, each having
     //    two messages with one SubQueueId each.
     bmqp::PushMessageIterator msgIterator(&bufferFactory, s_allocator_p);
-    const Data&               D   = data[0];
     int                       idx = 0;
 
     // 1st flattened event
     bmqp::Event flattenedEvent1(&(eventInfos[0].d_blob), s_allocator_p);
-    ASSERT_EQ(eventInfos[0].d_ids.size(), 2u);
+    ASSERT_EQ(eventInfos[0].d_ids.size(), size_t(count * numSubQueueIds - 1));
 
     flattenedEvent1.loadPushMessageIterator(&msgIterator, true);
     BSLS_ASSERT_OPT(msgIterator.isValid());
@@ -489,7 +496,7 @@ static void test2_flattenExplodesEvent()
         rc = msgIterator.loadMessagePayload(&payload);
         BSLS_ASSERT_OPT(rc == 0);
 
-        ASSERT_EQ(bdlbb::BlobUtil::compare(D.d_payload, payload), 0);
+        ASSERT_EQ(bdlbb::BlobUtil::compare(data[0].d_payload, payload), 0);
     }
 
     // Verify SubQueueInfos
@@ -506,14 +513,16 @@ static void test2_flattenExplodesEvent()
         BSLS_ASSERT_OPT(rc == 0);
         BSLS_ASSERT_OPT(subQueueInfos.size() == 1);
 
-        ASSERT_EQ(D.d_subQueueInfos[idx], subQueueInfos[0]);
+        ASSERT_EQ(data[0].d_subQueueInfos[0], subQueueInfos[0]);
+    }
 
-        // Verify that 'eventInfo' contains the queueId pair (id, subId)
-        // corresponding to this message
-        const int          id            = D.d_qid;
-        const unsigned int subcriptionId = D.d_subQueueInfos[idx].id();
+    // Verify that 'eventInfo' contains the queueId pair (id, subId)
+    // corresponding to this message
 
-        ASSERT(find(eventInfos[0], id, subcriptionId));
+    for (size_t i = 0; i < eventInfos[0].d_ids.size(); ++i) {
+        ASSERT_EQ(eventInfos[0].d_ids[i].d_subscriptionId, i % count + 1);
+        ASSERT_EQ(size_t(eventInfos[0].d_ids[i].d_header.queueId()),
+                  i / count);
     }
 
     ++idx;
@@ -529,7 +538,7 @@ static void test2_flattenExplodesEvent()
         rc = msgIterator.loadMessagePayload(&payload);
         BSLS_ASSERT_OPT(rc == 0);
 
-        ASSERT_EQ(bdlbb::BlobUtil::compare(D.d_payload, payload), 0);
+        ASSERT_EQ(bdlbb::BlobUtil::compare(data[0].d_payload, payload), 0);
     }
 
     // Verify SubQueueInfos
@@ -546,25 +555,19 @@ static void test2_flattenExplodesEvent()
         BSLS_ASSERT_OPT(rc == 0);
         BSLS_ASSERT_OPT(subQueueInfos.size() == 1);
 
-        ASSERT_EQ(D.d_subQueueInfos[idx], subQueueInfos[0]);
-
-        // Verify that 'eventInfo' contains the queueId pair (id, subId)
-        // corresponding to this message
-        const int          qId           = D.d_qid;
-        const unsigned int subcriptionId = D.d_subQueueInfos[idx].id();
-        ASSERT(find(eventInfos[0], qId, subcriptionId));
+        ASSERT_EQ(data[0].d_subQueueInfos[idx], subQueueInfos[0]);
     }
 
-    ++idx;
+    idx = count - 1;  // the last one did not fit the first event
 
     // 2nd flattened event
     bmqp::Event flattenedEvent2(&(eventInfos[1].d_blob), s_allocator_p);
-    ASSERT_EQ(eventInfos[1].d_ids.size(), 2u);
+    ASSERT_EQ(eventInfos[1].d_ids.size(), 1u);
 
     flattenedEvent2.loadPushMessageIterator(&msgIterator, true);
     BSLS_ASSERT_OPT(msgIterator.isValid());
 
-    // Third message
+    // 1st message in tne second event
     rc = msgIterator.next();
     BSLS_ASSERT_OPT(rc == 1);
     BSLS_ASSERT_OPT(msgIterator.hasOptions());
@@ -575,7 +578,7 @@ static void test2_flattenExplodesEvent()
         rc = msgIterator.loadMessagePayload(&payload);
         BSLS_ASSERT_OPT(rc == 0);
 
-        ASSERT_EQ(bdlbb::BlobUtil::compare(D.d_payload, payload), 0);
+        ASSERT_EQ(bdlbb::BlobUtil::compare(data[idx].d_payload, payload), 0);
     }
 
     // Verify SubQueueInfos
@@ -592,54 +595,22 @@ static void test2_flattenExplodesEvent()
         BSLS_ASSERT_OPT(rc == 0);
         BSLS_ASSERT_OPT(subQueueInfos.size() == 1);
 
-        ASSERT_EQ(D.d_subQueueInfos[idx].id(), subQueueInfos[0].id());
+        ASSERT_EQ(data[idx].d_subQueueInfos[idx].id(), subQueueInfos[0].id());
 
-        // Verify that 'eventInfo' contains the queueId (queueId, subQueueId)
-        // pair corresponding to this message
-        const int          qId           = D.d_qid;
-        const unsigned int subcriptionId = D.d_subQueueInfos[idx].id();
+        const int          qId           = data[idx].d_qid;
+        const unsigned int subcriptionId = data[idx].d_subQueueInfos[idx].id();
         ASSERT(find(eventInfos[1], qId, subcriptionId));
     }
 
-    ++idx;
+    // Verify that 'eventInfo' contains the queueId (queueId, subQueueId)
+    // pair corresponding to this message
 
-    // Fourth message
+    ASSERT_EQ(eventInfos[1].d_ids[0].d_subscriptionId,
+              data[count - 1].d_subQueueInfos.back().id());
+    ASSERT_EQ(eventInfos[1].d_ids[0].d_header.queueId(), count - 1);
+
+    // No more messages
     rc = msgIterator.next();
-    BSLS_ASSERT_OPT(rc == 1);
-    BSLS_ASSERT_OPT(msgIterator.hasOptions());
-
-    // Verify payload
-    {
-        bdlbb::Blob payload(&bufferFactory, s_allocator_p);
-        rc = msgIterator.loadMessagePayload(&payload);
-        BSLS_ASSERT_OPT(rc == 0);
-
-        ASSERT_EQ(bdlbb::BlobUtil::compare(D.d_payload, payload), 0);
-    }
-
-    // Verify SubQueueInfos
-    {
-        bmqp::OptionsView optionsView(s_allocator_p);
-        rc = msgIterator.loadOptionsView(&optionsView);
-        BSLS_ASSERT_OPT(rc == 0);
-        BSLS_ASSERT_OPT(optionsView.isValid());
-        BSLS_ASSERT_OPT(
-            optionsView.find(bmqp::OptionType::e_SUB_QUEUE_INFOS) !=
-            optionsView.end());
-        bmqp::Protocol::SubQueueInfosArray subQueueInfos(s_allocator_p);
-        rc = optionsView.loadSubQueueInfosOption(&subQueueInfos);
-        BSLS_ASSERT_OPT(rc == 0);
-        BSLS_ASSERT_OPT(subQueueInfos.size() == 1);
-
-        ASSERT_EQ(D.d_subQueueInfos[idx], subQueueInfos[0]);
-
-        // Verify that 'eventInfo' contains the queueId (queueId, subQueueId)
-        // pair corresponding to this message
-        const int          qId           = D.d_qid;
-        const unsigned int subcriptionId = D.d_subQueueInfos[idx].id();
-
-        ASSERT(find(eventInfos[1], qId, subcriptionId));
-    }
 }
 
 static void test3_flattenWithMessageProperties()

--- a/src/groups/bmq/bmqp/bmqp_optionutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionutil.t.cpp
@@ -306,9 +306,6 @@ static void test2_basicOptionsBoxCanAdd()
             const int    maxPayload  = k_MAX_SIZE - headerSize;
             const LimitT limit       = maxCanBeAdded(contentSize, maxPayload);
             ASSERT_EQ(Result::e_OPTION_TOO_BIG, limit.second);
-            const int sizeLeft = k_MAX_SIZE_SOFT - contentSize;
-            const int expected = sizeLeft / k_MAX_SIZE;
-            ASSERT_EQ(expected, limit.first);
         }
     }
 }

--- a/src/groups/bmq/bmqp/bmqp_protocol.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.cpp
@@ -394,6 +394,7 @@ const int MessagePropertyHeader::k_PROP_NAME_LEN_MASK = bdlb::BitMaskUtil::one(
 
 const int PutHeader::k_MAX_OPTIONS_SIZE;
 const int PutHeader::k_MAX_PAYLOAD_SIZE_SOFT;
+const int PutHeader::k_MAX_SIZE_SOFT;
 // Force variable/symbol definition so that it can be used in other files
 
 const int PutHeader::k_FLAGS_MASK = bdlb::BitMaskUtil::one(

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -823,9 +823,11 @@ struct EventHeader {
     /// an outgoing storage message can exceed
     /// `PutHeader::k_MAX_PAYLOAD_SIZE_SOFT`.  So, we assign a value of 65MB
     /// to `StorageHeader::k_MAX_PAYLOAD_SIZE_SOFT`, and assign a value of
-    /// 66MB to `'EventHeader::k_MAX_SIZE_SOFT` such that a PUT message
-    /// having the maximum allowable value is processed through the entire
-    /// BlazingMQ pipeline w/o any issues.  Also see notes in
+    /// at least 66MB to `EventHeader::k_MAX_SIZE_SOFT` such that a PUT
+    /// message having the maximum allowable value is processed through the
+    /// BlazingMQ pipeline w/o any issues.  The value of
+    /// `EventHeader::k_MAX_SIZE_SOFT` is 512Mb to improve batching at high
+    /// posting rates.  Also see notes for the
     /// `StorageHeader::k_MAX_PAYLOAD_SIZE_SOFT` constant.
     static const int k_MAX_SIZE_SOFT = 512 * 1024 * 1024;
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -827,7 +827,7 @@ struct EventHeader {
     /// having the maximum allowable value is processed through the entire
     /// BlazingMQ pipeline w/o any issues.  Also see notes in
     /// `StorageHeader::k_MAX_PAYLOAD_SIZE_SOFT` constant.
-    static const int k_MAX_SIZE_SOFT = (64 + 2) * 1024 * 1024;
+    static const int k_MAX_SIZE_SOFT = 512 * 1024 * 1024;
 
     /// Highest possible value for the type of an event.
     static const int k_MAX_TYPE = (1 << k_TYPE_NUM_BITS) - 1;
@@ -1492,6 +1492,7 @@ struct PutHeader {
     /// be increased but not up to `k_MAX_SIZE`.
     static const int k_MAX_PAYLOAD_SIZE_SOFT = 64 * 1024 * 1024;
 
+    static const int k_MAX_SIZE_SOFT = (64 + 2) * 1024 * 1024;
     /// Maximum size (bytes) of the options area.
     static const int k_MAX_OPTIONS_SIZE = ((1 << k_OPTIONS_WORDS_NUM_BITS) -
                                            1) *

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
@@ -84,7 +84,7 @@ PutEventBuilder::packMessageInternal(const bdlbb::Blob& appData, int queueId)
                               numPaddingBytes;
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(sizeNoOptions >
-                                              EventHeader::k_MAX_SIZE_SOFT)) {
+                                              PutHeader::k_MAX_SIZE_SOFT)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         return Result::e_EVENT_TOO_BIG;  // RETURN
     }

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -142,7 +142,10 @@ Application::Application(bdlmt::EventScheduler* scheduler,
                        1,
                        bsls::TimeInterval(120).totalMilliseconds(),
                        allocator)
-, d_bufferFactory(k_BLOBBUFFER_SIZE, d_allocators.get("BufferFactory"))
+, d_bufferFactory(k_BLOBBUFFER_SIZE,
+                  bsls::BlockGrowth::BSLS_CONSTANT,
+                  d_allocators.get("BufferFactory"))
+
 , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
                                     &d_bufferFactory,
                                     bdlf::PlaceHolders::_1,   // arena

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -302,6 +302,8 @@ int Dispatcher::startContext(bsl::ostream&                    errorDescription,
     //      We should have subcontext per each type of event (PUSH, PUT,
     //      CALLBACK, ACK, ...)
 
+    processorPoolConfig.setGrowBy(64 * 1024);
+
     context->d_processorPool_mp.load(
         new (*d_allocator_p) ProcessorPool(processorPoolConfig, d_allocator_p),
         d_allocator_p);
@@ -332,7 +334,7 @@ Dispatcher::ProcessorPool::Queue* Dispatcher::queueCreator(
     bsl::string queueName(os.str().data(), os.str().length());
 
     ProcessorPool::Queue* queue = new (*allocator)
-        ProcessorPool::Queue(config.queueSize(), allocator);
+        ProcessorPool::Queue(config.queueSizeLowWatermark(), allocator);
 
     queue->setWatermarks(config.queueSizeLowWatermark(),
                          config.queueSizeHighWatermark());

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -332,7 +332,7 @@ Dispatcher::ProcessorPool::Queue* Dispatcher::queueCreator(
     bsl::string queueName(os.str().data(), os.str().length());
 
     ProcessorPool::Queue* queue = new (*allocator)
-        ProcessorPool::Queue(config.queueSizeLowWatermark(), allocator);
+        ProcessorPool::Queue(config.queueSize(), allocator);
 
     queue->setWatermarks(config.queueSizeLowWatermark(),
                          config.queueSizeHighWatermark());

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -388,6 +388,16 @@ void Cluster::sendAck(bmqt::AckResult::Enum     status,
                     1);
             }
         }
+        else if (!isSelfGenerated) {
+            MWCU_THROTTLEDACTION_THROTTLE(
+                d_throttledFailedAckMessages,
+                BALL_LOG_WARN
+                    << description()
+                    << ": ACK message for queue with unknown queueId ["
+                    << queueId << ", guid: " << messageGUID << ", for node: "
+                    << nodeSession->clusterNode()->nodeDescription(););
+            return;  // RETURN
+        }
 
         // Throttle error log if this is a 'failed Ack': note that we log at
         // INFO level in order not to overwhelm the dashboard, if a queue is
@@ -1263,19 +1273,6 @@ void Cluster::onAckEvent(const mqbi::DispatcherEvent& event)
         return;  // RETURN
     }
 
-    QueueHandleMap&    queueHandles = ns->queueHandles();
-    QueueHandleMapIter queueIt      = queueHandles.find(ackMessage.queueId());
-    if (queueIt == queueHandles.end()) {
-        MWCU_THROTTLEDACTION_THROTTLE(
-            d_throttledFailedAckMessages,
-            BALL_LOG_WARN << description()
-                          << ": ACK message for queue with unknown queueId ["
-                          << ackMessage.queueId() << ", guid: "
-                          << ackMessage.messageGUID() << ", for node: "
-                          << realEvent->clusterNode()->nodeDescription(););
-        return;  // RETURN
-    }
-
     sendAck(bmqp::ProtocolUtil::ackResultFromCode(ackMessage.status()),
             ackMessage.correlationId(),
             ackMessage.messageGUID(),
@@ -1398,9 +1395,6 @@ void Cluster::onConfirmEvent(const mqbi::DispatcherEvent& event)
     int msgNum = 0;
     int rc     = 0;
 
-    bdlma::LocalSequentialAllocator<256> localAllocator(d_allocator_p);
-    mwcu::MemOutStream                   errorStream(&localAllocator);
-
     while ((rc = confIt.next() == 1)) {
         const int          id    = confIt.message().queueId();
         const unsigned int subId = static_cast<unsigned int>(
@@ -1408,12 +1402,11 @@ void Cluster::onConfirmEvent(const mqbi::DispatcherEvent& event)
         const bmqp::QueueId queueId(id, subId);
         mqbi::QueueHandle*  queueHandle = 0;
 
-        bool isValid = validateMessage(&queueHandle,
-                                       &errorStream,
-                                       queueId,
-                                       ns,
-                                       bmqp::EventType::e_CONFIRM);
-        if (isValid) {
+        ValidationResult result = validateMessage(&queueHandle,
+                                                  queueId,
+                                                  ns,
+                                                  bmqp::EventType::e_CONFIRM);
+        if (result == k_SUCCESS) {
             BSLS_ASSERT_SAFE(queueHandle);
 
             BALL_LOG_TRACE << description() << ": CONFIRM "
@@ -1429,14 +1422,12 @@ void Cluster::onConfirmEvent(const mqbi::DispatcherEvent& event)
             MWCU_THROTTLEDACTION_THROTTLE(
                 d_throttledFailedRejectMessages,
                 MWCTSK_ALARMLOG_ALARM("CLUSTER")
-                    << description() << ": CONFIRM " << errorStream.str()
-                    << " [queue: '"
+                    << ": CONFIRM " << validationResult(result) << " [queue: '"
                     << (queueHandle ? queueHandle->queue()->uri()
                                     : "<UNKNOWN>")
                     << "', queueId: " << queueId << ", GUID: "
                     << confIt.message().messageGUID() << "] from "
                     << source->nodeDescription() << MWCTSK_ALARMLOG_END;);
-            errorStream.reset();
         }
     }
 
@@ -1500,9 +1491,6 @@ void Cluster::onRejectEvent(const mqbi::DispatcherEvent& event)
     int msgNum = 0;
     int rc     = 0;
 
-    bdlma::LocalSequentialAllocator<256> localAllocator(d_allocator_p);
-    mwcu::MemOutStream                   errorStream(&localAllocator);
-
     while ((rc = rejectIt.next() == 1)) {
         const int          id    = rejectIt.message().queueId();
         const unsigned int subId = static_cast<unsigned int>(
@@ -1510,12 +1498,11 @@ void Cluster::onRejectEvent(const mqbi::DispatcherEvent& event)
         const bmqp::QueueId queueId(id, subId);
         mqbi::QueueHandle*  queueHandle = 0;
 
-        bool isValid = validateMessage(&queueHandle,
-                                       &errorStream,
-                                       queueId,
-                                       ns,
-                                       bmqp::EventType::e_REJECT);
-        if (isValid) {
+        ValidationResult result = validateMessage(&queueHandle,
+                                                  queueId,
+                                                  ns,
+                                                  bmqp::EventType::e_REJECT);
+        if (result == k_SUCCESS) {
             BSLS_ASSERT_SAFE(queueHandle);
 
             BALL_LOG_TRACE << description() << ": REJECT "
@@ -1531,14 +1518,12 @@ void Cluster::onRejectEvent(const mqbi::DispatcherEvent& event)
             MWCU_THROTTLEDACTION_THROTTLE(
                 d_throttledFailedRejectMessages,
                 MWCTSK_ALARMLOG_ALARM("CLUSTER")
-                    << description() << ": REJECT " << errorStream.str()
-                    << " [queue: '"
+                    << ": REJECT " << validationResult(result) << " [queue: '"
                     << (queueHandle ? queueHandle->queue()->uri()
                                     : "<UNKNOWN>")
                     << "', queueId: " << queueId << ", GUID: "
                     << rejectIt.message().messageGUID() << "] from "
                     << source->nodeDescription() << MWCTSK_ALARMLOG_END;);
-            errorStream.reset();
         }
     }
 
@@ -1555,11 +1540,11 @@ void Cluster::onRejectEvent(const mqbi::DispatcherEvent& event)
     }
 }
 
-bool Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
-                              bsl::ostream*             errorStream,
-                              const bmqp::QueueId&      queueId,
-                              mqbc::ClusterNodeSession* ns,
-                              bmqp::EventType::Enum     eventType)
+Cluster::ValidationResult
+Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
+                         const bmqp::QueueId&      queueId,
+                         mqbc::ClusterNodeSession* ns,
+                         bmqp::EventType::Enum     eventType)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE((eventType == bmqp::EventType::e_CONFIRM ||
@@ -1573,9 +1558,7 @@ bool Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(queueIt == queueHandles.end())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-        *errorStream << "message for unknown queue";
-
-        return false;  // RETURN
+        return k_UNKNOWN_QUEUE;  // RETURN
     }
 
     const QueueState&          queueState = queueIt->second;
@@ -1588,19 +1571,14 @@ bool Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
             subQueueIt == queueState.d_subQueueInfosMap.end())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-        *errorStream << "message for unknown queue";
-
-        return false;  // RETURN
+        return k_UNKNOWN_QUEUE;  // RETURN
     }
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
             queueState.d_isFinalCloseQueueReceived)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-        *errorStream << "message for which final closeQueue was already "
-                        "received";
-
-        return false;  // RETURN
+        return k_FINAL;  // RETURN
     }
 
     if (eventType == bmqp::EventType::e_CONFIRM) {
@@ -1610,7 +1588,7 @@ bool Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
             1);
     }
 
-    return true;
+    return k_SUCCESS;
 }
 
 void Cluster::onRelayRejectEvent(const mqbi::DispatcherEvent& event)
@@ -3315,8 +3293,7 @@ void Cluster::processEvent(const bmqp::Event&   event,
     } break;
     case bmqp::EventType::e_REPLICATION_RECEIPT: {
         // Receipt event arrives from replication nodes to primary.
-        DISPATCH_EVENT(mqbi::DispatcherEventType::e_REPLICATION_RECEIPT,
-                       false);
+        d_storageManager_mp->processReceiptEvent(event, source);
     } break;  // BREAK
     case bmqp::EventType::e_UNDEFINED:
     default: {
@@ -3410,10 +3387,7 @@ void Cluster::onDispatcherEvent(const mqbi::DispatcherEvent& event)
             onPushEvent(event);
         }
     } break;  // BREAK
-    case mqbi::DispatcherEventType::e_REPLICATION_RECEIPT: {
-        const mqbi::DispatcherReceiptEvent* realEvent = event.asReceiptEvent();
-        d_storageManager_mp->processReceiptEvent(*realEvent);
-    } break;
+    case mqbi::DispatcherEventType::e_REPLICATION_RECEIPT:
     case mqbi::DispatcherEventType::e_CONTROL_MSG:
     case mqbi::DispatcherEventType::e_DISPATCHER:
     case mqbi::DispatcherEventType::e_UNDEFINED:

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -523,8 +523,6 @@ class Cluster : public mqbi::Cluster,
     /// Execute `initiateShutdown` followed by `stop` and SIGINT
     void terminate(mqbu::ExitCode::Enum reason);
 
-    static const char* validationResult(const ValidationResult& result);
-
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(Cluster, bslma::UsesBslmaAllocator)

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -217,7 +217,38 @@ class Cluster : public mqbi::Cluster,
         const StopRequestManagerType::RequestContextSp& contextSp)>
         StopRequestCompletionCallback;
 
-    enum ValidationResult { k_SUCCESS = 0, k_UNKNOWN_QUEUE, k_FINAL };
+    struct ValidationResult {
+        enum Enum {
+            k_SUCCESS = 0,
+            k_UNKNOWN_QUEUE,
+            k_UNKNOWN_SUBQUEUE,
+            k_FINAL
+        };
+
+        // CLASS METHODS
+
+        /// Write the string representation of the specified enumeration
+        /// `value` to the specified output `stream`, and return a reference
+        /// to `stream`.  Optionally specify an initial indentation `level`,
+        /// whose absolute value is incremented recursively for nested
+        /// objects.  If `level` is specified, optionally specify
+        /// `spacesPerLevel`, whose absolute value indicates the number of
+        /// spaces per indentation level for this and all of its nested
+        /// objects.  If `level` is negative, suppress indentation of the
+        /// first line.  If `spacesPerLevel` is negative, format the entire
+        /// output on one line, suppressing all but the initial indentation
+        /// (as governed by `level`).  See `toAscii` for what constitutes
+        /// the string representation of a `State::Enum` value.
+        static bsl::ostream& print(bsl::ostream&          stream,
+                                   ValidationResult::Enum value,
+                                   int                    level          = 0,
+                                   int                    spacesPerLevel = 4);
+
+        /// Return the non-modifiable string representation corresponding to
+        /// the specified enumeration `value`.
+        static const char* toAscii(ValidationResult::Enum value);
+    };
+
     typedef bsl::function<void()> CompletionCallback;
 
   private:
@@ -423,15 +454,13 @@ class Cluster : public mqbi::Cluster,
 
     void onRelayPushEvent(const mqbi::DispatcherEvent& event);
 
-    ValidationResult validateMessage(mqbi::QueueHandle**       queueHandle,
-                                     const bmqp::QueueId&      queueId,
-                                     mqbc::ClusterNodeSession* ns,
-                                     bmqp::EventType::Enum     eventType);
+    ValidationResult::Enum validateMessage(mqbi::QueueHandle**  queueHandle,
+                                           const bmqp::QueueId& queueId,
+                                           mqbc::ClusterNodeSession* ns,
+                                           bmqp::EventType::Enum eventType);
     // Validate a message of the specified 'eventType' using the specified
-    // 'queueId' and 'ns'. Return true if the message is valid and false
-    // otherwise. Populate the specified 'queueHandle' if the queue is found
-    // and load a descriptive error message into the 'errorStream' if the
-    // message is invalid.
+    // 'queueId' and 'ns'. Return one of `ValidationResult` values. Populate
+    // the specified 'queueHandle' if the queue is found.
 
     bool validateRelayMessage(mqbc::ClusterNodeSession** ns,
                               bsl::ostream*              errorStream,
@@ -794,17 +823,6 @@ class Cluster : public mqbi::Cluster,
 // -------------
 // class Cluster
 // -------------
-// static
-inline const char* Cluster::validationResult(const ValidationResult& result)
-{
-    switch (result) {
-    case k_SUCCESS: return "SUCCESS";
-    case k_UNKNOWN_QUEUE: return "message for unknown queue";
-    case k_FINAL:
-        return "message for which final closeQueue was already received";
-    default: return "UNKNOWN";
-    }
-}
 
 inline Cluster::RequestManagerType& Cluster::requestManager()
 {

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -1380,7 +1380,7 @@ void RemoteQueue::expirePendingMessagesDispatched()
 
     if (numExpired) {
         if (d_throttledFailedPutMessages.requestPermission()) {
-            BALL_LOG_INFO << d_state_p->uri() << ": expired "
+            BALL_LOG_INFO << "[THROTTLED] " << d_state_p->uri() << ": expired "
                           << mwcu::PrintUtil::prettyNumber(numExpired)
                           << " pending PUT messages ("
                           << mwcu::PrintUtil::prettyNumber(numMessages -

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -1379,12 +1379,14 @@ void RemoteQueue::expirePendingMessagesDispatched()
     }
 
     if (numExpired) {
-        BALL_LOG_INFO << d_state_p->uri() << ": expired "
-                      << mwcu::PrintUtil::prettyNumber(numExpired)
-                      << " pending PUSH messages ("
-                      << mwcu::PrintUtil::prettyNumber(numMessages -
-                                                       numExpired)
-                      << " remaining messages).";
+        if (d_throttledFailedPutMessages.requestPermission()) {
+            BALL_LOG_INFO << d_state_p->uri() << ": expired "
+                          << mwcu::PrintUtil::prettyNumber(numExpired)
+                          << " pending PUT messages ("
+                          << mwcu::PrintUtil::prettyNumber(numMessages -
+                                                           numExpired)
+                          << " remaining messages).";
+        }
     }
 
     // reschedule

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1963,13 +1963,10 @@ void StorageManager::processRecoveryEvent(
                                      source));
 }
 
-void StorageManager::processReceiptEvent(
-    const mqbi::DispatcherReceiptEvent& event)
+void StorageManager::processReceiptEvent(const bmqp::Event&   event,
+                                         mqbnet::ClusterNode* source)
 {
-    // executed by *CLUSTER DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_dispatcher_p->inDispatcherThread(d_cluster_p));
+    // executed by *IO* thread
 
     mwcu::BlobPosition          position;
     BSLA_MAYBE_UNUSED const int rc = mwcu::BlobUtil::findOffsetSafe(
@@ -1979,7 +1976,7 @@ void StorageManager::processReceiptEvent(
     BSLS_ASSERT_SAFE(rc == 0);
 
     mwcu::BlobObjectProxy<bmqp::ReplicationReceipt> receipt(
-        event.blob().get(),
+        event.blob(),
         position,
         true,    // read mode
         false);  // no write
@@ -1998,7 +1995,7 @@ void StorageManager::processReceiptEvent(
                                      fs,
                                      receipt->primaryLeaseId(),
                                      receipt->sequenceNum(),
-                                     event.clusterNode()));
+                                     source));
 }
 
 void StorageManager::processPrimaryStatusAdvisory(

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -666,9 +666,10 @@ class StorageManager : public mqbi::StorageManager {
     virtual void processRecoveryEvent(
         const mqbi::DispatcherRecoveryEvent& event) BSLS_KEYWORD_OVERRIDE;
 
-    /// Executed in cluster dispatcher thread.
-    virtual void processReceiptEvent(const mqbi::DispatcherReceiptEvent& event)
-        BSLS_KEYWORD_OVERRIDE;
+    /// Executed in IO thread.
+    virtual void
+    processReceiptEvent(const bmqp::Event&   event,
+                        mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
 
     /// Executed by any thread.
     virtual void processPrimaryStatusAdvisory(

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4087,13 +4087,10 @@ void StorageManager::processRecoveryEvent(
                      "This method can only be invoked in non-CSL mode");
 }
 
-void StorageManager::processReceiptEvent(
-    const mqbi::DispatcherReceiptEvent& event)
+void StorageManager::processReceiptEvent(const bmqp::Event&   event,
+                                         mqbnet::ClusterNode* source)
 {
-    // executed by *CLUSTER DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_dispatcher_p->inDispatcherThread(d_cluster_p));
+    // executed by *IO* thread
 
     mwcu::BlobPosition          position;
     BSLA_MAYBE_UNUSED const int rc = mwcu::BlobUtil::findOffsetSafe(
@@ -4103,7 +4100,7 @@ void StorageManager::processReceiptEvent(
     BSLS_ASSERT_SAFE(rc == 0);
 
     mwcu::BlobObjectProxy<bmqp::ReplicationReceipt> receipt(
-        event.blob().get(),
+        event.blob(),
         position,
         true,    // read mode
         false);  // no write
@@ -4122,7 +4119,7 @@ void StorageManager::processReceiptEvent(
                                      fs,
                                      receipt->primaryLeaseId(),
                                      receipt->sequenceNum(),
-                                     event.clusterNode()));
+                                     source));
 }
 
 void StorageManager::processPrimaryStatusAdvisory(

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -930,9 +930,10 @@ class StorageManager
     virtual void processRecoveryEvent(
         const mqbi::DispatcherRecoveryEvent& event) BSLS_KEYWORD_OVERRIDE;
 
-    /// Executed in cluster dispatcher thread.
-    virtual void processReceiptEvent(const mqbi::DispatcherReceiptEvent& event)
-        BSLS_KEYWORD_OVERRIDE;
+    /// Executed in IO thread.
+    virtual void
+    processReceiptEvent(const bmqp::Event&   event,
+                        mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
 
     /// Executed by any thread.
     virtual void processPrimaryStatusAdvisory(

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1117,31 +1117,6 @@ bool StorageUtil::validateStorageEvent(
         return false;  // RETURN
     }
 
-    bmqp::StorageMessageIterator iter;
-    event.loadStorageMessageIterator(&iter);
-    BSLS_ASSERT_SAFE(iter.isValid());
-    while (iter.next() == 1) {
-        const bmqp::StorageHeader& header = iter.header();
-        if (static_cast<unsigned int>(partitionId) != header.partitionId()) {
-            // A storage event is sent by 'source' cluster node.  The node may
-            // be primary for one or more partitions, but as per the BMQ
-            // replication design, *all* messages in this event will belong to
-            // the *same* partition.  Any exception to this is a bug in the
-            // implementation of replication, and thus, if it occurs, we reject
-            // the *entire* storage event.
-
-            MWCTSK_ALARMLOG_ALARM("STORAGE")
-                << clusterData.identity().description() << ": Received storage"
-                << " event from node " << source->nodeDescription() << " with"
-                << " different PartitionId: [" << partitionId << "] vs ["
-                << header.partitionId() << "]"
-                << ". Ignoring entire storage event." << MWCTSK_ALARMLOG_END;
-            return false;  // RETURN
-        }
-
-        // NOTE: (leaseId, seqNum) will be checked later.
-    }
-
     return true;
 }
 

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -38,6 +38,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqp_event.h>
 #include <bmqt_uri.h>
 
 // BDE
@@ -368,9 +369,9 @@ class StorageManager : public mqbi::AppKeyGenerator {
     virtual void
     processRecoveryEvent(const mqbi::DispatcherRecoveryEvent& event) = 0;
 
-    /// Executed in cluster dispatcher thread.
-    virtual void
-    processReceiptEvent(const mqbi::DispatcherReceiptEvent& event) = 0;
+    /// Executed in IO thread.
+    virtual void processReceiptEvent(const bmqp::Event&   event,
+                                     mqbnet::ClusterNode* source) = 0;
 
     /// Executed by any thread.
     virtual void processPrimaryStatusAdvisory(

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -86,7 +86,7 @@ Channel::Channel(bdlbb::BlobBufferFactory* blobBufferFactory,
     bslmt::ThreadAttributes attr = mwcsys::ThreadUtil::defaultAttributes();
     bsl::string             threadName("bmqNet-");
     attr.setThreadName(threadName + d_name);
-    d_buffer.setWatermarks(500, 1000, 5000);
+    d_buffer.setWatermarks(50000, 100000, 500000);
     d_buffer.setStateCallback(
         bdlf::MemFnUtil::memFn(&Channel::onBufferStateChange, this));
     int rc = bslmt::ThreadUtil::createWithAllocator(

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -353,7 +353,7 @@ TransportManager::TransportManager(bdlmt::EventScheduler*    scheduler,
 , d_state(e_STOPPED)
 , d_scheduler_p(scheduler)
 , d_blobBufferFactory_p(blobBufferFactory)
-, d_itemPool(Channel::k_ITEM_SIZE, allocator)
+, d_itemPool(Channel::k_ITEM_SIZE, bsls::BlockGrowth::BSLS_CONSTANT, allocator)
 , d_negotiator_mp(negotiator)
 , d_statController_p(statController)
 , d_tcpSessionFactory_mp(0)

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3915,7 +3915,7 @@ void FileStore::processReceiptEvent(unsigned int         primaryLeaseId,
              affectedQueues.begin();
          it != affectedQueues.end();
          ++it) {
-        (*it)->queueEngine()->afterNewMessage(bmqt::MessageGUID(), 0);
+        (*it)->onReplicatedBatch();
     }
 }
 
@@ -4844,12 +4844,23 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
         journalRecordBufferSp,
         FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
 
-    bmqt::EventBuilderResult::Enum buildRc = d_storageEventBuilder.packMessage(
-        type,
-        d_config.partitionId(),
-        0,  // flags
-        journalOffsetWords,
-        journalRecordBlobBuffer);
+    bmqt::EventBuilderResult::Enum buildRc;
+    bool                           doRetry = false;
+    do {
+        buildRc = d_storageEventBuilder.packMessage(type,
+                                                    d_config.partitionId(),
+                                                    0,  // flags
+                                                    journalOffsetWords,
+                                                    journalRecordBlobBuffer);
+        if (buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG && !doRetry) {
+            flushIfNeeded(true);
+
+            doRetry = true;
+        }
+        else {
+            doRetry = false;
+        }
+    } while (doRetry);
 
     if (bmqt::EventBuilderResult::e_SUCCESS != buildRc) {
         MWCTSK_ALARMLOG_ALARM("REPLICATION")
@@ -4913,35 +4924,47 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
                                            mfd.mapping() + dataOffset);
         dataBlobBuffer.reset(dataBufferSp, totalDataLen);
     }
-
-    if (bmqp::StorageMessageType::e_DATA == type) {
-        buildRc = d_storageEventBuilder.packMessage(
-            bmqp::StorageMessageType::e_DATA,
-            d_config.partitionId(),
-            flags,
-            journalOffsetWords,
-            journalRecordBlobBuffer,
-            dataBlobBuffer);
-    }
-    else {
-        if (d_isFSMWorkflow) {
+    bool flushAndRetry = false;
+    do {
+        if (bmqp::StorageMessageType::e_DATA == type) {
             buildRc = d_storageEventBuilder.packMessage(
-                bmqp::StorageMessageType::e_QLIST,
-                d_config.partitionId(),
-                flags,
-                journalOffsetWords,
-                journalRecordBlobBuffer);
-        }
-        else {
-            buildRc = d_storageEventBuilder.packMessage(
-                bmqp::StorageMessageType::e_QLIST,
+                bmqp::StorageMessageType::e_DATA,
                 d_config.partitionId(),
                 flags,
                 journalOffsetWords,
                 journalRecordBlobBuffer,
                 dataBlobBuffer);
         }
-    }
+        else {
+            if (d_isFSMWorkflow) {
+                buildRc = d_storageEventBuilder.packMessage(
+                    bmqp::StorageMessageType::e_QLIST,
+                    d_config.partitionId(),
+                    flags,
+                    journalOffsetWords,
+                    journalRecordBlobBuffer);
+            }
+            else {
+                buildRc = d_storageEventBuilder.packMessage(
+                    bmqp::StorageMessageType::e_QLIST,
+                    d_config.partitionId(),
+                    flags,
+                    journalOffsetWords,
+                    journalRecordBlobBuffer,
+                    dataBlobBuffer);
+            }
+        }
+        if (buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG &&
+            !flushAndRetry) {
+            flushIfNeeded(true);
+
+            flushAndRetry = true;
+        }
+        else {
+            flushAndRetry = false;
+        }
+
+    } while (flushAndRetry);
 
     if (bmqt::EventBuilderResult::e_SUCCESS != buildRc) {
         MWCTSK_ALARMLOG_ALARM("REPLICATION")
@@ -5096,6 +5119,8 @@ void FileStore::flushIfNeeded(bool immediateFlush)
     if (immediateFlush ||
         d_storageEventBuilder.messageCount() >= d_nagglePacketCount) {
         dispatcherFlush(true, false);
+
+        notifyQueuesOnReplicatedBatch();
     }
 }
 
@@ -6106,8 +6131,30 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
     rawEvent.loadStorageMessageIterator(&iter);
     BSLS_ASSERT_SAFE(iter.isValid());
 
-    while (1 == iter.next()) {
-        const bmqp::StorageHeader&                header = iter.header();
+    if (1 != iter.next()) {
+        return;  // RETURN
+    }
+    const unsigned int      pid         = iter.header().partitionId();
+    FileStore::NodeContext* nodeContext = 0;
+
+    do {
+        const bmqp::StorageHeader& header = iter.header();
+        if (pid != header.partitionId()) {
+            // A storage event is sent by 'source' cluster node.  The node may
+            // be primary for one or more partitions, but as per the BMQ
+            // replication design, *all* messages in this event will belong to
+            // the *same* partition.  Any exception to this is a bug in the
+            // implementation of replication.
+
+            MWCTSK_ALARMLOG_ALARM("STORAGE")
+                << partitionDesc() << ": Received storage event from node "
+                << source->nodeDescription() << " with"
+                << " different PartitionId: [" << pid << "] vs ["
+                << header.partitionId() << "]"
+                << ". Ignoring storage event." << MWCTSK_ALARMLOG_END;
+            continue;  // CONTINUE
+        }
+
         mwcu::BlobPosition                        recordPosition;
         mwcu::BlobObjectProxy<mqbs::RecordHeader> recHeader;
 
@@ -6165,9 +6212,10 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
             if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(0 == rc)) {
                 if (header.flags() &
                     bmqp::StorageHeaderFlags::e_RECEIPT_REQUESTED) {
-                    issueReceipt(source,
-                                 recHeader->primaryLeaseId(),
-                                 recHeader->sequenceNumber());
+                    nodeContext = generateReceipt(nodeContext,
+                                                  source,
+                                                  recHeader->primaryLeaseId(),
+                                                  recHeader->sequenceNumber());
                 }
             }
         }
@@ -6218,7 +6266,9 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                 << ", rc: " << rc << ". Ignoring this message."
                 << MWCTSK_ALARMLOG_END;
         }
-    }  // end: while loop
+    } while (1 == iter.next());
+
+    sendReceipt(source, nodeContext);
 }
 
 int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
@@ -6385,34 +6435,40 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
     return rc_SUCCESS;
 }
 
-void FileStore::issueReceipt(mqbnet::ClusterNode* node,
-                             unsigned int         primaryLeaseId,
-                             bsls::Types::Uint64  sequenceNumber)
+FileStore::NodeContext*
+FileStore::generateReceipt(NodeContext*         nodeContext,
+                           mqbnet::ClusterNode* node,
+                           unsigned int         primaryLeaseId,
+                           bsls::Types::Uint64  sequenceNumber)
 {
-    const int                     nodeId = node->nodeId();
-    NodeReceiptContexts::iterator itNode = d_nodes.find(nodeId);
-    const DataStoreRecordKey      key(sequenceNumber, primaryLeaseId);
+    const DataStoreRecordKey key(sequenceNumber, primaryLeaseId);
 
-    if (itNode == d_nodes.end()) {
-        // no prior history about this node
-        itNode =
-            d_nodes
-                .insert(bsl::make_pair(
-                    nodeId,
-                    NodeContext(d_config.bufferFactory(), key, d_allocator_p)))
-                .first;
+    if (nodeContext == 0) {
+        const int                     nodeId = node->nodeId();
+        NodeReceiptContexts::iterator itNode = d_nodes.find(nodeId);
+
+        if (itNode == d_nodes.end()) {
+            // no prior history about this node
+            itNode = d_nodes
+                         .insert(bsl::make_pair(
+                             nodeId,
+                             NodeContext(d_config.bufferFactory(),
+                                         key,
+                                         d_allocator_p)))
+                         .first;
+        }
+        nodeContext = &itNode->second;
     }
-    else if (itNode->second.d_key < key) {
-        itNode->second.d_key = key;
+    else if (nodeContext->d_key < key) {
+        nodeContext->d_key = key;
     }
     else {
         // outdated receipt
-        return;  // RETURN
+        return nodeContext;  // RETURN
     }
-    NodeContext& nodeContext = itNode->second;
 
-    if (nodeContext.d_state && nodeContext.d_state->tryLock()) {
-        char*                     buffer = nodeContext.d_blob.buffer(0).data();
+    if (nodeContext->d_state && nodeContext->d_state->tryLock()) {
+        char* buffer = nodeContext->d_blob.buffer(0).data();
         bmqp::ReplicationReceipt* receipt =
             reinterpret_cast<bmqp::ReplicationReceipt*>(
                 buffer + sizeof(bmqp::EventHeader));
@@ -6422,28 +6478,39 @@ void FileStore::issueReceipt(mqbnet::ClusterNode* node,
             .setPrimaryLeaseId(primaryLeaseId)
             .setSequenceNum(sequenceNumber);
 
-        nodeContext.d_state->unlock();
+        nodeContext->d_state->unlock();
     }
     else {
-        bmqp::ProtocolUtil::buildReceipt(&nodeContext.d_blob,
+        bmqp::ProtocolUtil::buildReceipt(&nodeContext->d_blob,
                                          d_config.partitionId(),
                                          primaryLeaseId,
                                          sequenceNumber);
-        nodeContext.d_state = d_statePool_p->getObject();
+        nodeContext->d_state = d_statePool_p->getObject();
+    }
 
-        int rc = node->channel().writeBlob(
-            nodeContext.d_blob,
-            bmqp::EventType::e_REPLICATION_RECEIPT,
-            nodeContext.d_state);
+    return nodeContext;
+}
 
-        if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
-                rc != bmqt::GenericResult::e_SUCCESS)) {
-            BALL_LOG_INFO << partitionDesc() << "Failed to send Receipt for "
-                          << "[ primaryLeaseId: " << primaryLeaseId
-                          << ", sequence number: " << sequenceNumber << ".";
+void FileStore::sendReceipt(mqbnet::ClusterNode* node,
+                            NodeContext*         nodeContext)
+{
+    if (nodeContext == 0) {
+        return;  // RETURN
+    }
 
-            // Ignore the error and keep the blob
-        }
+    int rc = node->channel().writeBlob(nodeContext->d_blob,
+                                       bmqp::EventType::e_REPLICATION_RECEIPT,
+                                       nodeContext->d_state);
+
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+            rc != bmqt::GenericResult::e_SUCCESS)) {
+        BALL_LOG_INFO << partitionDesc() << "Failed to send Receipt for "
+                      << "[ primaryLeaseId: "
+                      << nodeContext->d_key.d_primaryLeaseId
+                      << ", sequence number: "
+                      << nodeContext->d_key.d_sequenceNum << ".";
+
+        // Ignore the error and keep the blob
     }
 }
 
@@ -6563,9 +6630,12 @@ void FileStore::setPrimary(mqbnet::ClusterNode* primaryNode,
                           << "primaryLeaseId = " << d_primaryLeaseId
                           << ", d_sequenceNum = " << d_sequenceNum << "].";
 
-            issueReceipt(primaryNode,
-                         d_lastRecoveredStrongConsistency.d_primaryLeaseId,
-                         d_lastRecoveredStrongConsistency.d_sequenceNum);
+            FileStore::NodeContext* nodeContext = generateReceipt(
+                0,
+                primaryNode,
+                d_lastRecoveredStrongConsistency.d_primaryLeaseId,
+                d_lastRecoveredStrongConsistency.d_sequenceNum);
+            sendReceipt(primaryNode, nodeContext);
         }
         return;  // RETURN
     }
@@ -6845,6 +6915,21 @@ void FileStore::dispatcherFlush(bool storage, bool queues)
         }
     }
     if (queues && d_storageEventBuilder.messageCount() == 0) {
+        // Empty 'd_storageEventBuilder' means it has been flushed and it is a
+        // good time to flush queues.
+        for (StorageMapIter it = d_storages.begin(); it != d_storages.end();
+             ++it) {
+            ReplicatedStorage* rs = it->second;
+            if (rs->queue()) {
+                rs->queue()->onReplicatedBatch();
+            }
+        }
+    }
+}
+
+void FileStore::notifyQueuesOnReplicatedBatch()
+{
+    if (d_storageEventBuilder.messageCount() == 0) {
         // Empty 'd_storageEventBuilder' means it has been flushed and it is a
         // good time to flush queues.
         for (StorageMapIter it = d_storages.begin(); it != d_storages.end();

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -4073,8 +4073,8 @@ int FileStore::writeMessageRecord(const bmqp::StorageHeader& header,
 
     // Check data offset in the replicated journal record sent by the primary
     // vs data offset maintained by self.  A mismatch means that replica's and
-    // primary's storages are no longer in sync, which indicates a bug in BMQ
-    // replication algorithm.
+    // primary's storages are no longer in sync, which indicates a bug in
+    // BlazingMQ replication algorithm.
     if (dataOffset !=
         static_cast<bsls::Types::Uint64>(msgRec->messageOffsetDwords()) *
             bmqp::Protocol::k_DWORD_SIZE) {
@@ -4852,7 +4852,9 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
                                                     0,  // flags
                                                     journalOffsetWords,
                                                     journalRecordBlobBuffer);
-        if (buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG && !doRetry) {
+        if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+                buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG) &&
+            !doRetry) {
             flushIfNeeded(true);
 
             doRetry = true;
@@ -4954,7 +4956,8 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
                     dataBlobBuffer);
             }
         }
-        if (buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG &&
+        if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+                buildRc == bmqt::EventBuilderResult::e_EVENT_TOO_BIG) &&
             !flushAndRetry) {
             flushIfNeeded(true);
 
@@ -6141,7 +6144,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
         const bmqp::StorageHeader& header = iter.header();
         if (pid != header.partitionId()) {
             // A storage event is sent by 'source' cluster node.  The node may
-            // be primary for one or more partitions, but as per the BMQ
+            // be primary for one or more partitions, but as per the BlazingMQ
             // replication design, *all* messages in this event will belong to
             // the *same* partition.  Any exception to this is a bug in the
             // implementation of replication.

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6150,8 +6150,8 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                 << partitionDesc() << ": Received storage event from node "
                 << source->nodeDescription() << " with"
                 << " different PartitionId: [" << pid << "] vs ["
-                << header.partitionId() << "]"
-                << ". Ignoring storage event." << MWCTSK_ALARMLOG_END;
+                << header.partitionId() << "]" << ". Ignoring storage event."
+                << MWCTSK_ALARMLOG_END;
             continue;  // CONTINUE
         }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -611,9 +611,11 @@ class FileStore : public DataStore {
     /// Send Replication Receipt to the specified `node` confirming the
     /// receipt of message with the specified `primaryLeaseId` and
     /// `sequenceNumber`.
-    void issueReceipt(mqbnet::ClusterNode* node,
-                      unsigned int         primaryLeaseId,
-                      bsls::Types::Uint64  sequenceNumber);
+    NodeContext* generateReceipt(NodeContext*         nodeContext,
+                                 mqbnet::ClusterNode* node,
+                                 unsigned int         primaryLeaseId,
+                                 bsls::Types::Uint64  sequenceNumber);
+    void sendReceipt(mqbnet::ClusterNode* node, NodeContext* nodeContext);
 
     /// Insert the specified `record` value by the specified `key` into the
     /// list of outstanding records, and assign to the specified `handle` an
@@ -865,6 +867,10 @@ class FileStore : public DataStore {
     /// all associated queues.  Behavior is undefined unless this node is
     /// the primary for this partition.
     void dispatcherFlush(bool storage, bool queues) BSLS_KEYWORD_OVERRIDE;
+
+    /// Call `onReplicatedBatch` on all associated queues if the storage
+    /// builder is empty (just flushed).
+    void notifyQueuesOnReplicatedBatch();
 
     /// Invoke the specified `functor` with each queue associated to the
     /// partition represented by this FileStore if the partition was

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -608,13 +608,17 @@ class FileStore : public DataStore {
     /// still pending receipt of quorum Receipts.
     void cancelUnreceipted(const DataStoreRecordKey& recordKey);
 
-    /// Send Replication Receipt to the specified `node` confirming the
+    /// Generate Replication Receipt for the specified `node` confirming the
     /// receipt of message with the specified `primaryLeaseId` and
-    /// `sequenceNumber`.
+    /// `sequenceNumber`.  Store cumulative receipt in the specified
+    /// `nodeContext`.
     NodeContext* generateReceipt(NodeContext*         nodeContext,
                                  mqbnet::ClusterNode* node,
                                  unsigned int         primaryLeaseId,
                                  bsls::Types::Uint64  sequenceNumber);
+
+    /// Send previously generated Replication Receipt to the specified `node`
+    /// using the specified `nodeContext`.
     void sendReceipt(mqbnet::ClusterNode* node, NodeContext* nodeContext);
 
     /// Insert the specified `record` value by the specified `key` into the

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
@@ -434,7 +434,19 @@ const bsl::shared_ptr<bdlbb::Blob>& VirtualStorageIterator::options() const
 const mqbi::StorageMessageAttributes&
 VirtualStorageIterator::attributes() const
 {
-    loadMessageAndAttributes();
+    // Do not load memory-mapped file message (expensive).
+
+    if (d_attributes.refCount() == 0) {
+        // No loaded Attributes for the current message yet.
+
+        mqbi::StorageResult::Enum rc = d_virtualStorage_p->d_storage_p->get(
+            &d_attributes,
+            d_iterator->first);
+        BSLS_ASSERT_SAFE(mqbi::StorageResult::e_SUCCESS == rc);
+        (void)rc;
+    }
+    // else return reference to the previously loaded attributes.
+
     return d_attributes;
 }
 

--- a/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.h
+++ b/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.h
@@ -1262,7 +1262,7 @@ inline MultiQueueThreadPool<TYPE>::MultiQueueThreadPool(
                               bdlf::PlaceHolders::_1,
                               // arena
                               bdlf::PlaceHolders::_2),  // allocator
-         -1,
+         256 * 1024,
          basicAllocator)
 , d_queueEmptyEvent(config.d_objectCreatorFn,
                     config.d_objectResetterFn,

--- a/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.h
+++ b/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.h
@@ -440,6 +440,8 @@ class MultiQueueThreadPoolConfig {
 
     bsls::TimeInterval d_monitorAlarmTimeout;
 
+    int d_growBy;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(MultiQueueThreadPoolConfig,
@@ -516,6 +518,9 @@ class MultiQueueThreadPoolConfig {
     MultiQueueThreadPoolConfig<TYPE>&
     setMonitorAlarm(bslstl::StringRef         alarmString,
                     const bsls::TimeInterval& timeout);
+
+    /// Set the `growBy` parameter for the ObjectPool to the specified `value`.
+    MultiQueueThreadPoolConfig<TYPE>& setGrowBy(int value);
 };
 
 // ==========================
@@ -914,6 +919,7 @@ inline MultiQueueThreadPoolConfig<TYPE>::MultiQueueThreadPoolConfig(
 , d_finalizeType(MWCC_FINALIZE_NONE)
 , d_monitorAlarmString(basicAllocator)
 , d_monitorAlarmTimeout()
+, d_growBy(-1)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!threadPool || threadPool->enabled());
@@ -939,6 +945,7 @@ inline MultiQueueThreadPoolConfig<TYPE>::MultiQueueThreadPoolConfig(
 , d_finalizeType(MWCC_FINALIZE_NONE)
 , d_monitorAlarmString(basicAllocator)
 , d_monitorAlarmTimeout()
+, d_growBy(-1)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!threadPool || threadPool->enabled());
@@ -965,6 +972,7 @@ inline MultiQueueThreadPoolConfig<TYPE>::MultiQueueThreadPoolConfig(
 , d_finalizeType(other.d_finalizeType)
 , d_monitorAlarmString(other.d_monitorAlarmString, basicAllocator)
 , d_monitorAlarmTimeout(other.d_monitorAlarmTimeout)
+, d_growBy(-1)
 {
     // NOTHING
 }
@@ -1024,6 +1032,15 @@ MultiQueueThreadPoolConfig<TYPE>::setMonitorAlarm(
 
     d_monitorAlarmString  = alarmString;
     d_monitorAlarmTimeout = timeout;
+
+    return *this;
+}
+
+template <typename TYPE>
+inline MultiQueueThreadPoolConfig<TYPE>&
+MultiQueueThreadPoolConfig<TYPE>::setGrowBy(int value)
+{
+    d_growBy = value;
 
     return *this;
 }
@@ -1262,7 +1279,7 @@ inline MultiQueueThreadPool<TYPE>::MultiQueueThreadPool(
                               bdlf::PlaceHolders::_1,
                               // arena
                               bdlf::PlaceHolders::_2),  // allocator
-         256 * 1024,
+         config.d_growBy,
          basicAllocator)
 , d_queueEmptyEvent(config.d_objectCreatorFn,
                     config.d_objectResetterFn,


### PR DESCRIPTION
First half of [181](https://github.com/bloomberg/blazingmq/pull/181)

1. Increase Event (batch) size. Keep PUT soft limit
2. Use bsls::BlockGrowth::BSLS_CONSTANT (instead of geometric) for pools
3. Avoid mwcu::MemOutStream while validating in Cluster
4. StorageManager::processReceiptEvent in IO thread (minus one thread switch)
5. FileStore generates Receipt at the end of received batch processing