### PR TITLE
build: Remove `bb` directories

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -92,7 +92,7 @@ jobs:
         run: ../docker/build_deps.sh
       - name: Build BlazingMQ
         env:
-          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig
         run: |
           cmake -S . -B build/blazingmq -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
@@ -112,7 +112,7 @@ jobs:
           path: |
             build/blazingmq
             deps
-            /opt/bb/include
+            /usr/local/include
           key: cache-${{ github.sha }}
 
   unit_tests_cxx:
@@ -149,7 +149,7 @@ jobs:
         run: ../docker/build_deps.sh
       - name: Build BlazingMQ UTs
         env:
-          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig
         run: |
           cmake -S . -B build/blazingmq -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
@@ -176,7 +176,7 @@ jobs:
           path: |
             build/blazingmq
             deps
-            /opt/bb/include
+            /usr/local/include
           key: cache-${{ github.sha }}
       - name: Run Python Unit Tests
         env:
@@ -205,7 +205,7 @@ jobs:
           path: |
             build/blazingmq
             deps
-            /opt/bb/include
+            /usr/local/include
           key: cache-${{ github.sha }}
       - name: Run Integration Tests
         run: |
@@ -236,7 +236,7 @@ jobs:
           path: |
             build/blazingmq
             deps
-            /opt/bb/include
+            /usr/local/include
           key: cache-${{ github.sha }}
       - name: Run Fuzz Test
         run: |
@@ -277,7 +277,7 @@ jobs:
           path: |
             build/blazingmq
             deps
-            /opt/bb/include
+            /usr/local/include
           key: cache-${{ github.sha }}
       - name: Set up plugins dependencies
         run: |
@@ -303,7 +303,7 @@ jobs:
         run:  ${{ github.workspace }}/src/plugins/bmqprometheus/build_prometheus_deps.sh
       - name: Build plugins
         env:
-          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig
         run: |
           cmake -S . -B build/blazingmq -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \

--- a/.github/workflows/sanitizers/build_sanitizer.sh
+++ b/.github/workflows/sanitizers/build_sanitizer.sh
@@ -171,9 +171,9 @@ export PATH
 # Build BDE + NTF
 pushd "${DIR_SRCS_EXT}/bde"
 eval "$(bbs_build_env -u dbg_64_safe_cpp20 -b "${DIR_BUILD_EXT}/bde")"
-bbs_build configure --toolchain "${TOOLCHAIN_PATH}"
-bbs_build build -j${PARALLELISM}
-bbs_build --install=/opt/bb --prefix=/ install
+bbs_build configure --toolchain "${TOOLCHAIN_PATH}" --prefix="/usr/local"
+bbs_build build -j${PARALLELISM} --prefix="/usr/local"
+bbs_build install --install_dir="/" --prefix="/usr/local"
 popd
 
 pushd "${DIR_SRCS_EXT}/ntf-core"
@@ -183,7 +183,7 @@ pushd "${DIR_SRCS_EXT}/ntf-core"
 sed -i 's/fcoroutines-ts/fcoroutines/g' 'repository.cmake'
 
 ./configure --keep \
-            --prefix /opt/bb             \
+            --prefix /usr/local             \
             --output "${DIR_BUILD_EXT}/ntf" \
             --without-warnings-as-errors \
             --without-usage-examples \
@@ -195,8 +195,8 @@ make install
 popd
 
 # Note: Hack to circumvent faulty behavior in "nts-targets.cmake"
-ln -sf "/opt/bb/include" "/opt/include"
-ln -sf "/opt/bb/lib64" "/opt/lib64"
+ln -sf "/usr/local/include" "/opt/include"
+ln -sf "/usr/local/lib64" "/opt/lib64"
 
 # Setup CMake options for all remaining builds
 CMAKE_OPTIONS=( \
@@ -209,20 +209,20 @@ CMAKE_OPTIONS=( \
 # Build GoogleTest
 cmake -B "${DIR_SRCS_EXT}/googletest/cmake.bld" \
       -S "${DIR_SRCS_EXT}/googletest" "${CMAKE_OPTIONS[@]}" \
-      -DCMAKE_INSTALL_PREFIX=/opt/bb
+      -DCMAKE_INSTALL_PREFIX=/usr/local
 cmake --build "${DIR_SRCS_EXT}/googletest/cmake.bld" -j${PARALLELISM}
-cmake --install "${DIR_SRCS_EXT}/googletest/cmake.bld" --prefix "/opt/bb"
+cmake --install "${DIR_SRCS_EXT}/googletest/cmake.bld" --prefix "/usr/local"
 
 # Build Google Benchmark
 cmake -B "${DIR_SRCS_EXT}/google-benchmark/cmake.bld" \
         -S "${DIR_SRCS_EXT}/google-benchmark" "${CMAKE_OPTIONS[@]}" \
-        -DCMAKE_INSTALL_PREFIX=/opt/bb \
+        -DCMAKE_INSTALL_PREFIX=/usr/local \
         -DBENCHMARK_DOWNLOAD_DEPENDENCIES="ON" \
         -DBENCHMARK_ENABLE_GTEST_TESTS="false" \
         -DHAVE_STD_REGEX="ON" \
         -DBENCHMARK_ENABLE_TESTING="OFF"
 cmake --build "${DIR_SRCS_EXT}/google-benchmark/cmake.bld" -j${PARALLELISM}
-cmake --install "${DIR_SRCS_EXT}/google-benchmark/cmake.bld" --prefix "/opt/bb"
+cmake --install "${DIR_SRCS_EXT}/google-benchmark/cmake.bld" --prefix "/usr/local"
 
 # Build zlib
 # Note: zlib has completely broken CMake install rules, so we must
@@ -230,14 +230,14 @@ cmake --install "${DIR_SRCS_EXT}/google-benchmark/cmake.bld" --prefix "/opt/bb"
 # time
 # https://discourse.cmake.org/t/cmake-install-prefix-not-work/5040
 cmake -B "${DIR_SRCS_EXT}/zlib/cmake.bld" -S "${DIR_SRCS_EXT}/zlib" \
-        -D CMAKE_INSTALL_PREFIX="/opt/bb" \
+        -D CMAKE_INSTALL_PREFIX="/usr/local" \
         "${CMAKE_OPTIONS[@]}"
 # Make and install zlib.
 cmake --build "${DIR_SRCS_EXT}/zlib/cmake.bld" -j${PARALLELISM}
 cmake --install "${DIR_SRCS_EXT}/zlib/cmake.bld"
 
 # Build BlazingMQ
-PKG_CONFIG_PATH="/opt/bb/lib64/pkgconfig:/opt/bb/lib/pkgconfig:/opt/bb/share/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
+PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/local/share/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
 cmake -B "${DIR_BUILD_BMQ}" -S "${DIR_SRC_BMQ}" -G Ninja \
     -DBDE_BUILD_TARGET_64=ON \
     -DBDE_BUILD_TARGET_CPP17=ON \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ COPY docker/build_deps.sh bin/build_deps.sh
 RUN bin/build_deps.sh
 
 ENV PATH=${PATH}:/workspace/srcs/bde-tools/bin
-ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/local/lib64/pkgconfig
 
 COPY CMakeLists.txt srcs/bmq/CMakeLists.txt
 COPY src srcs/bmq/src

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-# This script downloads, builds, and installs the required build dependencies of BMQ
-# from github.com/bloomberg. Software packages are installed to the /opt/bb prefix.
+# This script downloads, builds, and installs the required build dependencies
+# of BMQ from github.com/bloomberg. Software packages are installed to the
+# /usr/local prefix.
 
 set -euxo pipefail
 
@@ -41,9 +42,9 @@ configure() {
 
 build_bde() {
     pushd srcs/bde
-    bbs_build configure
-    bbs_build build -j8
-    bbs_build --install=/opt/bb --prefix=/ install
+    bbs_build configure --prefix="/usr/local"
+    bbs_build build -j8 --prefix="/usr/local"
+    bbs_build install --install_dir="/" --prefix="/usr/local"
     popd
 }
 
@@ -51,7 +52,7 @@ build_ntf() {
     pushd srcs/ntf-core
     ./configure                      \
         --keep                       \
-        --prefix /opt/bb             \
+        --prefix /usr/local          \
         --without-usage-examples     \
         --without-applications       \
         --without-warnings-as-errors \

--- a/src/plugins/bmqprometheus/build_prometheus_deps.sh
+++ b/src/plugins/bmqprometheus/build_prometheus_deps.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script downloads, builds, and installs the required build dependencies of Prometheus plugin
-# from github.com. Software packages are installed to the /opt/bb prefix.
+# from github.com. Software packages are installed to the /usr/local prefix.
 
 set -euxo pipefail
 
@@ -28,7 +28,7 @@ build_curl() {
         --disable-ipv6 --disable-sspi --disable-crypto-auth \
         --disable-ntlm-wb --disable-tls-srp --with-pic --without-nghttp2\
         --without-libidn2 --without-libssh2 --without-brotli \
-        --without-ssl --without-zlib --prefix=/opt/bb --libdir=/opt/bb/lib64
+        --without-ssl --without-zlib --prefix=/usr/local --libdir=/usr/local/lib64
     make curl_LDFLAGS=-all-static
     make curl_LDFLAGS=-all-static install
     popd
@@ -39,22 +39,22 @@ build_prometheus_cpp() {
 
     # fetch third-party dependencies
     git submodule init
-    git submodule update    
+    git submodule update
 
     mkdir -p build
 
-    PKG_CONFIG_PATH="/opt/bb/lib64/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
+    PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
     cmake -DBUILD_SHARED_LIBS=OFF \
             -DENABLE_PUSH=ON \
             -DENABLE_COMPRESSION=OFF \
             -DENABLE_TESTING=OFF \
             -DGENERATE_PKGCONFIG=ON \
-            -DCMAKE_INSTALL_PREFIX=/opt/bb \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
             -DCMAKE_INSTALL_LIBDIR=lib64 \
             -B build
     cmake --build build --parallel 16
-    cmake --install build --prefix /opt/bb
+    cmake --install build --prefix /usr/local
     popd
 }
 


### PR DESCRIPTION
This PR removes `/opt/bb` directories from the CI and Docker image, and replaces them with the more standard `/usr/local` directory.