### PR TITLE
UT[MWC]: C++20: Fix -Wvolatile warnings

### DIFF
--- a/src/groups/mwc/mwcsys/mwcsys_statmonitorsnapshotrecorder.t.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_statmonitorsnapshotrecorder.t.cpp
@@ -77,13 +77,13 @@ int doWork_cpuIntensive()
     volatile unsigned int sum        = 0;
     for (int i = 0; i < (k_1K * multiplier); ++i) {
         volatile int a = 50 * 9873 / 3;
-        sum += a;
+        sum            = sum + a;
 
         volatile int b = a * (a ^ (~0U));
-        sum += b;
+        sum            = sum + b;
 
         volatile int c = (a * (b ^ (~0U))) % 999983;
-        sum += c;
+        sum            = sum + c;
     }
 
     return sum;

--- a/src/groups/mwc/mwcu/mwcu_weakmemfn.t.cpp
+++ b/src/groups/mwc/mwcu/mwcu_weakmemfn.t.cpp
@@ -105,16 +105,6 @@ static void test1_weakMemFn_resultType()
         (bsl::is_same<mwcu::WeakMemFnResult<const R>,
                       mwcu::WeakMemFn<const R (C::*)()>::ResultType>::value));
 
-    // volatile R -> mwcu::WeakMemFnResult<volatile R>
-    ASSERT((bsl::is_same<
-            mwcu::WeakMemFnResult<volatile R>,
-            mwcu::WeakMemFn<volatile R (C::*)()>::ResultType>::value));
-
-    // const volatile R -> mwcu::WeakMemFnResult<const volatile R>
-    ASSERT((bsl::is_same<
-            mwcu::WeakMemFnResult<const volatile R>,
-            mwcu::WeakMemFn<const volatile R (C::*)()>::ResultType>::value));
-
     // R& -> mwcu::WeakMemFnResult<R&>
     ASSERT((bsl::is_same<mwcu::WeakMemFnResult<R&>,
                          mwcu::WeakMemFn<R& (C::*)()>::ResultType>::value));
@@ -243,16 +233,6 @@ static void test3_weakMemFnInstance_resultType()
     ASSERT((bsl::is_same<
             mwcu::WeakMemFnResult<const R>,
             mwcu::WeakMemFnInstance<const R (C::*)()>::ResultType>::value));
-
-    // volatile R -> mwcu::WeakMemFnResult<volatile R>
-    ASSERT((bsl::is_same<
-            mwcu::WeakMemFnResult<volatile R>,
-            mwcu::WeakMemFnInstance<volatile R (C::*)()>::ResultType>::value));
-
-    // const volatile R -> mwcu::WeakMemFnResult<const volatile R>
-    ASSERT((bsl::is_same<mwcu::WeakMemFnResult<const volatile R>,
-                         mwcu::WeakMemFnInstance<const volatile R (
-                             C::*)()>::ResultType>::value));
 
     // R& -> mwcu::WeakMemFnResult<R&>
     ASSERT((bsl::is_same<


### PR DESCRIPTION
C++20 has completely deprecated `volatile`, and GCC enables multiple warnings to catch invalid volatile uses.