### PR TITLE
Fix[MQBBLP]: prevent too much logging in dev build

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -863,10 +863,10 @@ QueueEngineUtil_AppState::QueueEngineUtil_AppState(
         &d_routing_sp->d_queue.d_evaluationContext;
 
     const mqbcfg::AppConfig& brkrCfg = mqbcfg::BrokerConfig::get();
-    const int maxActionsPerInterval = (brkrCfg.brokerVersion() ==
-                                      bmqp::Protocol::k_DEV_VERSION)
-                                          ? 128
-                                          : 1;
+    const int maxActionsPerInterval  = (brkrCfg.brokerVersion() ==
+                                       bmqp::Protocol::k_DEV_VERSION)
+                                           ? 128
+                                           : 1;
 
     d_throttledEarlyExits.initialize(maxActionsPerInterval,
                                      5 * bdlt::TimeUnitRatio::k_NS_PER_S);

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -863,9 +863,13 @@ QueueEngineUtil_AppState::QueueEngineUtil_AppState(
         &d_routing_sp->d_queue.d_evaluationContext;
 
     const mqbcfg::AppConfig& brkrCfg = mqbcfg::BrokerConfig::get();
-    const int maxActionsPerInterval = (brkrCfg.brokerVersion() == bmqp::Protocol::k_DEV_VERSION) ? 128 : 1;
+    const int maxActionsPerInterval = (brkrCfg.brokerVersion() ==
+                                      bmqp::Protocol::k_DEV_VERSION)
+                                          ? 128
+                                          : 1;
 
-    d_throttledEarlyExits.initialize(maxActionsPerInterval, 5 * bdlt::TimeUnitRatio::k_NS_PER_S);
+    d_throttledEarlyExits.initialize(maxActionsPerInterval,
+                                     5 * bdlt::TimeUnitRatio::k_NS_PER_S);
 }
 
 QueueEngineUtil_AppState::~QueueEngineUtil_AppState()
@@ -1333,7 +1337,7 @@ Routers::Result QueueEngineUtil_AppState::selectConsumer(
                                                           currentMessage);
     if (result == Routers::e_NO_CAPACITY_ALL) {
         if (d_throttledEarlyExits.requestPermission()) {
-            BALL_LOG_INFO << "Queue '" << d_queue_p->description()
+            BALL_LOG_INFO << "[THROTTLED] Queue '" << d_queue_p->description()
                           << "', appId = '" << d_appId
                           << "' does not have any subscription "
                              "capacity; early exits delivery at "

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -865,7 +865,7 @@ QueueEngineUtil_AppState::QueueEngineUtil_AppState(
     const mqbcfg::AppConfig& brkrCfg = mqbcfg::BrokerConfig::get();
     const int maxActionsPerInterval  = (brkrCfg.brokerVersion() ==
                                        bmqp::Protocol::k_DEV_VERSION)
-                                           ? 128
+                                           ? 32
                                            : 1;
 
     d_throttledEarlyExits.initialize(maxActionsPerInterval,


### PR DESCRIPTION
During throughput tests on a dev version, there are too many messages which flood the log files:
```
25JUL2024_16:23:39.267 (140702256199424) INFO mqbblp_queueengineutil.cpp:1335 Queue 'bmq://bmq.capmon.priority/test0', appId = '__default' does not have any subscription capacity; early exits delivery at 671ACA0000258660D57C053ED92D2F97
```
