### PR TITLE
[Do not merge]Feat[BMQTOOL]: auto adjust post rate in auto mode

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -160,6 +160,9 @@ class Application : public bmqa::SessionEventHandler {
     // to d_numExpectedAcks, the shutdown semaphore will be
     // posted.
 
+    bsl::shared_ptr<PostingContext> d_postingContext_sp;
+    // The current posting context.
+
     // PRIVATE MANIPULATORS
     //   (virtual: bmqa::SessionEventHandler)
 

--- a/src/applications/bmqtool/m_bmqtool_poster.h
+++ b/src/applications/bmqtool/m_bmqtool_poster.h
@@ -41,6 +41,7 @@
 
 // BDE
 #include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlmt_throttle.h>
 #include <bsl_string.h>
 
 namespace BloombergLP {
@@ -99,6 +100,12 @@ class PostingContext {
     // A value that will be auto-incremented and added to
     // the message properties.
 
+    bdlmt::Throttle d_adjustPostRateThrottle;
+    // A throttle used to control the speed of post rate
+    // auto adjustments.
+
+    bsls::AtomicUint64 d_recentNACKsCount;
+
   public:
     // CREATORS
 
@@ -116,6 +123,9 @@ class PostingContext {
     /// Post next message. The behavior is undefined unless pendingPost()
     /// is true.
     void postNext();
+
+    /// Notify poster about the NACK event, so the poster is able to adjust.
+    void notifyNACK();
 
     // ACCESSORS
 


### PR DESCRIPTION
We might want to automatically measure accurate throughput just before we hit the `LIMIT_MESSAGES` error. Previously, we had to manually run `bmqtool` with different settings to find the throughput, and this process was slow.

This branch is WIP to test this feature