### PR TITLE
Fix[mqbs::DataStoreRecordKeyHashAlgo]: prevent trivial collisions

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -463,7 +463,7 @@ class DataStoreConfig {
 
 /// Format the specified `value` to the specified output `stream` and return
 /// a reference to the modifiable `stream`.
-bsl::ostream& operator(bsl::ostream& stream, const DataStoreConfig& value);
+bsl::ostream& operator<<(bsl::ostream& stream, const DataStoreConfig& value);
 
 // ===========================
 // class DataStoreRecordHandle

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -231,7 +231,7 @@ template <class HASH_ALGORITHM>
 void hashAppend(HASH_ALGORITHM& hashAlgo, const DataStoreRecordKey& key);
 
 // ================================
-// class DataStoreRecordKey
+// class DataStoreRecordKeyHashAlgo
 // ================================
 
 /// This class provides a hashing algorithm for `mqbs::DataStoreRecordKey`.
@@ -240,7 +240,7 @@ void hashAppend(HASH_ALGORITHM& hashAlgo, const DataStoreRecordKey& key);
 /// `bslh::Hash<>`) in `bslh` framework lingo (see BDE "Modular Hashing"
 /// document).  Note that this class is not templatized on a
 /// `HASHING_ALGORITHM` (unlike recommended in the document).
-class DataStoreRecordKey {
+class DataStoreRecordKeyHashAlgo {
   public:
     // TYPES
     typedef bsls::Types::Uint64 result_type;

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -34,7 +34,6 @@
 // BlazingMQ storage mechanism testable.
 
 // MQB
-
 #include <mqbi_dispatcher.h>
 #include <mqbi_storage.h>
 #include <mqbs_filestoreprotocol.h>
@@ -834,7 +833,7 @@ inline DataStoreRecordKeyHashAlgo::result_type
 DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
 {
     return type.d_sequenceNum +
-           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId);
+           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId) << 32;
 }
 
 // -----------------------------

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -231,7 +231,7 @@ template <class HASH_ALGORITHM>
 void hashAppend(HASH_ALGORITHM& hashAlgo, const DataStoreRecordKey& key);
 
 // ================================
-// class DataStoreRecordKeyHashAlgo
+// class DataStoreRecordKey
 // ================================
 
 /// This class provides a hashing algorithm for `mqbs::DataStoreRecordKey`.
@@ -240,7 +240,7 @@ void hashAppend(HASH_ALGORITHM& hashAlgo, const DataStoreRecordKey& key);
 /// `bslh::Hash<>`) in `bslh` framework lingo (see BDE "Modular Hashing"
 /// document).  Note that this class is not templatized on a
 /// `HASHING_ALGORITHM` (unlike recommended in the document).
-class DataStoreRecordKeyHashAlgo {
+class DataStoreRecordKey {
   public:
     // TYPES
     typedef bsls::Types::Uint64 result_type;
@@ -833,7 +833,8 @@ inline DataStoreRecordKeyHashAlgo::result_type
 DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
 {
     return type.d_sequenceNum +
-           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId) << 32;
+           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
+           << 32;
 }
 
 // -----------------------------

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -463,7 +463,7 @@ class DataStoreConfig {
 
 /// Format the specified `value` to the specified output `stream` and return
 /// a reference to the modifiable `stream`.
-bsl::ostream& operator<<(bsl::ostream& stream, const DataStoreConfig& value);
+bsl::ostream& operator(bsl::ostream& stream, const DataStoreConfig& value);
 
 // ===========================
 // class DataStoreRecordHandle
@@ -833,8 +833,8 @@ inline DataStoreRecordKeyHashAlgo::result_type
 DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
 {
     return type.d_sequenceNum +
-               static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
-           << 32;
+               (static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
+           << 32);
 }
 
 // -----------------------------

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -833,7 +833,7 @@ inline DataStoreRecordKeyHashAlgo::result_type
 DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
 {
     return type.d_sequenceNum +
-           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
+               static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
            << 32;
 }
 

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -833,8 +833,7 @@ inline DataStoreRecordKeyHashAlgo::result_type
 DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
 {
     return type.d_sequenceNum +
-               (static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId)
-           << 32);
+           (static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId) << 32);
 }
 
 // -----------------------------


### PR DESCRIPTION
`mqbs::DataStoreRecordKey` has 2 fields `d_sequenceNum` (`uint64_t`) and `d_primaryLeaseId` (`uint32_t`):
https://github.com/bloomberg/blazingmq/blob/9d5ebe9fdbe5a2e71b8df31454f838ba751003aa/src/groups/mqb/mqbs/mqbs_datastore.h#L179

Before this PR, we calc a hash for this class as a sum `d_sequenceNum + d_primaryLeaseId` converted to `uint64_t`:
```c++
DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
{
    return type.d_sequenceNum +
           static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId);
}
```

Note that these 2 fields are monotonically incremented, also, when we increment `primaryLeaseId`, we set `sequenceNum` to `0`:
https://github.com/bloomberg/blazingmq/blob/536a3be43a699321933513e209fea61018bfdf0a/src/groups/mqb/mqbs/mqbs_filestore.cpp#L6537-L6542

So it's possible to have multiple colliding hashes like this:

```
primaryLeaseId | sequenceNum | sum (hash)
=========================================
             0 |           5 |          5
             1 |           4 |          5
             2 |           3 |          5
             3 |           2 |          5
             4 |           1 |          5
             5 |           0 |          5
```

Or another scenario, when an entire sequence of collisions is generated:

```
primaryLeaseId | sequenceNum | sum (hash)
=========================================
             1 |           0 |          1
             1 |           1 |          2
             1 |           2 |          3
             1 |           3 |          4
             1 |           4 |          5
>== primary changes, ++primaryLeaseId ==<
             2 |           0 |          2 COLLISION
             2 |           1 |          3 COLLISION
             2 |           2 |          4 COLLISION
             2 |           3 |          5 COLLISION
             2 |           4 |          6
```

The easy way to address this, is to left-shift `d_primaryLeaseId`, so this `uint32_t` value will be added to the highest bits of the hash:
```c++
DataStoreRecordKeyHashAlgo::operator()(const TYPE& type) const
{
    return type.d_sequenceNum +
           (static_cast<bsls::Types::Uint64>(type.d_primaryLeaseId) << 32);
}
```

From the real usage of this structure, we might expect small values for `d_primaryLeaseId less than 1000` and `d_sequenceNum up to 10s of millions`:
```
02AUG2024_18:10:36.918 (139806285756160) INFO mqbs_filestore.cpp:4664 PartitionId [2] (cluster: local): Received SyncPt indicating rollover: [ primaryLeaseId = 520 sequenceNum = 55479461 dataFileOffsetDwords = 805266269 qlistFileOffsetWords = 206 ], at journal offset: 14131124. Initiating rollover.
```

So it's very unprobable that `d_sequenceNumber` in the hash will reach bits occupied by the shifted `d_primaryLeaseId`.