### PR TITLE
Performance[MQBSTAT]: lookup for per-appId metrics O(n) -> O(1)

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -67,7 +67,7 @@ QueueState::QueueState(mqbi::Queue*            queue,
 , d_scheduler_p(0)
 , d_miscWorkThreadPool_p(0)
 , d_storage_mp(0)
-, d_stats()
+, d_stats(allocator)
 , d_messageThrottleConfig()
 , d_handleCatalog(queue, allocator)
 , d_context(queue->schemaLearner(), allocator)
@@ -80,7 +80,7 @@ QueueState::QueueState(mqbi::Queue*            queue,
     d_handleParameters.qId() = d_id;
 
     // Initialize stats
-    d_stats.initialize(d_uri, d_domain_p, allocator);
+    d_stats.initialize(d_uri, d_domain_p);
 
     // NOTE: The 'description' will be set by the owner of this object.
 

--- a/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
@@ -53,6 +53,8 @@ mqbc::ClusterDataIdentity clusterIdentity(const bslstl::StringRef& name,
     // Create client identity
     bmqp_ctrlmsg::ClientIdentity identity(allocator);
     if (!isRemote) {
+        BSLS_ASSERT_SAFE(netCluster->selfNode());
+
         identity.protocolVersion() = bmqp::Protocol::k_VERSION;
         identity.sdkVersion()      = bmqscm::Version::versionAsInt();
         identity.clientType()      = bmqp_ctrlmsg::ClientType::E_TCPBROKER;

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -156,6 +156,10 @@ void Cluster::_initializeNetcluster()
                                       : k_LEADER_NODE_ID + 1;
     dynamic_cast<mqbnet::MockCluster*>(d_netCluster_mp.get())
         ->_setSelfNodeId(selfNodeId);
+
+    if (d_isClusterMember) {
+        BSLS_ASSERT_OPT(0 != d_netCluster_mp->selfNode());
+    }
 }
 
 void Cluster::_initializeNodeSessions()
@@ -231,7 +235,12 @@ Cluster::Cluster(bdlbb::BlobBufferFactory* bufferFactory,
 , d_processor()
 {
     // PRECONDITIONS
-    BSLS_ASSERT_OPT(isClusterMember || !isLeader);
+    if (isClusterMember) {
+        BSLS_ASSERT_OPT(!clusterNodeDefs.empty());
+    }
+    else {
+        BSLS_ASSERT_OPT(!isLeader);
+    }
 
     _initializeClusterDefinition(name,
                                  location,

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -53,7 +53,7 @@ Queue::Queue(mqbi::Domain* domain, bslma::Allocator* allocator)
 , d_hasMultipleSubStreams(false)
 , d_handleParameters(allocator)
 , d_streamParameters(allocator)
-, d_stats()
+, d_stats(allocator)
 , d_domain_p(domain)
 , d_dispatcher_p(0)
 , d_queueEngine_p(0)
@@ -68,7 +68,7 @@ Queue::Queue(mqbi::Domain* domain, bslma::Allocator* allocator)
 
     // Initialize stats
     if (domain) {
-        d_stats.initialize(d_uri, domain, allocator);
+        d_stats.initialize(d_uri, domain);
     }
 }
 

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -662,11 +662,9 @@ void QueueStatsDomain::updateDomainAppIds(
         return;  // RETURN
     }
 
-    bsl::unordered_set<bsl::string> remainingAppIds(
-        appIds.begin(),
-        appIds.end(),
-        appIds.size() * 3,  // initial bucket num
-        d_allocator_p);
+    bsl::unordered_set<bsl::string> remainingAppIds(appIds.begin(),
+                                                    appIds.end(),
+                                                    d_allocator_p);
 
     // 1. Remove subcontexts for unneeded appIds
     bsl::list<StatSubContextMp>::iterator it = d_subContextsHolder.begin();

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -193,29 +193,6 @@ bool filterDirect(const mwcst::TableRecords::Record& record)
     return record.type() == mwcst::StatContext::e_TOTAL_VALUE;
 }
 
-/// Functor object returning `true`, i.e., filter out, if the specified 'name'
-/// matches context's name
-class ContextNameMatcher {
-  private:
-    // DATA
-    const bsl::string& d_name;
-
-  public:
-    // CREATORS
-    ContextNameMatcher(const bsl::string& name)
-    : d_name(name)
-    {
-        // NOTHING
-    }
-
-    // ACCESSORS
-    bool
-    operator()(const bslma::ManagedPtr<mwcst::StatContext>& context_mp) const
-    {
-        return (context_mp->name() == d_name);
-    }
-};
-
 }  // close unnamed namespace
 
 // -----------------------------
@@ -439,21 +416,21 @@ QueueStatsDomain::getValue(const mwcst::StatContext& context,
 #undef STAT_SINGLE
 }
 
-QueueStatsDomain::QueueStatsDomain()
-: d_statContext_mp(0)
-, d_subContexts_mp(0)
+QueueStatsDomain::QueueStatsDomain(bslma::Allocator* allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_statContext_mp(0)
+, d_subContextsHolder(d_allocator_p)
+, d_subContextsLookup(d_allocator_p)
 {
     // NOTHING
 }
 
-void QueueStatsDomain::initialize(const bmqt::Uri&  uri,
-                                  mqbi::Domain*     domain,
-                                  bslma::Allocator* allocator)
+void QueueStatsDomain::initialize(const bmqt::Uri& uri, mqbi::Domain* domain)
 {
     BSLS_ASSERT_SAFE(!d_statContext_mp && "initialize was already called");
 
     // Create subContext
-    bdlma::LocalSequentialAllocator<2048> localAllocator(allocator);
+    bdlma::LocalSequentialAllocator<2048> localAllocator(d_allocator_p);
 
     d_statContext_mp = domain->queueStatContext()->addSubcontext(
         mwcst::StatContextConfiguration(uri.canonical(), &localAllocator));
@@ -491,9 +468,6 @@ void QueueStatsDomain::initialize(const bmqt::Uri&  uri,
     if (!domain->cluster()->isRemote() &&
         domain->config().mode().isFanoutValue() &&
         domain->config().mode().fanout().publishAppIdMetrics()) {
-        d_subContexts_mp.load(new (*allocator)
-                                  bsl::list<StatSubContextMp>(allocator),
-                              allocator);
         const bsl::vector<bsl::string>& appIDs =
             domain->config().mode().fanout().appIDs();
         for (bsl::vector<bsl::string>::const_iterator cit = appIDs.begin();
@@ -501,7 +475,9 @@ void QueueStatsDomain::initialize(const bmqt::Uri&  uri,
              ++cit) {
             StatSubContextMp subContext = d_statContext_mp->addSubcontext(
                 mwcst::StatContextConfiguration(*cit, &localAllocator));
-            d_subContexts_mp->emplace_back(
+
+            d_subContextsLookup.insert(bsl::make_pair(*cit, subContext.get()));
+            d_subContextsHolder.emplace_back(
                 bslmf::MovableRefUtil::move(subContext));
         }
     }
@@ -609,25 +585,27 @@ void QueueStatsDomain::onEvent(EventType::Enum    type,
 
     BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
 
-    if (!d_subContexts_mp) {
+    if (d_subContextsLookup.empty()) {
         BALL_LOGTHROTTLE_WARN(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
-            << "[THROTTLED] No built sub contexts";
+            << "[THROTTLED] No built sub contexts for domain: "
+            << d_statContext_mp->name() << ", appId: " << appId;
         return;  // RETURN
     }
 
-    bsl::list<StatSubContextMp>::iterator it = bsl::find_if(
-        d_subContexts_mp->begin(),
-        d_subContexts_mp->end(),
-        ContextNameMatcher(appId));
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(it == d_subContexts_mp->end())) {
+    bsl::unordered_map<bsl::string, mwcst::StatContext*>::iterator it =
+        d_subContextsLookup.find(appId);
+
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(it ==
+                                              d_subContextsLookup.end())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
         BALL_LOGTHROTTLE_WARN(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
-            << "[THROTTLED] No matching StatContext for appId: " << appId;
+            << "[THROTTLED] No matching StatContext for domain: "
+            << d_statContext_mp->name() << ", appId: " << appId;
         return;  // RETURN
     }
 
-    mwcst::StatContext* appIdContext = it->get();
+    mwcst::StatContext* appIdContext = it->second;
     BSLS_ASSERT_SAFE(appIdContext);
 
     switch (type) {
@@ -678,37 +656,55 @@ void QueueStatsDomain::setQueueContentRaw(bsls::Types::Int64 messages,
 void QueueStatsDomain::updateDomainAppIds(
     const bsl::vector<bsl::string>& appIds)
 {
-    if (!d_subContexts_mp) {
+    if (appIds.empty()) {
+        d_subContextsLookup.clear();
+        d_subContextsHolder.clear();
         return;  // RETURN
     }
 
-    bdlma::LocalSequentialAllocator<2048> localAllocator;
+    bsl::unordered_set<bsl::string> remainingAppIds(
+        appIds.begin(),
+        appIds.end(),
+        appIds.size() * 3,  // initial bucket num
+        d_allocator_p);
 
-    // Add subcontexts for appIds that are not already present
-    for (bsl::vector<bsl::string>::const_iterator cit = appIds.begin();
-         cit != appIds.end();
-         ++cit) {
-        if (bsl::find_if(d_subContexts_mp->begin(),
-                         d_subContexts_mp->end(),
-                         ContextNameMatcher(*cit)) ==
-            d_subContexts_mp->end()) {
-            StatSubContextMp subContext = d_statContext_mp->addSubcontext(
-                mwcst::StatContextConfiguration(*cit, &localAllocator));
-            d_subContexts_mp->emplace_back(
-                bslmf::MovableRefUtil::move(subContext));
+    // 1. Remove subcontexts for unneeded appIds
+    bsl::list<StatSubContextMp>::iterator it = d_subContextsHolder.begin();
+    while (it != d_subContextsHolder.end()) {
+        const bsl::string& ctxAppId = it->get()->name();
+        bsl::unordered_set<bsl::string>::const_iterator sIt =
+            remainingAppIds.find(ctxAppId);
+        if (sIt == remainingAppIds.end()) {
+            // Subcontext for this appId is no longer needed, remove it from
+            // the holder and lookup table
+            d_subContextsLookup.erase(ctxAppId);
+            it = d_subContextsHolder.erase(it);
+        }
+        else {
+            // This appId is needed, but the stat context is already built for
+            // it
+            remainingAppIds.erase(sIt);
+            ++it;
         }
     }
 
-    // Remove subcontexts if appIds are not present in updated AppIds
-    bsl::list<StatSubContextMp>::iterator it = d_subContexts_mp->begin();
-    while (it != d_subContexts_mp->end()) {
-        if (bsl::find(appIds.begin(), appIds.end(), it->get()->name()) ==
-            appIds.end()) {
-            it = d_subContexts_mp->erase(it);
-        }
-        else {
-            ++it;
-        }
+    if (remainingAppIds.empty()) {
+        return;  // RETURN
+    }
+
+    // 2. Add the remaining appIds
+    bdlma::LocalSequentialAllocator<2048> localAllocator(d_allocator_p);
+
+    for (bsl::unordered_set<bsl::string>::const_iterator sIt =
+             remainingAppIds.begin();
+         sIt != remainingAppIds.end();
+         sIt++) {
+        StatSubContextMp subContext = d_statContext_mp->addSubcontext(
+            mwcst::StatContextConfiguration(*sIt, &localAllocator));
+
+        d_subContextsLookup.insert(bsl::make_pair(*sIt, subContext.get()));
+        d_subContextsHolder.emplace_back(
+            bslmf::MovableRefUtil::move(subContext));
     }
 }
 

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -197,12 +197,15 @@ class QueueStatsDomain {
     /// List of per-appId subcontexts stored as managed pointers.
     /// Note: `mwcst::StatContext` interface allocates subcontexts as
     ///       managed pointers.  We are not able to store managed pointers
-    ///       in a collection that might reallocate and copy its elements.
+    ///       in a collection that might reallocate and copy its elements,
+    ///       since ManagedPtr implementation on Solaris is constraining.
     ///       This is why list is used to store managed pointers.  But we
     ///       also want to perform fast lookups to subcontexts, and for this
     ///       we have `d_subContextsLookup` table that points to raw pointers
     ///       to subcontexts.  These both fields must be kept in sync during
     ///       reconfiguration.
+    /// TODO: use one bsl::unordered_map to store and lookup if Solaris support
+    ///       is stopped.
     bsl::list<StatSubContextMp> d_subContextsHolder;
 
     /// Lookup table for per-appId subcontexts.  Managed pointers to these

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
@@ -82,8 +82,8 @@ static void test1_breathingTest()
     QueueStatsClient queueStatsClient;
     queueStatsClient.initialize(bmqt::Uri(), client.get(), s_allocator_p);
 
-    QueueStatsDomain queueStatsDomain;
-    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain, s_allocator_p);
+    QueueStatsDomain queueStatsDomain(s_allocator_p);
+    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain);
 
     client->snapshot();
     domain->snapshot();
@@ -270,8 +270,8 @@ static void test3_queueStatsDomain()
     using namespace mqbstat;
     typedef QueueStatsDomain::Stat DomainStat;
 
-    QueueStatsDomain queueStatsDomain;
-    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain, s_allocator_p);
+    QueueStatsDomain queueStatsDomain(s_allocator_p);
+    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain);
 
     const int k_DUMMY = 0;
 
@@ -421,8 +421,8 @@ static void test4_queueStatsDomainContent()
     mqbmock::Domain                mockDomain(&mockCluster, s_allocator_p);
     mwcst::StatContext*            sc = mockDomain.queueStatContext();
 
-    mqbstat::QueueStatsDomain obj;
-    obj.initialize(bmqt::Uri(), &mockDomain, s_allocator_p);
+    mqbstat::QueueStatsDomain obj(s_allocator_p);
+    obj.initialize(bmqt::Uri(), &mockDomain);
 
     // Initial Snapshot
     {

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
@@ -17,6 +17,7 @@
 #include <mqbstat_queuestats.h>
 
 // MQB
+#include <mqbc_clusterutil.h>
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbmock_cluster.h>
@@ -80,10 +81,12 @@ static void test1_breathingTest()
 
     // Create queuestat objects and assert that subcontexts are created
     QueueStatsClient queueStatsClient;
-    queueStatsClient.initialize(bmqt::Uri(), client.get(), s_allocator_p);
+    queueStatsClient.initialize(bmqt::Uri(s_allocator_p),
+                                client.get(),
+                                s_allocator_p);
 
     QueueStatsDomain queueStatsDomain(s_allocator_p);
-    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain);
+    queueStatsDomain.initialize(bmqt::Uri(s_allocator_p), &mockDomain);
 
     client->snapshot();
     domain->snapshot();
@@ -144,7 +147,7 @@ static void test1_breathingTest()
 
 static void test2_queueStatsClient()
 // ------------------------------------------------------------------------
-// QUEUESTATSCLIENT
+// QUEUE STATS CLIENT
 //
 // Concerns:
 //   - Ensure that onEvent triggers value changes and the changed values
@@ -173,7 +176,9 @@ static void test2_queueStatsClient()
     typedef QueueStatsClient::Stat ClientStat;
 
     QueueStatsClient queueStatsClient;
-    queueStatsClient.initialize(bmqt::Uri(), client.get(), s_allocator_p);
+    queueStatsClient.initialize(bmqt::Uri(s_allocator_p),
+                                client.get(),
+                                s_allocator_p);
 
     const int k_DUMMY = 0;
 
@@ -241,7 +246,7 @@ static void test2_queueStatsClient()
 
 static void test3_queueStatsDomain()
 // ------------------------------------------------------------------------
-// QUEUESTATSDOMAIN
+// QUEUE STATS DOMAIN
 //
 // Concerns:
 //   - Ensure that onEvent triggers value changes and the changed values
@@ -271,7 +276,7 @@ static void test3_queueStatsDomain()
     typedef QueueStatsDomain::Stat DomainStat;
 
     QueueStatsDomain queueStatsDomain(s_allocator_p);
-    queueStatsDomain.initialize(bmqt::Uri(), &mockDomain);
+    queueStatsDomain.initialize(bmqt::Uri(s_allocator_p), &mockDomain);
 
     const int k_DUMMY = 0;
 
@@ -391,7 +396,7 @@ static void test3_queueStatsDomain()
 
 static void test4_queueStatsDomainContent()
 // ------------------------------------------------------------------------
-// QUEUESTATSDOMAINCONTENT
+// QUEUE STATS DOMAIN CONTENT
 //
 // Concerns:
 //   - Ensure that onEvent triggers value changes and the changed values
@@ -422,7 +427,7 @@ static void test4_queueStatsDomainContent()
     mwcst::StatContext*            sc = mockDomain.queueStatContext();
 
     mqbstat::QueueStatsDomain obj(s_allocator_p);
-    obj.initialize(bmqt::Uri(), &mockDomain);
+    obj.initialize(bmqt::Uri(s_allocator_p), &mockDomain);
 
     // Initial Snapshot
     {
@@ -490,6 +495,171 @@ static void test4_queueStatsDomainContent()
 #undef ASSERT_EQ_DOMAINSTAT
 }
 
+static void test5_appIdMetrics()
+// ------------------------------------------------------------------------
+// APP ID METRICS
+//
+// Concerns:
+//   - Ensure that per-appId configuration and reconfiguration for
+//     QueueStatsDomain works
+//   - Ensure that onEvent triggers value changes in subcontexts per appId,
+//     and the changed values are as expected for the queue content
+//
+// Plan:
+//   - Instantiate the component under test
+//   - Check valid appId subcontext initialization
+//   - Reconfigure the component with other appIds and check
+//   - Trigger onEvent with data for appIds
+//   - Ensure correct change in values
+//
+// Testing:
+//   QueueStatsDomain manipulation with per-appId metrics
+// ------------------------------------------------------------------------
+{
+    mwctst::TestHelper::printTestName("AppIdMetrics");
+
+    // Create a mock cluster/domain
+    const bool isClusterMember = true;
+    const bool isLeader        = true;
+    const bool isCSL           = false;
+    const bool isFSM           = false;
+
+    mqbmock::Cluster::ClusterNodeDefs clusterNodeDefs(s_allocator_p);
+    mqbc::ClusterUtil::appendClusterNode(&clusterNodeDefs,
+                                         "E1",
+                                         "US-EAST",
+                                         41234,
+                                         mqbmock::Cluster::k_LEADER_NODE_ID,
+                                         s_allocator_p);
+    mqbc::ClusterUtil::appendClusterNode(&clusterNodeDefs,
+                                         "E2",
+                                         "US-EAST",
+                                         41235,
+                                         mqbmock::Cluster::k_LEADER_NODE_ID +
+                                             1,
+                                         s_allocator_p);
+    mqbc::ClusterUtil::appendClusterNode(&clusterNodeDefs,
+                                         "W1",
+                                         "US-WEST",
+                                         41236,
+                                         mqbmock::Cluster::k_LEADER_NODE_ID +
+                                             2,
+                                         s_allocator_p);
+    mqbc::ClusterUtil::appendClusterNode(&clusterNodeDefs,
+                                         "W2",
+                                         "US-WEST",
+                                         41237,
+                                         mqbmock::Cluster::k_LEADER_NODE_ID +
+                                             3,
+                                         s_allocator_p);
+
+    bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+    mqbmock::Cluster               mockCluster(&bufferFactory,
+                                 s_allocator_p,
+                                 isClusterMember,
+                                 isLeader,
+                                 isCSL,
+                                 isFSM,
+                                 clusterNodeDefs);
+    mqbmock::Domain                mockDomain(&mockCluster, s_allocator_p);
+
+    // Reconfigure the domain with appIds and enabled appId metrics
+    const char* k_APPID_FOO = "foo";
+    const char* k_APPID_BAR = "bar";
+    const char* k_APPID_BAZ = "baz";
+
+    mqbconfm::Domain           domainConfig(s_allocator_p);
+    mqbconfm::QueueModeFanout& mode = domainConfig.mode().makeFanout();
+    mode.publishAppIdMetrics()      = true;
+    mode.appIDs().push_back(k_APPID_FOO);
+
+    mwcu::MemOutStream errorDesc(s_allocator_p);
+    mockDomain.configure(errorDesc, domainConfig);
+
+    // Do not use stat context (`mockDomain.queueStatContext()`) declared
+    // within mock domain, since it was not initialized using the proper
+    // config.  Init a new stats object from the scratch instead.
+    mqbstat::QueueStatsDomain stats(s_allocator_p);
+    stats.initialize(bmqt::Uri("bmq://mock-domain/abc", s_allocator_p),
+                     &mockDomain);
+
+    mwcst::StatContext* sc = stats.statContext();
+
+    // Make a snapshot to get a recent update with a newly initialized
+    // subcontext for "foo"
+    {
+        sc->snapshot();
+        ASSERT_EQ(1, sc->numSubcontexts());
+
+        const mwcst::StatContext* fooSc = sc->getSubcontext(k_APPID_FOO);
+        ASSERT_NE(bsl::nullptr_t(), fooSc);
+    }
+
+    // Add event for non-configured appId "bar", this value should not reach to
+    // the final stats
+    stats.onEvent(mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                  1000,
+                  k_APPID_BAR);
+
+    // Reconfigure queue domain stats, by excluding "foo" and including "bar"
+    // and "baz"
+    {
+        bsl::vector<bsl::string> appIds(s_allocator_p);
+        appIds.push_back(k_APPID_BAR);
+        appIds.push_back(k_APPID_BAZ);
+
+        stats.updateDomainAppIds(appIds);
+
+        sc->snapshot();
+        sc->cleanup();
+
+        ASSERT_EQ(2, sc->numSubcontexts());
+
+        const mwcst::StatContext* fooSc = sc->getSubcontext(k_APPID_FOO);
+        ASSERT_EQ(bsl::nullptr_t(), fooSc);
+
+        const mwcst::StatContext* barSc = sc->getSubcontext(k_APPID_BAR);
+        const mwcst::StatContext* bazSc = sc->getSubcontext(k_APPID_BAZ);
+        ASSERT_NE(bsl::nullptr_t(), barSc);
+        ASSERT_NE(bsl::nullptr_t(), bazSc);
+    }
+
+    // Report some metrics and check that they reached subcontexts
+    {
+        stats.onEvent(mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                      700,
+                      k_APPID_BAR);
+        stats.onEvent(mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                      900,
+                      k_APPID_BAR);
+        stats.onEvent(mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                      800,
+                      k_APPID_BAR);
+
+        stats.onEvent(mqbstat::QueueStatsDomain::EventType::e_CONFIRM_TIME,
+                      500,
+                      k_APPID_BAZ);
+
+        sc->snapshot();
+
+        const mwcst::StatContext* barSc = sc->getSubcontext(k_APPID_BAR);
+        const mwcst::StatContext* bazSc = sc->getSubcontext(k_APPID_BAZ);
+        ASSERT_NE(bsl::nullptr_t(), barSc);
+        ASSERT_NE(bsl::nullptr_t(), bazSc);
+
+        ASSERT_EQ(900,
+                  mqbstat::QueueStatsDomain::getValue(
+                      *barSc,
+                      -1,
+                      mqbstat::QueueStatsDomain::Stat::e_CONFIRM_TIME_MAX));
+        ASSERT_EQ(500,
+                  mqbstat::QueueStatsDomain::getValue(
+                      *bazSc,
+                      -1,
+                      mqbstat::QueueStatsDomain::Stat::e_CONFIRM_TIME_MAX));
+    }
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -508,6 +678,7 @@ int main(int argc, char* argv[])
             mqbstat::BrokerStatsUtil::initializeStatContext(30, s_allocator_p);
         switch (_testCase) {
         case 0:
+        case 5: test5_appIdMetrics(); break;
         case 4: test4_queueStatsDomainContent(); break;
         case 3: test3_queueStatsDomain(); break;
         case 2: test2_queueStatsClient(); break;


### PR DESCRIPTION
Previously, we used a `bsl::list<ManagedPtr<mwcst::StatContext> >` for 2 roles:
- Store managed pointers to subcontexts associated with appIds
- Lookup to subcontexts for each specific appId

The problem is that the `list` assumes linear search, which might be too slow if we have a decent number of appIds.

However, due to the interfaces of `ManagedPtr` (on `Solaris`), we cannot just use a container which might reallocate its elements on resize. So instead we keep&update 2 collections together: `bsl::list` to hold `ManagedPointer`s and `bsl::unordered_map` for fast lookup to raw pointers to the needed `StatContext`s

Full list of changes:
- `mqbstat::QueueStatsDomain`: hold managed pointers in `bsl::list<StatSubContextMp> d_subContextsHolder`, lookup to subcontexts with `bsl::unordered_map<bsl::string, mwcst::StatContext*> d_subContextsLookup`
- `mqbstat::QueueStatsDomain`: pass allocator in constructor
- `mqbstat::QueueStatsDomain`: improve logging when no subcontext found
- `mqbc::ClusterDataIdentity`: add safety check to prevent possible `nullptr` dereference
- `mqbmock::Cluster`: add safety checks to find cluster misconfiguration early
- `mqbstat_queuestats.t.cpp`: add UT to check per-appId subcontexts and metrics