### PR TITLE
Add community page to the website

### DIFF
--- a/docs/docs/community/index.md
+++ b/docs/docs/community/index.md
@@ -1,0 +1,31 @@
+---
+layout: default
+title: Community
+nav_order: 10
+has_children: false
+permalink: /community
+---
+
+# [](#community)Community
+{: .no_toc }
+
+* toc
+{:toc}
+
+Here is a list of community blogposts about BlazingMQ, tools that integrate
+with BlazingMQ, and other external projects using BlazingMQ.  We haven’t
+looked through all of these, so they may be out-of-date or may not work
+anymore.  Still, you may find inspiration from some of these resources.
+
+We’re looking to grow this list, so please [get in touch with us][get-in-touch]
+if you have written about or used BlazingMQ in your project.
+
+## Blogposts
+
+  - Andy Pearce’s series of blogposts on the features and architecture of
+    BlazingMQ: [BlazingMQ: Introduction][andy-pearce-introduction] and
+    [BlazingMQ: Clustering and Message Flow][andy-pearce-clustering-message-flow].
+
+[get-in-touch]: https://github.com/bloomberg/blazingmq/discussions
+[andy-pearce-introduction]: https://www.andy-pearce.com/blog/posts/2024/Jun/blazingmq-introduction/
+[andy-pearce-clustering-message-flow]: https://www.andy-pearce.com/blog/posts/2024/Jul/blazingmq-clustering-and-message-flow/

--- a/docs/docs/community/index.md
+++ b/docs/docs/community/index.md
@@ -18,7 +18,8 @@ looked through all of these, so they may be out-of-date or may not work
 anymore.  Still, you may find inspiration from some of these resources.
 
 We’re looking to grow this list, so please [get in touch with us][get-in-touch]
-if you have written about or used BlazingMQ in your project.
+if you have written about or used BlazingMQ in your project.  Better yet, [edit
+this page][edit-this-page] and then [send us a PR][contributing-guidelines]!
 
 ## Blogposts
 
@@ -26,6 +27,8 @@ if you have written about or used BlazingMQ in your project.
     BlazingMQ: [BlazingMQ: Introduction][andy-pearce-introduction] and
     [BlazingMQ: Clustering and Message Flow][andy-pearce-clustering-message-flow].
 
-[get-in-touch]: https://github.com/bloomberg/blazingmq/discussions
-[andy-pearce-introduction]: https://www.andy-pearce.com/blog/posts/2024/Jun/blazingmq-introduction/
 [andy-pearce-clustering-message-flow]: https://www.andy-pearce.com/blog/posts/2024/Jul/blazingmq-clustering-and-message-flow/
+[andy-pearce-introduction]: https://www.andy-pearce.com/blog/posts/2024/Jun/blazingmq-introduction/
+[contributing-guidelines]: https://github.com/bloomberg/.github/blob/main/CONTRIBUTING.md
+[edit-this-page]: https://github.com/bloomberg/blazingmq/edit/main/docs/docs/community/index.md
+[get-in-touch]: https://github.com/bloomberg/blazingmq/discussions


### PR DESCRIPTION
These two patches add a new "Community" page to our website, which right now just links to two blogposts by Andy Pearce about BlazingMQ.