### PR TITLE
Refactor[BMQEVAL]: fix -WConversion warnings during compilation

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -967,10 +967,10 @@ inline int CompilationContext::getPropertyIndex(const bsl::string& property,
     if (iter == d_properties.end()) {
         PropertyInfo info = {type, d_properties.size()};
         d_properties.insert(iter, bsl::make_pair(property, info));
-        return info.d_index;  // RETURN
+        return static_cast<int>(info.d_index);  // RETURN
     }
     if (iter->second.d_type == type) {
-        return iter->second.d_index;  // RETURN
+        return static_cast<int>(iter->second.d_index);  // RETURN
     }
     return -1;
 }


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #87 *

**Describe your changes**
This is a small good first issue contribution to fix -Wconversion warnings that pollutes the build log.

This particular PR deals with the following warnings in bmq:

```
/home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h:970:21: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 970 |  return info.d_index; // RETURN
```
```
/home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h:973:29: warning: conversion from ‘size_t’ {aka ‘long unsigned int’} to ‘int’ may change value [-Wconversion]
 973 |  return iter->second.d_index; // RETURN
```

**Testing performed**
Observed build logs to confirm that warnings were pruned. 

**Additional context**
Add any other context about your contribution here.
