### PR TITLE
Feat[BMQ, MQB]: shutdown v2, optimizing shutdown logic

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -1404,6 +1404,7 @@
     </annotation>
     <sequence>
       <element name='clusterName' type='string'/>
+      <element name='version' type='int' default='1'/>
     </sequence>
   </complexType>
 

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -4017,19 +4017,26 @@ const char* StatusCategory::toString(StatusCategory::Value value)
 
 const char StopRequest::CLASS_NAME[] = "StopRequest";
 
+const int StopRequest::DEFAULT_INITIALIZER_VERSION = 1;
+
 const bdlat_AttributeInfo StopRequest::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_CLUSTER_NAME,
      "clusterName",
      sizeof("clusterName") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT}};
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_VERSION,
+     "version",
+     sizeof("version") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC}};
 
 // CLASS METHODS
 
 const bdlat_AttributeInfo* StopRequest::lookupAttributeInfo(const char* name,
                                                             int nameLength)
 {
-    for (int i = 0; i < 1; ++i) {
+    for (int i = 0; i < 2; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             StopRequest::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -4047,6 +4054,8 @@ const bdlat_AttributeInfo* StopRequest::lookupAttributeInfo(int id)
     switch (id) {
     case ATTRIBUTE_ID_CLUSTER_NAME:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CLUSTER_NAME];
+    case ATTRIBUTE_ID_VERSION:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSION];
     default: return 0;
     }
 }
@@ -4055,25 +4064,29 @@ const bdlat_AttributeInfo* StopRequest::lookupAttributeInfo(int id)
 
 StopRequest::StopRequest(bslma::Allocator* basicAllocator)
 : d_clusterName(basicAllocator)
+, d_version(DEFAULT_INITIALIZER_VERSION)
 {
 }
 
 StopRequest::StopRequest(const StopRequest& original,
                          bslma::Allocator*  basicAllocator)
 : d_clusterName(original.d_clusterName, basicAllocator)
+, d_version(original.d_version)
 {
 }
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 StopRequest::StopRequest(StopRequest&& original) noexcept
-: d_clusterName(bsl::move(original.d_clusterName))
+: d_clusterName(bsl::move(original.d_clusterName)),
+  d_version(bsl::move(original.d_version))
 {
 }
 
 StopRequest::StopRequest(StopRequest&&     original,
                          bslma::Allocator* basicAllocator)
 : d_clusterName(bsl::move(original.d_clusterName), basicAllocator)
+, d_version(bsl::move(original.d_version))
 {
 }
 #endif
@@ -4088,6 +4101,7 @@ StopRequest& StopRequest::operator=(const StopRequest& rhs)
 {
     if (this != &rhs) {
         d_clusterName = rhs.d_clusterName;
+        d_version     = rhs.d_version;
     }
 
     return *this;
@@ -4099,6 +4113,7 @@ StopRequest& StopRequest::operator=(StopRequest&& rhs)
 {
     if (this != &rhs) {
         d_clusterName = bsl::move(rhs.d_clusterName);
+        d_version     = bsl::move(rhs.d_version);
     }
 
     return *this;
@@ -4108,6 +4123,7 @@ StopRequest& StopRequest::operator=(StopRequest&& rhs)
 void StopRequest::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_clusterName);
+    d_version = DEFAULT_INITIALIZER_VERSION;
 }
 
 // ACCESSORS
@@ -4118,6 +4134,7 @@ StopRequest::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("clusterName", this->clusterName());
+    printer.printAttribute("version", this->version());
     printer.end();
     return stream;
 }

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -7429,17 +7429,20 @@ namespace bmqp_ctrlmsg {
 class StopRequest {
     // INSTANCE DATA
     bsl::string d_clusterName;
+    int         d_version;
 
   public:
     // TYPES
-    enum { ATTRIBUTE_ID_CLUSTER_NAME = 0 };
+    enum { ATTRIBUTE_ID_CLUSTER_NAME = 0, ATTRIBUTE_ID_VERSION = 1 };
 
-    enum { NUM_ATTRIBUTES = 1 };
+    enum { NUM_ATTRIBUTES = 2 };
 
-    enum { ATTRIBUTE_INDEX_CLUSTER_NAME = 0 };
+    enum { ATTRIBUTE_INDEX_CLUSTER_NAME = 0, ATTRIBUTE_INDEX_VERSION = 1 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
+
+    static const int DEFAULT_INITIALIZER_VERSION;
 
     static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
 
@@ -7540,6 +7543,10 @@ class StopRequest {
     /// object.
     bsl::string& clusterName();
 
+    /// Return a reference to the non-modifiable "Version" attribute of this
+    /// object.
+    int& version();
+
     // ACCESSORS
 
     /// Format this object to the specified output `stream` at the
@@ -7587,6 +7594,10 @@ class StopRequest {
     /// Return a reference to the non-modifiable "ClusterName" attribute of
     /// this object.
     const bsl::string& clusterName() const;
+
+    /// Return a reference to the non-modifiable "Version" attribute of this
+    /// object.
+    int version() const;
 };
 
 // FREE OPERATORS
@@ -27150,6 +27161,12 @@ int StopRequest::manipulateAttributes(MANIPULATOR& manipulator)
         return ret;
     }
 
+    ret = manipulator(&d_version,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSION]);
+    if (ret) {
+        return ret;
+    }
+
     return ret;
 }
 
@@ -27162,6 +27179,10 @@ int StopRequest::manipulateAttribute(MANIPULATOR& manipulator, int id)
     case ATTRIBUTE_ID_CLUSTER_NAME: {
         return manipulator(&d_clusterName,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CLUSTER_NAME]);
+    }
+    case ATTRIBUTE_ID_VERSION: {
+        return manipulator(&d_version,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSION]);
     }
     default: return NOT_FOUND;
     }
@@ -27188,6 +27209,11 @@ inline bsl::string& StopRequest::clusterName()
     return d_clusterName;
 }
 
+inline int& StopRequest::version()
+{
+    return d_version;
+}
+
 // ACCESSORS
 template <class ACCESSOR>
 int StopRequest::accessAttributes(ACCESSOR& accessor) const
@@ -27200,6 +27226,10 @@ int StopRequest::accessAttributes(ACCESSOR& accessor) const
         return ret;
     }
 
+    ret = accessor(d_version, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSION]);
+    if (ret) {
+        return ret;
+    }
     return ret;
 }
 
@@ -27212,6 +27242,10 @@ int StopRequest::accessAttribute(ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_CLUSTER_NAME: {
         return accessor(d_clusterName,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CLUSTER_NAME]);
+    }
+    case ATTRIBUTE_ID_VERSION: {
+        return accessor(d_version,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSION]);
     }
     default: return NOT_FOUND;
     }
@@ -27236,6 +27270,11 @@ int StopRequest::accessAttribute(ACCESSOR&   accessor,
 inline const bsl::string& StopRequest::clusterName() const
 {
     return d_clusterName;
+}
+
+inline int StopRequest::version() const
+{
+    return d_version;
 }
 
 template <typename HASH_ALGORITHM>

--- a/src/groups/bmq/bmqp/bmqp_protocol.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.cpp
@@ -264,6 +264,8 @@ const char HighAvailabilityFeatures::k_BROADCAST_TO_PROXIES[] =
     "BROADCAST_TO_PROXIES";
 const char HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN[] =
     "GRACEFUL_SHUTDOWN";
+const char HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN_V2[] =
+    "GRACEFUL_SHUTDOWN_V2";
 
 // --------------------------------
 // struct MessagePropertiesFeatures

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -633,6 +633,8 @@ struct HighAvailabilityFeatures {
     static const char k_BROADCAST_TO_PROXIES[];
 
     static const char k_GRACEFUL_SHUTDOWN[];
+
+    static const char k_GRACEFUL_SHUTDOWN_V2[];
 };
 
 /// This struct defines feature names related to MessageProperties

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -1091,6 +1091,10 @@ void RequestManager<REQUEST, RESPONSE>::onRequestTimeout(int requestId)
 
         // Explicitly invalidate the timeout since we processed it
         request->d_timeoutSchedulerHandle.release();
+
+        if (!d_lateResponseMode) {
+            d_requests.erase(it);
+        }
     }  // close guard scope
 
     BALL_LOG_ERROR << "Request with '" << request->nodeDescription()

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.cpp
@@ -47,7 +47,7 @@ EncodingType::Enum SchemaEventBuilderUtil::bestEncodingSupported(
         return EncodingType::e_BER;  // RETURN
     }
 
-    // If remote suppports BER, return BER
+    // If remote supports BER, return BER
     if (bsl::find(encodingsSupported.cbegin(),
                   encodingsSupported.cend(),
                   bsl::string(EncodingFeature::k_ENCODING_BER)) !=

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -420,11 +420,11 @@ void AdminSession::tearDown(const bsl::shared_ptr<void>& session,
 
 void AdminSession::initiateShutdown(const ShutdownCb&         callback,
                                     const bsls::TimeInterval& timeout,
-                                    bool suppportShutdownV2)
+                                    bool supportShutdownV2)
 {
     // executed by the *ANY* thread
     (void)timeout;
-    (void)suppportShutdownV2;
+    (void)supportShutdownV2;
 
     dispatcher()->execute(
         bdlf::BindUtil::bind(&AdminSession::initiateShutdownDispatched,

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -419,10 +419,12 @@ void AdminSession::tearDown(const bsl::shared_ptr<void>& session,
 }
 
 void AdminSession::initiateShutdown(const ShutdownCb&         callback,
-                                    const bsls::TimeInterval& timeout)
+                                    const bsls::TimeInterval& timeout,
+                                    bool suppportShutdownV2)
 {
     // executed by the *ANY* thread
     (void)timeout;
+    (void)suppportShutdownV2;
 
     dispatcher()->execute(
         bdlf::BindUtil::bind(&AdminSession::initiateShutdownDispatched,

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -262,10 +262,13 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
     /// if the specified `timeout` is expired.
+    /// The optional (temporary) specified 'supportShutdownV2' indicates
+    /// shutdown V2 logic which is not applicable to `AdminSession`
+    /// implementation.
     void
     initiateShutdown(const ShutdownCb&         callback,
                      const bsls::TimeInterval& timeout,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Make the session abandon any work it has.
     void invalidate() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -264,7 +264,8 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     /// if the specified `timeout` is expired.
     void
     initiateShutdown(const ShutdownCb&         callback,
-                     const bsls::TimeInterval& timeout) BSLS_KEYWORD_OVERRIDE;
+                     const bsls::TimeInterval& timeout,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Make the session abandon any work it has.
     void invalidate() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -463,9 +463,9 @@ void Application::stop()
     d_transportManager_mp->initiateShutdown();
     BALL_LOG_INFO << "Stopped listening for new connections.";
 
-    bool suppportShutdownV2 = initiateShutdown();
+    bool supportShutdownV2 = initiateShutdown();
 
-    if (suppportShutdownV2) {
+    if (supportShutdownV2) {
         BALL_LOG_INFO << ": Executing GRACEFUL_SHUTDOWN_V2";
     }
     else {
@@ -484,7 +484,7 @@ void Application::stop()
          ++clusterIt, --count) {
         clusterIt.cluster()->initiateShutdown(
             bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch),
-            suppportShutdownV2);
+            supportShutdownV2);
     }
     latch.wait();
 

--- a/src/groups/mqb/mqba/mqba_application.h
+++ b/src/groups/mqb/mqba/mqba_application.h
@@ -169,6 +169,10 @@ class Application {
     /// Pendant operation of the `oneTimeInit` one.
     void oneTimeShutdown();
 
+    /// Attempt to execute shutdown logic v2.  Return 'true' if all nodes and
+    /// proxies support it.
+    bool initiateShutdown();
+
   private:
     // NOT IMPLEMENTED
     Application(const Application& other) BSLS_CPP11_DELETED;

--- a/src/groups/mqb/mqba/mqba_application.h
+++ b/src/groups/mqb/mqba/mqba_application.h
@@ -169,8 +169,12 @@ class Application {
     /// Pendant operation of the `oneTimeInit` one.
     void oneTimeShutdown();
 
-    /// Attempt to execute shutdown logic v2.  Return 'true' if all nodes and
-    /// proxies support it.
+    /// Attempt to execute graceful shutdown logic v2.
+    ///
+    /// If any node or proxy does not support the v2 graceful shutdown logic,
+    /// do not perform any shutdown actions and return `false`.  Otherwise,
+    /// send v2 shutdown requests to all nodes, shutdown clients and proxies,
+    /// and return `true`.
     bool initiateShutdown();
 
   private:

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -847,7 +847,7 @@ void ClientSession::onHandleConfiguredDispatched(
 void ClientSession::initiateShutdownDispatched(
     const ShutdownCb&         callback,
     const bsls::TimeInterval& timeout,
-    bool                      suppportShutdownV2)
+    bool                      supportShutdownV2)
 {
     // executed by the *CLIENT* dispatcher thread
 
@@ -889,7 +889,7 @@ void ClientSession::initiateShutdownDispatched(
         return;  // RETURN
     }
 
-    if (suppportShutdownV2) {
+    if (supportShutdownV2) {
         d_operationState = e_SHUTTING_DOWN_V2;
         d_queueSessionManager.shutDown();
 
@@ -2868,7 +2868,7 @@ void ClientSession::tearDown(const bsl::shared_ptr<void>& session,
 
 void ClientSession::initiateShutdown(const ShutdownCb&         callback,
                                      const bsls::TimeInterval& timeout,
-                                     bool suppportShutdownV2)
+                                     bool supportShutdownV2)
 {
     // executed by the *ANY* thread
 
@@ -2906,7 +2906,7 @@ void ClientSession::initiateShutdown(const ShutdownCb&         callback,
                     d_self.acquire()),
                 callback,
                 timeout,
-                suppportShutdownV2),
+                supportShutdownV2),
             this,
             mqbi::DispatcherEventType::e_DISPATCHER);
         // Use 'mqbi::DispatcherEventType::e_DISPATCHER' to avoid (re)enabling

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -273,7 +273,8 @@ class ClientSession : public mqbnet::Session,
     enum OperationState {
         e_RUNNING  // Running normally
         ,
-        // TEMPORARY, remove 'after switching to StopRequest V2
+        // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest
+        // V2.
         e_SHUTTING_DOWN  // Shutting down due to 'initiateShutdown' request
         ,
         e_SHUTTING_DOWN_V2  // Shutting down due to 'initiateShutdown' request
@@ -483,7 +484,7 @@ class ClientSession : public mqbnet::Session,
     /// if the specified `timeout` is expired.
     void initiateShutdownDispatched(const ShutdownCb&         callback,
                                     const bsls::TimeInterval& timeout,
-                                    bool suppportShutdownV2);
+                                    bool supportShutdownV2);
 
     void invalidateDispatched();
 
@@ -687,14 +688,14 @@ class ClientSession : public mqbnet::Session,
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
     /// if the specified `timeout` is expired.  If the optional (temporary)
-    /// specified 'suppportShutdownV2' is 'true' execute shutdown logic V2
+    /// specified 'supportShutdownV2' is 'true' execute shutdown logic V2
     /// where upstream (not downstream) nodes deconfigure  queues and the
     /// shutting down node (not downstream) waits for CONFIRMS.
     /// The shutdown is complete when 'tearDownAllQueuesDone'.
     void
     initiateShutdown(const ShutdownCb&         callback,
                      const bsls::TimeInterval& timeout,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Make the session abandon any work it has.
     void invalidate() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -133,7 +133,9 @@ void loadBrokerIdentity(bmqp_ctrlmsg::ClientIdentity* identity,
         .append(";")
         .append(bmqp::HighAvailabilityFeatures::k_FIELD_NAME)
         .append(":")
-        .append(bmqp::HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN);
+        .append(bmqp::HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN)
+        .append(",")
+        .append(bmqp::HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN_V2);
 
     if (shouldBroadcastToProxies) {
         features.append(",").append(

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -621,7 +621,8 @@ void Cluster::processCommandDispatched(mqbcmd::ClusterResult*        result,
     result->makeError().message() = os.str();
 }
 
-void Cluster::initiateShutdownDispatched(const VoidFunctor& callback)
+void Cluster::initiateShutdownDispatched(const VoidFunctor& callback,
+                                         bool               suppportShutdownV2)
 {
     // executed by the *DISPATCHER* thread
 
@@ -632,84 +633,107 @@ void Cluster::initiateShutdownDispatched(const VoidFunctor& callback)
 
     d_isStopping = true;
 
-    // Send StopRequest to all nodes and proxies.  The peers are expected not
-    // to send any PUT msgs to this node after receiving StopRequest.  For each
-    // queue for which this node is the primary, peers (replicas and proxies)
-    // will de-configure the queue, wait for configured timeout, close the
-    // queue, and respond with StopResponse.  The peers are expected not to
-    // send any PUT/PUSH/ACK/CONFIRM msgs to this node after sending
-    // StopResponse.
-    //
-    // Call 'initiateShutdown' for all client sessions.
-    //
-    // Also update self's status.  Note that this node does not explicitly
-    // issue a close-queue request for each of the queues.
-
     d_clusterData.membership().setSelfNodeStatus(
         bmqp_ctrlmsg::NodeStatus::E_STOPPING);
 
-    mwcu::OperationChainLink link(d_shutdownChain.allocator());
-    bsls::TimeInterval       shutdownTimeout;
-    shutdownTimeout.addMilliseconds(
-        d_clusterData.clusterConfig().queueOperations().shutdownTimeoutMs());
+    if (suppportShutdownV2) {
+        d_clusterOrchestrator.queueHelper().requestToStopPushing();
 
-    SessionSpVec sessions;
-    for (mqbnet::TransportManagerIterator sessIt(
+        bsls::TimeInterval whenToStop(
+            bsls::SystemTime::now(bsls::SystemClockType::e_MONOTONIC));
+        whenToStop.addMilliseconds(d_clusterData.clusterConfig()
+                                       .queueOperations()
+                                       .shutdownTimeoutMs());
+
+        d_shutdownChain.appendInplace(
+            bdlf::BindUtil::bind(&ClusterQueueHelper::checkUnconfirmedV2,
+                                 &d_clusterOrchestrator.queueHelper(),
+                                 whenToStop,
+                                 bdlf::PlaceHolders::_1));  // completionCb
+    }
+    else {
+        // Temporary, remove after switching all to version 2
+        // Send StopRequest to all nodes and proxies.  The peers are expected
+        // not to send any PUT msgs to this node after receiving StopRequest.
+        // For each queue for which this node is the primary, peers (replicas
+        // and proxies) will de-configure the queue, wait for configured
+        // timeout, close the queue, and respond with StopResponse.  The peers
+        // are expected not to send any PUT/PUSH/ACK/CONFIRM msgs to this node
+        // after sending StopResponse.
+        //
+        // Call 'initiateShutdown' for all client sessions.
+
+        mwcu::OperationChainLink link(d_shutdownChain.allocator());
+        bsls::TimeInterval       shutdownTimeout;
+        shutdownTimeout.addMilliseconds(d_clusterData.clusterConfig()
+                                            .queueOperations()
+                                            .shutdownTimeoutMs());
+
+        SessionSpVec sessions;
+        for (mqbnet::TransportManagerIterator sessIt(
              &d_clusterData.transportManager());
-         sessIt;
-         ++sessIt) {
-        bsl::shared_ptr<mqbnet::Session> sessionSp = sessIt.session().lock();
-        if (!sessionSp) {
-            continue;  // CONTINUE
-        }
-
-        const bmqp_ctrlmsg::NegotiationMessage& negoMsg =
-            sessionSp->negotiationMessage();
-
-        const bmqp_ctrlmsg::ClientIdentity& peerIdentity =
-            negoMsg.isClientIdentityValue()
-                ? negoMsg.clientIdentity()
-                : negoMsg.brokerResponse().brokerIdentity();
-
-        if (peerIdentity.clusterNodeId() ==
-            d_clusterData.membership().netCluster()->selfNodeId()) {
-            continue;  // CONTINUE
-        }
-
-        if (mqbnet::ClusterUtil::isClient(negoMsg)) {
-            link.insert(bdlf::BindUtil::bind(
-                &mqbnet::Session::initiateShutdown,
-                sessionSp,
-                bdlf::PlaceHolders::_1,  // completion callback
-                shutdownTimeout));
-            continue;  // CONTINUE
-        }
-
-        if (peerIdentity.clusterName() == name()) {
-            // Expect all proxies and nodes support this feature.
-            if (!bmqp::ProtocolUtil::hasFeature(
-                    bmqp::HighAvailabilityFeatures::k_FIELD_NAME,
-                    bmqp::HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN,
-                    peerIdentity.features())) {
-                BALL_LOG_ERROR << description() << ": Peer doesn't support "
-                               << "GRACEFUL_SHUTDOWN. Skip sending stopRequest"
-                               << " to [" << peerIdentity << "]";
+             sessIt;
+             ++sessIt) {
+            bsl::shared_ptr<mqbnet::Session> sessionSp =
+                sessIt.session().lock();
+            if (!sessionSp) {
                 continue;  // CONTINUE
             }
-            sessions.push_back(sessionSp);
+
+            const bmqp_ctrlmsg::NegotiationMessage& negoMsg =
+                sessionSp->negotiationMessage();
+
+            const bmqp_ctrlmsg::ClientIdentity& peerIdentity =
+                negoMsg.isClientIdentityValue()
+                    ? negoMsg.clientIdentity()
+                    : negoMsg.brokerResponse().brokerIdentity();
+
+            if (peerIdentity.clusterNodeId() ==
+                d_clusterData.membership().netCluster()->selfNodeId()) {
+                continue;  // CONTINUE
+            }
+
+            if (mqbnet::ClusterUtil::isClient(negoMsg)) {
+                //            if (!d_suppportShutdownV2) {
+                link.insert(bdlf::BindUtil::bind(
+                    &mqbnet::Session::initiateShutdown,
+                    sessionSp,
+                    bdlf::PlaceHolders::_1,  // completion callback
+                    shutdownTimeout,
+                    false));
+                //            }
+                // else there is no need to de-confgiure queues and wait for
+                // unconfirmed since V2 upstreams do that on StopRequest V2
+                continue;  // CONTINUE
+            }
+
+            if (peerIdentity.clusterName() == name()) {
+                // Expect all proxies and nodes support this feature.
+                if (!bmqp::ProtocolUtil::hasFeature(
+                        bmqp::HighAvailabilityFeatures::k_FIELD_NAME,
+                        bmqp::HighAvailabilityFeatures::k_GRACEFUL_SHUTDOWN,
+                        peerIdentity.features())) {
+                    BALL_LOG_ERROR
+                        << description() << ": Peer doesn't support "
+                        << "GRACEFUL_SHUTDOWN. Skip sending stopRequest"
+                        << " to [" << peerIdentity << "]";
+                    continue;  // CONTINUE
+                }
+                sessions.push_back(sessionSp);
+            }
         }
+
+        link.insert(bdlf::BindUtil::bind(
+            &Cluster::sendStopRequest,
+            this,
+            sessions,
+            bdlf::PlaceHolders::_1));  // completion callback
+
+        d_shutdownChain.append(&link);
     }
 
-    link.insert(
-        bdlf::BindUtil::bind(&Cluster::sendStopRequest,
-                             this,
-                             sessions,
-                             bdlf::PlaceHolders::_1));  // completion callback
-
-    d_shutdownChain.append(&link);
-
-    // Add callback to be invoked once all the client sessions are shut down
-    // and stop responses are received
+    // Also update self's status.  Note that this node does not explicitly
+    // issue a close-queue request for each of the queues.
 
     d_shutdownChain.appendInplace(
         bdlf::BindUtil::bind(&Cluster::continueShutdown,
@@ -727,7 +751,7 @@ void Cluster::sendStopRequest(const SessionSpVec&                  sessions,
     // Send a StopRequest to available cluster nodes and proxies connected to
     // the cluster
     StopRequestManagerType::RequestContextSp contextSp =
-        d_stopRequestsManager.createRequestContext();
+        d_stopRequestsManager_p->createRequestContext();
     bmqp_ctrlmsg::StopRequest& request = contextSp->request()
                                              .choice()
                                              .makeClusterMessage()
@@ -746,7 +770,7 @@ void Cluster::sendStopRequest(const SessionSpVec&                  sessions,
     BALL_LOG_INFO << "Sending StopRequest to " << sessions.size()
                   << " brokers; timeout is " << timeoutMs;
 
-    d_stopRequestsManager.sendRequest(contextSp, timeoutMs);
+    d_stopRequestsManager_p->sendRequest(contextSp, timeoutMs);
 
     // continue after receipt of all StopResponses or the timeout
 }
@@ -2520,6 +2544,7 @@ Cluster::Cluster(const bslstl::StringRef&           name,
                  BlobSpPool*                        blobSpPool,
                  bdlbb::BlobBufferFactory*          bufferFactory,
                  mqbnet::TransportManager*          transportManager,
+                 StopRequestManagerType*            stopRequestsManager,
                  bslma::Allocator*                  allocator,
                  const mqbnet::Session::AdminCommandEnqueueCb& adminCb)
 : d_allocator_p(allocator)
@@ -2557,7 +2582,7 @@ Cluster::Cluster(const bslstl::StringRef&           name,
 , d_throttledDroppedPushMessages(5000, 5)     // 5 logs per 5s interval
 , d_logSummarySchedulerHandle()
 , d_queueGcSchedulerHandle()
-, d_stopRequestsManager(&d_clusterData.requestManager(), allocator)
+, d_stopRequestsManager_p(stopRequestsManager)
 , d_shutdownChain(allocator)
 , d_adminCb(adminCb)
 {
@@ -2670,7 +2695,8 @@ int Cluster::start(bsl::ostream& errorDescription)
     return rc;
 }
 
-void Cluster::initiateShutdown(const VoidFunctor& callback)
+void Cluster::initiateShutdown(const VoidFunctor& callback,
+                               bool               suppportShutdownV2)
 {
     // executed by *ANY* thread
 
@@ -2682,7 +2708,8 @@ void Cluster::initiateShutdown(const VoidFunctor& callback)
     dispatcher()->execute(
         bdlf::BindUtil::bind(&Cluster::initiateShutdownDispatched,
                              this,
-                             callback),
+                             callback,
+                             suppportShutdownV2),
         this);
 
     // Wait for above event to complete.  This is needed because
@@ -3030,8 +3057,7 @@ void Cluster::processClusterControlMessage(
     case MsgChoice::SELECTION_ID_STORAGE_SYNC_RESPONSE:
     case MsgChoice::SELECTION_ID_PARTITION_SYNC_STATE_QUERY_RESPONSE:
     case MsgChoice::SELECTION_ID_PARTITION_SYNC_DATA_QUERY_RESPONSE:
-    case MsgChoice::SELECTION_ID_CLUSTER_SYNC_RESPONSE:
-    case MsgChoice::SELECTION_ID_STOP_RESPONSE: {
+    case MsgChoice::SELECTION_ID_CLUSTER_SYNC_RESPONSE: {
         // NOTE: that we cant simply just check if the msg has an id, because
         //       in cluster, it can receive requests which will have an id; so
         //       only messages that are response type should be sent to the
@@ -3047,6 +3073,11 @@ void Cluster::processClusterControlMessage(
                                  source),
             this);
     } break;  // BREAK
+
+    case MsgChoice::SELECTION_ID_STOP_RESPONSE: {
+        BALL_LOG_INFO << description() << ": processStopResponse: " << message;
+        d_stopRequestsManager_p->processResponse(message);
+    } break;
     case MsgChoice::SELECTION_ID_PARTITION_PRIMARY_ADVISORY: {
         dispatcher()->execute(
             bdlf::BindUtil::bind(

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -334,7 +334,7 @@ class Cluster : public mqbi::Cluster,
     // Scheduler handle for the recurring
     // queue gc check.
 
-    StopRequestManagerType d_stopRequestsManager;
+    StopRequestManagerType* d_stopRequestsManager_p;
 
     mwcu::OperationChain d_shutdownChain;
     // Mechanism used for the Cluster
@@ -414,8 +414,10 @@ class Cluster : public mqbi::Cluster,
                                   const mqbcmd::ClusterCommand& command);
 
     /// Executed by dispatcher thread.
-    void initiateShutdownDispatched(const VoidFunctor& callback);
+    void initiateShutdownDispatched(const VoidFunctor& callback,
+                                    bool               suppportShutdownV2);
 
+    // // Temporary, remove after switching all to version 2
     /// Send stop request to proxies and nodes specified in `sessions` using
     /// the specified `stopCb` as a callback to be called once all the
     /// requests get responses.
@@ -549,6 +551,7 @@ class Cluster : public mqbi::Cluster,
             BlobSpPool*                                   blobSpPool,
             bdlbb::BlobBufferFactory*                     bufferFactory,
             mqbnet::TransportManager*                     transportManager,
+            StopRequestManagerType*                       stopRequestsManager,
             bslma::Allocator*                             allocator,
             const mqbnet::Session::AdminCommandEnqueueCb& adminCb);
 
@@ -566,8 +569,13 @@ class Cluster : public mqbi::Cluster,
     /// Initiate the shutdown of the cluster.  It is expected that `stop()`
     /// will be called soon after this routine is invoked.  Invoke the
     /// specified `callback` upon completion of (asynchronous) shutdown
-    /// sequence.
-    void initiateShutdown(const VoidFunctor& callback) BSLS_KEYWORD_OVERRIDE;
+    /// sequence.    If the optional (temporary) specified 'suppportShutdownV2'
+    /// is 'true' execute shutdown logic V2 where upstream (not downstream)
+    /// nodes deconfigure  queues and he shutting down node (not downstream)
+    /// wait for CONFIRMS.
+    void
+    initiateShutdown(const VoidFunctor& callback,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -415,9 +415,11 @@ class Cluster : public mqbi::Cluster,
 
     /// Executed by dispatcher thread.
     void initiateShutdownDispatched(const VoidFunctor& callback,
-                                    bool               suppportShutdownV2);
+                                    bool               supportShutdownV2);
 
-    // // Temporary, remove after switching all to version 2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest
+    // V2.
+
     /// Send stop request to proxies and nodes specified in `sessions` using
     /// the specified `stopCb` as a callback to be called once all the
     /// requests get responses.
@@ -569,13 +571,13 @@ class Cluster : public mqbi::Cluster,
     /// Initiate the shutdown of the cluster.  It is expected that `stop()`
     /// will be called soon after this routine is invoked.  Invoke the
     /// specified `callback` upon completion of (asynchronous) shutdown
-    /// sequence.    If the optional (temporary) specified 'suppportShutdownV2'
+    /// sequence.    If the optional (temporary) specified 'supportShutdownV2'
     /// is 'true' execute shutdown logic V2 where upstream (not downstream)
-    /// nodes deconfigure  queues and he shutting down node (not downstream)
+    /// nodes deconfigure  queues and the shutting down node (not downstream)
     /// wait for CONFIRMS.
     void
     initiateShutdown(const VoidFunctor& callback,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -187,6 +187,7 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
                     d_blobSpPool_p,
                     d_bufferFactory_p,
                     d_transportManager_p,
+                    &d_stopRequestsManager,
                     clusterAllocator,
                     d_adminCb);
 
@@ -230,6 +231,7 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
                          d_blobSpPool_p,
                          d_dispatcher_p,
                          d_transportManager_p,
+                         &d_stopRequestsManager,
                          clusterAllocator);
 
         info.d_cluster_sp.reset(cluster, clusterAllocator);
@@ -383,6 +385,12 @@ ClusterCatalog::ClusterCatalog(bdlmt::EventScheduler*    scheduler,
 , d_reversedClusterConnections(d_allocator_p)
 , d_clusters(d_allocator_p)
 , d_statContexts(statContexts)
+, d_requestManager(bmqp::EventType::e_CONTROL,
+                   d_bufferFactory_p,
+                   d_scheduler_p,
+                   false,  // lateResponseMode
+                   d_allocator_p)
+, d_stopRequestsManager(&d_requestManager, d_allocator_p)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(scheduler->clockType() ==
@@ -396,7 +404,7 @@ ClusterCatalog::~ClusterCatalog()
                     "stop() must be called before destroying this object");
 }
 
-int ClusterCatalog::loadBrokerClusterConfig(bsl::ostream& errorDescription)
+int ClusterCatalog::loadBrokerClusterConfig(bsl::ostream&)
 {
     // executed by the *MAIN* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
@@ -292,7 +292,7 @@ class ClusterCatalog {
 
     mqbnet::Session::AdminCommandEnqueueCb d_adminCb;
     // Callback function to enqueue admin commands
-    
+
     RequestManagerType d_requestManager;
     // Request manager to use
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -880,7 +880,7 @@ void ClusterOrchestrator::processStopRequest(
                   << ", current status: " << ns->nodeStatus()
                   << ", new status: " << bmqp_ctrlmsg::NodeStatus::E_STOPPING;
 
-    // Temporary, remove after switching all to version 2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     if (stopRequest.version() == 1 && stopRequest.clusterName() != name) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         BALL_LOG_ERROR << d_clusterData_p->identity().description()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -158,7 +158,7 @@ void ClusterProxy::startDispatched()
 }
 
 void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
-                                              bool suppportShutdownV2)
+                                              bool supportShutdownV2)
 {
     // executed by the *DISPATCHER* thread
 
@@ -171,7 +171,7 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
     // Mark self as stopping.
     d_isStopping = true;
 
-    if (suppportShutdownV2) {
+    if (supportShutdownV2) {
         d_queueHelper.requestToStopPushing();
 
         bsls::TimeInterval whenToStop(
@@ -187,7 +187,8 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
                                  bdlf::PlaceHolders::_1));  // completionCb
     }
     else {
-        // Temporary, remove after switching all to version 2
+        // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest
+        // V2.
 
         // Fill the first link with client session shutdown operations
         mwcu::OperationChainLink link(d_shutdownChain.allocator());
@@ -197,7 +198,7 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
             clusterProxyConfig()->queueOperations().shutdownTimeoutMs());
 
         for (mqbnet::TransportManagerIterator sessIt(
-             &d_clusterData.transportManager());
+                 &d_clusterData.transportManager());
              sessIt;
              ++sessIt) {
             bsl::shared_ptr<mqbnet::Session> sessionSp =
@@ -1150,7 +1151,7 @@ int ClusterProxy::start(BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
 }
 
 void ClusterProxy::initiateShutdown(const VoidFunctor& callback,
-                                    bool               suppportShutdownV2)
+                                    bool               supportShutdownV2)
 {
     // executed by *ANY* thread
 
@@ -1163,7 +1164,7 @@ void ClusterProxy::initiateShutdown(const VoidFunctor& callback,
         bdlf::BindUtil::bind(&ClusterProxy::initiateShutdownDispatched,
                              this,
                              callback,
-                             suppportShutdownV2),
+                             supportShutdownV2),
         this);
 
     dispatcher()->synchronize(this);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -74,7 +74,7 @@ typedef bsl::function<void()> CompletionCallback;
 
 /// Utility function used in `mwcu::OperationChain` as the operation
 /// callback which just calls the completion callback.
-void allClientSessionsShutDown(const CompletionCallback& callback)
+void completeShutDown(const CompletionCallback& callback)
 {
     callback();
 }
@@ -157,7 +157,8 @@ void ClusterProxy::startDispatched()
                              this));
 }
 
-void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback)
+void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
+                                              bool suppportShutdownV2)
 {
     // executed by the *DISPATCHER* thread
 
@@ -170,51 +171,72 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback)
     // Mark self as stopping.
     d_isStopping = true;
 
-    // Fill the first link with client session shutdown operations
-    mwcu::OperationChainLink link(d_shutdownChain.allocator());
-    SessionSpVec             sessions;
-    bsls::TimeInterval       shutdownTimeout;
-    shutdownTimeout.addMilliseconds(
-        clusterProxyConfig()->queueOperations().shutdownTimeoutMs());
+    if (suppportShutdownV2) {
+        d_queueHelper.requestToStopPushing();
 
-    for (mqbnet::TransportManagerIterator sessIt(
+        bsls::TimeInterval whenToStop(
+            bsls::SystemTime::now(bsls::SystemClockType::e_MONOTONIC));
+        whenToStop.addMilliseconds(d_clusterData.clusterConfig()
+                                       .queueOperations()
+                                       .shutdownTimeoutMs());
+
+        d_shutdownChain.appendInplace(
+            bdlf::BindUtil::bind(&ClusterQueueHelper::checkUnconfirmedV2,
+                                 &d_queueHelper,
+                                 whenToStop,
+                                 bdlf::PlaceHolders::_1));  // completionCb
+    }
+    else {
+        // Temporary, remove after switching all to version 2
+
+        // Fill the first link with client session shutdown operations
+        mwcu::OperationChainLink link(d_shutdownChain.allocator());
+        SessionSpVec             sessions;
+        bsls::TimeInterval       shutdownTimeout;
+        shutdownTimeout.addMilliseconds(
+            clusterProxyConfig()->queueOperations().shutdownTimeoutMs());
+
+        for (mqbnet::TransportManagerIterator sessIt(
              &d_clusterData.transportManager());
-         sessIt;
-         ++sessIt) {
-        bsl::shared_ptr<mqbnet::Session> sessionSp = sessIt.session().lock();
-        if (!sessionSp) {
-            continue;  // CONTINUE
+             sessIt;
+             ++sessIt) {
+            bsl::shared_ptr<mqbnet::Session> sessionSp =
+                sessIt.session().lock();
+            if (!sessionSp) {
+                continue;  // CONTINUE
+            }
+
+            const bmqp_ctrlmsg::NegotiationMessage& negoMsg =
+                sessionSp->negotiationMessage();
+            if (mqbnet::ClusterUtil::isClientOrProxy(negoMsg)) {
+                if (mqbnet::ClusterUtil::isClient(negoMsg)) {
+                    link.insert(bdlf::BindUtil::bind(
+                        &mqbnet::Session::initiateShutdown,
+                        sessionSp,
+                        bdlf::PlaceHolders::_1,
+                        shutdownTimeout,
+                        false));
+                }
+                else {
+                    sessions.push_back(sessionSp);
+                }
+            }
         }
 
-        const bmqp_ctrlmsg::NegotiationMessage& negoMsg =
-            sessionSp->negotiationMessage();
-        if (mqbnet::ClusterUtil::isClientOrProxy(negoMsg)) {
-            if (mqbnet::ClusterUtil::isClient(negoMsg)) {
-                link.insert(
-                    bdlf::BindUtil::bind(&mqbnet::Session::initiateShutdown,
-                                         sessionSp,
-                                         bdlf::PlaceHolders::_1,
-                                         shutdownTimeout));
-            }
-            else {
-                sessions.push_back(sessionSp);
-            }
-        }
+        link.insert(bdlf::BindUtil::bind(
+            &ClusterProxy::sendStopRequest,
+            this,
+            sessions,
+            bdlf::PlaceHolders::_1));  // completion callback
+
+        d_shutdownChain.append(&link);
     }
 
-    link.insert(
-        bdlf::BindUtil::bind(&ClusterProxy::sendStopRequest,
-                             this,
-                             sessions,
-                             bdlf::PlaceHolders::_1));  // completion callback
-
-    d_shutdownChain.append(&link);
-
-    // Add callback to be invoked once all the client sessions are shut down
-    d_shutdownChain.appendInplace(
-        bdlf::BindUtil::bind(&allClientSessionsShutDown,
-                             bdlf::PlaceHolders::_1),
-        callback);
+    // Add callback to be invoked once V1 shuts down all client sessions or
+    // V2 finishes waiting for unconfirmed
+    d_shutdownChain.appendInplace(bdlf::BindUtil::bind(&completeShutDown,
+                                                       bdlf::PlaceHolders::_1),
+                                  callback);
 
     d_shutdownChain.start();
 }
@@ -681,6 +703,15 @@ void ClusterProxy::processEvent(const bmqp::Event&   event,
                     this);
                 return;  // RETURN
             }
+            if (clusterMessage.choice().isStopResponseValue()) {
+                dispatcher()->execute(
+                    bdlf::BindUtil::bind(
+                        &ClusterProxy::processPeerStopResponse,
+                        this,
+                        controlMessage),
+                    this);
+                return;  // RETURN
+            }
             if (clusterMessage.choice().isNodeStatusAdvisoryValue()) {
                 dispatcher()->execute(
                     bdlf::BindUtil::bind(
@@ -832,6 +863,14 @@ void ClusterProxy::processResponse(
         this);
 }
 
+void ClusterProxy::processPeerStopResponse(
+    const bmqp_ctrlmsg::ControlMessage& response)
+{
+    BALL_LOG_INFO << description() << ": processStopResponse: " << response;
+
+    d_stopRequestsManager_p->processResponse(response);
+}
+
 void ClusterProxy::processPeerStopRequest(
     mqbnet::ClusterNode*                clusterNode,
     const bmqp_ctrlmsg::ControlMessage& request)
@@ -841,11 +880,10 @@ void ClusterProxy::processPeerStopRequest(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
 
-    const bsl::vector<int>* noPartitions = 0;
     d_queueHelper.processNodeStoppingNotification(
         clusterNode,
         &request,
-        noPartitions,
+        0,
         bdlf::BindUtil::bind(&ClusterProxy::finishStopSequence,
                              this,
                              clusterNode));
@@ -859,6 +897,7 @@ void ClusterProxy::finishStopSequence(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
 
+    // REVISIT
     // Internal-ticket D169562052
     // TODO: handle/eliminate the possibility of Multiple StopRequests.
     // Currently, cannot switch the active node because another StopRequest can
@@ -966,7 +1005,7 @@ void ClusterProxy::sendStopRequest(const SessionSpVec& sessions,
 {
     // Send a StopRequest to available proxies connected to the virtual cluster
     StopRequestManagerType::RequestContextSp contextSp =
-        d_stopRequestsManager.createRequestContext();
+        d_stopRequestsManager_p->createRequestContext();
     bmqp_ctrlmsg::StopRequest& request = contextSp->request()
                                              .choice()
                                              .makeClusterMessage()
@@ -985,7 +1024,7 @@ void ClusterProxy::sendStopRequest(const SessionSpVec& sessions,
     BALL_LOG_INFO << "Sending StopRequest to " << sessions.size()
                   << " proxies; timeout is " << timeoutMs;
 
-    d_stopRequestsManager.sendRequest(contextSp, timeoutMs);
+    d_stopRequestsManager_p->sendRequest(contextSp, timeoutMs);
 
     // continue after receipt of all StopResponses or the timeout
 }
@@ -1012,6 +1051,7 @@ ClusterProxy::ClusterProxy(
     BlobSpPool*                           blobSpPool,
     mqbi::Dispatcher*                     dispatcher,
     mqbnet::TransportManager*             transportManager,
+    StopRequestManagerType*               stopRequestsManager,
     bslma::Allocator*                     allocator)
 : d_allocator_p(allocator)
 , d_isStarted(false)
@@ -1042,7 +1082,7 @@ ClusterProxy::ClusterProxy(
 , d_clusterMonitor(&d_clusterData, &d_state, d_allocator_p)
 , d_activeNodeLookupEventHandle()
 , d_shutdownChain(d_allocator_p)
-, d_stopRequestsManager(&d_clusterData.requestManager(), d_allocator_p)
+, d_stopRequestsManager_p(stopRequestsManager)
 {
     // PRECONDITIONS
     mqbnet::Cluster* netCluster_p = d_clusterData.membership().netCluster();
@@ -1109,7 +1149,8 @@ int ClusterProxy::start(BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
     return 0;
 }
 
-void ClusterProxy::initiateShutdown(const VoidFunctor& callback)
+void ClusterProxy::initiateShutdown(const VoidFunctor& callback,
+                                    bool               suppportShutdownV2)
 {
     // executed by *ANY* thread
 
@@ -1121,7 +1162,8 @@ void ClusterProxy::initiateShutdown(const VoidFunctor& callback)
     dispatcher()->execute(
         bdlf::BindUtil::bind(&ClusterProxy::initiateShutdownDispatched,
                              this,
-                             callback),
+                             callback,
+                             suppportShutdownV2),
         this);
 
     dispatcher()->synchronize(this);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -251,7 +251,8 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     // execution of the shutdown callbacks
     // from the client sessions.
 
-    StopRequestManagerType d_stopRequestsManager;
+    // Should be part of 'ClusterResources'
+    StopRequestManagerType* d_stopRequestsManager_p;
     // Request manager to send stop
     // requests to connected proxies.
 
@@ -264,7 +265,8 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// Initiate the shutdown of the cluster.  The specified `callback` will
     /// be called when the shutdown is completed.  This routine is invoked
     /// in the cluster-dispatcher thread.
-    void initiateShutdownDispatched(const VoidFunctor& callback);
+    void initiateShutdownDispatched(const VoidFunctor& callback,
+                                    bool suppportShutdownV2 = false);
 
     /// Stop the `Cluster`.
     void stopDispatched();
@@ -377,6 +379,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// transmitted request.
     void processResponse(const bmqp_ctrlmsg::ControlMessage& response)
         BSLS_KEYWORD_OVERRIDE;
+    void processPeerStopResponse(const bmqp_ctrlmsg::ControlMessage& response);
 
     void processPeerStopRequest(mqbnet::ClusterNode* clusterNode,
                                 const bmqp_ctrlmsg::ControlMessage& request);
@@ -398,6 +401,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     void
     processResponseDispatched(const bmqp_ctrlmsg::ControlMessage& response);
 
+    // Temporary, remove after switching all to version 2
     /// Send stop request to proxies specified in `sessions` using the
     /// specified `stopCb` as a callback to be called once all the requests
     /// get responses.
@@ -438,6 +442,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
                  BlobSpPool*                           blobSpPool,
                  mqbi::Dispatcher*                     dispatcher,
                  mqbnet::TransportManager*             transportManager,
+                 StopRequestManagerType*               stopRequestsManager,
                  bslma::Allocator*                     allocator);
 
     /// Destructor
@@ -451,11 +456,16 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// error.
     int start(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
 
-    /// Initiate the shutdown of the cluster.  It is expected that `stop()`
-    /// will be called soon after this routine is invoked.  Invoke the
-    /// specified `callback` upon completion of (asynchronous) shutdown
-    /// sequence.
-    void initiateShutdown(const VoidFunctor& callback) BSLS_KEYWORD_OVERRIDE;
+    /// Initiate the shutdown of the cluster and invoke the specified
+    /// `callback` upon completion of (asynchronous) shutdown sequence. It
+    /// is expected that `stop()` will be called soon after this routine is
+    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
+    /// deconfigure  queues and he shutting down node (not downstream) wait for
+    /// CONFIRMS.
+    void
+    initiateShutdown(const VoidFunctor& callback,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -266,7 +266,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// be called when the shutdown is completed.  This routine is invoked
     /// in the cluster-dispatcher thread.
     void initiateShutdownDispatched(const VoidFunctor& callback,
-                                    bool suppportShutdownV2 = false);
+                                    bool supportShutdownV2 = false);
 
     /// Stop the `Cluster`.
     void stopDispatched();
@@ -401,7 +401,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     void
     processResponseDispatched(const bmqp_ctrlmsg::ControlMessage& response);
 
-    // Temporary, remove after switching all to version 2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     /// Send stop request to proxies specified in `sessions` using the
     /// specified `stopCb` as a callback to be called once all the requests
     /// get responses.
@@ -459,13 +459,13 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// Initiate the shutdown of the cluster and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence. It
     /// is expected that `stop()` will be called soon after this routine is
-    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// invoked.  If the optional (temporary) specified 'supportShutdownV2' is
     /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
-    /// deconfigure  queues and he shutting down node (not downstream) wait for
-    /// CONFIRMS.
+    /// deconfigure  queues and the shutting down node (not downstream) wait
+    /// for CONFIRMS.
     void
     initiateShutdown(const VoidFunctor& callback,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -173,6 +173,12 @@ void handleHolderDummy(const bsl::shared_ptr<mqbi::QueueHandle>& handle)
         handle->queue()->dispatcher()->inDispatcherThread(handle->queue()));
 }
 
+void countUnconfirmed(bsls::Types::Int64* result, mqbi::Queue* queue)
+{
+    *result += queue->countUnconfirmed(
+        bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID);
+}
+
 }  // close unnamed namespace
 
 // -----------------------------------------
@@ -1438,6 +1444,9 @@ void ClusterQueueHelper::onReopenQueueResponse(
 
             --d_numPendingReopenQueueRequests;
 
+            // Process Close request instead of parking it
+            sqit->value().d_state = SubQueueContext::k_CLOSED;
+
             return;  // RETURN
         }
 
@@ -1468,7 +1477,8 @@ void ClusterQueueHelper::onReopenQueueResponse(
             notifyQueue(queueContext.get(),
                         upstreamSubQueueId,
                         generationCount,
-                        false);
+                        false,
+                        false);  // isWriterOnly
 
             // No need to send a configure-queue request for this queue.
             // Decrement the num pending reopen queue request counter though,
@@ -1746,7 +1756,8 @@ void ClusterQueueHelper::onConfigureQueueResponse(
         notifyQueue(queueContext.get(),
                     itStream->subId(),
                     generationCount,
-                    true);
+                    true,
+                    false);  // isWriterOnly
     }
 }
 
@@ -2013,7 +2024,8 @@ bool ClusterQueueHelper::createQueue(
             notifyQueue(queueContext,
                         bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID,
                         genCount,
-                        true);
+                        true,   // isOpen
+                        true);  // isWriterOnly
         }
 
         context.d_callback(status,
@@ -2625,7 +2637,8 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
 void ClusterQueueHelper::notifyQueue(QueueContext*       queueContext,
                                      unsigned int        upstreamSubQueueId,
                                      bsls::Types::Uint64 generationCount,
-                                     bool                isOpen)
+                                     bool                isOpen,
+                                     bool                isWriterOnly)
 {
     mqbi::Queue* queue = queueContext->d_liveQInfo.d_queue_sp.get();
     if (queue == 0) {
@@ -2644,7 +2657,8 @@ void ClusterQueueHelper::notifyQueue(QueueContext*       queueContext,
                 bdlf::BindUtil::bind(&mqbi::Queue::onOpenUpstream,
                                      queue,
                                      generationCount,
-                                     upstreamSubQueueId),
+                                     upstreamSubQueueId,
+                                     isWriterOnly),
                 queue);
         }
     }
@@ -2686,6 +2700,22 @@ void ClusterQueueHelper::configureQueueDispatched(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
+    if (d_suppportShutdownV2) {
+        BMQ_LOGTHROTTLE_INFO()
+            << d_cluster_p->description()
+            << ": Shutting down and skipping configure queue [: " << uri
+            << "], queueId: " << queueId
+            << ", stream parameters: " << streamParameters;
+        if (callback) {
+            bmqp_ctrlmsg::Status status;
+            status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+            status.message()  = "Shutting down.";
+            callback(status, streamParameters);
+        }
+
+        return;  // RETURN
+    }
 
     QueueContextMapIter queueContextIt = d_queues.find(uri);
 
@@ -2834,6 +2864,23 @@ void ClusterQueueHelper::releaseQueueDispatched(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
+    if (d_suppportShutdownV2) {
+        BMQ_LOGTHROTTLE_INFO()
+            << d_cluster_p->description()
+            << ": Shutting down and skipping close queue [: "
+            << handleParameters.uri()
+            << "], queueId: " << handleParameters.qId()
+            << ", handle parameters: " << handleParameters;
+        if (callback) {
+            bmqp_ctrlmsg::Status status;
+            status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+            status.message()  = "Shutting down.";
+            callback(status);
+        }
+
+        return;  // RETURN
+    }
 
     bmqt::Uri           uri(handleParameters.uri());
     QueueContextMapIter queueContextIt = d_queues.find(uri.canonical());
@@ -4485,6 +4532,7 @@ ClusterQueueHelper::ClusterQueueHelper(
 , d_numPendingReopenQueueRequests(0)
 , d_primaryNotLeaderAlarmRaised(false)
 , d_stopContexts(allocator)
+, d_suppportShutdownV2(false)
 {
     BSLS_ASSERT(
         d_clusterData_p->clusterConfig()
@@ -5227,17 +5275,53 @@ void ClusterQueueHelper::processShutdownEvent()
                       << "], queueKey [" << queueContextSp->key()
                       << "] which was assigned to PartitionId ["
                       << queueContextSp->partitionId()
-                      << "], because self is going down and this queue has no "
-                      << "handles.";
+                      << "], because self is going down.";
 
         deleteQueue(queueContextSp.get());
     }
 }
 
+/// Stop sending PUSHes but continue receiving CONFIRMs, receiving and
+/// sending PUTs and ACKs.
+void ClusterQueueHelper::requestToStopPushing()
+{
+    // executed by the cluster *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(
+        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
+    // Assume Shutdown V2
+    d_suppportShutdownV2 = true;
+
+    for (QueueContextMapIter it = d_queues.begin(); it != d_queues.end();
+         ++it) {
+        QueueContextSp& queueContextSp = it->second;
+        QueueLiveState& qinfo          = queueContextSp->d_liveQInfo;
+        mqbi::Queue*    queue          = qinfo.d_queue_sp.get();
+
+        if (!queue) {
+            continue;  // CONTINUE
+        }
+
+        queue->dispatcher()->execute(
+            bdlf::BindUtil::bind(&mqbi::Queue::stopPushing, queue),
+            queue);
+    }
+}
+
+void ClusterQueueHelper::onDeconfiguredHandle(
+    const bsl::shared_ptr<StopContext>& contextSp)
+{
+    BALL_LOG_INFO << d_clusterData_p->identity().description()
+                  << ": deconfiguring " << " " << contextSp.numReferences();
+    (void)contextSp;
+}
+
 void ClusterQueueHelper::processNodeStoppingNotification(
     mqbnet::ClusterNode*                clusterNode,
     const bmqp_ctrlmsg::ControlMessage* request,
-    const bsl::vector<int>*             partitions,
+    mqbc::ClusterNodeSession*           ns,
     const VoidFunctor&                  callback)
 {
     // executed by the cluster *DISPATCHER* thread
@@ -5250,6 +5334,11 @@ void ClusterQueueHelper::processNodeStoppingNotification(
     // The 'shared_ptr' serves as a reference count of all pending queue
     // operations.  Once all functors complete, the 'finishStopSequence'
     // deleter sends back StopResponse.
+
+    // TEMPORARY, remove 'timeout; 'after switching to StopRequest V2
+    // No need to wait for CONFIRMs, the waiting is done by the shutting down
+    // node.
+
     int timeout =
         d_clusterData_p->clusterConfig().queueOperations().stopTimeoutMs();
 
@@ -5287,12 +5376,137 @@ void ClusterQueueHelper::processNodeStoppingNotification(
                       << clusterNode->nodeDescription()
                       << " with timeout (ms) " << timeout;
 
-        // Self node needs to issue close-queue requests for all the queues for
-        // which specified 'source' node is the primary.
+        // TEMPORARY, remove 'after switching to StopRequest V2
+        bool suppportShutdownV2 = true;
 
-        if (!d_cluster_p->isRemote() ||
-            d_clusterData_p->electorInfo().leaderNode() == contextSp->d_peer) {
-            deconfigureQueues(contextSp, partitions);
+        if (request) {
+            const bmqp_ctrlmsg::StopRequest& stopRequest =
+                request->choice().clusterMessage().choice().stopRequest();
+
+            if (stopRequest.version() == 1) {
+                suppportShutdownV2 = false;
+            }
+            else {
+                BSLS_ASSERT_SAFE(stopRequest.version() == 2);
+            }
+        }
+        // StopRequests have replaced E_STOPPING advisory.
+        // In any case, do minimal (V2) work unless explicitly requested
+
+        if (suppportShutdownV2) {
+            if (ns) {
+                // As an Upstream, deconfigure queues of the (shutting down)
+                // ClusterNodeSession 'ns'.
+                // Call 'mqbi::QueueHandle::deconfigureAll' for each handle
+
+                const mqbc::ClusterNodeSession::QueueHandleMap& handles =
+                    ns->queueHandles();
+
+                for (mqbc::ClusterNodeSession::QueueHandleMap::const_iterator
+                         cit = handles.begin();
+                     cit != handles.end();
+                     ++cit) {
+                    cit->second.d_handle_p->deconfigureAll(
+                        bdlf::BindUtil::bind(
+                            &ClusterQueueHelper::onDeconfiguredHandle,
+                            this,
+                            contextSp));
+                }
+                BALL_LOG_INFO << d_clusterData_p->identity().description()
+                              << ": deconfigured " << handles.size()
+                              << " handles while processing StopRequest from "
+                              << clusterNode->nodeDescription() << " "
+                              << contextSp.numReferences();
+            }
+            // else, this is a ClusterProxy (downstream) receiving request from
+            // an upstream Cluster Node (a request from a Proxy would arrive to
+            // ClientSession).
+            // Downstreams do not deconfigure queues in V2.
+            // See comment in 'ClusterProxy::processPeerStopRequest'
+
+            // As a Downstream, notify relevant queues about their shutting
+            // down upstream
+            for (QueueContextMapConstIter cit = d_queues.begin();
+                 cit != d_queues.end();
+                 ++cit) {
+                const QueueContextSp& queueContextSp = cit->second;
+                const QueueLiveState& queueLiveState =
+                    queueContextSp->d_liveQInfo;
+                mqbi::Queue* queue = queueLiveState.d_queue_sp.get();
+
+                if (0 == queue || bmqp::QueueId::k_UNASSIGNED_QUEUE_ID ==
+                                      queueContextSp->d_liveQInfo.d_id) {
+                    continue;  // CONTINUE
+                }
+
+                if (!d_cluster_p->isRemote()) {
+                    const int pid = queueContextSp->partitionId();
+
+                    BSLS_ASSERT_SAFE(ns);
+
+                    const bsl::vector<int>& partitions =
+                        ns->primaryPartitions();
+                    if (partitions.end() ==
+                        bsl::find(partitions.begin(), partitions.end(), pid)) {
+                        continue;  // CONTINUE
+                    }
+                    const ClusterStatePartitionInfo& pinfo =
+                        d_clusterState_p->partition(pid);
+
+                    if (bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE !=
+                        pinfo.primaryStatus()) {
+                        // It's possible for a primary node to be non-active
+                        // when it is shutting down -- if it was stopped before
+                        // the node had a chance to transition to active
+                        // primary for this partition.
+
+                        continue;  // CONTINUE
+                    }
+                    BSLS_ASSERT(pinfo.primaryNode() == clusterNode);
+                }
+                else if (d_clusterData_p->electorInfo().leaderNode() !=
+                         clusterNode) {
+                    continue;  // CONTINUE
+                }
+
+                if (queueLiveState.d_subQueueIds.findBySubIdSafe(
+                        bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID) ==
+                    queueLiveState.d_subQueueIds.end()) {
+                    // Only buffering PUTs.  Still sending CONFIRMs
+                    continue;  // CONTINUE
+                }
+
+                queue->dispatcher()->execute(
+                    bdlf::BindUtil::bind(&mqbi::Queue::onOpenUpstream,
+                                         queue,
+                                         0,
+                                         bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID,
+                                         true),  // isWriterOnly
+                    queue);
+            }
+
+            // As a way to bind 'contextSp' to all 'onOpenUpstream'
+            d_cluster_p->dispatcher()->execute(
+                bdlf::BindUtil::bind(&ClusterQueueHelper::onDeconfiguredHandle,
+                                     this,
+                                     contextSp),
+                mqbi::DispatcherClientType::e_QUEUE);
+        }
+        else {
+            // TEMPORARY, remove 'after switching to StopRequest V2
+            // Downstreams do not need to deconfigure queues for which the
+            // shutting down node is the upstream.  The deconfiguring is done
+            // by the upstream of the shutting down node instead.
+            // Nor do they need to wait for CONFIRMs, the waiting is done by
+            // the shutting down node.
+
+            if (ns) {
+                deconfigureQueues(contextSp, &ns->primaryPartitions());
+            }
+            else if (d_clusterData_p->electorInfo().leaderNode() ==
+                     contextSp->d_peer) {
+                deconfigureQueues(contextSp, 0);
+            }
         }
     }
     else {
@@ -5378,6 +5592,8 @@ void ClusterQueueHelper::deconfigureQueues(
     const bsl::shared_ptr<StopContext>& contextSp,
     const bsl::vector<int>*             partitions)
 {
+    // TEMPORARY, remove after switching all to StopRequest V2
+
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
@@ -5440,7 +5656,8 @@ void ClusterQueueHelper::deconfigureQueues(
                 bdlf::BindUtil::bind(&mqbi::Queue::onOpenUpstream,
                                      queue,
                                      0,
-                                     bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID),
+                                     bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID,
+                                     true),  // isWriterOnly
                 queue);
             queue->dispatcher()->synchronize(queue);
 
@@ -5657,6 +5874,92 @@ void ClusterQueueHelper::checkUnconfirmed(
             queueContextSp,
             subId),
         queueSp.get());
+}
+
+void ClusterQueueHelper::checkUnconfirmedV2(
+    const bsls::TimeInterval&    whenToStop,
+    const bsl::function<void()>& completionCallback)
+{
+    d_cluster_p->dispatcher()->execute(
+        bdlf::BindUtil::bind(&ClusterQueueHelper::checkUnconfirmedV2Dispatched,
+                             this,
+                             whenToStop,
+                             completionCallback),
+        d_cluster_p);
+}
+
+void ClusterQueueHelper::checkUnconfirmedV2Dispatched(
+    const bsls::TimeInterval&    whenToStop,
+    const bsl::function<void()>& completionCallback)
+{
+    // executed by the cluster *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(
+        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
+    bsls::Types::Int64 result = 0;
+    for (QueueContextMapIter it = d_queues.begin(); it != d_queues.end();
+         ++it) {
+        QueueContextSp& queueContextSp = it->second;
+        QueueLiveState& qinfo          = queueContextSp->d_liveQInfo;
+        mqbi::Queue*    queue          = qinfo.d_queue_sp.get();
+
+        if (!queue) {
+            continue;  // CONTINUE
+        }
+
+        queue->dispatcher()->execute(
+            bdlf::BindUtil::bind(&countUnconfirmed, &result, queue),
+            queue);
+        queue->dispatcher()->synchronize(queue);
+    }
+
+    // Synchronize with all Queue Dispatcher threads
+    bslmt::Latch latch(1);
+    d_cluster_p->dispatcher()->execute(
+        mqbi::Dispatcher::ProcessorFunctor(),  // empty
+        mqbi::DispatcherClientType::e_QUEUE,
+        bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
+
+    latch.wait();
+
+    if (result == 0) {
+        BALL_LOG_INFO << d_cluster_p->description()
+                      << ": no unconfirmed message(s)";
+
+        completionCallback();
+        return;
+    }
+
+    bsls::TimeInterval t = bsls::SystemTime::now(
+        bsls::SystemClockType::e_MONOTONIC);
+
+    if (t < whenToStop) {
+        BALL_LOG_INFO << d_cluster_p->description() << ": waiting for "
+                      << result << " unconfirmed message(s)";
+
+        t.addSeconds(1);
+        if (t > whenToStop) {
+            t = whenToStop;
+        }
+        bdlmt::EventScheduler::EventHandle eventHandle;
+        // Never cancel the timer
+        d_clusterData_p->scheduler()->scheduleEvent(
+            &eventHandle,
+            t,
+            bdlf::BindUtil::bind(&ClusterQueueHelper::checkUnconfirmedV2,
+                                 this,
+                                 whenToStop,
+                                 completionCallback));
+
+        return;  // RETURN
+    }
+    else {
+        BALL_LOG_WARN << d_cluster_p->description() << ": giving up on "
+                      << result << " unconfirmed message(s)";
+        completionCallback();
+    }
 }
 
 void ClusterQueueHelper::checkUnconfirmedQueueDispatched(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -166,7 +166,8 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
         // State of the upstream
 
         bdlmt::EventScheduler::EventHandle d_timer;
-        // TEMPORARY, remove 'after switching to StopRequest V2
+        // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest
+        // V2.
         // (timer handle 1s) when waiting for
         // unconfirmed.  This is to cancel the timer in
         // the case when this broker stops while
@@ -484,7 +485,9 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
 
     StopContexts d_stopContexts;
 
-    bool d_suppportShutdownV2;
+    /// When `true`, all cluster nodes support StopRequest V2 and this node
+    /// executes shutdown V2 logic.
+    bool d_supportShutdownV2;
 
   private:
     // PRIVATE MANIPULATORS
@@ -855,7 +858,7 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
     void deconfigureQueue(const bsl::shared_ptr<StopContext>& contextSp,
                           const QueueContextSp&               queueContextSp);
 
-    // TEMPORARY, remove 'after switching to StopRequest V2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     /// Second step of StopRequest / CLOSING node advisory processing
     /// (after de-configure response).  Start timer to wait the configured
     /// `stopTimeoutMs` is there are any pending PUSH messages to collect
@@ -873,7 +876,7 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
                             unsigned int                        subId,
                             bsls::TimeInterval&                 t);
 
-    // TEMPORARY, remove 'after switching to StopRequest V2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     void checkUnconfirmed(const bsl::shared_ptr<StopContext>& contextSp,
                           const QueueContextSp&               queueContextSp,
                           unsigned int                        subId);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -912,7 +912,8 @@ class ClusterQueueHelper : public mqbc::ClusterStateObserver,
     /// Send StopResponse to the request in the specified 'context.
     void finishStopSequenceDispatched(StopContext* context);
 
-    void onDeconfiguredHandle(const bsl::shared_ptr<StopContext>& contextSp);
+    void contextHolder(const bsl::shared_ptr<StopContext>& contextSp,
+                       const VoidFunctor&                  action);
 
     // PRIVATE ACCESSORS
 

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -957,9 +957,7 @@ bsls::Types::Int64 Queue::countUnconfirmed(unsigned int subId)
 
 void Queue::stopPushing()
 {
-    d_state.routingContext().shutdown();
-
-    queueEngine()->resetState(true);  // keepConfirming
+    queueEngine()->resetState(true);  // isShuttingDown
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -576,7 +576,8 @@ void Queue::onOpenFailure(unsigned int subQueueId)
 }
 
 void Queue::onOpenUpstream(bsls::Types::Uint64 genCount,
-                           unsigned int        subQueueId)
+                           unsigned int        subQueueId,
+                           bool                isWriterOnly)
 {
     // executed by the *QUEUE* dispatcher thread
 
@@ -584,7 +585,7 @@ void Queue::onOpenUpstream(bsls::Types::Uint64 genCount,
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
 
     if (d_remoteQueue_mp) {
-        d_remoteQueue_mp->onOpenUpstream(genCount, subQueueId);
+        d_remoteQueue_mp->onOpenUpstream(genCount, subQueueId, isWriterOnly);
     }
 }
 
@@ -926,6 +927,11 @@ bsls::Types::Int64 Queue::countUnconfirmed(unsigned int subId)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
 
+    if (subId == bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID) {
+        return d_state.handleCatalog().countUnconfirmed();  // RETURN
+    }
+
+    // Temporary, remove after switching all to shutdown version 2
     struct local {
         static void sum(bsls::Types::Int64*                  sum,
                         mqbi::QueueHandle*                   handle,
@@ -947,6 +953,13 @@ bsls::Types::Int64 Queue::countUnconfirmed(unsigned int subId)
                              subId));
 
     return result;
+}
+
+void Queue::stopPushing()
+{
+    d_state.routingContext().shutdown();
+
+    queueEngine()->resetState(true);  // keepConfirming
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -931,7 +931,7 @@ bsls::Types::Int64 Queue::countUnconfirmed(unsigned int subId)
         return d_state.handleCatalog().countUnconfirmed();  // RETURN
     }
 
-    // Temporary, remove after switching all to shutdown version 2
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     struct local {
         static void sum(bsls::Types::Int64*                  sum,
                         mqbi::QueueHandle*                   handle,

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -315,6 +315,8 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
     /// and current upstream `genCount`, then the PUT message gets dropped
     /// to avoid out of order PUTs.  If the `upstreamSubQueueId` is
     /// `k_ANY_SUBQUEUE_ID`, all SubQueues are reopen.
+    /// If the optionally specified isWriterOnly is true, ignore CONFIRMs. This
+    /// should be specified if the upstream is stopping.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -265,6 +265,10 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
     bsls::Types::Int64
     countUnconfirmed(unsigned int subId) BSLS_KEYWORD_OVERRIDE;
 
+    /// Stop sending PUSHes but continue receiving CONFIRMs, receiving and
+    /// sending PUTs and ACKs.
+    void stopPushing() BSLS_KEYWORD_OVERRIDE;
+
     void onPushMessage(
         const bmqt::MessageGUID&             msgGUID,
         const bsl::shared_ptr<bdlbb::Blob>&  appData,
@@ -314,7 +318,8 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,
-                        unsigned int upstreamSubQueueId) BSLS_KEYWORD_OVERRIDE;
+                        unsigned int        upstreamSubQueueId,
+                        bool isWriterOnly = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Notify the (remote) queue about reopen failure.  The queue NACKs all
     /// pending and incoming PUTs and drops CONFIRMs related to to the

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -875,8 +875,10 @@ QueueEngineUtil_AppState::QueueEngineUtil_AppState(
 QueueEngineUtil_AppState::~QueueEngineUtil_AppState()
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!hasConsumers());
     BSLS_ASSERT_SAFE(!d_throttleEventHandle);
+
+    // In the case of `convertToLocal`, the new `RootQueueEngine` can reuse the
+    // existing `RelayQueueEngine` routing contexts.
 }
 
 size_t

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -1271,7 +1271,7 @@ void QueueEngineUtil_AppState::cancelThrottle()
     }
 }
 
-void QueueEngineUtil_AppState::reset()
+void QueueEngineUtil_AppState::undoRouting()
 {
     d_priorityCount = 0;
     cancelThrottle();
@@ -1288,7 +1288,7 @@ void QueueEngineUtil_AppState::rebuildConsumers(
 {
     // Rebuild ConsumersState for this app
     // Prepare the app for rebuilding consumers
-    reset();
+    undoRouting();
 
     bsl::shared_ptr<Routers::AppContext> previous = d_routing_sp;
     d_routing_sp                                  = replacement;

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -410,7 +410,7 @@ struct QueueEngineUtil_AppState {
                               bool                     isExpired);
 
     /// Reset the internal state to have no consumers.
-    void reset();
+    void undoRouting();
 
     /// Deliver all messages in the storage to the consumer represented by
     /// this instance.  Load the message delay into the specified `delay`.

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -1000,7 +1000,11 @@ void QueueHandle::deconfigureAll(
         bdlf::BindUtil::bind(&QueueHandle::deconfigureDispatched,
                              this,
                              deconfiguredCb),
-        d_queue_sp.get());
+        d_queue_sp.get(),
+        mqbi::DispatcherEventType::e_DISPATCHER);
+
+    // Use 'mqbi::DispatcherEventType::e_DISPATCHER' to avoid (re)enabling
+    // 'd_flushList'
 }
 
 void QueueHandle::deconfigureDispatched(

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -659,7 +659,7 @@ void QueueHandle::registerSubscription(unsigned int downstreamSubId,
     // Ceil the limits values, so that if max redeliveries is 1, it will
     // compute ok
     const bsls::Types::Int64 lowWatermarkBytes =
-        static_cast<const bsls::Types::Int64>(
+        static_cast<bsls::Types::Int64>(
             bsl::ceil(ci.maxUnconfirmedBytes() * k_WATERMARK_RATIO));
 
     // We only care about whether we are at or above the `capacity`

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
@@ -122,7 +122,7 @@ void QueueHandleCatalog::queueHandleDeleter(mqbi::QueueHandle* handle)
 QueueHandleCatalog::QueueHandleCatalog(mqbi::Queue*      queue,
                                        bslma::Allocator* allocator)
 : d_queue_p(queue)
-, d_handleFactory_mp(new (*allocator) DefaultHandleFactory(), allocator)
+, d_handleFactory_mp(new(*allocator) DefaultHandleFactory(), allocator)
 , d_handles(allocator)
 , d_allocator_p(allocator)
 {
@@ -362,6 +362,26 @@ void QueueHandleCatalog::loadInternals(
         out->back().clientDescription() = description.str();
         handle->loadInternals(&out->back());
     }
+}
+
+bsls::Types::Int64 QueueHandleCatalog::countUnconfirmed() const
+{
+    // executed by the *QUEUE* dispatcher thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_queue_p->dispatcher()->inDispatcherThread(d_queue_p));
+
+    bsls::Types::Int64 result = 0;
+
+    for (HandleMap::const_iterator cit = d_handles.begin();
+         cit != d_handles.end();
+         ++cit) {
+        const mqbi::QueueHandle* handle(cit->value().get());
+
+        result += handle->countUnconfirmed(
+            bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID);
+    }
+    return result;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.h
@@ -30,9 +30,9 @@
 // must be executed by the dispatcher thread of the associated queue.
 
 // MQB
-
 #include <mqbi_queue.h>
 #include <mqbi_storage.h>
+#include <mqbu_resourceusagemonitor.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
@@ -170,7 +170,8 @@ class QueueHandleCatalog {
     // CREATOR
 
     /// Create a new object associated to the specified `queue`.  Use the
-    /// specified `allocator` for any memory allocations.
+    /// specified `allocator` for any memory allocations.  Use the specified
+    /// 'counter' to aggregate the counting of  unconfirmed by each handle.
     QueueHandleCatalog(mqbi::Queue* queue, bslma::Allocator* allocator);
 
     /// Destructor.
@@ -240,6 +241,8 @@ class QueueHandleCatalog {
     /// Load into the specified `out` list the internal details about the
     /// handles managed by this catalog.
     void loadInternals(bsl::vector<mqbcmd::QueueHandle>* out) const;
+
+    bsls::Types::Int64 countUnconfirmed() const;
 };
 
 // ============================================================================

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -203,7 +203,9 @@ class QueueState {
 
     /// Create a new `QueueState` associated to the specified `queue` and
     /// having the specified `uri`, `id`, `key`, `partitionId` and `domain`.
-    /// Use the specified `allocator` for any memory allocations.
+    /// Use the specified `allocator` for any memory allocations.  Use the
+    /// specified 'unconfirmedCounter' to aggregate the  counting of
+    /// unconfirmed by each queue handle.
     QueueState(mqbi::Queue*            queue,
                const bmqt::Uri&        uri,
                unsigned int            id,

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -909,15 +909,17 @@ int RelayQueueEngine::configure(
     return 0;
 }
 
-void RelayQueueEngine::resetState()
+void RelayQueueEngine::resetState(bool keepConfirming)
 {
-    d_self.reset(this);
+    // d_self.reset(this);
 
     for (AppsMap::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
         it->second->reset();
-        it->second->d_routing_sp.reset();
+        // Keep the routing which new engine can reuse
     }
-    d_apps.clear();
+    if (!keepConfirming) {
+        d_apps.clear();
+    }
 }
 
 int RelayQueueEngine::rebuildInternalState(

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -810,7 +810,7 @@ void RelayQueueEngine::applyConfiguration(App_State&        app,
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->dispatcher()->inDispatcherThread(
         d_queueState_p->queue()));
 
-    app.reset();
+    app.undoRouting();
 
     app.d_routing_sp = context.d_routing_sp;
 
@@ -911,10 +911,8 @@ int RelayQueueEngine::configure(
 
 void RelayQueueEngine::resetState(bool isShuttingDown)
 {
-    // d_self.reset(this);
-
     for (AppsMap::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
-        it->second->reset();
+        it->second->undoRouting();
         if (isShuttingDown) {
             it->second->d_routing_sp->reset();
         }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -909,15 +909,18 @@ int RelayQueueEngine::configure(
     return 0;
 }
 
-void RelayQueueEngine::resetState(bool keepConfirming)
+void RelayQueueEngine::resetState(bool isShuttingDown)
 {
     // d_self.reset(this);
 
     for (AppsMap::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
         it->second->reset();
-        // Keep the routing which new engine can reuse
+        if (isShuttingDown) {
+            it->second->d_routing_sp->reset();
+        }
+        // else, keep the routing which new engine can reuse
     }
-    if (!keepConfirming) {
+    if (!isShuttingDown) {
         d_apps.clear();
     }
 }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -379,7 +379,7 @@ class RelayQueueEngine : public mqbi::QueueEngine {
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
     /// processing.
-    virtual void resetState(bool keepConfirming = false) BSLS_KEYWORD_OVERRIDE;
+    virtual void resetState(bool isShuttingDown = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -376,8 +376,10 @@ class RelayQueueEngine : public mqbi::QueueEngine {
     virtual int
     configure(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the internal state of this engine.
-    virtual void resetState() BSLS_KEYWORD_OVERRIDE;
+    /// Reset the internal state of this engine.  If the optionally specified
+    /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
+    /// processing.
+    virtual void resetState(bool keepConfirming = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -255,6 +255,10 @@ class RemoteQueue {
 
     StateSpPool* d_statePool_p;
 
+    SubStreamContext d_producerState;
+    // To discern consumer and producer which share the same
+    // `k_DEFAULT_SUBQUEUE_ID` in the priority mode.
+
     bslma::Allocator* d_allocator_p;
     // Allocator to use
   private:
@@ -457,7 +461,8 @@ class RemoteQueue {
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,
-                        unsigned int        upstreamSubQueueId);
+                        unsigned int        upstreamSubQueueId,
+                        bool                isWriterOnly = false);
 
     /// Notify the (remote) queue about reopen failure.  The queue NACKs all
     /// pending and incoming PUTs and drops CONFIRMs related to to the

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -458,6 +458,8 @@ class RemoteQueue {
     /// and current upstream `genCount`, then the PUT message gets dropped
     /// to avoid out of order PUTs.  If the `upstreamSubQueueId` is
     /// `k_ANY_SUBQUEUE_ID`, all SubQueues are reopen.
+    /// If the optionally specified isWriterOnly is true, ignore CONFIRMs. This
+    /// should be specified if the upstream is stopping.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -428,7 +428,7 @@ int RootQueueEngine::initializeAppId(const bsl::string& appId,
 void RootQueueEngine::resetState(bool isShuttingDown)
 {
     for (Apps::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
-        it->value()->reset();
+        it->value()->undoRouting();
         it->value()->d_routing_sp->reset();
     }
 
@@ -893,7 +893,7 @@ void RootQueueEngine::configureHandle(
 
     const AppStateSp& affectedApp = iter->value();
     // prepare the App for rebuilding consumers
-    affectedApp->reset();
+    affectedApp->undoRouting();
 
     // Rebuild the highest priority state for all affected apps.
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -425,7 +425,7 @@ int RootQueueEngine::initializeAppId(const bsl::string& appId,
     return 0;
 }
 
-void RootQueueEngine::resetState(bool keepConfirming)
+void RootQueueEngine::resetState(bool isShuttingDown)
 {
     for (Apps::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
         it->value()->reset();
@@ -434,7 +434,7 @@ void RootQueueEngine::resetState(bool keepConfirming)
 
     d_consumptionMonitor.reset();
 
-    if (!keepConfirming) {
+    if (!isShuttingDown) {
         d_apps.clear();
     }
 }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -425,10 +425,18 @@ int RootQueueEngine::initializeAppId(const bsl::string& appId,
     return 0;
 }
 
-void RootQueueEngine::resetState()
+void RootQueueEngine::resetState(bool keepConfirming)
 {
+    for (Apps::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
+        it->value()->reset();
+        it->value()->d_routing_sp->reset();
+    }
+
     d_consumptionMonitor.reset();
-    d_apps.clear();
+
+    if (!keepConfirming) {
+        d_apps.clear();
+    }
 }
 
 void RootQueueEngine::rebuildSelectedApp(

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -258,8 +258,10 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     virtual int
     configure(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the internal state of this engine.
-    virtual void resetState() BSLS_KEYWORD_OVERRIDE;
+    /// Reset the internal state of this engine.  If the optionally specified
+    /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
+    /// processing.
+    virtual void resetState(bool keepConfirming = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -261,7 +261,7 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
     /// processing.
-    virtual void resetState(bool keepConfirming = false) BSLS_KEYWORD_OVERRIDE;
+    virtual void resetState(bool isShuttingDown = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -595,6 +595,8 @@ class Routers {
 
         bmqeval::EvaluationContext d_evaluationContext;
 
+        bool d_isShuttingDown;
+
         bslma::Allocator* d_allocator_p;
 
         QueueRoutingContext(bmqp::SchemaLearner& schemaLearner,
@@ -606,6 +608,8 @@ class Routers {
 
         bool onUsable(unsigned int* upstreamSubQueueId,
                       unsigned int  upstreamSubscriptionId);
+
+        void shutdown();
 
         void loadInternals(mqbcmd::Routing* out) const;
     };
@@ -842,9 +846,10 @@ inline Routers::QueueRoutingContext::QueueRoutingContext(
 : d_expressions(allocator)
 , d_nextSubscriptionId(0)
 , d_groupIds(allocator)
-, d_preader(new (*allocator) MessagePropertiesReader(schemaLearner, allocator),
+, d_preader(new(*allocator) MessagePropertiesReader(schemaLearner, allocator),
             allocator)
 , d_evaluationContext(0, allocator)
+, d_isShuttingDown(false)
 , d_allocator_p(allocator)
 {
     d_evaluationContext.setPropertiesReader(d_preader.get());
@@ -878,6 +883,11 @@ Routers::QueueRoutingContext::onUsable(unsigned int* upstreamSubQueueId,
         }
     }
     return false;
+}
+
+inline void Routers::QueueRoutingContext::shutdown()
+{
+    d_isShuttingDown = true;
 }
 
 // -----------------------------

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -609,8 +609,6 @@ class Routers {
         bool onUsable(unsigned int* upstreamSubQueueId,
                       unsigned int  upstreamSubscriptionId);
 
-        void shutdown();
-
         void loadInternals(mqbcmd::Routing* out) const;
     };
 
@@ -883,11 +881,6 @@ Routers::QueueRoutingContext::onUsable(unsigned int* upstreamSubQueueId,
         }
     }
     return false;
-}
-
-inline void Routers::QueueRoutingContext::shutdown()
-{
-    d_isShuttingDown = true;
 }
 
 // -----------------------------

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -595,8 +595,6 @@ class Routers {
 
         bmqeval::EvaluationContext d_evaluationContext;
 
-        bool d_isShuttingDown;
-
         bslma::Allocator* d_allocator_p;
 
         QueueRoutingContext(bmqp::SchemaLearner& schemaLearner,
@@ -847,7 +845,6 @@ inline Routers::QueueRoutingContext::QueueRoutingContext(
 , d_preader(new(*allocator) MessagePropertiesReader(schemaLearner, allocator),
             allocator)
 , d_evaluationContext(0, allocator)
-, d_isShuttingDown(false)
 , d_allocator_p(allocator)
 {
     d_evaluationContext.setPropertiesReader(d_preader.get());

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
@@ -142,7 +142,7 @@ int ClusterStateLedgerUtil::validateFileHeader(
     const ClusterStateFileHeader& header,
     const mqbu::StorageKey&       expectedLogId)
 {
-    if (static_cast<const int>(header.protocolVersion()) !=
+    if (static_cast<int>(header.protocolVersion()) !=
         ClusterStateLedgerProtocol::k_VERSION) {
         return ClusterStateLedgerUtilRc::e_INVALID_PROTOCOL_VERSION;  // RETURN
     }

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -266,8 +266,12 @@ class Cluster : public DispatcherClient {
     /// Initiate the shutdown of the cluster and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence. It
     /// is expected that `stop()` will be called soon after this routine is
-    /// invoked.
-    virtual void initiateShutdown(const VoidFunctor& callback) = 0;
+    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
+    /// deconfigure  queues and he shutting down node (not downstream) wait for
+    /// CONFIRMS.
+    virtual void initiateShutdown(const VoidFunctor& callback,
+                                  bool suppportShutdownV2 = false) = 0;
 
     /// Stop the `Cluster`; this is the counterpart of the `start()`
     /// operation.

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -266,12 +266,12 @@ class Cluster : public DispatcherClient {
     /// Initiate the shutdown of the cluster and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence. It
     /// is expected that `stop()` will be called soon after this routine is
-    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// invoked.  If the optional (temporary) specified 'supportShutdownV2' is
     /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
-    /// deconfigure  queues and he shutting down node (not downstream) wait for
-    /// CONFIRMS.
+    /// deconfigure  queues and the shutting down node (not downstream) wait
+    /// for CONFIRMS.
     virtual void initiateShutdown(const VoidFunctor& callback,
-                                  bool suppportShutdownV2 = false) = 0;
+                                  bool supportShutdownV2 = false) = 0;
 
     /// Stop the `Cluster`; this is the counterpart of the `start()`
     /// operation.

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -856,6 +856,8 @@ class Queue : public DispatcherClient {
     /// and current upstream `genCount`, then the PUT message gets dropped
     /// to avoid out of order PUTs.  If the `upstreamSubQueueId` is
     /// `k_ANY_SUBQUEUE_ID`, all SubQueues are reopen.
+    /// If the optionally specified isWriterOnly is true, ignore CONFIRMs. This
+    /// should be specified if the upstream is stopping.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void onOpenUpstream(bsls::Types::Uint64 genCount,

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -803,6 +803,10 @@ class Queue : public DispatcherClient {
     /// `specified `subId'.
     virtual bsls::Types::Int64 countUnconfirmed(unsigned int subId) = 0;
 
+    /// Stop sending PUSHes but continue receiving CONFIRMs, receiving and
+    /// sending PUTs and ACKs.
+    virtual void stopPushing() = 0;
+
     /// Called when a message with the specified `msgGUID`, `appData`,
     /// `options`, `compressionAlgorithmType` payload is pushed to this
     /// queue.  Note that depending upon the location of the queue instance,
@@ -855,7 +859,8 @@ class Queue : public DispatcherClient {
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void onOpenUpstream(bsls::Types::Uint64 genCount,
-                                unsigned int        upstreamSubQueueId) = 0;
+                                unsigned int        upstreamSubQueueId,
+                                bool                isWriterOnly = false) = 0;
 
     /// Notify the (remote) queue about (re)open failure.  The queue NACKs
     /// all pending and incoming PUTs and drops CONFIRMs related to to the

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -75,9 +75,9 @@ class QueueEngine {
     virtual int configure(bsl::ostream& errorDescription) = 0;
 
     /// Reset the internal state of this engine.  If the optionally specified
-    /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
-    /// processing.
-    virtual void resetState(bool keepConfirming = false) = 0;
+    /// 'isShuttingDown' is 'true', clear the routing state but keep the Apps
+    /// state for CONFIRMs processing.
+    virtual void resetState(bool isShuttingDown = false) = 0;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -74,8 +74,10 @@ class QueueEngine {
     /// otherwise and populate the specified `errorDescription`.
     virtual int configure(bsl::ostream& errorDescription) = 0;
 
-    /// Reset the internal state of this engine.
-    virtual void resetState() = 0;
+    /// Reset the internal state of this engine.  If the optionally specified
+    /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
+    /// processing.
+    virtual void resetState(bool keepConfirming = false) = 0;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -326,7 +326,7 @@ int Cluster::start(BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
 
 void Cluster::initiateShutdown(
     BSLS_ANNOTATION_UNUSED const VoidFunctor& callback,
-    BSLS_ANNOTATION_UNUSED bool               suppportShutdownV2)
+    BSLS_ANNOTATION_UNUSED bool               supportShutdownV2)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(!d_isStarted &&

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -325,7 +325,8 @@ int Cluster::start(BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription)
 }
 
 void Cluster::initiateShutdown(
-    BSLS_ANNOTATION_UNUSED const VoidFunctor& callback)
+    BSLS_ANNOTATION_UNUSED const VoidFunctor& callback,
+    BSLS_ANNOTATION_UNUSED bool               suppportShutdownV2)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(!d_isStarted &&

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -299,11 +299,16 @@ class Cluster : public mqbi::Cluster {
     /// error.
     int start(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
 
-    /// Initiate the shutdown of the cluster.  It is expected that `stop()`
-    /// will be called soon after this routine is invoked.  Invoke the
-    /// specified `callback` upon completion of (asynchronous) shutdown
-    /// sequence.
-    void initiateShutdown(const VoidFunctor& callback) BSLS_KEYWORD_OVERRIDE;
+    /// Initiate the shutdown of the cluster and invoke the specified
+    /// `callback` upon completion of (asynchronous) shutdown sequence. It
+    /// is expected that `stop()` will be called soon after this routine is
+    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
+    /// deconfigure  queues and he shutting down node (not downstream) wait for
+    /// CONFIRMS.
+    void
+    initiateShutdown(const VoidFunctor& callback,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -302,13 +302,13 @@ class Cluster : public mqbi::Cluster {
     /// Initiate the shutdown of the cluster and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence. It
     /// is expected that `stop()` will be called soon after this routine is
-    /// invoked.  If the optional (temporary) specified 'suppportShutdownV2' is
+    /// invoked.  If the optional (temporary) specified 'supportShutdownV2' is
     /// 'true' execute shutdown logic V2 where upstream (not downstream) nodes
-    /// deconfigure  queues and he shutting down node (not downstream) wait for
-    /// CONFIRMS.
+    /// deconfigure  queues and the shutting down node (not downstream) wait
+    /// for CONFIRMS.
     void
     initiateShutdown(const VoidFunctor& callback,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the `Cluster`.
     void stop() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -251,6 +251,11 @@ Queue::countUnconfirmed(BSLS_ANNOTATION_UNUSED unsigned int subId)
     return 0;
 }
 
+void Queue::stopPushing()
+{
+    // NOT IMPLENTED
+}
+
 void Queue::onPushMessage(
     BSLS_ANNOTATION_UNUSED const bmqt::MessageGUID& msgGUID,
     BSLS_ANNOTATION_UNUSED const bsl::shared_ptr<bdlbb::Blob>& appData,
@@ -348,7 +353,8 @@ void Queue::onLostUpstream()
 }
 
 void Queue::onOpenUpstream(BSLS_ANNOTATION_UNUSED bsls::Types::Uint64 genCount,
-                           BSLS_ANNOTATION_UNUSED unsigned int subQueueId)
+                           BSLS_ANNOTATION_UNUSED unsigned int subQueueId,
+                           BSLS_ANNOTATION_UNUSED bool         isWriterOnly)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -303,6 +303,8 @@ class Queue : public mqbi::Queue {
     /// and current upstream `genCount`, then the PUT message gets dropped
     /// to avoid out of order PUTs.  If the `upstreamSubQueueId` is
     /// `k_ANY_SUBQUEUE_ID`, all SubQueues are reopen.
+    /// If the optionally specified isWriterOnly is true, ignore CONFIRMs. This
+    /// should be specified if the upstream is stopping.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -249,6 +249,10 @@ class Queue : public mqbi::Queue {
     bsls::Types::Int64
     countUnconfirmed(unsigned int subId) BSLS_KEYWORD_OVERRIDE;
 
+    /// Stop sending PUSHes but continue receiving CONFIRMs, receiving and
+    /// sending PUTs and ACKs.
+    void stopPushing() BSLS_KEYWORD_OVERRIDE;
+
     /// Called when a message with the specified `msgGUID`, `appData`,
     /// `options` and compressionAlgorithmType payload is pushed to this
     /// queue.  Note that depending upon the location of the queue instance,
@@ -302,7 +306,8 @@ class Queue : public mqbi::Queue {
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onOpenUpstream(bsls::Types::Uint64 genCount,
-                        unsigned int upstreamSubQueueId) BSLS_KEYWORD_OVERRIDE;
+                        unsigned int        upstreamSubQueueId,
+                        bool isWriterOnly = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Notify the (remote) queue about reopen failure.  The queue NACKs all
     /// pending and incoming PUTs and drops CONFIRMs related to to the

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
@@ -46,7 +46,7 @@ int QueueEngine::configure(
     return 0;
 }
 
-void QueueEngine::resetState()
+void QueueEngine::resetState(BSLS_ANNOTATION_UNUSED bool keepConfirming)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.h
@@ -88,8 +88,10 @@ class QueueEngine : public mqbi::QueueEngine {
     virtual int
     configure(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the internal state of this engine.
-    virtual void resetState() BSLS_KEYWORD_OVERRIDE;
+    /// Reset the internal state of this engine.  If the optionally specified
+    /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
+    /// processing.
+    virtual void resetState(bool keepConfirming = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Rebuild the internal state of this engine.  This method is invoked
     /// when the queue this engine is associated with is created from an

--- a/src/groups/mqb/mqbnet/mqbnet_dummysession.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_dummysession.cpp
@@ -59,7 +59,7 @@ void DummySession::tearDown(
 void DummySession::initiateShutdown(
     BSLS_ANNOTATION_UNUSED const ShutdownCb& callback,
     BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout,
-    BSLS_ANNOTATION_UNUSED bool                      suppportShutdownV2)
+    BSLS_ANNOTATION_UNUSED bool                      supportShutdownV2)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbnet/mqbnet_dummysession.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_dummysession.cpp
@@ -58,7 +58,8 @@ void DummySession::tearDown(
 
 void DummySession::initiateShutdown(
     BSLS_ANNOTATION_UNUSED const ShutdownCb& callback,
-    BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout)
+    BSLS_ANNOTATION_UNUSED const bsls::TimeInterval& timeout,
+    BSLS_ANNOTATION_UNUSED bool                      suppportShutdownV2)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbnet/mqbnet_dummysession.h
+++ b/src/groups/mqb/mqbnet/mqbnet_dummysession.h
@@ -136,13 +136,13 @@ class DummySession : public Session {
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
     /// if the specified `timeout` is expired.  If the optional (temporary)
-    /// specified 'suppportShutdownV2' is 'true' execute shutdown logic V2
+    /// specified 'supportShutdownV2' is 'true' execute shutdown logic V2
     /// where upstream (not downstream) nodes deconfigure  queues and the
     /// shutting down node (not downstream) waits for CONFIRMS.
     void
     initiateShutdown(const ShutdownCb&         callback,
                      const bsls::TimeInterval& timeout,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
+                     bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Make the session abandon any work it has.
     void invalidate() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbnet/mqbnet_dummysession.h
+++ b/src/groups/mqb/mqbnet/mqbnet_dummysession.h
@@ -135,10 +135,14 @@ class DummySession : public Session {
 
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
-    /// if the specified `timeout` is expired.
+    /// if the specified `timeout` is expired.  If the optional (temporary)
+    /// specified 'suppportShutdownV2' is 'true' execute shutdown logic V2
+    /// where upstream (not downstream) nodes deconfigure  queues and the
+    /// shutting down node (not downstream) waits for CONFIRMS.
     void
     initiateShutdown(const ShutdownCb&         callback,
-                     const bsls::TimeInterval& timeout) BSLS_KEYWORD_OVERRIDE;
+                     const bsls::TimeInterval& timeout,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Make the session abandon any work it has.
     void invalidate() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -252,6 +252,8 @@ class MultiRequestManager {
 
     void sendRequest(const RequestContextSp& context,
                      bsls::TimeInterval      timeout);
+
+    void processResponse(const bmqp_ctrlmsg::ControlMessage& message);
 };
 
 // ============================================================================
@@ -485,6 +487,13 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
         context->d_responseCb(context);
     }
 }
+
+template <class REQUEST, class RESPONSE, class TARGET>
+inline void MultiRequestManager<REQUEST, RESPONSE, TARGET>::processResponse(
+    const bmqp_ctrlmsg::ControlMessage& response)
+{
+    d_requestManager_p->processResponse(response);
+};
 
 template <class REQUEST, class RESPONSE, class TARGET>
 inline const bsl::string&

--- a/src/groups/mqb/mqbnet/mqbnet_session.h
+++ b/src/groups/mqb/mqbnet/mqbnet_session.h
@@ -130,12 +130,12 @@ class Session : public SessionEventProcessor {
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
     /// if the specified `timeout` is expired.  If the optional (temporary)
-    /// specified 'suppportShutdownV2' is 'true' execute shutdown logic V2
+    /// specified 'supportShutdownV2' is 'true' execute shutdown logic V2
     /// where upstream (not downstream) nodes deconfigure  queues and the
     /// shutting down node (not downstream) waits for CONFIRMS.
     virtual void initiateShutdown(const ShutdownCb&         callback,
                                   const bsls::TimeInterval& timeout,
-                                  bool suppportShutdownV2 = false) = 0;
+                                  bool supportShutdownV2 = false) = 0;
 
     /// Make the session abandon any work it has.
     virtual void invalidate() = 0;

--- a/src/groups/mqb/mqbnet/mqbnet_session.h
+++ b/src/groups/mqb/mqbnet/mqbnet_session.h
@@ -129,9 +129,13 @@ class Session : public SessionEventProcessor {
 
     /// Initiate the shutdown of the session and invoke the specified
     /// `callback` upon completion of (asynchronous) shutdown sequence or
-    /// if the specified `timeout` is expired.
+    /// if the specified `timeout` is expired.  If the optional (temporary)
+    /// specified 'suppportShutdownV2' is 'true' execute shutdown logic V2
+    /// where upstream (not downstream) nodes deconfigure  queues and the
+    /// shutting down node (not downstream) waits for CONFIRMS.
     virtual void initiateShutdown(const ShutdownCb&         callback,
-                                  const bsls::TimeInterval& timeout) = 0;
+                                  const bsls::TimeInterval& timeout,
+                                  bool suppportShutdownV2 = false) = 0;
 
     /// Make the session abandon any work it has.
     virtual void invalidate() = 0;

--- a/src/groups/mqb/mqbnet/mqbnet_session.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_session.t.cpp
@@ -69,10 +69,9 @@ struct SessionTestImp : bsls::ProtocolTestImp<mqbnet::Session> {
         markDone();
     }
 
-    void
-    initiateShutdown(const ShutdownCb&         callback,
-                     const bsls::TimeInterval& timeout,
-                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE
+    void initiateShutdown(const ShutdownCb&         callback,
+                          const bsls::TimeInterval& timeout,
+                          bool supportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE
     {
         markDone();
     }

--- a/src/groups/mqb/mqbnet/mqbnet_session.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_session.t.cpp
@@ -71,7 +71,8 @@ struct SessionTestImp : bsls::ProtocolTestImp<mqbnet::Session> {
 
     void
     initiateShutdown(const ShutdownCb&         callback,
-                     const bsls::TimeInterval& timeout) BSLS_KEYWORD_OVERRIDE
+                     const bsls::TimeInterval& timeout,
+                     bool suppportShutdownV2 = false) BSLS_KEYWORD_OVERRIDE
     {
         markDone();
     }

--- a/src/integration-tests/test_maxunconfirmed.py
+++ b/src/integration-tests/test_maxunconfirmed.py
@@ -48,7 +48,7 @@ class TestMaxunconfirmed:
         )
         return all(res == Client.e_SUCCESS for res in results)
 
-    @tweak.cluster.queue_operations.stop_timeout_ms(1000)
+    @tweak.cluster.queue_operations.shutdown_timeout_ms(1000)
     def test_maxunconfirmed(self, multi_node: Cluster):
         # Post 100 messages
         assert self.post_n_msgs(tc.URI_PRIORITY, 100)


### PR DESCRIPTION
Changing shutdown logic to minimize control plane traffic.

1.  StopRequest is now per App (not Cluster)
2. Downstreams of the the shutting down do not deconfigure queues.  Upstreams do.
3. The shutting down waits for unconfirmed (not the downstreams)

```
DownStream              Shutting down broker:           Upstream

                            InitiateShutdown:
                
                            ClientSessions:
                                changes the state
                    
                            Broker sessions:
                    <--         StopRequest V2          -->

Clusters                                                    Clusters
and                                                             The ClusterNodeSession:
ClusterProxies (CQH):                                               QueueHandles:
    Queues:                                                             deconfigureAll
        buffer PUTs
                                                            ClusterProxies:
                                                                The ClientSession:
                                                                    QueueHandles:
                                                                        deconfigureAll
                    -->         StopResponse V2         <--
            
                            Clusters:
                                stopPushing
                                checkUnconfirmedV2
                        
                                continueShutdownDispatched
                                    change the state(s)
                                    cancelAllRequests
                                    delete (dirty) queues
```                                    