### PR TITLE
Fix subscription md doc formatting

### DIFF
--- a/docs/docs/features/subscriptions.md
+++ b/docs/docs/features/subscriptions.md
@@ -318,13 +318,14 @@ manipulation, as a tiny subset of the C programming language.
 - Negation requires one argument
 - Junctions require two boolean arguments
 - Junctions are short-circuiting: if the left side of `&&` is `false`, or if
-  the left side of `||` is `true`, the right side is not evaluated. As a
-  consequence, identifiers in an expression do not all need to have a
-  corresponding property of the right type. For example, `type == "i" && shares
-  > 1000 || shares == "all"` is valid, as long as the value of `type` and the
-  type of `shares` are properly correlated. `order == "limit" and limit == 0`
-  can be used to detect the messages that represent a Limit Order with a silly
-  limit value, and e.g. log an error message.
+  the left side of `||` is `true`, the right side is not evaluated.
+  - As a consequence, identifiers in an expression do not all need to have a
+  corresponding property of the right type.
+  - For example, `type == "i" && shares 1000 || shares == "all"` is valid as
+  long as the value of `type` and the type of `shares` are properly correlated.
+  `order == "limit" and limit == 0` can be used to detect the messages that
+  represent a Limit Order with a silly limit value, and e.g. log an error
+  message.
 
 ### Operator Precedence
 {:.no_toc}


### PR DESCRIPTION
The wrapping here was causing an unintentional blockquote:
![Screenshot 2024-08-15 at 10 38 37 AM](https://github.com/user-attachments/assets/e2bfbf4b-3873-4fa9-83ca-727d05cc9c0c)


This is what it looks like after my changes:
![Screenshot 2024-08-15 at 10 38 17 AM](https://github.com/user-attachments/assets/d437763f-eb23-41f5-91e5-f18ad8802d61)
