### PR TITLE
Provide read-only access to the ntc stream socket interface

### DIFF
--- a/src/groups/mwc/mwcio/mwcio_ntcchannel.cpp
+++ b/src/groups/mwc/mwcio/mwcio_ntcchannel.cpp
@@ -1407,6 +1407,12 @@ bslma::Allocator* NtcChannel::allocator() const
     return d_allocator_p;
 }
 
+const ntci::StreamSocket& NtcChannel::streamSocket() const
+{
+    BSLS_ASSERT(d_streamSocket_sp);
+    return *d_streamSocket_sp;
+}
+
 // ---------------------
 // struct NtcChannelUtil
 // ---------------------

--- a/src/groups/mwc/mwcio/mwcio_ntcchannel.h
+++ b/src/groups/mwc/mwcio/mwcio_ntcchannel.h
@@ -37,6 +37,7 @@
 
 // NTC
 #include <ntcf_system.h>
+#include <ntci_streamsocket.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -426,6 +427,10 @@ class NtcChannel : public mwcio::Channel,
 
     /// Return the allocator this object was created with.
     bslma::Allocator* allocator() const;
+
+    /// Return the socket interface for this channel. This function is
+    /// undefined unless the channel has succesfully established a connection.
+    const ntci::StreamSocket& streamSocket() const;
 };
 
 // =====================


### PR DESCRIPTION
There are several interesting `const` accessors on the `ntci::StreamSocket` interface that can be useful to understand. We expose the socket stream interface here for convenience.