### PR TITLE
Fix[bmqt_messageguid.h]: fix possible UB due to misalignment

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_messageguid.h
+++ b/src/groups/bmq/bmqt/bmqt_messageguid.h
@@ -363,11 +363,14 @@ MessageGUIDHashAlgo::operator()(const void*                   data,
         }
     };
 
-    const bsls::Types::Uint64* start =
-        reinterpret_cast<const bsls::Types::Uint64*>(data);
-    const bsls::Types::Uint64 h1 = LocalFuncs::mix(start[0]);
-    const bsls::Types::Uint64 h2 = LocalFuncs::mix(start[1]);
-    d_result                     = LocalFuncs::combine(h1, h2);
+    // `data` buffer might not be aligned to 8 bytes, so recasting the pointer
+    // might lead to UB
+    bsls::Types::Uint64 parts[2];
+    bsl::memcpy(parts, data, bmqt::MessageGUID::e_SIZE_BINARY);
+
+    parts[0] = LocalFuncs::mix(parts[0]);
+    parts[1] = LocalFuncs::mix(parts[1]);
+    d_result = LocalFuncs::combine(parts[0], parts[1]);
 }
 
 inline MessageGUIDHashAlgo::result_type MessageGUIDHashAlgo::computeHash()


### PR DESCRIPTION
`mxm_non_aligned` might have UB, `mxm` has fix

# Mac M2

Debug
```
           Name |     Iters | Total time (ns) | Per hash (ns) | Hash rate (1/sec)
=================================================================================
       baseline | 100000000 |       809572583 |             8 |         123521969
        default | 100000000 |      4424295708 |            44 |          22602467
   legacy(djb2) | 100000000 |      2932044583 |            29 |          34105893
            mx3 | 100000000 |      1752195042 |            17 |          57071272
mxm_non_aligned | 100000000 |      1197614625 |            11 |          83499314
            mxm | 100000000 |      1438789500 |            14 |          69502870
```

RelWithDebInfo
```
           Name |     Iters | Total time (ns) | Per hash (ns) | Hash rate (1/sec)
=================================================================================
       baseline | 100000000 |        47113000 |             0 |        2122556406
        default | 100000000 |       510100208 |             5 |         196039912
   legacy(djb2) | 100000000 |       329263209 |             3 |         303708392
            mx3 | 100000000 |       183929375 |             1 |         543686945
mxm_non_aligned | 100000000 |        90532959 |             0 |        1104570104
            mxm | 100000000 |       102430959 |             1 |         976267341
```

# GNU/Linux host 3GHz amd64

RelWithDebInfo
```
           Name |     Iters | Total time (ns) | Per hash (ns) | Hash rate (1/sec)
=================================================================================
       baseline | 100000000 |        42197292 |             0 |        2369820319
        default | 100000000 |       218523883 |             2 |         457615884
   legacy(djb2) | 100000000 |       875467362 |             8 |         114224703
            mx3 | 100000000 |       425392768 |             4 |         235076869
mxm_non_aligned | 100000000 |       210435393 |             2 |         475205233
            mxm | 100000000 |       203974863 |             2 |         490256488
```
