### PR TITLE
Fix[mqbs::FileStore]: Do not remove purge record even if app is deleted

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1957,7 +1957,9 @@ void StorageUtil::recoveredQueuesCb(
                 // (something like 'inRecovery=true'), based on which storage
                 // implementation may or may not invoke certain business logic.
 
-                rs->purge(appKey);
+                if (rs->hasVirtualStorage(appKey)) {
+                    rs->purge(appKey);
+                }
             }
 
             // TBD: check if adding 'else if' clauses for 'ADDITION',

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1732,23 +1732,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     }
                 }
 
-                if (!appKey.isNull()) {
-                    // Specific appKey is purged.
-                    StorageKeysOffsetsConstIter appKeyIt =
-                        deletedAppKeysOffsets.find(appKey);
-
-                    if (appKeyIt != deletedAppKeysOffsets.end()) {
-                        BSLS_ASSERT_SAFE(jit->recordOffset() !=
-                                         appKeyIt->second);
-                        if (jit->recordOffset() < appKeyIt->second) {
-                            // This record appears before the QueueOp.DELETION
-                            // record for this appKey so should be ignored.
-
-                            continue;  // CONTINUE
-                        }
-                    }
-                }
-                else {
+                if (appKey.isNull()) {
                     // Entire queue is purged.
                     purgedQueueKeys.insert(queueKey);
                 }


### PR DESCRIPTION
We had a journal file inconsistency bug if a replica node contains a purge appId record preceding a removal record for that appId, and bounces before rollover. Primary, who rolled over fine, would write that purge record to the new file. Replica, who bounced, [would not keep this record in memory](https://github.com/kaikulimu/blazingmq/blob/c1866745f5caed6b2d2d9d2ed14e19eae05f26c0/src/groups/mqb/mqbs/mqbs_filestore.cpp#L1736-L1751) during recovery, and thus would not write the record to the new file during rollover. This is because rollover logic [decides the set of records to roll over](https://github.com/kaikulimu/blazingmq/blob/c1866745f5caed6b2d2d9d2ed14e19eae05f26c0/src/groups/mqb/mqbs/mqbs_filestore.cpp#L2553-L2564) based on the in-memory data structure `d_records`. This caused journal file inconsistency between primary and replica, where replica's file offset would be behind due to missing certain purge appId records.

The fix is to not skip purge record even if app is deleted, during recovery.