### PR TITLE
Fix[MQB]: app refcount is numVirtualStorages

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -2061,15 +2061,7 @@ RootQueueEngine::head(const AppStateSp app) const
 //   (virtual mqbi::QueueEngine)
 unsigned int RootQueueEngine::messageReferenceCount() const
 {
-    unsigned refCount = d_isFanout ? d_queueState_p->domain()
-                                         ->config()
-
-                                         .mode()
-                                         .fanout()
-                                         .appIDs()
-                                         .size()
-                                   : 1;
-
+    unsigned int refCount    = d_queueState_p->storage()->numVirtualStorages();
     unsigned int numNegative = d_queueState_p->storage()->numAutoConfirms();
 
     BSLS_ASSERT_SAFE(numNegative <= refCount);


### PR DESCRIPTION
The  race:

1.  Domain is being reconfigured with one less app
2.  Domain saves the new config as `d_config` _before_ proceeding with updating Apps (in Cluster thread)
3.  PUT arrives and picks the "reduced" count but the storage for the App being removed is not removed yet.  Queue inserts the PUT into the App storage that is about to be removed.  (In queue thread)
4.  Queue thread starts unregistering the App and as the result decrements the PUT refCount.  Now, the count is one less than the number of Apps (`N`)
5.  `N - 1` Confirms arrive (where `N` is the number of Apps after reconfiguration).
6. refCount drops to zero because it is off by `1`.
7. Queue attempts to remove the PUT but there is still `N`th storage without confirm.  And this asserts

this can manifest the other way - when we add new App
