### PR TITLE
Fix[MQB]: Add missing epoch to TTL logline

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7020,6 +7020,7 @@ bool FileStore::gcExpiredMessages(const bdlt::Datetime& currentTimeUtc)
                       << "Timestamp (UTC) of the latest encountered message: "
                       << bdlt::EpochUtil::convertFromTimeT64(
                              latestMsgTimestamp)
+                      << " (Epoch: " << latestMsgTimestamp
                       << "). Current time (UTC): " << currentTimeUtc
                       << " (Epoch: " << currentSecondsFromEpoch << ")."
                       << " Num messages remaining in the storage: "


### PR DESCRIPTION
I noticed that we print two timestamps, but only one epoch. Adding this epoch makes it a little easier to reason about the timestamps being logged in the context of TTL.

There was already a dangling `)` with no open parenthesis, so maybe this was a mistake in some previous cleanup or something?