### PR TITLE
Fix[mqbstat_domainstats.cpp]: empty tier StringRef leading to assert in Datum::copyString

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_domainstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_domainstats.cpp
@@ -136,7 +136,10 @@ void DomainStats::initialize(mqbi::Domain*       domain,
                      bdld::Datum::copyString(domain->cluster()->name(),
                                              alloc));
     builder.pushBack("domain", bdld::Datum::copyString(uri.domain(), alloc));
-    builder.pushBack("tier", bdld::Datum::copyString(uri.tier(), alloc));
+    builder.pushBack("tier",
+                     bdld::Datum::copyString(uri.tier().isEmpty() ? ""
+                                                                  : uri.tier(),
+                                             alloc));
 
     datum->adopt(builder.commit());
 }


### PR DESCRIPTION
Should fix the sanitizer error:
```
TEST /home/runner/work/blazingmq/blazingmq/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp CASE 46
/home/runner/work/blazingmq/blazingmq/deps/srcs/bde/groups/bdl/bdld/bdld_datum.cpp:1018:35: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x55e153d67781 in BloombergLP::bdld::Datum::copyString(char const*, unsigned long, BloombergLP::bslma::Allocator*) /home/runner/work/blazingmq/blazingmq/deps/srcs/bde/groups/bdl/bdld/bdld_datum.cpp:1018:9
    #1 0x55e1536430f9 in BloombergLP::bdld::Datum::copyString(BloombergLP::bslstl::StringRefImp<char> const&, BloombergLP::bslma::Allocator*) /opt/bb/include/bdld_datum.h:3568:12
    #2 0x55e153647d46 in BloombergLP::mqbstat::DomainStats::initialize(BloombergLP::mqbi::Domain*, BloombergLP::mwcst::StatContext*, BloombergLP::bslma::Allocator*) /home/runner/work/blazingmq/blazingmq/src/groups/mqb/mqbstat/mqbstat_domainstats.cpp:139:30
    #3 0x55e15326b3a8 in BloombergLP::mqbmock::Domain::Domain(BloombergLP::mqbi::Cluster*, BloombergLP::bslma::Allocator*) /home/runner/work/blazingmq/blazingmq/src/groups/mqb/mqbmock/mqbmock_domain.cpp:62:20
    #4 0x55e152af4b12 in BloombergLP::mqbblp::QueueEngineTester::init(BloombergLP::mqbconfm::Domain const&, bool) /home/runner/work/blazingmq/blazingmq/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp:451:30
    #5 0x55e152af3907 in BloombergLP::mqbblp::QueueEngineTester::QueueEngineTester(BloombergLP::mqbconfm::Domain const&, bool, BloombergLP::bslma::Allocator*) /home/runner/work/blazingmq/blazingmq/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp:393:5
```

Sometimes the `tier` might be unset:
```
UriBuilder& UriBuilder::setQualifiedDomain(const bslstl::StringRef& value)
{
    bslstl::StringRef tier = bdlb::StringRefUtil::strrstr(value,
                                                          k_TIER_PREFIX);

    if (tier.length() > 0) {
        d_uri.d_domain = bslstl::StringRef(value.begin(), tier.begin());
        d_uri.d_tier   = bslstl::StringRef(tier.end(), value.end());
    }
    else {
        d_uri.d_domain = value;
        d_uri.d_tier.reset(); // <-------- here
    }

    return *this;
}
```