### PR TITLE
Fix[bmqa_message.h]: Enable message `d_groupId` field regardless of build

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -121,11 +121,11 @@ struct MessageImpl {
     // SubscriptionHandle this message is
     // associated with
 
-#ifdef BMQ_ENABLE_MSG_GROUPID
+    // #ifdef BMQ_ENABLE_MSG_GROUPID
     bsl::string d_groupId;
     // Optional Group Id this message is
     // associated with
-#endif
+    // #endif
 };
 
 // ===============================


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #426*

**Describe your changes**
We currently do some cleverness with where and when we enable the incomplete message group ID feature in `CMakeLists.txt`.  However, when using the `build-darwin.sh` and `build-ubuntu.sh` scripts, as we currently recommend, the libraries we install using `make install` have this feature enabled.

Unfortunately, enabling message group IDs changes the size of `bmqa_message`’s `MessageImpl`, so a library built with message group IDs enabled is ABI-incompatible with an application built with message group IDs disabled.  Because we don’t advertise this feature anywhere or export the definition from CMake, users are unlikely to know they need to compile with the flag `-DBMQ_ENABLE_MSG_GROUPID`, and will run into characteristic ABI-incompatibility issues: buffer overruns, stack clobbering, and segmentation faults.

This patch makes a minimal change until we decide what to do with message group IDs: the API is still sensitive to `BMQ_ENABLE_MSG_GROUPID`, but the message structure itself always carries a `d_groupId` field, regardless of its presence.  This field is default-initialized and is otherwise unused.

**Testing performed**
This change fixes the minimal example given in #426.  I will let the CI run all the tests to ensure no breakage.