### PR TITLE
Test[MWC,MQB,BMQ]: Enable benchmark tests on Darwin

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -21,7 +21,7 @@
 #include <bmqeval_simpleevaluatorscanner.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -76,7 +76,7 @@ class MockPropertiesReader : public PropertiesReader {
     }
 };
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_SimpleEvaluator_GoogleBenchmark(benchmark::State& state)
 {
     mwctst::TestHelper::printTestName("GOOGLE BENCHMARK: SimpleEvaluator");
@@ -502,7 +502,7 @@ int main(int argc, char* argv[])
     } break;
     }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -37,7 +37,7 @@
 #include <bsls_timeutil.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -964,7 +964,7 @@ static void testN3_performanceCompressionRatio()
 }
 
 // Begin Benchmarking Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_performanceCompressionDecompressionDefault_GoogleBenchmark(
     benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -1043,7 +1043,7 @@ static void testN2_calculateThroughput_GoogleBenchmark(benchmark::State& state)
     }
     // </time>
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -1076,7 +1076,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqp/bmqp_crc32c.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_crc32c.t.cpp
@@ -46,7 +46,7 @@
 #include <bsls_timeutil.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -128,7 +128,7 @@ static int populateBufferLengthsSorted(bsl::vector<int>* bufferLengths)
     return bufferLengths->back();
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 /// Populate the specified `bufferLengths` with various lengths in
 /// increasing sorted order. Apply these arguments to Google Benchmark
 /// internals Note that upper bound is 64 Ki
@@ -2174,7 +2174,7 @@ static void testN6_bdldPerformanceDefault()
     s_allocator_p->deallocate(buffer);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 
 static void
 testN1_performanceDefaultUserInput_GoogleBenchmark(benchmark::State& state)
@@ -2533,7 +2533,7 @@ testN6_bdldPerformanceDefault_GoogleBenchmark(benchmark::State& state)
     s_allocator_p->deallocate(buffer);
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -2607,7 +2607,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
@@ -47,7 +47,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -1846,7 +1846,7 @@ static void testN10_hashCollisionsComparison()
 
 // Begin Benchmarking Tests
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_decode_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // DECODE
@@ -2327,7 +2327,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
@@ -28,7 +28,7 @@
 #include <bsls_types.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -435,7 +435,7 @@ static void testN4_orderedMapWithCustomHashBenchmark()
          << " insertions per second.\n";
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void
 testN1_defaultHashBenchmark_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -594,7 +594,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
@@ -46,7 +46,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -928,7 +928,7 @@ BSLA_MAYBE_UNUSED static void testN8_orderedMapWithCustomHashBenchmark()
 }
 
 // Begin Benchmarking Library
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_decode_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // DECODE
@@ -1376,7 +1376,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mqb/mqbu/mqbu_storagekey.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_storagekey.t.cpp
@@ -37,7 +37,7 @@
 #include <bsls_types.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -711,7 +711,7 @@ void testN6_orderedMapWithCustomHashBenchmark()
 }
 
 // Begin Google Benchmark Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void
 testN1_defaultHashBenchmark_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -929,7 +929,7 @@ static void testN6_orderedMapWithCustomHashBenchmark_GoogleBenchmark(
     // </time>
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 }  // close unnamed namespace
 
@@ -986,7 +986,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mwc/mwcc/mwcc_array.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_array.t.cpp
@@ -32,14 +32,14 @@
 // TEST DRIVER
 #include <mwctst_testhelper.h>
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 // BENCHMARK
 #include <benchmark/benchmark.h>
 #include <chrono>
 #include <cmath>
 #include <iostream>
 #include <vector>
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -851,7 +851,7 @@ static void test10_pushBackSelfRef()
     }
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 
 using namespace BloombergLP;
 
@@ -903,7 +903,7 @@ static void VectorAssign_GoogleBenchmark(benchmark::State& state)
     }
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -924,7 +924,7 @@ int main(int argc, char* argv[])
     case 3: test3_noMemoryAllocation(); break;
     case 2: test2_outOfBoundValidation(); break;
     case 1: test1_breathingTest(); break;
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     case -1:
         benchmark::Initialize(&argc, argv);
         BENCHMARK(VectorAssign_GoogleBenchmark)->Range(8, 4096);
@@ -936,7 +936,7 @@ int main(int argc, char* argv[])
         BENCHMARK(VectorFindLarge_GoogleBenchmark)->Range(256, 8192);
         benchmark::RunSpecifiedBenchmarks();
         break;
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         s_testStatus = -1;

--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccfixedqueue.t.cpp
@@ -40,7 +40,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -549,7 +549,7 @@ static void testN1_MonitoredQueue_performance()
     PRINT("s_antiOptimization = " << s_antiOptimization);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void
 testN1_MonitoredQueue_performance_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -801,7 +801,7 @@ static void testN1_bdlccFixedQueueThreaded_performance_GoogleBenchmark(
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 //=============================================================================
 //                                MAIN PROGRAM
@@ -816,7 +816,7 @@ int main(int argc, char* argv[])
     case 2: test2_MonitoredQueue_reset(); break;
     case 1: test1_MonitoredQueue_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
         BENCHMARK(testN1_MonitoredQueue_performance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_MonitoredQueueThreaded_performance_GoogleBenchmark)

--- a/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccsingleconsumerqueue.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_monitoredqueue_bdlccsingleconsumerqueue.t.cpp
@@ -41,7 +41,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -537,7 +537,7 @@ static void testN1_MonitoredSingleConsumerQueue_performance()
 }
 
 // Begin Benchmark Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_MonitoredSingleConsumerQueue_performance_GoogleBenchmark(
     benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -796,7 +796,7 @@ testN1_bdlccSingleConsumerQueueThreaded_performance_GoogleBenchmark(
     }
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 //=============================================================================
 //                                MAIN PROGRAM
@@ -811,7 +811,7 @@ int main(int argc, char* argv[])
     case 2: test2_MonitoredSingleConsumerQueue_exceed_reset(); break;
     case 1: test1_MonitoredSingleConsumerQueue_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
         BENCHMARK(
             testN1_MonitoredSingleConsumerQueue_performance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);

--- a/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_multiqueuethreadpool.t.cpp
@@ -45,7 +45,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -373,7 +373,7 @@ static void testN1_performance()
     printProcessedItems(k_NUM_ITERATIONS, endTime - startTime);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_performance_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // PERFORMANCE TEST
@@ -503,7 +503,7 @@ static void testN1_fixedPerformance_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 //=============================================================================
 //                                MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -516,7 +516,7 @@ int main(int argc, char* argv[])
     case 0:
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
         BENCHMARK(testN1_fixedPerformance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_performance_GoogleBenchmark)

--- a/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
+++ b/src/groups/mwc/mwcc/mwcc_orderedhashmap.t.cpp
@@ -32,7 +32,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -1101,7 +1101,7 @@ BSLA_MAYBE_UNUSED static void testN3_profile()
 }
 
 // Begin benchmarking library tests (Linux only)
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 
 static void
 testN1_insertPerformanceUnordered_GoogleBenchmark(benchmark::State& state)
@@ -1215,7 +1215,7 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -1275,7 +1275,7 @@ int main(int argc, char* argv[])
         s_testStatus = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mwc/mwcma/mwcma_countingallocator.t.cpp
+++ b/src/groups/mwc/mwcma/mwcma_countingallocator.t.cpp
@@ -38,7 +38,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -635,7 +635,7 @@ static void testN1_performance_allocation()
               << '\n';
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void
 testN1_bslmaperformance_allocation_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -766,7 +766,7 @@ int main(int argc, char** argv)
     case 2: test2_allocate(); break;
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
         BENCHMARK(testN1_defaultperformance_allocation_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_bslmaperformance_allocation_GoogleBenchmark)

--- a/src/groups/mwc/mwcsys/mwcsys_time.t.cpp
+++ b/src/groups/mwc/mwcsys/mwcsys_time.t.cpp
@@ -31,7 +31,7 @@
 #include <mwctst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #include <benchmark/benchmark.h>
 #endif
 
@@ -314,7 +314,7 @@ static void testN1_performance()
 }
 
 // Begin benchmarking tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 static void testN1_defaultPerformance_GoogleBenchmark(benchmark::State& state)
 {
     // Default function call
@@ -390,7 +390,7 @@ int main(int argc, char* argv[])
     case 2: test2_defaultInitializeShutdown(); break;
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
         BENCHMARK(testN1_defaultPerformance_GoogleBenchmark)
             ->RangeMultiplier(10)
             ->Range(1000, 100000000)

--- a/src/groups/mwc/mwctst/mwctst_testhelper.h
+++ b/src/groups/mwc/mwctst/mwctst_testhelper.h
@@ -713,15 +713,15 @@
     void Test##NAME ::body()
 
 /*Define benchmarking macros*/
-#ifdef BSLS_PLATFORM_OS_LINUX
+#if defined(BSLS_PLATFORM_OS_LINUX) || defined(BSLS_PLATFORM_OS_DARWIN)
 #define MWC_BENCHMARK_WITH_ARGS(BM_NAME, ARGS)                                \
     BENCHMARK(BM_NAME##_GoogleBenchmark)->ARGS;
 #define MWC_BENCHMARK(BM_NAME) BENCHMARK(BM_NAME##_GoogleBenchmark);
-#else  // !BSLS_PLATFORM_OS_LINUX
+#else  // !(BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN)
 #define MWC_BENCHMARK(BM_NAME) BM_NAME();
 #define MWC_BENCHMARK_WITH_ARGS(BM_NAME, ARGS) BM_NAME();
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX || BSLS_PLATFORM_OS_DARWIN
 
 namespace BloombergLP {
 namespace mwctst {


### PR DESCRIPTION
**Describe your changes**
These test were previously ifdef'd to be linux-only, but can be enabled on Darwin.

