### PR TITLE
Fix[bmqeval]: limit expression length to avoid stack overflow

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -82,6 +82,13 @@ void SimpleEvaluator::parse(const bsl::string&  expression,
     context.d_numProperties = 0;
     context.d_os.reset();
 
+    if (expression.length() > k_MAX_EXPRESSION_LENGTH) {
+        context.d_os << "expression is too long (" << expression.length()
+                     << "), max allowed length: " << k_MAX_EXPRESSION_LENGTH;
+        context.d_lastError = ErrorType::e_TOO_LONG;
+        return;  // RETURN
+    }
+
     bsl::istringstream     is(expression, context.d_allocator);
     SimpleEvaluatorScanner scanner;
     scanner.switch_streams(&is, &context.d_os);
@@ -90,28 +97,27 @@ void SimpleEvaluator::parse(const bsl::string&  expression,
 
     if (parser.parse() != 0) {
         context.d_lastError = ErrorType::e_SYNTAX;
-
         return;  // RETURN
     }
 
     if (context.d_numOperators > k_MAX_OPERATORS) {
-        context.d_os << "too many operators";
+        context.d_os << "too many operators (" << context.d_numOperators
+                     << "), max allowed operators: " << k_MAX_OPERATORS;
         context.d_lastError = ErrorType::e_TOO_COMPLEX;
-
         return;  // RETURN
     }
 
     if (context.d_numProperties == 0) {
         context.d_os << "expression does not use any properties";
         context.d_lastError = ErrorType::e_NO_PROPERTIES;
-
         return;  // RETURN
     }
 
     if (context.d_numProperties > k_MAX_PROPERTIES) {
-        context.d_os << "expression uses too many properties";
+        context.d_os << "expression uses too many properties ("
+                     << context.d_numProperties
+                     << "), max allowed properties: " << k_MAX_PROPERTIES;
         context.d_lastError = ErrorType::e_TOO_COMPLEX;
-
         return;  // RETURN
     }
 }
@@ -204,8 +210,8 @@ SimpleEvaluator::IntegerLiteral::evaluate(EvaluationContext& context) const
 // class SimpleEvaluator::BooleanLiteral
 // -------------------------------------
 
-bdld::Datum
-SimpleEvaluator::BooleanLiteral::evaluate(EvaluationContext& context) const
+bdld::Datum SimpleEvaluator::BooleanLiteral::evaluate(
+    BSLS_ANNOTATION_UNUSED EvaluationContext& context) const
 {
     return bdld::Datum::createBoolean(d_value);
 }

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -79,17 +79,25 @@ class EvaluationContext;
 
 struct ErrorType {
     enum Enum {
-        e_OK = 0  // no error
-        ,
+        /// no error
+        e_OK = 0,
+
         e_COMPILATION_FIRST = -100,
-        e_SYNTAX            = -100  // syntax error
-        ,
-        e_NO_PROPERTIES = -101  // expression does not use any property
-        ,
-        e_TOO_COMPLEX = -102  // too many properties
-                              // or operators in expression
-        ,
-        e_COMPILATION_LAST = -102,
+
+        /// syntax error
+        e_SYNTAX = -100,
+
+        /// expression does not use any property
+        e_NO_PROPERTIES = -101,
+
+        /// too many properties or operators in expression
+        e_TOO_COMPLEX = -102,
+
+        /// expression string is too long
+        e_TOO_LONG = -103,
+
+        e_COMPILATION_LAST = -103,
+
         e_EVALUATION_FIRST = -1,
         e_NAME             = -1,
         e_TYPE             = -2,
@@ -492,10 +500,14 @@ class SimpleEvaluator {
   public:
     // PUBLIC CONSTANTS
     enum {
+        /// The maximum length of an expression string.
+        k_MAX_EXPRESSION_LENGTH = 128,
+
         /// The maximum number of operators allowed in a single expression.
-        k_MAX_OPERATORS  = 10,
+        k_MAX_OPERATORS = 10,
+
+        /// The maximum number of properties allowed in a single expression.
         k_MAX_PROPERTIES = 10
-        // The maximum number of properties allowed in a single expression.
     };
 
     // CREATORS
@@ -706,19 +718,36 @@ class EvaluationContext {
 inline const char* ErrorType::toString(ErrorType::Enum value)
 {
     switch (value) {
-    case 0: return "";                                         // RETURN
-    case bmqeval::ErrorType::e_SYNTAX: return "syntax error";  // RETURN
-    case bmqeval::ErrorType::e_TOO_COMPLEX:
-        return "subscription expression is too complex";  // RETURN
-    case bmqeval::ErrorType::e_NO_PROPERTIES:
+    case bmqeval::ErrorType::e_OK: {
+        return "";  // RETURN
+    }
+    case bmqeval::ErrorType::e_SYNTAX: {
+        return "syntax error";  // RETURN
+    }
+    case bmqeval::ErrorType::e_NO_PROPERTIES: {
         return "expression does not use any property";  // RETURN
-    case bmqeval::ErrorType::e_NAME:
+    }
+    case bmqeval::ErrorType::e_TOO_COMPLEX: {
+        return "subscription expression is too complex";  // RETURN
+    }
+    case bmqeval::ErrorType::e_TOO_LONG: {
+        return "subscription expression is too long";  // RETURN
+    }
+    case bmqeval::ErrorType::e_NAME: {
         return "undefined name in subscription expression";  // RETURN
-    case bmqeval::ErrorType::e_TYPE:
+    }
+    case bmqeval::ErrorType::e_TYPE: {
         return "type error in expression";  // RETURN
-    case bmqeval::ErrorType::e_BINARY:
+    }
+    case bmqeval::ErrorType::e_BINARY: {
         return "binary properties are not supported";  // RETURN
-    default: return "unknown error";                   // RETURN
+    }
+    case bmqeval::ErrorType::e_UNDEFINED: {
+        return "undefined error";  // RETURN
+    }
+    default: {
+        return "unknown error";  // RETURN
+    }
     }
 }
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
@@ -112,7 +112,7 @@ expression
         { $$ = ctx.makeLiteral<SimpleEvaluator::IntegerLiteral>($1); }
     | OVERFLOW
         {
-            ctx.d_os << " integer overflow at offset " << scanner.lastTokenLocation();
+            ctx.d_os << "integer overflow at offset " << scanner.lastTokenLocation();
             YYABORT;
         }
     | STRING


### PR DESCRIPTION
If we pass a 1MB `NOT` expression, there will be a segfault, even if we just validate it:
`zsh: segmentation fault  ./src/groups/bmq/bmqeval_simpleevaluator.t.tsk 1`

This PR:
- Limits expression length to reasonable 128 bytes.
- Introduces a new error type for expression validation `e_TOO_LONG`.
- Improves error messages on errors with concrete info about limitations.
- Fixes a few warnings related to bmqeval UT.