### PR TITLE
Docs[BMQ] bde -> doxygen conversion fixes

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
@@ -63,17 +63,13 @@ class CloseQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open
-    /// queue operation
+    /// queueId associated with the open queue operation
     QueueId d_queueId;
 
-    /// Result code of the operation
-    /// (success, failure)
+    /// Result code of the operation (success, failure)
     bmqt::CloseQueueResult::Enum d_result;
 
-    /// Optional string with a human
-    /// readable description of the error,
-    /// if any
+    /// Optional string with a human readable description of the error, if any
     bsl::string d_errorDescription;
 
   public:
@@ -82,9 +78,9 @@ class CloseQueueStatus {
 
     // TYPES
 
-    /// Use of an `UnspecifiedBool` to prevent implicit conversions to
-    /// integral values, and comparisons between different classes which
-    /// have boolean operators.
+    // Use of an `UnspecifiedBool` to prevent implicit conversions to
+    // integral values, and comparisons between different classes which
+    // have boolean operators.
     typedef bsls::UnspecifiedBool<CloseQueueStatus>::BoolType BoolType;
 
     // CREATORS

--- a/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
@@ -63,7 +63,7 @@ class CloseQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open queue operation
+    /// QueueId associated with the open queue operation
     QueueId d_queueId;
 
     /// Result code of the operation (success, failure)

--- a/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_closequeuestatus.h
@@ -62,18 +62,19 @@ namespace bmqa {
 class CloseQueueStatus {
   private:
     // DATA
+
+    /// queueId associated with the open
+    /// queue operation
     QueueId d_queueId;
-    // queueId associated with the open
-    // queue operation
 
+    /// Result code of the operation
+    /// (success, failure)
     bmqt::CloseQueueResult::Enum d_result;
-    // Result code of the operation
-    // (success, failure)
 
+    /// Optional string with a human
+    /// readable description of the error,
+    /// if any
     bsl::string d_errorDescription;
-    // Optional string with a human
-    // readable description of the error,
-    // if any
 
   public:
     // TRAITS
@@ -81,9 +82,9 @@ class CloseQueueStatus {
 
     // TYPES
 
-    // Use of an `UnspecifiedBool` to prevent implicit conversions to
-    // integral values, and comparisons between different classes which
-    // have boolean operators.
+    /// Use of an `UnspecifiedBool` to prevent implicit conversions to
+    /// integral values, and comparisons between different classes which
+    /// have boolean operators.
     typedef bsls::UnspecifiedBool<CloseQueueStatus>::BoolType BoolType;
 
     // CREATORS

--- a/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
@@ -62,17 +62,13 @@ class ConfigureQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open
-    /// queue operation
+    /// queueId associated with the open queue operation
     QueueId d_queueId;
 
-    /// Status code of the operation
-    /// (success, failure)
+    /// Status code of the operation (success, failure)
     bmqt::ConfigureQueueResult::Enum d_result;
 
-    /// Optional string with a human
-    /// readable description of the error,
-    /// if any
+    /// Optional string with a human readable description of the error, if any
     bsl::string d_errorDescription;
 
   public:

--- a/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
@@ -61,18 +61,19 @@ namespace bmqa {
 class ConfigureQueueStatus {
   private:
     // DATA
+
+    /// queueId associated with the open
+    /// queue operation
     QueueId d_queueId;
-    // queueId associated with the open
-    // queue operation
 
+    /// Status code of the operation
+    /// (success, failure)
     bmqt::ConfigureQueueResult::Enum d_result;
-    // Status code of the operation
-    // (success, failure)
 
+    /// Optional string with a human
+    /// readable description of the error,
+    /// if any
     bsl::string d_errorDescription;
-    // Optional string with a human
-    // readable description of the error,
-    // if any
 
   public:
     // TRAITS

--- a/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_configurequeuestatus.h
@@ -62,7 +62,7 @@ class ConfigureQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open queue operation
+    /// QueueId associated with the open queue operation
     QueueId d_queueId;
 
     /// Status code of the operation (success, failure)

--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -118,7 +118,7 @@ struct MessageImpl {
     bmqt::SubscriptionHandle d_subscriptionHandle;
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
-    /// Optional Group Id this message is associated with
+    /// Optional GroupId this message is associated with
     bsl::string d_groupId;
 #endif
 };

--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -102,30 +102,24 @@ class MessageProperties;
 struct MessageImpl {
     // PUBLIC DATA
 
-    /// Pointer to the Event this message is
-    /// associated with
+    /// Pointer to the Event this message is associated with
     bmqimp::Event* d_event_p;
 
-    /// May point to a bmqimp::Event (in case
-    /// this Message is a clone)
+    /// May point to a bmqimp::Event (in case this Message is a clone)
     bsl::shared_ptr<bmqimp::Event> d_clonedEvent_sp;
 
-    /// QueueId this message is associated
-    /// with
+    /// QueueId this message is associated with
     bmqa::QueueId d_queueId;
 
-    /// CorrelationId this message is
-    /// associated with
+    /// CorrelationId this message is associated with
     bmqt::CorrelationId d_correlationId;
 
-    /// SubscriptionHandle this message is
-    /// associated with
+    /// SubscriptionHandle this message is associated with
     bmqt::SubscriptionHandle d_subscriptionHandle;
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
+    /// Optional Group Id this message is associated with
     bsl::string d_groupId;
-    // Optional Group Id this message is
-    // associated with
 #endif
 };
 

--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -101,25 +101,26 @@ class MessageProperties;
 ///                      `bmqa::MessageIterator.nextMessage()`.
 struct MessageImpl {
     // PUBLIC DATA
+
+    /// Pointer to the Event this message is
+    /// associated with
     bmqimp::Event* d_event_p;
-    // Pointer to the Event this message is
-    // associated with
 
+    /// May point to a bmqimp::Event (in case
+    /// this Message is a clone)
     bsl::shared_ptr<bmqimp::Event> d_clonedEvent_sp;
-    // May point to a bmqimp::Event (in case
-    // this Message is a clone)
 
+    /// QueueId this message is associated
+    /// with
     bmqa::QueueId d_queueId;
-    // QueueId this message is associated
-    // with
 
+    /// CorrelationId this message is
+    /// associated with
     bmqt::CorrelationId d_correlationId;
-    // CorrelationId this message is
-    // associated with
 
+    /// SubscriptionHandle this message is
+    /// associated with
     bmqt::SubscriptionHandle d_subscriptionHandle;
-    // SubscriptionHandle this message is
-    // associated with
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
     bsl::string d_groupId;
@@ -136,11 +137,12 @@ struct MessageImpl {
 class MessageConfirmationCookie {
   private:
     // DATA
-    bmqa::QueueId d_queueId;
-    // QueueID associated to this cookie
 
+    /// QueueID associated to this cookie
+    bmqa::QueueId d_queueId;
+
+    /// GUID associated to this cookie
     bmqt::MessageGUID d_guid;
-    // GUID associated to this cookie
 
   public:
     // CREATORS

--- a/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
+++ b/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
@@ -284,30 +284,31 @@ namespace bmqa {
 /// to expose them publicly).
 struct MessageEventBuilderImpl {
     // PUBLIC DATA
-    MessageEvent d_msgEvent;  // This is needed so that 'getMessageEvent()' can
-                              // return a const ref.
 
-    Message d_msg;  // This is needed so that 'startMessage()' can
-                    // return a ref.
+    // This is needed so that 'getMessageEvent()' can return a const ref.
+    MessageEvent d_msgEvent;
 
-    bsl::shared_ptr<bmqp::MessageGUIDGenerator> d_guidGenerator_sp;
+    // This is needed so that 'startMessage()' can return a ref.
+    Message d_msg;
+
     // GUID generator object.
+    bsl::shared_ptr<bmqp::MessageGUIDGenerator> d_guidGenerator_sp;
 
-    int d_messageCountFinal;
     // The final number of messages in the current 'd_msgEvent' cached on
     // switching this MessageEvent from WRITE to READ mode.
     // This cached value exists because we are not able to access the
     // underlying PutEventBuilder once downgraded to READ.
     // CONTRACT: the stored value is correct every moment when in READ mode,
     // and the value is not guaranteed to be correct when in WRITE mode.
+    int d_messageCountFinal;
 
-    int d_messageEventSizeFinal;
     // The final message event size of the current 'd_msgEvent' cached on
     // switching this MessageEvent from WRITE to READ mode.
     // This cached value exists because we are not able to access the
     // underlying PutEventBuilder once downgraded to READ.
     // CONTRACT: the stored value is correct every moment when in READ mode,
     // and the value is not guaranteed to be correct when in WRITE mode.
+    int d_messageEventSizeFinal;
 };
 
 // =========================

--- a/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
+++ b/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
@@ -285,10 +285,10 @@ namespace bmqa {
 struct MessageEventBuilderImpl {
     // PUBLIC DATA
 
-    // This is needed so that 'getMessageEvent()' can return a const ref.
+    /// This is needed so that `getMessageEvent()` can return a const ref.
     MessageEvent d_msgEvent;
 
-    // This is needed so that 'startMessage()' can return a ref.
+    /// This is needed so that `startMessage()` can return a ref.
     Message d_msg;
 
     // GUID generator object.

--- a/src/groups/bmq/bmqa/bmqa_messageiterator.h
+++ b/src/groups/bmq/bmqa/bmqa_messageiterator.h
@@ -68,13 +68,13 @@ struct MessageIteratorImpl {
     /// Raw pointer to the event
     bmqimp::Event* d_event_p;
 
-    /// A 'Message', representing a view to the current message pointing at by
-    /// this iterator.  This is so that 'message' can return a 'const Message&'
+    /// A `Message`, representing a view to the current message pointing at by
+    /// this iterator.  This is so that `message` can return a 'const Message&'
     /// to clearly indicate the lifetime of the Message, and so that we only
     /// create one such object per MessageIterator.
     bmqa::Message d_message;
 
-    /// Position of 'd_message' in the underlying message event.
+    /// Position of `d_message` in the underlying message event.
     int d_messageIndex;
 };
 

--- a/src/groups/bmq/bmqa/bmqa_messageiterator.h
+++ b/src/groups/bmq/bmqa/bmqa_messageiterator.h
@@ -64,17 +64,17 @@ namespace bmqa {
 /// without publicly exposing private members.
 struct MessageIteratorImpl {
     // PUBLIC DATA
-    bmqimp::Event* d_event_p;  // Raw pointer to the event
 
-    bmqa::Message d_message;  // A 'Message', representing a view to the
-                              // current message pointing at by this iterator.
-                              // This is so that 'message' can return a 'const
-                              // Message&' to clearly indicate the lifetime of
-                              // the Message, and so that we only create one
-                              // such object per MessageIterator.
+    /// Raw pointer to the event
+    bmqimp::Event* d_event_p;
 
-    /// Position of 'd_message' in the underlying
-    /// message event.
+    /// A 'Message', representing a view to the current message pointing at by
+    /// this iterator.  This is so that 'message' can return a 'const Message&'
+    /// to clearly indicate the lifetime of the Message, and so that we only
+    /// create one such object per MessageIterator.
+    bmqa::Message d_message;
+
+    /// Position of 'd_message' in the underlying message event.
     int d_messageIndex;
 };
 

--- a/src/groups/bmq/bmqa/bmqa_messageiterator.h
+++ b/src/groups/bmq/bmqa/bmqa_messageiterator.h
@@ -73,9 +73,9 @@ struct MessageIteratorImpl {
                               // the Message, and so that we only create one
                               // such object per MessageIterator.
 
+    /// Position of 'd_message' in the underlying
+    /// message event.
     int d_messageIndex;
-    // Position of 'd_message' in the underlying
-    // message event.
 };
 
 // =====================

--- a/src/groups/bmq/bmqa/bmqa_messageproperties.h
+++ b/src/groups/bmq/bmqa/bmqa_messageproperties.h
@@ -96,9 +96,9 @@ class MessageProperties {
   private:
     // PRIVATE CONSTANTS
 
-    // Constant representing the maximum size of a
-    // `bmqp::MessageProperties` object, so that the below AlignedBuffer
-    // is big enough.
+    /// Constant representing the maximum size of a
+    /// `bmqp::MessageProperties` object, so that the below AlignedBuffer
+    /// is big enough.
     static const int k_MAX_SIZEOF_BMQP_MESSAGEPROPERTIES = 184;
 
     // PRIVATE TYPES
@@ -107,18 +107,19 @@ class MessageProperties {
 
   private:
     // DATA
-    mutable bmqp::MessageProperties* d_impl_p;
-    // Pointer to the implementation object
-    // in 'd_buffer', providing a shortcut
-    // type safe cast to that object.  This
-    // variable *must* *be* the first
-    // member of this class, as other
-    // components in bmqa package may
-    // reinterpret_cast to that variable.
 
+    /// Pointer to the implementation object
+    /// in 'd_buffer', providing a shortcut
+    /// type safe cast to that object.  This
+    /// variable *must* *be* the first
+    /// member of this class, as other
+    /// components in bmqa package may
+    /// reinterpret_cast to that variable.
+    mutable bmqp::MessageProperties* d_impl_p;
+
+    /// Buffer containing the implementation
+    /// object, maximally aligned.
     ImplBuffer d_buffer;
-    // Buffer containing the implementation
-    // object, maximally aligned.
 
     bslma::Allocator* d_allocator_p;
 

--- a/src/groups/bmq/bmqa/bmqa_messageproperties.h
+++ b/src/groups/bmq/bmqa/bmqa_messageproperties.h
@@ -108,7 +108,7 @@ class MessageProperties {
   private:
     // DATA
 
-    /// Pointer to the implementation object in 'd_buffer', providing a
+    /// Pointer to the implementation object in `d_buffer`, providing a
     /// shortcut type safe cast to that object. This variable *must* *be* the
     /// first member of this class, as other components in bmqa package may
     /// reinterpret_cast to that variable.

--- a/src/groups/bmq/bmqa/bmqa_messageproperties.h
+++ b/src/groups/bmq/bmqa/bmqa_messageproperties.h
@@ -108,17 +108,13 @@ class MessageProperties {
   private:
     // DATA
 
-    /// Pointer to the implementation object
-    /// in 'd_buffer', providing a shortcut
-    /// type safe cast to that object.  This
-    /// variable *must* *be* the first
-    /// member of this class, as other
-    /// components in bmqa package may
+    /// Pointer to the implementation object in 'd_buffer', providing a
+    /// shortcut type safe cast to that object. This variable *must* *be* the
+    /// first member of this class, as other components in bmqa package may
     /// reinterpret_cast to that variable.
     mutable bmqp::MessageProperties* d_impl_p;
 
-    /// Buffer containing the implementation
-    /// object, maximally aligned.
+    /// Buffer containing the implementation object, maximally aligned.
     ImplBuffer d_buffer;
 
     bslma::Allocator* d_allocator_p;
@@ -129,21 +125,20 @@ class MessageProperties {
     /// Maximum number of properties that can appear in a `bmqa::Message`.
     static const int k_MAX_NUM_PROPERTIES = 255;
 
+    /// Maximum length of all the properties (including their names, values
+    /// and the wire protocol overhead).  Note that this value is just under
+    /// 64 MB.
     static const int k_MAX_PROPERTIES_AREA_LENGTH = (64 * 1024 * 1024) - 8;
-    // Maximum length of all the properties (including their names, values
-    // and the wire protocol overhead).  Note that this value is just under
-    // 64 MB.
 
     /// Maximum length of a property name.
     static const int k_MAX_PROPERTY_NAME_LENGTH = 4095;
 
-    static const int k_MAX_PROPERTY_VALUE_LENGTH =
-        67104745;  // ~64 MB
-                   // Maximum length of a property value.  Note that this value
-                   // is just under 64 MB.  Also note that this value is
-                   // calculated assuming that there is only one property and
-                   // property's name has maximum allowable length, and also
-                   // takes into consideration the protocol overhead.
+    /// ~64 MB
+    /// Maximum length of a property value.  Note that this value is just under
+    /// 64 MB.  Also note that this value is calculated assuming that there is
+    /// only one property and property's name has maximum allowable length, and
+    /// also takes into consideration the protocol overhead.
+    static const int k_MAX_PROPERTY_VALUE_LENGTH = 67104745;
 
   public:
     // TRAITS

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -609,11 +609,11 @@ struct MockSessionUtil {
     // PRIVATE TYPES
 
     /// Event impl shared pointer to access
-    /// the pimpl of 'bmqa::Event'.
+    /// the pimpl of `bmqa::Event`.
     typedef bsl::shared_ptr<bmqimp::Event> EventImplSp;
 
     /// Queue impl shared pointer to access
-    /// the pimpl of 'bmqa::QueueId'.
+    /// the pimpl of `bmqa::QueueId`.
     typedef bsl::shared_ptr<bmqimp::Queue> QueueImplSp;
 
   public:
@@ -626,13 +626,13 @@ struct MockSessionUtil {
         /// Status code
         bmqt::AckResult::Enum d_status;
 
-        /// Correlation id
+        /// CorrelationId
         bmqt::CorrelationId d_correlationId;
 
         /// Message GUID of confirmed message
         bmqt::MessageGUID d_guid;
 
-        /// Queue id for message being referred to
+        /// QueueId for message being referred to
         QueueId d_queueId;
 
         // CREATORS
@@ -654,7 +654,7 @@ struct MockSessionUtil {
         /// Payload of message
         bdlbb::Blob d_payload;
 
-        /// Queue Id for this message
+        /// QueueId for this message
         QueueId d_queueId;
 
         /// GUID for message
@@ -823,7 +823,7 @@ class MockSession : public AbstractSession {
     struct Job {
         // PUBLIC DATA
 
-        /// Signature of a 'void' callback method
+        /// Signature of a `void` callback method
         CallbackFn d_callback;
 
         /// Queue associated with this job
@@ -839,7 +839,7 @@ class MockSession : public AbstractSession {
 
     typedef bdlb::Variant<Event, Job> EventOrJob;
 
-    /// Enumeration for the methods in the 'MockSession' protocol.  Each
+    /// Enumeration for the methods in the `MockSession` protocol.  Each
     /// enum value corresponds to a method.
     enum Method {
         e_START,

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -607,13 +607,14 @@ class ConfirmEventBuilder;
 struct MockSessionUtil {
   private:
     // PRIVATE TYPES
-    typedef bsl::shared_ptr<bmqimp::Event> EventImplSp;
-    // Event impl shared pointer to access
-    // the pimpl of 'bmqa::Event'.
 
+    /// Event impl shared pointer to access
+    /// the pimpl of 'bmqa::Event'.
+    typedef bsl::shared_ptr<bmqimp::Event> EventImplSp;
+
+    /// Queue impl shared pointer to access
+    /// the pimpl of 'bmqa::QueueId'.
     typedef bsl::shared_ptr<bmqimp::Queue> QueueImplSp;
-    // Queue impl shared pointer to access
-    // the pimpl of 'bmqa::QueueId'.
 
   public:
     // PUBLIC TYPES
@@ -621,16 +622,18 @@ struct MockSessionUtil {
     /// Struct representing parameters for an ack message.
     struct AckParams {
         // PUBLIC DATA
-        bmqt::AckResult::Enum d_status;  // Status code
 
+        /// Status code
+        bmqt::AckResult::Enum d_status;
+
+        /// Correlation id
         bmqt::CorrelationId d_correlationId;
-        // Correlation id
 
-        bmqt::MessageGUID d_guid;  // Message GUID of confirmed message
+        /// Message GUID of confirmed message
+        bmqt::MessageGUID d_guid;
 
+        /// Queue id for message being referred to
         QueueId d_queueId;
-        // Queue id for message being referred
-        // to
 
         // CREATORS
 
@@ -815,25 +818,26 @@ class MockSession : public AbstractSession {
     /// operation executed with a user-specified callback
     struct Job {
         // PUBLIC DATA
+
+        /// Signature of a 'void' callback method
         CallbackFn d_callback;
-        // Signature of a 'void' callback method
 
+        /// Queue associated with this job
         QueueImplSp d_queue;
-        // Queue associated with this job
 
+        /// Type of queue event associated with
+        /// this job (OPEN,CONFIGURE, or CLOSE)
         bmqt::SessionEventType::Enum d_type;
-        // Type of queue event associated with
-        // this job (OPEN,CONFIGURE, or CLOSE)
 
+        /// Status of the queue operation
         int d_status;
-        // Status of the queue operation
     };
 
     typedef bdlb::Variant<Event, Job> EventOrJob;
 
+    /// Enumeration for the methods in the 'MockSession' protocol.  Each
+    /// enum value corresponds to a method.
     enum Method {
-        // Enumeration for the methods in the 'MockSession' protocol.  Each
-        // enum value corresponds to a method.
         e_START,
         e_START_ASYNC,
         e_STOP,
@@ -859,78 +863,81 @@ class MockSession : public AbstractSession {
 
     struct Call {
         // PUBLIC TYPES
-        typedef bsl::vector<EventOrJob> EventsAndJobs;  // Vector of events
+
+        /// Vector of events
+        typedef bsl::vector<EventOrJob> EventsAndJobs;
 
         // PUBLIC DATA
+
+        /// Value to be returned on call
         int d_rc;
-        // Value to be returned on call
 
+        /// The type of method
         Method d_method;
-        // The type of method
 
+        /// Line number
         int d_line;
-        // Line number
 
+        /// File
         bsl::string d_file;
-        // File
 
+        /// Uri associated with this call
         bmqt::Uri d_uri;
-        // Uri associated with this call
 
+        /// Flags associated with this call
         bsls::Types::Uint64 d_flags;
-        // Flags associated with this call
 
+        /// QueueOptions associated with this
+        /// call
         bmqt::QueueOptions d_queueOptions;
-        // QueueOptions associated with this
-        // call
 
+        /// Timeout interval associated with
+        /// this call
         bsls::TimeInterval d_timeout;
-        // Timeout interval associated with
-        // this call
 
-        OpenQueueCallback d_openQueueCallback;
         // Callback to be invoked upon emission
         // of an async openQueue (if callback
         // was provided)
+        OpenQueueCallback d_openQueueCallback;
 
+        /// Callback to be invoked upon emission
+        /// of an async configureQueue (if
+        /// callback was provided)
         ConfigureQueueCallback d_configureQueueCallback;
-        // Callback to be invoked upon emission
-        // of an async configureQueue (if
-        // callback was provided)
 
+        /// Callback to be invoked upon emission
+        /// of an async closeQueue (if callback
+        /// was provided)
         CloseQueueCallback d_closeQueueCallback;
-        // Callback to be invoked upon emission
-        // of an async closeQueue (if callback
-        // was provided)
 
+        /// The result of an open queue
+        /// operation
         bmqa::OpenQueueStatus d_openQueueResult;
-        // The result of an open queue
-        // operation
 
+        /// The result of a configure queue
+        /// operation
         bmqa::ConfigureQueueStatus d_configureQueueResult;
-        // The result of a configure queue
-        // operation
 
+        /// The result of a close queue
+        /// operation
         bmqa::CloseQueueStatus d_closeQueueResult;
-        // The result of a close queue
-        // operation
 
+        /// Events to be emitted on this call
         EventsAndJobs d_emittedEvents;
-        // Events to be emitted on this call
 
+        /// Event to be returned on this call
         Event d_returnEvent;
-        // Event to be returned on this call
 
+        /// MessageEvent associated with this
+        /// call
         MessageEvent d_messageEvent;
-        // MessageEvent associated with this
-        // call
 
+        /// MessageConfirmationCookie associated
+        /// with this call
         MessageConfirmationCookie d_cookie;
-        // MessageConfirmationCookie associated
-        // with this call
 
+        /// Allocator
         bslma::Allocator* d_allocator_p;
-        // Allocator
 
         // TRAITS
         BSLMF_NESTED_TRAIT_DECLARATION(Call, bslma::UsesBslmaAllocator)
@@ -1006,56 +1013,57 @@ class MockSession : public AbstractSession {
     typedef bsl::deque<bmqa::MessageEvent> PostedEvents;
 
     // DATA
+
+    /// Buffer factory
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
-    // Buffer factory
 
+    /// Event handler (set only in
+    /// asynchronous mode)
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;
-    // Event handler (set only in
-    // asynchronous mode)
 
+    /// sequence of method calls that are
+    /// expected
     mutable CallQueue d_calls;
-    // sequence of method calls that are
-    // expected
 
+    /// events waiting to be emitted
     mutable bsl::deque<EventOrJob> d_eventsAndJobs;
-    // events waiting to be emitted
 
+    /// GUIDS of unconfirmed messages
     bsl::unordered_set<bmqt::MessageGUID> d_unconfirmedGUIDs;
-    // GUIDS of unconfirmed messages
 
+    /// Aligned buffer of two key hash map
+    /// uri, corrid to queues
     TwoKeyHashMapBuffer d_twoKeyHashMapBuffer;
-    // Aligned buffer of two key hash map
-    // uri, corrid to queues
 
+    /// Currently installed failure callback
+    /// that is invoked if methods are
+    /// called incorrectly or out of order.
     FailureCb d_failureCb;
-    // Currently installed failure callback
-    // that is invoked if methods are
-    // called incorrectly or out of order.
 
+    /// QueueId
     int d_lastQueueId;
-    // QueueId
 
+    /// Mock correlationId container
     CorrelationIdContainerSp d_corrIdContainer_sp;
-    // Mock correlationId container
 
+    /// Queue of posted events
     PostedEvents d_postedEvents;
-    // Queue of posted events
 
+    /// protects all public methods
     mutable bslmt::Mutex d_mutex;
-    // protects all public methods
 
+    /// Top level stat context for this
+    /// mocked Session.
     mwcst::StatContext d_rootStatContext;
-    // Top level stat context for this
-    // mocked Session.
 
+    /// Stats for all queues
     StatImplSp d_queuesStats_sp;
-    // Stats for all queues
 
+    /// Session Options for current session
     bmqt::SessionOptions d_sessionOptions;
-    // Session Options for current session
 
+    /// Allocator
     bslma::Allocator* d_allocator_p;
-    // Allocator
 
   private:
     // PRIVATE CLASS METHODS

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -650,14 +650,18 @@ struct MockSessionUtil {
     /// Struct representing parameters for a push message.
     struct PushMessageParams {
         // PUBLIC DATA
-        bdlbb::Blob d_payload;  // Payload of message
 
-        QueueId d_queueId;  // Queue Id for this message
+        /// Payload of message
+        bdlbb::Blob d_payload;
 
-        bmqt::MessageGUID d_guid;  // GUID for message
+        /// Queue Id for this message
+        QueueId d_queueId;
 
-        MessageProperties d_properties;  // Optionally specified properties for
-                                         // message
+        /// GUID for message
+        bmqt::MessageGUID d_guid;
+
+        /// Optionally specified properties for message
+        MessageProperties d_properties;
 
         // CREATORS
 
@@ -787,10 +791,10 @@ class MockSession : public AbstractSession {
   private:
     // CONSTANTS
 
-    // Constant representing the maximum size of a `mwcc::TwoKeyHashMap`
-    // object, so that the below AlignedBuffer is big enough.  No `mwc`
-    // headers can be included in `bmq` public headers, to prevent build
-    // time dependency.
+    /// Constant representing the maximum size of a `mwcc::TwoKeyHashMap`
+    /// object, so that the below AlignedBuffer is big enough.  No `mwc`
+    /// headers can be included in `bmq` public headers, to prevent build
+    /// time dependency.
     static const int k_MAX_SIZEOF_MWCC_TWOKEYHASHMAP = 256;
 
     // PRIVATE TYPES
@@ -825,8 +829,8 @@ class MockSession : public AbstractSession {
         /// Queue associated with this job
         QueueImplSp d_queue;
 
-        /// Type of queue event associated with
-        /// this job (OPEN,CONFIGURE, or CLOSE)
+        /// Type of queue event associated with this job (OPEN, CONFIGURE, or
+        /// CLOSE)
         bmqt::SessionEventType::Enum d_type;
 
         /// Status of the queue operation
@@ -887,39 +891,31 @@ class MockSession : public AbstractSession {
         /// Flags associated with this call
         bsls::Types::Uint64 d_flags;
 
-        /// QueueOptions associated with this
-        /// call
+        /// QueueOptions associated with this call
         bmqt::QueueOptions d_queueOptions;
 
-        /// Timeout interval associated with
-        /// this call
+        /// Timeout interval associated with this call
         bsls::TimeInterval d_timeout;
 
-        // Callback to be invoked upon emission
-        // of an async openQueue (if callback
-        // was provided)
+        /// Callback to be invoked upon emission of an async openQueue (if
+        /// callback was provided)
         OpenQueueCallback d_openQueueCallback;
 
-        /// Callback to be invoked upon emission
-        /// of an async configureQueue (if
+        /// Callback to be invoked upon emission of an async configureQueue (if
         /// callback was provided)
         ConfigureQueueCallback d_configureQueueCallback;
 
-        /// Callback to be invoked upon emission
-        /// of an async closeQueue (if callback
-        /// was provided)
+        /// Callback to be invoked upon emission of an async closeQueue (if
+        /// callback was provided)
         CloseQueueCallback d_closeQueueCallback;
 
-        /// The result of an open queue
-        /// operation
+        /// The result of an open queue operation
         bmqa::OpenQueueStatus d_openQueueResult;
 
-        /// The result of a configure queue
-        /// operation
+        /// The result of a configure queue operation
         bmqa::ConfigureQueueStatus d_configureQueueResult;
 
-        /// The result of a close queue
-        /// operation
+        /// The result of a close queue operation
         bmqa::CloseQueueStatus d_closeQueueResult;
 
         /// Events to be emitted on this call
@@ -928,12 +924,10 @@ class MockSession : public AbstractSession {
         /// Event to be returned on this call
         Event d_returnEvent;
 
-        /// MessageEvent associated with this
-        /// call
+        /// MessageEvent associated with this call
         MessageEvent d_messageEvent;
 
-        /// MessageConfirmationCookie associated
-        /// with this call
+        /// MessageConfirmationCookie associated with this call
         MessageConfirmationCookie d_cookie;
 
         /// Allocator
@@ -1017,12 +1011,10 @@ class MockSession : public AbstractSession {
     /// Buffer factory
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
 
-    /// Event handler (set only in
-    /// asynchronous mode)
+    /// Event handler (set only in asynchronous mode)
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;
 
-    /// sequence of method calls that are
-    /// expected
+    /// sequence of method calls that are expected
     mutable CallQueue d_calls;
 
     /// events waiting to be emitted
@@ -1031,12 +1023,10 @@ class MockSession : public AbstractSession {
     /// GUIDS of unconfirmed messages
     bsl::unordered_set<bmqt::MessageGUID> d_unconfirmedGUIDs;
 
-    /// Aligned buffer of two key hash map
-    /// uri, corrid to queues
+    /// Aligned buffer of two key hash map uri, corrid to queues
     TwoKeyHashMapBuffer d_twoKeyHashMapBuffer;
 
-    /// Currently installed failure callback
-    /// that is invoked if methods are
+    /// Currently installed failure callback that is invoked if methods are
     /// called incorrectly or out of order.
     FailureCb d_failureCb;
 
@@ -1052,8 +1042,7 @@ class MockSession : public AbstractSession {
     /// protects all public methods
     mutable bslmt::Mutex d_mutex;
 
-    /// Top level stat context for this
-    /// mocked Session.
+    /// Top level stat context for this mocked Session.
     mwcst::StatContext d_rootStatContext;
 
     /// Stats for all queues

--- a/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
@@ -62,18 +62,19 @@ namespace bmqa {
 class OpenQueueStatus {
   private:
     // DATA
+
+    /// queueId associated with the open
+    /// queue operation
     QueueId d_queueId;
-    // queueId associated with the open
-    // queue operation
 
+    /// Result code of the operation
+    /// (success, failure)
     bmqt::OpenQueueResult::Enum d_result;
-    // Result code of the operation
-    // (success, failure)
 
+    /// Optional string with a human
+    /// readable description of the error,
+    /// if any
     bsl::string d_errorDescription;
-    // Optional string with a human
-    // readable description of the error,
-    // if any
 
   public:
     // TRAITS
@@ -81,9 +82,9 @@ class OpenQueueStatus {
 
     // TYPES
 
-    // Use of an `UnspecifiedBool` to prevent implicit conversions to
-    // integral values, and comparisons between different classes which
-    // have boolean operators.
+    /// Use of an `UnspecifiedBool` to prevent implicit conversions to
+    /// integral values, and comparisons between different classes which
+    /// have boolean operators.
     typedef bsls::UnspecifiedBool<OpenQueueStatus>::BoolType BoolType;
 
     // CREATORS

--- a/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
@@ -63,17 +63,13 @@ class OpenQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open
-    /// queue operation
+    /// queueId associated with the open queue operation
     QueueId d_queueId;
 
-    /// Result code of the operation
-    /// (success, failure)
+    /// Result code of the operation (success, failure)
     bmqt::OpenQueueResult::Enum d_result;
 
-    /// Optional string with a human
-    /// readable description of the error,
-    /// if any
+    /// Optional string with a human readable description of the error, if any
     bsl::string d_errorDescription;
 
   public:

--- a/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
+++ b/src/groups/bmq/bmqa/bmqa_openqueuestatus.h
@@ -63,7 +63,7 @@ class OpenQueueStatus {
   private:
     // DATA
 
-    /// queueId associated with the open queue operation
+    /// QueueId associated with the open queue operation
     QueueId d_queueId;
 
     /// Result code of the operation (success, failure)

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -640,13 +640,10 @@ struct SessionImpl {
     /// The allocator to use
     bslma::Allocator* d_allocator_p;
 
-    /// Session options as provided by
-    /// the application.
+    /// Session options as provided by the application.
     bmqt::SessionOptions d_sessionOptions;
 
-    /// Event handler, if any, to use
-    /// for notifying application of
-    /// events.
+    /// Event handler, if any, to use for notifying application of events.
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;
 
     /// GUID generator object.

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -636,23 +636,24 @@ class SessionEventHandler {
 /// Care should be taken though since `Session` is a polymorphic class.
 struct SessionImpl {
     // PUBLIC DATA
+
+    /// The allocator to use
     bslma::Allocator* d_allocator_p;
-    // The allocator to use
 
+    /// Session options as provided by
+    /// the application.
     bmqt::SessionOptions d_sessionOptions;
-    // Session options as provided by
-    // the application.
 
+    /// Event handler, if any, to use
+    /// for notifying application of
+    /// events.
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;
-    // Event handler, if any, to use
-    // for notifying application of
-    // events.
 
+    /// GUID generator object.
     bsl::shared_ptr<bmqp::MessageGUIDGenerator> d_guidGenerator_sp;
-    // GUID generator object.
 
+    /// The application object.
     bslma::ManagedPtr<bmqimp::Application> d_application_mp;
-    // The application object.
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/bmq/bmqt/bmqt_correlationid.h
+++ b/src/groups/bmq/bmqt/bmqt_correlationid.h
@@ -214,9 +214,9 @@ class CorrelationId {
 
     // DATA
 
-    /// The variant used to hold the value of a 'CorrelationId', that may
+    /// The variant used to hold the value of a `CorrelationId`, that may
     /// either be unset, hold a 64-bit integer, a raw pointer, a shared
-    /// pointer, or an 'AutoValue'.
+    /// pointer, or an `AutoValue`.
     bdlb::Variant4<bsls::Types::Int64, void*, bsl::shared_ptr<void>, AutoValue>
         d_variant;
 

--- a/src/groups/bmq/bmqt/bmqt_correlationid.h
+++ b/src/groups/bmq/bmqt/bmqt_correlationid.h
@@ -213,12 +213,13 @@ class CorrelationId {
     typedef bsls::Types::Uint64 AutoValue;
 
     // DATA
+
+    /// The variant used to hold the value of a
+    /// 'CorrelationId', that may either be unset,
+    /// hold a 64-bit integer, a raw pointer, a
+    /// shared pointer, or an 'AutoValue'.
     bdlb::Variant4<bsls::Types::Int64, void*, bsl::shared_ptr<void>, AutoValue>
         d_variant;
-    // The variant used to hold the value of a
-    // 'CorrelationId', that may either be unset,
-    // hold a 64-bit integer, a raw pointer, a
-    // shared pointer, or an 'AutoValue'.
 
     // PRIVATE ACCESSORS
 

--- a/src/groups/bmq/bmqt/bmqt_correlationid.h
+++ b/src/groups/bmq/bmqt/bmqt_correlationid.h
@@ -214,10 +214,9 @@ class CorrelationId {
 
     // DATA
 
-    /// The variant used to hold the value of a
-    /// 'CorrelationId', that may either be unset,
-    /// hold a 64-bit integer, a raw pointer, a
-    /// shared pointer, or an 'AutoValue'.
+    /// The variant used to hold the value of a 'CorrelationId', that may
+    /// either be unset, hold a 64-bit integer, a raw pointer, a shared
+    /// pointer, or an 'AutoValue'.
     bdlb::Variant4<bsls::Types::Int64, void*, bsl::shared_ptr<void>, AutoValue>
         d_variant;
 

--- a/src/groups/bmq/bmqt/bmqt_messageguid.h
+++ b/src/groups/bmq/bmqt/bmqt_messageguid.h
@@ -102,13 +102,15 @@ class MessageGUID {
 
   public:
     // TYPES
+
+    /// Enum representing the size of a buffer needed to represent a GUID
     enum Enum {
-        // Enum representing the size of a buffer needed to represent a GUID
-        e_SIZE_BINARY = 16  // Binary format of the GUID
+        /// Binary format of the GUID
+        e_SIZE_BINARY = 16
 
         ,
+        /// Hexadecimal string representation of the GUID
         e_SIZE_HEX = 2 * e_SIZE_BINARY
-        // Hexadecimal string representation of the GUID
     };
 
     // TRAITS
@@ -118,8 +120,9 @@ class MessageGUID {
 
   private:
     // PRIVATE CONSTANTS
+
+    /// Constant representing an unset GUID
     static const char k_UNSET_GUID[e_SIZE_BINARY];
-    //  Constant representing an unset GUID
 
   private:
     // IMPLEMENTATION NOTE: Some structs in bmqp::Protocol.h blindly

--- a/src/groups/bmq/bmqt/bmqt_queueoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_queueoptions.h
@@ -67,12 +67,10 @@ class QueueOptions {
   public:
     // PUBLIC CONSTANTS
 
-    /// Constant representing the minimum
-    /// valid consumer priority
+    /// Constant representing the minimum valid consumer priority
     static const int k_CONSUMER_PRIORITY_MIN;
 
-    /// Constant representing the maximum
-    /// valid consumer priority
+    /// Constant representing the maximum valid consumer priority
     static const int k_CONSUMER_PRIORITY_MAX;
 
     static const int  k_DEFAULT_MAX_UNCONFIRMED_MESSAGES;
@@ -88,15 +86,13 @@ class QueueOptions {
     // DATA
     Subscription d_info;
 
-    /// Whether the queue suspends operation
-    /// while the host is unhealthy.
+    /// Whether the queue suspends operation while the host is unhealthy.
     bsl::optional<bool> d_suspendsOnBadHostHealth;
 
     Subscriptions d_subscriptions;
 
-    /// 'true' if 'd_subscriptions' had a value, 'false'
-    /// otherwise.  Emulates 'bsl::optional' for
-    /// 'd_subscriptions'.
+    /// 'true' if 'd_subscriptions' had a value, 'false' otherwise.  Emulates
+    /// 'bsl::optional' for 'd_subscriptions'.
     bool d_hadSubscriptions;
 
     /// Allocator

--- a/src/groups/bmq/bmqt/bmqt_queueoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_queueoptions.h
@@ -91,8 +91,8 @@ class QueueOptions {
 
     Subscriptions d_subscriptions;
 
-    /// 'true' if 'd_subscriptions' had a value, 'false' otherwise.  Emulates
-    /// 'bsl::optional' for 'd_subscriptions'.
+    /// `true` if `d_subscriptions` had a value, `false` otherwise.  Emulates
+    /// `bsl::optional` for `d_subscriptions`.
     bool d_hadSubscriptions;
 
     /// Allocator

--- a/src/groups/bmq/bmqt/bmqt_queueoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_queueoptions.h
@@ -66,13 +66,14 @@ namespace bmqt {
 class QueueOptions {
   public:
     // PUBLIC CONSTANTS
-    static const int k_CONSUMER_PRIORITY_MIN;
-    // Constant representing the minimum
-    // valid consumer priority
 
+    /// Constant representing the minimum
+    /// valid consumer priority
+    static const int k_CONSUMER_PRIORITY_MIN;
+
+    /// Constant representing the maximum
+    /// valid consumer priority
     static const int k_CONSUMER_PRIORITY_MAX;
-    // Constant representing the maximum
-    // valid consumer priority
 
     static const int  k_DEFAULT_MAX_UNCONFIRMED_MESSAGES;
     static const int  k_DEFAULT_MAX_UNCONFIRMED_BYTES;
@@ -87,19 +88,19 @@ class QueueOptions {
     // DATA
     Subscription d_info;
 
+    /// Whether the queue suspends operation
+    /// while the host is unhealthy.
     bsl::optional<bool> d_suspendsOnBadHostHealth;
-    // Whether the queue suspends operation
-    // while the host is unhealthy.
 
     Subscriptions d_subscriptions;
 
+    /// 'true' if 'd_subscriptions' had a value, 'false'
+    /// otherwise.  Emulates 'bsl::optional' for
+    /// 'd_subscriptions'.
     bool d_hadSubscriptions;
-    // 'true' if 'd_subscriptions' had a value, 'false'
-    // otherwise.  Emulates 'bsl::optional' for
-    // 'd_subscriptions'.
 
+    /// Allocator
     bslma::Allocator* d_allocator_p;
-    // Allocator
 
   public:
     // PUBLIC TYPES

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -165,42 +165,35 @@ class SessionOptions {
     /// Default URI of the 'bmqbrkr' to connect to.
     static const char k_BROKER_DEFAULT_URI[];
 
-    /// Default port the 'bmqbrkr' is listening to for client
-    /// to connect.
+    /// Default port the 'bmqbrkr' is listening to for client to connect.
     static const int k_BROKER_DEFAULT_PORT = 30114;
 
-    /// The default, and minimum recommended, value for queue
-    /// operations (open, configure, close).
+    /// The default, and minimum recommended, value for queue operations (open,
+    /// configure, close).
     static const int k_QUEUE_OPERATION_DEFAULT_TIMEOUT =
         5 * bdlt::TimeUnitRatio::k_SECONDS_PER_MINUTE;
 
   private:
     // DATA
 
-    /// URI of the broker to connect to (ex:
-    /// 'tcp://localhost:30114').  Default
+    /// URI of the broker to connect to (ex: 'tcp://localhost:30114'). Default
     /// is to connect to the local broker.
     bsl::string d_brokerUri;
 
-    /// If not empty, use this value for the
-    /// processName in the identity message
-    /// (useful for scripted language
-    /// bindings).
+    /// If not empty, use this value for the processName in the identity
+    /// message (useful for scripted language bindings).
     bsl::string d_processNameOverride;
 
-    /// Number of processing threads.
-    /// Default is 1 thread.
+    /// Number of processing threads. Default is 1 thread.
     int d_numProcessingThreads;
 
     /// Size of the blobs buffer.
     int d_blobBufferSize;
 
-    /// Write cache high watermark to use on
-    /// the channel
+    /// Write cache high watermark to use on the channel
     bsls::Types::Int64 d_channelHighWatermark;
 
-    /// Interval at which to dump stats to
-    /// log file (0 to disable dump)
+    /// Interval at which to dump stats to log file (0 to disable dump)
     bsls::TimeInterval d_statsDumpInterval;
 
     bsls::TimeInterval d_connectTimeout;
@@ -211,19 +204,16 @@ class SessionOptions {
 
     bsls::TimeInterval d_configureQueueTimeout;
 
-    /// Timeout for operations of the
-    /// corresponding type.
+    /// Timeout for operations of the corresponding type.
     bsls::TimeInterval d_closeQueueTimeout;
 
     int d_eventQueueLowWatermark;
 
-    /// Parameters to configure the
-    /// EventQueue.
+    /// Parameters to configure the EventQueue.
     int d_eventQueueHighWatermark;
 
-    /// DEPRECATED: This parameter is no
-    /// longer relevant and will be removed
-    /// in future release of libbmq.
+    /// DEPRECATED: This parameter is no longer relevant and will be removed in
+    /// future release of libbmq.
     int d_eventQueueSize;
 
     bsl::shared_ptr<bmqpi::HostHealthMonitor> d_hostHealthMonitor_sp;

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -161,45 +161,47 @@ namespace bmqt {
 class SessionOptions {
   public:
     // CONSTANTS
+
+    /// Default URI of the 'bmqbrkr' to connect to.
     static const char k_BROKER_DEFAULT_URI[];
-    // Default URI of the 'bmqbrkr' to connect to.
 
+    /// Default port the 'bmqbrkr' is listening to for client
+    /// to connect.
     static const int k_BROKER_DEFAULT_PORT = 30114;
-    // Default port the 'bmqbrkr' is listening to for client
-    // to connect.
 
+    /// The default, and minimum recommended, value for queue
+    /// operations (open, configure, close).
     static const int k_QUEUE_OPERATION_DEFAULT_TIMEOUT =
         5 * bdlt::TimeUnitRatio::k_SECONDS_PER_MINUTE;
-    // The default, and minimum recommended, value for queue
-    // operations (open, configure, close).
 
   private:
     // DATA
+
+    /// URI of the broker to connect to (ex:
+    /// 'tcp://localhost:30114').  Default
+    /// is to connect to the local broker.
     bsl::string d_brokerUri;
-    // URI of the broker to connect to (ex:
-    // 'tcp://localhost:30114').  Default
-    // is to connect to the local broker.
 
+    /// If not empty, use this value for the
+    /// processName in the identity message
+    /// (useful for scripted language
+    /// bindings).
     bsl::string d_processNameOverride;
-    // If not empty, use this value for the
-    // processName in the identity message
-    // (useful for scripted language
-    // bindings).
 
+    /// Number of processing threads.
+    /// Default is 1 thread.
     int d_numProcessingThreads;
-    // Number of processing threads.
-    // Default is 1 thread.
 
+    /// Size of the blobs buffer.
     int d_blobBufferSize;
-    // Size of the blobs buffer.
 
+    /// Write cache high watermark to use on
+    /// the channel
     bsls::Types::Int64 d_channelHighWatermark;
-    // Write cache high watermark to use on
-    // the channel
 
+    /// Interval at which to dump stats to
+    /// log file (0 to disable dump)
     bsls::TimeInterval d_statsDumpInterval;
-    // Interval at which to dump stats to
-    // log file (0 to disable dump)
 
     bsls::TimeInterval d_connectTimeout;
 
@@ -209,20 +211,20 @@ class SessionOptions {
 
     bsls::TimeInterval d_configureQueueTimeout;
 
+    /// Timeout for operations of the
+    /// corresponding type.
     bsls::TimeInterval d_closeQueueTimeout;
-    // Timeout for operations of the
-    // corresponding type.
 
     int d_eventQueueLowWatermark;
 
+    /// Parameters to configure the
+    /// EventQueue.
     int d_eventQueueHighWatermark;
-    // Parameters to configure the
-    // EventQueue.
 
+    /// DEPRECATED: This parameter is no
+    /// longer relevant and will be removed
+    /// in future release of libbmq.
     int d_eventQueueSize;
-    // DEPRECATED: This parameter is no
-    // longer relevant and will be removed
-    // in future release of libbmq.
 
     bsl::shared_ptr<bmqpi::HostHealthMonitor> d_hostHealthMonitor_sp;
 

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -162,10 +162,10 @@ class SessionOptions {
   public:
     // CONSTANTS
 
-    /// Default URI of the 'bmqbrkr' to connect to.
+    /// Default URI of the `bmqbrkr` to connect to.
     static const char k_BROKER_DEFAULT_URI[];
 
-    /// Default port the 'bmqbrkr' is listening to for client to connect.
+    /// Default port the `bmqbrkr` is listening to for client to connect.
     static const int k_BROKER_DEFAULT_PORT = 30114;
 
     /// The default, and minimum recommended, value for queue operations (open,
@@ -176,7 +176,7 @@ class SessionOptions {
   private:
     // DATA
 
-    /// URI of the broker to connect to (ex: 'tcp://localhost:30114'). Default
+    /// URI of the broker to connect to (ex: `tcp://localhost:30114`). Default
     /// is to connect to the local broker.
     bsl::string d_brokerUri;
 

--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -69,9 +69,10 @@ class SubscriptionHandle {
     unsigned int d_id;
     // Internal, unique key
 
+    /// User-specified, not required to be
+    /// unique
     bmqt::CorrelationId d_correlationId;
-    // User-specified, not required to be
-    // unique
+
   private:
     // PRIVATE CLASS METHODS
     static unsigned int nextId();
@@ -122,11 +123,13 @@ class SubscriptionHandle {
 class SubscriptionExpression {
   public:
     // TYPES
+
+    /// Enum representing criteria format
     enum Enum {
-        // Enum representing criteria format
-        e_NONE = 0  // EMPTY
-        ,
-        e_VERSION_1 = 1  // Simple Evaluator
+        /// EMPTY
+        e_NONE = 0,
+        /// Simple Evaluator
+        e_VERSION_1 = 1
     };
 
   private:
@@ -164,13 +167,14 @@ class SubscriptionExpression {
 class Subscription {
   public:
     // PUBLIC CONSTANTS
-    static const int k_CONSUMER_PRIORITY_MIN;
-    // Constant representing the minimum
-    // valid consumer priority
 
+    /// Constant representing the minimum
+    /// valid consumer priority
+    static const int k_CONSUMER_PRIORITY_MIN;
+
+    /// Constant representing the maximum
+    /// valid consumer priority
     static const int k_CONSUMER_PRIORITY_MAX;
-    // Constant representing the maximum
-    // valid consumer priority
 
     static const int k_DEFAULT_MAX_UNCONFIRMED_MESSAGES;
     static const int k_DEFAULT_MAX_UNCONFIRMED_BYTES;
@@ -178,25 +182,27 @@ class Subscription {
 
   private:
     // PRIVATE DATA
+
+    /// Maximum number of outstanding
+    /// messages that can be sent by the
+    /// broker without being confirmed.
     bsl::optional<int> d_maxUnconfirmedMessages;
-    // Maximum number of outstanding
-    // messages that can be sent by the
-    // broker without being confirmed.
 
+    /// Maximum accumulated bytes of all
+    /// outstanding messages that can be
+    /// sent by the broker without being
+    /// confirmed.
     bsl::optional<int> d_maxUnconfirmedBytes;
-    // Maximum accumulated bytes of all
-    // outstanding messages that can be
-    // sent by the broker without being
-    // confirmed.
 
+    /// Priority of a consumer with respect
+    /// to delivery of messages
     bsl::optional<int> d_consumerPriority;
-    // Priority of a consumer with respect
-    // to delivery of messages
 
     SubscriptionExpression d_expression;
 
   public:
     // CREATORS
+
     /// Create a new Subscription
     Subscription();
 

--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -61,7 +61,7 @@ class SubscriptionHandle {
     friend class bmqa::MessageIterator;
 
   public:
-    /// Initial (invalid) value for 'bmqt::SubscriptionHandle::d_id'
+    /// Initial (invalid) value for `bmqt::SubscriptionHandle::d_id`
     static const unsigned int k_INVALID_HANDLE_ID = 0;
 
   private:

--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -61,16 +61,16 @@ class SubscriptionHandle {
     friend class bmqa::MessageIterator;
 
   public:
+    /// Initial (invalid) value for 'bmqt::SubscriptionHandle::d_id'
     static const unsigned int k_INVALID_HANDLE_ID = 0;
-    // Initial (invalid) value for 'bmqt::SubscriptionHandle::d_id'
 
   private:
     // PRIVATE DATA
-    unsigned int d_id;
-    // Internal, unique key
 
-    /// User-specified, not required to be
-    /// unique
+    /// Internal, unique key
+    unsigned int d_id;
+
+    /// User-specified, not required to be unique
     bmqt::CorrelationId d_correlationId;
 
   private:
@@ -127,7 +127,9 @@ class SubscriptionExpression {
     /// Enum representing criteria format
     enum Enum {
         /// EMPTY
-        e_NONE = 0,
+        e_NONE = 0
+
+        ,
         /// Simple Evaluator
         e_VERSION_1 = 1
     };
@@ -135,8 +137,8 @@ class SubscriptionExpression {
   private:
     bsl::string d_expression;  // e.g., "firmId == foo"
 
-    Enum d_version;  // Required to support newer style
-                     // of expressions in future
+    // Required to support newer style of expressions in future
+    Enum d_version;
 
   public:
     // CREATORS
@@ -168,12 +170,10 @@ class Subscription {
   public:
     // PUBLIC CONSTANTS
 
-    /// Constant representing the minimum
-    /// valid consumer priority
+    /// Constant representing the minimum valid consumer priority
     static const int k_CONSUMER_PRIORITY_MIN;
 
-    /// Constant representing the maximum
-    /// valid consumer priority
+    /// Constant representing the maximum valid consumer priority
     static const int k_CONSUMER_PRIORITY_MAX;
 
     static const int k_DEFAULT_MAX_UNCONFIRMED_MESSAGES;
@@ -183,19 +183,15 @@ class Subscription {
   private:
     // PRIVATE DATA
 
-    /// Maximum number of outstanding
-    /// messages that can be sent by the
-    /// broker without being confirmed.
+    /// Maximum number of outstanding messages that can be sent by the broker
+    /// without being confirmed.
     bsl::optional<int> d_maxUnconfirmedMessages;
 
-    /// Maximum accumulated bytes of all
-    /// outstanding messages that can be
-    /// sent by the broker without being
-    /// confirmed.
+    /// Maximum accumulated bytes of all outstanding messages that can be sent
+    /// by the broker without being confirmed.
     bsl::optional<int> d_maxUnconfirmedBytes;
 
-    /// Priority of a consumer with respect
-    /// to delivery of messages
+    /// Priority of a consumer with respect to delivery of messages
     bsl::optional<int> d_consumerPriority;
 
     SubscriptionExpression d_expression;

--- a/src/groups/bmq/bmqt/bmqt_uri.h
+++ b/src/groups/bmq/bmqt/bmqt_uri.h
@@ -174,27 +174,31 @@ class Uri {
 
   private:
     // DATA
-    bsl::string d_uri;  // The full URI
 
-    bslstl::StringRef d_scheme;  // URI scheme (must be "bmq").
+    /// The full URI
+    bsl::string d_uri;
 
-    bslstl::StringRef d_authority;  // URI authority (domain + optional
-                                    // tier)
+    /// URI scheme (must be "bmq").
+    bslstl::StringRef d_scheme;
 
-    bslstl::StringRef d_domain;  // URI domain
+    /// URI authority (domain + optional tier)
+    bslstl::StringRef d_authority;
 
-    bslstl::StringRef d_tier;  // URI tier
+    /// URI domain
+    bslstl::StringRef d_domain;
 
-    bslstl::StringRef d_path;  // URI path (i.e queue name).
+    /// URI tier
+    bslstl::StringRef d_tier;
 
-    bslstl::StringRef d_query_id;  // Optional application id, part of the
-                                   // URI query if present.
+    /// URI path (i.e queue name).
+    bslstl::StringRef d_path;
 
+    /// Optional application id, part of the URI query if present.
+    bslstl::StringRef d_query_id;
+
+    /// Flag indicating whether the URI parser was initialized (and whether
+    /// shutdown should be called on it at destruction)
     bool d_wasParserInitialized;
-    // Flag indicating whether the URI
-    // parser was initialized (and whether
-    // shutdown should be called on it at
-    // destruction)
 
   private:
     // PRIVATE MANIPULATORS


### PR DESCRIPTION
Relates to: #118 

**Describe your changes**
This PR fixes a few places where tooling failed to migrate BDE-style docs to doxygen for data members and associated types/enums. I've tried to keep the comment style intact without changing the structure.