### PR TITLE
Docs[BMQ]: Use `.dox` files rather than `.md` files

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -989,7 +989,8 @@ INPUT_FILE_ENCODING    =
 FILE_PATTERNS          = *.c \
                          *.cpp \
                          *.h \
-                         *.md
+                         *.md \
+                         *.dox
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.

--- a/src/groups/bmq/bmqa/README.dox
+++ b/src/groups/bmq/bmqa/README.dox
@@ -1,6 +1,8 @@
+/**
 @dir bmqa
 
 @brief The `BMQA` (BlazingMQ API) package provides applications a public API
 
 The `bmqa` package provides the public API of the BlazingMQ SDK for
 applications to use.
+*/

--- a/src/groups/bmq/bmqpi/README.dox
+++ b/src/groups/bmq/bmqpi/README.dox
@@ -1,3 +1,4 @@
+/**
 @dir bmqpi
 
 @brief The `BMQPI` (BlazingMQ Public Interfaces) package provides class
@@ -8,3 +9,4 @@ clients to extend in their own applications and libraries. These extension
 points facilitate integration with other aspects of a runtime environment (e.g.
 authentication, host health-checking), which may vary significantly from
 organization to organization.
+*/

--- a/src/groups/bmq/bmqt/README.dox
+++ b/src/groups/bmq/bmqt/README.dox
@@ -1,3 +1,4 @@
+/**
 @dir bmqt
 
 @brief The `BMQT` (BlazingMQ (vocabulary) Types) package provides
@@ -5,3 +6,4 @@ value-semantic vocabulary types.
 
 The ‘bmqt‘ package provides low level value-semantic vocabulary types for use
 by the BlazingMQ SDK.
+*/


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #118 *

Package group documentation in `libbmq` was converted to Markdown files named `README.md`, and which was tied to the directory containing the code for the package group using Doxygen `@dir` commands.  However, when generating the documentation, this left several empty pages in the documentation named `README`, which we were not able to remove.

The solution for this that this patch uses is to switch from `.md` files to `.dox` files, which contain a single Doxygen-style C++ comment containing the `@dir` command.  Unlike `.md` files, these do not automatically create pages, so there is no empty `README` page created for each package group.  The cost of this is that `.dox` files cannot be simple Markdown files, but instead need to be wrapped in a C++ comment.

## Testing

To verify these changes, run `doxygen` in the root directory of the project and ensure that
(1) there are no empty `README` pages generated, and (2) the package groups are still properly documented.