### PR TITLE
fix: configurator: default values for modes

### DIFF
--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -216,9 +216,8 @@ class Cluster(AbstractCluster):
         return self._add_domain(Domain(self, domain))
 
     def broadcast_domain(self, name: str) -> "Domain":
-        parameters = self.configurator.domain_definition()
+        parameters = self.configurator.broadcast_domain()
         parameters.name = name
-        parameters.mode = mqbconf.QueueMode(broadcast=mqbconf.QueueModeBroadcast())
         parameters.storage.config.in_memory = mqbconf.InMemoryStorage()
         parameters.storage.config.file_backed = None
         domain = mqbconf.DomainDefinition(self.name, parameters)
@@ -226,17 +225,15 @@ class Cluster(AbstractCluster):
         return self._add_domain(Domain(self, domain))
 
     def fanout_domain(self, name: str, app_ids: List[str]) -> "Domain":
-        parameters = self.configurator.domain_definition()
+        parameters = self.configurator.fanout_domain()
         parameters.name = name
-        parameters.mode = mqbconf.QueueMode(fanout=mqbconf.QueueModeFanout([*app_ids]))
         domain = mqbconf.DomainDefinition(self.name, parameters)
 
         return self._add_domain(Domain(self, domain))
 
     def priority_domain(self, name: str) -> "Domain":
-        parameters = self.configurator.domain_definition()
+        parameters = self.configurator.priority_domain()
         parameters.name = name
-        parameters.mode = mqbconf.QueueMode(priority=mqbconf.QueueModePriority())
         domain = mqbconf.DomainDefinition(self.name, parameters)
 
         return self._add_domain(Domain(self, domain))
@@ -314,6 +311,11 @@ class Proto:
     domain: mqbconf.Domain = field(
         default_factory=functools.partial(
             mqbconf.Domain,
+            mode=mqbconf.QueueMode(
+                broadcast=mqbconf.QueueModeBroadcast(),
+                fanout=mqbconf.QueueModeFanout(),
+                priority=mqbconf.QueueModePriority(),
+            ),
             max_delivery_attempts=0,
             deduplication_time_ms=300000,
             consistency=mqbconf.Consistency(strong=mqbconf.QueueConsistencyStrong()),
@@ -338,7 +340,6 @@ class Proto:
             max_consumers=0,
             max_queues=0,
             max_idle_time=0,
-            mode=None,  # overwritten
         )
     )
 

--- a/src/python/blazingmq/dev/configurator/configurator.py
+++ b/src/python/blazingmq/dev/configurator/configurator.py
@@ -94,7 +94,33 @@ class Configurator:
         return copy.deepcopy(self.proto.virtual_cluster)
 
     def domain_definition(self):
-        return copy.deepcopy(self.proto.domain)
+        domain = copy.deepcopy(self.proto.domain)
+        domain.mode.broadcast = None
+        domain.mode.fanout = None
+        domain.mode.priority = None
+
+        return domain
+
+    def broadcast_domain(self):
+        domain = copy.deepcopy(self.proto.domain)
+        domain.mode.fanout = None
+        domain.mode.priority = None
+
+        return domain
+
+    def fanout_domain(self):
+        domain = copy.deepcopy(self.proto.domain)
+        domain.mode.broadcast = None
+        domain.mode.priority = None
+
+        return domain
+
+    def priority_domain(self):
+        domain = copy.deepcopy(self.proto.domain)
+        domain.mode.broadcast = None
+        domain.mode.fanout = None
+
+        return domain
 
     def broker(
         self,


### PR DESCRIPTION
In `configurator.Proto`, provide default values for `mqbconf.Domain.mode` for all modes.