### PR TITLE
CI: Add CI checks with clang-tidy

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,14 +94,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
         run: |
-          cmake -S . -B build/blazingmq -G Ninja \
-            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DBDE_BUILD_TARGET_SAFE=ON \
-            -DBDE_BUILD_TARGET_64=ON \
-            -DBDE_BUILD_TARGET_CPP17=ON \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
-            -DCMAKE_INSTALL_LIBDIR=lib64
+          cmake --preset linux-x64-githubci
           cmake --build build/blazingmq --parallel 8 --target all
       - name: Clean-up build directories before caching
         run: |
@@ -151,14 +144,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
         run: |
-          cmake -S . -B build/blazingmq -G Ninja \
-            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DBDE_BUILD_TARGET_SAFE=ON \
-            -DBDE_BUILD_TARGET_64=ON \
-            -DBDE_BUILD_TARGET_CPP17=ON \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
-            -DCMAKE_INSTALL_LIBDIR=lib64
+          cmake --preset linux-x64-githubci
           cmake --build build/blazingmq --parallel 8 --target all.t
       - name: Run C++ Unit Tests
         run: |
@@ -305,15 +291,7 @@ jobs:
         env:
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
         run: |
-          cmake -S . -B build/blazingmq -G Ninja \
-            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DBDE_BUILD_TARGET_SAFE=ON \
-            -DBDE_BUILD_TARGET_64=ON \
-            -DBDE_BUILD_TARGET_CPP17=ON \
-            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
-            -DCMAKE_INSTALL_LIBDIR=lib64 \
-            -DINSTALL_TARGETS=prometheus
+          cmake --preset linux-x64-githubci -DINSTALL_TARGETS=prometheus
           cmake --build build/blazingmq --parallel 8 --target all
       - name: Create prometheus dir
         run:  mkdir -p prometheus_dir
@@ -334,6 +312,48 @@ jobs:
           ./prometheus_dir/prometheus-2.45.1.linux-amd64/prometheus --config.file=${{ github.workspace }}/src/plugins/bmqprometheus/tests/prometheus_localhost.yaml --web.enable-lifecycle --storage.tsdb.path=${{ github.workspace }}/prometheus_dir/data &
       - name: Run Prometheus plugin integration test in "push" mode
         run: ${{ github.workspace }}/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p ${{ github.workspace }}/build/blazingmq -m push --no-docker
+
+  clang_tidy:
+    name: Clang Tidy
+    runs-on: ubuntu-latest
+    needs: build_dependencies
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get dependencies hash
+        id: get-hash
+        run: echo "deps_hash=`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
+      - uses: actions/cache/restore@v4
+        with:
+          path: deps
+          key: deps-${{ steps.get-hash.outputs.deps_hash }}
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy build-essential \
+            gdb \
+            curl \
+            python3.10 \
+            python3-pip \
+            cmake \
+            ninja-build \
+            pkg-config \
+            bison \
+            clang-tidy \
+            libfl-dev \
+            libbenchmark-dev \
+            libgmock-dev \
+            libz-dev
+      - name: Install cached non packaged dependencies
+        working-directory: deps
+        run: ../docker/build_deps.sh
+      - name: Configure BlazingMQ
+        env:
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+        run: |
+          cmake --preset linux-x64-githubci-cpp03
+      - name: Run clang-tidy
+        run: |
+          run-clang-tidy -p build/blazingmq -checks="-*,clang-analyzer-*"
 
   documentation:
     name: "Documentation"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,8 +17,10 @@
         },
         {
             "name": "macos-arm64-vcpkg",
-            "description": "VCPKG based configuration for building on arm-based MacOS",
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "description":
+                "VCPKG based configuration for building on arm-based MacOS",
+            "toolchainFile":
+                "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "inherits": "base",
             "cacheVariables": {
                 "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
@@ -27,8 +29,10 @@
         },
         {
             "name": "macos-x64-vcpkg",
-            "description": "VCPKG based configuration for building on x86_64-based MacOS",
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "description":
+                "VCPKG based configuration for building on x86_64-based MacOS",
+            "toolchainFile":
+                "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "inherits": "base",
             "cacheVariables": {
                 "VCPKG_INSTALL_OPTIONS": "--allow-unsupported",
@@ -37,9 +41,42 @@
         },
         {
             "name": "linux-x64-vcpkg",
-            "description": "VCPKG based configuration for building on x86_64-based Linux",
-            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+            "description":
+                "VCPKG based configuration for building on x86_64-based Linux",
+            "toolchainFile":
+                "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
             "inherits": "base"
+        },
+        {
+            "name": "linux-x64-githubci",
+            "description":
+                "GitHub CI based configuration for building on x86_64-based Linux",
+            "toolchainFile":
+                "$env{GITHUB_WORKSPACE}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake",
+            "binaryDir": "build/blazingmq",
+            "generator": "Ninja",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
+                "CMAKE_BUILD_TYPE": "Debug",
+                "CMAKE_PREFIX_PATH":
+                    "$env{GITHUB_WORKSPACE}/deps/srcs/bde-tools/BdeBuildSystem",
+                "DCMAKE_INSTALL_LIBDIR": "lib64",
+                "BDE_BUILD_TARGET_SAFE": true,
+                "BDE_BUILD_TARGET_64": true,
+                "BDE_BUILD_TARGET_CPP17": true,
+                "CMAKE_CXX_STANDARD": "17",
+                "CMAKE_INSTALL_LIBDIR": "lib64"
+            }
+        },
+        {
+            "name": "linux-x64-githubci-cpp03",
+            "description":
+                "GitHub CI based configuration for building on x86_64-based Linux (C++03)",
+            "inherits": "linux-x64-githubci",
+            "cacheVariables": {
+                "BDE_BUILD_TARGET_CPP03": true,
+                "CMAKE_CXX_STANDARD": "03"
+            }
         }
     ]
 }


### PR DESCRIPTION
This adds a new check to our workflows using clang-tidy. Right now we only enable analyzer checks, though we could look at expanding to more in the future. We are primarily interested in getting another pass over our code checking for C++03 syntax compatibility, since we've had a few instances of modern syntax constructs getting into the code base. `clang-tidy` will do a bit more than syntax checks, but I believe having will be a boon overall.
