### PR TITLE
Fix: m_bmqstoragetool::FileManagerImpl: Asserts not have side effects

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -129,8 +129,10 @@ QueueMap FileManagerImpl::buildQueueMap(const bsl::string& cslFile,
         cslFile.c_str());
     bsl::string pattern(alloc);
     bsl::string location(alloc);
-    BSLS_ASSERT(bdls::PathUtil::getBasename(&pattern, cslFile) == 0);
-    BSLS_ASSERT(bdls::PathUtil::getDirname(&location, cslFile) == 0);
+    int         rc = bdls::PathUtil::getBasename(&pattern, cslFile);
+    BSLS_ASSERT(rc == 0);
+    rc = bdls::PathUtil::getDirname(&location, cslFile);
+    BSLS_ASSERT(rc == 0);
     ledgerConfig.setLocation(location)
         .setPattern(pattern)
         .setMaxLogSize(fileSize)
@@ -145,7 +147,10 @@ QueueMap FileManagerImpl::buildQueueMap(const bsl::string& cslFile,
 
     // Create and open the ledger
     mqbsl::Ledger ledger(ledgerConfig, alloc);
-    BSLS_ASSERT(ledger.open(mqbsi::Ledger::e_READ_ONLY) == 0);
+    rc = ledger.open(mqbsi::Ledger::e_READ_ONLY);
+    BSLS_ASSERT(rc == 0);
+    (void)rc;  // Compiler happiness
+
     // Set guard to close the ledger
     bdlb::ScopeExitAny guard(bdlf::BindUtil::bind(closeLedger, &ledger));
 


### PR DESCRIPTION
If operations are contained within `BSLS_ASSERT`s, then when we run in optimized mode the asserts will be ignored and those operations will be skipped.

@waldgange @alexander-e1off @bbpetukhov  For awareness