### PR TITLE
Doc: Document app subscriptions

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 # gem "rails"
 
-gem "jekyll", "~> 4.2.2"
+gem "jekyll", "~> 4.3.3"
 gem "jekyll-seo-tag"
 gem "jekyll-github-metadata"
 gem "webrick"

--- a/docs/docs/features/subscriptions.md
+++ b/docs/docs/features/subscriptions.md
@@ -37,8 +37,8 @@ to filter out messages for certain applications but not others, thereby
 Concretely speaking, producer applications can put any interesting message
 attributes in the *message properties* section of the message (*message
 properties* are a list of key/value pairs that a producer can associate with a
-message), and consumers can filter messages using one or more of those *message
-properties*.
+message), and consumers can request BlazingMQ to filter messages using one or
+more of those *message properties*.
 
 For example, if a message contains these three properties:
 


### PR DESCRIPTION
Docs relating to #190 

**Describe your changes**
This PR adds public documentation for Application Subscriptions. The primary focus of these docs are:
- Document there are two types of subscriptions
- Make the behavior of app vs consumer subscriptions clear
- Motivate when to use one or the other (TODO)

I also needed to bump the jekyll version to get the docs to build locally on my mac.