### PR TITLE
Fix[MQB]: misc warnings

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -376,13 +376,14 @@ ClusterCatalog::ClusterCatalog(mqbi::Dispatcher*             dispatcher,
 , d_reversedClusterConnections(d_allocator_p)
 , d_clusters(d_allocator_p)
 , d_statContexts(statContexts)
+, d_resources(resources)
+, d_adminCb()
 , d_requestManager(bmqp::EventType::e_CONTROL,
                    resources.bufferFactory(),
                    resources.scheduler(),
                    false,  // lateResponseMode
                    d_allocator_p)
 , d_stopRequestsManager(&d_requestManager, d_allocator_p)
-, d_resources(resources)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_resources.scheduler()->clockType() ==

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -1255,7 +1255,8 @@ void RecoveryManager::setLiveDataSource(mqbnet::ClusterNode* source,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(source);
     BSLS_ASSERT_SAFE(0 <= partitionId);
-    BSLS_ASSERT_SAFE(partitionId < d_recoveryContextVec.size());
+    BSLS_ASSERT_SAFE(partitionId <
+                     static_cast<int>(d_recoveryContextVec.size()));
 
     RecoveryContext& recoveryCtx = d_recoveryContextVec[partitionId];
 


### PR DESCRIPTION
```
blazingmq/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp:1258:34: warning: comparison of integer expressions of different signedness: 'int' and 'bsl::vectorBase<BloombergLP::mqbc::RecoveryManager::RecoveryContext>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
 1258 |     BSLS_ASSERT_SAFE(partitionId < d_recoveryContextVec.size());
```

```
blazingmq/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h:282:28: warning: 'BloombergLP::mqbblp::ClusterCatalog::d_stopRequestsManager' will be initialized after [-Wreorder]
  282 |     StopRequestManagerType d_stopRequestsManager;
```

```
blazingmq/src/groups/mqb/mqbblp/mqbblp_cluster.cpp:3859:40: warning: comparison of integer expressions of different signedness: 'int' and 'bsl::vectorBase<BloombergLP::mqbc::ClusterStatePartitionInfo>::size_type' {aka 'long unsigned int'} [-Wsign-compare]
 3859 |     if (partitionId < 0 || partitionId >= partitions.size()) {
```

```
In function 'void operator delete(void*, BloombergLP::bslma::Allocator&)',
    inlined from 'void BloombergLP::mqbblp::Cluster::startDispatched(std::ostream*, int*)' at blazingmq/src/groups/mqb/mqbblp/mqbblp_cluster.cpp:223:46:
include/bslma_allocator.h:687:30: warning: '<anonymous>' may be used uninitialized [-Wmaybe-uninitialized]
  687 |     basicAllocator.deallocate(address);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~
blazingmq/src/groups/mqb/mqbblp/mqbblp_cluster.cpp: In member function 'void BloombergLP::mqbblp::Cluster::startDispatched(std::ostream*, int*)':
blazingmq/src/groups/mqb/mqbblp/mqbblp_cluster.cpp:223:46: note: '<anonymous>' was declared here
  223 |                       storageManagerAllocator)),
```