### PR TITLE
Misc: mqbc::StorageUtil, mqbi::StorageMgr: updateQueue -> updateQueuePrimary

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1913,7 +1913,7 @@ void RootQueueEngine::afterAppIdRegistered(
 
     BSLS_ASSERT_SAFE(!key.isNull());
 
-    d_queueState_p->storageManager()->updateQueue(
+    d_queueState_p->storageManager()->updateQueuePrimary(
         d_queueState_p->uri(),
         d_queueState_p->key(),
         d_queueState_p->partitionId(),
@@ -1966,7 +1966,7 @@ void RootQueueEngine::afterAppIdUnregistered(
         }
     }
 
-    d_queueState_p->storageManager()->updateQueue(
+    d_queueState_p->storageManager()->updateQueuePrimary(
         d_queueState_p->uri(),
         d_queueState_p->key(),
         d_queueState_p->partitionId(),
@@ -1974,8 +1974,8 @@ void RootQueueEngine::afterAppIdUnregistered(
         mqbi::Storage::AppIdKeyPairs(1,
                                      mqbi::Storage::AppIdKeyPair(appId,
                                                                  appKey)));
-    // No need to log in case of failure because 'updateQueue' does it (even in
-    // case of success FTM).
+    // No need to log in case of failure because 'updateQueuePrimary' does it
+    // (even in case of success FTM).
 
     d_consumptionMonitor.unregisterSubStream(appKey);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1110,11 +1110,11 @@ void StorageManager::unregisterQueue(const bmqt::Uri& uri, int partitionId)
     d_fileStores[partitionId]->dispatchEvent(queueEvent);
 }
 
-int StorageManager::updateQueue(const bmqt::Uri&        uri,
-                                const mqbu::StorageKey& queueKey,
-                                int                     partitionId,
-                                const AppIdKeyPairs&    addedIdKeyPairs,
-                                const AppIdKeyPairs&    removedIdKeyPairs)
+int StorageManager::updateQueuePrimary(const bmqt::Uri&        uri,
+                                       const mqbu::StorageKey& queueKey,
+                                       int                     partitionId,
+                                       const AppIdKeyPairs&    addedIdKeyPairs,
+                                       const AppIdKeyPairs& removedIdKeyPairs)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -1123,7 +1123,7 @@ int StorageManager::updateQueue(const bmqt::Uri&        uri,
                      partitionId < static_cast<int>(d_fileStores.size()));
     BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
 
-    return mqbc::StorageUtil::updateQueue(
+    return mqbc::StorageUtil::updateQueuePrimary(
         &d_storages[partitionId],
         &d_storagesLock,
         d_fileStores[partitionId].get(),

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -540,12 +540,12 @@ class StorageManager : public mqbi::StorageManager {
     /// queue is configured in fanout mode.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    virtual int
-    updateQueue(const bmqt::Uri&        uri,
-                const mqbu::StorageKey& queueKey,
-                int                     partitionId,
-                const AppIdKeyPairs&    addedIdKeyPairs,
-                const AppIdKeyPairs& removedIdKeyPairs) BSLS_KEYWORD_OVERRIDE;
+    virtual int updateQueuePrimary(const bmqt::Uri&        uri,
+                                   const mqbu::StorageKey& queueKey,
+                                   int                     partitionId,
+                                   const AppIdKeyPairs&    addedIdKeyPairs,
+                                   const AppIdKeyPairs&    removedIdKeyPairs)
+        BSLS_KEYWORD_OVERRIDE;
 
     virtual void
     registerQueueReplica(int                     partitionId,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3718,11 +3718,11 @@ void StorageManager::unregisterQueue(const bmqt::Uri& uri, int partitionId)
     d_fileStores[partitionId]->dispatchEvent(queueEvent);
 }
 
-int StorageManager::updateQueue(const bmqt::Uri&        uri,
-                                const mqbu::StorageKey& queueKey,
-                                int                     partitionId,
-                                const AppIdKeyPairs&    addedIdKeyPairs,
-                                const AppIdKeyPairs&    removedIdKeyPairs)
+int StorageManager::updateQueuePrimary(const bmqt::Uri&        uri,
+                                       const mqbu::StorageKey& queueKey,
+                                       int                     partitionId,
+                                       const AppIdKeyPairs&    addedIdKeyPairs,
+                                       const AppIdKeyPairs& removedIdKeyPairs)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -3731,18 +3731,19 @@ int StorageManager::updateQueue(const bmqt::Uri&        uri,
                      partitionId < static_cast<int>(d_fileStores.size()));
     BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
 
-    return StorageUtil::updateQueue(&d_storages[partitionId],
-                                    &d_storagesLock,
-                                    d_fileStores[partitionId].get(),
-                                    &d_appKeysVec[partitionId],
-                                    &d_appKeysLock,
-                                    d_clusterData_p->identity().description(),
-                                    uri,
-                                    queueKey,
-                                    partitionId,
-                                    addedIdKeyPairs,
-                                    removedIdKeyPairs,
-                                    true);  // isCSLMode
+    return StorageUtil::updateQueuePrimary(
+        &d_storages[partitionId],
+        &d_storagesLock,
+        d_fileStores[partitionId].get(),
+        &d_appKeysVec[partitionId],
+        &d_appKeysLock,
+        d_clusterData_p->identity().description(),
+        uri,
+        queueKey,
+        partitionId,
+        addedIdKeyPairs,
+        removedIdKeyPairs,
+        true);  // isCSLMode
 }
 
 void StorageManager::registerQueueReplica(int                     partitionId,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -875,12 +875,12 @@ class StorageManager
     /// queue is configured in fanout mode.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    virtual int
-    updateQueue(const bmqt::Uri&        uri,
-                const mqbu::StorageKey& queueKey,
-                int                     partitionId,
-                const AppIdKeyPairs&    addedIdKeyPairs,
-                const AppIdKeyPairs& removedIdKeyPairs) BSLS_KEYWORD_OVERRIDE;
+    virtual int updateQueuePrimary(const bmqt::Uri&        uri,
+                                   const mqbu::StorageKey& queueKey,
+                                   int                     partitionId,
+                                   const AppIdKeyPairs&    addedIdKeyPairs,
+                                   const AppIdKeyPairs&    removedIdKeyPairs)
+        BSLS_KEYWORD_OVERRIDE;
 
     virtual void
     registerQueueReplica(int                     partitionId,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -212,34 +212,34 @@ struct StorageUtil {
                             const AppIdKeyPairs& appIdKeyPairs);
 
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    static void
-    updateQueueDispatched(const mqbi::Dispatcher::ProcessorHandle& processor,
-                          mqbs::ReplicatedStorage*                 storage,
-                          bslmt::Mutex*        storagesLock,
-                          mqbs::FileStore*     fs,
-                          AppKeys*             appKeys,
-                          bslmt::Mutex*        appKeysLock,
-                          const bsl::string&   clusterDescription,
-                          int                  partitionId,
-                          const AppIdKeyPairs& addedIdKeyPairs,
-                          const AppIdKeyPairs& removedIdKeyPairs,
-                          bool                 isFanout,
-                          bool                 isCSLMode);
+    static void updateQueuePrimaryDispatched(
+        const mqbi::Dispatcher::ProcessorHandle& processor,
+        mqbs::ReplicatedStorage*                 storage,
+        bslmt::Mutex*                            storagesLock,
+        mqbs::FileStore*                         fs,
+        AppKeys*                                 appKeys,
+        bslmt::Mutex*                            appKeysLock,
+        const bsl::string&                       clusterDescription,
+        int                                      partitionId,
+        const AppIdKeyPairs&                     addedIdKeyPairs,
+        const AppIdKeyPairs&                     removedIdKeyPairs,
+        bool                                     isFanout,
+        bool                                     isCSLMode);
 
     /// StorageManager's storages lock must be locked before calling this
     /// method.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    static int updateQueueRaw(mqbs::ReplicatedStorage* storage,
-                              mqbs::FileStore*         fs,
-                              AppKeys*                 appKeys,
-                              bslmt::Mutex*            appKeysLock,
-                              const bsl::string&       clusterDescription,
-                              int                      partitionId,
-                              const AppIdKeyPairs&     addedIdKeyPairs,
-                              const AppIdKeyPairs&     removedIdKeyPairs,
-                              bool                     isFanout,
-                              bool                     isCSLMode);
+    static int updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
+                                     mqbs::FileStore*         fs,
+                                     AppKeys*                 appKeys,
+                                     bslmt::Mutex*            appKeysLock,
+                                     const bsl::string&   clusterDescription,
+                                     int                  partitionId,
+                                     const AppIdKeyPairs& addedIdKeyPairs,
+                                     const AppIdKeyPairs& removedIdKeyPairs,
+                                     bool                 isFanout,
+                                     bool                 isCSLMode);
 
     static int
     addVirtualStoragesInternal(mqbs::ReplicatedStorage* storage,
@@ -663,18 +663,18 @@ struct StorageUtil {
     /// queue is configured in fanout mode.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    static int updateQueue(StorageSpMap*           storageMap,
-                           bslmt::Mutex*           storagesLock,
-                           mqbs::FileStore*        fs,
-                           AppKeys*                appKeys,
-                           bslmt::Mutex*           appKeysLock,
-                           const bsl::string&      clusterDescription,
-                           const bmqt::Uri&        uri,
-                           const mqbu::StorageKey& queueKey,
-                           int                     partitionId,
-                           const AppIdKeyPairs&    addedIdKeyPairs,
-                           const AppIdKeyPairs&    removedIdKeyPairs,
-                           bool                    isCSLMode);
+    static int updateQueuePrimary(StorageSpMap*           storageMap,
+                                  bslmt::Mutex*           storagesLock,
+                                  mqbs::FileStore*        fs,
+                                  AppKeys*                appKeys,
+                                  bslmt::Mutex*           appKeysLock,
+                                  const bsl::string&      clusterDescription,
+                                  const bmqt::Uri&        uri,
+                                  const mqbu::StorageKey& queueKey,
+                                  int                     partitionId,
+                                  const AppIdKeyPairs&    addedIdKeyPairs,
+                                  const AppIdKeyPairs&    removedIdKeyPairs,
+                                  bool                    isCSLMode);
 
     static void
     registerQueueReplicaDispatched(int*                 status,

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -256,11 +256,11 @@ class StorageManager : public mqbi::AppKeyGenerator {
     /// queue is configured in fanout mode.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    virtual int updateQueue(const bmqt::Uri&        uri,
-                            const mqbu::StorageKey& queueKey,
-                            int                     partitionId,
-                            const AppIdKeyPairs&    addedIdKeyPairs,
-                            const AppIdKeyPairs&    removedIdKeyPairs) = 0;
+    virtual int updateQueuePrimary(const bmqt::Uri&        uri,
+                                   const mqbu::StorageKey& queueKey,
+                                   int                     partitionId,
+                                   const AppIdKeyPairs&    addedIdKeyPairs,
+                                   const AppIdKeyPairs& removedIdKeyPairs) = 0;
 
     virtual void registerQueueReplica(int                     partitionId,
                                       const bmqt::Uri&        uri,

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
@@ -73,7 +73,7 @@ void StorageManager::unregisterQueue(
     // NOTHING
 }
 
-int StorageManager::updateQueue(
+int StorageManager::updateQueuePrimary(
     BSLS_ANNOTATION_UNUSED const bmqt::Uri& uri,
     BSLS_ANNOTATION_UNUSED const mqbu::StorageKey& queueKey,
     BSLS_ANNOTATION_UNUSED int                     partitionId,

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
@@ -100,12 +100,12 @@ class StorageManager : public mqbi::StorageManager {
     /// queue is configured in fanout mode.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread.
-    virtual int
-    updateQueue(const bmqt::Uri&        uri,
-                const mqbu::StorageKey& queueKey,
-                int                     partitionId,
-                const AppIdKeyPairs&    addedIdKeyPairs,
-                const AppIdKeyPairs& removedIdKeyPairs) BSLS_KEYWORD_OVERRIDE;
+    virtual int updateQueuePrimary(const bmqt::Uri&        uri,
+                                   const mqbu::StorageKey& queueKey,
+                                   int                     partitionId,
+                                   const AppIdKeyPairs&    addedIdKeyPairs,
+                                   const AppIdKeyPairs&    removedIdKeyPairs)
+        BSLS_KEYWORD_OVERRIDE;
 
     virtual void
     registerQueueReplica(int                     partitionId,


### PR DESCRIPTION
Makes it easier to reason about whether the `updateQueue` call is going through primary or replica. `StorageManager::updateQueueReplica` and friends already exist.