### PR TITLE
Feat[MQB]:Enhance filebackedstorage/inmemorystorage alarm log with app subscription info

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1619,6 +1619,132 @@ void RootQueueEngine::onTimer(bsls::Types::Int64 currentTimer)
     d_consumptionMonitor.onTimer(currentTimer);
 }
 
+bsl::ostream&
+RootQueueEngine::logAppSubscriptionInfo(bsl::ostream&           stream,
+                                        const mqbu::StorageKey& appKey) const
+{
+    // executed by the *QUEUE DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_queueState_p->queue()->dispatcher()->inDispatcherThread(
+        d_queueState_p->queue()));
+
+    // Get AppState by appKey.
+    Apps::const_iterator cItApp = d_apps.findByKey2(AppKeyCount(appKey, 0));
+    if (cItApp == d_apps.end()) {
+        BALL_LOG_WARN << "No app found for appKey: " << appKey;
+        stream << "\nSubscription info: no app found for appKey: " << appKey;
+        return stream;  // RETURN
+    }
+
+    const AppStateSp& app = cItApp->value();
+    return logAppSubscriptionInfo(stream, app);
+}
+
+bsl::ostream&
+RootQueueEngine::logAppSubscriptionInfo(bsl::ostream&     stream,
+                                        const AppStateSp& appState) const
+{
+    mqbi::Storage* const storage = d_queueState_p->storage();
+
+    // Log un-delivered messages info
+    stream << "\nFor appId: " << appState->appId() << "\n\n";
+    stream << "Put aside list size: "
+           << bmqu::PrintUtil::prettyNumber(static_cast<bsls::Types::Int64>(
+                  appState->putAsideListSize()))
+           << '\n';
+    stream << "Redelivery list size: "
+           << bmqu::PrintUtil::prettyNumber(static_cast<bsls::Types::Int64>(
+                  appState->redeliveryListSize()))
+           << '\n';
+    stream << "Number of messages: "
+           << bmqu::PrintUtil::prettyNumber(
+                  storage->numMessages(appState->appKey()))
+           << '\n';
+    stream << "Number of bytes: "
+           << bmqu::PrintUtil::prettyBytes(
+                  storage->numBytes(appState->appKey()))
+           << "\n\n";
+
+    // Log consumer subscriptions
+    mqbblp::Routers::QueueRoutingContext& routingContext =
+        appState->routing()->d_queue;
+    mqbcmd::Routing routing;
+    routingContext.loadInternals(&routing);
+    const bsl::vector<mqbcmd::SubscriptionGroup>& subscrGroups =
+        routing.subscriptionGroups();
+    if (!subscrGroups.empty()) {
+        // Limit to log only k_EXPR_NUM_LIMIT expressions
+        static const size_t k_EXPR_NUM_LIMIT = 50;
+        bmqu::MemOutStream  ss(d_allocator_p);
+
+        size_t exprNum = 0;
+        for (bsl::vector<mqbcmd::SubscriptionGroup>::const_iterator cIt =
+                 subscrGroups.begin();
+             cIt != subscrGroups.end() && exprNum < k_EXPR_NUM_LIMIT;
+             ++cIt) {
+            if (!cIt->expression().empty()) {
+                ss << cIt->expression() << '\n';
+                ++exprNum;
+            }
+        }
+        if (exprNum) {
+            if (exprNum == k_EXPR_NUM_LIMIT) {
+                stream << "First " << k_EXPR_NUM_LIMIT
+                       << " of consumer subscription expressions: ";
+            }
+            else {
+                stream << "Consumer subscription expressions: ";
+            }
+            stream << '\n' << ss.str() << '\n';
+        }
+    }
+
+    // Log the first (oldest) message in a put aside list and its properties
+    if (!appState->putAsideList().empty()) {
+        bslma::ManagedPtr<mqbi::StorageIterator> storageIt_mp;
+        mqbi::StorageResult::Enum                rc = storage->getIterator(
+            &storageIt_mp,
+            appState->appKey(),
+            appState->putAsideList().first());
+        if (rc == mqbi::StorageResult::e_SUCCESS) {
+            // Log timestamp
+            stream << "Oldest message in the 'Put aside' list:\n";
+            mqbcmd::Result result;
+            mqbs::StoragePrintUtil::listMessage(&result.makeMessage(),
+                                                storage,
+                                                *storageIt_mp);
+            mqbcmd::HumanPrinter::print(stream, result);
+            stream << '\n';
+            // Log message properties
+            const bsl::shared_ptr<bdlbb::Blob>& appData =
+                storageIt_mp->appData();
+            const bmqp::MessagePropertiesInfo& logic =
+                storageIt_mp->attributes().messagePropertiesInfo();
+            bmqp::MessageProperties properties;
+            int ret = properties.streamIn(*appData, logic.isExtended());
+            if (!ret) {
+                stream << "Message Properties: " << properties << '\n';
+            }
+            else {
+                BALL_LOG_WARN << "Failed to streamIn MessageProperties, rc = "
+                              << rc;
+                stream << "Message Properties: Failed to acquire [rc: " << rc
+                       << "]\n";
+            }
+        }
+        else {
+            BALL_LOG_WARN << "Failed to get storage iterator for GUID: "
+                          << appState->putAsideList().first()
+                          << ", rc = " << rc;
+            stream << "'Put aside' list: Failed to acquire [rc: " << rc
+                   << "]\n";
+        }
+    }
+
+    return stream;
+}
+
 bool RootQueueEngine::logAlarmCb(const mqbu::StorageKey& appKey,
                                  bool                    enableLog) const
 {
@@ -1711,83 +1837,7 @@ bool RootQueueEngine::logAlarmCb(const mqbu::StorageKey& appKey,
         << " consumers." << ss.str() << '\n';
 
     // Log un-delivered messages info
-    out << "\nFor appId: " << app->appId() << '\n';
-    out << "Put aside list size: " << app->putAsideListSize() << '\n';
-    out << "Redelivery list size: " << app->redeliveryListSize() << '\n';
-    out << "Number of messages: " << storage->numMessages(appKey) << '\n';
-    out << "Number of bytes: " << storage->numBytes(appKey) << "\n\n";
-
-    // Log consumer subscriptions
-    mqbblp::Routers::QueueRoutingContext& routingContext =
-        app->routing()->d_queue;
-    mqbcmd::Routing routing;
-    routingContext.loadInternals(&routing);
-    const bsl::vector<mqbcmd::SubscriptionGroup>& subscrGroups =
-        routing.subscriptionGroups();
-
-    // Limit to log only k_EXPR_NUM_LIMIT expressions
-    static const size_t k_EXPR_NUM_LIMIT = 50;
-    ss.reset();
-    size_t exprNum = 0;
-    for (bsl::vector<mqbcmd::SubscriptionGroup>::const_iterator cIt =
-             subscrGroups.begin();
-         cIt != subscrGroups.end() && exprNum < k_EXPR_NUM_LIMIT;
-         ++cIt) {
-        if (!cIt->expression().empty()) {
-            ss << cIt->expression() << '\n';
-            ++exprNum;
-        }
-    }
-    if (exprNum) {
-        if (exprNum == k_EXPR_NUM_LIMIT) {
-            out << "First " << k_EXPR_NUM_LIMIT
-                << " of consumer subscription expressions: ";
-        }
-        else {
-            out << "Consumer subscription expressions: ";
-        }
-        out << '\n' << ss.str() << '\n';
-    }
-
-    // Log the first (oldest) message in a put aside list and its properties
-    if (!app->putAsideList().empty()) {
-        bslma::ManagedPtr<mqbi::StorageIterator> storageIt_mp;
-        mqbi::StorageResult::Enum                rc = storage->getIterator(
-            &storageIt_mp,
-            appKey,
-            app->putAsideList().first());
-        if (rc == mqbi::StorageResult::e_SUCCESS) {
-            // Log timestamp
-            out << "Oldest message in the 'Put aside' list:\n";
-            mqbcmd::Result result;
-            mqbs::StoragePrintUtil::listMessage(&result.makeMessage(),
-                                                storage,
-                                                *storageIt_mp);
-            mqbcmd::HumanPrinter::print(out, result);
-            out << '\n';
-            // Log message properties
-            const bsl::shared_ptr<bdlbb::Blob>& appData =
-                storageIt_mp->appData();
-            const bmqp::MessagePropertiesInfo& logic =
-                storageIt_mp->attributes().messagePropertiesInfo();
-            bmqp::MessageProperties properties;
-            int ret = properties.streamIn(*appData, logic.isExtended());
-            if (!ret) {
-                out << "Message Properties: " << properties << '\n';
-            }
-            else {
-                BALL_LOG_WARN << "Failed to streamIn MessageProperties, rc = "
-                              << rc;
-                out << "Message Properties: Failed to acquire [rc: " << rc
-                    << "]\n";
-            }
-        }
-        else {
-            BALL_LOG_WARN << "Failed to get storage iterator for GUID: "
-                          << app->putAsideList().first() << ", rc = " << rc;
-            out << "'Put aside' list: Failed to acquire [rc: " << rc << "]\n";
-        }
-    }
+    logAppSubscriptionInfo(out, app);
 
     // Print the 10 oldest messages in the queue
     static const int k_NUM_MSGS = 10;

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1676,28 +1676,27 @@ RootQueueEngine::logAppSubscriptionInfo(bsl::ostream&     stream,
     if (!subscrGroups.empty()) {
         // Limit to log only k_EXPR_NUM_LIMIT expressions
         static const size_t k_EXPR_NUM_LIMIT = 50;
-        bmqu::MemOutStream  ss(d_allocator_p);
+        if (subscrGroups.size() > k_EXPR_NUM_LIMIT) {
+            stream << "First " << k_EXPR_NUM_LIMIT
+                   << " of consumer subscription expressions: \n";
+        }
+        else {
+            stream << "Consumer subscription expressions: \n";
+        }
 
         size_t exprNum = 0;
         for (bsl::vector<mqbcmd::SubscriptionGroup>::const_iterator cIt =
                  subscrGroups.begin();
              cIt != subscrGroups.end() && exprNum < k_EXPR_NUM_LIMIT;
-             ++cIt) {
-            if (!cIt->expression().empty()) {
-                ss << cIt->expression() << '\n';
-                ++exprNum;
-            }
-        }
-        if (exprNum) {
-            if (exprNum == k_EXPR_NUM_LIMIT) {
-                stream << "First " << k_EXPR_NUM_LIMIT
-                       << " of consumer subscription expressions: ";
+             ++cIt, ++exprNum) {
+            if (cIt->expression().empty()) {
+                stream << "<Empty>\n";
             }
             else {
-                stream << "Consumer subscription expressions: ";
+                stream << cIt->expression() << '\n';
             }
-            stream << '\n' << ss.str() << '\n';
         }
+        stream << '\n';
     }
 
     // Log the first (oldest) message in a put aside list and its properties

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -211,11 +211,6 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// un-delivered messages and `false` otherwise.
     bool logAlarmCb(const mqbu::StorageKey& appKey, bool enableLog) const;
 
-    /// Log appllication subscription info for the specified `appKey` into the
-    /// specified `stream`.
-    bsl::ostream& logAppSubscriptionInfo(bsl::ostream&     stream,
-                                         const AppStateSp& appState) const;
-
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(RootQueueEngine, bslma::UsesBslmaAllocator)
@@ -472,6 +467,12 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     virtual bsl::ostream& logAppSubscriptionInfo(
         bsl::ostream&           stream,
         const mqbu::StorageKey& appKey) const BSLS_KEYWORD_OVERRIDE;
+
+  private:
+    /// Log appllication subscription info for the specified `appState` into
+    /// the specified `stream`.
+    bsl::ostream& logAppSubscriptionInfo(bsl::ostream&     stream,
+                                         const AppStateSp& appState) const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -211,6 +211,11 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// un-delivered messages and `false` otherwise.
     bool logAlarmCb(const mqbu::StorageKey& appKey, bool enableLog) const;
 
+    /// Log appllication subscription info for the specified `appKey` into the
+    /// specified `stream`.
+    bsl::ostream& logAppSubscriptionInfo(bsl::ostream&     stream,
+                                         const AppStateSp& appState) const;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(RootQueueEngine, bslma::UsesBslmaAllocator)
@@ -458,6 +463,15 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void
     loadInternals(mqbcmd::QueueEngine* out) const BSLS_KEYWORD_OVERRIDE;
+
+    /// Log appllication subscription info for the specified `appKey` into the
+    /// specified `stream`.
+    ///
+    /// THREAD: This method is called from the Queue's
+    /// dispatcher thread.
+    virtual bsl::ostream& logAppSubscriptionInfo(
+        bsl::ostream&           stream,
+        const mqbu::StorageKey& appKey) const BSLS_KEYWORD_OVERRIDE;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbi/mqbi_queueengine.cpp
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.cpp
@@ -63,5 +63,12 @@ void QueueEngine::unregisterStorage(
     // NOTHING
 }
 
+bsl::ostream&
+QueueEngine::logAppSubscriptionInfo(bsl::ostream&           stream,
+                                    const mqbu::StorageKey& appKey) const
+{
+    return stream;
+};
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -246,6 +246,14 @@ class QueueEngine {
     /// Load into the specified `out` object the internal information about
     /// this queue engine and associated queue handles.
     virtual void loadInternals(mqbcmd::QueueEngine* out) const = 0;
+
+    /// Log appllication subscription info for the specified `appKey` into the
+    /// specified `stream`.
+    ///
+    /// THREAD: This method is called from the Queue's dispatcher thread.
+    virtual bsl::ostream&
+    logAppSubscriptionInfo(bsl::ostream&           stream,
+                           const mqbu::StorageKey& appKey) const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -1029,7 +1029,7 @@ bsl::ostream&
 FileBackedStorage::logAppsSubscriptionInfoCb(bsl::ostream& stream) const
 {
     if (queue()) {
-        mqbi::Storage::AppInfos appInfos;
+        mqbi::Storage::AppInfos appInfos(d_allocator_p);
         loadVirtualStorageDetails(&appInfos);
 
         for (mqbi::Storage::AppInfos::const_iterator cit = appInfos.begin();

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -1029,12 +1029,11 @@ bsl::ostream&
 FileBackedStorage::logAppsSubscriptionInfoCb(bsl::ostream& stream) const
 {
     if (queue()) {
-        mqbi::Storage::AppIdKeyPairs appIdKeyPairs;
-        loadVirtualStorageDetails(&appIdKeyPairs);
+        mqbi::Storage::AppInfos appInfos;
+        loadVirtualStorageDetails(&appInfos);
 
-        for (mqbi::Storage::AppIdKeyPairs::const_iterator cit =
-                 appIdKeyPairs.begin();
-             cit != appIdKeyPairs.end();
+        for (mqbi::Storage::AppInfos::const_iterator cit = appInfos.begin();
+             cit != appInfos.end();
              ++cit) {
             queue()->queueEngine()->logAppSubscriptionInfo(stream,
                                                            cit->second);

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -118,9 +118,14 @@ FileBackedStorage::FileBackedStorage(
       this,
       allocatorStore ? allocatorStore->get("VirtualHandles") : d_allocator_p)
 , d_ttlSeconds(config.messageTtl())
-, d_capacityMeter("queue [" + queueUri.asString() + "]",
-                  parentCapacityMeter,
-                  allocator)
+, d_capacityMeter(
+      "queue [" + queueUri.asString() + "]",
+      parentCapacityMeter,
+      allocator,
+      bdlf::BindUtil::bind(&FileBackedStorage::logAppsSubscriptionInfoCb,
+                           this,
+                           bdlf::PlaceHolders::_1)  // stream
+      )
 , d_handles(bsls::TimeInterval()
                 .addMilliseconds(config.deduplicationTimeMs())
                 .totalNanoseconds(),
@@ -1018,6 +1023,25 @@ void FileBackedStorage::clearSelection()
     d_autoConfirms.clear();
 
     d_currentlyAutoConfirming = bmqt::MessageGUID();
+}
+
+bsl::ostream&
+FileBackedStorage::logAppsSubscriptionInfoCb(bsl::ostream& stream) const
+{
+    if (queue()) {
+        mqbi::Storage::AppIdKeyPairs appIdKeyPairs;
+        loadVirtualStorageDetails(&appIdKeyPairs);
+
+        for (mqbi::Storage::AppIdKeyPairs::const_iterator cit =
+                 appIdKeyPairs.begin();
+             cit != appIdKeyPairs.end();
+             ++cit) {
+            queue()->queueEngine()->logAppSubscriptionInfo(stream,
+                                                           cit->second);
+        }
+    }
+
+    return stream;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -224,6 +224,12 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// Clear the state created by 'selectForAutoConfirming'.
     void clearSelection();
 
+    // PRIVATE ACCESSORS
+
+    /// Callback function called by `d_capacityMeter` to log appllications
+    /// subscription info into the specified `stream`.
+    bsl::ostream& logAppsSubscriptionInfoCb(bsl::ostream& stream) const;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(FileBackedStorage,

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -610,12 +610,11 @@ bsl::ostream&
 InMemoryStorage::logAppsSubscriptionInfoCb(bsl::ostream& stream) const
 {
     if (queue()) {
-        mqbi::Storage::AppIdKeyPairs appIdKeyPairs;
-        loadVirtualStorageDetails(&appIdKeyPairs);
+        mqbi::Storage::AppInfos appInfos;
+        loadVirtualStorageDetails(&appInfos);
 
-        for (mqbi::Storage::AppIdKeyPairs::const_iterator cit =
-                 appIdKeyPairs.begin();
-             cit != appIdKeyPairs.end();
+        for (mqbi::Storage::AppInfos::const_iterator cit = appInfos.begin();
+             cit != appInfos.end();
              ++cit) {
             queue()->queueEngine()->logAppSubscriptionInfo(stream,
                                                            cit->second);

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -610,7 +610,7 @@ bsl::ostream&
 InMemoryStorage::logAppsSubscriptionInfoCb(bsl::ostream& stream) const
 {
     if (queue()) {
-        mqbi::Storage::AppInfos appInfos;
+        mqbi::Storage::AppInfos appInfos(d_allocator_p);
         loadVirtualStorageDetails(&appInfos);
 
         for (mqbi::Storage::AppInfos::const_iterator cit = appInfos.begin();

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -229,6 +229,12 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// Not implemented
     InMemoryStorage& operator=(const InMemoryStorage&) BSLS_KEYWORD_DELETED;
 
+    // PRIVATE ACCESSORS
+
+    /// Callback function called by `d_capacityMeter` to log appllications
+    /// subscription info into the specified `stream`.
+    bsl::ostream& logAppsSubscriptionInfoCb(bsl::ostream& stream) const;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(InMemoryStorage, bslma::UsesBslmaAllocator)

--- a/src/groups/mqb/mqbu/mqbu_capacitymeter.cpp
+++ b/src/groups/mqb/mqbu/mqbu_capacitymeter.cpp
@@ -83,6 +83,10 @@ void CapacityMeter::logOnMonitorStateTransition(
     switch (stateTransition) {
     case ResourceUsageMonitorStateTransition::e_HIGH_WATERMARK:
     case ResourceUsageMonitorStateTransition::e_FULL: {
+        if (d_logEnhancedStorageInfoCb) {
+            d_logEnhancedStorageInfoCb(stream);
+        }
+
         BMQTSK_ALARMLOG_RAW_ALARM(categoryStream.str())
             << stream.str() << BMQTSK_ALARMLOG_END;
     } break;
@@ -100,8 +104,9 @@ void CapacityMeter::logOnMonitorStateTransition(
     }
 }
 
-CapacityMeter::CapacityMeter(const bsl::string& name,
-                             bslma::Allocator*  allocator)
+CapacityMeter::CapacityMeter(const bsl::string&       name,
+                             bslma::Allocator*        allocator,
+                             LogEnhancedStorageInfoCb logEnhancedStorageInfoCb)
 : d_name(name, allocator)
 , d_isDisabled(false)
 , d_parent_p(0)
@@ -115,13 +120,15 @@ CapacityMeter::CapacityMeter(const bsl::string& name,
 , d_nbMessagesReserved(0)
 , d_nbBytesReserved(0)
 , d_lock(bsls::SpinLock::s_unlocked)
+, d_logEnhancedStorageInfoCb(logEnhancedStorageInfoCb)
 {
     // NOTHING
 }
 
-CapacityMeter::CapacityMeter(const bsl::string& name,
-                             CapacityMeter*     parent,
-                             bslma::Allocator*  allocator)
+CapacityMeter::CapacityMeter(const bsl::string&       name,
+                             CapacityMeter*           parent,
+                             bslma::Allocator*        allocator,
+                             LogEnhancedStorageInfoCb logEnhancedStorageInfoCb)
 : d_name(name, allocator)
 , d_isDisabled(false)
 , d_parent_p(parent)
@@ -135,6 +142,7 @@ CapacityMeter::CapacityMeter(const bsl::string& name,
 , d_nbMessagesReserved(0)
 , d_nbBytesReserved(0)
 , d_lock()
+, d_logEnhancedStorageInfoCb(logEnhancedStorageInfoCb)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbu/mqbu_capacitymeter.h
+++ b/src/groups/mqb/mqbu/mqbu_capacitymeter.h
@@ -151,6 +151,7 @@
 
 #include <mqbcmd_messages.h>
 #include <mqbu_resourceusagemonitor.h>
+#include <mqbu_storagekey.h>
 
 // BDE
 #include <ball_log.h>
@@ -189,6 +190,11 @@ class CapacityMeter {
         e_LIMIT_BYTES = 2  // bytes limit was hit
     };
 
+    // Callback function to log enhanced storage info into the
+    // specified `stream`.
+    typedef bsl::function<bsl::ostream&(bsl::ostream& stream)>
+        LogEnhancedStorageInfoCb;
+
   private:
     // DATA
     bsl::string d_name;
@@ -218,6 +224,10 @@ class CapacityMeter {
     // SpinLock for synchronization of this
     // component
 
+    LogEnhancedStorageInfoCb d_logEnhancedStorageInfoCb;
+    // Callback function to log enhanced storage info into the
+    // specified `stream`.
+
     // FRIENDS
     friend struct CapacityMeterUtil;
 
@@ -243,16 +253,20 @@ class CapacityMeter {
 
     // CREATORS
 
-    /// Create a new un-configured object having the specified `name` and
-    /// using the specified `allocator`.
-    CapacityMeter(const bsl::string& name, bslma::Allocator* allocator);
+    /// Create a new un-configured object having the specified `name`,
+    /// using the specified `allocator` and optionally specified
+    /// `logEnhancedStorageInfoCb`.
+    CapacityMeter(const bsl::string&       name,
+                  bslma::Allocator*        allocator,
+                  LogEnhancedStorageInfoCb logEnhancedStorageInfoCb = 0);
 
     /// Create a new un-configured object having the specified `name`, being
     /// a child of the specified `parent` meter and using the specified
-    /// `allocator`.
-    CapacityMeter(const bsl::string& name,
-                  CapacityMeter*     parent,
-                  bslma::Allocator*  allocator);
+    /// `allocator` and optionally specified `logEnhancedStorageInfoCb`.
+    CapacityMeter(const bsl::string&       name,
+                  CapacityMeter*           parent,
+                  bslma::Allocator*        allocator,
+                  LogEnhancedStorageInfoCb logEnhancedStorageInfoCb = 0);
 
     // MANIPULATORS
 

--- a/src/groups/mqb/mqbu/mqbu_capacitymeter.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_capacitymeter.t.cpp
@@ -33,6 +33,16 @@ using namespace BloombergLP;
 using namespace bsl;
 
 // ============================================================================
+//                                    HELPERS
+// ----------------------------------------------------------------------------
+
+bsl::ostream& logEnhancedStorageInfoCb(bsl::ostream& stream)
+{
+    stream << "Test enhanced storage Info";
+    return stream;
+}
+
+// ============================================================================
 //                                    TESTS
 // ----------------------------------------------------------------------------
 
@@ -229,6 +239,79 @@ static void test2_logStateChange()
     }
 }
 
+static void test3_enhancedLog()
+// ------------------------------------------------------------------------
+// ENHANCED ALARM LOG
+//
+// Concerns:
+//   Ensure that enhanced alarm log is printed if callback is passed.
+//
+// Plan:
+//   1. Pass LogEnhancedStorageInfoCb callback during initialization
+//   2. Set resources to the high watermark and ensure the enhanced
+//      error message was logged.
+//
+// Testing:
+//   logging
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("ENHANCED ALARM LOG");
+
+    // Set resource to the high watermark, it should log one
+    PV("STATE - HIGH WATERMARK");
+
+    s_ignoreCheckDefAlloc = true;
+    // Logging infrastructure allocates using the default allocator, and
+    // that logging is beyond the control of this function.
+
+    const bsls::Types::Int64 k_MSGS_LIMIT                = 10;
+    const double             k_MSGS_THRESHOLD            = 0.5;
+    const bsls::Types::Int64 k_MSGS_HIGH_WATERMARK_VALUE = k_MSGS_LIMIT *
+                                                           k_MSGS_THRESHOLD;
+    const bsls::Types::Int64 k_BYTES_LIMIT                = 1024;
+    const double             k_BYTES_THRESHOLD            = 0.8;
+    const bsls::Types::Int64 k_BYTES_HIGH_WATERMARK_VALUE = k_BYTES_LIMIT *
+                                                            k_BYTES_THRESHOLD;
+
+    bmqtst::ScopedLogObserver observer(ball::Severity::WARN, s_allocator_p);
+    mqbu::CapacityMeter       capacityMeter(
+        "dummy",
+        s_allocator_p,
+        bdlf::BindUtil::bind(&logEnhancedStorageInfoCb,
+                             bdlf::PlaceHolders::_1)  // stream
+    );
+    capacityMeter.setLimits(k_MSGS_LIMIT, k_BYTES_LIMIT);
+    capacityMeter.setWatermarkThresholds(k_MSGS_THRESHOLD, k_BYTES_THRESHOLD);
+
+    bsls::Types::Int64 nbMessagesAvailable;
+    bsls::Types::Int64 nbBytesAvailable;
+    capacityMeter.reserve(&nbMessagesAvailable,
+                          &nbBytesAvailable,
+                          k_MSGS_HIGH_WATERMARK_VALUE,
+                          10);
+    BSLS_ASSERT_OPT(nbMessagesAvailable == k_MSGS_HIGH_WATERMARK_VALUE);
+    BSLS_ASSERT_OPT(nbBytesAvailable == 10);
+
+    ASSERT(observer.records().empty());
+
+    capacityMeter.commit(k_MSGS_HIGH_WATERMARK_VALUE, 10);
+
+    ASSERT_EQ(observer.records().size(), 1U);
+
+    const ball::Record& record = observer.records()[0];
+    ASSERT_EQ(record.fixedFields().severity(), ball::Severity::ERROR);
+
+    ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
+        record,
+        "ALARM \\[CAPACITY_STATE_HIGH_WATERMARK\\]",
+        s_allocator_p));
+    // Check log from callback
+    ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
+        record,
+        "Test enhanced storage Info",
+        s_allocator_p));
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -241,6 +324,7 @@ int main(int argc, char* argv[])
     case 0:
     case 2: test2_logStateChange(); break;
     case 1: test1_breathingTest(); break;
+    case 3: test3_enhancedLog(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         s_testStatus = -1;


### PR DESCRIPTION
When a queue starts to fill up, it is valuable to see information about which AppIds are impacted, and information about the messages in the queue.
Especially in the case of subscriptions (which we are enabling for everyone now), messages that match no subscription expression will build up in the put aside list.
To help make this situation clearer to operators and users (what apps are impacted, why are messages building up, how old is the head of the queue for each app, etc), we can log more information when the filebackedstorage alarm is triggered:
 - Sizes of put-aside list and redelivery list for each app for that queue;
 - Consumer subscriptions;
 - Oldest message's timestamp in put aside list & its message properties;

This is to help debug why a message doesn't match a subscription.

Enhanced log looks like this:
```
ALARM: ALARM [CAPACITY_STATE_FULL] for 'queue [bmq://bmq.test.persistent.fanout/my1]': [Messages (STATE_FULL): 3 (limit: 3), Bytes (STATE_NORMAL): 165  B (limit: 1.00 MB)]
For appId: foo

Put aside list size: 2
Redelivery list size: 0
Number of messages: 2
Number of bytes: 110  B

Consumer subscription expressions:
<Empty>
x == 1
y == 2

Oldest message in the 'Put aside' list:
GUID                              Size        Timestamp (UTC)
4000010000417F0461B0F00A8CE52964       55  B  18OCT2024_09:03:27.485301+0000
Message Properties: [ sample_str (STRING) = "foo bar" x (INT32) = 3 ]

For appId: bar

Put aside list size: 2
Redelivery list size: 0
Number of messages: 2
Number of bytes: 110  B

Consumer subscription expressions:
x == 1
y == 2

Oldest message in the 'Put aside' list:
GUID                              Size        Timestamp (UTC)
4000010000417F0461B0F00A8CE52964       55  B  18OCT2024_09:03:27.485301+0000
Message Properties: [ sample_str (STRING) = "foo bar" x (INT32) = 3 ]
```


