### PR TITLE
Performance[MQB,BMQ]: return constructed blobs as pointers

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_confirmeventbuilder.cpp
+++ b/src/groups/bmq/bmqa/bmqa_confirmeventbuilder.cpp
@@ -100,7 +100,7 @@ const bdlbb::Blob& ConfirmEventBuilder::blob() const
     // PRECONDITIONS
     BSLS_ASSERT(d_impl.d_builder_p);
 
-    return d_impl.d_builder_p->blob();
+    return *d_impl.d_builder_p->blob();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqa/bmqa_message.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.t.cpp
@@ -196,7 +196,7 @@ static void test2_validPushMessagePrint()
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add SubQueueInfo option
@@ -207,7 +207,7 @@ static void test2_validPushMessagePrint()
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     // 'eventSize()' excludes unpacked messages
     ASSERT_LT(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // But the option is written to the underlying blob
     rc = peb.packMessage(payload,
                          queueId,
@@ -219,7 +219,7 @@ static void test2_validPushMessagePrint()
     ASSERT_LT(payload.length(), peb.eventSize());
     ASSERT_EQ(1, peb.messageCount());
 
-    bmqp::Event bmqpEvent(&peb.blob(),
+    bmqp::Event bmqpEvent(peb.blob().get(),
                           bmqtst::TestHelperUtil::allocator(),
                           true);
     implPtr->configureAsMessageEvent(bmqpEvent);
@@ -322,7 +322,7 @@ static void test3_messageProperties()
     queue->setId(queueId);
     implPtr->insertQueue(subQueueId, queue);
 
-    bmqp::Event bmqpEvent(&peb.blob(),
+    bmqp::Event bmqpEvent(peb.blob().get(),
                           bmqtst::TestHelperUtil::allocator(),
                           true);
 
@@ -471,7 +471,7 @@ static void test4_subscriptionHandle()
                   static_cast<size_t>(peb.eventSize()));
         // 'eventSize()' excludes unpacked messages
         ASSERT_LT(sizeof(bmqp::EventHeader),
-                  static_cast<size_t>(peb.blob().length()));
+                  static_cast<size_t>(peb.blob()->length()));
         // But the option is written to the underlying blob
 
         // Add message
@@ -485,7 +485,7 @@ static void test4_subscriptionHandle()
         ASSERT_LT(payload.length(), peb.eventSize());
         ASSERT_EQ(1, peb.messageCount());
 
-        bmqp::Event bmqpEvent(&peb.blob(),
+        bmqp::Event bmqpEvent(peb.blob().get(),
                               bmqtst::TestHelperUtil::allocator(),
                               true);
         implPtr->configureAsMessageEvent(bmqpEvent);
@@ -538,7 +538,7 @@ static void test4_subscriptionHandle()
         ASSERT_LT(payload.length(), peb.eventSize());
         ASSERT_EQ(1, peb.messageCount());
 
-        bmqp::Event bmqpEvent(&peb.blob(),
+        bmqp::Event bmqpEvent(peb.blob().get(),
                               bmqtst::TestHelperUtil::allocator(),
                               true);
         implPtr->configureAsMessageEvent(bmqpEvent);
@@ -584,7 +584,7 @@ static void test4_subscriptionHandle()
         ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
         ASSERT_EQ(1, builder.messageCount());
 
-        bmqp::Event bmqpEvent(&builder.blob(),
+        bmqp::Event bmqpEvent(builder.blob().get(),
                               bmqtst::TestHelperUtil::allocator());
         implPtr->configureAsMessageEvent(bmqpEvent);
 
@@ -621,7 +621,7 @@ static void test4_subscriptionHandle()
         ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
         ASSERT_EQ(1, builder.messageCount());
 
-        bmqp::Event bmqpEvent(&builder.blob(),
+        bmqp::Event bmqpEvent(builder.blob().get(),
                               bmqtst::TestHelperUtil::allocator());
         implPtr->configureAsMessageEvent(bmqpEvent);
 

--- a/src/groups/bmq/bmqa/bmqa_message.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.t.cpp
@@ -166,6 +166,10 @@ static void test2_validPushMessagePrint()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqa::Event                    event;
 
     EventImplSp& implPtr = reinterpret_cast<EventImplSp&>(event);
@@ -188,7 +192,7 @@ static void test2_validPushMessagePrint()
               bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
@@ -250,6 +254,10 @@ static void test3_messageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     const int               queueId = 4321;
     const bmqt::MessageGUID guid;
@@ -280,7 +288,7 @@ static void test3_messageProperties()
     bdlbb::BlobUtil::append(&payload, buffer, bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
 
     // Add SubQueueInfo option
@@ -422,6 +430,10 @@ static void test4_subscriptionHandle()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
 
     queueSp->setId(queueId);
@@ -445,7 +457,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PushEventBuilder
-        bmqp::PushEventBuilder peb(&bufferFactory,
+        bmqp::PushEventBuilder peb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
         ASSERT_EQ(0, peb.messageCount());
 
@@ -510,7 +522,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PushEventBuilder
-        bmqp::PushEventBuilder peb(&bufferFactory,
+        bmqp::PushEventBuilder peb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
         ASSERT_EQ(0, peb.messageCount());
 
@@ -558,7 +570,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder builder(&bufferFactory,
+        bmqp::PutEventBuilder builder(&blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
         ASSERT_EQ(0, builder.messageCount());
 
@@ -599,7 +611,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create AckEventBuilder
-        bmqp::AckEventBuilder builder(&bufferFactory,
+        bmqp::AckEventBuilder builder(&blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
         ASSERT_EQ(0, builder.messageCount());
 

--- a/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
@@ -178,7 +178,8 @@ static void test2_ackMesageIteratorTest()
     PVV("Appending messages");
     appendMessages(&builder, &messages, k_NUM_MSGS);
 
-    bmqp::Event rawEvent(&builder.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(builder.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<bmqimp::Event> eventImpl;
     eventImpl.createInplace(bmqtst::TestHelperUtil::allocator(),
@@ -252,7 +253,8 @@ static void test3_putMessageIteratorTest()
         ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
     }
 
-    bmqp::Event rawEvent(&builder.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(builder.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<bmqimp::Event> eventImpl;
     eventImpl.createInplace(bmqtst::TestHelperUtil::allocator(),

--- a/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
@@ -167,7 +167,11 @@ static void test2_ackMesageIteratorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder builder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder builder(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<AckData>  messages(bmqtst::TestHelperUtil::allocator());
 
@@ -229,7 +233,11 @@ static void test3_putMessageIteratorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder builder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder builder(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<PutData>  messages(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -300,7 +300,7 @@ Event MockSessionUtil::createAckEvent(const bsl::vector<AckParams>& acks,
 
     // TODO: deprecate `createAckEvent` with bufferFactory arg and introduce
     // another function with BlobSpPool arg.
-    bmqa::Session::BlobSpPool blobSpPool(
+    BlobSpPool blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(bufferFactory, allocator));
 
     bmqp::AckEventBuilder ackBuilder(&blobSpPool, alloc);
@@ -318,7 +318,7 @@ Event MockSessionUtil::createAckEvent(const bsl::vector<AckParams>& acks,
     }
 
     implPtr->configureAsMessageEvent(
-        bmqp::Event(&ackBuilder.blob(), alloc, true));
+        bmqp::Event(ackBuilder.blob().get(), alloc, true));
     for (size_t i = 0; i != acks.size(); ++i) {
         implPtr->addCorrelationId(acks[i].d_correlationId);
     }
@@ -343,7 +343,7 @@ Event MockSessionUtil::createPushEvent(
 
     // TODO: deprecate `createPushEvent` with bufferFactory arg and introduce
     // another function with BlobSpPool arg.
-    bmqa::Session::BlobSpPool blobSpPool(
+    BlobSpPool blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(bufferFactory, allocator));
 
     bmqp::PushEventBuilder pushBuilder(&blobSpPool, alloc);
@@ -379,7 +379,7 @@ Event MockSessionUtil::createPushEvent(
         implPtr->addCorrelationId(bmqt::CorrelationId());
     }
 
-    bmqp::Event bmqpEvent(&pushBuilder.blob(), alloc, true);
+    bmqp::Event bmqpEvent(pushBuilder.blob().get(), alloc, true);
     implPtr->configureAsMessageEvent(bmqpEvent);
 
     return event;

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -749,6 +749,11 @@ struct MockSessionUtil {
 /// Mechanism to mock a `bmqa::Session`
 class MockSession : public AbstractSession {
   public:
+    // TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bmqa::Session::BlobSpPool BlobSpPool;
+
     // CLASS METHODS
 
     /// Perform a one time initialization needed by components used in
@@ -1009,6 +1014,9 @@ class MockSession : public AbstractSession {
 
     /// Buffer factory
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
+
+    /// Pool of shared pointers to blobs
+    BlobSpPool d_blobSpPool;
 
     /// Event handler (set only in asynchronous mode)
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -1024,7 +1024,7 @@ class MockSession : public AbstractSession {
 
     // DATA
 
-    /// Buffer factory
+    /// Buffer factory used to build Blobs with `d_blobSpPool`
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
 
     /// Pool of shared pointers to blobs

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -556,6 +556,7 @@
 #include <bdlb_variant.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlcc_sharedobjectpool.h>
 #include <bsl_cstddef.h>
 #include <bsl_deque.h>
 #include <bsl_functional.h>
@@ -606,6 +607,13 @@ class ConfirmEventBuilder;
 struct MockSessionUtil {
   private:
     // PRIVATE TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
 
     /// Event impl shared pointer to access
     /// the pimpl of `bmqa::Event`.
@@ -751,9 +759,6 @@ class MockSession : public AbstractSession {
   public:
     // TYPES
 
-    /// Pool of shared pointers to Blobs
-    typedef bmqa::Session::BlobSpPool BlobSpPool;
-
     // CLASS METHODS
 
     /// Perform a one time initialization needed by components used in
@@ -802,6 +807,13 @@ class MockSession : public AbstractSession {
     static const int k_MAX_SIZEOF_BMQC_TWOKEYHASHMAP = 256;
 
     // PRIVATE TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
 
     /// Aligned buffer holding the two key hash map
     typedef bsls::AlignedBuffer<k_MAX_SIZEOF_BMQC_TWOKEYHASHMAP>

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -787,7 +787,7 @@ MessageEventBuilder Session::createMessageEventBuilder()
     eventImplSpRef = d_impl.d_application_mp->brokerSession().createEvent();
 
     eventImplSpRef->configureAsMessageEvent(
-        d_impl.d_application_mp->bufferFactory());
+        d_impl.d_application_mp->blobSpPool());
 
     return builder;
 }
@@ -814,7 +814,7 @@ void Session::loadMessageEventBuilder(MessageEventBuilder* builder)
     eventImplSpRef = d_impl.d_application_mp->brokerSession().createEvent();
 
     eventImplSpRef->configureAsMessageEvent(
-        d_impl.d_application_mp->bufferFactory());
+        d_impl.d_application_mp->blobSpPool());
 }
 
 void Session::loadConfirmEventBuilder(ConfirmEventBuilder* builder)
@@ -837,7 +837,7 @@ void Session::loadConfirmEventBuilder(ConfirmEventBuilder* builder)
     }
 
     new (builderImplRef.d_buffer.buffer())
-        bmqp::ConfirmEventBuilder(d_impl.d_application_mp->bufferFactory(),
+        bmqp::ConfirmEventBuilder(d_impl.d_application_mp->blobSpPool(),
                                   d_impl.d_allocator_p);
 
     builderImplRef.d_builder_p = reinterpret_cast<bmqp::ConfirmEventBuilder*>(

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -565,6 +565,7 @@
 
 // BDE
 #include <ball_log.h>
+#include <bdlcc_sharedobjectpool.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
@@ -678,6 +679,13 @@ struct SessionImpl {
 class Session : public AbstractSession {
   public:
     // TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
 
     /// Invoked as a response to an asynchronous open queue operation,
     /// `OpenQueueCallback` is an alias for a callback function object

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -565,7 +565,6 @@
 
 // BDE
 #include <ball_log.h>
-#include <bdlcc_sharedobjectpool.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
@@ -679,13 +678,6 @@ struct SessionImpl {
 class Session : public AbstractSession {
   public:
     // TYPES
-
-    /// Pool of shared pointers to Blobs
-    typedef bdlcc::SharedObjectPool<
-        bdlbb::Blob,
-        bdlcc::ObjectPoolFunctors::DefaultCreator,
-        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
-        BlobSpPool;
 
     /// Invoked as a response to an asynchronous open queue operation,
     /// `OpenQueueCallback` is an alias for a callback function object

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -553,6 +553,9 @@ Application::Application(
 , d_channelsTip(&d_allocator)
 , d_blobBufferFactory(sessionOptions.blobBufferSize(),
                       d_allocators.get("BlobBufferFactory"))
+, d_blobSpPool(
+      bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
+                                         d_allocators.get("BlobSpPool")))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC, &d_allocator)
 , d_channelFactory(ntcCreateInterfaceConfig(sessionOptions, allocator),
                    &d_blobBufferFactory,
@@ -582,11 +585,13 @@ Application::Application(
                                      negotiationMessage,
                                      sessionOptions.connectTimeout(),
                                      &d_blobBufferFactory,
+                                     &d_blobSpPool,
                                      allocator),
       allocator)
 , d_connectHandle_mp()
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,
+                  &d_blobSpPool,
                   d_sessionOptions,
                   eventHandlerCB,
                   bdlf::MemFnUtil::memFn(&Application::stateCb, this),

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -584,7 +584,6 @@ Application::Application(
       NegotiatedChannelFactoryConfig(&d_statChannelFactory,
                                      negotiationMessage,
                                      sessionOptions.connectTimeout(),
-                                     &d_blobBufferFactory,
                                      &d_blobSpPool,
                                      allocator),
       allocator)

--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -78,16 +78,18 @@ namespace bmqimp {
 
 /// Top level object to manipulate a session with bmqbrkr
 class Application {
+  public:
+    // PUBLIC TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // PRIVATE TYPES
     typedef bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle>
         ChannelFactoryOpHandleMp;
 
-  private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("BMQIMP.APPLICATION");
 
-  private:
     // DATA
     bmqst::StatContext d_allocatorStatContext;
     // Stat context for counting allocators
@@ -115,6 +117,9 @@ class Application {
 
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
     // Factory for blob buffers
+
+    /// Pool of shared pointers to blobs.
+    BlobSpPool d_blobSpPool;
 
     bdlmt::EventScheduler d_scheduler;
     // Scheduler
@@ -259,7 +264,9 @@ class Application {
     /// instance.
     bdlbb::BlobBufferFactory* bufferFactory();
 
-    // MANIPULATORS
+    /// Return a pointer to the blob shared pointer pool used by this instance.
+    /// Note that lifetime of the pointed-to pool is bound by this instance.
+    BlobSpPool* blobSpPool();
 
     /// Start the session and the session pool. Return 0 on success or a
     /// non-zero negative code otherwise.  Calling start on an already
@@ -323,6 +330,11 @@ inline bool Application::isStarted() const
 inline bdlbb::BlobBufferFactory* Application::bufferFactory()
 {
     return &d_blobBufferFactory;
+}
+
+inline Application::BlobSpPool* Application::blobSpPool()
+{
+    return &d_blobSpPool;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -259,11 +259,6 @@ class Application {
 
     // MANIPULATORS
 
-    /// Return a pointer to the blob buffer factory used by this instance.
-    /// Note that lifetime of the pointed-to buffer factory is bound by this
-    /// instance.
-    bdlbb::BlobBufferFactory* bufferFactory();
-
     /// Return a pointer to the blob shared pointer pool used by this instance.
     /// Note that lifetime of the pointed-to pool is bound by this instance.
     BlobSpPool* blobSpPool();
@@ -325,11 +320,6 @@ inline bool Application::isStarted() const
     // the session is started
     return (state == bmqimp::BrokerSession::State::e_STARTED ||
             state == bmqimp::BrokerSession::State::e_RECONNECTING);
-}
-
-inline bdlbb::BlobBufferFactory* Application::bufferFactory()
-{
-    return &d_blobBufferFactory;
 }
 
 inline Application::BlobSpPool* Application::blobSpPool()

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -4530,7 +4530,7 @@ void BrokerSession::transferAckEvent(bmqp::AckEventBuilder*  ackBuilder,
     // Our event is full at this point so send this ack event to the user and
     // reset the builder to append the ack that was rejected.
 
-    bmqp::Event event(&ackBuilder->blob(), d_allocator_p, true);
+    bmqp::Event event(ackBuilder->blob().get(), d_allocator_p, true);
     // clone = true
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
             d_messageDumper.isEventDumpEnabled<bmqp::EventType::e_ACK>())) {
@@ -4820,7 +4820,7 @@ bool BrokerSession::appendOrSend(
     if (result == bmqt::EventBuilderResult::e_PAYLOAD_TOO_BIG) {
         // Send the current event, reset the builder.
         bmqt::GenericResult::Enum res = writeOrBuffer(
-            builder.blob(),
+            *builder.blob(),
             d_sessionOptions.channelHighWatermark());
 
         if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
@@ -4943,7 +4943,7 @@ void BrokerSession::retransmitPendingMessages()
     // Send the final PUT event if there are any messages in the builder
     if (putBuilder.messageCount()) {
         bmqt::GenericResult::Enum res = writeOrBuffer(
-            putBuilder.blob(),
+            *putBuilder.blob(),
             d_sessionOptions.channelHighWatermark());
 
         if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
@@ -7330,7 +7330,7 @@ int BrokerSession::confirmMessage(const bsl::shared_ptr<bmqimp::Queue>& queue,
                        << rc;
         return rc;  // RETURN
     }
-    bool isAccepted = acceptUserEvent(builder.blob(), timeout);
+    bool isAccepted = acceptUserEvent(*builder.blob(), timeout);
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isAccepted)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -2444,7 +2444,7 @@ void TestSession::sendControlMessage(
     int rc = builder.setMessage(message, bmqp::EventType::e_CONTROL);
     ASSERT_EQ(0, rc);
 
-    const bdlbb::Blob& packet = builder.blob();
+    const bdlbb::Blob& packet = *builder.blob();
 
     PVVV_SAFE("Send control message");
     d_brokerSession.processPacket(packet);
@@ -4088,7 +4088,7 @@ static void test11_disconnect()
                                 bmqp::EventType::e_CONTROL);
         ASSERT_EQ(rc, 0);
 
-        obj.processPacket(builder.blob());
+        obj.processPacket(*builder.blob());
 
         // Reset the channel
         obj.setChannel(bsl::shared_ptr<bmqio::Channel>());
@@ -4190,7 +4190,7 @@ static void test11_disconnect()
                                 bmqp::EventType::e_CONTROL);
         ASSERT_EQ(rc, 0);
 
-        obj.processPacket(builder.blob());
+        obj.processPacket(*builder.blob());
 
         // Reset the channel
         obj.setChannel(bsl::shared_ptr<bmqio::Channel>());
@@ -4755,7 +4755,7 @@ static void test21_post_Limit()
     ASSERT_EQ(bmqt::EventBuilderResult::e_SUCCESS,
               builder.packMessage(pQueue->id()));
 
-    int rc = obj.session().post(builder.blob(), postTimeout);
+    int rc = obj.session().post(*builder.blob(), postTimeout);
 
     PVV_SAFE("Step 5. Ensure the PUT message is accepted");
     ASSERT_EQ(rc, bmqt::PostResult::e_SUCCESS);
@@ -4770,7 +4770,7 @@ static void test21_post_Limit()
     ASSERT(rawEvent.isPutEvent());
 
     PVV_SAFE("Step 6. Ensure e_BW_LIMIT is returned for the second post");
-    rc = obj.session().post(builder.blob(), postTimeout);
+    rc = obj.session().post(*builder.blob(), postTimeout);
 
     ASSERT_EQ(rc, bmqt::PostResult::e_BW_LIMIT);
     ASSERT_EQ(obj.channel().writeCalls().size(), 0u);
@@ -4784,7 +4784,7 @@ static void test21_post_Limit()
 
     // Call post with a bigger timeout so that LWM event arrives before it
     // expires.
-    rc = obj.session().post(builder.blob(), timeout);
+    rc = obj.session().post(*builder.blob(), timeout);
 
     PVV_SAFE("Step 8. Ensure e_SUCCESS is returned");
     ASSERT_EQ(rc, bmqt::PostResult::e_SUCCESS);
@@ -4804,7 +4804,7 @@ static void test21_post_Limit()
     PVV_SAFE("Step 9. Set the channel to return e_GENERIC_ERROR on write");
     obj.channel().setWriteStatus(bmqio::StatusCategory::e_GENERIC_ERROR);
 
-    rc = obj.session().post(builder.blob(), postTimeout);
+    rc = obj.session().post(*builder.blob(), postTimeout);
 
     PVV_SAFE("Step 10. Ensure e_SUCCESS is returned");
     ASSERT_EQ(rc, bmqt::PostResult::e_SUCCESS);
@@ -4888,7 +4888,7 @@ static void test22_confirm_Limit()
                                    bmqt::MessageGUID());
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
-    rc = obj.session().confirmMessages(builder.blob(), confirmTimeout);
+    rc = obj.session().confirmMessages(*builder.blob(), confirmTimeout);
 
     PVV_SAFE("Step 5. Ensure e_SUCCESS is returned");
     ASSERT_EQ(rc, bmqt::GenericResult::e_SUCCESS);
@@ -4912,7 +4912,7 @@ static void test22_confirm_Limit()
 
     // Call confirm with a bigger timeout so that LWM event arrives before it
     // expires.
-    rc = obj.session().confirmMessages(builder.blob(), timeout);
+    rc = obj.session().confirmMessages(*builder.blob(), timeout);
 
     PVV_SAFE("Step 7. Ensure e_SUCCESS is returned");
     ASSERT_EQ(rc, bmqt::GenericResult::e_SUCCESS);
@@ -4930,7 +4930,7 @@ static void test22_confirm_Limit()
     PVV_SAFE("Step 8. Set the channel to return e_GENERIC_ERROR on write");
     obj.channel().setWriteStatus(bmqio::StatusCategory::e_GENERIC_ERROR);
 
-    rc = obj.session().confirmMessages(builder.blob(), confirmTimeout);
+    rc = obj.session().confirmMessages(*builder.blob(), confirmTimeout);
 
     PVV_SAFE("Step 9. Ensure e_SUCCESS");
 
@@ -6750,7 +6750,7 @@ static void test33_queueNackTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using just event blob
-    int res = obj.session().post(eventBuilder.blob(), timeout);
+    int res = obj.session().post(*eventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 
@@ -9170,7 +9170,7 @@ static void test50_putRetransmittingTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using event blob
-    int res = obj.session().post(putEventBuilder.blob(), timeout);
+    int res = obj.session().post(*putEventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 
@@ -9185,7 +9185,7 @@ static void test50_putRetransmittingTest()
                                   guidFirst,
                                   pQueue->id());
 
-    obj.session().processPacket(ackEventBuilder.blob());
+    obj.session().processPacket(*ackEventBuilder.blob());
 
     bsl::shared_ptr<bmqimp::Event> ackEvent = obj.waitAckEvent();
 
@@ -9216,7 +9216,7 @@ static void test50_putRetransmittingTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using event blob
-    res = obj.session().post(putEventBuilder.blob(), timeout);
+    res = obj.session().post(*putEventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 
@@ -9289,7 +9289,7 @@ static void test50_putRetransmittingTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using event blob
-    res = obj.session().post(putEventBuilder.blob(), timeout);
+    res = obj.session().post(*putEventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 
@@ -9453,7 +9453,7 @@ static void test51_putRetransmittingNoAckTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using event blob
-    int res = obj.session().post(putEventBuilder.blob(), timeout);
+    int res = obj.session().post(*putEventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 
@@ -9478,7 +9478,7 @@ static void test51_putRetransmittingNoAckTest()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Post the event using event blob
-    res = obj.session().post(putEventBuilder.blob(), timeout);
+    res = obj.session().post(*putEventBuilder.blob(), timeout);
 
     ASSERT_EQ(res, bmqt::PostResult::e_SUCCESS);
 

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -21,6 +21,7 @@
 #include <bmqimp_manualhosthealthmonitor.h>
 #include <bmqimp_queue.h>
 #include <bmqp_ackeventbuilder.h>
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_confirmeventbuilder.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
@@ -396,6 +397,9 @@ struct TestSession BSLS_CPP11_FINAL {
     // Buffer factory provided to the
     // various builders
 
+    /// Blob pool used to provide blobs to event builders.
+    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+
     bdlmt::EventScheduler& d_scheduler;
     // event scheduler used in the
     // broker session
@@ -450,8 +454,8 @@ struct TestSession BSLS_CPP11_FINAL {
     // ACCESSORS
     bmqimp::BrokerSession&    session();
     bmqio::TestChannel&       channel();
-    bslma::Allocator*         allocator();
-    bdlbb::BlobBufferFactory& blobBufferFactory();
+    bslma::Allocator*               allocator();
+    bmqp::BlobPoolUtil::BlobSpPool& blobSpPool();
 
     // MANIPULATORS
 
@@ -838,11 +842,15 @@ TestSession::TestSession(const bmqt::SessionOptions& sessionOptions,
                          bslma::Allocator*           allocator)
 : d_allocator_p(allocator)
 , d_blobBufferFactory(1024, d_allocator_p)
+, d_blobSpPool(
+      bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
+                                         bmqtst::TestHelperUtil::allocator()))
 , d_scheduler(scheduler)
 , d_testChannel(d_allocator_p)
 , d_eventQueue(bsls::SystemClockType::e_MONOTONIC, d_allocator_p)
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,
+                  &d_blobSpPool,
                   sessionOptions,
                   useEventHandler
                       ? bdlf::BindUtil::bind(&sessionEventHandler,
@@ -870,11 +878,15 @@ TestSession::TestSession(const bmqt::SessionOptions& sessionOptions,
                          bslma::Allocator*           allocator)
 : d_allocator_p(allocator)
 , d_blobBufferFactory(1024, d_allocator_p)
+, d_blobSpPool(
+      bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
+                                         bmqtst::TestHelperUtil::allocator()))
 , d_scheduler(testClock.d_scheduler)
 , d_testChannel(d_allocator_p)
 , d_eventQueue(bsls::SystemClockType::e_MONOTONIC, d_allocator_p)
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,
+                  &d_blobSpPool,
                   sessionOptions,
                   useEventHandler
                       ? bdlf::BindUtil::bind(&sessionEventHandler,
@@ -926,9 +938,9 @@ bslma::Allocator* TestSession::allocator()
     return d_allocator_p;
 }
 
-bdlbb::BlobBufferFactory& TestSession::blobBufferFactory()
+bmqp::BlobPoolUtil::BlobSpPool& TestSession::blobSpPool()
 {
-    return d_blobBufferFactory;
+    return d_blobSpPool;
 }
 
 // MANIPULATORS
@@ -2426,7 +2438,9 @@ void TestSession::getOutboundControlMessage(
 void TestSession::sendControlMessage(
     const bmqp_ctrlmsg::ControlMessage& message)
 {
-    bmqp::SchemaEventBuilder builder(&d_blobBufferFactory, d_allocator_p);
+    bmqp::SchemaEventBuilder builder(&d_blobSpPool,
+                                     bmqp::EncodingType::e_BER,
+                                     d_allocator_p);
     int rc = builder.setMessage(message, bmqp::EventType::e_CONTROL);
     ASSERT_EQ(0, rc);
 
@@ -2820,6 +2834,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     sessionOptions.setNumProcessingThreads(1);
 
@@ -2830,6 +2848,7 @@ static void test1_breathingTest()
     bmqimp::BrokerSession session(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         emptyEventHandler,  // emptyEventHandler,
         bdlf::BindUtil::bind(&stateCb,
@@ -2884,6 +2903,10 @@ static void test2_basicAccessorsTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
 
     bdlmt::EventScheduler scheduler(bsls::SystemClockType::e_MONOTONIC,
@@ -2894,6 +2917,7 @@ static void test2_basicAccessorsTest()
 
     bmqimp::BrokerSession obj(&scheduler,
                               &blobBufferFactory,
+                              &blobSpPool,
                               sessionOptions,
                               emptyEventHandler,
                               emptyStateCb,
@@ -2930,6 +2954,10 @@ static void test3_nullChannelTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     bsls::AtomicInt                eventCounter(0);
     bsls::AtomicInt                startCounter(0);
@@ -2942,6 +2970,7 @@ static void test3_nullChannelTest()
     bmqimp::BrokerSession obj(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         bdlf::BindUtil::bind(&channelEventHandler,
                              bdlf::PlaceHolders::_1,
@@ -3024,6 +3053,10 @@ static void test4_createEventTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
 
     bmqimp::EventQueue::EventHandlerCallback emptyEventHandler;
@@ -3031,6 +3064,7 @@ static void test4_createEventTest()
 
     bmqimp::BrokerSession obj(&scheduler,
                               &blobBufferFactory,
+                              &blobSpPool,
                               sessionOptions,
                               emptyEventHandler,
                               emptyStateCb,
@@ -3048,6 +3082,10 @@ static void queueErrorsTest(bsls::Types::Uint64 queueFlags)
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     bmqt::QueueOptions             queueOptions;
     bsl::shared_ptr<bmqimp::Event> eventSp;
@@ -3077,6 +3115,7 @@ static void queueErrorsTest(bsls::Types::Uint64 queueFlags)
     bmqimp::BrokerSession session(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         eventCallback,
         bdlf::BindUtil::bind(&stateCb,
@@ -3279,6 +3318,10 @@ static void test6_setChannelTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     bsls::AtomicInt                eventCounter(0);
     bsls::AtomicInt                startCounter(0);
@@ -3292,6 +3335,7 @@ static void test6_setChannelTest()
     bmqimp::BrokerSession obj(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         bdlf::BindUtil::bind(&channelSetEventHandler,
                              bdlf::PlaceHolders::_1,
@@ -3945,6 +3989,10 @@ static void test11_disconnect()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlcc::Deque<bsl::shared_ptr<bmqimp::Event> > eventQueue(
         bsls::SystemClockType::e_MONOTONIC,
         bmqtst::TestHelperUtil::allocator());
@@ -3967,6 +4015,7 @@ static void test11_disconnect()
         bmqimp::BrokerSession obj(
             &scheduler,
             &blobBufferFactory,
+            &blobSpPool,
             options,
             bdlf::BindUtil::bind(&sessionEventHandler,
                                  &eventQueue,
@@ -4032,7 +4081,8 @@ static void test11_disconnect()
             disconnectMessage.rId().value());
         disconnectResponseMessage.choice().makeDisconnectResponse();
 
-        bmqp::SchemaEventBuilder builder(&blobBufferFactory,
+        bmqp::SchemaEventBuilder builder(&blobSpPool,
+                                         bmqp::EncodingType::e_BER,
                                          bmqtst::TestHelperUtil::allocator());
         rc = builder.setMessage(disconnectResponseMessage,
                                 bmqp::EventType::e_CONTROL);
@@ -4072,6 +4122,7 @@ static void test11_disconnect()
         bmqimp::BrokerSession obj(
             &scheduler,
             &blobBufferFactory,
+            &blobSpPool,
             options,
             bmqimp::EventQueue::EventHandlerCallback(),
             bdlf::BindUtil::bind(&stateCb,
@@ -4132,7 +4183,8 @@ static void test11_disconnect()
             disconnectMessage.rId().value());
         disconnectResponseMessage.choice().makeDisconnectResponse();
 
-        bmqp::SchemaEventBuilder builder(&blobBufferFactory,
+        bmqp::SchemaEventBuilder builder(&blobSpPool,
+                                         bmqp::EncodingType::e_BER,
                                          bmqtst::TestHelperUtil::allocator());
         rc = builder.setMessage(disconnectResponseMessage,
                                 bmqp::EventType::e_CONTROL);
@@ -4692,7 +4744,7 @@ static void test21_post_Limit()
 
     PVV_SAFE("Step 4. Create and post PUT message");
     bmqp::Crc32c::initialize();
-    bmqp::PutEventBuilder builder(&obj.blobBufferFactory(), obj.allocator());
+    bmqp::PutEventBuilder builder(&obj.blobSpPool(), obj.allocator());
 
     const char* k_PAYLOAD     = "abcdefghijklmnopqrstuvwxyz";
     const int   k_PAYLOAD_LEN = bsl::strlen(k_PAYLOAD);
@@ -4829,8 +4881,7 @@ static void test22_confirm_Limit()
     obj.channel().setWriteStatus(bmqio::StatusCategory::e_LIMIT);
 
     PVV_SAFE("Step 4. Create the blob and confirm messages");
-    bmqp::ConfirmEventBuilder builder(&obj.blobBufferFactory(),
-                                      obj.allocator());
+    bmqp::ConfirmEventBuilder builder(&obj.blobSpPool(), obj.allocator());
 
     int rc = builder.appendMessage(pQueue->id(),
                                    pQueue->subQueueId(),
@@ -5713,6 +5764,10 @@ static void test25_sessionFsmTable()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     sessionOptions.setNumProcessingThreads(1).setHostHealthMonitor(monitor_sp);
 
@@ -5727,6 +5782,7 @@ static void test25_sessionFsmTable()
     bmqimp::BrokerSession obj(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         emptyEventHandler,  // emptyEventHandler,
         bdlf::BindUtil::bind(&transitionCb,
@@ -6641,7 +6697,11 @@ static void test33_queueNackTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder          eventBuilder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder          eventBuilder(&blobSpPool,
                                        bmqtst::TestHelperUtil::allocator());
     const bmqt::CorrelationId      corrId(243);
     bmqt::MessageGUID     guid = bmqp::MessageGUIDGenerator::testGUID();
@@ -7731,6 +7791,10 @@ static void test40_syncCalledFromEventHandler()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &blobBufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqt::SessionOptions           sessionOptions;
     bmqt::QueueOptions             queueOptions;
     bsl::shared_ptr<bmqimp::Event> eventSp;
@@ -7754,6 +7818,7 @@ static void test40_syncCalledFromEventHandler()
     bmqimp::BrokerSession session(
         &scheduler,
         &blobBufferFactory,
+        &blobSpPool,
         sessionOptions,
         bdlf::BindUtil::bind(&eventHandlerSyncCall,
                              &eventSp,
@@ -9028,11 +9093,15 @@ static void test50_putRetransmittingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder     putEventBuilder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder     putEventBuilder(&blobSpPool,
                                           bmqtst::TestHelperUtil::allocator());
     bmqp::PutMessageIterator  putIter(&bufferFactory,
                                      bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder     ackEventBuilder(&bufferFactory,
+    bmqp::AckEventBuilder     ackEventBuilder(&blobSpPool,
                                           bmqtst::TestHelperUtil::allocator());
     bmqp::Event               rawEvent(bmqtst::TestHelperUtil::allocator());
     const bmqt::CorrelationId corrIdFirst(243);
@@ -9317,7 +9386,11 @@ static void test51_putRetransmittingNoAckTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder     putEventBuilder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder     putEventBuilder(&blobSpPool,
                                           bmqtst::TestHelperUtil::allocator());
     bmqp::PutMessageIterator  putIter(&bufferFactory,
                                      bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqimp/bmqimp_event.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.cpp
@@ -293,16 +293,17 @@ Event& Event::configureAsMessageEvent(const bmqp::Event& rawEvent)
     return *this;
 }
 
-Event& Event::configureAsMessageEvent(bdlbb::BlobBufferFactory* bufferFactory)
+Event&
+Event::configureAsMessageEvent(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(type() == EventType::e_UNINITIALIZED);
-    BSLS_ASSERT_SAFE(bufferFactory);
+    BSLS_ASSERT_SAFE(blobSpPool_p);
 
     d_type         = EventType::e_MESSAGE;
     d_msgEventMode = MessageEventMode::e_WRITE;
     new (d_putEventBuilderBuffer.buffer())
-        bmqp::PutEventBuilder(bufferFactory, d_allocator_p);
+        bmqp::PutEventBuilder(blobSpPool_p, d_allocator_p);
     d_isPutEventBuilderConstructed = true;
 
     return *this;

--- a/src/groups/bmq/bmqimp/bmqimp_event.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.cpp
@@ -320,7 +320,7 @@ Event& Event::downgradeMessageEventModeToRead()
 
     d_msgEventMode = MessageEventMode::e_READ;
 
-    d_rawEvent.reset(&(d_putEventBuilderBuffer.object().blob()));
+    d_rawEvent.reset(d_putEventBuilderBuffer.object().blob().get());
 
     BSLS_ASSERT(d_rawEvent.isPutEvent());
     // Only PUT events can be built via SDK

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -332,11 +332,12 @@ class Event {
     Event& configureAsMessageEvent(const bmqp::Event& rawEvent);
 
     /// Configure this instance as a message event in write mode with the
-    /// specified `bufferFactory` to allocate blob buffers when needed.
+    /// specified `blobSpPool_p` to allocate shared pointers to blobs.
     /// Behavior is undefined unless `bufferFactory` points to a valid blob
     /// buffer factory.  Also change the type of this Event to be
     /// `MESSAGEEVENT`, and type of message event mode to `WRITE`.
-    Event& configureAsMessageEvent(bdlbb::BlobBufferFactory* bufferFactory);
+    Event&
+    configureAsMessageEvent(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p);
 
     /// Change the message event mode with which this instance is currently
     /// configured to MessageEventMode::READ *without* *any* modification to

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -1209,8 +1209,8 @@ static void test8_putEventBuilder()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = builder.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(builder.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     ASSERT(rawEvent.isValid());
     ASSERT(rawEvent.isPutEvent());

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -767,6 +767,10 @@ static void test6_comparisonOperatorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqimp::Event obj1(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqimp::Event obj2(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqt::SessionEventType::Enum   sessionType =
@@ -807,8 +811,8 @@ static void test6_comparisonOperatorTest()
     PV("Configure as MesageEvent");
     bmqimp::Event obj3(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqimp::Event obj4(&bufferFactory, bmqtst::TestHelperUtil::allocator());
-    obj3.configureAsMessageEvent(&bufferFactory);
-    obj4.configureAsMessageEvent(&bufferFactory);
+    obj3.configureAsMessageEvent(&blobSpPool);
+    obj4.configureAsMessageEvent(&blobSpPool);
 
     // NOTE: Message event can not be equal. Is it expected?
     ASSERT(obj3 != obj4);
@@ -1101,6 +1105,10 @@ static void test8_putEventBuilder()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 #ifdef BMQ_ENABLE_MSG_GROUPID
     const bmqp::Protocol::MsgGroupId k_MSG_GROUP_ID(
         "gid:0",
@@ -1129,7 +1137,7 @@ static void test8_putEventBuilder()
 
     // Create PutEventBuilder
     bmqimp::Event obj(&bufferFactory, bmqtst::TestHelperUtil::allocator());
-    obj.configureAsMessageEvent(&bufferFactory);
+    obj.configureAsMessageEvent(&blobSpPool);
     bmqp::PutEventBuilder& builder = *(obj.putEventBuilder());
 
     builder.startMessage();
@@ -1551,12 +1559,16 @@ static void test12_upgradeDowngradeMessageEvent()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     // 1. Create session event
     bmqimp::Event obj(&bufferFactory, bmqtst::TestHelperUtil::allocator());
 
     // 2. Configure event as message event in WRITE mode.
-    obj.configureAsMessageEvent(&bufferFactory);
+    obj.configureAsMessageEvent(&blobSpPool);
     ASSERT_EQ(bmqimp::Event::MessageEventMode::e_WRITE,
               obj.messageEventMode());
 

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
@@ -285,7 +285,7 @@ static void test2_capacityTest()
                            bmqtst::TestHelperUtil::allocator());
 
     builder.startMessage();
-    const bdlbb::Blob& eventBlob = builder.blob();
+    const bdlbb::Blob& eventBlob = *builder.blob();
 
     bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
     bsl::shared_ptr<bmqimp::Event> event;
@@ -630,7 +630,7 @@ static void test6_workingStatsTest()
     obj.initializeStats(&rootStatContext, start, end);
 
     builder.startMessage();
-    const bdlbb::Blob& eventBlob = builder.blob();
+    const bdlbb::Blob& eventBlob = *builder.blob();
 
     bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
     bsl::shared_ptr<bmqimp::Event> event;

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
@@ -260,7 +260,11 @@ static void test2_capacityTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder         builder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder         builder(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bmqimp::EventQueue::EventPool eventPool(
         bdlf::BindUtil::bind(&poolCreateEvent,
@@ -563,7 +567,11 @@ static void test6_workingStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder         builder(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder         builder(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bmqimp::EventQueue::EventPool eventPool(
         bdlf::BindUtil::bind(&poolCreateEvent,

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -140,6 +140,9 @@ struct Tester BSLS_CPP11_FINAL {
     // Buffer factory provided to the
     // various builders
 
+    /// Blob shared pointer pool used in event builders.
+    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+
     bmqp::PushEventBuilder d_pushEventBuilder;
     // PUSH event builder
 
@@ -333,10 +336,11 @@ Tester::Tester(bslma::Allocator* allocator)
 , d_nextCorrelationId(0)
 , d_time(0, 0)
 , d_bufferFactory(1024, allocator)
-, d_pushEventBuilder(&d_bufferFactory, allocator)
-, d_ackEventBuilder(&d_bufferFactory, allocator)
-, d_putEventBuilder(&d_bufferFactory, allocator)
-, d_confirmEventBuilder(&d_bufferFactory, allocator)
+, d_blobSpPool(bmqp::BlobPoolUtil::createBlobPool(&d_bufferFactory, allocator))
+, d_pushEventBuilder(&d_blobSpPool, allocator)
+, d_ackEventBuilder(&d_blobSpPool, allocator)
+, d_putEventBuilder(&d_blobSpPool, allocator)
+, d_confirmEventBuilder(&d_blobSpPool, allocator)
 , d_allocator_p(allocator)
 {
     bmqsys::Time::initialize(

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -657,7 +657,7 @@ bmqp::Event& Tester::pushEvent(bmqp::Event* event) const
     // PRECONDITIONS
     BSLS_ASSERT_OPT(event && "'event' must be provided");
 
-    event->reset(&d_pushEventBuilder.blob(), true);
+    event->reset(d_pushEventBuilder.blob().get(), true);
 
     return *event;
 }
@@ -667,7 +667,7 @@ bmqp::Event& Tester::ackEvent(bmqp::Event* event) const
     // PRECONDITIONS
     BSLS_ASSERT_OPT(event && "'event' must be provided");
 
-    event->reset(&d_ackEventBuilder.blob(), true);
+    event->reset(d_ackEventBuilder.blob().get(), true);
 
     return *event;
 }
@@ -677,7 +677,7 @@ bmqp::Event& Tester::putEvent(bmqp::Event* event) const
     // PRECONDITIONS
     BSLS_ASSERT_OPT(event && "'event' must be provided");
 
-    event->reset(&d_putEventBuilder.blob(), true);
+    event->reset(d_putEventBuilder.blob().get(), true);
 
     return *event;
 }
@@ -687,7 +687,7 @@ bmqp::Event& Tester::confirmEvent(bmqp::Event* event) const
     // PRECONDITIONS
     BSLS_ASSERT_OPT(event && "'event' must be provided");
 
-    event->reset(&d_confirmEventBuilder.blob(), true);
+    event->reset(d_confirmEventBuilder.blob().get(), true);
 
     return *event;
 }

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
@@ -67,11 +67,13 @@ NegotiatedChannelFactoryConfig::NegotiatedChannelFactoryConfig(
     const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
     const bsls::TimeInterval&               negotiationTimeout,
     bdlbb::BlobBufferFactory*               bufferFactory,
+    BlobSpPool*                             blobSpPool_p,
     bslma::Allocator*                       basicAllocator)
 : d_baseFactory_p(base)
 , d_negotiationMessage(negotiationMessage, basicAllocator)
 , d_negotiationTimeout(negotiationTimeout)
 , d_bufferFactory_p(bufferFactory)
+, d_blobSpPool_p(blobSpPool_p)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     // PRECONDITIONS
@@ -86,6 +88,7 @@ NegotiatedChannelFactoryConfig::NegotiatedChannelFactoryConfig(
 , d_negotiationMessage(original.d_negotiationMessage, basicAllocator)
 , d_negotiationTimeout(original.d_negotiationTimeout)
 , d_bufferFactory_p(original.d_bufferFactory_p)
+, d_blobSpPool_p(original.d_blobSpPool_p)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     // NOTHING
@@ -124,9 +127,9 @@ void NegotiatedChannelFactory::negotiate(
 {
     static const bmqp::EncodingType::Enum k_DEFAULT_ENCODING =
         bmqp::EncodingType::e_BER;
-    bmqp::SchemaEventBuilder builder(d_config.d_bufferFactory_p,
-                                     d_config.d_allocator_p,
-                                     k_DEFAULT_ENCODING);
+    bmqp::SchemaEventBuilder builder(d_config.d_blobSpPool_p,
+                                     k_DEFAULT_ENCODING,
+                                     d_config.d_allocator_p);
     const int rc = builder.setMessage(d_config.d_negotiationMessage,
                                       bmqp::EventType::e_CONTROL);
     if (rc != 0) {

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
@@ -66,19 +66,16 @@ NegotiatedChannelFactoryConfig::NegotiatedChannelFactoryConfig(
     bmqio::ChannelFactory*                  base,
     const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
     const bsls::TimeInterval&               negotiationTimeout,
-    bdlbb::BlobBufferFactory*               bufferFactory,
     BlobSpPool*                             blobSpPool_p,
     bslma::Allocator*                       basicAllocator)
 : d_baseFactory_p(base)
 , d_negotiationMessage(negotiationMessage, basicAllocator)
 , d_negotiationTimeout(negotiationTimeout)
-, d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool_p)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     // PRECONDITIONS
     BSLS_ASSERT(base);
-    BSLS_ASSERT(bufferFactory);
 }
 
 NegotiatedChannelFactoryConfig::NegotiatedChannelFactoryConfig(
@@ -87,7 +84,6 @@ NegotiatedChannelFactoryConfig::NegotiatedChannelFactoryConfig(
 : d_baseFactory_p(original.d_baseFactory_p)
 , d_negotiationMessage(original.d_negotiationMessage, basicAllocator)
 , d_negotiationTimeout(original.d_negotiationTimeout)
-, d_bufferFactory_p(original.d_bufferFactory_p)
 , d_blobSpPool_p(original.d_blobSpPool_p)
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
@@ -146,8 +142,8 @@ void NegotiatedChannelFactory::negotiate(
                   << "': " << d_config.d_negotiationMessage;
     bmqio::Status status;
     BALL_LOG_TRACE << "Sending blob:\n"
-                   << bmqu::BlobStartHexDumper(&builder.blob());
-    channel->write(&status, builder.blob());
+                   << bmqu::BlobStartHexDumper(builder.blob().get());
+    channel->write(&status, *builder.blob());
     if (!status) {
         BALL_LOG_ERROR << "Negotiation failed [reason: 'failed sending packet'"
                        << ", status: " << status << "]";

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
@@ -30,14 +30,13 @@
 // peer on top of a channel created using a base 'bmqio::ChannelFactory'.
 
 // BMQ
-
-#include <bmqp_ctrlmsg_messages.h>
-
 #include <bmqio_channel.h>
 #include <bmqio_channelfactory.h>
 #include <bmqio_connectoptions.h>
 #include <bmqio_listenoptions.h>
 #include <bmqio_status.h>
+#include <bmqp_blobpoolutil.h>
+#include <bmqp_ctrlmsg_messages.h>
 #include <bmqu_sharedresource.h>
 
 // BDE
@@ -59,12 +58,17 @@ namespace bmqimp {
 
 /// Configuration for a `NegotiatedChannelFactory`.
 class NegotiatedChannelFactoryConfig {
+  public:
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // PRIVATE DATA
     bmqio::ChannelFactory*           d_baseFactory_p;
     bmqp_ctrlmsg::NegotiationMessage d_negotiationMessage;
     bsls::TimeInterval               d_negotiationTimeout;
     bdlbb::BlobBufferFactory*        d_bufferFactory_p;
+    BlobSpPool*                      d_blobSpPool_p;
     bslma::Allocator*                d_allocator_p;
 
     // FRIENDS
@@ -81,6 +85,7 @@ class NegotiatedChannelFactoryConfig {
         const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
         const bsls::TimeInterval&               negotiationTimeout,
         bdlbb::BlobBufferFactory*               bufferFactory,
+        BlobSpPool*                             blobSpPool_p,
         bslma::Allocator*                       basicAllocator = 0);
 
     NegotiatedChannelFactoryConfig(

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
@@ -67,7 +67,6 @@ class NegotiatedChannelFactoryConfig {
     bmqio::ChannelFactory*           d_baseFactory_p;
     bmqp_ctrlmsg::NegotiationMessage d_negotiationMessage;
     bsls::TimeInterval               d_negotiationTimeout;
-    bdlbb::BlobBufferFactory*        d_bufferFactory_p;
     BlobSpPool*                      d_blobSpPool_p;
     bslma::Allocator*                d_allocator_p;
 
@@ -84,7 +83,6 @@ class NegotiatedChannelFactoryConfig {
         bmqio::ChannelFactory*                  base,
         const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
         const bsls::TimeInterval&               negotiationTimeout,
-        bdlbb::BlobBufferFactory*               bufferFactory,
         BlobSpPool*                             blobSpPool_p,
         bslma::Allocator*                       basicAllocator = 0);
 

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
@@ -629,8 +629,8 @@ static void test9_pushStatsTest()
 
     BSLS_ASSERT_SAFE(rc == bmqt::EventBuilderResult::e_SUCCESS);
 
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -738,8 +738,8 @@ static void test10_putStatsTest()
 
     BSLS_ASSERT_SAFE(rc == bmqt::EventBuilderResult::e_SUCCESS);
 
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPutEvent());

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
@@ -590,7 +590,11 @@ static void test9_pushStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqt::Uri   uri(k_URI, bmqtst::TestHelperUtil::allocator());
@@ -704,7 +708,11 @@ static void test10_putStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder peb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder peb(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bmqt::Uri             uri(k_URI, bmqtst::TestHelperUtil::allocator());
     bmqimp::QueueManager::QueueSp  queueSp;

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
@@ -38,10 +38,18 @@ AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
                                  bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
 , d_blob_sp(0, allocator)  // initialized in `reset()`
+, d_emptyBlob_sp(blobSpPool_p->getObject())
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
+
+    // Assume that items built with the given `blobSpPool_p` either all have or
+    // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
+    // We require this since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_emptyBlob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();
 }
@@ -49,11 +57,6 @@ AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
 void AckEventBuilder::reset()
 {
     d_blob_sp = d_blobSpPool_p->getObject();
-
-    // The following prerequisite is necessary since we do `Blob::setLength`:
-    BSLS_ASSERT_SAFE(
-        NULL != d_blob_sp->factory() &&
-        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     d_msgCount = 0;
 
@@ -114,7 +117,7 @@ AckEventBuilder::appendMessage(int                      status,
     return bmqt::EventBuilderResult::e_SUCCESS;
 }
 
-const bdlbb::Blob& AckEventBuilder::blob() const
+const bsl::shared_ptr<bdlbb::Blob>& AckEventBuilder::blob() const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
@@ -122,27 +125,7 @@ const bdlbb::Blob& AckEventBuilder::blob() const
     // Empty event
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return ProtocolUtil::emptyBlob();  // RETURN
-    }
-
-    // Fix packet's length in header now that we know it.  Following is valid
-    // (see comment in reset).
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(
-        d_blob_sp->buffer(0).data());
-    eh.setLength(d_blob_sp->length());
-
-    return *d_blob_sp;
-}
-
-bsl::shared_ptr<bdlbb::Blob> AckEventBuilder::blob_sp() const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
-
-    // Empty event
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return bsl::shared_ptr<bdlbb::Blob>();  // RETURN
+        return d_emptyBlob_sp;  // RETURN
     }
 
     // Fix packet's length in header now that we know it.  Following is valid

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
@@ -37,12 +37,14 @@ namespace bmqp {
 AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
                                  bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
-, d_blob_sp(0, allocator)  // initialized in `reset()`
-, d_emptyBlob_sp(blobSpPool_p->getObject())
+, d_blob_sp(0, allocator)       // initialized in `reset()`
+, d_emptyBlob_sp(0, allocator)  // initialized later in constructor
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
+
+    d_emptyBlob_sp = blobSpPool_p->getObject();
 
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
@@ -57,7 +57,7 @@
 //..
 
 // BMQ
-
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_protocol.h>
 #include <bmqt_messageguid.h>
 #include <bmqt_resultcode.h>
@@ -80,12 +80,19 @@ namespace bmqp {
 
 /// Mechanism to build a BlazingMQ ACK event
 class AckEventBuilder BSLS_CPP11_FINAL {
+  public:
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // DATA
-    mutable bdlbb::Blob d_blob;  // blob being built by this object.
-                                 // This has been done mutable to be able to
-                                 // skip writing the length until the blob
-                                 // is retrieved.
+    /// Blob pool to use.  Held, not owned.
+    BlobSpPool* d_blobSpPool_p;
+
+    /// Blob being built by this object.
+    /// `mutable` to skip writing the length until the blob is retrieved.
+    mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
+
     int d_msgCount;              // number of messages currently in the
                                  // event
 
@@ -103,10 +110,11 @@ class AckEventBuilder BSLS_CPP11_FINAL {
   public:
     // CREATORS
 
-    /// Create a new `AckEventBuilder` using the specified `bufferFactory`
-    /// and `allocator` for the blob.
-    AckEventBuilder(bdlbb::BlobBufferFactory* bufferFactory,
-                    bslma::Allocator*         allocator);
+    /// Create a new `PushEventBuilder` using the specified `blobSpPool_p` and
+    /// `allocator` for the blob.  We require BlobSpPool to build Blobs with
+    /// set BlobBufferFactory since we might want to expand the built Blob
+    /// dynamically.
+    AckEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
 
     // MANIPULATORS
 
@@ -141,6 +149,13 @@ class AckEventBuilder BSLS_CPP11_FINAL {
     /// by this event.  If no messages were added, this will return an empty
     /// blob, i.e., a blob with length == 0.
     const bdlbb::Blob& blob() const;
+
+    /// Return a shared pointer to the built Blob.  If no messages were added,
+    /// this will return an empty shared pointer.
+    /// Note that a shared pointer is returned by value, so the user holds to
+    /// the copy of a pointer.  The Blob in that copy will be valid even if we
+    /// `reset` this builder and modify the internal shared pointer.
+    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
 };
 
 // ============================================================================
@@ -171,7 +186,7 @@ inline int AckEventBuilder::eventSize() const
         return 0;  // RETURN
     }
 
-    return d_blob.length();
+    return d_blob_sp->length();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
@@ -41,18 +41,22 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::BlobPooledBlobBufferFactory bufferFactory(1024, d_allocator_p);
-//  bmqp::AckEventBuilder builder(&bufferFactory, d_allocator_p);
+//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
+//  bmqp::AckEventBuilder builder(&blobSpPool, d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.appendMessage(0, 1, bmqt::MessageGUID(), 1);
 //  builder.appendMessage(-1, 2, bmqt::MessageGUID(), 1);
 //
-//  const bdlbb::Blob& eventBlob = builder.blob();
+//  const bsl::shared_ptr<bdlbb::Blob>& eventBlob = builder.blob();
 //  // Send the blob ...
 //
 //  // We can reset the builder to reuse it; note that this invalidates the
-//  // 'eventBlob' retrieved above
+//  // 'eventBlob' shared pointer reference retrieved above.  To keep the
+//  // bdlbb::Blob valid the shared pointer should be copied, and the copy
+//  // should be passed and kept in IO components.
 //  builder.reset();
 //..
 
@@ -93,6 +97,9 @@ class AckEventBuilder BSLS_CPP11_FINAL {
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
+    /// Empty blob to be returned when no messages were added to this builder.
+    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
+
     int d_msgCount;              // number of messages currently in the
                                  // event
 
@@ -110,7 +117,7 @@ class AckEventBuilder BSLS_CPP11_FINAL {
   public:
     // CREATORS
 
-    /// Create a new `PushEventBuilder` using the specified `blobSpPool_p` and
+    /// Create a new `AckEventBuilder` using the specified `blobSpPool_p` and
     /// `allocator` for the blob.  We require BlobSpPool to build Blobs with
     /// set BlobBufferFactory since we might want to expand the built Blob
     /// dynamically.
@@ -145,17 +152,13 @@ class AckEventBuilder BSLS_CPP11_FINAL {
     /// were added, this will return 0.
     int eventSize() const;
 
-    /// Return a reference not offering modifiable access to the blob built
-    /// by this event.  If no messages were added, this will return an empty
-    /// blob, i.e., a blob with length == 0.
-    const bdlbb::Blob& blob() const;
-
-    /// Return a shared pointer to the built Blob.  If no messages were added,
-    /// this will return an empty shared pointer.
-    /// Note that a shared pointer is returned by value, so the user holds to
-    /// the copy of a pointer.  The Blob in that copy will be valid even if we
-    /// `reset` this builder and modify the internal shared pointer.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    /// Return a reference to the shared pointer to the built Blob.  If no
+    /// messages were added, the Blob object under this reference will be
+    /// empty.
+    /// Note that this accessor exposes an internal shared pointer object, and
+    /// it is the user's responsibility to make a copy of it if it needs to be
+    /// passed and kept in another thread while this builder object is used.
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
@@ -97,10 +97,11 @@ static void verifyContent(const bmqp::AckEventBuilder& builder,
                           (data.size() * sizeof(bmqp::AckMessage));
     ASSERT_EQ(static_cast<size_t>(builder.messageCount()), data.size());
     ASSERT_EQ(static_cast<size_t>(builder.eventSize()), expectedSize);
-    ASSERT_EQ(static_cast<size_t>(builder.blob().length()), expectedSize);
+    ASSERT_EQ(static_cast<size_t>(builder.blob()->length()), expectedSize);
 
     PVV("Iterating over messages");
-    bmqp::Event event(&builder.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event event(builder.blob().get(),
+                      bmqtst::TestHelperUtil::allocator());
 
     ASSERT_EQ(event.isValid(), true);
     ASSERT_EQ(event.isAckEvent(), true);
@@ -152,7 +153,7 @@ static void test1_breathingTest()
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_NE(obj.maxMessageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PVV("Appending one message");
     appendMessages(&obj, &messages, 1);
@@ -211,7 +212,7 @@ static void test3_reset()
     PV("Verifying accessors");
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PV("Appending another message");
     messages.clear();
@@ -323,7 +324,7 @@ static void testN1_decodeFromFile()
 
     BSLS_ASSERT(ofile.good() == true);
 
-    bdlbb::BlobUtil::copy(buf, obj.blob(), 0, obj.blob().length());
+    bdlbb::BlobUtil::copy(buf, *obj.blob(), 0, obj.blob()->length());
     ofile.write(buf, k_SIZE);
     ofile.close();
     bsl::memset(buf, 0, k_SIZE);
@@ -342,9 +343,9 @@ static void testN1_decodeFromFile()
     bdlbb::BlobBuffer     dataBlobBuffer(dataBufferSp, k_SIZE);
 
     outBlob.appendDataBuffer(dataBlobBuffer);
-    outBlob.setLength(obj.blob().length());
+    outBlob.setLength(obj.blob()->length());
 
-    ASSERT_EQ(bdlbb::BlobUtil::compare(obj.blob(), outBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*obj.blob(), outBlob), 0);
 
     // Decode event
     bmqp::Event event(&outBlob, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
@@ -140,7 +140,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -167,7 +171,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -186,7 +194,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -218,7 +230,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -272,7 +288,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::AckEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::AckEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
@@ -1,0 +1,62 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqp_blobpoolutil.cpp                                              -*-C++-*-
+#include <bmqp_blobpoolutil.h>
+
+#include <bmqscm_version.h>
+
+// BDE
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace bmqp {
+
+namespace {
+const int k_BLOB_POOL_GROWTH_STRATEGY = 1024;
+
+/// Create a new blob at the specified `arena` address, using the specified
+/// `bufferFactory` and `allocator`.
+void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
+                void*                     arena,
+                bslma::Allocator*         allocator)
+{
+    new (arena) bdlbb::Blob(bufferFactory, allocator);
+}
+
+}  // close unnamed namespace
+
+// ------------------
+// class BlobPoolUtil
+// ------------------
+
+BlobPoolUtil::BlobSpPool
+BlobPoolUtil::createBlobPool(bdlbb::BlobBufferFactory* blobBufferFactory_p,
+                             bslma::Allocator*         allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT(blobBufferFactory_p);
+
+    return BlobSpPool(
+        bdlf::BindUtil::bind(&createBlob,
+                             blobBufferFactory_p,
+                             bdlf::PlaceHolders::_1,   // arena
+                             bdlf::PlaceHolders::_2),  // allocator
+        k_BLOB_POOL_GROWTH_STRATEGY,
+        bslma::Default::allocator(allocator));
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqp/bmqp_blobpoolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_blobpoolutil.h
@@ -1,0 +1,60 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqp_blobpoolutil.h                                                -*-C++-*-
+#ifndef INCLUDED_BMQP_BLOBPOOLUTIL
+#define INCLUDED_BMQP_BLOBPOOLUTIL
+
+//@PURPOSE: Provide a mechanism to build Blob shared pointer pools compatible
+//  with event builders used in BlazingMQ.
+//
+//@CLASSES:
+//  bmqp::BlobPoolUtil: mechanism to build bdlbb::Blob shared pointer pool.
+//
+//@DESCRIPTION:
+//
+
+// BDE
+#include <bdlbb_blob.h>
+#include <bdlcc_sharedobjectpool.h>
+#include <bslma_allocator.h>
+
+namespace BloombergLP {
+namespace bmqp {
+
+struct BlobPoolUtil {
+    // TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
+
+    // CLASS METHODS
+
+    /// Create a blob shared pointer pool, using the specified
+    /// `blobBufferFactory_p`.  Use the optionally specified `allocator`
+    /// for memory allocations.
+    static BlobSpPool
+    createBlobPool(bdlbb::BlobBufferFactory* blobBufferFactory_p,
+                   bslma::Allocator*         allocator = 0);
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.cpp
@@ -38,10 +38,18 @@ ConfirmEventBuilder::ConfirmEventBuilder(BlobSpPool*       blobSpPool_p,
                                          bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
 , d_blob_sp(0, allocator)  // initialized in `reset()`
+, d_emptyBlob_sp(blobSpPool_p->getObject())
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
+
+    // Assume that items built with the given `blobSpPool_p` either all have or
+    // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
+    // We require this since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_emptyBlob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();
 }
@@ -49,11 +57,6 @@ ConfirmEventBuilder::ConfirmEventBuilder(BlobSpPool*       blobSpPool_p,
 void ConfirmEventBuilder::reset()
 {
     d_blob_sp = d_blobSpPool_p->getObject();
-
-    // The following prerequisite is necessary since we do `Blob::setLength`:
-    BSLS_ASSERT_SAFE(
-        NULL != d_blob_sp->factory() &&
-        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     d_msgCount = 0;
 
@@ -116,7 +119,7 @@ ConfirmEventBuilder::appendMessage(int                      queueId,
     return bmqt::EventBuilderResult::e_SUCCESS;
 }
 
-const bdlbb::Blob& ConfirmEventBuilder::blob() const
+const bsl::shared_ptr<bdlbb::Blob>& ConfirmEventBuilder::blob() const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
@@ -124,27 +127,7 @@ const bdlbb::Blob& ConfirmEventBuilder::blob() const
     // Empty event
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return ProtocolUtil::emptyBlob();  // RETURN
-    }
-
-    // Fix packet's length in header now that we know it.  Following is valid
-    // (see comment in reset).
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(
-        d_blob_sp->buffer(0).data());
-    eh.setLength(d_blob_sp->length());
-
-    return *d_blob_sp;
-}
-
-bsl::shared_ptr<bdlbb::Blob> ConfirmEventBuilder::blob_sp() const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
-
-    // Empty event
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return bsl::shared_ptr<bdlbb::Blob>();  // RETURN
+        return d_emptyBlob_sp;  // RETURN
     }
 
     // Fix packet's length in header now that we know it.  Following is valid

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.cpp
@@ -37,12 +37,14 @@ namespace bmqp {
 ConfirmEventBuilder::ConfirmEventBuilder(BlobSpPool*       blobSpPool_p,
                                          bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
-, d_blob_sp(0, allocator)  // initialized in `reset()`
-, d_emptyBlob_sp(blobSpPool_p->getObject())
+, d_blob_sp(0, allocator)       // initialized in `reset()`
+, d_emptyBlob_sp(0, allocator)  // initialized later in constructor
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
+
+    d_emptyBlob_sp = blobSpPool_p->getObject();
 
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.h
@@ -41,18 +41,22 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::BlobPooledBlobBufferFactory bufferFactory(1024, d_allocator_p);
-//  bmqp::ConfirmEventBuilder builder(&bufferFactory, d_allocator_p);
+//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
+//  bmqp::ConfirmEventBuilder builder(&blobSpPool, d_allocator_p);
 //
 //  // Append multiple messages, from same or different queue
 //  builder.appendMessage(k_QUEUEID1, k_SUBQUEUEID1, bmqt::MessageGUID());
 //  builder.appendMessage(k_QUEUEID2, k_SUBQUEUEID2, bmqt::MessageGUID());
 //
-//  const bdlbb::Blob& eventBlob = builder.blob();
+//  const bsl::shared_ptr<bdlbb::Blob>& eventBlob = builder.blob();
 //  // Send the blob ...
 //
 //  // We can reset the builder to reuse it; note that this invalidates the
-//  // 'eventBlob' retrieved above
+//  // 'eventBlob' shared pointer reference retrieved above.  To keep the
+//  // bdlbb::Blob valid the shared pointer should be copied, and the copy
+//  // should be passed and kept in IO components.
 //  builder.reset();
 //
 //..
@@ -92,6 +96,9 @@ class ConfirmEventBuilder {
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
+    /// Empty blob to be returned when no messages were added to this builder.
+    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
+
     int d_msgCount;              // number of messages currently in the
                                  // event
 
@@ -111,9 +118,9 @@ class ConfirmEventBuilder {
   public:
     // CREATORS
 
-    /// Create a new `PushEventBuilder` using the specified `blobSpPool_p` and
-    /// `allocator` for the blob.  We require BlobSpPool to build Blobs with
-    /// set BlobBufferFactory since we might want to expand the built Blob
+    /// Create a new `ConfirmEventBuilder` using the specified `blobSpPool_p`
+    /// and `allocator` for the blob.  We require BlobSpPool to build Blobs
+    /// with set BlobBufferFactory since we might want to expand the built Blob
     /// dynamically.
     ConfirmEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
 
@@ -144,17 +151,13 @@ class ConfirmEventBuilder {
     /// were added, this will return 0.
     int eventSize() const;
 
-    /// Return a reference not offering modifiable access to the blob built
-    /// by this event.  If no messages were added, this will return an empty
-    /// blob, i.e., a blob with length == 0.
-    const bdlbb::Blob& blob() const;
-
-    /// Return a shared pointer to the built Blob.  If no messages were added,
-    /// this will return an empty shared pointer.
-    /// Note that a shared pointer is returned by value, so the user holds to
-    /// the copy of a pointer.  The Blob in that copy will be valid even if we
-    /// `reset` this builder and modify the internal shared pointer.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    /// Return a reference to the shared pointer to the built Blob.  If no
+    /// messages were added, the Blob object under this reference will be
+    /// empty.
+    /// Note that this accessor exposes an internal shared pointer object, and
+    /// it is the user's responsibility to make a copy of it if it needs to be
+    /// passed and kept in another thread while this builder object is used.
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
@@ -137,7 +137,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::ConfirmEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::ConfirmEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -164,7 +168,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::ConfirmEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::ConfirmEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -183,7 +191,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::ConfirmEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::ConfirmEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -215,7 +227,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::ConfirmEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::ConfirmEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -271,7 +287,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::ConfirmEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::ConfirmEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
@@ -95,10 +95,11 @@ static void verifyContent(const bmqp::ConfirmEventBuilder& builder,
                           (data.size() * sizeof(bmqp::ConfirmMessage));
     ASSERT_EQ(static_cast<size_t>(builder.messageCount()), data.size());
     ASSERT_EQ(static_cast<size_t>(builder.eventSize()), expectedSize);
-    ASSERT_EQ(static_cast<size_t>(builder.blob().length()), expectedSize);
+    ASSERT_EQ(static_cast<size_t>(builder.blob()->length()), expectedSize);
 
     PVV("Iterating over messages");
-    bmqp::Event event(&builder.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event event(builder.blob().get(),
+                      bmqtst::TestHelperUtil::allocator());
 
     ASSERT_EQ(event.isValid(), true);
     ASSERT_EQ(event.isConfirmEvent(), true);
@@ -149,7 +150,7 @@ static void test1_breathingTest()
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_NE(obj.maxMessageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PVV("Appending one message");
     appendMessages(&obj, &messages, 1);
@@ -208,7 +209,7 @@ static void test3_reset()
     PV("Verifying accessors");
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PV("Appending another message");
     messages.clear();
@@ -302,11 +303,11 @@ static void testN1_decodeFromFile()
     PVV("Appending messages");
     appendMessages(&obj, &messages, k_NUM_MSGS);
 
-    ASSERT_NE(obj.blob().length(), 0);
+    ASSERT_NE(obj.blob()->length(), 0);
 
     os << "msg_confirm_" << guid << ".bin" << bsl::ends;
 
-    const int blobLen = obj.blob().length();
+    const int blobLen = obj.blob()->length();
     char*     buf     = new char[blobLen];
 
     /// Functor invoked to delete the file at the specified `filePath`
@@ -326,7 +327,7 @@ static void testN1_decodeFromFile()
 
     BSLS_ASSERT(ofile.good() == true);
 
-    bdlbb::BlobUtil::copy(buf, obj.blob(), 0, blobLen);
+    bdlbb::BlobUtil::copy(buf, *obj.blob(), 0, blobLen);
     ofile.write(buf, blobLen);
     ofile.close();
     bsl::memset(buf, 0, blobLen);
@@ -347,7 +348,7 @@ static void testN1_decodeFromFile()
     outBlob.appendDataBuffer(dataBlobBuffer);
     outBlob.setLength(blobLen);
 
-    ASSERT_EQ(bdlbb::BlobUtil::compare(obj.blob(), outBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*obj.blob(), outBlob), 0);
 
     // Decode event
     bmqp::Event event(&outBlob, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_event.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_event.t.cpp
@@ -548,7 +548,7 @@ static void test4_eventLoading()
                                      test.d_encodingType,
                                      bmqtst::TestHelperUtil::allocator());
 
-        BSLS_ASSERT_OPT(obj.blob().length() == 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() == 0);
         {
             PVV(test.d_line << ": Create a control message");
 
@@ -561,12 +561,12 @@ static void test4_eventLoading()
             // Encode the message
             rc = obj.setMessage(ctrlMessage, bmqp::EventType::e_CONTROL);
             BSLS_ASSERT_OPT(rc == 0);
-            BSLS_ASSERT_OPT(obj.blob().length() > 0);
-            BSLS_ASSERT_OPT(obj.blob().length() % 4 == 0);
+            BSLS_ASSERT_OPT(obj.blob()->length() > 0);
+            BSLS_ASSERT_OPT(obj.blob()->length() % 4 == 0);
 
             PVV(test.d_line << ": Decode and compare message");
 
-            bmqp::Event ctrlEvent(&obj.blob(),
+            bmqp::Event ctrlEvent(obj.blob().get(),
                                   bmqtst::TestHelperUtil::allocator());
 
             ASSERT_EQ(ctrlEvent.isValid(), true);
@@ -586,14 +586,14 @@ static void test4_eventLoading()
         PVV(test.d_line << ": Reset");
 
         obj.reset();
-        BSLS_ASSERT_OPT(obj.blob().length() == 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() == 0);
     }
 
     {
         bmqp::SchemaEventBuilder obj(&blobSpPool,
                                      bmqp::EncodingType::e_BER,
                                      bmqtst::TestHelperUtil::allocator());
-        BSLS_ASSERT_OPT(obj.blob().length() == 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() == 0);
 
         PVV(L_ << ": Create an elector message");
 
@@ -604,12 +604,12 @@ static void test4_eventLoading()
         rc = obj.setMessage(electorMsg, bmqp::EventType::e_ELECTOR);
 
         BSLS_ASSERT_OPT(rc == 0);
-        BSLS_ASSERT_OPT(obj.blob().length() > 0);
-        BSLS_ASSERT_OPT(obj.blob().length() % 4 == 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() > 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() % 4 == 0);
 
         PVV(L_ << ": Decode and compare message");
 
-        bmqp::Event electorEvent(&obj.blob(),
+        bmqp::Event electorEvent(obj.blob().get(),
                                  bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(electorEvent.isValid());
@@ -624,7 +624,7 @@ static void test4_eventLoading()
         PVV(L_ << ": Reset");
 
         obj.reset();
-        BSLS_ASSERT_OPT(obj.blob().length() == 0);
+        BSLS_ASSERT_OPT(obj.blob()->length() == 0);
     }
 
     bmqp::ProtocolUtil::shutdown();

--- a/src/groups/bmq/bmqp/bmqp_event.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_event.t.cpp
@@ -524,6 +524,10 @@ static void test4_eventLoading()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     struct Test {
         int                      d_line;
@@ -540,9 +544,9 @@ static void test4_eventLoading()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << "encoding");
 
-        bmqp::SchemaEventBuilder obj(&bufferFactory,
-                                     bmqtst::TestHelperUtil::allocator(),
-                                     test.d_encodingType);
+        bmqp::SchemaEventBuilder obj(&blobSpPool,
+                                     test.d_encodingType,
+                                     bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(obj.blob().length() == 0);
         {
@@ -586,7 +590,8 @@ static void test4_eventLoading()
     }
 
     {
-        bmqp::SchemaEventBuilder obj(&bufferFactory,
+        bmqp::SchemaEventBuilder obj(&blobSpPool,
+                                     bmqp::EncodingType::e_BER,
                                      bmqtst::TestHelperUtil::allocator());
         BSLS_ASSERT_OPT(obj.blob().length() == 0);
 

--- a/src/groups/bmq/bmqp/bmqp_eventutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.cpp
@@ -60,6 +60,8 @@ BSLMF_ASSERT(Protocol::SubQueueIdsArrayOld::static_size >= 1);
 class Flattener {
   private:
     // PRIVATE TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
     enum RcEnum {
         // Value for the various RC error categories
         rc_SUCCESS = 0  // No error
@@ -180,10 +182,11 @@ class Flattener {
     // CREATORS
 
     /// Create a `Flattener` using the specified `eventInfos`, `event`,
-    /// `bufferFactory` and `allocator`
+    /// `blobSpPool_p`, `bufferFactory` and `allocator`
     Flattener(bsl::vector<EventUtilEventInfo>* eventInfos,
               const Event&                     event,
               bdlbb::BlobBufferFactory*        bufferFactory,
+              BlobSpPool*                      blobSpPool_p,
               bslma::Allocator*                allocator);
 
     // MANIPULATORS
@@ -400,10 +403,11 @@ void Flattener::advanceEvent()
 Flattener::Flattener(bsl::vector<EventUtilEventInfo>* eventInfos,
                      const Event&                     event,
                      bdlbb::BlobBufferFactory*        bufferFactory,
+                     BlobSpPool*                      blobSpPool_p,
                      bslma::Allocator*                allocator)
 : d_eventInfos_p(eventInfos)
 , d_allocator_p(allocator)
-, d_builder(bufferFactory, allocator)
+, d_builder(blobSpPool_p, allocator)
 , d_msgIterator(bufferFactory, allocator)
 , d_currEventInfo(allocator)
 , d_appData(bufferFactory, allocator)
@@ -486,6 +490,7 @@ int Flattener::flattenPushEvent()
 int EventUtil::flattenPushEvent(bsl::vector<EventUtilEventInfo>* eventInfos,
                                 const Event&                     event,
                                 bdlbb::BlobBufferFactory*        bufferFactory,
+                                BlobSpPool*                      blobSpPool_p,
                                 bslma::Allocator*                allocator)
 {
     // PRECONDITIONS
@@ -495,7 +500,11 @@ int EventUtil::flattenPushEvent(bsl::vector<EventUtilEventInfo>* eventInfos,
     BSLS_ASSERT_SAFE(bufferFactory);
     BSLS_ASSERT_SAFE(allocator);
 
-    Flattener flattener(eventInfos, event, bufferFactory, allocator);
+    Flattener flattener(eventInfos,
+                        event,
+                        bufferFactory,
+                        blobSpPool_p,
+                        allocator);
     return flattener.flattenPushEvent();
 }
 

--- a/src/groups/bmq/bmqp/bmqp_eventutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.cpp
@@ -394,7 +394,7 @@ void Flattener::advanceEvent()
     BSLS_ASSERT_SAFE(d_builder.messageCount() > 0);
     BSLS_ASSERT_SAFE(!d_currEventInfo.d_ids.empty());
 
-    d_eventInfos_p->emplace_back(d_builder.blob(), d_currEventInfo.d_ids);
+    d_eventInfos_p->emplace_back(*d_builder.blob(), d_currEventInfo.d_ids);
 
     d_currEventInfo.d_ids.clear();
     d_builder.reset();

--- a/src/groups/bmq/bmqp/bmqp_eventutil.h
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.h
@@ -30,12 +30,13 @@
 // Thread safe.
 
 // BMQ
-
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_protocol.h>
 #include <bmqp_queueid.h>
 
 // BDE
 #include <bdlbb_blob.h>
+#include <bdlcc_sharedobjectpool.h>
 #include <bsl_unordered_set.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
@@ -113,6 +114,9 @@ struct EventUtilEventInfo {
 
 /// Utilities for BlazingMQ protocol events.
 struct EventUtil {
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
     // CLASS METHODS
 
     /// PushEvent Utilities
@@ -125,10 +129,12 @@ struct EventUtil {
     /// case of failure.  The behavior is undefined unless the `event` is a
     /// valid push event.  Note that this function is exclusively used by
     /// the SDK and thus we can assume that the messages will only contain
-    /// old flavor of SubQueueIdsArray (i.e. SubQueueIdsArrayOld).
+    /// old flavor of SubQueueIdsArray (i.e. SubQueueIdsArrayOld).  Use the
+    /// specified `blobSpPool_p` to allocate shared pointer to blobs.
     static int flattenPushEvent(bsl::vector<EventUtilEventInfo>* eventInfos,
                                 const Event&                     event,
                                 bdlbb::BlobBufferFactory*        bufferFactory,
+                                BlobSpPool*                      blobSpPool_p,
                                 bslma::Allocator*                allocator);
 };
 

--- a/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
@@ -251,8 +251,12 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::PushEventBuilder pushEventBuilder(
-        &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>      data(bmqtst::TestHelperUtil::allocator());
     int                    payloadLength    = 0;
@@ -317,6 +321,7 @@ static void test1_breathingTest()
         &eventInfos,
         event,
         &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(eventInfos.size(), 1u);
@@ -449,8 +454,12 @@ static void test2_flattenExplodesEvent()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::PushEventBuilder pushEventBuilder(
-        &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>      data(bmqtst::TestHelperUtil::allocator());
     int                    payloadLength  = 0;
@@ -488,6 +497,7 @@ static void test2_flattenExplodesEvent()
         &eventInfos,
         event,
         &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(eventInfos.size(), 2u);
@@ -672,10 +682,14 @@ static void test3_flattenWithMessageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::MessageProperties msgProperties(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob             appData(bmqtst::TestHelperUtil::allocator());
     bmqp::PushEventBuilder  pushEventBuilder(
-        &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     bmqt::EventBuilderResult::Enum result;
     int                            payloadLength    = 0;
@@ -756,6 +770,7 @@ static void test3_flattenWithMessageProperties()
         &eventInfos,
         event,
         &bufferFactory,
+        &blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(rc, 0);
     ASSERT_EQ(eventInfos.size(), 1U);

--- a/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
@@ -311,7 +311,7 @@ static void test1_breathingTest()
 
     // Create event
     appendMessages(&pushEventBuilder, data);
-    bmqp::Event event(&(pushEventBuilder.blob()),
+    bmqp::Event event(pushEventBuilder.blob().get(),
                       bmqtst::TestHelperUtil::allocator());
 
     // 2) Flatten the event
@@ -487,7 +487,7 @@ static void test2_flattenExplodesEvent()
 
     // Create event
     appendMessages(&pushEventBuilder, data);
-    bmqp::Event event(&(pushEventBuilder.blob()),
+    bmqp::Event event(pushEventBuilder.blob().get(),
                       bmqtst::TestHelperUtil::allocator());
 
     // 2) Flatten the event
@@ -760,7 +760,7 @@ static void test3_flattenWithMessageProperties()
                                           logic);
     BSLS_ASSERT_OPT(result == bmqt::EventBuilderResult::e_SUCCESS);
 
-    bmqp::Event event(&(pushEventBuilder.blob()),
+    bmqp::Event event(pushEventBuilder.blob().get(),
                       bmqtst::TestHelperUtil::allocator());
 
     // 2) Flatten the event.

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
@@ -59,12 +59,10 @@ const char k_PADDING_DATA[9][8] = {
 /// Array of all potential padding buffers used for word and dword padding.
 bsls::ObjectBuffer<bdlbb::BlobBuffer> g_paddingBlobBuffer[9];
 
+/// Static prefilled blobs respectively containing a heartbeat request and
+/// a heartbeat response.
 bsls::ObjectBuffer<bdlbb::Blob> g_heartbeatReqBlob;
 bsls::ObjectBuffer<bdlbb::Blob> g_heartbeatRspBlob;
-
-/// Static prefilled blobs respectively containing a heartbeat request,
-/// heartbeat response and an empty blob.
-bsls::ObjectBuffer<bdlbb::Blob> g_emptyBlob;
 
 /// Integer to keep track of the number of calls to `initialize` for the
 /// `ProtocolUtil`.  If the value is non-zero, then it has already been
@@ -160,9 +158,6 @@ void ProtocolUtil::initialize(bslma::Allocator* allocator)
         new (g_heartbeatRspBlob.buffer()) bdlbb::Blob(alloc);
         g_heartbeatRspBlob.object().appendDataBuffer(buffer);
     }
-
-    // Create empty blob
-    new (g_emptyBlob.buffer()) bdlbb::Blob(alloc);
 }
 
 void ProtocolUtil::shutdown()
@@ -178,7 +173,6 @@ void ProtocolUtil::shutdown()
 
     g_heartbeatRspBlob.object().bdlbb::Blob::~Blob();
     g_heartbeatReqBlob.object().bdlbb::Blob::~Blob();
-    g_emptyBlob.object().bdlbb::Blob::~Blob();
 
     for (int i = 0; i < 9; ++i) {
         g_paddingBlobBuffer[i].object().reset();
@@ -290,11 +284,6 @@ const bdlbb::Blob& ProtocolUtil::heartbeatReqBlob()
 const bdlbb::Blob& ProtocolUtil::heartbeatRspBlob()
 {
     return g_heartbeatRspBlob.object();
-}
-
-const bdlbb::Blob& ProtocolUtil::emptyBlob()
-{
-    return g_emptyBlob.object();
 }
 
 void ProtocolUtil::hexToBinary(char* buffer, int length, const char* hex)

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -406,8 +406,8 @@ struct ProtocolUtil {
     buildEvent(ACTION_FUNCTOR_TYPE&   actionCb,
                OVERFLOW_FUNCTOR_TYPE& overflowCb);
 
-    /// Encode Receipt into the specified `blob` for the specified
-    /// `partitionId`, `primaryLeaseId`, and `sequenceNumber`.
+    /// Encode Receipt into the specified `blob` (expected to be empty) for
+    /// the specified `partitionId`, `primaryLeaseId`, and `sequenceNumber`.
     static void buildReceipt(bdlbb::Blob*        blob,
                              int                 partitionId,
                              unsigned int        primaryLeaseId,
@@ -732,7 +732,8 @@ inline void ProtocolUtil::buildReceipt(bdlbb::Blob*        blob,
                                        unsigned int        primaryLeaseId,
                                        bsls::Types::Uint64 sequenceNumber)
 {
-    blob->removeAll();
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(0 == blob->length());
 
     blob->setLength(sizeof(EventHeader) + sizeof(ReplicationReceipt));
 

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -284,13 +284,6 @@ struct ProtocolUtil {
     /// event.
     static const bdlbb::Blob& heartbeatRspBlob();
 
-    /// Return const reference to the pre-allocated empty blob.  If you need
-    /// an empty blob and not going to modify it use this method instead of
-    /// creating another blob.  Heap allocate it to prevent 'exit-time-
-    /// destructor needed' compiler warning.  Causes valgrind-reported
-    /// memory leak.
-    static const bdlbb::Blob& emptyBlob();
-
     /// Hex/Binary conversion
     ///---------------------
 

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
@@ -861,10 +861,14 @@ static void test11_parseMessageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::MessageProperties in(bmqtst::TestHelperUtil::allocator());
     encode(&in);
     const int             queueId = 4;
-    bmqp::PutEventBuilder peb(&bufferFactory,
+    bmqp::PutEventBuilder peb(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
@@ -526,13 +526,6 @@ static void test6_heartbeatAndEmptyBlobs()
                          sizeof(bmqp::EventHeader)));
     }
 
-    PV("Verifying emtpy blob")
-    {
-        const bdlbb::Blob& blob = bmqp::ProtocolUtil::emptyBlob();
-        ASSERT_EQ(0, blob.length());
-        ASSERT_EQ(0, blob.numDataBuffers());
-    }
-
     bmqp::ProtocolUtil::shutdown();
 }
 
@@ -887,7 +880,8 @@ static void test11_parseMessageProperties()
     bmqp::PutMessageIterator putIt(&bufferFactory,
                                    bmqtst::TestHelperUtil::allocator(),
                                    true);
-    bmqp::Event rawEvent(&peb.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event              rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(rawEvent.isPutEvent());
     rawEvent.loadPutMessageIterator(&putIt);

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
@@ -103,9 +103,6 @@ class PushEventBuilder {
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
-    /// Empty blob to be returned when no messages were added to this builder.
-    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
-
     int d_msgCount;
     // number of messages currently in
     // the event.

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
@@ -40,18 +40,22 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, d_allocator_p);
-//  bmqp::PushEventBuilder builder(&bufferFactory, d_allocator_p);
+//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
+//  bmqp::PushEventBuilder builder(&blobSpPool, d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.packMessage("hello", 5, 0, bmqt::MessageGUID());
 //  builder.packMessage(myBlob, 0, bmqt::MessageGUID());
 //
-//  const bdlbb::Blob& eventBlob = builder.blob();
+//  const bsl::shared_ptr<bdlbb::Blob>& eventBlob = builder.blob();
 //  // Send the blob ...
 //
 //  // We can reset the builder to reuse it; note that this invalidates the
-//  // 'eventBlob' retrieved above
+//  // 'eventBlob' shared pointer reference retrieved above.  To keep the
+//  // bdlbb::Blob valid the shared pointer should be copied, and the copy
+//  // should be passed and kept in IO components.
 //  builder.reset();
 //..
 
@@ -98,6 +102,9 @@ class PushEventBuilder {
     /// Blob being built by this object.
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
+
+    /// Empty blob to be returned when no messages were added to this builder.
+    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
 
     int d_msgCount;
     // number of messages currently in
@@ -245,17 +252,13 @@ class PushEventBuilder {
     /// Return the number of messages currently in the event being built.
     int messageCount() const;
 
-    /// Return a reference not offering modifiable access to the blob built
-    /// by this event.  If no messages were added, this will return a blob
-    /// composed only of an `EventHeader`.
-    const bdlbb::Blob& blob() const;
-
-    /// Return a shared pointer to the built Blob.  If no messages were added,
-    /// this will return an empty shared pointer.
-    /// Note that a shared pointer is returned by value, so the user holds to
-    /// the copy of a pointer.  The Blob in that copy will be valid even if we
-    /// `reset` this builder and modify the internal shared pointer.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    /// Return a reference to the shared pointer to the built Blob.  If no
+    /// messages were added, the Blob object under this reference will be
+    /// empty.
+    /// Note that this accessor exposes an internal shared pointer object, and
+    /// it is the user's responsibility to make a copy of it if it needs to be
+    /// passed and kept in another thread while this builder object is used.
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
@@ -273,6 +273,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::Protocol::SubQueueInfosArray subQueueInfos(
         bmqtst::TestHelperUtil::allocator());
 
@@ -292,7 +296,7 @@ static void test1_breathingTest()
               bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
@@ -393,6 +397,10 @@ static void test2_buildEventBackwardsCompatibility()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::Protocol::SubQueueInfosArray subQueueInfos(
         bmqtst::TestHelperUtil::allocator());
 
@@ -412,7 +420,7 @@ static void test2_buildEventBackwardsCompatibility()
               bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
@@ -514,6 +522,10 @@ static void test3_buildEventWithPackedOption()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::Protocol::SubQueueInfosArray subQueueInfos(
         bmqtst::TestHelperUtil::allocator());
 
@@ -529,7 +541,7 @@ static void test3_buildEventWithPackedOption()
               bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
@@ -622,7 +634,11 @@ static void test4_buildEventWithMultipleMessages()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
 
     bsl::vector<Data> data(bmqtst::TestHelperUtil::allocator());
@@ -732,6 +748,10 @@ static void test5_buildEventWithPayloadTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     const bmqt::MessageGUID        guid;
     bdlbb::Blob                        bigMsgPayload(&bufferFactory,
                               bmqtst::TestHelperUtil::allocator());
@@ -752,7 +772,7 @@ static void test5_buildEventWithPayloadTooBig()
                      bigMsgPayload.length());
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
@@ -849,12 +869,16 @@ static void test6_buildEventWithImplicitPayload()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     const bmqt::MessageGUID        guid;
     const int                      queueId = 4321;
     const int flags = bmqp::PushHeaderFlags::e_IMPLICIT_PAYLOAD;
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder         peb(&bufferFactory,
+    bmqp::PushEventBuilder         peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
     bmqt::EventBuilderResult::Enum rc = peb.packMessage(
         queueId,
@@ -929,6 +953,10 @@ static void test7_buildEventOptionTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     int                                numSubQueueInfos;
     int                                optionSize;
     bmqp::Protocol::SubQueueInfosArray subQueueInfos(
@@ -949,7 +977,7 @@ static void test7_buildEventOptionTooBig()
     generateSubQueueInfos(&subQueueInfos, numSubQueueInfos);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
 
     // Add option larger than maximum allowed
@@ -1106,6 +1134,10 @@ static void test8_buildEventTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     const bmqt::MessageGUID        guid;
     bdlbb::Blob                    validPayload1(&bufferFactory,
                               bmqtst::TestHelperUtil::allocator());
@@ -1122,7 +1154,7 @@ static void test8_buildEventTooBig()
     bdlbb::BlobUtil::append(&validPayload1, s.c_str(), validLen);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&bufferFactory,
+    bmqp::PushEventBuilder peb(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
 
     // Add message with valid payload size
@@ -1194,6 +1226,10 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payloadBlob(&bufferFactory,
                             bmqtst::TestHelperUtil::allocator());
@@ -1207,7 +1243,7 @@ static void testN1_decodeFromFile()
     bdlbb::BlobUtil::append(&payloadBlob, k_PAYLOAD, k_PAYLOAD_LEN);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder obj(&bufferFactory,
+    bmqp::PushEventBuilder obj(&blobSpPool,
                                bmqtst::TestHelperUtil::allocator());
 
     // Pack one msg

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
@@ -300,7 +300,7 @@ static void test1_breathingTest()
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add SubQueueInfo option
@@ -312,7 +312,7 @@ static void test1_breathingTest()
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     // 'eventSize()' excludes unpacked messages
     ASSERT_LT(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // But the option is written to the underlying blob
     rc = peb.packMessage(payload,
                          queueId,
@@ -327,8 +327,8 @@ static void test1_breathingTest()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -424,7 +424,7 @@ static void test2_buildEventBackwardsCompatibility()
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add SubQueueInfo option
@@ -436,7 +436,7 @@ static void test2_buildEventBackwardsCompatibility()
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     // 'eventSize()' excludes unpacked messages
     ASSERT_LT(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // But the option is written to the underlying blob
     rc = peb.packMessage(payload,
                          queueId,
@@ -451,8 +451,8 @@ static void test2_buildEventBackwardsCompatibility()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -545,7 +545,7 @@ static void test3_buildEventWithPackedOption()
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add SubQueueInfo option
@@ -560,7 +560,7 @@ static void test3_buildEventWithPackedOption()
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     // 'eventSize()' excludes unpacked messages
     ASSERT_LT(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // But the option is written to the underlying blob
     rc = peb.packMessage(payload,
                          queueId,
@@ -575,8 +575,8 @@ static void test3_buildEventWithPackedOption()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -657,8 +657,8 @@ static void test4_buildEventWithMultipleMessages()
     }
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -776,7 +776,7 @@ static void test5_buildEventWithPayloadTooBig()
                                bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add a valid size option
@@ -786,7 +786,7 @@ static void test5_buildEventWithPayloadTooBig()
 
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_LT(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // We expect 'addSubQueueInfosOption' to write directly to the underlying
     // blob
     ASSERT_EQ(0, peb.messageCount());
@@ -801,7 +801,7 @@ static void test5_buildEventWithPayloadTooBig()
     ASSERT_EQ(rc, bmqt::EventBuilderResult::e_PAYLOAD_TOO_BIG);
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // Already-written options have to be removed if packing a message
     // fails
     ASSERT_EQ(0, peb.messageCount());
@@ -829,8 +829,8 @@ static void test5_buildEventWithPayloadTooBig()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -896,8 +896,9 @@ static void test6_buildEventWithImplicitPayload()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and bmqp
     // iterators are lower than bmqp builders, and thus, can be used to test
     // them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
+
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
 
@@ -1009,7 +1010,7 @@ static void test7_buildEventOptionTooBig()
 
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_EQ(sizeof(bmqp::EventHeader),
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     ASSERT_EQ(0, peb.messageCount());
 
     // Add option of valid size
@@ -1032,7 +1033,7 @@ static void test7_buildEventOptionTooBig()
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(peb.eventSize()));
     ASSERT_LE(sizeof(bmqp::EventHeader) + sizeof(bmqp::PushHeader) +
                   optionSize,
-              static_cast<size_t>(peb.blob().length()));
+              static_cast<size_t>(peb.blob()->length()));
     // Less than or equal due to possible padding
     ASSERT_EQ(0, peb.messageCount());
 
@@ -1061,15 +1062,15 @@ static void test7_buildEventOptionTooBig()
                           regularPayload.length();
     ASSERT_LE(evtSizeUnpadded, peb.eventSize());
     // Less than or equal due to possible padding
-    ASSERT_LE(evtSizeUnpadded, peb.blob().length());
+    ASSERT_LE(evtSizeUnpadded, peb.blob()->length());
     // Less than or equal due to possible padding
     ASSERT_EQ(1, peb.messageCount());
 
     // Get blob and use bmqp iterator to test.  Note that bmqp event and bmqp
     // iterators are lower than bmqp builders, and thus, can be used to test
     // them.
-    const bdlbb::Blob& eventBlob = peb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_SAFE(true == rawEvent.isValid());
     BSLS_ASSERT_SAFE(true == rawEvent.isPushEvent());
@@ -1272,7 +1273,7 @@ static void testN1_decodeFromFile()
 
     BSLS_ASSERT(ofile.good() == true);
 
-    bdlbb::BlobUtil::copy(buf, obj.blob(), 0, obj.blob().length());
+    bdlbb::BlobUtil::copy(buf, *obj.blob(), 0, obj.blob()->length());
     ofile.write(buf, k_SIZE);
     ofile.close();
     bsl::memset(buf, 0, k_SIZE);
@@ -1291,9 +1292,9 @@ static void testN1_decodeFromFile()
     bdlbb::BlobBuffer     dataBlobBuffer(dataBufferSp, k_SIZE);
 
     outBlob.appendDataBuffer(dataBlobBuffer);
-    outBlob.setLength(obj.blob().length());
+    outBlob.setLength(obj.blob()->length());
 
-    ASSERT_EQ(bdlbb::BlobUtil::compare(obj.blob(), outBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*obj.blob(), outBlob), 0);
 
     // Decode event
     bmqp::Event rawEvent(&outBlob, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
@@ -105,8 +105,8 @@ PutEventBuilder::packMessageInternal(const bdlbb::Blob& appData, int queueId)
 
     // Add the PutHeader
     bmqu::BlobPosition offset;
-    bmqu::BlobUtil::reserve(&offset, &d_blob, sizeof(PutHeader));
-    bmqu::BlobObjectProxy<PutHeader> putHeader(&d_blob,
+    bmqu::BlobUtil::reserve(&offset, d_blob_sp.get(), sizeof(PutHeader));
+    bmqu::BlobObjectProxy<PutHeader> putHeader(d_blob_sp.get(),
                                                offset,
                                                false,  // no read
                                                true);  // write mode
@@ -132,7 +132,7 @@ PutEventBuilder::packMessageInternal(const bdlbb::Blob& appData, int queueId)
             return res;  // RETURN
         }
         optionBox.add(
-            &d_blob,
+            d_blob_sp.get(),
             reinterpret_cast<const char*>(d_msgGroupId.value().data()),
             msgGroupId);
     }
@@ -159,22 +159,23 @@ PutEventBuilder::packMessageInternal(const bdlbb::Blob& appData, int queueId)
     putHeader.reset();  // i.e., flush writing to blob..
 
     // Just a sanity test.  Should still be word aligned.
-    BSLS_ASSERT_SAFE(isWordAligned(d_blob));
+    BSLS_ASSERT_SAFE(isWordAligned(*d_blob_sp));
 
-    bdlbb::BlobUtil::append(&d_blob, appData);
+    bdlbb::BlobUtil::append(d_blob_sp.get(), appData);
 
     // Add padding
-    ProtocolUtil::appendPaddingRaw(&d_blob, numPaddingBytes);
+    ProtocolUtil::appendPaddingRaw(d_blob_sp.get(), numPaddingBytes);
 
     ++d_msgCount;
 
     return Result::e_SUCCESS;
 }
 
-PutEventBuilder::PutEventBuilder(bdlbb::BlobBufferFactory* bufferFactory,
-                                 bslma::Allocator*         allocator)
-: d_bufferFactory_p(bufferFactory)
-, d_blob(bufferFactory, allocator)
+PutEventBuilder::PutEventBuilder(BlobSpPool*       blobSpPool_p,
+                                 bslma::Allocator* allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_blobSpPool_p(blobSpPool_p)
+, d_blob_sp(0, allocator)  // initialized in `reset()`
 , d_msgStarted(false)
 , d_blobPayload_p(0)
 , d_rawPayload_p(0)
@@ -188,14 +189,22 @@ PutEventBuilder::PutEventBuilder(bdlbb::BlobBufferFactory* bufferFactory,
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
 , d_lastPackedMessageCompressionRatio(-1)
 , d_messagePropertiesInfo()
-, d_allocator_p(allocator)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(blobSpPool_p);
+
     reset();
 }
 
 int PutEventBuilder::reset()
 {
-    d_blob.removeAll();
+    d_blob_sp = d_blobSpPool_p->getObject();
+
+    // The following prerequisite is necessary since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_blob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
+
     d_msgStarted       = false;
     d_blobPayload_p    = 0;
     d_rawPayload_p     = 0;
@@ -218,8 +227,8 @@ int PutEventBuilder::reset()
     // Use placement new to create the object directly in the blob buffer,
     // while still calling it's constructor (to memset memory and initialize
     // some fields)
-    d_blob.setLength(sizeof(EventHeader));
-    new (d_blob.buffer(0).data()) EventHeader(EventType::e_PUT);
+    d_blob_sp->setLength(sizeof(EventHeader));
+    new (d_blob_sp->buffer(0).data()) EventHeader(EventType::e_PUT);
 
     return 0;
 }
@@ -238,7 +247,8 @@ PutEventBuilder::packMessageInOldStyle(int queueId)
 
     // Calculate length of entire application data (includes payload, message
     // properties and padding, if any).
-    bdlbb::Blob applicationData(d_bufferFactory_p, d_allocator_p);
+    bsl::shared_ptr<bdlbb::Blob> applicationData_sp =
+        d_blobSpPool_p->getObject();
 
     const bdlbb::Blob* propertiesBlob = 0;
     if (d_properties_p && 0 != d_properties_p->numProperties()) {
@@ -250,10 +260,10 @@ PutEventBuilder::packMessageInOldStyle(int queueId)
         d_messagePropertiesInfo = MessagePropertiesInfo::makeNoSchema();
 
         // propertiesBlob include 6 byte mph along with properties
-        propertiesBlob = &(d_properties_p->streamOut(d_bufferFactory_p,
+        propertiesBlob = &(d_properties_p->streamOut(d_blob_sp->factory(),
                                                      d_messagePropertiesInfo));
 
-        bdlbb::BlobUtil::append(&applicationData, *propertiesBlob);
+        bdlbb::BlobUtil::append(applicationData_sp.get(), *propertiesBlob);
     }
     else {
         BSLS_ASSERT_SAFE(!d_messagePropertiesInfo.isPresent());
@@ -261,39 +271,41 @@ PutEventBuilder::packMessageInOldStyle(int queueId)
 
     // Add the payload
     if (d_rawPayload_p) {
-        bdlbb::BlobUtil::append(&applicationData,
+        bdlbb::BlobUtil::append(applicationData_sp.get(),
                                 d_rawPayload_p,
                                 d_rawPayloadLength);
     }
     else {
-        bdlbb::BlobUtil::append(&applicationData, *d_blobPayload_p);
+        bdlbb::BlobUtil::append(applicationData_sp.get(), *d_blobPayload_p);
     }
 
     // Compress
-    if (applicationData.length() >= Protocol::k_COMPRESSION_MIN_APPDATA_SIZE &&
+    if (applicationData_sp->length() >=
+            Protocol::k_COMPRESSION_MIN_APPDATA_SIZE &&
         d_compressionAlgorithmType != bmqt::CompressionAlgorithmType::e_NONE) {
-        bdlbb::Blob        compressedApplicationData(d_bufferFactory_p,
-                                              d_allocator_p);
+        bsl::shared_ptr<bdlbb::Blob> compressedApplicationData_sp =
+            d_blobSpPool_p->getObject();
         bmqu::MemOutStream error(d_allocator_p);
 
-        int rc = Compression::compress(&compressedApplicationData,
-                                       d_bufferFactory_p,
+        int rc = Compression::compress(compressedApplicationData_sp.get(),
+                                       d_blob_sp->factory(),
                                        d_compressionAlgorithmType,
-                                       applicationData,
+                                       *applicationData_sp,
                                        &error,
                                        d_allocator_p);
         if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
-                rc == Result::e_SUCCESS && compressedApplicationData.length() <
-                                               applicationData.length())) {
+                rc == Result::e_SUCCESS &&
+                compressedApplicationData_sp->length() <
+                    applicationData_sp->length())) {
             // Compression is successful and is worth using!
-            d_crc32c = Crc32c::calculate(compressedApplicationData);
+            d_crc32c = Crc32c::calculate(*compressedApplicationData_sp);
 
             // Keep track of the compression ratio.
             d_lastPackedMessageCompressionRatio =
-                static_cast<double>(applicationData.length()) /
-                compressedApplicationData.length();
+                static_cast<double>(applicationData_sp->length()) /
+                compressedApplicationData_sp->length();
 
-            return packMessageInternal(compressedApplicationData,
+            return packMessageInternal(*compressedApplicationData_sp,
                                        queueId);  // RETURN
         }
     }
@@ -304,10 +316,10 @@ PutEventBuilder::packMessageInOldStyle(int queueId)
     // worth using. In either way, we fall back to using the original blob.
     // Explicitly set the 'd_compressionAlgorithmType' to 'NONE'.
     d_compressionAlgorithmType = bmqt::CompressionAlgorithmType::e_NONE;
-    d_crc32c                   = Crc32c::calculate(applicationData);
+    d_crc32c                   = Crc32c::calculate(*applicationData_sp);
     d_lastPackedMessageCompressionRatio = 1;
 
-    return packMessageInternal(applicationData, queueId);
+    return packMessageInternal(*applicationData_sp, queueId);
 }
 
 bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
@@ -323,8 +335,8 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
 
     // Calculate length of entire application data (includes payload, message
     // properties and padding, if any).
-    bdlbb::Blob        bufferBlob(d_bufferFactory_p, d_allocator_p);
-    bdlbb::Blob        resultBlob(d_bufferFactory_p, d_allocator_p);
+    bsl::shared_ptr<bdlbb::Blob> bufferBlob_sp = d_blobSpPool_p->getObject();
+    bsl::shared_ptr<bdlbb::Blob> resultBlob_sp = d_blobSpPool_p->getObject();
     const bdlbb::Blob* payloadBlob = d_blobPayload_p;
 
     if (d_properties_p && 0 != d_properties_p->numProperties()) {
@@ -340,10 +352,10 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
 
         // propertiesBlob include 6 byte mph along with properties
         const bdlbb::Blob& propertiesBlob = d_properties_p->streamOut(
-            d_bufferFactory_p,
+            d_blob_sp->factory(),
             d_messagePropertiesInfo);
 
-        bdlbb::BlobUtil::append(&resultBlob, propertiesBlob);
+        bdlbb::BlobUtil::append(resultBlob_sp.get(), propertiesBlob);
     }
     else {
         BSLS_ASSERT_SAFE(!d_messagePropertiesInfo.isPresent());
@@ -351,10 +363,10 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
 
     // Add the payload
     if (d_rawPayload_p) {
-        bdlbb::BlobUtil::append(&bufferBlob,
+        bdlbb::BlobUtil::append(bufferBlob_sp.get(),
                                 d_rawPayload_p,
                                 d_rawPayloadLength);
-        payloadBlob = &bufferBlob;
+        payloadBlob = bufferBlob_sp.get();
     }
     else {
         payloadBlob = d_blobPayload_p;
@@ -363,28 +375,30 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
     // Compress
     if (payloadBlob->length() >= Protocol::k_COMPRESSION_MIN_APPDATA_SIZE &&
         d_compressionAlgorithmType != bmqt::CompressionAlgorithmType::e_NONE) {
-        bdlbb::Blob compressedPayloadBlob(d_bufferFactory_p, d_allocator_p);
+        bsl::shared_ptr<bdlbb::Blob> compressedPayloadBlob_sp =
+            d_blobSpPool_p->getObject();
         bmqu::MemOutStream error(d_allocator_p);
 
-        int rc = Compression::compress(&compressedPayloadBlob,
-                                       d_bufferFactory_p,
+        int rc = Compression::compress(compressedPayloadBlob_sp.get(),
+                                       d_blob_sp->factory(),
                                        d_compressionAlgorithmType,
                                        *payloadBlob,
                                        &error,
                                        d_allocator_p);
         if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
                 rc == Result::e_SUCCESS &&
-                compressedPayloadBlob.length() < payloadBlob->length())) {
+                compressedPayloadBlob_sp->length() < payloadBlob->length())) {
             // Compression is successful and is worth using!
 
             // Keep track of the compression ratio.
             d_lastPackedMessageCompressionRatio =
                 static_cast<double>(payloadBlob->length()) /
-                compressedPayloadBlob.length();
-            bdlbb::BlobUtil::append(&resultBlob, compressedPayloadBlob);
-            d_crc32c = Crc32c::calculate(resultBlob);
+                compressedPayloadBlob_sp->length();
+            bdlbb::BlobUtil::append(resultBlob_sp.get(),
+                                    *compressedPayloadBlob_sp);
+            d_crc32c = Crc32c::calculate(*resultBlob_sp);
 
-            return packMessageInternal(resultBlob, queueId);  // RETURN
+            return packMessageInternal(*resultBlob_sp, queueId);  // RETURN
         }
     }
 
@@ -392,13 +406,13 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessage(int queueId)
     // was bigger and not worth using. In either way, we fall back to using the
     // original blob. Explicitly set the 'd_compressionAlgorithmType' to
     // 'NONE'.
-    bdlbb::BlobUtil::append(&resultBlob, *payloadBlob);
+    bdlbb::BlobUtil::append(resultBlob_sp.get(), *payloadBlob);
 
     d_compressionAlgorithmType = bmqt::CompressionAlgorithmType::e_NONE;
-    d_crc32c                   = Crc32c::calculate(resultBlob);
+    d_crc32c                   = Crc32c::calculate(*resultBlob_sp);
     d_lastPackedMessageCompressionRatio = 1;
 
-    return packMessageInternal(resultBlob, queueId);
+    return packMessageInternal(*resultBlob_sp, queueId);
 }
 
 bmqt::EventBuilderResult::Enum PutEventBuilder::packMessageRaw(int queueId)
@@ -418,10 +432,22 @@ const bdlbb::Blob& PutEventBuilder::blob() const
 {
     // Fix packet's length in header now that we know it ..  Following is valid
     // (see comment in reset)
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(d_blob.buffer(0).data());
-    eh.setLength(d_blob.length());
+    EventHeader& eh = *reinterpret_cast<EventHeader*>(
+        d_blob_sp->buffer(0).data());
+    eh.setLength(d_blob_sp->length());
 
-    return d_blob;
+    return *d_blob_sp;
+}
+
+bsl::shared_ptr<bdlbb::Blob> PutEventBuilder::blob_sp() const
+{
+    // Fix packet's length in header now that we know it ..  Following is valid
+    // (see comment in reset)
+    EventHeader& eh = *reinterpret_cast<EventHeader*>(
+        d_blob_sp->buffer(0).data());
+    eh.setLength(d_blob_sp->length());
+
+    return d_blob_sp;
 }
 
 const bmqp::MessageProperties* PutEventBuilder::messageProperties() const

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.cpp
@@ -428,18 +428,7 @@ bmqt::EventBuilderResult::Enum PutEventBuilder::packMessageRaw(int queueId)
     return packMessageInternal(*d_blobPayload_p, queueId);
 }
 
-const bdlbb::Blob& PutEventBuilder::blob() const
-{
-    // Fix packet's length in header now that we know it ..  Following is valid
-    // (see comment in reset)
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(
-        d_blob_sp->buffer(0).data());
-    eh.setLength(d_blob_sp->length());
-
-    return *d_blob_sp;
-}
-
-bsl::shared_ptr<bdlbb::Blob> PutEventBuilder::blob_sp() const
+const bsl::shared_ptr<bdlbb::Blob>& PutEventBuilder::blob() const
 {
     // Fix packet's length in header now that we know it ..  Following is valid
     // (see comment in reset)

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
@@ -343,8 +343,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -445,7 +445,7 @@ static void test1_breathingTest()
         ASSERT_GT(obj.eventSize(), k_PAYLOAD_BIGGER_LEN);
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -570,8 +570,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -678,7 +678,7 @@ static void test1_breathingTest()
         ASSERT_LT(obj.eventSize(), k_PAYLOAD_BIGGER_LEN);
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -811,8 +811,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -925,7 +925,7 @@ static void test1_breathingTest()
         ASSERT_LT(obj.eventSize(), k_PAYLOAD_BIGGER_LEN);
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -1057,8 +1057,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -1161,7 +1161,7 @@ static void test1_breathingTest()
         ASSERT_GT(obj.eventSize(), k_PAYLOAD_LEN);
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -1287,8 +1287,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -1390,7 +1390,7 @@ static void test1_breathingTest()
         ASSERT_GT(obj.eventSize(), k_PAYLOAD_BIGGER_LEN);
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -1495,8 +1495,8 @@ static void test1_breathingTest()
         // Get blob and use bmqp iterator to test.  Note that bmqp event and
         // bmqp iterators are lower than bmqp builders, and thus, can be used
         // to test them.
-        const bdlbb::Blob& eventBlob = obj.blob();
-        bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+        bmqp::Event rawEvent(obj.blob().get(),
+                             bmqtst::TestHelperUtil::allocator());
 
         BSLS_ASSERT_OPT(rawEvent.isValid());
         BSLS_ASSERT_OPT(rawEvent.isPutEvent());
@@ -1579,7 +1579,7 @@ static void test1_breathingTest()
         ASSERT_GT(obj.eventSize(), payload.length());
         ASSERT_EQ(obj.messageCount(), 1);
 
-        rawEvent.reset(&obj.blob());
+        rawEvent.reset(obj.blob().get());
         rawEvent.loadPutMessageIterator(&putIter, true);
 
         ASSERT_EQ(1, putIter.next());
@@ -1742,8 +1742,8 @@ static void test2_manipulators_one()
     }
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = obj.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(obj.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT_OPT(true == rawEvent.isValid());
     BSLS_ASSERT_OPT(true == rawEvent.isPutEvent());
@@ -1882,8 +1882,8 @@ static void test3_eventTooBig()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and bmqp
     // iterators are lower than bmqp builders, and thus, can be used to test
     // them.
-    const bdlbb::Blob& eventBlob = obj.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(obj.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isPutEvent());
@@ -1968,8 +1968,8 @@ static void test4_manipulators_two()
     }
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = obj.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(obj.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isPutEvent());
@@ -2049,8 +2049,8 @@ static void test5_putEventWithZeroLengthMessage()
     ASSERT_EQ_D(0, rc, bmqt::EventBuilderResult::e_SUCCESS);
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = obj.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(obj.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isPutEvent());
@@ -2279,8 +2279,8 @@ static void test7_multiplePackMessage()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and
     // bmqp iterators are lower than bmqp builders, and thus, can be used
     // to test them.
-    const bdlbb::Blob& eventBlob = obj.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(obj.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     ASSERT(rawEvent.isValid());
     ASSERT(rawEvent.isPutEvent());
@@ -2372,7 +2372,7 @@ static void test7_multiplePackMessage()
 #endif
     ASSERT_EQ(obj.compressionAlgorithmType(),
               bmqt::CompressionAlgorithmType::e_NONE);
-    rawEvent.reset(&obj.blob());
+    rawEvent.reset(obj.blob().get());
     rawEvent.loadPutMessageIterator(&putIter, true);
 
     // we want to test the 3rd message so we call next thrice
@@ -2512,7 +2512,7 @@ static void testN1_decodeFromFile()
 
     BSLS_ASSERT(ofile.good() == true);
 
-    bdlbb::BlobUtil::copy(buf, obj.blob(), 0, obj.blob().length());
+    bdlbb::BlobUtil::copy(buf, *obj.blob(), 0, obj.blob()->length());
     ofile.write(buf, k_SIZE);
     ofile.close();
     bsl::memset(buf, 0, k_SIZE);
@@ -2531,9 +2531,9 @@ static void testN1_decodeFromFile()
     bdlbb::BlobBuffer     dataBlobBuffer(dataBufferSp, k_SIZE);
 
     outBlob.appendDataBuffer(dataBlobBuffer);
-    outBlob.setLength(obj.blob().length());
+    outBlob.setLength(obj.blob()->length());
 
-    ASSERT_EQ(bdlbb::BlobUtil::compare(obj.blob(), outBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*obj.blob(), outBlob), 0);
 
     // Decode event
     bmqp::Event rawEvent(&outBlob, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
@@ -217,6 +217,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 #ifdef BMQ_ENABLE_MSG_GROUPID
     const bmqp::Protocol::MsgGroupId k_MSG_GROUP_ID(
         "gid:0",
@@ -257,7 +261,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(obj.crc32c(), 0U);
@@ -484,7 +488,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(obj.crc32c(), 0U);
@@ -717,7 +721,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(obj.crc32c(), 0U);
@@ -965,7 +969,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(obj.crc32c(), 0U);
@@ -1201,7 +1205,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(obj.crc32c(), 0U);
@@ -1419,7 +1423,7 @@ static void test1_breathingTest()
         PVV("DO NOT USE COMPRESSION FOR RELAYED PUT MESSAGES");
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&bufferFactory,
+        bmqp::PutEventBuilder obj(&blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
         ASSERT_EQ(obj.crc32c(), 0U);
         bmqu::MemOutStream error(bmqtst::TestHelperUtil::allocator());
@@ -1673,7 +1677,11 @@ static void test2_manipulators_one()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     // Properties.
@@ -1821,6 +1829,10 @@ static void test3_eventTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlbb::Blob bigMsgPayload(&bufferFactory,
                               bmqtst::TestHelperUtil::allocator());
 #ifdef BMQ_ENABLE_MSG_GROUPID
@@ -1839,7 +1851,7 @@ static void test3_eventTooBig()
                 bigMsgPayload.length());
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     obj.startMessage();
@@ -1933,7 +1945,11 @@ static void test4_manipulators_two()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder          obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder          obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   k_NUM_MSGS = 1000;
@@ -2014,7 +2030,11 @@ static void test5_putEventWithZeroLengthMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     data(bmqtst::TestHelperUtil::allocator());
 
@@ -2065,6 +2085,10 @@ static void test6_emptyBuilder()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 #ifdef BMQ_ENABLE_MSG_GROUPID
     bmqp::Protocol::MsgGroupId k_MSG_GROUP_ID(
         "gid:0",
@@ -2083,7 +2107,7 @@ static void test6_emptyBuilder()
 
     const char* k_PAYLOAD = "abcdefghijklmnopqrstuvwxyz";
 
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     ASSERT_EQ(obj.unpackedMessageSize(), 0);
@@ -2155,6 +2179,10 @@ static void test7_multiplePackMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 #ifdef BMQ_ENABLE_MSG_GROUPID
     const bmqp::Protocol::MsgGroupId k_MSG_GROUP_ID(
         "gid:0",
@@ -2191,7 +2219,7 @@ static void test7_multiplePackMessage()
     ASSERT_EQ(k_NUM_PROPERTIES, msgProps.numProperties());
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     ASSERT_EQ(obj.crc32c(), 0U);
@@ -2399,6 +2427,10 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payloadBlob(bmqtst::TestHelperUtil::allocator());
     bmqu::MemOutStream             os(bmqtst::TestHelperUtil::allocator());
@@ -2439,7 +2471,7 @@ static void testN1_decodeFromFile()
         bmqp::PutHeaderFlags::e_MESSAGE_PROPERTIES);
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&bufferFactory,
+    bmqp::PutEventBuilder obj(&blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
 
     obj.startMessage();

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
@@ -39,15 +39,14 @@ namespace bmqp {
 // --------------------------
 
 // CREATORS
-RecoveryEventBuilder::RecoveryEventBuilder(
-    bdlbb::BlobBufferFactory* bufferFactory,
-    bslma::Allocator*         allocator)
-: d_blob(bufferFactory, allocator)
+RecoveryEventBuilder::RecoveryEventBuilder(BlobSpPool*       blobSpPool_p,
+                                           bslma::Allocator* allocator)
+: d_blobSpPool_p(blobSpPool_p)
+, d_blob_sp(0, allocator)  // initialized in `reset()`
 , d_msgCount(0)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(bufferFactory);
-    BSLS_ASSERT_SAFE(allocator);
+    BSLS_ASSERT_SAFE(blobSpPool_p);
 
     reset();
 }
@@ -55,7 +54,13 @@ RecoveryEventBuilder::RecoveryEventBuilder(
 // MANIPULATORS
 void RecoveryEventBuilder::reset()
 {
-    d_blob.removeAll();
+    d_blob_sp = d_blobSpPool_p->getObject();
+
+    // The following prerequisite is necessary since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_blob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
+
     d_msgCount = 0;
 
     // NOTE: Since RecoveryEventBuilder owns the blob and we just reset it, we
@@ -67,8 +72,8 @@ void RecoveryEventBuilder::reset()
     // Use placement new to create the object directly in the blob buffer,
     // while still calling it's constructor (to memset memory and initialize
     // some fields)
-    d_blob.setLength(sizeof(EventHeader));
-    new (d_blob.buffer(0).data()) EventHeader(EventType::e_RECOVERY);
+    d_blob_sp->setLength(sizeof(EventHeader));
+    new (d_blob_sp->buffer(0).data()) EventHeader(EventType::e_RECOVERY);
 }
 
 bmqt::EventBuilderResult::Enum
@@ -103,9 +108,9 @@ RecoveryEventBuilder::packMessage(unsigned int                partitionId,
 
     // Add RecoveryHeader
     bmqu::BlobPosition offset;
-    bmqu::BlobUtil::reserve(&offset, &d_blob, sizeof(RecoveryHeader));
+    bmqu::BlobUtil::reserve(&offset, d_blob_sp.get(), sizeof(RecoveryHeader));
 
-    bmqu::BlobObjectProxy<RecoveryHeader> recoveryHeader(&d_blob,
+    bmqu::BlobObjectProxy<RecoveryHeader> recoveryHeader(d_blob_sp.get(),
                                                          offset,
                                                          false,  // no read
                                                          true);  // write mode
@@ -139,7 +144,7 @@ RecoveryEventBuilder::packMessage(unsigned int                partitionId,
     if (0 != payloadLen) {
         // Per bdlbb::Blob contract, specifying a buffer of zero length in
         // 'appendDataBuffer' is undefined.
-        d_blob.appendDataBuffer(chunkBuffer);
+        d_blob_sp->appendDataBuffer(chunkBuffer);
     }
 
     ++d_msgCount;
@@ -155,10 +160,27 @@ const bdlbb::Blob& RecoveryEventBuilder::blob() const
 
     // Fix packet's length in header now that we know it ..  Following is valid
     // (see comment in reset)
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(d_blob.buffer(0).data());
-    eh.setLength(d_blob.length());
+    EventHeader& eh = *reinterpret_cast<EventHeader*>(
+        d_blob_sp->buffer(0).data());
+    eh.setLength(d_blob_sp->length());
 
-    return d_blob;
+    return *d_blob_sp;
+}
+
+bsl::shared_ptr<bdlbb::Blob> RecoveryEventBuilder::blob_sp() const
+{
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        return bsl::shared_ptr<bdlbb::Blob>();  // RETURN
+    }
+
+    // Fix packet's length in header now that we know it ..  Following is valid
+    // (see comment in reset)
+    EventHeader& eh = *reinterpret_cast<EventHeader*>(
+        d_blob_sp->buffer(0).data());
+    eh.setLength(d_blob_sp->length());
+
+    return d_blob_sp;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
@@ -43,10 +43,18 @@ RecoveryEventBuilder::RecoveryEventBuilder(BlobSpPool*       blobSpPool_p,
                                            bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
 , d_blob_sp(0, allocator)  // initialized in `reset()`
+, d_emptyBlob_sp(blobSpPool_p->getObject())
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
+
+    // Assume that items built with the given `blobSpPool_p` either all have or
+    // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
+    // We require this since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_emptyBlob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();
 }
@@ -55,11 +63,6 @@ RecoveryEventBuilder::RecoveryEventBuilder(BlobSpPool*       blobSpPool_p,
 void RecoveryEventBuilder::reset()
 {
     d_blob_sp = d_blobSpPool_p->getObject();
-
-    // The following prerequisite is necessary since we do `Blob::setLength`:
-    BSLS_ASSERT_SAFE(
-        NULL != d_blob_sp->factory() &&
-        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     d_msgCount = 0;
 
@@ -151,27 +154,11 @@ RecoveryEventBuilder::packMessage(unsigned int                partitionId,
     return bmqt::EventBuilderResult::e_SUCCESS;
 }
 
-const bdlbb::Blob& RecoveryEventBuilder::blob() const
+const bsl::shared_ptr<bdlbb::Blob>& RecoveryEventBuilder::blob() const
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return ProtocolUtil::emptyBlob();  // RETURN
-    }
-
-    // Fix packet's length in header now that we know it ..  Following is valid
-    // (see comment in reset)
-    EventHeader& eh = *reinterpret_cast<EventHeader*>(
-        d_blob_sp->buffer(0).data());
-    eh.setLength(d_blob_sp->length());
-
-    return *d_blob_sp;
-}
-
-bsl::shared_ptr<bdlbb::Blob> RecoveryEventBuilder::blob_sp() const
-{
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return bsl::shared_ptr<bdlbb::Blob>();  // RETURN
+        return d_emptyBlob_sp;  // RETURN
     }
 
     // Fix packet's length in header now that we know it ..  Following is valid

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.cpp
@@ -43,17 +43,16 @@ RecoveryEventBuilder::RecoveryEventBuilder(BlobSpPool*       blobSpPool_p,
                                            bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
 , d_blob_sp(0, allocator)  // initialized in `reset()`
-, d_emptyBlob_sp(blobSpPool_p->getObject())
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
 
     // Assume that items built with the given `blobSpPool_p` either all have or
-    // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
+    // all don't have buffer factory, and check it once for a sample blob.
     // We require this since we do `Blob::setLength`:
     BSLS_ASSERT_SAFE(
-        NULL != d_emptyBlob_sp->factory() &&
+        NULL != blobSpPool_p->getObject()->factory() &&
         "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();
@@ -156,10 +155,8 @@ RecoveryEventBuilder::packMessage(unsigned int                partitionId,
 
 const bsl::shared_ptr<bdlbb::Blob>& RecoveryEventBuilder::blob() const
 {
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        return d_emptyBlob_sp;  // RETURN
-    }
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
 
     // Fix packet's length in header now that we know it ..  Following is valid
     // (see comment in reset)

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.h
@@ -99,9 +99,6 @@ class RecoveryEventBuilder BSLS_CPP11_FINAL {
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
-    /// Empty blob to be returned when no messages were added to this builder.
-    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
-
     int d_msgCount;  // number of messages currently in the
                      // event
 
@@ -156,9 +153,7 @@ class RecoveryEventBuilder BSLS_CPP11_FINAL {
     /// Return the number of messages currently in the event being built.
     int messageCount() const;
 
-    /// Return a reference to the shared pointer to the built Blob.  If no
-    /// messages were added, the Blob object under this reference will be
-    /// empty.
+    /// Return a reference to the shared pointer to the built Blob.
     /// Note that this accessor exposes an internal shared pointer object, and
     /// it is the user's responsibility to make a copy of it if it needs to be
     /// passed and kept in another thread while this builder object is used.

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
@@ -153,9 +153,8 @@ static void test1_breathingTest()
     // Get blob and use bmqp iterator to test.  Note that bmqp event and bmqp
     // iterators are lower than bmqp builders, and thus, can be used to test
     // them.
-
-    const bdlbb::Blob& eventBlob = reb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(reb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isRecoveryEvent());
@@ -183,7 +182,7 @@ static void test1_breathingTest()
     ASSERT_EQ(recoveryIter.loadChunkPosition(&position), 0);
     int res, compareResult;
     res = bmqu::BlobUtil::compareSection(&compareResult,
-                                         eventBlob,
+                                         *reb.blob(),
                                          position,
                                          CHUNK,
                                          CHUNK_LEN);
@@ -229,8 +228,8 @@ static void test2_multipleMessagesTest()
     }
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = reb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(reb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isRecoveryEvent());
@@ -267,7 +266,7 @@ static void test2_multipleMessagesTest()
 
         int res, compareResult;
         res = bmqu::BlobUtil::compareSection(&compareResult,
-                                             eventBlob,
+                                             *reb.blob(),
                                              chunkPosition,
                                              D.d_chunk.c_str(),
                                              D.d_chunk.size());
@@ -342,8 +341,8 @@ static void test3_eventTooBigTest()
               static_cast<unsigned int>(reb.eventSize()));
     ASSERT_EQ(reb.messageCount(), 1);
 
-    const bdlbb::Blob& eventBlob = reb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(reb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isRecoveryEvent());
@@ -368,7 +367,7 @@ static void test3_eventTooBigTest()
     ASSERT_EQ(recoveryIter.loadChunkPosition(&position), 0);
     int res, compareResult;
     res = bmqu::BlobUtil::compareSection(&compareResult,
-                                         eventBlob,
+                                         *reb.blob(),
                                          position,
                                          k_SMALL_CHUNK,
                                          k_SMALL_CHUNK_LEN);
@@ -415,8 +414,8 @@ static void test4_emptyPayloadTest()
     //           static_cast<unsigned int>(reb.eventSize()));
     ASSERT_EQ(reb.messageCount(), 1);
 
-    const bdlbb::Blob& eventBlob = reb.blob();
-    bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
+    bmqp::Event rawEvent(reb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
     BSLS_ASSERT(true == rawEvent.isRecoveryEvent());

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
@@ -115,6 +115,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     const char*                    CHUNK = "abcdefghijklmnopqrstuvwx";
 
     // Note that chunk must be word aligned per RecoveryEventBuilder's
@@ -126,7 +130,7 @@ static void test1_breathingTest()
 
     // Create RecoveryEventBuilder.
 
-    bmqp::RecoveryEventBuilder reb(&bufferFactory,
+    bmqp::RecoveryEventBuilder reb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(sizeof(bmqp::EventHeader), static_cast<size_t>(reb.eventSize()));
     ASSERT_EQ(reb.messageCount(), 0);
@@ -206,7 +210,11 @@ static void test2_multipleMessagesTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RecoveryEventBuilder     reb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RecoveryEventBuilder     reb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -286,7 +294,11 @@ static void test3_eventTooBigTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RecoveryEventBuilder reb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RecoveryEventBuilder reb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
     bsl::string                bigChunk(bmqtst::TestHelperUtil::allocator());
     bigChunk.resize(bmqp::RecoveryHeader::k_MAX_PAYLOAD_SIZE_SOFT + 4, 'a');
@@ -378,7 +390,11 @@ static void test4_emptyPayloadTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RecoveryEventBuilder reb(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RecoveryEventBuilder reb(&blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<char> chunkBufferSp(

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.cpp
@@ -37,18 +37,20 @@ namespace bmqp {
 RejectEventBuilder::RejectEventBuilder(BlobSpPool*       blobSpPool_p,
                                        bslma::Allocator* allocator)
 : d_blobSpPool_p(blobSpPool_p)
-, d_blob_sp(0, allocator)  // initialized in `reset()`
-, d_emptyBlob_sp(blobSpPool_p->getObject())
+, d_blob_sp(0, allocator)       // initialized in `reset()`
+, d_emptyBlob_sp(0, allocator)  // initialized later in constructor
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
 
+    d_emptyBlob_sp = blobSpPool_p->getObject();
+
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
     // We require this since we do `Blob::setLength`:
     BSLS_ASSERT_SAFE(
-        NULL != d_emptyBlob_sp->factory() &&
+        NULL != blobSpPool_p->getObject()->factory() &&
         "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
@@ -58,7 +58,7 @@
 //..
 
 // BMQ
-
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_protocol.h>
 #include <bmqt_messageguid.h>
 #include <bmqt_resultcode.h>
@@ -79,12 +79,19 @@ namespace bmqp {
 
 /// Mechanism to build a BlazingMQ REJECT event
 class RejectEventBuilder {
+  public:
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // DATA
-    mutable bdlbb::Blob d_blob;  // blob being built by this object
-                                 // This has been done mutable to be able to
-                                 // skip writing the length until the blob
-                                 // is retrieved.
+    /// Blob pool to use.  Held, not owned.
+    BlobSpPool* d_blobSpPool_p;
+
+    /// Blob being built by this object.
+    /// `mutable` to skip writing the length until the blob is retrieved.
+    mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
+
     int d_msgCount;              // number of messages currently in the
                                  // event
 
@@ -104,10 +111,11 @@ class RejectEventBuilder {
   public:
     // CREATORS
 
-    /// Create a new `RejectEventBuilder` using the specified
-    /// `bufferFactory` and `allocator` for the blob.
-    RejectEventBuilder(bdlbb::BlobBufferFactory* bufferFactory,
-                       bslma::Allocator*         allocator);
+    /// Create a new `PushEventBuilder` using the specified `blobSpPool_p` and
+    /// `allocator` for the blob.  We require BlobSpPool to build Blobs with
+    /// set BlobBufferFactory since we might want to expand the built Blob
+    /// dynamically.
+    RejectEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
 
     // MANIPULATORS
 
@@ -140,6 +148,13 @@ class RejectEventBuilder {
     /// by this event.  If no messages were added, this will return an empty
     /// blob, i.e., a blob with length == 0.*/
     const bdlbb::Blob& blob() const;
+
+    /// Return a shared pointer to the built Blob.  If no messages were added,
+    /// this will return an empty shared pointer.
+    /// Note that a shared pointer is returned by value, so the user holds to
+    /// the copy of a pointer.  The Blob in that copy will be valid even if we
+    /// `reset` this builder and modify the internal shared pointer.
+    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
 };
 
 // ============================================================================
@@ -170,7 +185,7 @@ inline int RejectEventBuilder::eventSize() const
         return 0;  // RETURN
     }
 
-    return d_blob.length();
+    return d_blob_sp->length();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
@@ -41,18 +41,22 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::BlobPooledBlobBufferFactory bufferFactory(1024, d_allocator_p);
-//  bmqp::RejectEventBuilder builder(&bufferFactory, d_allocator_p);
+//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
+//  bmqp::RejectEventBuilder builder(&blobSpPool, d_allocator_p);
 //
 //  // Append multiple messages, from same or different queue
 //  builder.appendMessage(k_QUEUEID1, k_SUBQUEUEID1, bmqt::MessageGUID(), 5);
 //  builder.appendMessage(k_QUEUEID2, k_SUBQUEUEID2, bmqt::MessageGUID(), 16);
 //
-//  const bdlbb::Blob& eventBlob = builder.blob();
+//  const bsl::shared_ptr<bdlbb::Blob>& eventBlob = builder.blob();
 //  // Send the blob ...
 //
 //  // We can reset the builder to reuse it; note that this invalidates the
-//  // 'eventBlob' retrieved above
+//  // 'eventBlob' shared pointer reference retrieved above.  To keep the
+//  // bdlbb::Blob valid the shared pointer should be copied, and the copy
+//  // should be passed and kept in IO components.
 //  builder.reset();
 //
 //..
@@ -92,6 +96,9 @@ class RejectEventBuilder {
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
+    /// Empty blob to be returned when no messages were added to this builder.
+    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
+
     int d_msgCount;              // number of messages currently in the
                                  // event
 
@@ -111,9 +118,9 @@ class RejectEventBuilder {
   public:
     // CREATORS
 
-    /// Create a new `PushEventBuilder` using the specified `blobSpPool_p` and
-    /// `allocator` for the blob.  We require BlobSpPool to build Blobs with
-    /// set BlobBufferFactory since we might want to expand the built Blob
+    /// Create a new `RejectEventBuilder` using the specified `blobSpPool_p`
+    /// and `allocator` for the blob.  We require BlobSpPool to build Blobs
+    /// with set BlobBufferFactory since we might want to expand the built Blob
     /// dynamically.
     RejectEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
 
@@ -144,17 +151,13 @@ class RejectEventBuilder {
     /// were added, this will return 0.
     int eventSize() const;
 
-    /// Return a reference not offering modifiable access to the blob built
-    /// by this event.  If no messages were added, this will return an empty
-    /// blob, i.e., a blob with length == 0.*/
-    const bdlbb::Blob& blob() const;
-
-    /// Return a shared pointer to the built Blob.  If no messages were added,
-    /// this will return an empty shared pointer.
-    /// Note that a shared pointer is returned by value, so the user holds to
-    /// the copy of a pointer.  The Blob in that copy will be valid even if we
-    /// `reset` this builder and modify the internal shared pointer.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    /// Return a reference to the shared pointer to the built Blob.  If no
+    /// messages were added, the Blob object under this reference will be
+    /// empty.
+    /// Note that this accessor exposes an internal shared pointer object, and
+    /// it is the user's responsibility to make a copy of it if it needs to be
+    /// passed and kept in another thread while this builder object is used.
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
@@ -137,7 +137,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RejectEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RejectEventBuilder obj(&blobSpPool,
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -164,7 +168,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RejectEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RejectEventBuilder obj(&blobSpPool,
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -183,7 +191,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RejectEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RejectEventBuilder obj(&blobSpPool,
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -215,7 +227,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RejectEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RejectEventBuilder obj(&blobSpPool,
                                  bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -271,7 +287,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::RejectEventBuilder obj(&bufferFactory,
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+    bmqp::RejectEventBuilder obj(&blobSpPool,
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
@@ -95,10 +95,11 @@ static void verifyContent(const bmqp::RejectEventBuilder& builder,
                           (data.size() * sizeof(bmqp::RejectMessage));
     ASSERT_EQ(static_cast<size_t>(builder.messageCount()), data.size());
     ASSERT_EQ(static_cast<size_t>(builder.eventSize()), expectedSize);
-    ASSERT_EQ(static_cast<size_t>(builder.blob().length()), expectedSize);
+    ASSERT_EQ(static_cast<size_t>(builder.blob()->length()), expectedSize);
 
     PVV("Iterating over messages");
-    bmqp::Event event(&builder.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event event(builder.blob().get(),
+                      bmqtst::TestHelperUtil::allocator());
 
     ASSERT(event.isValid());
     ASSERT(event.isRejectEvent());
@@ -149,7 +150,7 @@ static void test1_breathingTest()
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_NE(obj.maxMessageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PVV("Appending one message");
     appendMessages(&obj, &messages, 1);
@@ -208,7 +209,7 @@ static void test3_reset()
     PV("Verifying accessors");
     ASSERT_EQ(obj.messageCount(), 0);
     ASSERT_EQ(obj.eventSize(), 0);
-    ASSERT_EQ(obj.blob().length(), 0);
+    ASSERT_EQ(obj.blob()->length(), 0);
 
     PV("Appending another message");
     messages.clear();
@@ -302,11 +303,11 @@ static void testN1_decodeFromFile()
     PVV("Appending messages");
     appendMessages(&obj, &messages, k_NUM_MSGS);
 
-    ASSERT_NE(obj.blob().length(), 0);
+    ASSERT_NE(obj.blob()->length(), 0);
 
     os << "msg_reject_" << guid << ".bin" << bsl::ends;
 
-    const int blobLen = obj.blob().length();
+    const int blobLen = obj.blob()->length();
     char*     buf     = new char[blobLen];
 
     /// Functor invoked to delete the file at the specified `filePath`
@@ -326,7 +327,7 @@ static void testN1_decodeFromFile()
     bsl::ofstream ofile(os.str().data(), bsl::ios::binary);
     BSLS_ASSERT(ofile.good());
 
-    bdlbb::BlobUtil::copy(buf, obj.blob(), 0, blobLen);
+    bdlbb::BlobUtil::copy(buf, *obj.blob(), 0, blobLen);
     ofile.write(buf, blobLen);
     ofile.close();
     bsl::memset(buf, 0, blobLen);
@@ -346,7 +347,7 @@ static void testN1_decodeFromFile()
     outBlob.appendDataBuffer(dataBlobBuffer);
     outBlob.setLength(blobLen);
 
-    ASSERT_EQ(bdlbb::BlobUtil::compare(obj.blob(), outBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*obj.blob(), outBlob), 0);
 
     // Decode event
     bmqp::Event event(&outBlob, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -1365,7 +1365,7 @@ bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
 
     // Send the request
     request->d_sendTime              = bmqsys::Time::highResolutionTimer();
-    bmqt::GenericResult::Enum sendRc = sendFn(d_schemaEventBuilder.blob_sp());
+    bmqt::GenericResult::Enum sendRc = sendFn(d_schemaEventBuilder.blob());
     if (sendRc != bmqt::GenericResult::e_SUCCESS) {
         bmqu::MemOutStream errorDesc;
         errorDesc << "WRITE_FAILED, status: " << sendRc;

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.h
@@ -163,13 +163,7 @@ class SchemaEventBuilder {
     /// Note that if `setMessage` has not been called on this
     /// SchemaEventBuilder, or if `reset` has been called since, the blob
     /// returned will be an empty one.
-    const bdlbb::Blob& blob() const;
-
-    /// Return the fully formatted blob corresponding to the message built.
-    /// Note that if `setMessage` has not been called on this
-    /// SchemaEventBuilder, or if `reset` has been called since, the blob
-    /// returned will be an empty one.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // =============================
@@ -291,16 +285,7 @@ int SchemaEventBuilder::setMessage(const TYPE& message, EventType::Enum type)
     return 0;
 }
 
-inline const bdlbb::Blob& SchemaEventBuilder::blob() const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
-    BSLS_ASSERT_SAFE(d_blob_sp->length() % 4 == 0);
-
-    return *d_blob_sp;
-}
-
-inline bsl::shared_ptr<bdlbb::Blob> SchemaEventBuilder::blob_sp() const
+inline const bsl::shared_ptr<bdlbb::Blob>& SchemaEventBuilder::blob() const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
@@ -83,7 +83,7 @@ static void test1_breathingTest()
                                      bmqtst::TestHelperUtil::allocator());
 
         PVV(test.d_line << ": Verifying accessors");
-        ASSERT_EQ(obj.blob().length(), 0);
+        ASSERT_EQ(obj.blob()->length(), 0);
 
         PVV(test.d_line << ": Create a message");
         bmqp_ctrlmsg::ControlMessage message(
@@ -95,11 +95,12 @@ static void test1_breathingTest()
         // Encode the message
         rc = obj.setMessage(message, bmqp::EventType::e_CONTROL);
         ASSERT_EQ(rc, 0);
-        ASSERT_NE(obj.blob().length(), 0);
-        ASSERT_EQ(obj.blob().length() % 4, 0);
+        ASSERT_NE(obj.blob()->length(), 0);
+        ASSERT_EQ(obj.blob()->length() % 4, 0);
 
         PVV(test.d_line << ": Decode and compare message");
-        bmqp::Event event(&obj.blob(), bmqtst::TestHelperUtil::allocator());
+        bmqp::Event event(obj.blob().get(),
+                          bmqtst::TestHelperUtil::allocator());
 
         ASSERT_EQ(event.isValid(), true);
         ASSERT_EQ(event.isControlEvent(), true);
@@ -115,7 +116,7 @@ static void test1_breathingTest()
 
         PVV("Reset");
         obj.reset();
-        ASSERT_EQ(obj.blob().length(), 0);
+        ASSERT_EQ(obj.blob()->length(), 0);
     }
 }
 
@@ -137,7 +138,7 @@ void testDecodeFromFileHelper(bmqp::SchemaEventBuilder*       obj,
     // Encode the message
     rc = obj->setMessage(message, bmqp::EventType::e_CONTROL);
     ASSERT_EQ(rc, 0);
-    ASSERT_NE(obj->blob().length(), 0);
+    ASSERT_NE(obj->blob()->length(), 0);
 
     bmqu::MemOutStream os(bmqtst::TestHelperUtil::allocator());
     bdlb::Guid         guid = bdlb::GuidUtil::generate();
@@ -160,15 +161,15 @@ void testDecodeFromFileHelper(bmqp::SchemaEventBuilder*       obj,
 
     BSLS_ASSERT(ofile.good() == true);
 
-    const int blobLen = obj->blob().length();
+    const int blobLen = obj->blob()->length();
     char*     buf     = new char[blobLen];
-    bdlbb::BlobUtil::copy(buf, obj->blob(), 0, blobLen);
+    bdlbb::BlobUtil::copy(buf, *obj->blob(), 0, blobLen);
     ofile.write(buf, blobLen);
     ofile.close();
     bsl::memset(buf, 0, blobLen);
 
     obj->reset();
-    ASSERT_EQ(obj->blob().length(), 0);
+    ASSERT_EQ(obj->blob()->length(), 0);
 
     // Read blob from file
     bsl::ifstream ifile(os.str().data(), bsl::ios::binary);

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
@@ -58,6 +58,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     struct Test {
         int                      d_line;
@@ -74,9 +78,9 @@ static void test1_breathingTest()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << "encoding");
 
-        bmqp::SchemaEventBuilder obj(&bufferFactory,
-                                     bmqtst::TestHelperUtil::allocator(),
-                                     test.d_encodingType);
+        bmqp::SchemaEventBuilder obj(&blobSpPool,
+                                     test.d_encodingType,
+                                     bmqtst::TestHelperUtil::allocator());
 
         PVV(test.d_line << ": Verifying accessors");
         ASSERT_EQ(obj.blob().length(), 0);
@@ -281,6 +285,10 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     struct Test {
         int                      d_line;
@@ -297,9 +305,9 @@ static void testN1_decodeFromFile()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << " encoding");
 
-        bmqp::SchemaEventBuilder obj(&bufferFactory,
-                                     bmqtst::TestHelperUtil::allocator(),
-                                     test.d_encodingType);
+        bmqp::SchemaEventBuilder obj(&blobSpPool,
+                                     test.d_encodingType,
+                                     bmqtst::TestHelperUtil::allocator());
 
         PVV(test.d_line << ": Status message");
         {

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.cpp
@@ -110,14 +110,16 @@ StorageEventBuilder::StorageEventBuilder(int storageProtocolVersion,
 : d_blobSpPool_p(blobSpPool_p)
 , d_storageProtocolVersion(storageProtocolVersion)
 , d_eventType(eventType)
-, d_blob_sp(0, allocator)  // initialized in `reset()`
-, d_emptyBlob_sp(blobSpPool_p->getObject())
+, d_blob_sp(0, allocator)       // initialized in `reset()`
+, d_emptyBlob_sp(0, allocator)  // initialized later in constructor
 , d_msgCount(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
     BSLS_ASSERT_SAFE(EventType::e_STORAGE == eventType ||
                      EventType::e_PARTITION_SYNC == eventType);
+
+    d_emptyBlob_sp = blobSpPool_p->getObject();
 
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
@@ -192,6 +194,9 @@ StorageEventBuilder::packMessageRaw(const bdlbb::Blob&        blob,
 
 const bsl::shared_ptr<bdlbb::Blob>& StorageEventBuilder::blob() const
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_blob_sp->length() <= EventHeader::k_MAX_SIZE_SOFT);
+
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageCount() == 0)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         return d_emptyBlob_sp;  // RETURN

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
@@ -60,7 +60,7 @@
 //
 
 // BMQ
-
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_protocol.h>
 #include <bmqt_messageguid.h>
 #include <bmqt_resultcode.h>
@@ -69,6 +69,7 @@
 
 // BDE
 #include <bdlbb_blob.h>
+#include <bdlcc_sharedobjectpool.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -86,18 +87,23 @@ namespace bmqp {
 
 /// Mechanism to build a BlazingMQ STORAGE event
 class StorageEventBuilder BSLS_CPP11_FINAL {
+  public:
+    /// Pool of shared pointers to Blobs
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // DATA
+    BlobSpPool* d_blobSpPool_p;
+
     int d_storageProtocolVersion;
     // file storage protocol version
 
     EventType::Enum d_eventType;
     // Event type, either 'e_STORAGE' or 'e_PARTITION_SYNC'
 
-    mutable bdlbb::Blob d_blob;
-    // blob being built by this PushEventBuilder.
-    // This has been done mutable to be able to skip
-    // writing the length until the blob is retrieved.
+    /// Blob being built by this object.
+    /// `mutable` to skip writing the length until the blob is retrieved.
+    mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
 
     int d_msgCount;
     // number of messages currently in the event
@@ -133,10 +139,10 @@ class StorageEventBuilder BSLS_CPP11_FINAL {
     /// blob, and operating with the specified `storageProtocolVersion`.
     /// Behavior is undefined unless `eventType` is `e_STORAGE` or
     /// `e_PARTITION_SYNC`.
-    StorageEventBuilder(int                       storageProtocolVersion,
-                        EventType::Enum           eventType,
-                        bdlbb::BlobBufferFactory* bufferFactory,
-                        bslma::Allocator*         allocator);
+    StorageEventBuilder(int               storageProtocolVersion,
+                        EventType::Enum   eventType,
+                        BlobSpPool*       blobSpPool_p,
+                        bslma::Allocator* allocator);
 
     // MANIPULATORS
 
@@ -197,6 +203,13 @@ class StorageEventBuilder BSLS_CPP11_FINAL {
     /// by this event.  If no messages were added, this will return an empty
     /// blob, i.e., a blob with length == 0.
     const bdlbb::Blob& blob() const;
+
+    /// Return a shared pointer to the built Blob.  If no messages were added,
+    /// this will return an empty shared pointer.
+    /// Note that a shared pointer is returned by value, so the user holds to
+    /// the copy of a pointer.  The Blob in that copy will be valid even if we
+    /// `reset` this builder and modify the internal shared pointer.
+    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
 };
 
 // ============================================================================
@@ -272,7 +285,7 @@ inline EventType::Enum StorageEventBuilder::eventType() const
 
 inline int StorageEventBuilder::eventSize() const
 {
-    return d_blob.length();
+    return d_blob_sp->length();
 }
 
 inline int StorageEventBuilder::messageCount() const

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
@@ -42,18 +42,22 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, d_allocator_p);
-//  bmqp::StorageEventBuilder builder(&bufferFactory, d_allocator_p);
+//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
+//  bmqp::StorageEventBuilder builder(&blobSpPool, d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.packMessage(...);
-//  builder.packMessage(...;
+//  builder.packMessage(...);
 //
-//  const bdlbb::Blob& eventBlob = builder.blob();
+//  const bsl::shared_ptr<bdlbb::Blob>& eventBlob = builder.blob();
 //  // Send the blob ...
 //
 //  // We can reset the builder to reuse it; note that this invalidates the
-//  // 'eventBlob' retrieved above
+//  // 'eventBlob' shared pointer reference retrieved above.  To keep the
+//  // bdlbb::Blob valid the shared pointer should be copied, and the copy
+//  // should be passed and kept in IO components.
 //  builder.reset();
 //
 //..
@@ -104,6 +108,9 @@ class StorageEventBuilder BSLS_CPP11_FINAL {
     /// Blob being built by this object.
     /// `mutable` to skip writing the length until the blob is retrieved.
     mutable bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
+
+    /// Empty blob to be returned when no messages were added to this builder.
+    bsl::shared_ptr<bdlbb::Blob> d_emptyBlob_sp;
 
     int d_msgCount;
     // number of messages currently in the event
@@ -199,17 +206,13 @@ class StorageEventBuilder BSLS_CPP11_FINAL {
     /// Return the number of messages currently in the event being built.
     int messageCount() const;
 
-    /// Return a reference not offering modifiable access to the blob built
-    /// by this event.  If no messages were added, this will return an empty
-    /// blob, i.e., a blob with length == 0.
-    const bdlbb::Blob& blob() const;
-
-    /// Return a shared pointer to the built Blob.  If no messages were added,
-    /// this will return an empty shared pointer.
-    /// Note that a shared pointer is returned by value, so the user holds to
-    /// the copy of a pointer.  The Blob in that copy will be valid even if we
-    /// `reset` this builder and modify the internal shared pointer.
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const;
+    /// Return a reference to the shared pointer to the built Blob.  If no
+    /// messages were added, the Blob object under this reference will be
+    /// empty.
+    /// Note that this accessor exposes an internal shared pointer object, and
+    /// it is the user's responsibility to make a copy of it if it needs to be
+    /// passed and kept in another thread while this builder object is used.
+    const bsl::shared_ptr<bdlbb::Blob>& blob() const;
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
@@ -187,6 +187,10 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     const char*                    PAYLOAD     = "abcdefghijklmnopqrstuvwx";
     const unsigned int             PAYLOAD_LEN = bsl::strlen(PAYLOAD);  // 24
     const char*                    JOURNAL_REC = "12345678";
@@ -198,7 +202,7 @@ static void test1_breathingTest()
     // Create StorageEventBuilder
     bmqp::StorageEventBuilder seb(1,  // storage protocol version
                                   bmqp::EventType::e_STORAGE,
-                                  &bufferFactory,
+                                  &blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     ASSERT_EQ(seb.eventSize(), static_cast<int>(sizeof(bmqp::EventHeader)));
     ASSERT_EQ(seb.messageCount(), 0);
@@ -290,9 +294,14 @@ static void test2_storageEventHavingMultipleMessages()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
+
     bmqp::StorageEventBuilder      seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &bufferFactory,
+                                  &blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -380,6 +389,10 @@ static void test3_packMessage_payloadTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
 
     const int          k_SPV               = 1;  // Storage proto version
     const char*        PAYLOAD             = "abcdefghijklmnopqrstuvwx";
@@ -390,7 +403,7 @@ static void test3_packMessage_payloadTooBig()
 
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &bufferFactory,
+                                  &blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     bsl::string               bigPayload(bmqtst::TestHelperUtil::allocator());
     bigPayload.resize(bmqp::StorageHeader::k_MAX_PAYLOAD_SIZE_SOFT + 4, 'a');
@@ -515,9 +528,13 @@ static void test4_packMessageRaw()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::StorageEventBuilder      sebA(k_SPV,
                                    bmqp::EventType::e_STORAGE,
-                                   &bufferFactory,
+                                   &blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -546,7 +563,7 @@ static void test4_packMessageRaw()
     // Iterate over event 'A', and create event 'B' using 'packMessageRaw'.
     bmqp::StorageEventBuilder sebB(k_SPV,
                                    bmqp::EventType::e_STORAGE,
-                                   &bufferFactory,
+                                   &blobSpPool,
                                    bmqtst::TestHelperUtil::allocator());
 
     while (1 == iterA.next() && dataIndex < NUM_MSGS) {
@@ -648,9 +665,13 @@ static void test5_packMessageRaw_emptyMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &bufferFactory,
+                                  &blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
     bdlbb::Blob emptyBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());
@@ -689,11 +710,15 @@ static void test6_packMessageRaw_invalidPosition()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     bdlbb::Blob               k_EMPTY_BLOB(&bufferFactory,
                              bmqtst::TestHelperUtil::allocator());
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &bufferFactory,
+                                  &blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
 
     // 1.

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
@@ -234,7 +234,7 @@ static void test1_breathingTest()
     // Get blob and use bmqp iterator to test
     // Note that bmqp event and bmqp iterators are lower than bmqp builders,
     // and thus, can be used to test them.
-    const bdlbb::Blob& eventBlob = seb.blob();
+    const bdlbb::Blob& eventBlob = *seb.blob();
     bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
@@ -317,7 +317,7 @@ static void test2_storageEventHavingMultipleMessages()
     }
 
     // Iterate and check
-    const bdlbb::Blob& eventBlob = seb.blob();
+    const bdlbb::Blob& eventBlob = *seb.blob();
     bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
@@ -459,7 +459,7 @@ static void test3_packMessage_payloadTooBig()
               static_cast<unsigned int>(seb.eventSize()));
     ASSERT_EQ(seb.messageCount(), 1);
 
-    const bdlbb::Blob& eventBlob = seb.blob();
+    const bdlbb::Blob& eventBlob = *seb.blob();
     bmqp::Event rawEvent(&eventBlob, bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEvent.isValid());
@@ -549,7 +549,7 @@ static void test4_packMessageRaw()
         ASSERT_EQ_D(dataIdx, rc, bmqt::EventBuilderResult::e_SUCCESS);
     }
 
-    const bdlbb::Blob& eventA = sebA.blob();
+    const bdlbb::Blob& eventA = *sebA.blob();
     bmqp::Event        rawEventA(&eventA, bmqtst::TestHelperUtil::allocator());
     BSLS_ASSERT(rawEventA.isValid() == true);
     BSLS_ASSERT(rawEventA.isStorageEvent() == true);
@@ -585,7 +585,7 @@ static void test4_packMessageRaw()
     ASSERT_EQ(iterA.isValid(), false);
 
     // Finally, iterate over event 'B' and verify.
-    const bdlbb::Blob& eventB = sebB.blob();
+    const bdlbb::Blob& eventB = *sebB.blob();
     bmqp::Event        rawEventB(&eventB, bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(true == rawEventB.isValid());
@@ -683,7 +683,7 @@ static void test5_packMessageRaw_emptyMessage()
     // Above we packMessageRaw with 'length' of 10 because we need an
     // arbitrary 'length > 0' to not trigger an assert and at the same time
     // ensure that packing an empty blob succeeds.
-    ASSERT_EQ(bdlbb::BlobUtil::compare(seb.blob(), emptyBlob), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*seb.blob(), emptyBlob), 0);
     ASSERT_EQ(seb.messageCount(), 0);
     ASSERT_EQ(seb.eventSize(), static_cast<int>(sizeof(bmqp::EventHeader)));
 }
@@ -734,7 +734,7 @@ static void test6_packMessageRaw_invalidPosition()
     bmqu::BlobPosition invalidPosition(-1, -1);
     ASSERT_NE(seb.packMessageRaw(message, invalidPosition, message.length()),
               bmqt::EventBuilderResult::e_SUCCESS);
-    ASSERT_EQ(bdlbb::BlobUtil::compare(seb.blob(), k_EMPTY_BLOB), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*seb.blob(), k_EMPTY_BLOB), 0);
     ASSERT_EQ(seb.messageCount(), 0);
     ASSERT_EQ(seb.eventSize(), static_cast<int>(sizeof(bmqp::EventHeader)));
 }

--- a/src/groups/bmq/bmqp/package/bmqp.mem
+++ b/src/groups/bmq/bmqp/package/bmqp.mem
@@ -1,5 +1,6 @@
 bmqp_ackeventbuilder
 bmqp_ackmessageiterator
+bmqp_blobpoolutil
 bmqp_compression
 bmqp_confirmeventbuilder
 bmqp_confirmmessageiterator

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -114,7 +114,7 @@ AdminSessionState::AdminSessionState(BlobSpPool*               blobSpPool,
 , d_dispatcherClientData()
 , d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool)
-, d_schemaEventBuilder(bufferFactory, allocator, encodingType)
+, d_schemaEventBuilder(blobSpPool, encodingType, allocator)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(encodingType != bmqp::EncodingType::e_UNKNOWN);

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -92,9 +92,6 @@ struct AdminSessionState {
     // Dispatcher client data associated to
     // this session.
 
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
-    // Blob buffer factory to use.
-
     BlobSpPool* d_blobSpPool_p;
     // Pool of shared pointers to blob to
     // use.
@@ -118,14 +115,13 @@ struct AdminSessionState {
 
     // CREATORS
 
-    /// Constructor of a new session state using the specified `dispatcher`,
-    /// `blobSpPool` and `bufferFactory`.  The specified `encodingType` is
-    /// the encoding which the schema event builder will use.  Memory
-    /// allocations are performed using the specified `allocator`.
-    AdminSessionState(BlobSpPool*               blobSpPool,
-                      bdlbb::BlobBufferFactory* bufferFactory,
-                      bmqp::EncodingType::Enum  encodingType,
-                      bslma::Allocator*         allocator);
+    /// Constructor of a new session state using the specified `dispatcher` and
+    /// `blobSpPool`.  The specified `encodingType` is the encoding which the
+    /// schema event builder will use.  Memory allocations are performed using
+    /// the specified `allocator`.
+    AdminSessionState(BlobSpPool*              blobSpPool,
+                      bmqp::EncodingType::Enum encodingType,
+                      bslma::Allocator*        allocator);
 };
 
 // ==================
@@ -230,20 +226,18 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     // CREATORS
 
     /// Constructor of a new session associated to the specified `channel`
-    /// and using the specified `dispatcher`, `blobSpPool`, `bufferFactory`
-    /// and `scheduler`.  The specified `negotiationMessage` represents the
-    /// identity received from the peer during negotiation, and the
-    /// specified `sessionDescription` is the short form description of the
-    /// session.  Memory allocations are performed using the specified
-    /// `allocator`.  The specified `adminEnqueueCb` callback is used to
-    /// enqueue admin commands to entity that is responsible for executing
-    /// admin commands.
+    /// and using the specified `dispatcher`, `blobSpPool` and `scheduler`.
+    /// The specified `negotiationMessage` represents the  identity received
+    /// from the peer during negotiation, and the specified
+    /// `sessionDescription` is the short form description of the session.
+    /// Memory allocations are performed using the specified `allocator`.
+    /// The specified `adminEnqueueCb` callback is used to enqueue admin
+    /// commands to entity that is responsible for executing admin commands.
     AdminSession(const bsl::shared_ptr<bmqio::Channel>&  channel,
                  const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
                  const bsl::string&                      sessionDescription,
                  mqbi::Dispatcher*                       dispatcher,
                  AdminSessionState::BlobSpPool*          blobSpPool,
-                 bdlbb::BlobBufferFactory*               bufferFactory,
                  bdlmt::EventScheduler*                  scheduler,
                  const mqbnet::Session::AdminCommandEnqueueCb& adminEnqueueCb,
                  bslma::Allocator*                             allocator);

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -171,7 +171,6 @@ class TestBench {
            "sessionDescription",
            setInDispatcherThread(&d_mockDispatcher),
            &d_blobSpPool,
-           &d_bufferFactory,
            &d_scheduler,
            adminEnqueueCb,
            allocator)
@@ -258,7 +257,7 @@ static void test1_watermark()
     int rc = builder.setMessage(admin, bmqp::EventType::e_CONTROL);
     ASSERT_EQ(rc, 0);
 
-    bmqp::Event adminEvent(&builder.blob(),
+    bmqp::Event adminEvent(builder.blob().get(),
                            bmqtst::TestHelperUtil::allocator());
     BSLS_ASSERT(adminEvent.isValid());
     BSLS_ASSERT(adminEvent.isControlEvent());

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -251,9 +251,9 @@ static void test1_watermark()
     admin.choice().makeAdminCommand();
     admin.choice().adminCommand().command() = command;
 
-    bmqp::SchemaEventBuilder builder(&tb.d_bufferFactory,
-                                     tb.d_allocator_p,
-                                     bmqp::EncodingType::e_JSON);
+    bmqp::SchemaEventBuilder builder(&tb.d_blobSpPool,
+                                     bmqp::EncodingType::e_JSON,
+                                     tb.d_allocator_p);
 
     int rc = builder.setMessage(admin, bmqp::EventType::e_CONTROL);
     ASSERT_EQ(rc, 0);

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -356,9 +356,9 @@ ClientSessionState::ClientSessionState(
 , d_statContext_mp(clientStatContext)
 , d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool)
-, d_schemaEventBuilder(bufferFactory, allocator, encodingType)
-, d_pushBuilder(bufferFactory, allocator)
-, d_ackBuilder(bufferFactory, allocator)
+, d_schemaEventBuilder(blobSpPool, encodingType, allocator)
+, d_pushBuilder(blobSpPool, allocator)
+, d_ackBuilder(blobSpPool, allocator)
 , d_throttledFailedAckMessages()
 , d_throttledFailedPutMessages()
 {

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -422,7 +422,8 @@ void ClientSession::sendErrorResponse(
     sendPacketDispatched(d_state.d_schemaEventBuilder.blob(), true);
 }
 
-void ClientSession::sendPacket(const bdlbb::Blob& blob, bool flushBuilders)
+void ClientSession::sendPacket(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                               bool flushBuilders)
 {
     dispatcher()->execute(
         bdlf::BindUtil::bind(&ClientSession::sendPacketDispatched,
@@ -432,8 +433,9 @@ void ClientSession::sendPacket(const bdlbb::Blob& blob, bool flushBuilders)
         this);
 }
 
-void ClientSession::sendPacketDispatched(const bdlbb::Blob& blob,
-                                         bool               flushBuilders)
+void ClientSession::sendPacketDispatched(
+    const bsl::shared_ptr<bdlbb::Blob>& blob,
+    bool                                flushBuilders)
 {
     // executed by the *CLIENT* dispatcher thread
 
@@ -484,7 +486,7 @@ void ClientSession::sendPacketDispatched(const bdlbb::Blob& blob,
     // the message to the channelBufferQueue, and we'll send it later, once we
     // get the lowWatermark notification.
     bmqio::Status status;
-    d_channel_sp->write(&status, blob);
+    d_channel_sp->write(&status, *blob);
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
             status.category() != bmqio::StatusCategory::e_SUCCESS)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
@@ -496,7 +498,7 @@ void ClientSession::sendPacketDispatched(const bdlbb::Blob& blob,
         if (status.category() == bmqio::StatusCategory::e_LIMIT) {
             BALL_LOG_WARN << "#CLIENT_SEND_FAILURE " << description()
                           << ": Failed to send data [size: "
-                          << bmqu::PrintUtil::prettyNumber(blob.length())
+                          << bmqu::PrintUtil::prettyNumber(blob->length())
                           << " bytes] to client due to channel watermark limit"
                           << "; enqueuing to the ChannelBufferQueue.";
             d_state.d_channelBufferQueue.push_back(blob);
@@ -504,7 +506,7 @@ void ClientSession::sendPacketDispatched(const bdlbb::Blob& blob,
         else {
             BALL_LOG_INFO << "#CLIENT_SEND_FAILURE " << description()
                           << ": Failed to send data [size: "
-                          << bmqu::PrintUtil::prettyNumber(blob.length())
+                          << bmqu::PrintUtil::prettyNumber(blob->length())
                           << " bytes] to client with status: " << status;
         }
     }
@@ -527,10 +529,11 @@ void ClientSession::flushChannelBufferQueue()
 
     // Try to send as many data as possible
     while (!d_state.d_channelBufferQueue.empty()) {
-        const bdlbb::Blob& blob = d_state.d_channelBufferQueue.front();
+        const bsl::shared_ptr<bdlbb::Blob>& blob_sp =
+            d_state.d_channelBufferQueue.front();
 
         bmqio::Status status;
-        d_channel_sp->write(&status, blob);
+        d_channel_sp->write(&status, *blob_sp);
         if (status.category() == bmqio::StatusCategory::e_LIMIT) {
             // We are hitting the limit again, can't continue.. stop sending
             // and we'll resume with the next lowWatermark notification.

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -155,7 +155,7 @@ struct ClientSessionState {
     bslma::Allocator* d_allocator_p;
     // Allocator to use.
 
-    bsl::deque<bdlbb::Blob> d_channelBufferQueue;
+    bsl::deque<bsl::shared_ptr<bdlbb::Blob> > d_channelBufferQueue;
     // Queue of data pending being sent to
     // the client.  This should almost
     // always be empty, and is meant to
@@ -183,8 +183,10 @@ struct ClientSessionState {
     // context for any queue in this
     // domain.
 
+    /// Blob buffer factory to use.
+    /// TODO: this field should be removed once we retire the code for
+    ///       message properties conversion.
     bdlbb::BlobBufferFactory* d_bufferFactory_p;
-    // Blob buffer factory to use.
 
     BlobSpPool* d_blobSpPool_p;
     // Pool of shared pointers to blob to
@@ -427,8 +429,10 @@ class ClientSession : public mqbnet::Session,
     /// ACK) will be flushed and sent before `blob`; this is necessary to
     /// guarantee strict serialization of events when sending a control
     /// message.
-    void sendPacket(const bdlbb::Blob& blob, bool flushBuilders);
-    void sendPacketDispatched(const bdlbb::Blob& blob, bool flushBuilders);
+    void sendPacket(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                    bool                                flushBuilders);
+    void sendPacketDispatched(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                              bool flushBuilders);
 
     /// Flush as much as possible of the content of the internal
     /// `channelBufferQueue`.

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -780,7 +780,7 @@ class TestBench {
         int rc = obj.setMessage(controlMessage, bmqp::EventType::e_CONTROL);
         ASSERT_EQ(rc, 0);
 
-        bmqp::Event event(&obj.blob(), d_allocator_p);
+        bmqp::Event event(obj.blob().get(), d_allocator_p);
 
         d_cs.processEvent(event);
     }
@@ -808,7 +808,7 @@ class TestBench {
         int rc = obj.setMessage(controlMessage, bmqp::EventType::e_CONTROL);
         ASSERT_EQ(rc, 0);
 
-        bmqp::Event event(&obj.blob(), d_allocator_p);
+        bmqp::Event event(obj.blob().get(), d_allocator_p);
 
         d_cs.processEvent(event);
     }
@@ -1931,7 +1931,8 @@ static void test9_newStylePush()
     ASSERT_EQ(bmqt::EventBuilderResult::e_SUCCESS, rc);
 
     mqbi::DispatcherEvent putEvent(bmqtst::TestHelperUtil::allocator());
-    bmqp::Event rawEvent(&peb.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event           rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(rawEvent.isValid());
     BSLS_ASSERT(rawEvent.isPutEvent());
@@ -1941,17 +1942,11 @@ static void test9_newStylePush()
     rawEvent.loadPutMessageIterator(&putIt, false);
     BSLS_ASSERT(putIt.next());
 
-    bsl::shared_ptr<bdlbb::Blob> blobSp;
-    blobSp.createInplace(bmqtst::TestHelperUtil::allocator(),
-                         &tb.d_bufferFactory,
-                         bmqtst::TestHelperUtil::allocator());
-    *blobSp = peb.blob();
-
     putEvent.setType(mqbi::DispatcherEventType::e_PUT)
         .setIsRelay(true)     // Relay message
         .setSource(&tb.d_cs)  // DispatcherClient *value
         .setPutHeader(putIt.header())
-        .setBlob(blobSp);  // const bsl::shared_ptr<bdlbb::Blob>& value
+        .setBlob(peb.blob());  // const bsl::shared_ptr<bdlbb::Blob>& value
 
     tb.dispatch(putEvent);
 
@@ -2047,7 +2042,8 @@ static void test10_newStyleCompressedPush()
     ASSERT_EQ(bmqt::EventBuilderResult::e_SUCCESS, rc);
 
     mqbi::DispatcherEvent putEvent(bmqtst::TestHelperUtil::allocator());
-    bmqp::Event rawEvent(&peb.blob(), bmqtst::TestHelperUtil::allocator());
+    bmqp::Event           rawEvent(peb.blob().get(),
+                         bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(rawEvent.isValid());
     BSLS_ASSERT(rawEvent.isPutEvent());
@@ -2057,17 +2053,11 @@ static void test10_newStyleCompressedPush()
     rawEvent.loadPutMessageIterator(&putIt, false);
     BSLS_ASSERT(putIt.next());
 
-    bsl::shared_ptr<bdlbb::Blob> blobSp;
-    blobSp.createInplace(bmqtst::TestHelperUtil::allocator(),
-                         &tb.d_bufferFactory,
-                         bmqtst::TestHelperUtil::allocator());
-    *blobSp = peb.blob();
-
     putEvent.setType(mqbi::DispatcherEventType::e_PUT)
         .setIsRelay(true)     // Relay message
         .setSource(&tb.d_cs)  // DispatcherClient *value
         .setPutHeader(putIt.header())
-        .setBlob(blobSp)  // const bsl::shared_ptr<bdlbb::Blob>& value
+        .setBlob(peb.blob())  // const bsl::shared_ptr<bdlbb::Blob>& value
         .setCompressionAlgorithmType(bmqt::CompressionAlgorithmType::e_ZLIB);
 
     tb.dispatch(putEvent);

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -762,7 +762,9 @@ class TestBench {
     /// this testbench's `ClientSession`.
     void openQueue(const bsl::string& uri, const int queueId)
     {
-        bmqp::SchemaEventBuilder     obj(&d_bufferFactory, d_allocator_p);
+        bmqp::SchemaEventBuilder     obj(&d_blobSpPool,
+                                     bmqp::EncodingType::e_BER,
+                                     d_allocator_p);
         bmqp_ctrlmsg::ControlMessage controlMessage(d_allocator_p);
         bmqp_ctrlmsg::OpenQueue&     openQueue =
             controlMessage.choice().makeOpenQueue();
@@ -787,7 +789,9 @@ class TestBench {
     /// this testbench's `ClientSession`.
     void closeQueue(const bsl::string& uri, const int queueId)
     {
-        bmqp::SchemaEventBuilder     obj(&d_bufferFactory, d_allocator_p);
+        bmqp::SchemaEventBuilder     obj(&d_blobSpPool,
+                                     bmqp::EncodingType::e_BER,
+                                     d_allocator_p);
         bmqp_ctrlmsg::ControlMessage controlMessage(d_allocator_p);
         bmqp_ctrlmsg::CloseQueue&    closeQueue =
             controlMessage.choice().makeCloseQueue();
@@ -1908,7 +1912,7 @@ static void test9_newStylePush()
     bmqp::MessageProperties in(bmqtst::TestHelperUtil::allocator());
     encode(&in);
 
-    bmqp::PutEventBuilder peb(&tb.d_bufferFactory,
+    bmqp::PutEventBuilder peb(&tb.d_blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob           payload(&tb.d_bufferFactory,
                         bmqtst::TestHelperUtil::allocator());
@@ -2023,7 +2027,7 @@ static void test10_newStyleCompressedPush()
     bmqp::MessageProperties in(bmqtst::TestHelperUtil::allocator());
     encode(&in);
 
-    bmqp::PutEventBuilder peb(&tb.d_bufferFactory,
+    bmqp::PutEventBuilder peb(&tb.d_blobSpPool,
                               bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob           payload(&tb.d_bufferFactory,
                         bmqtst::TestHelperUtil::allocator());

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -686,9 +686,9 @@ int SessionNegotiator::sendNegotiationMessage(
     // Build connection response event
     bdlma::LocalSequentialAllocator<2048> localAllocator(d_allocator_p);
 
-    bmqp::SchemaEventBuilder builder(d_bufferFactory_p,
-                                     &localAllocator,
-                                     encodingType);
+    bmqp::SchemaEventBuilder builder(d_blobSpPool_p,
+                                     encodingType,
+                                     &localAllocator);
 
     int rc = builder.setMessage(message, bmqp::EventType::e_CONTROL);
     if (rc != 0) {

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -699,7 +699,7 @@ int SessionNegotiator::sendNegotiationMessage(
 
     // Send response event
     bmqio::Status status;
-    context->d_channelSp->write(&status, builder.blob());
+    context->d_channelSp->write(&status, *builder.blob());
     if (!status) {
         errorDescription << "Failed sending NegotiationMessage "
                          << "[status: " << status << ", message: " << message
@@ -736,7 +736,6 @@ void SessionNegotiator::createSession(bsl::ostream& errorDescription,
                          description,
                          d_dispatcher_p,
                          d_blobSpPool_p,
-                         d_bufferFactory_p,
                          d_scheduler_p,
                          d_adminCb,
                          d_allocator_p);

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -150,9 +150,10 @@ class SessionNegotiator : public mqbnet::Negotiator {
     bslma::Allocator* d_allocator_p;
     // Allocator to use
 
+    /// Buffer factory to use in constructed client sessions
+    /// TODO: this field should be removed once we retire the code for
+    ///       message properties conversion in `mqba::ClientSession`.
     bdlbb::BlobBufferFactory* d_bufferFactory_p;
-    // Buffer factory to inject into new client
-    // sessions
 
     mqbi::Dispatcher* d_dispatcher_p;
     // Dispatcher to inject into new client

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -378,7 +378,7 @@ ClusterCatalog::ClusterCatalog(mqbi::Dispatcher*             dispatcher,
 , d_resources(resources)
 , d_adminCb()
 , d_requestManager(bmqp::EventType::e_CONTROL,
-                   resources.bufferFactory(),
+                   resources.blobSpPool(),
                    resources.scheduler(),
                    false,  // lateResponseMode
                    d_allocator_p)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -592,7 +592,8 @@ ClusterOrchestrator::ClusterOrchestrator(
                             //      Strong
                             d_clusterData_p,
                             clusterState,
-                            &d_clusterData_p->bufferFactory())),
+                            &d_clusterData_p->bufferFactory(),
+                            &d_clusterData_p->blobSpPool())),
                     k_WATCHDOG_TIMEOUT_DURATION,
                     d_allocators.get("ClusterStateManager")))
           : static_cast<mqbi::ClusterStateManager*>(
@@ -611,7 +612,8 @@ ClusterOrchestrator::ClusterOrchestrator(
                             //      Strong
                             d_clusterData_p,
                             clusterState,
-                            &d_clusterData_p->bufferFactory())),
+                            &d_clusterData_p->bufferFactory(),
+                            &d_clusterData_p->blobSpPool())),
                     d_allocators.get("ClusterStateManager"))),
       d_allocator_p)
 , d_queueHelper(d_clusterData_p,
@@ -706,7 +708,7 @@ int ClusterOrchestrator::start(bsl::ostream& errorDescription)
                                  _3,   // LeaderNodeId
                                  _4),  // Term
             electorTerm,
-            &d_clusterData_p->bufferFactory(),
+            &d_clusterData_p->blobSpPool(),
             d_allocator_p),
         d_allocator_p);
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -592,7 +592,6 @@ ClusterOrchestrator::ClusterOrchestrator(
                             //      Strong
                             d_clusterData_p,
                             clusterState,
-                            &d_clusterData_p->bufferFactory(),
                             &d_clusterData_p->blobSpPool())),
                     k_WATCHDOG_TIMEOUT_DURATION,
                     d_allocators.get("ClusterStateManager")))
@@ -612,7 +611,6 @@ ClusterOrchestrator::ClusterOrchestrator(
                             //      Strong
                             d_clusterData_p,
                             clusterState,
-                            &d_clusterData_p->bufferFactory(),
                             &d_clusterData_p->blobSpPool())),
                     d_allocators.get("ClusterStateManager"))),
       d_allocator_p)

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -1522,7 +1522,7 @@ int RecoveryManager::sendFile(RequestContext*                   context,
 
     unsigned int               sequenceNumber = 0;
     bsls::Types::Uint64        currOffset     = beginOffset;
-    bmqp::RecoveryEventBuilder builder(&d_clusterData_p->bufferFactory(),
+    bmqp::RecoveryEventBuilder builder(&d_clusterData_p->blobSpPool(),
                                        d_allocator_p);
 
     while ((currOffset + chunkSize) < endOffset) {
@@ -1552,7 +1552,7 @@ int RecoveryManager::sendFile(RequestContext*                   context,
         }
 
         bmqt::GenericResult::Enum writeRc = context->requesterNode()->write(
-            builder.blob(),
+            builder.blob_sp(),
             bmqp::EventType::e_RECOVERY);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1600,7 +1600,7 @@ int RecoveryManager::sendFile(RequestContext*                   context,
     }
 
     bmqt::GenericResult::Enum writeRc = context->requesterNode()->write(
-        builder.blob(),
+        builder.blob_sp(),
         bmqp::EventType::e_RECOVERY);
 
     if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1707,7 +1707,7 @@ int RecoveryManager::replayPartition(
 
     bmqp::StorageEventBuilder builder(mqbs::FileStoreProtocol::k_VERSION,
                                       bmqp::EventType::e_PARTITION_SYNC,
-                                      &d_clusterData_p->bufferFactory(),
+                                      &d_clusterData_p->blobSpPool(),
                                       d_allocator_p);
 
     // Note that partition has to be replayed from the record *after*
@@ -1803,7 +1803,7 @@ int RecoveryManager::replayPartition(
                 .syncConfig()
                 .partitionSyncEventSize() <= builder.eventSize()) {
             bmqt::GenericResult::Enum writeRc = destination->write(
-                builder.blob(),
+                builder.blob_sp(),
                 bmqp::EventType::e_PARTITION_SYNC);
 
             if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1827,7 +1827,7 @@ int RecoveryManager::replayPartition(
 
     if (0 < builder.messageCount()) {
         bmqt::GenericResult::Enum writeRc = destination->write(
-            builder.blob(),
+            builder.blob_sp(),
             bmqp::EventType::e_PARTITION_SYNC);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -3271,7 +3271,7 @@ void RecoveryManager::processStorageEvent(
 
     bmqp::StorageEventBuilder seb(mqbs::FileStoreProtocol::k_VERSION,
                                   bmqp::EventType::e_STORAGE,
-                                  &d_clusterData_p->bufferFactory(),
+                                  &d_clusterData_p->blobSpPool(),
                                   d_allocator_p);
 
     while (1 == iter.next()) {

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -1552,7 +1552,7 @@ int RecoveryManager::sendFile(RequestContext*                   context,
         }
 
         bmqt::GenericResult::Enum writeRc = context->requesterNode()->write(
-            builder.blob_sp(),
+            builder.blob(),
             bmqp::EventType::e_RECOVERY);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1600,7 +1600,7 @@ int RecoveryManager::sendFile(RequestContext*                   context,
     }
 
     bmqt::GenericResult::Enum writeRc = context->requesterNode()->write(
-        builder.blob_sp(),
+        builder.blob(),
         bmqp::EventType::e_RECOVERY);
 
     if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1803,7 +1803,7 @@ int RecoveryManager::replayPartition(
                 .syncConfig()
                 .partitionSyncEventSize() <= builder.eventSize()) {
             bmqt::GenericResult::Enum writeRc = destination->write(
-                builder.blob_sp(),
+                builder.blob(),
                 bmqp::EventType::e_PARTITION_SYNC);
 
             if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -1827,7 +1827,7 @@ int RecoveryManager::replayPartition(
 
     if (0 < builder.messageCount()) {
         bmqt::GenericResult::Enum writeRc = destination->write(
-            builder.blob_sp(),
+            builder.blob(),
             bmqp::EventType::e_PARTITION_SYNC);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -3297,12 +3297,7 @@ void RecoveryManager::processStorageEvent(
     // nothing to buffer in this event.
 
     if (0 < seb.messageCount()) {
-        bsl::shared_ptr<bdlbb::Blob> blobSp;
-        blobSp.createInplace(d_allocator_p,
-                             &d_clusterData_p->bufferFactory(),
-                             d_allocator_p);
-        *blobSp = seb.blob();
-        recoveryCtx.addStorageEvent(blobSp);
+        recoveryCtx.addStorageEvent(seb.blob());
     }
 
     recoveryCtx.setNewSyncPoint(syncPoint);

--- a/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
@@ -117,12 +117,12 @@ ClusterData::ClusterData(
                       cluster->isRemote(),
                       allocator))
 , d_cluster_p(cluster)
-, d_messageTransmitter(resources.bufferFactory(),
+, d_messageTransmitter(resources.blobSpPool(),
                        cluster,
                        transportManager,
                        allocator)
 , d_requestManager(bmqp::EventType::e_CONTROL,
-                   resources.bufferFactory(),
+                   resources.blobSpPool(),
                    resources.scheduler(),
                    false,  // lateResponseMode
                    allocator)

--- a/src/groups/mqb/mqbc/mqbc_controlmessagetransmitter.cpp
+++ b/src/groups/mqb/mqbc/mqbc_controlmessagetransmitter.cpp
@@ -51,9 +51,8 @@ void ControlMessageTransmitter::sendMessageHelper(
         return;  // RETURN
     }
 
-    bmqt::GenericResult::Enum writeRc = destination->write(
-        schemaBuilder->blob_sp(),
-        bmqp::EventType::e_CONTROL);
+    bmqt::GenericResult::Enum writeRc =
+        destination->write(schemaBuilder->blob(), bmqp::EventType::e_CONTROL);
     if (bmqt::GenericResult::e_SUCCESS != writeRc) {
         BALL_LOG_ERROR << "#CLUSTER_SEND_FAILURE "
                        << "Failed to write schema message: " << message
@@ -84,7 +83,7 @@ void ControlMessageTransmitter::broadcastMessageHelper(
     // Broadcast to cluster, using the unicast channel to ensure ordering of
     // events.
 
-    d_cluster_p->netCluster().writeAll(schemaBuilder->blob_sp(),
+    d_cluster_p->netCluster().writeAll(schemaBuilder->blob(),
                                        bmqp::EventType::e_CONTROL);
 
     BALL_LOG_INFO << "Broadcasted message '" << message
@@ -115,7 +114,7 @@ void ControlMessageTransmitter::broadcastMessageHelper(
                 bmqp::HighAvailabilityFeatures::k_BROADCAST_TO_PROXIES,
                 negoMsg.clientIdentity().features())) {
             bmqio::Status status;
-            sessionSp->channel()->write(&status, schemaBuilder->blob());
+            sessionSp->channel()->write(&status, *schemaBuilder->blob());
             if (status.category() == bmqio::StatusCategory::e_SUCCESS) {
                 BALL_LOG_INFO << "Sent message '" << message << "' to proxy "
                               << sessionSp->description();
@@ -190,7 +189,7 @@ void ControlMessageTransmitter::sendMessage(
     }
 
     bmqio::Status status;
-    channel->write(&status, d_schemaBuilder.blob());
+    channel->write(&status, *d_schemaBuilder.blob());
     if (status.category() != bmqio::StatusCategory::e_SUCCESS) {
         BALL_LOG_ERROR << "#CLUSTER_SEND_FAILURE "
                        << "Failed to write schema message: " << message

--- a/src/groups/mqb/mqbc/mqbc_controlmessagetransmitter.h
+++ b/src/groups/mqb/mqbc/mqbc_controlmessagetransmitter.h
@@ -69,17 +69,19 @@ namespace mqbc {
 /// This class provides a mechanism to transmit messages to peer nodes in
 /// the same cluster.
 class ControlMessageTransmitter {
+  public:
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBC.ControlMessageTransmitter");
 
-  private:
     // DATA
     bslma::Allocator* d_allocator_p;
     // Allocator to use.
 
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
-    // Blob buffer factory to use.
+    /// Blob pool to use.  Held, not owned.
+    BlobSpPool* d_blobSpPool_p;
 
     bmqp::SchemaEventBuilder d_schemaBuilder;
     // Schema event builder to use.  Must be used
@@ -127,9 +129,9 @@ class ControlMessageTransmitter {
     // CREATORS
 
     /// Create an instance of `ControlMessageTransmitter` associated with
-    /// the specified `cluster` and using the specified `bufferFactory`.
+    /// the specified `cluster` and using the specified `blobSpPool_p`.
     /// Use the specified `allocator` for memory allocations.
-    ControlMessageTransmitter(bdlbb::BlobBufferFactory* bufferFactory,
+    ControlMessageTransmitter(BlobSpPool*               blobSpPool_p,
                               mqbi::Cluster*            cluster,
                               mqbnet::TransportManager* transportManager,
                               bslma::Allocator*         allocator);

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -523,8 +523,10 @@ int IncoreClusterStateLedger::applyRecordInternal(
             // record offset should be 0.
             BSLS_ASSERT_SAFE(recordOffset == 0);
 
-            bdlbb::Blob advisoryEvent(d_bufferFactory_p, d_allocator_p);
-            constructEventBlob(&advisoryEvent, record);
+            bsl::shared_ptr<bdlbb::Blob> advisoryEvent =
+                d_blobSpPool_p->getObject();
+
+            constructEventBlob(advisoryEvent.get(), record);
             d_clusterData_p->membership().netCluster()->writeAll(
                 advisoryEvent,
                 bmqp::EventType::e_CLUSTER_STATE);
@@ -566,8 +568,10 @@ int IncoreClusterStateLedger::applyRecordInternal(
             }
         }
         else {
-            bdlbb::Blob ackEvent(d_bufferFactory_p, d_allocator_p);
-            constructEventBlob(&ackEvent, ackRecord);
+            bsl::shared_ptr<bdlbb::Blob> ackEvent =
+                d_blobSpPool_p->getObject();
+
+            constructEventBlob(ackEvent.get(), ackRecord);
 
             mqbnet::ClusterNode* leaderNode =
                 d_clusterData_p->electorInfo().leaderNode();
@@ -631,8 +635,10 @@ int IncoreClusterStateLedger::applyRecordInternal(
         }
 
         if (isSelfLeader()) {
-            bdlbb::Blob commitEvent(d_bufferFactory_p, d_allocator_p);
-            constructEventBlob(&commitEvent, record);
+            bsl::shared_ptr<bdlbb::Blob> commitEvent =
+                d_blobSpPool_p->getObject();
+
+            constructEventBlob(commitEvent.get(), record);
             d_clusterData_p->membership().netCluster()->writeAll(
                 commitEvent,
                 bmqp::EventType::e_CLUSTER_STATE);
@@ -1178,11 +1184,13 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
     ClusterData*                        clusterData,
     ClusterState*                       clusterState,
     bdlbb::BlobBufferFactory*           bufferFactory,
+    BlobSpPool*                         blobSpPool_p,
     bslma::Allocator*                   allocator)
 : d_allocator_p(allocator)
 , d_isFirstLeaderAdvisory(true)
 , d_isOpen(false)
 , d_bufferFactory_p(bufferFactory)
+, d_blobSpPool_p(blobSpPool_p)
 , d_description(allocator)
 , d_commitCb()
 , d_clusterData_p(clusterData)

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -268,12 +268,12 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
          ++advisoryIt) {
         ClusterMessageInfo& info = advisoryIt->second;
 
-        bdlbb::Blob                  record(d_bufferFactory_p, d_allocator_p);
+        bsl::shared_ptr<bdlbb::Blob> record = d_blobSpPool_p->getObject();
         ClusterStateRecordType::Enum recordType =
             info.d_clusterMessage.choice().isLeaderAdvisoryValue()
                 ? ClusterStateRecordType::e_SNAPSHOT
                 : ClusterStateRecordType::e_UPDATE;
-        rc = ClusterStateLedgerUtil::appendRecord(&record,
+        rc = ClusterStateLedgerUtil::appendRecord(record.get(),
                                                   info.d_clusterMessage,
                                                   advisoryIt->first,
                                                   currentTime(),
@@ -283,9 +283,9 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
         }
 
         rc = d_ledger_mp->writeRecord(&(info.d_recordId),
-                                      record,
+                                      *record,
                                       bmqu::BlobPosition(),
-                                      record.length());
+                                      record->length());
         if (rc != 0) {
             return 10 * rc + rc_WRITE_RECORD_FAILURE;  // RETURN
         }
@@ -343,9 +343,9 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
     ClusterMessageInfo info;
     info.d_clusterMessage.choice().makeLeaderAdvisory(leaderAdvisory);
 
-    bdlbb::Blob record(d_bufferFactory_p, d_allocator_p);
-    rc = ClusterStateLedgerUtil::appendRecord(
-        &record,
+    bsl::shared_ptr<bdlbb::Blob> record = d_blobSpPool_p->getObject();
+    rc                                  = ClusterStateLedgerUtil::appendRecord(
+        record.get(),
         info.d_clusterMessage,
         leaderAdvisory.sequenceNumber(),
         currentTime(),
@@ -355,9 +355,9 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
     }
 
     rc = d_ledger_mp->writeRecord(&(info.d_recordId),
-                                  record,
+                                  *record,
                                   bmqu::BlobPosition(),
-                                  record.length());
+                                  record->length());
     if (rc != 0) {
         return 10 * rc + rc_WRITE_RECORD_FAILURE;  // RETURN
     }
@@ -415,8 +415,8 @@ int IncoreClusterStateLedger::applyAdvisoryInternal(
     }
 
     // Do leader logic: apply and broadcast advisory, then apply its ack
-    bdlbb::Blob advisoryRecord(d_bufferFactory_p, d_allocator_p);
-    int         rc = ClusterStateLedgerUtil::appendRecord(&advisoryRecord,
+    bsl::shared_ptr<bdlbb::Blob> advisoryRecord = d_blobSpPool_p->getObject();
+    int rc = ClusterStateLedgerUtil::appendRecord(advisoryRecord.get(),
                                                   clusterMessage,
                                                   sequenceNumber,
                                                   currentTime(),
@@ -425,7 +425,7 @@ int IncoreClusterStateLedger::applyAdvisoryInternal(
         return 10 * rc + rc_CREATE_RECORD_FAILURE;  // RETURN
     }
 
-    rc = applyRecordInternal(advisoryRecord,
+    rc = applyRecordInternal(*advisoryRecord,
                              0,
                              clusterMessage,
                              sequenceNumber,
@@ -545,9 +545,9 @@ int IncoreClusterStateLedger::applyRecordInternal(
         ackMessage.choice().makeLeaderAdvisoryAck().sequenceNumberAcked() =
             sequenceNumber;
 
-        bdlbb::Blob ackRecord(d_bufferFactory_p, d_allocator_p);
+        bsl::shared_ptr<bdlbb::Blob> ackRecord = d_blobSpPool_p->getObject();
         rc = ClusterStateLedgerUtil::appendRecord(
-            &ackRecord,
+            ackRecord.get(),
             ackMessage,
             sequenceNumber,
             currentTime(),
@@ -558,7 +558,7 @@ int IncoreClusterStateLedger::applyRecordInternal(
 
         // If leader, apply Ack to self.  Else, reply Ack back to leader
         if (isSelfLeader()) {
-            rc = applyRecordInternal(ackRecord,
+            rc = applyRecordInternal(*ackRecord,
                                      0,
                                      ackMessage,
                                      sequenceNumber,
@@ -571,7 +571,7 @@ int IncoreClusterStateLedger::applyRecordInternal(
             bsl::shared_ptr<bdlbb::Blob> ackEvent =
                 d_blobSpPool_p->getObject();
 
-            constructEventBlob(ackEvent.get(), ackRecord);
+            constructEventBlob(ackEvent.get(), *ackRecord);
 
             mqbnet::ClusterNode* leaderNode =
                 d_clusterData_p->electorInfo().leaderNode();
@@ -700,9 +700,10 @@ int IncoreClusterStateLedger::applyRecordInternal(
                           << ", creating and applying commit advisory: "
                           << commitMessage << ".";
 
-            bdlbb::Blob commitRecord(d_bufferFactory_p, d_allocator_p);
+            bsl::shared_ptr<bdlbb::Blob> commitRecord =
+                d_blobSpPool_p->getObject();
             rc = ClusterStateLedgerUtil::appendRecord(
-                &commitRecord,
+                commitRecord.get(),
                 commitMessage,
                 commitAdvisory.sequenceNumber(),
                 currentTime(),
@@ -711,7 +712,7 @@ int IncoreClusterStateLedger::applyRecordInternal(
                 return 10 * rc + rc_CREATE_COMMIT_FAILURE;  // RETURN
             }
 
-            rc = applyRecordInternal(commitRecord,
+            rc = applyRecordInternal(*commitRecord,
                                      0,
                                      commitMessage,
                                      commitAdvisory.sequenceNumber(),
@@ -1183,13 +1184,11 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
     ClusterStateLedgerConsistency::Enum consistencyLevel,
     ClusterData*                        clusterData,
     ClusterState*                       clusterState,
-    bdlbb::BlobBufferFactory*           bufferFactory,
     BlobSpPool*                         blobSpPool_p,
     bslma::Allocator*                   allocator)
 : d_allocator_p(allocator)
 , d_isFirstLeaderAdvisory(true)
 , d_isOpen(false)
-, d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool_p)
 , d_description(allocator)
 , d_commitCb()

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -127,11 +127,14 @@ struct IncoreClusterStateLedger_ClusterMessageInfo {
 /// cluster nodes themselves instead of being offloaded to an external meta
 /// data (e.g., ZooKeeper).
 class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
+  public:
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBC.INCORECLUSTERSTATELEDGER");
 
-  private:
     // TYPES
     typedef IncoreClusterStateLedger_ClusterMessageInfo ClusterMessageInfo;
     typedef ClusterStateLedgerCommitStatus              CommitStatus;
@@ -167,6 +170,9 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     // Buffer factory for the headers and
     // payloads of the messages to be
     // written
+
+    /// Pool of shared pointers to blobs
+    BlobSpPool* d_blobSpPool_p;
 
     bsl::string d_description;
     // Brief description for logging
@@ -301,6 +307,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
         ClusterData*                        clusterData,
         ClusterState*                       clusterState,
         bdlbb::BlobBufferFactory*           bufferFactory,
+        BlobSpPool*                         blobSpPool_p,
         bslma::Allocator*                   allocator);
 
     /// Destructor.

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -166,11 +166,6 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     // Flag to indicate open/close status
     // of this object
 
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
-    // Buffer factory for the headers and
-    // payloads of the messages to be
-    // written
-
     /// Pool of shared pointers to blobs
     BlobSpPool* d_blobSpPool_p;
 
@@ -306,7 +301,6 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
         ClusterStateLedgerConsistency::Enum consistencyLevel,
         ClusterData*                        clusterData,
         ClusterState*                       clusterState,
-        bdlbb::BlobBufferFactory*           bufferFactory,
         BlobSpPool*                         blobSpPool_p,
         bslma::Allocator*                   allocator);
 

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -292,7 +292,6 @@ struct Tester {
                     d_consistencyLevel,
                     d_cluster_mp->_clusterData(),
                     &d_cluster_mp->_state(),
-                    d_cluster_mp->_bufferFactory(),
                     d_cluster_mp->_blobSpPool(),
                     bmqtst::TestHelperUtil::allocator()),
             bmqtst::TestHelperUtil::allocator());

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -293,6 +293,7 @@ struct Tester {
                     d_cluster_mp->_clusterData(),
                     &d_cluster_mp->_state(),
                     d_cluster_mp->_bufferFactory(),
+                    d_cluster_mp->_blobSpPool(),
                     bmqtst::TestHelperUtil::allocator()),
             bmqtst::TestHelperUtil::allocator());
         d_clusterStateLedger_mp->setCommitCb(

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -117,13 +117,13 @@ void RecoveryManager::ReceiveDataContext::reset()
 
 // CREATORS
 RecoveryManager::RecoveryManager(
-    bdlbb::BlobBufferFactory*        bufferFactory,
+    BlobSpPool*                      blobSpPool_p,
     const mqbcfg::ClusterDefinition& clusterConfig,
     const mqbc::ClusterData&         clusterData,
     const mqbs::DataStoreConfig&     dataStoreConfig,
     bslma::Allocator*                allocator)
 : d_allocator_p(allocator)
-, d_bufferFactory_p(bufferFactory)
+, d_blobSpPool_p(blobSpPool_p)
 , d_clusterConfig(clusterConfig)
 , d_dataStoreConfig(dataStoreConfig)
 , d_clusterData(clusterData)
@@ -422,7 +422,7 @@ int RecoveryManager::processSendDataChunks(
 
     bmqp::StorageEventBuilder builder(mqbs::FileStoreProtocol::k_VERSION,
                                       bmqp::EventType::e_PARTITION_SYNC,
-                                      d_bufferFactory_p,
+                                      d_blobSpPool_p,
                                       d_allocator_p);
 
     // Note that partition has to be replayed from the record *after*
@@ -509,7 +509,7 @@ int RecoveryManager::processSendDataChunks(
                 .syncConfig()
                 .partitionSyncEventSize() <= builder.eventSize()) {
             const bmqt::GenericResult::Enum writeRc = destination->write(
-                builder.blob(),
+                builder.blob_sp(),
                 bmqp::EventType::e_PARTITION_SYNC);
 
             if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -533,7 +533,7 @@ int RecoveryManager::processSendDataChunks(
 
     if (0 < builder.messageCount()) {
         const bmqt::GenericResult::Enum writeRc = destination->write(
-            builder.blob(),
+            builder.blob_sp(),
             bmqp::EventType::e_PARTITION_SYNC);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -117,13 +117,12 @@ void RecoveryManager::ReceiveDataContext::reset()
 
 // CREATORS
 RecoveryManager::RecoveryManager(
-    BlobSpPool*                      blobSpPool_p,
     const mqbcfg::ClusterDefinition& clusterConfig,
-    const mqbc::ClusterData&         clusterData,
+    mqbc::ClusterData&               clusterData,
     const mqbs::DataStoreConfig&     dataStoreConfig,
     bslma::Allocator*                allocator)
 : d_allocator_p(allocator)
-, d_blobSpPool_p(blobSpPool_p)
+, d_blobSpPool_p(&clusterData.blobSpPool())
 , d_clusterConfig(clusterConfig)
 , d_dataStoreConfig(dataStoreConfig)
 , d_clusterData(clusterData)
@@ -509,7 +508,7 @@ int RecoveryManager::processSendDataChunks(
                 .syncConfig()
                 .partitionSyncEventSize() <= builder.eventSize()) {
             const bmqt::GenericResult::Enum writeRc = destination->write(
-                builder.blob_sp(),
+                builder.blob(),
                 bmqp::EventType::e_PARTITION_SYNC);
 
             if (bmqt::GenericResult::e_SUCCESS != writeRc) {
@@ -533,7 +532,7 @@ int RecoveryManager::processSendDataChunks(
 
     if (0 < builder.messageCount()) {
         const bmqt::GenericResult::Enum writeRc = destination->write(
-            builder.blob_sp(),
+            builder.blob(),
             bmqp::EventType::e_PARTITION_SYNC);
 
         if (bmqt::GenericResult::e_SUCCESS != writeRc) {

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -26,7 +26,6 @@
 // storage recovery in a cluster node.
 
 // MQB
-
 #include <mqbc_clusterdata.h>
 #include <mqbcfg_messages.h>
 #include <mqbnet_cluster.h>
@@ -64,6 +63,12 @@ namespace mqbc {
 /// This component provides a mechanism to manage storage recovery in a
 /// cluster node.
 class RecoveryManager {
+  public:
+    // TYPES
+    /// Pool of shared pointers to Blobs
+    typedef mqbs::FileStore::BlobSpPool BlobSpPool;
+
+  private:
     // ==================
     // class ChunkDeleter
     // ==================
@@ -259,11 +264,11 @@ class RecoveryManager {
 
   private:
     // DATA
-    bslma::Allocator* d_allocator_p;
     /// Allocator to use
+    bslma::Allocator* d_allocator_p;
 
-    /// Blob buffer factory to use
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
+    /// Blob shared pointer pool to use
+    BlobSpPool* d_blobSpPool_p;
 
     /// Cluster configuration to use
     const mqbcfg::ClusterDefinition& d_clusterConfig;
@@ -297,7 +302,7 @@ class RecoveryManager {
     /// Create a `RecoveryManager` object with the specified `bufferFactory`,
     /// `clusterConfig`, `dataStoreConfig`, and `clusterData`. Use the
     /// specified `allocator` for any memory allocation.
-    RecoveryManager(bdlbb::BlobBufferFactory*        bufferFactory,
+    RecoveryManager(BlobSpPool*                      blobSpPool_p,
                     const mqbcfg::ClusterDefinition& clusterConfig,
                     const mqbc::ClusterData&         clusterData,
                     const mqbs::DataStoreConfig&     dataStoreConfig,

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -299,12 +299,11 @@ class RecoveryManager {
 
     // CREATORS
 
-    /// Create a `RecoveryManager` object with the specified `bufferFactory`,
-    /// `clusterConfig`, `dataStoreConfig`, and `clusterData`. Use the
-    /// specified `allocator` for any memory allocation.
-    RecoveryManager(BlobSpPool*                      blobSpPool_p,
-                    const mqbcfg::ClusterDefinition& clusterConfig,
-                    const mqbc::ClusterData&         clusterData,
+    /// Create a `RecoveryManager` object with the specified `clusterConfig`,
+    /// `clusterData` and `dataStoreConfig`. Use the specified `allocator`
+    /// for any memory allocation.
+    RecoveryManager(const mqbcfg::ClusterDefinition& clusterConfig,
+                    mqbc::ClusterData&               clusterData,
                     const mqbs::DataStoreConfig&     dataStoreConfig,
                     bslma::Allocator*                allocator);
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3527,12 +3527,12 @@ int StorageManager::start(bsl::ostream& errorDescription)
     bslma::Allocator* recoveryManagerAllocator = d_allocators.get(
         "RecoveryManager");
 
-    d_recoveryManager_mp.load(new (*recoveryManagerAllocator) RecoveryManager(
-                                  &d_clusterData_p->bufferFactory(),
-                                  d_clusterConfig,
-                                  *d_clusterData_p,
-                                  dsCfg,
-                                  recoveryManagerAllocator),
+    d_recoveryManager_mp.load(new (*recoveryManagerAllocator)
+                                  RecoveryManager(d_blobSpPool_p,
+                                                  d_clusterConfig,
+                                                  *d_clusterData_p,
+                                                  dsCfg,
+                                                  recoveryManagerAllocator),
                               recoveryManagerAllocator);
 
     rc = d_recoveryManager_mp->start(errorDescription);

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3342,7 +3342,6 @@ StorageManager::StorageManager(
 , d_lowDiskspaceWarning(false)
 , d_unrecognizedDomainsLock()
 , d_unrecognizedDomains(allocator)
-, d_blobSpPool_p(&clusterData->blobSpPool())
 , d_domainFactory_p(domainFactory)
 , d_dispatcher_p(dispatcher)
 , d_cluster_p(cluster)
@@ -3500,7 +3499,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
         d_dispatcher_p,
         partitionCfg,
         &d_fileStores,
-        d_blobSpPool_p,
+        &d_clusterData_p->blobSpPool(),
         &d_allocators,
         errorDescription,
         d_replicationFactor,
@@ -3528,8 +3527,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
         "RecoveryManager");
 
     d_recoveryManager_mp.load(new (*recoveryManagerAllocator)
-                                  RecoveryManager(d_blobSpPool_p,
-                                                  d_clusterConfig,
+                                  RecoveryManager(d_clusterConfig,
                                                   *d_clusterData_p,
                                                   dsCfg,
                                                   recoveryManagerAllocator),

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -235,9 +235,6 @@ class StorageManager
     //
     // THREAD: Protected by 'd_unrecognizedDomainsLock'.
 
-    BlobSpPool* d_blobSpPool_p;
-    // SharedObjectPool of blobs to use
-
     mqbi::DomainFactory* d_domainFactory_p;
     // Domain factory to use
 

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -129,14 +129,10 @@ class Cluster : public mqbi::Cluster {
     typedef bsl::shared_ptr<bmqst::StatContext> StatContextSp;
     typedef mqbc::ClusterData::StatContextsMap  StatContextsMap;
 
-    typedef bdlcc::SharedObjectPool<
-        bdlbb::Blob,
-        bdlcc::ObjectPoolFunctors::DefaultCreator,
-        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
-        BlobSpPool;
-
   public:
     // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
     typedef bsl::vector<mqbcfg::ClusterNode> ClusterNodeDefs;
 
     typedef bsl::shared_ptr<bmqio::TestChannel> TestChannelSp;
@@ -420,6 +416,9 @@ class Cluster : public mqbi::Cluster {
     /// Get a modifiable reference to this object's buffer factory.
     bdlbb::BlobBufferFactory* _bufferFactory();
 
+    /// Get a modifiable reference to this object's blob shared pointer pool.
+    BlobSpPool* _blobSpPool();
+
     /// Get a modifiable reference to this object's _scheduler.
     bdlmt::EventScheduler& _scheduler();
 
@@ -567,6 +566,11 @@ inline void Cluster::_setEventProcessor(const EventProcessor& processor)
 inline bdlbb::BlobBufferFactory* Cluster::_bufferFactory()
 {
     return d_bufferFactory_p;
+}
+
+inline Cluster::BlobSpPool* Cluster::_blobSpPool()
+{
+    return &d_blobSpPool;
 }
 
 inline bdlmt::EventScheduler& Cluster::_scheduler()

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -41,7 +41,7 @@ size_t Channel::ControlArgs::eventSize() const
         return 0;  // RETURN
     }
 
-    return d_data.length();
+    return d_data_sp->length();
 }
 
 // --------------------
@@ -67,14 +67,17 @@ Channel::Channel(bdlbb::BlobBufferFactory* blobBufferFactory,
                  bslma::Allocator*         allocator)
 : d_allocators(allocator)
 , d_allocator_p(d_allocators.get("Channel"))
-, d_putBuilder(blobBufferFactory, d_allocator_p)
-, d_pushBuilder(blobBufferFactory, d_allocator_p)
-, d_ackBuilder(blobBufferFactory, d_allocator_p)
-, d_confirmBuilder(blobBufferFactory, d_allocator_p)
-, d_rejectBuilder(blobBufferFactory, d_allocator_p)
+, d_blobSpPool(
+      bmqp::BlobPoolUtil::createBlobPool(blobBufferFactory,
+                                         d_allocators.get("BlobSpPool")))
+, d_putBuilder(&d_blobSpPool, d_allocator_p)
+, d_pushBuilder(&d_blobSpPool, d_allocator_p)
+, d_ackBuilder(&d_blobSpPool, d_allocator_p)
+, d_confirmBuilder(&d_blobSpPool, d_allocator_p)
+, d_rejectBuilder(&d_blobSpPool, d_allocator_p)
 , d_itemPool(sizeof(Item),
              bsls::BlockGrowth::BSLS_CONSTANT,
-             d_allocators.get(bsl::string("ItemPool")))
+             d_allocators.get("ItemPool"))
 , d_buffer(1024, allocator)
 , d_secondaryBuffer(1024, allocator)
 , d_doStop(false)
@@ -116,14 +119,12 @@ void Channel::deleteItem(void* item, void* cookie)
 bmqt::GenericResult::Enum
 Channel::writePut(const bmqp::PutHeader&                    ph,
                   const bsl::shared_ptr<bdlbb::Blob>&       data,
-                  const bsl::shared_ptr<bmqu::AtomicState>& state,
-                  bool                                      keepWeakPtr)
+                  const bsl::shared_ptr<bmqu::AtomicState>& state)
 {
-    bslma::ManagedPtr<Item> item(
-        new (d_itemPool.allocate())
-            Item(ph, data, keepWeakPtr, state, d_allocator_p),
-        this,
-        deleteItem);
+    bslma::ManagedPtr<Item> item(new (d_itemPool.allocate())
+                                     Item(ph, data, state, d_allocator_p),
+                                 this,
+                                 deleteItem);
     return enqueue(item);
 }
 
@@ -227,7 +228,7 @@ Channel::writeReject(int                                       queueId,
 }
 
 bmqt::GenericResult::Enum
-Channel::writeBlob(const bdlbb::Blob&                        data,
+Channel::writeBlob(const bsl::shared_ptr<bdlbb::Blob>&       data,
                    bmqp::EventType::Enum                     type,
                    const bsl::shared_ptr<bmqu::AtomicState>& state)
 {
@@ -483,7 +484,7 @@ bmqt::EventBuilderResult::Enum Channel::pack(bmqp::PutEventBuilder& builder,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_internalThreadChecker.inSameThread());
 
-    if (!args.d_data) {
+    if (!args.d_data_sp.get()) {
         return bmqt::EventBuilderResult::e_PAYLOAD_EMPTY;
     }
     const bmqp::PutHeader& ph = args.d_putHeader;
@@ -491,7 +492,7 @@ bmqt::EventBuilderResult::Enum Channel::pack(bmqp::PutEventBuilder& builder,
     builder.startMessage();
     builder.setMessageGUID(ph.messageGUID())
         .setFlags(ph.flags())
-        .setMessagePayload(args.d_data.get())
+        .setMessagePayload(args.d_data_sp.get())
         .setCompressionAlgorithmType(ph.compressionAlgorithmType())
         .setCrc32c(ph.crc32c())
         .setMessagePropertiesInfo(bmqp::MessagePropertiesInfo(ph));
@@ -512,7 +513,7 @@ bmqt::EventBuilderResult::Enum Channel::pack(bmqp::PushEventBuilder& builder,
         args.d_subQueueInfos);
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
             rc == bmqt::EventBuilderResult::e_SUCCESS)) {
-        rc = builder.packMessage(*args.d_data.get(),
+        rc = builder.packMessage(*args.d_data_sp,
                                  args.d_queueId,
                                  args.d_msgId,
                                  args.d_flags,

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -123,12 +123,17 @@ class Channel {
     // PRIVATE TYPES
     struct Item;
 
+    typedef bmqc::MonitoredQueue<
+        bdlcc::SingleConsumerQueue<bslma::ManagedPtr<Item> > >
+        ItemQueue;
+
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
     /// Const references to everything needed to writeBufferedItem PUT.
     /// This is template parameter to generalized writing code.
     struct PutArgs {
         const bmqp::PutHeader&              d_putHeader;
-        const bsl::shared_ptr<bdlbb::Blob>& d_data;
-        const bool                          d_hasWeakPtr;
+        const bsl::shared_ptr<bdlbb::Blob>& d_data_sp;
 
         PutArgs(Item& item);
 
@@ -157,7 +162,7 @@ class Channel {
     /// data.
     /// This is template parameter to generalized writing code.
     struct ExplicitPushArgs : PushArgsBase {
-        const bsl::shared_ptr<bdlbb::Blob>& d_data;
+        const bsl::shared_ptr<bdlbb::Blob>& d_data_sp;
 
         const bmqp::Protocol::SubQueueInfosArray& d_subQueueInfos;
 
@@ -220,7 +225,7 @@ class Channel {
     /// `control` builder.
     struct ControlArgs {
         bmqp::EventType::Enum d_type;
-        const bdlbb::Blob&    d_data;
+        const bsl::shared_ptr<bdlbb::Blob>& d_data_sp;
         int                   d_messageCount;
 
         ControlArgs(Item& item);
@@ -243,8 +248,6 @@ class Channel {
 
         // union of event data copies
         const bmqp::PutHeader                      d_putHeader;
-        const bsl::weak_ptr<bdlbb::Blob>           d_data_wp;
-        const bool                                 d_hasWeakPtr;
         const bsl::shared_ptr<bdlbb::Blob>         d_data_sp;
         const int                                  d_queueId;
         const int                                  d_subQueueId;
@@ -252,15 +255,11 @@ class Channel {
         const int                                  d_flags;
         const bmqt::CompressionAlgorithmType::Enum d_compressionAlgorithmType;
         const bmqp::MessagePropertiesInfo          d_messagePropertiesInfo;
-        const bdlbb::Blob                          d_data;
         const bmqp::Protocol::SubQueueInfosArray   d_subQueueInfos;
         const int                                  d_correlationId;
         const int                                  d_status;
 
         const bsl::shared_ptr<bmqu::AtomicState> d_state;
-
-        bsl::shared_ptr<bdlbb::Blob> d_tempData_sp;
-        bsl::shared_ptr<bdlbb::Blob> d_tempOptions_sp;
 
         size_t d_numBytes;
 
@@ -268,7 +267,6 @@ class Channel {
 
         Item(const bmqp::PutHeader&                    ph,
              const bsl::shared_ptr<bdlbb::Blob>&       data,
-             bool                                      keepWeakPtr,
              const bsl::shared_ptr<bmqu::AtomicState>& state,
              bslma::Allocator*                         allocator);
 
@@ -305,7 +303,7 @@ class Channel {
              bmqp::EventType::Enum                     type,
              bslma::Allocator*                         allocator);
 
-        Item(const bdlbb::Blob&                        data,
+        Item(const bsl::shared_ptr<bdlbb::Blob>&       data,
              bmqp::EventType::Enum                     type,
              const bsl::shared_ptr<bmqu::AtomicState>& state,
              bslma::Allocator*                         allocator);
@@ -348,9 +346,6 @@ class Channel {
 
   public:
     // PUBLIC TYPES
-    typedef bmqc::MonitoredQueue<
-        bdlcc::SingleConsumerQueue<bslma::ManagedPtr<Item> > >
-        ItemQueue;
     enum EnumState {
         e_INITIAL = 0  // Not connected
         ,
@@ -374,6 +369,8 @@ class Channel {
 
     /// Counting allocator
     bslma::Allocator* d_allocator_p;
+
+    BlobSpPool d_blobSpPool;
 
     bmqp::PutEventBuilder d_putBuilder;
 
@@ -525,14 +522,11 @@ class Channel {
     void closeChannel();
 
     /// Write PUT message using the specified `ph`, `data`, and `state`.
-    /// Return e_SUCCESS even if the channel is in HWM. If the specified
-    /// `keepWeakPtr` is `true`, keep `weak_ptr` when enqueueing thus
-    /// allowing caller to release the blobs before processing.
+    /// Return e_SUCCESS even if the channel is in HWM.
     bmqt::GenericResult::Enum
     writePut(const bmqp::PutHeader&                    ph,
              const bsl::shared_ptr<bdlbb::Blob>&       data,
-             const bsl::shared_ptr<bmqu::AtomicState>& state,
-             bool                                      keepWeakPtr = false);
+             const bsl::shared_ptr<bmqu::AtomicState>& state);
 
     /// Write `explicit` PUSH message using the specified `payload`,
     /// `queueId`, `msgId`, `flags`, `compressionType`, `subQueueInfos`, and
@@ -597,7 +591,7 @@ class Channel {
     /// Replication Receipt).  Return e_SUCCESS even if the channel is in
     /// High WaterMark.
     bmqt::GenericResult::Enum
-    writeBlob(const bdlbb::Blob&                        data,
+    writeBlob(const bsl::shared_ptr<bdlbb::Blob>&       data,
               bmqp::EventType::Enum                     type,
               const bsl::shared_ptr<bmqu::AtomicState>& state = 0);
 
@@ -636,8 +630,7 @@ inline Channel::PutArgs::~PutArgs()
 
 inline Channel::PutArgs::PutArgs(Item& item)
 : d_putHeader(item.d_putHeader)
-, d_data(item.data())
-, d_hasWeakPtr(item.d_hasWeakPtr)
+, d_data_sp(item.d_data_sp)
 {
     // NOTHING
 }
@@ -676,7 +669,7 @@ inline Channel::ExplicitPushArgs::ExplicitPushArgs(Item& item)
                item.d_flags,
                item.d_compressionAlgorithmType,
                item.d_messagePropertiesInfo)
-, d_data(item.d_data_sp)
+, d_data_sp(item.d_data_sp)
 , d_subQueueInfos(item.d_subQueueInfos)
 {
     // NOTHING
@@ -764,7 +757,7 @@ inline Channel::RejectArgs::~RejectArgs()
 
 inline Channel::ControlArgs::ControlArgs(Item& item)
 : d_type(item.d_type)
-, d_data(item.d_data)
+, d_data_sp(item.d_data_sp)
 , d_messageCount(1)
 {
     // NOTHING
@@ -777,7 +770,7 @@ inline Channel::ControlArgs::~ControlArgs()
 
 inline const bdlbb::Blob& Channel::ControlArgs::blob() const
 {
-    return d_data;
+    return *d_data_sp;
 }
 
 inline size_t Channel::ControlArgs::messageCount() const
@@ -797,35 +790,35 @@ inline void Channel::ControlArgs::reset()
 // CREATORS
 inline Channel::Item::Item(bslma::Allocator* allocator)
 : d_type(bmqp::EventType::e_UNDEFINED)
-, d_hasWeakPtr(false)
+, d_putHeader()
+, d_data_sp(0, allocator)
 , d_queueId(0)
 , d_subQueueId(0)
+, d_msgId()
 , d_flags(0)
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
-, d_data(allocator)
 , d_subQueueInfos(allocator)
 , d_correlationId(0)
 , d_status(0)
+, d_state(0)
 , d_numBytes(0)
 {
     // NOTHING
 }
 
-inline Channel::Item::Item(const bmqp::PutHeader&              ph,
-                           const bsl::shared_ptr<bdlbb::Blob>& data,
-                           bool                                keepWeakPtr,
+inline Channel::Item::Item(const bmqp::PutHeader&                    ph,
+                           const bsl::shared_ptr<bdlbb::Blob>&       data,
                            const bsl::shared_ptr<bmqu::AtomicState>& state,
                            bslma::Allocator*                         allocator)
 : d_type(bmqp::EventType::e_PUT)
 , d_putHeader(ph)
-, d_data_wp(keepWeakPtr ? data : 0)
-, d_hasWeakPtr(false)
-, d_data_sp(keepWeakPtr ? 0 : data)
+, d_data_sp(data)
 , d_queueId(0)
 , d_subQueueId(0)
+, d_msgId()
 , d_flags(0)
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
-, d_data(allocator)
+, d_messagePropertiesInfo()
 , d_subQueueInfos(allocator)
 , d_correlationId(0)
 , d_status(0)
@@ -846,7 +839,7 @@ inline Channel::Item::Item(
     const bsl::shared_ptr<bmqu::AtomicState>& state,
     bslma::Allocator*                         allocator)
 : d_type(bmqp::EventType::e_PUSH)
-, d_hasWeakPtr(false)
+, d_putHeader()
 , d_data_sp(payload)
 , d_queueId(queueId)
 , d_subQueueId(0)
@@ -854,7 +847,6 @@ inline Channel::Item::Item(
 , d_flags(flags)
 , d_compressionAlgorithmType(compressionAlgorithmType)
 , d_messagePropertiesInfo(messagePropertiesInfo)
-, d_data(allocator)
 , d_subQueueInfos(subQueueInfos, allocator)
 , d_correlationId(0)
 , d_status(0)
@@ -874,14 +866,14 @@ inline Channel::Item::Item(
     const bsl::shared_ptr<bmqu::AtomicState>& state,
     bslma::Allocator*                         allocator)
 : d_type(bmqp::EventType::e_PUSH)
-, d_hasWeakPtr(false)
+, d_putHeader()
+, d_data_sp(0, allocator)
 , d_queueId(queueId)
 , d_subQueueId(0)
 , d_msgId(msgId)
 , d_flags(flags)
 , d_compressionAlgorithmType(compressionAlgorithmType)
 , d_messagePropertiesInfo(messagePropertiesInfo)
-, d_data(allocator)
 , d_subQueueInfos(subQueueInfos, allocator)
 , d_correlationId(0)
 , d_status(0)
@@ -899,13 +891,14 @@ inline Channel::Item::Item(int                      status,
                            const bsl::shared_ptr<bmqu::AtomicState>& state,
                            bslma::Allocator*                         allocator)
 : d_type(bmqp::EventType::e_ACK)
-, d_hasWeakPtr(false)
+, d_putHeader()
+, d_data_sp(0, allocator)
 , d_queueId(queueId)
 , d_subQueueId(0)
 , d_msgId(guid)
 , d_flags(0)
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
-, d_data(allocator)
+, d_messagePropertiesInfo()
 , d_subQueueInfos(allocator)
 , d_correlationId(correlationId)
 , d_status(status)
@@ -922,13 +915,14 @@ inline Channel::Item::Item(int                      queueId,
                            bmqp::EventType::Enum                     type,
                            bslma::Allocator*                         allocator)
 : d_type(type)
-, d_hasWeakPtr(false)
+, d_putHeader()
+, d_data_sp(0, allocator)
 , d_queueId(queueId)
 , d_subQueueId(subQueueId)
 , d_msgId(guid)
 , d_flags(0)
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
-, d_data(allocator)
+, d_messagePropertiesInfo()
 , d_subQueueInfos(allocator)
 , d_correlationId(0)
 , d_status(0)
@@ -947,22 +941,24 @@ inline Channel::Item::Item(int                      queueId,
     }
 }
 
-inline Channel::Item::Item(const bdlbb::Blob&                        data,
+inline Channel::Item::Item(const bsl::shared_ptr<bdlbb::Blob>&       data,
                            bmqp::EventType::Enum                     type,
                            const bsl::shared_ptr<bmqu::AtomicState>& state,
                            bslma::Allocator*                         allocator)
 : d_type(type)
-, d_hasWeakPtr(false)
+, d_putHeader()
+, d_data_sp(data)
 , d_queueId(0)
 , d_subQueueId(0)
+, d_msgId()
 , d_flags(0)
 , d_compressionAlgorithmType(bmqt::CompressionAlgorithmType::e_NONE)
-, d_data(data, allocator)
+, d_messagePropertiesInfo()
 , d_subQueueInfos(allocator)
 , d_correlationId(0)
 , d_status(0)
 , d_state(state)
-, d_numBytes(data.length())
+, d_numBytes(data->length())
 {
     // NOTHING
 }
@@ -974,10 +970,6 @@ inline Channel::Item::~Item()
 
 inline const bsl::shared_ptr<bdlbb::Blob>& Channel::Item::data()
 {
-    if (d_hasWeakPtr) {
-        d_tempData_sp = d_data_wp.lock();
-        return d_tempData_sp;  // RETURN
-    }
     return d_data_sp;
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -1058,7 +1058,7 @@ Channel::flushBuilder(Builder&                               builder,
     bmqio::Status st;
 
     if (builder.messageCount()) {
-        channel->write(&st, builder.blob());
+        channel->write(&st, *builder.blob());
 
         if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
                 st.category() == bmqio::StatusCategory::e_SUCCESS)) {

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -54,16 +54,17 @@ namespace bmqio {
 
 class TestChannelEx : public TestChannel {
   private:
-    size_t                   d_limit;
-    mqbnet::Channel&         d_channel;
-    bool                     d_isInHWM;
-    bslmt::ReaderWriterMutex d_mutex;
-    bdlbb::Blob              d_eof;
+    size_t                       d_limit;
+    mqbnet::Channel&             d_channel;
+    bool                         d_isInHWM;
+    bslmt::ReaderWriterMutex     d_mutex;
+    bsl::shared_ptr<bdlbb::Blob> d_eof_sp;
 
   public:
-    TestChannelEx(mqbnet::Channel&          channel,
-                  bdlbb::BlobBufferFactory* factory,
-                  bslma::Allocator*         basicAllocator);
+    TestChannelEx(mqbnet::Channel&                channel,
+                  bdlbb::BlobBufferFactory*       factory,
+                  bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p,
+                  bslma::Allocator*               basicAllocator);
     ~TestChannelEx() BSLS_KEYWORD_OVERRIDE;
 
     void write(bmqio::Status*     status,
@@ -84,16 +85,21 @@ const char   k_CONTENT[]   = "Being is always the Being of a being";
 const size_t k_BUFFER_SIZE = sizeof(k_CONTENT) * 100;
 
 struct PseudoBuilder {
-    bdlbb::Blob d_payload;
-    PseudoBuilder(bdlbb::PooledBlobBufferFactory* bufferFactory,
+    bslma::Allocator*               d_allocator_p;
+    bmqp::BlobPoolUtil::BlobSpPool* d_blobSpPool_p;
+    bsl::shared_ptr<bdlbb::Blob>    d_payload_sp;
+
+    PseudoBuilder(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p,
                   bslma::Allocator*               allocator_p)
-    : d_payload(bufferFactory, allocator_p)
+    : d_allocator_p(bslma::Default::allocator(allocator_p))
+    , d_blobSpPool_p(blobSpPool_p)
+    , d_payload_sp(d_blobSpPool_p->getObject())
     {
         // NOTHING
     }
-    int  messageCount() const { return d_payload.length() ? 1 : 0; }
-    void reset() { d_payload.removeAll(); }
-    const bdlbb::Blob& blob() const { return d_payload; }
+    int  messageCount() const { return d_payload_sp->length() ? 1 : 0; }
+    void reset() { d_payload_sp = d_blobSpPool_p->getObject(); }
+    bsl::shared_ptr<bdlbb::Blob> blob_sp() const { return d_payload_sp; }
 };
 template <class Builder>
 struct Iterator {
@@ -104,11 +110,15 @@ struct Iterator {
 
 template <class Builder>
 class Tester {
+  public:
+    typedef bsl::deque<bsl::shared_ptr<bdlbb::Blob> > BlobDeque;
+
   private:
     Builder                         d_builder;
     bdlbb::PooledBlobBufferFactory& d_bufferFactory;
+    bmqp::BlobPoolUtil::BlobSpPool& d_blobSpPool;
     mqbnet::Channel&                d_channel;
-    bsl::deque<bdlbb::Blob>         d_history;
+    BlobDeque                       d_history;
     bslmt::ThreadUtil::Handle       d_threadHandle;
     bsls::AtomicBool                d_stop;
     bslma::Allocator*               d_allocator_p;
@@ -122,6 +132,7 @@ class Tester {
 
     Tester(mqbnet::Channel&                channel,
            bdlbb::PooledBlobBufferFactory& bufferFactory,
+           bmqp::BlobPoolUtil::BlobSpPool& blobSpPool,
            bslma::Allocator*               allocator_p);
 
     void   test();
@@ -290,15 +301,17 @@ inline void setContent(bdlbb::BlobBuffer* buffer)
 namespace BloombergLP {
 namespace bmqio {
 
-TestChannelEx::TestChannelEx(mqbnet::Channel&          channel,
-                             bdlbb::BlobBufferFactory* factory,
-                             bslma::Allocator*         basicAllocator)
+TestChannelEx::TestChannelEx(mqbnet::Channel&                channel,
+                             bdlbb::BlobBufferFactory*       factory,
+                             bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p,
+                             bslma::Allocator*               basicAllocator)
 : TestChannel(basicAllocator)
 , d_limit(0)
 , d_channel(channel)
 , d_isInHWM(false)
-, d_eof(factory, basicAllocator)
+, d_eof_sp(0, basicAllocator)
 {
+    d_eof_sp                      = blobSpPool_p->getObject();
     static const char signature[] = "12345";
     bdlbb::BlobBuffer blobBuffer;
     factory->allocate(&blobBuffer);
@@ -307,7 +320,7 @@ TestChannelEx::TestChannelEx(mqbnet::Channel&          channel,
 
     bsl::memcpy(blobBuffer.data(), signature, sizeof(signature));
 
-    d_eof.appendDataBuffer(blobBuffer);
+    d_eof_sp->appendDataBuffer(blobBuffer);
 }
 
 TestChannelEx::~TestChannelEx()
@@ -380,10 +393,10 @@ void TestChannelEx::write(bmqio::Status*     status,
 
 bool TestChannelEx::waitForChannel(const bsls::TimeInterval& interval)
 {
-    ASSERT_EQ(d_channel.writeBlob(d_eof, bmqp::EventType::e_CONTROL),
+    ASSERT_EQ(d_channel.writeBlob(d_eof_sp, bmqp::EventType::e_CONTROL),
               bmqt::GenericResult::e_SUCCESS);
 
-    return waitFor(d_eof, interval);
+    return waitFor(*d_eof_sp, interval);
 }
 
 }
@@ -396,9 +409,11 @@ bool TestChannelEx::waitForChannel(const bsls::TimeInterval& interval)
 template <class Builder>
 inline Tester<Builder>::Tester(mqbnet::Channel&                channel,
                                bdlbb::PooledBlobBufferFactory& bufferFactory,
+                               bmqp::BlobPoolUtil::BlobSpPool& blobSpPool,
                                bslma::Allocator*               allocator_p)
-: d_builder(&bufferFactory, allocator_p)
+: d_builder(&blobSpPool, allocator_p)
 , d_bufferFactory(bufferFactory)
+, d_blobSpPool(blobSpPool)
 , d_channel(channel)
 , d_history(allocator_p)
 , d_threadHandle()
@@ -417,7 +432,7 @@ inline void Tester<Builder>::test()
             bmqt::EventBuilderResult::e_OPTION_TOO_BIG == rc)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-        d_history.push_back(d_builder.blob());
+        d_history.push_back(d_builder.blob_sp());
         d_builder.reset();
 
         rc = build();
@@ -432,9 +447,7 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::PutEventBuilder>::build()
     static int                   queueId = 0;
     bmqp::PutHeader              ph;
     const int                    flags = 0;
-    bsl::shared_ptr<bdlbb::Blob> payload(
-        new (*d_allocator_p) bdlbb::Blob(&d_bufferFactory, d_allocator_p),
-        d_allocator_p);
+    bsl::shared_ptr<bdlbb::Blob>       payload_sp = d_blobSpPool.getObject();
     bdlbb::BlobBuffer                  blobBuffer;
     bsl::shared_ptr<bmqu::AtomicState> state(new (*d_allocator_p)
                                                  bmqu::AtomicState,
@@ -444,7 +457,7 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::PutEventBuilder>::build()
 
     setContent(&blobBuffer);
 
-    payload->appendDataBuffer(blobBuffer);
+    payload_sp->appendDataBuffer(blobBuffer);
 
     ph.setCorrelationId(++id);
     ph.setMessageGUID(bmqp::MessageGUIDGenerator::testGUID());
@@ -456,14 +469,14 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::PutEventBuilder>::build()
 
     d_builder.setMessageGUID(ph.messageGUID())
         .setFlags(ph.flags())
-        .setMessagePayload(payload.get())
+        .setMessagePayload(payload_sp.get())
         .setCompressionAlgorithmType(ph.compressionAlgorithmType())
         .setCrc32c(ph.crc32c());
 
     bmqt::EventBuilderResult::Enum rc = d_builder.packMessage(queueId);
 
     if (rc == bmqt::EventBuilderResult::e_SUCCESS) {
-        d_channel.writePut(ph, payload, state);
+        d_channel.writePut(ph, payload_sp, state);
     }
     return rc;
 }
@@ -501,24 +514,23 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::PushEventBuilder>::build()
         }
     }
     else {
-        bsl::shared_ptr<bdlbb::Blob> payload(
-            new (*d_allocator_p) bdlbb::Blob(&d_bufferFactory, d_allocator_p),
-            d_allocator_p);
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = d_blobSpPool.getObject();
         bdlbb::BlobBuffer blobBuffer;
 
-        d_bufferFactory.allocate(&blobBuffer);
+        ASSERT(0 != payload_sp->factory());
+        payload_sp->factory()->allocate(&blobBuffer);
 
         setContent(&blobBuffer);
 
-        payload->appendDataBuffer(blobBuffer);
+        payload_sp->appendDataBuffer(blobBuffer);
 
-        rc = d_builder.packMessage(*payload,
+        rc = d_builder.packMessage(*payload_sp,
                                    queueId,
                                    guid,
                                    flags,
                                    bmqt::CompressionAlgorithmType::e_NONE);
         if (rc == bmqt::EventBuilderResult::e_SUCCESS) {
-            d_channel.writePush(payload,
+            d_channel.writePush(payload_sp,
                                 queueId,
                                 guid,
                                 flags,
@@ -590,23 +602,24 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::AckEventBuilder>::build()
 template <>
 inline bmqt::EventBuilderResult::Enum Tester<PseudoBuilder>::build()
 {
-    d_builder.d_payload.setLength(sizeof(bmqp::EventHeader));
+    d_builder.d_payload_sp->setLength(sizeof(bmqp::EventHeader));
 
-    bmqp::EventHeader* eventHeader = new (d_builder.d_payload.buffer(0).data())
+    bmqp::EventHeader* eventHeader = new (
+        d_builder.d_payload_sp->buffer(0).data())
         bmqp::EventHeader(bmqp::EventType::e_CONTROL);
 
     bdlbb::BlobBuffer blobBuffer;
 
     d_bufferFactory.allocate(&blobBuffer);
     setContent(&blobBuffer);
-    d_builder.d_payload.appendDataBuffer(blobBuffer);
+    d_builder.d_payload_sp->appendDataBuffer(blobBuffer);
 
-    eventHeader->setLength(d_builder.d_payload.length());
+    eventHeader->setLength(d_builder.d_payload_sp->length());
 
-    d_channel.writeBlob(d_builder.d_payload, bmqp::EventType::e_CONTROL);
+    d_channel.writeBlob(d_builder.d_payload_sp, bmqp::EventType::e_CONTROL);
 
     // never return e_EVENT_TOO_BIG
-    d_history.push_back(d_builder.d_payload);
+    d_history.push_back(d_builder.d_payload_sp);
     d_builder.reset();
 
     return bmqt::EventBuilderResult::e_SUCCESS;
@@ -617,7 +630,7 @@ inline size_t Tester<Builder>::verify(
     const bsl::shared_ptr<bmqio::TestChannelEx>& testChannel)
 {
     if (d_builder.messageCount()) {
-        d_history.push_back(d_builder.blob());
+        d_history.push_back(d_builder.blob_sp());
         d_builder.reset();
     }
 
@@ -628,11 +641,11 @@ inline size_t Tester<Builder>::verify(
     size_t            counter    = 0;
     size_t            writeBlobs = 0;
 
-    for (bsl::deque<bdlbb::Blob>::iterator itHistory = d_history.begin();
+    for (BlobDeque::iterator itHistory = d_history.begin();
          itHistory != d_history.end();
          ++itHistory) {
-        const bdlbb::Blob& blob = *itHistory;
-        bmqp::Event        eventHistory(&blob, d_allocator_p);
+        const bsl::shared_ptr<BloombergLP::bdlbb::Blob>& blob_sp = *itHistory;
+        bmqp::Event        eventHistory(blob_sp.get(), d_allocator_p);
         Iterator<Builder>  itHistoryEvents(&d_bufferFactory, d_allocator_p);
 
         itHistoryEvents.load(eventHistory);
@@ -727,6 +740,10 @@ static void test1_write()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     mqbnet::Channel channel(&bufferFactory,
                             "test",
                             bmqtst::TestHelperUtil::allocator());
@@ -735,25 +752,31 @@ static void test1_write()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
+                                 &blobSpPool,
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
+                                        blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannel>(testChannel));
@@ -807,6 +830,10 @@ static void test2_highWatermark()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     mqbnet::Channel channel(&bufferFactory,
                             "test",
                             bmqtst::TestHelperUtil::allocator());
@@ -815,28 +842,35 @@ static void test2_highWatermark()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
+                                 &blobSpPool,
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
+                                        blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<PseudoBuilder>            control(channel,
                                   bufferFactory,
+                                  blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     bslmt::Barrier phase1(6 + 1);
@@ -913,6 +947,10 @@ static void test3_highWatermarkInWriteCb()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     mqbnet::Channel channel(&bufferFactory,
                             "test",
                             bmqtst::TestHelperUtil::allocator());
@@ -921,25 +959,31 @@ static void test3_highWatermarkInWriteCb()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
+                                 &blobSpPool,
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
+                                        blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     bslmt::Barrier phase1(5 + 1);
@@ -1017,6 +1061,10 @@ static void test4_controlBlob()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     mqbnet::Channel channel(&bufferFactory,
                             "test",
                             bmqtst::TestHelperUtil::allocator());
@@ -1025,25 +1073,31 @@ static void test4_controlBlob()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
+                                 &blobSpPool,
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
+                                        blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
+                                      blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
+        blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
@@ -1056,19 +1110,18 @@ static void test4_controlBlob()
 
     // cannot assert 'writeCalls().size() == 0' because of auto-flushing
 
-    bdlbb::Blob       payload = bdlbb::Blob(&bufferFactory,
-                                      bmqtst::TestHelperUtil::allocator());
+    bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
     bdlbb::BlobBuffer blobBuffer;
 
     bufferFactory.allocate(&blobBuffer);
     bsl::memset(blobBuffer.data(), 0, blobBuffer.size());
 
-    payload.appendDataBuffer(blobBuffer);
+    payload_sp->appendDataBuffer(blobBuffer);
 
     // Flush ACKs which are secondary
     channel.flush();
 
-    ASSERT_EQ(channel.writeBlob(payload, bmqp::EventType::e_CONTROL),
+    ASSERT_EQ(channel.writeBlob(payload_sp, bmqp::EventType::e_CONTROL),
               bmqt::GenericResult::e_SUCCESS);
 
     ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(1)), true);
@@ -1086,7 +1139,7 @@ static void test4_controlBlob()
     const bdlbb::Blob& lastWrite = (--testChannel->writeCalls().end())->d_blob;
 
     // make sure the control is the last
-    ASSERT_EQ(bdlbb::BlobUtil::compare(payload, lastWrite), 0);
+    ASSERT_EQ(bdlbb::BlobUtil::compare(*payload_sp, lastWrite), 0);
 }
 
 static void test5_reconnect()
@@ -1101,6 +1154,10 @@ static void test5_reconnect()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
+    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+        bmqp::BlobPoolUtil::createBlobPool(
+            &bufferFactory,
+            bmqtst::TestHelperUtil::allocator()));
     mqbnet::Channel channel(&bufferFactory,
                             "test",
                             bmqtst::TestHelperUtil::allocator());
@@ -1109,42 +1166,41 @@ static void test5_reconnect()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
+                                 &blobSpPool,
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
 
     {
-        bdlbb::Blob       payload = bdlbb::Blob(&bufferFactory,
-                                          bmqtst::TestHelperUtil::allocator());
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);
         setContent(&blobBuffer);
-        payload.appendDataBuffer(blobBuffer);
+        payload_sp->appendDataBuffer(blobBuffer);
 
-        ASSERT_EQ(channel.writeBlob(payload, bmqp::EventType::e_CONTROL),
+        ASSERT_EQ(channel.writeBlob(payload_sp, bmqp::EventType::e_CONTROL),
                   bmqt::GenericResult::e_SUCCESS);
 
         ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(1)), true);
         const bdlbb::Blob& write = testChannel->writeCalls().begin()->d_blob;
 
-        ASSERT_EQ(bdlbb::BlobUtil::compare(payload, write), 0);
+        ASSERT_EQ(bdlbb::BlobUtil::compare(*payload_sp, write), 0);
     }
     ASSERT_EQ(testChannel->writeCalls().size(), 1U);
 
     testChannel->setWriteStatus(bmqio::StatusCategory::e_CONNECTION);
 
     {
-        bdlbb::Blob       payload = bdlbb::Blob(&bufferFactory,
-                                          bmqtst::TestHelperUtil::allocator());
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);
         setContent(&blobBuffer);
-        payload.appendDataBuffer(blobBuffer);
+        payload_sp->appendDataBuffer(blobBuffer);
 
-        ASSERT_EQ(channel.writeBlob(payload, bmqp::EventType::e_CONTROL),
+        ASSERT_EQ(channel.writeBlob(payload_sp, bmqp::EventType::e_CONTROL),
                   bmqt::GenericResult::e_SUCCESS);
     }
     ASSERT_EQ(testChannel->writeCalls().size(), 1U);
@@ -1156,107 +1212,24 @@ static void test5_reconnect()
     testChannel->setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
 
     {
-        bdlbb::Blob       payload = bdlbb::Blob(&bufferFactory,
-                                          bmqtst::TestHelperUtil::allocator());
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);
         setContent(&blobBuffer);
-        payload.appendDataBuffer(blobBuffer);
+        payload_sp->appendDataBuffer(blobBuffer);
 
-        ASSERT_EQ(channel.writeBlob(payload, bmqp::EventType::e_CONTROL),
+        ASSERT_EQ(channel.writeBlob(payload_sp, bmqp::EventType::e_CONTROL),
                   bmqt::GenericResult::e_SUCCESS);
 
         ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(1)), true);
         const bdlbb::Blob& write =
             (++testChannel->writeCalls().begin())->d_blob;
 
-        ASSERT_EQ(bdlbb::BlobUtil::compare(payload, write), 0);
+        ASSERT_EQ(bdlbb::BlobUtil::compare(*payload_sp, write), 0);
     }
 
     ASSERT_EQ(testChannel->writeCalls().size(), 2U);
-}
-
-static void test6_weakData()
-// ------------------------------------------------------------------------
-//
-// Call writePut which takes weak_ptr under HWM causing the channel to
-// buffer data.  Release the data, simulate LWM, and observe negative
-// return code,
-//
-// ------------------------------------------------------------------------
-{
-    bdlbb::PooledBlobBufferFactory bufferFactory(
-        k_BUFFER_SIZE,
-        bmqtst::TestHelperUtil::allocator());
-    mqbnet::Channel channel(&bufferFactory,
-                            "test",
-                            bmqtst::TestHelperUtil::allocator());
-
-    bsl::shared_ptr<bmqio::TestChannelEx> testChannel(
-        new (*bmqtst::TestHelperUtil::allocator())
-            bmqio::TestChannelEx(channel,
-                                 &bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator()),
-        bmqtst::TestHelperUtil::allocator());
-
-    channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
-
-    // Saturate the channel causing it to buffer next write
-    channel.onWatermark(bmqio::ChannelWatermarkType::e_HIGH_WATERMARK);
-
-    {
-        bsl::shared_ptr<bdlbb::Blob> payload(
-            new (*bmqtst::TestHelperUtil::allocator())
-                bdlbb::Blob(&bufferFactory,
-                            bmqtst::TestHelperUtil::allocator()),
-            bmqtst::TestHelperUtil::allocator());
-        bdlbb::BlobBuffer                  blobBuffer;
-        bsl::shared_ptr<bmqu::AtomicState> state(
-            new (*bmqtst::TestHelperUtil::allocator()) bmqu::AtomicState,
-            bmqtst::TestHelperUtil::allocator());
-        bmqp::PutHeader                    ph;
-
-        bufferFactory.allocate(&blobBuffer);
-
-        payload->appendDataBuffer(blobBuffer);
-        ph.setMessageGUID(bmqp::MessageGUIDGenerator::testGUID());
-
-        // This write ends up in the builder and cannot be canceled.
-        ASSERT_EQ(channel.writePut(ph, payload, state, false),
-                  bmqt::GenericResult::e_SUCCESS);
-        // After 'onWatermark', the channel starts buffering.
-    }
-    ASSERT_EQ(testChannel->writeCalls().size(), 0U);
-
-    // Next write
-    {
-        bsl::shared_ptr<bdlbb::Blob> payload(
-            new (*bmqtst::TestHelperUtil::allocator())
-                bdlbb::Blob(&bufferFactory,
-                            bmqtst::TestHelperUtil::allocator()),
-            bmqtst::TestHelperUtil::allocator());
-        bdlbb::BlobBuffer                  blobBuffer;
-        bsl::shared_ptr<bmqu::AtomicState> state(
-            new (*bmqtst::TestHelperUtil::allocator()) bmqu::AtomicState,
-            bmqtst::TestHelperUtil::allocator());
-        bmqp::PutHeader                    ph;
-
-        bufferFactory.allocate(&blobBuffer);
-
-        payload->appendDataBuffer(blobBuffer);
-        ph.setMessageGUID(bmqp::MessageGUIDGenerator::testGUID());
-
-        ASSERT_EQ(channel.writePut(ph, payload, state, true),
-                  bmqt::GenericResult::e_SUCCESS);
-    }
-
-    channel.onWatermark(bmqio::ChannelWatermarkType::e_LOW_WATERMARK);
-
-    ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(1)), true);
-
-    // Only the first write makes it to IO.
-    ASSERT_EQ(testChannel->writeCalls().size(), 1U);
 }
 
 // ============================================================================
@@ -1279,7 +1252,6 @@ int main(int argc, char* argv[])
     case 3: test3_highWatermarkInWriteCb(); break;
     case 4: test4_controlBlob(); break;
     case 5: test5_reconnect(); break;
-    case 6: test6_weakData(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -99,7 +99,7 @@ struct PseudoBuilder {
     }
     int  messageCount() const { return d_payload_sp->length() ? 1 : 0; }
     void reset() { d_payload_sp = d_blobSpPool_p->getObject(); }
-    bsl::shared_ptr<bdlbb::Blob> blob_sp() const { return d_payload_sp; }
+    bsl::shared_ptr<bdlbb::Blob> blob() const { return d_payload_sp; }
 };
 template <class Builder>
 struct Iterator {
@@ -432,7 +432,7 @@ inline void Tester<Builder>::test()
             bmqt::EventBuilderResult::e_OPTION_TOO_BIG == rc)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-        d_history.push_back(d_builder.blob_sp());
+        d_history.push_back(d_builder.blob());
         d_builder.reset();
 
         rc = build();
@@ -630,7 +630,7 @@ inline size_t Tester<Builder>::verify(
     const bsl::shared_ptr<bmqio::TestChannelEx>& testChannel)
 {
     if (d_builder.messageCount()) {
-        d_history.push_back(d_builder.blob_sp());
+        d_history.push_back(d_builder.blob());
         d_builder.reset();
     }
 

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -147,8 +147,9 @@ class ClusterNode {
     /// success, and a non-zero value otherwise.  Note that success does not
     /// imply that the data has been written or will be successfully written
     /// to the underlying stream used by this channel.
-    virtual bmqt::GenericResult::Enum write(const bdlbb::Blob&    blob,
-                                            bmqp::EventType::Enum type) = 0;
+    virtual bmqt::GenericResult::Enum
+    write(const bsl::shared_ptr<bdlbb::Blob>& blob,
+          bmqp::EventType::Enum               type) = 0;
 
     // ACCESSORS
 
@@ -214,13 +215,13 @@ class Cluster {
     /// nodes of this cluster (with the exception of the current node).
     /// Return the maximum number of pending items across all cluster
     /// channels prior to broadcasting.
-    virtual int writeAll(const bdlbb::Blob&    blob,
-                         bmqp::EventType::Enum type) = 0;
+    virtual int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                         bmqp::EventType::Enum               type) = 0;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
     /// (exception of the current node).  Return the maximum number of
     /// pending items across all cluster channels prior to broadcasting.
-    virtual int broadcast(const bdlbb::Blob& blob) = 0;
+    virtual int broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) = 0;
 
     /// Close the channels associated to all nodes in this cluster.
     virtual void closeChannels() = 0;

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
@@ -76,7 +76,7 @@ struct ClusterNodeTestImp : bsls::ProtocolTestImp<mqbnet::ClusterNode> {
     void closeChannel() BSLS_KEYWORD_OVERRIDE { markDone(); }
 
     bmqt::GenericResult::Enum
-    write(const bdlbb::Blob&    blob,
+    write(const bsl::shared_ptr<bdlbb::Blob>& blob,
           bmqp::EventType::Enum type = bmqp::EventType::e_CONTROL)
         BSLS_KEYWORD_OVERRIDE
     {
@@ -129,14 +129,15 @@ struct ClusterTestImp : bsls::ProtocolTestImp<mqbnet::Cluster> {
         return markDone();
     }
 
-    int writeAll(const bdlbb::Blob&    blob,
+    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
                  bmqp::EventType::Enum type = bmqp::EventType::e_CONTROL)
         BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
     }
 
-    int broadcast(const bdlbb::Blob& blob) BSLS_KEYWORD_OVERRIDE
+    int
+    broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
     }
@@ -304,7 +305,7 @@ static void test2_ClusterNode()
         PV("Verify that methods are public and virtual");
 
         bsl::weak_ptr<bmqio::Channel> dummyWeakChannel;
-        bdlbb::Blob                   dummyBlob;
+        bsl::shared_ptr<bdlbb::Blob>  dummyBlob_sp;
         bmqp_ctrlmsg::ClientIdentity  identity;
 
         BSLS_PROTOCOLTEST_ASSERT(testObj,
@@ -315,7 +316,8 @@ static void test2_ClusterNode()
         BSLS_PROTOCOLTEST_ASSERT(testObj, closeChannel());
         BSLS_PROTOCOLTEST_ASSERT(testObj, resetChannel());
         BSLS_PROTOCOLTEST_ASSERT(testObj,
-                                 write(dummyBlob, bmqp::EventType::e_CONTROL));
+                                 write(dummyBlob_sp,
+                                       bmqp::EventType::e_CONTROL));
         BSLS_PROTOCOLTEST_ASSERT(testObj, channel());
         BSLS_PROTOCOLTEST_ASSERT(testObj, identity());
         BSLS_PROTOCOLTEST_ASSERT(testObj, nodeId());
@@ -386,7 +388,7 @@ static void test3_Cluster()
         PV("Verify that methods are public and virtual");
 
         mqbnet::ClusterObserver* dummyClusterObserver_p = 0;
-        bdlbb::Blob              dummyBlob;
+        bsl::shared_ptr<bdlbb::Blob> dummyBlob_sp;
         int                      dummyInt = 0;
 
         BSLS_PROTOCOLTEST_ASSERT(testObj,
@@ -394,9 +396,9 @@ static void test3_Cluster()
         BSLS_PROTOCOLTEST_ASSERT(testObj,
                                  unregisterObserver(dummyClusterObserver_p));
         BSLS_PROTOCOLTEST_ASSERT(testObj,
-                                 writeAll(dummyBlob,
+                                 writeAll(dummyBlob_sp,
                                           bmqp::EventType::e_CONTROL));
-        BSLS_PROTOCOLTEST_ASSERT(testObj, broadcast(dummyBlob));
+        BSLS_PROTOCOLTEST_ASSERT(testObj, broadcast(dummyBlob_sp));
         BSLS_PROTOCOLTEST_ASSERT(testObj, closeChannels());
         BSLS_PROTOCOLTEST_ASSERT(testObj, lookupNode(dummyInt));
         BSLS_PROTOCOLTEST_ASSERT(testObj, enableRead());

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -142,8 +142,9 @@ void ClusterNodeImp::closeChannel()
     d_channel.closeChannel();
 }
 
-bmqt::GenericResult::Enum ClusterNodeImp::write(const bdlbb::Blob&    blob,
-                                                bmqp::EventType::Enum type)
+bmqt::GenericResult::Enum
+ClusterNodeImp::write(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                      bmqp::EventType::Enum               type)
 {
     return d_channel.writeBlob(blob, type);
 }
@@ -231,7 +232,8 @@ Cluster* ClusterImp::unregisterObserver(ClusterObserver* observer)
     return this;
 }
 
-int ClusterImp::writeAll(const bdlbb::Blob& blob, bmqp::EventType::Enum type)
+int ClusterImp::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                         bmqp::EventType::Enum               type)
 {
     unsigned int maxPushChannelPendingItems = 0;
     unsigned int maxChannelPendingItems     = 0;
@@ -262,7 +264,7 @@ int ClusterImp::writeAll(const bdlbb::Blob& blob, bmqp::EventType::Enum type)
                 if (d_failedWritesThrottler.requestPermission()) {
                     BALL_LOG_ERROR << "#CLUSTER_SEND_FAILURE "
                                    << "Failed to write blob of length ["
-                                   << blob.length() << "] bytes, to node "
+                                   << blob->length() << "] bytes, to node "
                                    << it->nodeDescription() << ", rc: " << rc
                                    << ".";
                 }
@@ -277,7 +279,7 @@ int ClusterImp::writeAll(const bdlbb::Blob& blob, bmqp::EventType::Enum type)
     return maxPushChannelPendingItems;
 }
 
-int ClusterImp::broadcast(const bdlbb::Blob& blob)
+int ClusterImp::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
     return writeAll(blob, bmqp::EventType::e_STORAGE);
 }

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -151,8 +151,8 @@ class ClusterNodeImp : public ClusterNode {
     /// imply that the data has been written or will be successfully written
     /// to the underlying stream used by this channel.
     bmqt::GenericResult::Enum
-    write(const bdlbb::Blob&    blob,
-          bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
+    write(const bsl::shared_ptr<bdlbb::Blob>& blob,
+          bmqp::EventType::Enum               type) BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
     const bmqp_ctrlmsg::ClientIdentity& identity() const BSLS_KEYWORD_OVERRIDE;
@@ -296,13 +296,14 @@ class ClusterImp : public Cluster {
     /// nodes of this cluster (with the exception of the current node).
     /// Return the maximum number of pending items across all cluster
     /// channels prior to broadcasting.
-    int writeAll(const bdlbb::Blob&    blob,
+    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
                  bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
     /// (exception of the current node).  Return the maximum number of
     /// pending items across all cluster channels prior to broadcasting.
-    int broadcast(const bdlbb::Blob& blob) BSLS_KEYWORD_OVERRIDE;
+    int
+    broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 
     /// Close the channels associated to all nodes in this cluster.
     void closeChannels() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbnet/mqbnet_elector.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_elector.cpp
@@ -2091,7 +2091,7 @@ void Elector::emitIOEvent(const ElectorStateMachineOutput& output)
     }
 
     // Retrieve the encoded event
-    const bsl::shared_ptr<bdlbb::Blob> blob = builder.blob_sp();
+    const bsl::shared_ptr<bdlbb::Blob> blob = builder.blob();
     if (k_ALL_NODES_ID == output.destination()) {
         // Broadcast to cluster, using the unicast channel to ensure ordering
         // of events

--- a/src/groups/mqb/mqbnet/mqbnet_elector.h
+++ b/src/groups/mqb/mqbnet/mqbnet_elector.h
@@ -790,6 +790,9 @@ class Elector : public SessionEventProcessor {
     BALL_LOG_SET_CLASS_CATEGORY("MQBNET.ELECTOR");
 
   public:
+    // TYPES
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+
     // PUBLIC CLASS DATA
     static const bsls::Types::Uint64 k_INVALID_TERM =
         ElectorStateMachine::k_INVALID_TERM;
@@ -833,7 +836,7 @@ class Elector : public SessionEventProcessor {
     // DATA
     bslma::Allocator* d_allocator_p;
 
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
+    BlobSpPool* d_blobSpPool_p;
 
     mqbi::Cluster* d_cluster_p;
 
@@ -1008,13 +1011,13 @@ class Elector : public SessionEventProcessor {
     /// Create an elector instance with the specified `config`, invoking the
     /// specified `callback` whenever elector state changes, using the
     /// specified `cluster` for emitting I/O events, using the specified
-    /// `initalTerm` and using the specified `bufferFactory` for blobs
+    /// `initalTerm` and using the specified `blobSpPool_p` for blobs
     /// allocation and `allocator` for memory allocation.
     Elector(mqbcfg::ElectorConfig&      config,
             mqbi::Cluster*              cluster,
             const ElectorStateCallback& callback,
             bsls::Types::Uint64         initialTerm,
-            bdlbb::BlobBufferFactory*   bufferFactory,
+            BlobSpPool*                 blobSpPool_p,
             bslma::Allocator*           allocator);
 
     /// Destroy this instance.  Behavior is undefined unless this instance

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
@@ -118,8 +118,9 @@ void MockClusterNode::closeChannel()
     d_channel.closeChannel();
 }
 
-bmqt::GenericResult::Enum MockClusterNode::write(const bdlbb::Blob&    blob,
-                                                 bmqp::EventType::Enum type)
+bmqt::GenericResult::Enum
+MockClusterNode::write(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                       bmqp::EventType::Enum               type)
 {
     return d_channel.writeBlob(blob, type);
 }
@@ -195,7 +196,8 @@ Cluster* MockCluster::unregisterObserver(ClusterObserver* observer)
     return this;
 }
 
-int MockCluster::writeAll(const bdlbb::Blob& blob, bmqp::EventType::Enum type)
+int MockCluster::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                          bmqp::EventType::Enum               type)
 {
     for (bsl::list<MockClusterNode>::iterator it = d_nodes.begin();
          it != d_nodes.end();
@@ -209,7 +211,7 @@ int MockCluster::writeAll(const bdlbb::Blob& blob, bmqp::EventType::Enum type)
     return 0;
 }
 
-int MockCluster::broadcast(const bdlbb::Blob& blob)
+int MockCluster::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
     if (d_disableBroadcast) {
         return 0;  // RETURN

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -136,8 +136,8 @@ class MockClusterNode : public ClusterNode {
     /// imply that the data has been written or will be successfully written
     /// to the underlying stream used by this channel.
     bmqt::GenericResult::Enum
-    write(const bdlbb::Blob&    blob,
-          bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
+    write(const bsl::shared_ptr<bdlbb::Blob>& blob,
+          bmqp::EventType::Enum               type) BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
     //   (virtual mqbnet::ClusterNode)
@@ -271,13 +271,14 @@ class MockCluster : public Cluster {
     /// nodes of this cluster (with the exception of the current node).
     /// Return the maximum number of pending items across all cluster
     /// channels prior to broadcasting.
-    int writeAll(const bdlbb::Blob&    blob,
+    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
                  bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
     /// (exception of the current node).  Return the maximum number of
     /// pending items across all cluster channels prior to broadcasting.
-    int broadcast(const bdlbb::Blob& blob) BSLS_KEYWORD_OVERRIDE;
+    int
+    broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 
     /// Close the channels associated to all nodes in this cluster.
     void closeChannels() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -196,8 +196,9 @@ class MultiRequestManager {
 
   private:
     // PRIVATE MANIPULATORS
-    static bmqt::GenericResult::Enum sendHelper(bmqio::Channel*    channel,
-                                                const bdlbb::Blob& blob);
+    static bmqt::GenericResult::Enum
+    sendHelper(bmqio::Channel*                     channel,
+               const bsl::shared_ptr<bdlbb::Blob>& blob);
 
     /// Create a `MultiRequestManagerRequestContext` object at the specified
     /// `address` using the supplied `allocator`.  This is used by the
@@ -336,11 +337,11 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::response() const
 template <class REQUEST, class RESPONSE, class TARGET>
 inline bmqt::GenericResult::Enum
 MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendHelper(
-    bmqio::Channel*    channel,
-    const bdlbb::Blob& blob)
+    bmqio::Channel*                     channel,
+    const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
     bmqio::Status status;
-    channel->write(&status, blob);
+    channel->write(&status, *blob);
 
     switch (status.category()) {
     case bmqio::StatusCategory::e_SUCCESS:

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -122,6 +122,9 @@ class TestContext {
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
     // Buffer factory provided to the various builders
 
+    /// Blob shared pointer pool used in event builders.
+    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+
     ReqManagerTypeSp d_requestManager;
     // RequestManager object under testing
 
@@ -233,6 +236,9 @@ class TestContext {
 
 TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
 : d_blobBufferFactory(1024, allocator)
+, d_blobSpPool(
+      bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
+                                         bmqtst::TestHelperUtil::allocator()))
 , d_requestManager(0)
 , d_multiRequestManager(0)
 , d_requestContextSp(0)
@@ -260,7 +266,7 @@ TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
 
     d_requestManager = bsl::make_shared<ReqManagerType>(
         bmqp::EventType::e_CONTROL,
-        &d_blobBufferFactory,
+        &d_blobSpPool,
         &d_cluster_mp->_scheduler(),
         false,  // lateResponseMode
         d_allocator_p);

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6978,7 +6978,7 @@ void FileStore::flushStorage()
                        << d_storageEventBuilder.messageCount()
                        << " STORAGE messages.";
         const int maxChannelPendingItems = d_cluster_p->broadcast(
-            d_storageEventBuilder.blob_sp());
+            d_storageEventBuilder.blob());
         if (maxChannelPendingItems > 0) {
             if (d_nagglePacketCount < k_NAGLE_PACKET_COUNT) {
                 // back off

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -142,13 +142,9 @@ class FileStore : public DataStore {
   public:
     // TYPES
 
-    /// Pool of shared pointers to Blobs
-    typedef bdlcc::SharedObjectPool<
-        bdlbb::Blob,
-        bdlcc::ObjectPoolFunctors::DefaultCreator,
-        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
-        BlobSpPool;
+    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
 
+    /// Pool of shared pointers to AtomicStates
     typedef bdlcc::SharedObjectPool<
         bmqu::AtomicState,
         bdlcc::ObjectPoolFunctors::DefaultCreator,
@@ -241,16 +237,15 @@ class FileStore : public DataStore {
     };
 
     struct NodeContext {
+        /// Last Receipt from/to this node (Replica/Primary).
         DataStoreRecordKey d_key;
-        // last Receipt from/to this
-        // node (Replica/Primary).
-        bdlbb::Blob d_blob;
-        // Receipt to this node.
+
+        /// Receipt to this node.
+        bsl::shared_ptr<bdlbb::Blob> d_blob_sp;
+
         bsl::shared_ptr<bmqu::AtomicState> d_state;
 
-        NodeContext(bdlbb::BlobBufferFactory* factory,
-                    const DataStoreRecordKey& key,
-                    bslma::Allocator*         basicAllocator = 0);
+        NodeContext(BlobSpPool* blobSpPool_p, const DataStoreRecordKey& key);
     };
     typedef bmqc::OrderedHashMap<DataStoreRecordKey,
                                  ReceiptContext,
@@ -1116,11 +1111,10 @@ inline FileStore::ReceiptContext::ReceiptContext(
 // class FileStore::NodeContext
 // ----------------------------
 
-inline FileStore::NodeContext::NodeContext(bdlbb::BlobBufferFactory* factory,
-                                           const DataStoreRecordKey& key,
-                                           bslma::Allocator* basicAllocator)
+inline FileStore::NodeContext::NodeContext(BlobSpPool* blobSpPool_p,
+                                           const DataStoreRecordKey& key)
 : d_key(key)
-, d_blob(factory, basicAllocator)
+, d_blob_sp(blobSpPool_p->getObject())
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -31,6 +31,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocolutil.h>
 #include <bmqt_messageguid.h>
@@ -89,12 +90,6 @@ typedef mqbs::DataStore::AppInfos                      AppInfos;
 typedef mqbs::FileStore::SyncPointOffsetPairs          SyncPointOffsetPairs;
 typedef bsl::pair<mqbs::DataStoreRecordHandle, Record> HandleRecordPair;
 
-typedef bdlcc::SharedObjectPool<
-    bdlbb::Blob,
-    bdlcc::ObjectPoolFunctors::DefaultCreator,
-    bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
-    BlobSpPool;
-
 // FUNCTIONS
 
 /// Create a new blob at the specified `arena` address, using the specified
@@ -147,7 +142,7 @@ struct Tester {
     bdlbb::PooledBlobBufferFactory         d_bufferFactory;
     bsl::string                            d_clusterLocation;
     bsl::string                            d_clusterArchiveLocation;
-    BlobSpPool                             d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPool         d_blobSpPool;
     mqbcfg::PartitionConfig                d_partitionCfg;
     mqbcfg::ClusterDefinition              d_clusterCfg;
     bsl::vector<mqbcfg::ClusterNode>       d_clusterNodesCfg;
@@ -172,12 +167,9 @@ struct Tester {
     , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_clusterLocation(location, bmqtst::TestHelperUtil::allocator())
     , d_clusterArchiveLocation(location, bmqtst::TestHelperUtil::allocator())
-    , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
-                                        &d_bufferFactory,
-                                        bdlf::PlaceHolders::_1,   // arena
-                                        bdlf::PlaceHolders::_2),  // alloc
-                   1024,  // blob pool growth strategy
-                   bmqtst::TestHelperUtil::allocator())
+    , d_blobSpPool(bmqp::BlobPoolUtil::createBlobPool(
+          &d_bufferFactory,
+          bmqtst::TestHelperUtil::allocator()))
     , d_partitionCfg(bmqtst::TestHelperUtil::allocator())
     , d_clusterCfg(bmqtst::TestHelperUtil::allocator())
     , d_clusterNodesCfg(bmqtst::TestHelperUtil::allocator())


### PR DESCRIPTION
# Overview

In some code paths, we need to write similar Blobs of data to multiple cluster nodes at once (replication for example). Previously, we copied these Blobs for every `mqbnet::Channel` holding a single connection to another cluster node. Blob class has a vector of BlobBuffer objects, and when we copy a Blob, we reallocate a new vector of BlobBuffers, using the provided allocator. We spend a lot of time on this, and the situation becomes even worse if where are more nodes in the cluster or the throughput is high.

Note that even if we write data even to one node, we still made a copy of a Blob when we pass it to `mqbnet::Channel`.

The main change in this PR is that we store shared pointers to the same Blob when we enqueue Items to `mqbnet::Channel` to write. By doing this, we avoid making a vector copy for every Blob and do not allocate without a need.

However, to make this change possible, we need to provide shared pointers to Blobs from the very level where these Blobs are constructed - in event builders.

Another change that affects performance is using Blob shared pointer pools for event builders. By reusing the already built Blobs from these pools, we make sure that vectors containing BlobBuffers have probably enough capacity to contain all the needed BlobBuffers for write after some warmup.

# Changes

- Introduce a new component `bmqp::BlobPoolUtil` that defines `BlobSpPool` type and also provides an utility function `createPool` that simplifies `BlobSpPool` construction.
- Event builders: require `BlobSpPool` as an argument, store the built Blob as a shared pointer, use `BlobSpPool` to get new Blob shared pointers on `reset`, provide Blob shared pointer copy via new `blob_sp()` accessor.
- Unit tests: build and pass `BlobSpPool` as an argument where needed.
- `mqbnet::Channel`: change the class API so now it only accepts shared pointers to Blobs to enqueue, add independent `BlobSpPool` per each `mqbnet::Channel` to use in its builders (do not want to share the global `BlobSpPool` between too many threads), remove legacy flavours how we store Items in Channel (before, we had Blobs by value, by weak pointer, by shared pointer - now we only store them by shared pointer).
- `mqbnet::Channel` unit test: removed test for weak pointer Blob passed to Channel. This feature is not used in the code at all and so it's removed.
- `bmqp::SchemaEventBuilder`: reorder arguments to met allocator usage guidelines, the allocator arg now is the last one as expected, had to explicitly add the default encoding type where it's needed. Also, got rid of the tmp `MemOutStream` and cache it as a field to reduce allocations: `bmqu::MemOutStream d_errorStream`.

# Stress test

Priority queue, 100k msgs/s, 1 consumer, 1 producer, 1 queue in strong consistency domain, 6 nodes cluster (3 datacenters) with 2 client proxies.

The graph shows the current number of unconfirmed messages currently stored in the queue over a 10 minute run. Blue line is the current PR's revision (near to 0 pending messages on every moment), orange line shows the commit just before this PR.

This PR behaves much better on 100k msgs/s than the previous revision.

![Screenshot 2024-10-30 at 19 25 24](https://github.com/user-attachments/assets/60cda013-dca9-42ab-958b-5bb8b7e05f53)

# Profiler

On the same stress scenario, there were 3.6% of samples across all threads taken within Blob constructor calls. With the new change, these 3.6% are freed. Since these 3.6% were within queue dispatcher thread, this thread will be less busy and be able to process higher throughput.

Before:

![Screenshot 2024-10-30 at 18 56 51](https://github.com/user-attachments/assets/6ade84d6-8526-4fc2-9d62-1520f71f122b)

![Screenshot 2024-10-30 at 18 58 40](https://github.com/user-attachments/assets/3ae84441-d762-4e42-bc62-70ecc79fdc8c)

After:

![Screenshot 2024-10-30 at 18 22 37](https://github.com/user-attachments/assets/e870dc46-7d30-4ce4-b0e5-21c2531a8f80)

![Screenshot 2024-10-30 at 18 23 16](https://github.com/user-attachments/assets/98cd715c-6f17-44ae-80b5-09c1d59f1df2)

# Allocator stats

This PR reduces the number of unnecessary allocations by many millions (see `Channel` rows in before and after). Since we use counting allocator with tree-structure to report updates down to the root allocator, we save CPU on these updates.
The only remaining place within `TransportManager` with many allocations is `TCPSessionFactory`.

Before:
```
    TransportManager             |       1,472,768| -11,520|           4,852,112| 219,401,090|  94,459|   219,400,120|  94,459
      *direct*                   |           1,392|        |               1,392|          12|        |             2|        
      cl6_dc3                    |         946,720| -11,520|           1,071,664| 120,518,092|  58,380|   120,517,921|  58,380
        *direct*                 |          28,208|        |              28,208|          59|        |             0|        
        node3                    |         366,736|  -2,304|             402,768|  24,103,630|  11,676|    24,103,595|  11,676
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          ItemPool               |         266,880|        |             266,880|          20|        |             0|        
          Channel                |             704|  -2,304|              36,736|  24,103,603|  11,676|    24,103,595|  11,676
        node1                    |         113,072|  -2,304|             150,864|  24,103,600|  11,676|    24,103,584|  11,676
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          ItemPool               |          13,344|        |              13,344|           1|        |             0|        
          Channel                |             576|  -2,304|              38,368|  24,103,592|  11,676|    24,103,584|  11,676
        node2                    |         113,072|  -2,304|             149,536|  24,103,601|  11,676|    24,103,585|  11,676
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          ItemPool               |          13,344|        |              13,344|           1|        |             0|        
          Channel                |             576|  -2,304|              37,040|  24,103,593|  11,676|    24,103,585|  11,676
        node5                    |         113,072|  -2,304|             147,712|  24,103,593|  11,676|    24,103,577|  11,676
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          ItemPool               |          13,344|        |              13,344|           1|        |             0|        
          Channel                |             576|  -2,304|              35,216|  24,103,585|  11,676|    24,103,577|  11,676
        node4                    |         113,072|  -2,304|             144,144|  24,103,596|  11,676|    24,103,580|  11,676
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          ItemPool               |          13,344|        |              13,344|           1|        |             0|        
          Channel                |             576|  -2,304|              31,648|  24,103,588|  11,676|    24,103,580|  11,676
        node0                    |          99,488|        |              99,488|          13|        |             0|        
          *direct*               |          99,152|        |              99,152|           7|        |             0|        
          Channel                |             336|        |                 336|           6|        |             0|        
      Interface45115             |         524,016|        |           4,156,544|  98,882,981|  36,079|    98,882,197|  36,079
      ConnectionStates           |             640|        |                 640|           5|        |             0|        
    SessionNegotiator            |          14,496|        |              23,264|       1,389|       2|         1,330|       2
    DomainManager                |           2,064|        |               2,064|          11|        |             0|        
    ConfigProvider               |             272|        |                 272|           2|        |             0|        
```

After:
```
    TransportManager             |       1,930,032|        |           5,523,808|  87,961,870|        |    87,960,968|        
      *direct*                   |           1,392|        |               1,392|          12|        |             2|        
      cl6_dc3                    |       1,541,024|        |           1,541,088|         193|        |            11|        
        *direct*                 |          29,104|        |              29,104|          59|        |             0|        
        node4                    |         322,016|        |             322,080|          32|        |             4|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         115,104|        |             115,168|          10|        |             3|        
          ItemPool               |         107,360|        |             107,360|          11|        |             0|        
          Channel                |             176|        |                 176|           2|        |             0|        
        node2                    |         302,448|        |             302,448|          29|        |             3|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         115,056|        |             115,104|           9|        |             2|        
          ItemPool               |          87,840|        |              87,840|           9|        |             0|        
          Channel                |             176|        |                 176|           2|        |             0|        
        node1                    |         224,336|        |             224,336|          19|        |             1|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         115,024|        |             115,024|           7|        |             0|        
          ItemPool               |           9,760|        |               9,760|           1|        |             0|        
          Channel                |             176|        |                 176|           2|        |             0|        
        node3                    |         224,336|        |             224,336|          19|        |             1|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         115,024|        |             115,024|           7|        |             0|        
          ItemPool               |           9,760|        |               9,760|           1|        |             0|        
          Channel                |             176|        |                 176|           2|        |             0|        
        node5                    |         224,336|        |             224,336|          19|        |             1|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         115,024|        |             115,024|           7|        |             0|        
          ItemPool               |           9,760|        |               9,760|           1|        |             0|        
          Channel                |             176|        |                 176|           2|        |             0|        
        node0                    |         214,448|        |             214,448|          16|        |             1|        
          *direct*               |          99,376|        |              99,376|           9|        |             1|        
          BlobSpPool             |         114,976|        |             114,976|           6|        |             0|        
          Channel                |              96|        |                  96|           1|        |             0|        
      Interface37387             |         386,976|        |           4,156,544|  87,961,660|        |    87,960,955|        
      ConnectionStates           |             640|        |                 640|           5|        |             0|        
    SessionNegotiator            |          15,024|        |              23,792|       1,379|       2|         1,325|       2
    DomainManager                |           2,064|        |               2,064|          11|        |             0|        
    ConfigProvider               |             272|        |                 272|           2|        |             0|        
```