### PR TITLE
Misc[docker]: Adding dependency of bmqbrkr to bmqtool in docker-compose.yaml single-node example

### DIFF
--- a/docker/single-node/docker-compose.yaml
+++ b/docker/single-node/docker-compose.yaml
@@ -17,6 +17,9 @@ services:
       context: ../..
       dockerfile: docker/Dockerfile
     hostname: earth
+    depends_on:
+      bmqbrkr:
+        condition: service_started
     # This "service" will exit immediately. It's OK, this is a
     # container sitting on the same network as the single node, to be started
     # in interactive mode with `docker-compose run`


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #476 *

**Describe your changes**
Great project! 

Testing the examples listed on the [official Getting Started page](https://bloomberg.github.io/blazingmq/docs/getting_started/blazingmq_in_action/) on a M1 Macbook Pro (darwin/arm64) and I notice the build and example instructions don't work. 

Think this is due to two reasons:
1. The project fails to build due to many compiler warnings. Temporarily commenting out `-DBDE_BUILD_SAFE=on` works.
2. The instructions on starting the `bmqtool` in the doc link above doesn't work - `start` fails to connect, because the `bmqbrkr` is not started. This is probably because `bmqtool` doesn't depend on `bmqbrkr` service container - which it should.

This PR fixes the 2nd issue by adding a dependency on `bmqbrkr` in `bmqtool` via  `depends_on`. I am still going through how broker health checks work - it should be `service_healthy` instead, but I couldn't find an easy way to do this in the `bmqtool` CLI help. So using `service_started` instead - to only start `bmqtool` container once 

Partially addresses #476 

**Testing performed**
Follow all the steps listed [here](https://bloomberg.github.io/blazingmq/docs/getting_started/blazingmq_in_action/) with workaround suggested in 1 and the `depends_on` changes in this PR - everything from building and testing the queue should work as intended.

**Additional context**
N/A. I might make more PRs - this project looks interesting.
