### PR TITLE
Perf[BMQ]: do not create tmp functors in PutEventBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ settings.json
 .cache/
 .venv/
 
+# fuzz-test output folder
+**/boofuzz-results
+
 # Symlink from 'src/applications/bmqbrkr/run'
 src/applications/bmqbrkr/etc/etc
 

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.h
@@ -61,7 +61,6 @@
 //
 
 // BMQ
-
 #include <bmqp_messageproperties.h>
 #include <bmqp_protocol.h>
 #include <bmqt_compressionalgorithmtype.h>
@@ -92,6 +91,18 @@ class PutEventBuilder {
     typedef bdlb::NullableValue<bmqp::Protocol::MsgGroupId> NullableMsgGroupId;
 
   private:
+    // TYPES
+    /// Mechanism to automatically reset PutEventBuilder on a built message
+    struct ResetGuard {
+        // DATA
+        PutEventBuilder& d_putEventBuilder;
+
+        // CREATORS
+        explicit ResetGuard(PutEventBuilder& putEventBuilder);
+
+        ~ResetGuard();
+    };
+
     // DATA
     bdlbb::BlobBufferFactory* d_bufferFactory_p;
 
@@ -169,13 +180,10 @@ class PutEventBuilder {
     PutEventBuilder& operator=(const PutEventBuilder&) BSLS_CPP11_DELETED;
 
   private:
-    // CLASS LEVEL METHODS
-
-    /// Reset flags and message guid of PutEventBuilder instance pointed by
-    /// the specified `ptr`.
-    static void resetFields(void* ptr);
-
     // PRIVATE MANIPULATORS
+    /// Reset flags and message guid of this object.
+    void resetFields();
+
     bmqt::EventBuilderResult::Enum
     packMessageInternal(const bdlbb::Blob& appData, int queueId);
 


### PR DESCRIPTION
Constructing local `bdlb::ScopeExitAny` makes a copy of a functor and allocates memory.

Before:
![Screenshot 2024-10-25 at 22 09 03](https://github.com/user-attachments/assets/3634de77-ef3e-4698-8d42-8f84dda4e1c8)

After:
![Screenshot 2024-10-26 at 00 39 49](https://github.com/user-attachments/assets/0efba752-99d6-4e2c-a6c2-762d8b86785a)

