### PR TITLE
Perf[MQB]: remove unnecessary shared_ptr copy

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -199,8 +199,8 @@ bool Routers::Expression::evaluate()
 bool Routers::PriorityGroup::evaluate(
     BSLS_ANNOTATION_UNUSED const bsl::shared_ptr<bdlbb::Blob>& data)
 {
-    const Expressions::SharedItem it         = d_itId->value().d_itExpression;
-    Expression&                   expression = it->value();
+    const Expressions::SharedItem& it         = d_itId->value().d_itExpression;
+    Expression&                    expression = it->value();
 
     return expression.evaluate();
 }


### PR DESCRIPTION
Before:
![Screenshot 2024-10-26 at 03 35 56](https://github.com/user-attachments/assets/78f1407a-ff63-4abb-8e7e-22343cf80528)

After (`PriorityGroup::evaluate` was inlined):
![Screenshot 2024-10-26 at 06 33 23](https://github.com/user-attachments/assets/d8295d73-1cea-4865-9414-d33b67b6b0fb)
