### PR TITLE
Perf[MQB]: throttle logs critical for broadcast

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -453,6 +453,7 @@ RemoteQueue::RemoteQueue(QueueState*       state,
 , d_pendingMessagesTimerEventHandle()
 , d_ackWindowSize(ackWindowSize)
 , d_unackedPutCounter(0)
+, d_expiredPutNum(0)
 , d_subStreams(allocator)
 , d_statePool_p(statePool)
 , d_producerState()
@@ -473,6 +474,9 @@ RemoteQueue::RemoteQueue(QueueState*       state,
         1,
         5 * bdlt::TimeUnitRatio::k_NS_PER_S);
     d_throttledFailedConfirmMessages.initialize(
+        1,
+        5 * bdlt::TimeUnitRatio::k_NS_PER_S);
+    d_throttledCachedPutMessages.initialize(
         1,
         5 * bdlt::TimeUnitRatio::k_NS_PER_S);
     // 1 log per 5s interval
@@ -1176,12 +1180,17 @@ void RemoteQueue::onAckMessageDispatched(const mqbi::DispatcherAckEvent& event)
     if (d_state_p->isAtMostOnce()) {
         // Consider this a "non-soft" ACK for all previous broadcasted PUTs.
         size_t numErased = 1 + erasePendingMessages(it);
+        d_expiredPutNum += numErased;
 
         erasePendingMessage(it);
 
-        BALL_LOG_INFO << d_state_p->uri() << ": erased window of " << numErased
-                      << " cached broadcasted PUTs upon "
-                      << bmqt::AckResult::toAscii(ackResult);
+        if (d_throttledCachedPutMessages.requestPermission()) {
+            BALL_LOG_INFO << d_state_p->uri() << ": erased window of "
+                          << numErased << " (" << d_expiredPutNum
+                          << " from the last log) cached broadcasted PUTs on "
+                          << bmqt::AckResult::toAscii(ackResult);
+            d_expiredPutNum = 0;
+        }
 
         return;  // RETURN
     }
@@ -1340,9 +1349,9 @@ void RemoteQueue::expirePendingMessagesDispatched()
     }
     else {
         d_pendingMessagesTimerEventHandle.release();
-        BALL_LOG_INFO << d_state_p->uri() << ": "
-                      << "no more timer scheduled to check expiration of "
-                      << "pending PUSH messages";
+        BALL_LOG_DEBUG << d_state_p->uri() << ": "
+                       << "no more timer scheduled to check expiration of "
+                       << "pending PUSH messages";
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -219,6 +219,9 @@ class RemoteQueue {
     // ThrottledAction parameters for
     // failed confirms
 
+    // ThrottledAction parameters for expired puts logging
+    bdlmt::Throttle d_throttledCachedPutMessages;
+
     bsls::Types::Int64 d_pendingPutsTimeoutNs;
     // Configured timeout in ns upon
     // which retransmission attempts
@@ -242,6 +245,9 @@ class RemoteQueue {
     int d_unackedPutCounter;
     // Counter of unacked broadcast
     // PUTs in the current window.
+
+    /// Counter of expired put messages since the last throttled logging
+    size_t d_expiredPutNum;
 
     SubQueueIds d_subStreams;
     // SubStream states.

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -219,9 +219,6 @@ class RemoteQueue {
     // ThrottledAction parameters for
     // failed confirms
 
-    // ThrottledAction parameters for expired puts logging
-    bdlmt::Throttle d_throttledCachedPutMessages;
-
     bsls::Types::Int64 d_pendingPutsTimeoutNs;
     // Configured timeout in ns upon
     // which retransmission attempts
@@ -245,9 +242,6 @@ class RemoteQueue {
     int d_unackedPutCounter;
     // Counter of unacked broadcast
     // PUTs in the current window.
-
-    /// Counter of expired put messages since the last throttled logging
-    size_t d_expiredPutNum;
 
     SubQueueIds d_subStreams;
     // SubStream states.


### PR DESCRIPTION
Logging every 500 cached PUTs expiration not only generates gigabytes of logs, but also potentially limits broadcast speed.