### PR TITLE
Perf[BMQIO]: remove unnecessary function copy

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.h
@@ -99,9 +99,6 @@ class NtcRead {
     /// Set the timer to the specified `timer`.
     void setTimer(const bsl::shared_ptr<ntci::Timer>& timer);
 
-    /// Set the operation as completed.
-    void setComplete();
-
     /// Set the operation as completed and clear all resources.
     void clear();
 


### PR DESCRIPTION
IO thread should spend 7.5% (1.7 / 22.96) less cpu

Before:
<img width="800" alt="Screenshot 2024-10-28 at 16 33 12" src="https://github.com/user-attachments/assets/1d5601a1-545a-4ef5-8df1-4ab242060c7d">

After:
<img width="772" alt="Screenshot 2024-10-28 at 17 27 43" src="https://github.com/user-attachments/assets/8ce3bca1-19f3-4bbb-a22d-f251b879e85c">
