### PR TITLE
CI: Collect broker logs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     branches:
       - main
@@ -220,16 +220,9 @@ jobs:
             --tb long                           \
             --reruns=3                          \
             -n 4 -v
-      - name: List folder contents
-        run: |
-          ls -lah
-      - name: List folder contents
-        run: |
-          ls -lah ${{ github.workspace }}/src/integration-tests/
-          echo "test" > ${{ github.workspace }}/src/integration-tests/failure-logs/test.log
-          ls -lah ${{ github.workspace }}/src/integration-tests/
+
       - name: Upload failure-logs as artifacts
-        # if: failure()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: failure_logs_${{ matrix.mode }}_${{ matrix.cluster }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Tests
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
     branches:
       - main
@@ -220,6 +220,21 @@ jobs:
             --tb long                           \
             --reruns=3                          \
             -n 4 -v
+      - name: List folder contents
+        run: |
+          ls -lah
+      - name: List folder contents
+        run: |
+          ls -lah ${{ github.workspace }}/src/integration-tests/
+          echo "test" > ${{ github.workspace }}/src/integration-tests/failure-logs/test.log
+          ls -lah ${{ github.workspace }}/src/integration-tests/
+      - name: Upload failure-logs as artifacts
+        # if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: failure_logs_${{ matrix.mode }}_${{ matrix.cluster }}
+          path: ${{ github.workspace }}/src/integration-tests/failure-logs
+          retention-days: 5
 
   fuzz_tests_ubuntu:
     name: Fuzz test [${{ matrix.request }}]


### PR DESCRIPTION

**Describe your changes**
In case when integration tests fail, the folder 'failure-logs' is created containing broker logs. Example log file is attached.
[test_open_alarm_authorize_post[multi_node_fsm].log](https://github.com/user-attachments/files/17561427/test_open_alarm_authorize_post.multi_node_fsm.log)

This PR allows to upload 'failure-logs' folder as a pipeline artifact.

According to my experiments 'failure-logs' is created even on successful run. However if the folder exists, but is empty, it is not uploaded as artifact.

**Testing performed**

![Screenshot 2024-10-29 202419](https://github.com/user-attachments/assets/a0c5a85d-f815-48c8-b663-c859d6566864)

![Screenshot 2024-10-29 202451](https://github.com/user-attachments/assets/06fdbecb-fc43-4f43-a682-19614f3c1bce)


**Additional context**

