### PR TITLE
CI: Add job to build API documentation on push to `main`

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -45,7 +45,9 @@ jobs:
           ( cat Doxyfile ; echo "PROJECT_NUMBER=${{ github.sha }}" ) | doxygen -
 
       - name: Commit new API documentation to `gh-pages`
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: Update docs for `main`@${{ github.sha }}
-          repository: docs
+        run: |
+          cd docs/
+          git config --global user.name "${{ github.actor }}"
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git commit -am "Update C++ API docs from commit ${{ github.sha }} on main"
+          git push

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -49,5 +49,5 @@ jobs:
           cd docs/
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-          git commit -am "Update C++ API docs from commit ${{ github.sha }} on main"
+          git commit -s -am "Update C++ API docs from commit ${{ github.sha }} on main"
           git push

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,0 +1,51 @@
+name: Generate documentation
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  documentation-main:
+    name: Build Doxygen documentation on `main`
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Let the default GITHUB_TOKEN commit and push.
+      contents: write
+
+    steps:
+      - name: Checkout `main`
+        uses: actions/checkout@v4
+
+      - name: Clear out `docs/` subdirectory
+        run: rm -rf docs
+
+      - name: Checkout `gh-pages` into `docs/`
+        uses: actions/checkout@v4
+        with:
+          path: docs
+          ref: gh-pages
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy doxygen
+
+      - name: Build documentation
+        # Best way to pass Doxygen config overrides on the command line is
+        # using stdin.
+        run: |
+          ( cat Doxyfile ; echo "PROJECT_NUMBER=${{ github.sha }}" ) | doxygen -
+
+      - name: Commit new API documentation to `gh-pages`
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update docs for `main`@${{ github.sha }}
+          repository: docs


### PR DESCRIPTION
This PR adds a job that runs on pushes to the `main` branch and on manual workflows to regenerate documentation from `main`, and push it to the `gh-pages` branch.

In the future we'll want to:
  1. Run a similar job on versioned releases.
  2. Teach cmake to use Doxygen (this is a bit more involved than it should be, because of our BDE-ish cmake), and use cmake to build.
  3. Warn about Doxygen errors on PRs.
  
These will be future PRs.  This PR is just aimed at getting our website in shape.

Please review this patch carefully.  I have run the commands I expect to happen manually in a shell, but if my understanding of the canned GitHub Actions is incorrect, this action may fail in new and fun ways after merge, and I don't believe there is an effective way to test beforehand.