### PR TITLE
Docs: Fix `bmqa_mocksession` doxygen failure

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -393,7 +393,7 @@
 ///       `emitting` on the @ref BMQA_EXPECT_CALL macro in synchronous mode is
 ///       meaningless.
 ///
-///```
+/// ```
 /// void unitTest()
 /// {
 ///     // MockSession created without an eventHandler.


### PR DESCRIPTION
The `bqma_mocksession` component does not generate docs due to a Markdown syntax error:

```
/…/blazingmq/src/groups/bmq/bmqa/bmqa_mocksession.h:1520: warning: reached end of file while inside a '```' block! The command that should end the block seems to be missing!
```

The syntax error prevents any component-level documentation from being generated for this file.  This patch fixes the syntax error, which then allows the component-level documentation to be built.