### PR TITLE
CI: Add untracked generated documentation files when publishing

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -49,5 +49,4 @@ jobs:
           cd docs/
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-          git commit -s -am "Update C++ API docs from commit ${{ github.sha }} on main"
-          git push
+          git add docs/apidocs/cpp_apidocs/ && git commit -s -am "Update C++ API docs from commit ${{ github.sha }} on main" && git push || true


### PR DESCRIPTION
If generating the documentation creates files that do not already exist on the `gh-pages` branch, the current GitHub Action to generate documentation will not add them.  Instead, it will only update existing files.  This may happen when a new component is added, or when the Doxygen version differs from prior runs.  This bit us on our first run of the documentation-generation GitHub Action, because the version that GitHub Actions uses is different than the version that built our original documentation.

This patch explicitly adds all files generated under the `docs/docs/apidocs/cpp_apidocs` directory, including both untracked files and tracked, modified files.