### PR TITLE
Fix[mqbblp::RemoteQueue]: 0 deduplication timeout causes expired PUTs

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -64,6 +64,16 @@
 namespace BloombergLP {
 namespace mqbblp {
 
+namespace {
+
+/// The default timeout for scheduled PUT expiration clean-up event.
+static const bsls::Types::Int64 k_DEFAULT_PUT_EXPIRATION_TIMEOUT_MINUTES = 5;
+static const bsls::Types::Int64 k_DEFAULT_PUT_EXPIRATION_TIMEOUT_NS =
+    k_DEFAULT_PUT_EXPIRATION_TIMEOUT_MINUTES *
+    bdlt::TimeUnitRatio::k_NANOSECONDS_PER_MINUTE;
+
+}  // close unnamed namespace
+
 // -----------------
 // class RemoteQueue
 // -----------------
@@ -484,13 +494,12 @@ RemoteQueue::RemoteQueue(QueueState*       state,
     d_state_p->setDescription(os.str());
 
     if (deduplicationTimeMs <= 0) {
-        d_pendingPutsTimeoutNs = 5 *
-                                 bdlt::TimeUnitRatio::k_NANOSECONDS_PER_MINUTE;
+        d_pendingPutsTimeoutNs = k_DEFAULT_PUT_EXPIRATION_TIMEOUT_NS;
         BALL_LOG_WARN << "Remote queue [" << d_state_p->description()
-                      << "]: cannot schedule PUT deduplication timer with a "
+                      << "]: cannot schedule PUT expiration timer with a "
                       << "non-positive timeout from config ["
                       << deduplicationTimeMs << " ms], use a default PUT "
-                      << "deduplication timeout for scheduler instead ["
+                      << "expiration timeout for scheduler instead ["
                       << bmqu::PrintUtil::prettyTimeInterval(
                              d_pendingPutsTimeoutNs)
                       << "]";


### PR DESCRIPTION
`deduplicationTimeMs` parameter serves at least 2 roles:
- it defines if queue history is saved or not on PRIMARY
- it is used on REPLICA/PROXY to schedule PUT expiration if PRIMARY node is not available

With the second point, we got a bug. When we provide 0 timeout, we schedule PUT expiration almost immediately on REPLICA/PROXY, causing some of the PUTs to expire before reaching PRIMARY.

This PR handles 0 (and just for safety negative values, if someone wants to pass -1) for `deduplicationTimeMs`, and now we assume that "zero deduplication timeout means we don't want to expire messages for as long as we can". We use a default 5 minute timer in this case.

The sample WARN log from PROXY:
`
31OCT2024_17:33:11.257 (140251446843136) WARN mqbblp_remotequeue.cpp:488 Remote queue [@bmq://bmq.capmon.priority.sc/dummy]: cannot schedule PUT expiration timer with a non-positive timeout from config [0 ms], use a default PUT expiration timeout for scheduler instead [5.00 m]
`