### PR TITLE
Fix[MQB]: Enable strong consistency CSL and fix leader activeness

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -3549,10 +3549,13 @@ void Cluster::onClusterLeader(mqbnet::ClusterNode*                node,
     }
 
     d_clusterOrchestrator.updateDatumStats();
-    d_clusterData.stats().setIsLeader(
-        d_clusterData.membership().selfNode() == node
-            ? mqbstat::ClusterStats::LeaderStatus::e_LEADER
-            : mqbstat::ClusterStats::LeaderStatus::e_FOLLOWER);
+
+    if (status == mqbc::ElectorInfoLeaderStatus::e_ACTIVE) {
+        d_clusterData.stats().setIsLeader(
+            d_clusterData.membership().selfNode() == node
+                ? mqbstat::ClusterStats::LeaderStatus::e_LEADER
+                : mqbstat::ClusterStats::LeaderStatus::e_FOLLOWER);
+    }
 }
 
 void Cluster::onLeaderPassiveThreshold()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -587,9 +587,7 @@ ClusterOrchestrator::ClusterOrchestrator(
                             mqbc::IncoreClusterStateLedger>(
                             d_allocators.get("ClusterStateLedger"),
                             clusterConfig,
-                            mqbc::ClusterStateLedgerConsistency::e_EVENTUAL,
-                            // TODO Add cluster config to determine Eventual vs
-                            //      Strong
+                            mqbc::ClusterStateLedgerConsistency::e_STRONG,
                             d_clusterData_p,
                             clusterState,
                             &d_clusterData_p->blobSpPool())),
@@ -606,9 +604,7 @@ ClusterOrchestrator::ClusterOrchestrator(
                             mqbc::IncoreClusterStateLedger>(
                             d_allocators.get("ClusterStateLedger"),
                             clusterConfig,
-                            mqbc::ClusterStateLedgerConsistency::e_EVENTUAL,
-                            // TODO Add cluster config to determine Eventual vs
-                            //      Strong
+                            mqbc::ClusterStateLedgerConsistency::e_STRONG,
                             d_clusterData_p,
                             clusterState,
                             &d_clusterData_p->blobSpPool())),

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -392,6 +392,10 @@ void ClusterProxy::onActiveNodeUp(mqbnet::ClusterNode* activeNode)
         mqbnet::ElectorState::e_LEADER,
         d_clusterData.electorInfo().electorTerm() + 1,
         activeNode,
+        mqbc::ElectorInfoLeaderStatus::e_PASSIVE);
+    // It is **prohibited** to set leader status directly from e_UNDEFINED
+    // to e_ACTIVE.  Hence, we do: e_UNDEFINED -> e_PASSIVE -> e_ACTIVE
+    d_clusterData.electorInfo().setLeaderStatus(
         mqbc::ElectorInfoLeaderStatus::e_ACTIVE);
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -3911,7 +3911,9 @@ void ClusterQueueHelper::onClusterLeader(
                   << (node ? node->nodeDescription() : "** none **")
                   << ", leader status: " << status;
 
-    restoreState(mqbs::DataStore::k_ANY_PARTITION_ID);
+    if (status == mqbc::ElectorInfoLeaderStatus::e_ACTIVE) {
+        restoreState(mqbs::DataStore::k_ANY_PARTITION_ID);
+    }
 
     if (d_cluster_p->isRemote()) {
         // non-proxy (replica) case is handled by

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -463,7 +463,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
         const bmqp_ctrlmsg::ControlMessage& message,
         mqbnet::ClusterNode*                source) BSLS_KEYWORD_OVERRIDE;
 
-    /// Process the specified `event`.
+    /// Process the specified cluster state `event`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
@@ -218,6 +218,19 @@ struct TestHelper {
             isActive ? mqbc::ElectorInfoLeaderStatus::e_ACTIVE
                      : mqbc::ElectorInfoLeaderStatus::e_PASSIVE;
 
+        if (d_cluster_mp->_clusterData()->electorInfo().leaderStatus() ==
+                mqbc::ElectorInfoLeaderStatus::e_UNDEFINED &&
+            status == mqbc::ElectorInfoLeaderStatus::e_ACTIVE) {
+            // It is **prohibited** to set leader status directly from
+            // e_UNDEFINED to e_ACTIVE, so we set to e_PASSIVE first then
+            // immediately to e_ACTIVE
+            d_cluster_mp->_clusterData()->electorInfo().setElectorInfo(
+                mqbnet::ElectorState::e_LEADER,
+                1,
+                node,
+                mqbc::ElectorInfoLeaderStatus::e_PASSIVE);
+        }
+
         d_cluster_mp->_clusterData()->electorInfo().setElectorInfo(
             mqbnet::ElectorState::e_LEADER,
             1,

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
@@ -306,8 +306,6 @@ class ClusterStateLedger : public ElectorInfoObserver {
     virtual int apply(const bdlbb::Blob&   record,
                       mqbnet::ClusterNode* source) = 0;
 
-    virtual void setIsFirstLeaderAdvisory(bool isFirstLeaderAdvisory) = 0;
-
     /// Set the commit callback to the specified `value`.
     virtual void setCommitCb(const CommitCb& value) = 0;
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
@@ -107,13 +107,6 @@ struct ClusterStateLedgerTestImp
         return markDone();
     }
 
-    void
-    setIsFirstLeaderAdvisory(BSLS_ANNOTATION_UNUSED bool isFirstLeaderAdvisory)
-        BSLS_KEYWORD_OVERRIDE
-    {
-        markDone();
-    }
-
     // ACCESSORS
     void setCommitCb(BSLS_ANNOTATION_UNUSED const CommitCb& value)
         BSLS_KEYWORD_OVERRIDE
@@ -205,7 +198,6 @@ static void test1_clusterStateLedger_protocol()
                                  apply(bmqp_ctrlmsg::LeaderAdvisory()));
         BSLS_PROTOCOLTEST_ASSERT(testObj,
                                  apply(bmqp_ctrlmsg::ClusterMessage()));
-        BSLS_PROTOCOLTEST_ASSERT(testObj, setIsFirstLeaderAdvisory(true));
         BSLS_PROTOCOLTEST_ASSERT(
             testObj,
             setCommitCb(mqbc::ClusterStateLedger::CommitCb()));

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1878,14 +1878,16 @@ void ClusterStateManager::onNodeStopped()
 
 // MANIPULATORS
 //   (virtual: mqbc::ElectorInfoObserver)
-void ClusterStateManager::onClusterLeader(
-    mqbnet::ClusterNode*   node,
-    BSLS_ANNOTATION_UNUSED ElectorInfoLeaderStatus::Enum status)
+void ClusterStateManager::onClusterLeader(mqbnet::ClusterNode*          node,
+                                          ElectorInfoLeaderStatus::Enum status)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(
+        (node && (ElectorInfoLeaderStatus::e_UNDEFINED != status)) ||
+        (!node && (ElectorInfoLeaderStatus::e_UNDEFINED == status)));
 
     if (!node) {
         // Leader lost
@@ -1899,21 +1901,27 @@ void ClusterStateManager::onClusterLeader(
         return;  // RETURN
     }
 
+    // We can only reach this code path if leader `node` is not null.  Here, we
+    // only care about transitioning from no leader to having a leader.  We
+    // don't care about leader status changing between e_PASSIVE and e_ACTIVE.
+    if (d_clusterFSM.state() != ClusterFSM::State::e_UNKNOWN) {
+        return;  // RETURN
+    }
+
+    // IMPORTANT: This is the main entry point to start running the Cluster FSM
     InputMessages inputMessages(1, d_allocator_p);
     inputMessages.at(0).setSource(node);  // leader node
 
     if (d_clusterData_p->membership().selfNode()->nodeId() == node->nodeId()) {
-        BALL_LOG_INFO << d_clusterData_p->identity().description() << ": "
-                      << (d_clusterFSM.isSelfLeader() ? "Re-" : "")
-                      << "Transitioning to leader in the Cluster FSM.";
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Transitioning to leader in the Cluster FSM.";
 
         applyFSMEvent(ClusterFSM::Event::e_SLCT_LDR,
                       ClusterFSMEventMetadata(inputMessages));
     }
     else {
-        BALL_LOG_INFO << d_clusterData_p->identity().description() << ": "
-                      << (d_clusterFSM.isSelfFollower() ? "Re-" : "")
-                      << "Transitioning to follower in the Cluster FSM.";
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Transitioning to follower in the Cluster FSM.";
 
         applyFSMEvent(ClusterFSM::Event::e_SLCT_FOL,
                       ClusterFSMEventMetadata(inputMessages));

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1746,35 +1746,6 @@ void ClusterStateManager::processClusterStateEvent(
     bmqp::Event          rawEvent(event.blob().get(), d_allocator_p);
     BSLS_ASSERT_SAFE(rawEvent.isClusterStateEvent());
 
-    // NOTE: Any validation of the event would go here.
-    if (source != d_clusterData_p->electorInfo().leaderNode()) {
-        BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << ": ignoring cluster state event from cluster node "
-                      << source->nodeDescription() << " as this node is not "
-                      << "the current perceived leader. Current leader: ["
-                      << d_clusterData_p->electorInfo().leaderNodeId() << ": "
-                      << (d_clusterData_p->electorInfo().leaderNode()
-                              ? d_clusterData_p->electorInfo()
-                                    .leaderNode()
-                                    ->nodeDescription()
-                              : "* UNKNOWN *")
-                      << "]";
-        return;  // RETURN
-    }
-    // 'source' is the perceived leader
-
-    // TBD: Suppress the following check for now, which will help some
-    // integration tests to pass.  At this point, it is not clear if it is safe
-    // to process cluster state events while self is stopping.
-    //
-    // if (   bmqp_ctrlmsg::NodeStatus::E_STOPPING
-    //     == d_clusterData_p->membership().selfNodeStatus()) {
-    //     return;                                                    // RETURN
-    // }
-
-    // TODO: Validate the incoming advisory and potentially buffer it for later
-    //       if the node is currently starting.
-
     const int rc = d_clusterStateLedger_mp->apply(*rawEvent.blob(), source);
     if (rc != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -558,7 +558,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
         const bmqp_ctrlmsg::ControlMessage& message,
         mqbnet::ClusterNode*                source) BSLS_KEYWORD_OVERRIDE;
 
-    /// Process the specified `event`.
+    /// Process the specified cluster state `event`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -86,6 +86,7 @@ typedef mqbc::ClusterStateManager::ClusterStateLedgerMp ClusterStateLedgerMp;
 struct Tester {
   public:
     // PUBLIC DATA
+    bool                                         d_isLeader;
     bdlbb::PooledBlobBufferFactory               d_bufferFactory;
     bmqu::TempDirectory                          d_tempDir;
     bslma::ManagedPtr<mqbmock::Cluster>          d_cluster_mp;
@@ -96,7 +97,8 @@ struct Tester {
   public:
     // CREATORS
     Tester(bool isLeader)
-    : d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
+    : d_isLeader(isLeader)
+    , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     , d_cluster_mp(0)
     , d_clusterStateLedger_p(0)
@@ -140,7 +142,7 @@ struct Tester {
                 mqbmock::Cluster(&d_bufferFactory,
                                  bmqtst::TestHelperUtil::allocator(),
                                  true,  // isClusterMember
-                                 isLeader,
+                                 d_isLeader,
                                  true,  // isCSLMode
                                  true,  // isFSMWorkflow
                                  clusterNodeDefs,
@@ -211,7 +213,8 @@ struct Tester {
                 mqbmock::Cluster::k_LEADER_NODE_ID);
         BSLS_ASSERT_OPT(leaderNode != 0);
         d_cluster_mp->_clusterData()->electorInfo().setElectorInfo(
-            mqbnet::ElectorState::e_LEADER,
+            d_isLeader ? mqbnet::ElectorState::e_LEADER
+                       : mqbnet::ElectorState::e_FOLLOWER,
             electorTerm,
             leaderNode,
             mqbc::ElectorInfoLeaderStatus::e_PASSIVE);

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -200,8 +200,9 @@ void applyQueueUpdate(mqbc::ClusterState* clusterState,
                     << clusterData.identity().description()
                     << ": Received QueueUpdateAdvisory for known queue [uri: "
                     << uri << "] with a mismatched queueKey "
-                    << "[expected: " << cit->second->key() << ", received: " << queueKey
-                    << "]: " << queueUpdate << BMQTSK_ALARMLOG_END;
+                    << "[expected: " << cit->second->key()
+                    << ", received: " << queueKey << "]: " << queueUpdate
+                    << BMQTSK_ALARMLOG_END;
                 return;  // RETURN
             }
         }

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -200,7 +200,7 @@ void applyQueueUpdate(mqbc::ClusterState* clusterState,
                     << clusterData.identity().description()
                     << ": Received QueueUpdateAdvisory for known queue [uri: "
                     << uri << "] with a mismatched queueKey "
-                    << "[expected: " << queueKey << ", received: " << queueKey
+                    << "[expected: " << cit->second->key() << ", received: " << queueKey
                     << "]: " << queueUpdate << BMQTSK_ALARMLOG_END;
                 return;  // RETURN
             }
@@ -1213,10 +1213,10 @@ void ClusterUtil::registerAppId(ClusterData*        clusterData,
 
     if (mqbnet::ElectorState::e_LEADER !=
         clusterData->electorInfo().electorState()) {
-        BALL_LOG_ERROR << clusterData->identity().description()
-                       << ": Failed to register appId '" << appId
-                       << "' for domain '" << domain->name()
-                       << "'. Self is not leader.";
+        BALL_LOG_WARN << clusterData->identity().description()
+                      << ": Not registering appId '" << appId
+                      << "' for domain '" << domain->name()
+                      << "'. Self is not leader.";
         return;  // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_electorinfo.cpp
+++ b/src/groups/mqb/mqbc/mqbc_electorinfo.cpp
@@ -96,9 +96,22 @@ void ElectorInfo::onHealedLeader()
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_electorState == mqbnet::ElectorState::e_LEADER);
 
-    BALL_LOG_INFO << "#ELECTOR_INFO: onHealedLeader()";
+    BALL_LOG_INFO << "#ELECTOR_INFO: onHealedLeader()"
+                  << ", LSN = " << d_leaderMessageSequence << ".";
 
     onSelfActiveLeader();
+}
+
+void ElectorInfo::onHealedFollower()
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_electorState == mqbnet::ElectorState::e_FOLLOWER);
+
+    BALL_LOG_INFO << "#ELECTOR_INFO: onHealedFollower()"
+                  << ", leader = " << d_leaderNode_p->nodeDescription()
+                  << ", LSN = " << d_leaderMessageSequence << ".";
+
+    setLeaderStatus(mqbc::ElectorInfoLeaderStatus::e_ACTIVE);
 }
 
 // MANIPULATORS
@@ -132,6 +145,11 @@ ElectorInfo& ElectorInfo::setLeaderStatus(ElectorInfoLeaderStatus::Enum value)
     BSLS_ASSERT_SAFE(
         (d_leaderNode_p && (ElectorInfoLeaderStatus::e_UNDEFINED != value)) ||
         (!d_leaderNode_p && (ElectorInfoLeaderStatus::e_UNDEFINED == value)));
+    // It is **prohibited** to set leader status directly from e_UNDEFINED to
+    // e_ACTIVE.
+    if (d_leaderStatus == ElectorInfoLeaderStatus::e_UNDEFINED) {
+        BSLS_ASSERT_SAFE(value != ElectorInfoLeaderStatus::e_ACTIVE);
+    }
 
     BALL_LOG_INFO << "#ELECTOR_INFO: leader: "
                   << (d_leaderNode_p ? d_leaderNode_p->nodeDescription()
@@ -169,6 +187,11 @@ ElectorInfo& ElectorInfo::setElectorInfo(mqbnet::ElectorState::Enum    state,
     BSLS_ASSERT_SAFE(
         (node && (ElectorInfoLeaderStatus::e_UNDEFINED != status)) ||
         (!node && (ElectorInfoLeaderStatus::e_UNDEFINED == status)));
+    // It is **prohibited** to set leader status directly from e_UNDEFINED to
+    // e_ACTIVE.
+    if (d_leaderStatus == ElectorInfoLeaderStatus::e_UNDEFINED) {
+        BSLS_ASSERT_SAFE(status != ElectorInfoLeaderStatus::e_ACTIVE);
+    }
 
     mqbnet::ClusterNode* oldLeader = d_leaderNode_p;
 

--- a/src/groups/mqb/mqbc/mqbc_electorinfo.h
+++ b/src/groups/mqb/mqbc/mqbc_electorinfo.h
@@ -213,6 +213,12 @@ class ElectorInfo : public ClusterFSMObserver {
     ///         dispatcher thread.
     void onHealedLeader() BSLS_KEYWORD_OVERRIDE;
 
+    /// Invoked when the Cluster FSM transitions to `FOL_HEALED` state.
+    ///
+    /// THREAD: This method is invoked in the associated cluster's
+    ///         dispatcher thread.
+    void onHealedFollower() BSLS_KEYWORD_OVERRIDE;
+
     // MANIPULATORS
 
     /// Register the specified `observer` to be notified of elector changes.
@@ -230,9 +236,12 @@ class ElectorInfo : public ClusterFSMObserver {
     /// cluster's dispatcher thread.
     ElectorInfo& unregisterObserver(ElectorInfoObserver* observer);
 
-    ElectorInfo& setElectorState(mqbnet::ElectorState::Enum value);
     ElectorInfo& setElectorTerm(bsls::Types::Uint64 value);
     ElectorInfo& setLeaderNode(mqbnet::ClusterNode* value);
+
+    /// Set the leader status to the specified `value`.  Note that it is
+    /// **prohibited** to set leader status directly from e_UNDEFINED to
+    /// e_ACTIVE.
     ElectorInfo& setLeaderStatus(ElectorInfoLeaderStatus::Enum value);
 
     /// Set the corresponding member to the specified `value` and return a
@@ -245,7 +254,9 @@ class ElectorInfo : public ClusterFSMObserver {
     /// is the leader with the specified `status`, or a null pointer if
     /// there are no leader.  If the leader has changed, this will notify
     /// all active observers by invoking `onClusterLeader()` on each of
-    /// them, with the `node` as parameter.
+    /// them, with the `node` as parameter.  Note that it is
+    /// **prohibited** to set leader status directly from e_UNDEFINED to
+    /// e_ACTIVE.
     ElectorInfo& setElectorInfo(mqbnet::ElectorState::Enum    state,
                                 bsls::Types::Uint64           term,
                                 mqbnet::ClusterNode*          node,
@@ -316,13 +327,6 @@ inline ElectorInfo::ElectorInfo(mqbi::Cluster* cluster)
 }
 
 // MANIPULATORS
-inline ElectorInfo&
-ElectorInfo::setElectorState(mqbnet::ElectorState::Enum value)
-{
-    d_electorState = value;
-    return *this;
-}
-
 inline ElectorInfo& ElectorInfo::setElectorTerm(bsls::Types::Uint64 value)
 {
     d_leaderMessageSequence.electorTerm()    = value;

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -249,13 +249,6 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
         return rc_SUCCESS;  // RETURN
     }
 
-    if (bmqp_ctrlmsg::NodeStatus::E_AVAILABLE !=
-        d_clusterData_p->membership().selfNodeStatus()) {
-        // If self is not available, then the cluster state snapshot is likely
-        // incomplete, so there is no point in writing it.
-        return rc_SUCCESS;  // RETURN
-    }
-
     // Determine the correct LSN to put in the cluster state snapshot, which is
     // the maximum of current LSN from ElectorInfo and the largest LSN from
     // uncommitted advisories.
@@ -780,10 +773,18 @@ int IncoreClusterStateLedger::applyRecordInternal(
 
 void IncoreClusterStateLedger::cancelUncommittedAdvisories()
 {
+    AdvisoriesMapIter iter = d_uncommittedAdvisories.begin();
+    if (iter != d_uncommittedAdvisories.end()) {
+        const bmqp_ctrlmsg::LeaderMessageSequence& seqNum = iter->first;
+        BALL_LOG_INFO << description() << "Canceling "
+                      << d_uncommittedAdvisories.size()
+                      << " uncommitted advisories in the incore CSL starting "
+                         "at seqNum = "
+                      << seqNum;
+    }
+
     if (isSelfLeader()) {
-        for (AdvisoriesMapIter iter = d_uncommittedAdvisories.begin();
-             iter != d_uncommittedAdvisories.end();
-             ++iter) {
+        for (; iter != d_uncommittedAdvisories.end(); ++iter) {
             const ClusterMessageInfo&    info = iter->second;
             bmqp_ctrlmsg::ControlMessage controlMessage;
             controlMessage.choice().makeClusterMessage(info.d_clusterMessage);
@@ -798,8 +799,7 @@ void IncoreClusterStateLedger::cancelUncommittedAdvisories()
 }
 
 int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
-                                        mqbnet::ClusterNode* source,
-                                        bool                 delayed)
+                                        mqbnet::ClusterNode* source)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
@@ -810,28 +810,24 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     BSLS_ASSERT_SAFE(source);
     BSLS_ASSERT_SAFE(source->nodeId() !=
                      d_clusterData_p->membership().selfNode()->nodeId());
-    BSLS_ASSERT_SAFE(
-        isSelfLeader() ||
-        source->nodeId() ==
-            d_clusterData_p->electorInfo().leaderNode()->nodeId());
 
     enum RcEnum {
         // Value for the various RC error categories
         rc_SUCCESS = 0  // Success
         ,
-        rc_MISSING_HEADER = -1  // Event or record header is missing
+        rc_INVALID_SOURCE = -1  // Source is not leader
         ,
-        rc_INVALID_HEADER = -2  // Event or record header is invalid
+        rc_MISSING_HEADER = -2  // Event or record header is missing
         ,
-        rc_INVALID_SOURCE = -3  // Source is not leader
+        rc_INVALID_HEADER = -3  // Event or record header is invalid
         ,
-        rc_RECORD_STALE = -4  // Record is stale
+        rc_UNEXPECTED_RECORD_TYPE = -4  // Unexpected record type
         ,
         rc_RECORD_ALREADY_APPLIED = -5  // Record was already applied
         ,
-        rc_LOAD_MESSAGE_FAILURE = -6  // Fail to load cluster message
+        rc_RECORD_STALE = -6  // Record is stale
         ,
-        rc_NODE_STOPPING = -7  // Self node is stopping
+        rc_LOAD_MESSAGE_FAILURE = -7  // Fail to load cluster message
         ,
         rc_ADVISORY_INVALID = -8  // Advisory is invalid, as determined
                                   // by type-specific validation
@@ -842,7 +838,24 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     BALL_LOG_INFO << "Applying cluster state record event from node '"
                   << source->nodeDescription() << "'";
 
-    // Sanity check on record
+    if (!isSelfLeader() &&
+        d_clusterData_p->electorInfo().leaderNodeId() != source->nodeId()) {
+        BALL_LOG_ERROR << description()
+                       << ": Ignoring cluster state record event from '"
+                       << source->nodeDescription()
+                       << "'. Reason: Source node is not the leader"
+                       << " [source: " << source->nodeDescription()
+                       << ", leader: "
+                       << (d_clusterData_p->electorInfo().leaderNode()
+                               ? d_clusterData_p->electorInfo()
+                                     .leaderNode()
+                                     ->nodeDescription()
+                               : "** none **")
+                       << "].";
+        return rc_INVALID_SOURCE;  // RETURN
+    }
+
+    // Sanity check event header
     bmqu::BlobObjectProxy<bmqp::EventHeader> eventHeader(
         &event,
         -bmqp::EventHeader::k_MIN_HEADER_SIZE,
@@ -864,6 +877,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     BSLS_ASSERT_SAFE(eventHeader->length() == event.length());
     BSLS_ASSERT_SAFE(eventHeader->type() == bmqp::EventType::e_CLUSTER_STATE);
 
+    // Sanity check record header
     bmqu::BlobPosition recordHeaderPosition;
     int rc = bmqu::BlobUtil::findOffsetSafe(&recordHeaderPosition,
                                             event,
@@ -897,59 +911,70 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     BSLS_ASSERT_SAFE(ClusterStateLedgerUtil::recordSize(*recordHeader) ==
                      (event.length() - eventHeaderSize));
 
+    // Validate sequence number and record type
     bmqp_ctrlmsg::LeaderMessageSequence seqNum;
     seqNum.electorTerm()    = recordHeader->electorTerm();
     seqNum.sequenceNumber() = recordHeader->sequenceNumber();
-    if (recordHeader->recordType() != ClusterStateRecordType::e_ACK &&
-        d_uncommittedAdvisories.find(seqNum) !=
+
+    if (isSelfLeader()) {
+        // Leader should only receive Acks.
+        if (recordHeader->recordType() != ClusterStateRecordType::e_ACK) {
+            BALL_LOG_ERROR
+                << description()
+                << ": Ignoring cluster state record event with seqNum = "
+                << seqNum << " from '" << source->nodeDescription()
+                << "'. Reason: Leader should only receive Acks, "
+                   "but we received record of type: "
+                << recordHeader->recordType();
+            return rc_UNEXPECTED_RECORD_TYPE;  // RETURN
+        }
+
+        BSLS_ASSERT_SAFE(
+            seqNum <= d_clusterData_p->electorInfo().leaderMessageSequence());
+
+        if (d_uncommittedAdvisories.find(seqNum) ==
             d_uncommittedAdvisories.end()) {
-        BALL_LOG_ERROR << description() << ": Failed to apply record from '"
-                       << source->nodeDescription()
-                       << "'. Reason: record was already applied. ";
-        return rc_RECORD_ALREADY_APPLIED;  // RETURN
+            BALL_LOG_INFO
+                << description()
+                << ": Ignoring cluster state record ack with seqNum = "
+                << seqNum << " from '" << source->nodeDescription()
+                << "', as quorum of acks has already been reached.";
+            return rc_SUCCESS;  // RETURN
+        }
     }
+    else {
+        // Follower should only receive advisories and commits.
+        if (recordHeader->recordType() != ClusterStateRecordType::e_SNAPSHOT &&
+            recordHeader->recordType() != ClusterStateRecordType::e_UPDATE &&
+            recordHeader->recordType() != ClusterStateRecordType::e_COMMIT) {
+            BALL_LOG_ERROR
+                << description()
+                << ": Ignoring cluster state record event with seqNum = "
+                << seqNum << " from '" << source->nodeDescription()
+                << "'. Reason: Follower should only receive advisories and "
+                   "commits, but we received record of type: "
+                << recordHeader->recordType();
+            return rc_UNEXPECTED_RECORD_TYPE;  // RETURN
+        }
 
-    // Validate advisory and source
-    if (!delayed) {
-        // Source (leader) and leader sequence number should not be validated
-        // for delayed (aka buffered) advisories.  Those attributes were
-        // validated when buffered advisories were received.
-
-        if (d_clusterData_p->electorInfo().leaderNode() != source) {
-            // Different leader.  Ignore message.
-            BALL_LOG_ERROR << description() << ": Ignoring event from '"
-                           << source->nodeDescription()
-                           << "'. Reason: Source node is not the leader"
-                           << " [source: " << source->nodeDescription()
-                           << ", leader: "
-                           << (d_clusterData_p->electorInfo().leaderNode()
-                                   ? d_clusterData_p->electorInfo()
-                                         .leaderNode()
-                                         ->nodeDescription()
-                                   : "** none **")
-                           << "].";
-            return rc_INVALID_SOURCE;  // RETURN
+        if (d_uncommittedAdvisories.find(seqNum) !=
+            d_uncommittedAdvisories.end()) {
+            BALL_LOG_ERROR << description()
+                           << ": Failed to apply record with seqNum = "
+                           << seqNum << " from '" << source->nodeDescription()
+                           << "'. Reason: record was already applied. ";
+            return rc_RECORD_ALREADY_APPLIED;  // RETURN
         }
 
         if (seqNum < d_clusterData_p->electorInfo().leaderMessageSequence()) {
             BALL_LOG_ERROR
-                << description() << ": Failed to apply record from '"
-                << source->nodeDescription() << "'. Reason: record is stale "
-                << "[sequenceNumber: " << seqNum << ", leaderMessageSeq: "
+                << description()
+                << ": Failed to apply record with seqNum = " << seqNum
+                << " from '" << source->nodeDescription()
+                << "'. Reason: record is stale; self leaderMessageSeq = "
                 << d_clusterData_p->electorInfo().leaderMessageSequence()
                 << "].";
             return rc_RECORD_STALE;  // RETURN
-        }
-
-        // Leader status and sequence number are updated unconditionally.  It
-        // may have been updated by one of the callers of this routine, but
-        // there is no harm is setting these values again.
-        if (d_clusterData_p->clusterConfig()
-                .clusterAttributes()
-                .isCSLModeEnabled()) {
-            d_clusterData_p->electorInfo().setLeaderMessageSequence(seqNum);
-            d_clusterData_p->electorInfo().setLeaderStatus(
-                mqbc::ElectorInfoLeaderStatus::e_ACTIVE);
         }
     }
 
@@ -963,47 +988,38 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         return rc * 10 + rc_LOAD_MESSAGE_FAILURE;  // RETURN
     }
 
-    // CONDITIONS: If advisory is delayed, it must be a queue advisory (only
-    //             those are buffered) or a commit of queue advisory
-    BSLS_ASSERT_SAFE(!delayed ||
-                     message.choice().isQueueAssignmentAdvisoryValue() ||
+    BSLS_ASSERT_SAFE(message.choice().isQueueAssignmentAdvisoryValue() ||
                      message.choice().isQueueUnassignedAdvisoryValue() ||
-                     message.choice().isQueueUnAssignmentAdvisoryValue() ||
+                     message.choice().isQueueUpdateAdvisoryValue() ||
+                     message.choice().isPartitionPrimaryAdvisoryValue() ||
+                     message.choice().isLeaderAdvisoryValue() ||
+                     message.choice().isLeaderAdvisoryAckValue() ||
                      message.choice().isLeaderAdvisoryCommitValue());
 
-    // More validations (type-specific): A queue advisory
-    if (message.choice().isQueueAssignmentAdvisoryValue() ||
-        message.choice().isQueueUnassignedAdvisoryValue() ||
-        message.choice().isQueueUnAssignmentAdvisoryValue()) {
-        // Queue advisory
+    BALL_LOG_INFO << description() << ": Applying cluster message with type = "
+                  << recordHeader->recordType() << " and seqNum = " << seqNum
+                  << " from '" << source->nodeDescription()
+                  << "': " << message;
 
-        // TBD: Suppress the following check for now, which will help some
-        // integration tests to pass.  At this point, it is not clear if it is
-        // safe to process queue advisory messages self is stopping.
-        //
-        // if (   d_clusterData_p->membership().selfNodeStatus()
-        //     == bmqp_ctrlmsg::NodeStatus::E_STOPPING) {
-        //     // No need to process the advisory since self is stopping.
-        //     BALL_LOG_INFO << description()
-        //                   << "Ignoring event from '"
-        //                   << source->nodeDescription()
-        //                   << "'. Reason: Self is stopping.";
-        //     return rc_NODE_STOPPING;                               // RETURN
-        // }
-    }
-    else if (message.choice().isPartitionPrimaryAdvisoryValue()) {
+    // Validate partition-primary mappings, if any
+    if (message.choice().isPartitionPrimaryAdvisoryValue() ||
+        message.choice().isLeaderAdvisoryValue()) {
         const bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>& partitions =
-            message.choice().partitionPrimaryAdvisory().partitions();
+            message.choice().isPartitionPrimaryAdvisoryValue()
+                ? message.choice().partitionPrimaryAdvisory().partitions()
+                : message.choice().leaderAdvisory().partitions();
+
         // Validate the notification.  If *any* part of notification is found
         // invalid, we reject the *entire* notification.
         for (int i = 0; i < static_cast<int>(partitions.size()); ++i) {
             const bmqp_ctrlmsg::PartitionPrimaryInfo& info = partitions[i];
-            if (info.partitionId() >=
-                static_cast<int>(d_clusterState_p->partitions().size())) {
+            if ((info.partitionId() < 0) ||
+                (info.partitionId() >=
+                 static_cast<int>(d_clusterState_p->partitions().size()))) {
                 BMQTSK_ALARMLOG_ALARM("CLUSTER")
                     << d_clusterData_p->identity().description()
-                    << ": Invalid partitionId: " << info
-                    << " specified in partition-primary advisory. "
+                    << ": Invalid Partition Id: " << info
+                    << " specified in advisory: " << message << ". "
                     << "Ignoring this *ENTIRE* advisory message."
                     << BMQTSK_ALARMLOG_END;
                 return rc_ADVISORY_INVALID;  // RETURN
@@ -1016,29 +1032,8 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                 BMQTSK_ALARMLOG_ALARM("CLUSTER")
                     << d_clusterData_p->identity().description()
                     << ": Invalid primaryNodeId: " << info
-                    << " specified in partition-primary advisory."
+                    << " specified in advisory: " << message << ". "
                     << " Ignoring this *ENTIRE* advisory."
-                    << BMQTSK_ALARMLOG_END;
-                return rc_ADVISORY_INVALID;  // RETURN
-            }
-
-            if (proposedPrimaryNode ==
-                    d_clusterData_p->membership().selfNode() &&
-                bmqp_ctrlmsg::NodeStatus::E_STARTING ==
-                    d_clusterData_p->membership().selfNodeStatus()) {
-                // Self is the proposed primary but self is STARTING.  This is
-                // a bug because if this node perceives self as STARTING, any
-                // other node (including the leader) *cannot* perceive this
-                // node as AVAILABLE.  This node might be STOPPING, but that's
-                // ok since its possible that it transitioned from AVAILABLE to
-                // other state immediately after leader broadcast the advisory.
-                // Lower layers will take care of that scenario.
-
-                BMQTSK_ALARMLOG_ALARM("CLUSTER")
-                    << d_clusterData_p->identity().description()
-                    << ": proposed primary specified in partition/primary : "
-                    << info << " is self but self is STARTING. "
-                    << "Ignoring this *ENTIRE* advisory."
                     << BMQTSK_ALARMLOG_END;
                 return rc_ADVISORY_INVALID;  // RETURN
             }
@@ -1058,7 +1053,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                 // currently not supported, so self node will exit.  Note that
                 // this scnenario can be witnessed in a bad network where some
                 // nodes cannot see other nodes intermittently.  See
-                // 'onLeaderSyncDataQueryResponseDispatched' for similar check.
+                // 'onLeaderSyncDataQueryResponse' for similar check.
                 BMQTSK_ALARMLOG_ALARM("CLUSTER")
                     << d_clusterData_p->identity().description()
                     << ": Partition [" << info.partitionId()
@@ -1074,23 +1069,49 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                 // EXIT
             }
 
-            if (d_isFirstLeaderAdvisory) {
-                // If this node just started and recovered from a peer, it will
-                // already be aware of the *current* primaryLeaseId for each
-                // partition, but not its primary node (this is because leaseId
-                // is retrieved from the storage, but not the primary nodeId,
-                // because we don't persist the primary nodeId).  When this
-                // node becomes AVAILABLE, the leader simply sends the
-                // partition/primary advisory without bumping up the leaseId.
-                // 'd_isFirstLeaderAdvisory' flag takes care of this scenario.
-
-                // Note that 'pi.primaryNode()' may not be zero because
-                // currently, we update the cluster state even upon receiving
-                // primary status advisory from a primary node, so self node
-                // may or may not have received a primary-status advisory from
-                // the primary node.
+            if ((pi.primaryNode() == proposedPrimaryNode) ||
+                (pi.primaryNode() == 0)) {
+                // Proposed primary node is same as self's primary node, or
+                // self views this partition as orphan.  In either case,
+                // leaseId cannot be smaller.  It can, however, be equal.
+                // The case in which 'pi.primaryNode() ==
+                // proposedPrimaryNode' and leaseId is same, is obvious --
+                // the leader simply re-sent the partition primary mapping
+                // advisory.  But the case where pi.primaryNode() is null
+                // (and 'proposedPrimaryNode' is valid) *and* leaseId is
+                // same can be explained in this way: this node (replica)
+                // was aware of the primary and leaseId, but then at some
+                // point, lost connection to the primary, and marked this
+                // partition as orphan.  Note that primary node did not
+                // crash.  After some time, connection was re-established,
+                // and leader/primary resent the primary mapping again --
+                // with same leaseId.  This scenario was seen when cluster
+                // was running on VM boxes.  Also note that above scenario
+                // is different from the case where a node has not heard
+                // from leader even once.
 
                 if (info.primaryLeaseId() < pi.primaryLeaseId()) {
+                    BMQTSK_ALARMLOG_ALARM("CLUSTER")
+                        << d_clusterData_p->identity().description()
+                        << ": Stale primaryLeaseId specified "
+                        << "in: " << info
+                        << ", current primaryLeaseId: " << pi.primaryLeaseId()
+                        << ". Primary node viewed by self: "
+                        << (pi.primaryNode() != 0
+                                ? pi.primaryNode()->nodeDescription()
+                                : "** null **")
+                        << ", proposed primary node: "
+                        << proposedPrimaryNode->nodeDescription()
+                        << ". Ignoring this *ENTIRE* advisory."
+                        << BMQTSK_ALARMLOG_END;
+                    return rc_ADVISORY_INVALID;  // RETURN
+                }
+            }
+            else {
+                // Different (non-zero) primary nodes.  Proposed leaseId
+                // must be greater.
+
+                if (info.primaryLeaseId() <= pi.primaryLeaseId()) {
                     BMQTSK_ALARMLOG_ALARM("CLUSTER")
                         << d_clusterData_p->identity().description()
                         << ": Stale primaryLeaseId specified in: " << info
@@ -1100,66 +1121,8 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                     return rc_ADVISORY_INVALID;  // RETURN
                 }
             }
-            else {
-                if ((pi.primaryNode() == proposedPrimaryNode) ||
-                    (pi.primaryNode() == 0)) {
-                    // Proposed primary node is same as self's primary node, or
-                    // self views this partition as orphan.  In either case,
-                    // leaseId cannot be smaller.  It can, however, be equal.
-                    // The case in which 'pi.primaryNode() ==
-                    // proposedPrimaryNode' and leaseId is same, is obvious --
-                    // the leader simply re-sent the partition primary mapping
-                    // advisory.  But the case where pi.primaryNode() is null
-                    // (and 'proposedPrimaryNode' is valid) *and* leaseId is
-                    // same can be explained in this way: this node (replica)
-                    // was aware of the primary and leaseId, but then at some
-                    // point, lost connection to the primary, and marked this
-                    // partition as orphan.  Note that primary node did not
-                    // crash.  After some time, connection was re-established,
-                    // and leader/primary resent the primary mapping again --
-                    // with same leaseId.  This scenario was seen when cluster
-                    // was running on VM boxes.  Also note that above scenario
-                    // is different from the case where a node has not heard
-                    // from leader even once.
-
-                    if (info.primaryLeaseId() < pi.primaryLeaseId()) {
-                        BMQTSK_ALARMLOG_ALARM("CLUSTER")
-                            << d_clusterData_p->identity().description()
-                            << ": Stale primaryLeaseId specified "
-                            << "in: " << info << ", current primaryLeaseId: "
-                            << pi.primaryLeaseId()
-                            << ". Primary node viewed by self: "
-                            << (pi.primaryNode() != 0
-                                    ? pi.primaryNode()->nodeDescription()
-                                    : "** null **")
-                            << ", proposed primary node: "
-                            << proposedPrimaryNode->nodeDescription()
-                            << ". Ignoring this *ENTIRE* advisory."
-                            << BMQTSK_ALARMLOG_END;
-                        return rc_ADVISORY_INVALID;  // RETURN
-                    }
-                }
-                else {
-                    // Different (non-zero) primary nodes.  Proposed leaseId
-                    // must be greater.
-
-                    if (info.primaryLeaseId() <= pi.primaryLeaseId()) {
-                        BMQTSK_ALARMLOG_ALARM("CLUSTER")
-                            << d_clusterData_p->identity().description()
-                            << ": Stale primaryLeaseId specified in: " << info
-                            << ", current primaryLeaseId: "
-                            << pi.primaryLeaseId()
-                            << ". Ignoring this *ENTIRE* advisory."
-                            << BMQTSK_ALARMLOG_END;
-                        return rc_ADVISORY_INVALID;  // RETURN
-                    }
-                }
-            }
         }
     }
-
-    BALL_LOG_INFO << description() << ": Applying cluster message from '"
-                  << source->nodeDescription() << "': " << message;
 
     rc = applyRecordInternal(event,
                              eventHeaderSize,
@@ -1189,7 +1152,6 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
     BlobSpPool*                         blobSpPool_p,
     bslma::Allocator*                   allocator)
 : d_allocator_p(allocator)
-, d_isFirstLeaderAdvisory(true)
 , d_isOpen(false)
 , d_blobSpPool_p(blobSpPool_p)
 , d_description(allocator)
@@ -1210,7 +1172,7 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
     // Create description
     bmqu::MemOutStream osstr;
     osstr << "IncoreClusterStateLedger (cluster: "
-          << d_clusterData_p->identity().name() << ") : ";
+          << d_clusterData_p->identity().name() << ")";
     d_description.assign(osstr.str().data(), osstr.str().length());
 
     // Instantiate ledger config
@@ -1264,11 +1226,9 @@ void IncoreClusterStateLedger::onClusterLeader(
         d_clusterData_p->cluster().dispatcher()->inDispatcherThread(
             &d_clusterData_p->cluster()));
 
-    if (status == ElectorInfoLeaderStatus::e_PASSIVE) {
-        return;  // RETURN
+    if (status == ElectorInfoLeaderStatus::e_UNDEFINED) {
+        cancelUncommittedAdvisories();
     }
-
-    cancelUncommittedAdvisories();
 }
 
 // MANIPULATORS
@@ -1512,14 +1472,7 @@ int IncoreClusterStateLedger::apply(const bdlbb::Blob&   event,
         d_clusterData_p->cluster().dispatcher()->inDispatcherThread(
             &d_clusterData_p->cluster()));
 
-    return applyImpl(event, source,
-                     false);  // delayed
-}
-
-void IncoreClusterStateLedger::setIsFirstLeaderAdvisory(
-    bool isFirstLeaderAdvisory)
-{
-    d_isFirstLeaderAdvisory = isFirstLeaderAdvisory;
+    return applyImpl(event, source);
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -263,8 +263,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     ///
     /// THREAD: This method can be invoked only in the associated cluster's
     ///         dispatcher thread.
-    int applyImpl(const bdlbb::Blob&   event,
-                  mqbnet::ClusterNode* source);
+    int applyImpl(const bdlbb::Blob& event, mqbnet::ClusterNode* source);
 
     // PRIVATE ACCESSORS
 

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -153,15 +153,6 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     bslma::Allocator* d_allocator_p;
     // Allocator used to supply memory
 
-    bool d_isFirstLeaderAdvisory;
-    // Flag to indicate whether this is
-    // first leader advisory.  *NOTE*: this
-    // flag is a workaround to address the
-    // existing cyclic dependency b/w
-    // leader and primary at node startup
-    // and will be removed once all CSL
-    // phases are complete.
-
     bool d_isOpen;
     // Flag to indicate open/close status
     // of this object
@@ -266,16 +257,14 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     void cancelUncommittedAdvisories();
 
     /// Apply the specified raw cluster state record `event` received from
-    /// the specified `source` node according to the specified `delayed`
-    /// flag indicating if the event was previously buffered.  Note that
-    /// while a replica node may receive any type of records from the
-    /// leader, the leader may *only* receive ack records from a replica.
+    /// the specified `source` node.  Note that while a replica node may
+    /// receive any type of records from the leader, the leader may *only*
+    /// receive ack records from a replica.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's
     ///         dispatcher thread.
     int applyImpl(const bdlbb::Blob&   event,
-                  mqbnet::ClusterNode* source,
-                  bool                 delayed);
+                  mqbnet::ClusterNode* source);
 
     // PRIVATE ACCESSORS
 
@@ -388,9 +377,6 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     ///         dispatcher thread.
     int apply(const bdlbb::Blob&   event,
               mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    setIsFirstLeaderAdvisory(bool isFirstLeaderAdvisory) BSLS_KEYWORD_OVERRIDE;
 
     /// Set the commit callback to the specified `value`.
     void setCommitCb(const CommitCb& value) BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -356,10 +356,12 @@ struct Tester {
         bdlbb::BlobUtil::append(event, record);
     }
 
-    /// Let the specified `ledger` receive the specified `numAcks` acks for the record having the specific `sequenceNumber`.  Behavior is undefined unless the caller is the leader node.
-    void receiveAck(mqbc::IncoreClusterStateLedger *ledger,
+    /// Let the specified `ledger` receive the specified `numAcks` acks for the
+    /// record having the specific `sequenceNumber`.  Behavior is undefined
+    /// unless the caller is the leader node.
+    void receiveAck(mqbc::IncoreClusterStateLedger*            ledger,
                     const bmqp_ctrlmsg::LeaderMessageSequence& sequenceNumber,
-                    int numAcks)
+                    int                                        numAcks)
     {
         // PRECONDITIONS
         BSLS_ASSERT_OPT(d_isLeader);
@@ -372,16 +374,17 @@ struct Tester {
 
         bdlbb::Blob ackEvent(d_cluster_mp->_bufferFactory(), s_allocator_p);
         constructEventBlob(&ackEvent,
-                                  message,
-                                  ack.sequenceNumberAcked(),
-                                  123456,
-                                  mqbc::ClusterStateRecordType::e_ACK);
+                           message,
+                           ack.sequenceNumberAcked(),
+                           123456,
+                           mqbc::ClusterStateRecordType::e_ACK);
 
         for (int i = 1; i <= numAcks; ++i) {
-            BMQTST_ASSERT_EQ(ledger->apply(ackEvent,
-                                 d_cluster_mp->netCluster().lookupNode(
-                                     mqbmock::Cluster::k_LEADER_NODE_ID + i)),
-                      0);
+            BMQTST_ASSERT_EQ(
+                ledger->apply(ackEvent,
+                              d_cluster_mp->netCluster().lookupNode(
+                                  mqbmock::Cluster::k_LEADER_NODE_ID + i)),
+                0);
         }
     }
 
@@ -402,7 +405,9 @@ struct Tester {
         return true;
     }
 
-    /// Return true if we the follower has sent `number` messages to the leader, false otherwise.  Behavior is undefined unless the caller is a follower node.
+    /// Return true if we the follower has sent `number` messages to the
+    /// leader, false otherwise.  Behavior is undefined unless the caller is a
+    /// follower node.
     bool hasSentMessagesToLeader(int number) const
     {
         // PRECONDITIONS
@@ -417,7 +422,8 @@ struct Tester {
                     return false;  // RETURN
                 }
                 BSLS_ASSERT_OPT(citer->second->writeCalls().size() >= number);
-            } else {
+            }
+            else {
                 BSLS_ASSERT_OPT((!citer->second->waitFor(1)));
                 BSLS_ASSERT_OPT(citer->second->writeCalls().empty());
             }
@@ -426,7 +432,8 @@ struct Tester {
         return true;
     }
 
-    /// Return true if we the leader has broadcast `number` messages, false otherwise.  Behavior is undefined unless the caller is the leader node.
+    /// Return true if we the leader has broadcast `number` messages, false
+    /// otherwise.  Behavior is undefined unless the caller is the leader node.
     bool hasBroadcastedMessages(int number) const
     {
         // PRECONDITIONS
@@ -610,7 +617,8 @@ static void test3_apply_QueueAssignmentAdvisory()
 // QUEUE ASSIGNMENT ADVISORY
 //
 // Concerns:
-//   Applying 'QueueAssignmentAdvisory' (only at leader), receive a quorum of acks, then commit the advisory.
+//   Applying 'QueueAssignmentAdvisory' (only at leader), receive a quorum of
+//   acks, then commit the advisory.
 //
 // Testing:
 //   int apply(const bmqp_ctrlmsg::QueueAssignmentAdvisory& advisory);
@@ -666,7 +674,8 @@ static void test4_apply_QueueUnassignedAdvisory()
 // QUEUE UNASSIGNED ADVISORY
 //
 // Concerns:
-//   Applying 'QueueUnassignedAdvisory' (only at leader), receive a quorum of acks, then commit the advisory.
+//   Applying 'QueueUnassignedAdvisory' (only at leader), receive a quorum of
+//   acks, then commit the advisory.
 //
 // Testing:
 //   int apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory);
@@ -718,7 +727,8 @@ static void test5_apply_QueueUpdateAdvisory()
 // QUEUE UPDATE ADVISORY
 //
 // Concerns:
-//   Applying 'QueueUpdateAdvisory' (only at leader), receive a quorum of acks, then commit the advisory.
+//   Applying 'QueueUpdateAdvisory' (only at leader), receive a quorum of acks,
+//   then commit the advisory.
 //
 // Testing:
 //   int apply(const bmqp_ctrlmsg::QueueUpdateAdvisory& advisory);
@@ -787,7 +797,8 @@ static void test6_apply_LeaderAdvisory()
 // LEADER ADVISORY
 //
 // Concerns:
-//   Applying 'LeaderAdvisory' (only at leader), receive a quorum of acks, then commit the advisory.
+//   Applying 'LeaderAdvisory' (only at leader), receive a quorum of acks, then
+//   commit the advisory.
 //
 // Testing:
 //   int apply(const bmqp_ctrlmsg::LeaderAdvisory& advisory);
@@ -885,9 +896,9 @@ static void test7_apply_ClusterStateRecord()
 
     // Apply the update record
     BMQTST_ASSERT_EQ(obj->apply(updateEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
 
@@ -933,9 +944,9 @@ static void test7_apply_ClusterStateRecord()
 
     // Apply the snapshot record
     BMQTST_ASSERT_EQ(obj->apply(snapshotEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
 
@@ -996,9 +1007,9 @@ static void test8_apply_ClusterStateRecordCommit()
                               mqbc::ClusterStateRecordType::e_UPDATE);
 
     BMQTST_ASSERT_EQ(obj->apply(advisoryEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
 
@@ -1020,9 +1031,9 @@ static void test8_apply_ClusterStateRecordCommit()
                               mqbc::ClusterStateRecordType::e_COMMIT);
 
     BMQTST_ASSERT_EQ(obj->apply(commitEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 1U);
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
 
@@ -1035,23 +1046,23 @@ static void test8_apply_ClusterStateRecordCommit()
 
     // 2. Should fail for an advisory that has already been committed
     BMQTST_ASSERT_NE(obj->apply(commitEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 1U);
 
     // 3. Should fail for an invalid sequence number
     bmqp_ctrlmsg::LeaderAdvisoryCommit invalidCommit;
-    invalidCommit.sequenceNumberCommitted().electorTerm()        = 999U;
-    invalidCommit.sequenceNumberCommitted().sequenceNumber()     = 999U;
-    invalidCommit.sequenceNumber().electorTerm()    = 1U;
-    invalidCommit.sequenceNumber().sequenceNumber() = 4U;
+    invalidCommit.sequenceNumberCommitted().electorTerm()    = 999U;
+    invalidCommit.sequenceNumberCommitted().sequenceNumber() = 999U;
+    invalidCommit.sequenceNumber().electorTerm()             = 1U;
+    invalidCommit.sequenceNumber().sequenceNumber()          = 4U;
 
     bmqp_ctrlmsg::ClusterMessage invalidCommitMessage;
     invalidCommitMessage.choice().makeLeaderAdvisoryCommit(invalidCommit);
 
     bdlbb::Blob invalidCommitEvent(tester.d_cluster_mp->_bufferFactory(),
-                            s_allocator_p);
+                                   s_allocator_p);
     tester.constructEventBlob(&invalidCommitEvent,
                               invalidCommitMessage,
                               invalidCommit.sequenceNumber(),
@@ -1059,9 +1070,9 @@ static void test8_apply_ClusterStateRecordCommit()
                               mqbc::ClusterStateRecordType::e_COMMIT);
 
     BMQTST_ASSERT_NE(obj->apply(invalidCommitEvent,
-                         tester.d_cluster_mp->netCluster().lookupNode(
-                             mqbmock::Cluster::k_LEADER_NODE_ID)),
-              0);
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 1U);
 
     BSLS_ASSERT_OPT(obj->close() == 0);
@@ -1138,7 +1149,7 @@ static void test9_persistanceLeader()
     qupdate.partitionId() = 1U;
     key.loadBinary(&qupdate.key());
     qupdate.addedAppIds().resize(1);
-    qupdate.domain() = "bmq.test.mmap.fanout";
+    qupdate.domain()                    = "bmq.test.mmap.fanout";
     bmqp_ctrlmsg::AppIdInfo& addedAppId = qupdate.addedAppIds().back();
     addedAppId.appId()                  = "qux";
     mqbu::StorageKey appKey1(mqbu::StorageKey::BinaryRepresentation(),
@@ -1261,7 +1272,8 @@ static void test9_persistanceLeader()
     rc = cslIter->loadClusterMessage(&msg);
     BMQTST_ASSERT_EQ(rc, 0);
     BMQTST_ASSERT(msg.choice().isQueueUnassignedAdvisoryValue());
-    BMQTST_ASSERT_EQ(msg.choice().queueUnassignedAdvisory(), qUnassignedAdvisory);
+    BMQTST_ASSERT_EQ(msg.choice().queueUnassignedAdvisory(),
+                     qUnassignedAdvisory);
 
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
     BMQTST_ASSERT(cslIter->isValid());
@@ -2077,7 +2089,7 @@ static void test12_rolloverUncommittedAdvisories()
             .makeQueueAssignmentAdvisory(qAssignAdvisory);
         BSLS_ASSERT_OPT(tester.numCommittedMessages() == i + 1);
         BSLS_ASSERT_OPT(tester.committedMessage(i) == expected);
-        BSLS_ASSERT_OPT(tester.hasSentMessagesToLeader(i+ 4));
+        BSLS_ASSERT_OPT(tester.hasSentMessagesToLeader(i + 4));
 
         ++i;
     }

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -372,7 +372,8 @@ struct Tester {
         bmqp_ctrlmsg::ClusterMessage message;
         message.choice().makeLeaderAdvisoryAck(ack);
 
-        bdlbb::Blob ackEvent(d_cluster_mp->_bufferFactory(), s_allocator_p);
+        bdlbb::Blob ackEvent(d_cluster_mp->_bufferFactory(),
+                             bmqtst::TestHelperUtil::allocator());
         constructEventBlob(&ackEvent,
                            message,
                            ack.sequenceNumberAcked(),
@@ -1062,7 +1063,7 @@ static void test8_apply_ClusterStateRecordCommit()
     invalidCommitMessage.choice().makeLeaderAdvisoryCommit(invalidCommit);
 
     bdlbb::Blob invalidCommitEvent(tester.d_cluster_mp->_bufferFactory(),
-                                   s_allocator_p);
+                                   bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&invalidCommitEvent,
                               invalidCommitMessage,
                               invalidCommit.sequenceNumber(),

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -302,7 +302,7 @@ class ClusterStateManager {
     processRegistrationRequest(const bmqp_ctrlmsg::ControlMessage& message,
                                mqbnet::ClusterNode*                source) = 0;
 
-    /// Process the specified `event`.
+    /// Process the specified cluster state `event`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
@@ -51,7 +51,6 @@ int ClusterStateLedger::applyAdvisoryInternal(
 ClusterStateLedger::ClusterStateLedger(mqbc::ClusterData* clusterData,
                                        bslma::Allocator*  allocator)
 : d_allocator_p(allocator)
-, d_isFirstLeaderAdvisory(true)
 , d_isOpen(false)
 , d_pauseCommitCb(false)
 , d_commitCb()

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
@@ -73,10 +73,6 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
     bslma::Allocator* d_allocator_p;
     // Allocator used to supply memory.
 
-    bool d_isFirstLeaderAdvisory;
-    // Flag to indicate whether this is the first leader
-    // advisory.
-
     bool d_isOpen;
     // Flag to indicate open/close status of this object.
 
@@ -186,9 +182,6 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
     int apply(const bdlbb::Blob&   record,
               mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
 
-    void
-    setIsFirstLeaderAdvisory(bool isFirstLeaderAdvisory) BSLS_KEYWORD_OVERRIDE;
-
     /// Set the commit callback to the specified `value`.
     void setCommitCb(const CommitCb& value) BSLS_KEYWORD_OVERRIDE;
 
@@ -254,19 +247,6 @@ inline bool ClusterStateLedger::isSelfLeader() const
 
 // MANIPULATORS
 //   (virtual mqbc::ClusterStateLedger)
-inline void
-ClusterStateLedger::setIsFirstLeaderAdvisory(bool isFirstLeaderAdvisory)
-{
-    // executed by the *CLUSTER DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(
-        d_clusterData_p->cluster().dispatcher()->inDispatcherThread(
-            &d_clusterData_p->cluster()));
-
-    d_isFirstLeaderAdvisory = isFirstLeaderAdvisory;
-}
-
 inline void ClusterStateLedger::setCommitCb(const CommitCb& value)
 {
     d_commitCb = value;


### PR DESCRIPTION
1. Enable strong consistency by default everywhere we use CSL. Before, it was in eventual consistency everywhere. I updated the unit tests to also test in strong consistency. Most integration tests pass in strong consistency, except a few related to appIds. This proves the race condition around [`Domain::configure`](https://github.com/bloomberg/blazingmq/blob/527fa18619d64895ef9e2143ee5f399e67cf3430/src/groups/mqb/mqbblp/mqbblp_domain.cpp#L539-L573), which @dorjesinpo fixed in #493.

2. I enhanced the resiliency of the elector logic by prohibiting to set leader status directly from `e_UNDEFINED` to `e_ACTIVE`. It should always go from `e_UNDEFINED -> e_PASSIVE -> e_ACTIVE`. [Here](https://bbgithub.dev.bloomberg.com/yyan82/knowledge/blob/main/blazingmq/storage/ElectorInfo_LeaderStatus.png) is a small diagram of the current triggers to leader status transition. I am adding a new transition from `e_PASSIVE` to `e_ACTIVE` during `ElectorInfo::onHealedFollower()` in this PR. I also fixed the logic of some observers to the leader status via the `onClusterLeader` method.