### PR TITLE
Fix[MQB]: remove maxDeliveryAttempts range check

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -194,34 +194,6 @@ int normalizeConfig(mqbconfm::Domain* defn,
 {
     int updatedValues = 0;
 
-    const unsigned int maxDeliveryAttempts = defn->maxDeliveryAttempts();
-    const mqbcfg::MessageThrottleConfig& messageThrottleConfig =
-        domain.cluster()->isClusterMember()
-            ? domain.cluster()->clusterConfig()->messageThrottleConfig()
-            : domain.cluster()->clusterProxyConfig()->messageThrottleConfig();
-
-    const unsigned int highThresh = messageThrottleConfig.highThreshold();
-    const unsigned int minValue   = highThresh + 1;
-
-    // 'maxDeliveryAttempts' can be zero, which indicates unlimited attempts.
-    if (maxDeliveryAttempts && maxDeliveryAttempts < minValue) {
-        errorDescription << domain.cluster()->name() << ", " << domain.name()
-                         << ": maxDeliveryAttempts is less than message "
-                            "throttling high threshold value. "
-                            "maxDeliveryAttempts: "
-                         << maxDeliveryAttempts
-                         << ", highThreshold: " << highThresh
-                         << ". Updated "
-                            "maxDeliveryAttempts to have a value of "
-                         << minValue
-                         << ". Please update the value of "
-                            "maxDeliveryAttempts in this domain's config to "
-                            "have a value of at least "
-                         << minValue << ".\n";
-        defn->maxDeliveryAttempts() = minValue;
-        ++updatedValues;
-    }
-
     if (defn->mode().isBroadcastValue() &&
         defn->consistency().selectionId() ==
             mqbconfm::Consistency::SELECTION_ID_STRONG) {
@@ -515,7 +487,7 @@ int Domain::configure(bsl::ostream&           errorDescription,
             // Invoke callbacks for each added and removed ID on each queue.
             bsl::unordered_set<bsl::string>::const_iterator it =
                 addedIds.cbegin();
-            QueueMap::const_iterator                 qIt;
+            QueueMap::const_iterator qIt;
             for (; it != addedIds.cend(); it++) {
                 for (qIt = d_queues.cbegin(); qIt != d_queues.cend(); ++qIt) {
                     d_dispatcher_p->execute(

--- a/src/integration-tests/test_poison_messages.py
+++ b/src/integration-tests/test_poison_messages.py
@@ -158,8 +158,8 @@ class TestPoisonMessages:
         # 2. send a message to the consumer
         # 3. open a consumer
         # 4. kill a consumer
-        # 5. force a leader change
-        # 6. open a consumer
+        # 5. open a consumer
+        # 6. force a leader change
         # 7. kill a consumer a again
         # 8. open a consumer
         # The message should still exist and be delivered to the consumer (the
@@ -443,7 +443,7 @@ class TestPoisonMessages:
             multi_node, proxy, tc.DOMAIN_FANOUT, ["?id=foo", "?id=bar", "?id=baz"]
         )
 
-    @max_delivery_attempts(2)
+    @max_delivery_attempts(3)
     def test_poison_rda_reset_priority_active(self, multi_node: Cluster):
         proxies = multi_node.proxy_cycle()
         # pick proxy in datacenter opposite to the primary's


### PR DESCRIPTION
A user uncovered an unfortunate (and undocumented) limitation in the behavior of poison pill configurations, we do not allow users to set this to 1-4 (using the default broker configurations).

We should allow users to configure these as valid values for the number of delivery attempts.