### PR TITLE
UT[BMQIO]: remove UT designed with a race condition

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.h
@@ -355,6 +355,8 @@ class NtcChannel : public bmqio::Channel,
         BSLS_KEYWORD_OVERRIDE;
 
     /// Cancel the operation.
+    /// Note: the result callback might still be called after close due to
+    ///       concurrency.
     void cancel() BSLS_KEYWORD_OVERRIDE;
 
     /// Cancel all pending read requests, and invoke their read callbacks

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
@@ -1128,47 +1128,11 @@ static void test4_cancelHandleTest()
 {
     bmqtst::TestHelper::printTestName("Cancel Handle Test");
 
-    Tester t(s_allocator_p);
-
-    // Concerns 'a'
-    t.init(L_);
-
-    t.listen(L_, "listenHandle", "127.0.0.1:0");
-
-    t.connect(L_, "connectHandle", "listenHandle");
-    t.connect(L_, "connect2Handle", "listenHandle");
-    t.cancelHandle(L_, "connect2Handle");
-
-    // First connect succeeded
-    t.checkResultCallback(L_, "listenHandle", "listen1Channel");
-    t.checkResultCallback(L_, "connectHandle", "connect1Channel");
-    t.checkChannelClose(L_, "listen1Channel", false);
-    t.checkChannelClose(L_, "connect1Channel", false);
-
-    // Second one didn't finish, and may have been closed before the
-    // listening socket accepts the connection. See implementation note 3
-    // at the top of this test driver.
-    //
-    // t.checkResultCallback(L_, "listenHandle", "listen2Channel");
-    // t.checkChannelClose(L_, "listen2Channel");
-    t.checkNoResultCallback(L_, "connect2Handle");
-
-    // Concern 'b'
-    t.connect(L_, "connect3Handle", "listenHandle");
-    t.cancelHandle(L_, "listenHandle");
-    t.checkNoResultCallback(L_, "listenHandle");
-    // Can't check if the connect3Handle got a channel because we can't
-    // guarantee that the connect came in before we canceled the listen, and
-    // waiting for some time would make the test flaky. Test the failure
-    // is reported as the overall failure of the connection operation. See
-    // implementation note 4 at the top of this test driver.
-
-    t.connect(L_, "connect4Handle", "listenHandle");
-    t.checkNoResultCallback(L_, "listenHandle");
-    t.checkResultCallback(L_,
-                          "connect4Handle",
-                          ChannelFactoryEvent::e_CONNECT_ATTEMPT_FAILED,
-                          StatusCategory::e_CONNECTION);
+    // This test's original design was based on the assumption that `connect`
+    // and `listen` operations are slower than `cancel`, however, this is
+    // not the case in general.  We don't have non-invasive means to introduce
+    // more synchronizations to NtcChannel now just to test this in a
+    // controlled way, so this test is removed.
 }
 
 static void test3_watermarkTest()


### PR DESCRIPTION
This test is designed with a thread race, so we are removing it:

```
[2024-11-04T21:39:45.781Z] 04NOV2024_21:39:11.821 92542:139652027287296 TRACE /blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp:540 BMQIO.NTCCHANNEL NTC channel 0x000000027cad30 at 127.0.0.1:50102 to 127.0.0.1:37048 connection complete: [ type = COMPLETE context = [ endpoint = 127.0.0.1:37048 name = localhost:37048 latency = (0, 1670645) source = SYSTEM ] ] 

[2024-11-04T21:39:45.781Z] 04NOV2024_21:39:11.821 92542:139652027287296 TRACE /blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp:143 BMQIO.NTCCHANNELFACTORY NTC factory event CHANNEL_UP status [ Category = SUCCESS ] 

[2024-11-04T21:39:45.781Z] 04NOV2024_21:39:11.821 92542:139652027287296 TRACE /blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp:1524 BMQIO.NTCCHANNEL NTC listener 0x000000027bbec0 at 127.0.0.1:37048 closed: [ Category = CANCELED ] 

[2024-11-04T21:39:45.781Z] 04NOV2024_21:39:11.821 92542:139652027287296 TRACE /blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp:120 BMQIO.NTCCHANNELFACTORY NTC listener 0x000000027bbec0 at 127.0.0.1:37048 deregistered 

[2024-11-04T21:39:45.781Z] Error /blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp(928): 1159    (failed)
```