### PR TITLE
fix: getting rid of d_appKeysVec[partitionId]

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -408,15 +408,12 @@ void StorageManager::queueCreationCb(int*                    status,
         status,
         &d_storages[partitionId],
         &d_storagesLock,
-        &d_appKeysVec[partitionId],
-        &d_appKeysLock,
         d_domainFactory_p,
         d_clusterData_p->identity().description(),
         partitionId,
         uri,
         queueKey,
-        appIdKeyPairs,
-        d_cluster_p->isCSLModeEnabled());
+        appIdKeyPairs);
 }
 
 void StorageManager::queueDeletionCb(int*                    status,
@@ -446,8 +443,6 @@ void StorageManager::queueDeletionCb(int*                    status,
         &d_storages[partitionId],
         &d_storagesLock,
         d_fileStores[partitionId].get(),
-        &d_appKeysVec[partitionId],
-        &d_appKeysLock,
         d_clusterData_p->identity().description(),
         partitionId,
         uri,
@@ -479,8 +474,6 @@ void StorageManager::recoveredQueuesCb(int                    partitionId,
         &d_storages[partitionId],
         &d_storagesLock,
         d_fileStores[partitionId].get(),
-        &d_appKeysVec[partitionId],
-        &d_appKeysLock,
         d_domainFactory_p,
         &d_unrecognizedDomainsLock,
         &d_unrecognizedDomains[partitionId],
@@ -1002,8 +995,6 @@ StorageManager::StorageManager(
 , d_partitionPrimaryStatusCb(partitionPrimaryStatusCb)
 , d_storagesLock()
 , d_storages(allocator)
-, d_appKeysLock()
-, d_appKeysVec(allocator)
 , d_storageMonitorEventHandle()
 , d_gcMessagesEventHandle()
 , d_recoveredPrimaryLeaseIds(allocator)
@@ -1025,7 +1016,6 @@ StorageManager::StorageManager(
     d_storages.resize(partitionCfg.numPartitions());
     d_recoveredPrimaryLeaseIds.resize(partitionCfg.numPartitions());
     d_partitionInfoVec.resize(partitionCfg.numPartitions());
-    d_appKeysVec.resize(partitionCfg.numPartitions());
 
     d_minimumRequiredDiskSpace = mqbc::StorageUtil::findMinReqDiskSpace(
         partitionCfg);
@@ -1066,8 +1056,6 @@ void StorageManager::registerQueue(const bmqt::Uri&        uri,
                                      &d_storages[partitionId],
                                      &d_storagesLock,
                                      d_fileStores[partitionId].get(),
-                                     &d_appKeysVec[partitionId],
-                                     &d_appKeysLock,
                                      &d_allocators,
                                      processorForPartition(partitionId),
                                      uri,
@@ -1123,15 +1111,12 @@ int StorageManager::updateQueuePrimary(const bmqt::Uri&        uri,
         &d_storages[partitionId],
         &d_storagesLock,
         d_fileStores[partitionId].get(),
-        &d_appKeysVec[partitionId],
-        &d_appKeysLock,
         d_clusterData_p->identity().description(),
         uri,
         queueKey,
         partitionId,
         addedIdKeyPairs,
-        removedIdKeyPairs,
-        d_cluster_p->isCSLModeEnabled());
+        removedIdKeyPairs);
 }
 
 void StorageManager::registerQueueReplica(int                     partitionId,
@@ -1211,8 +1196,6 @@ void StorageManager::unregisterQueueReplica(int              partitionId,
             &d_storages[partitionId],
             &d_storagesLock,
             d_fileStores[partitionId].get(),
-            &d_appKeysVec[partitionId],
-            &d_appKeysLock,
             d_clusterData_p->identity().description(),
             partitionId,
             uri,
@@ -1256,15 +1239,12 @@ void StorageManager::updateQueueReplica(int                     partitionId,
             static_cast<int*>(0),
             &d_storages[partitionId],
             &d_storagesLock,
-            &d_appKeysVec[partitionId],
-            &d_appKeysLock,
             d_domainFactory_p,
             d_clusterData_p->identity().description(),
             partitionId,
             uri,
             queueKey,
             appIdKeyPairs,
-            d_cluster_p->isCSLModeEnabled(),
             domain,
             allowDuplicate));
 

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -272,8 +272,7 @@ class StorageManager : public mqbi::StorageManager {
     mutable bslmt::Mutex d_storagesLock;
     // Mutex to protect access to
     // 'd_storages' and its elements.  See
-    // comments for 'd_storages' and
-    // 'd_appKeysLock' variables as well.
+    // comments for 'd_storages'.
 
     StorageSpMapVec d_storages;
     // Vector of (CanonicalQueueUri ->
@@ -287,39 +286,6 @@ class StorageManager : public mqbi::StorageManager {
     // because they are accessed from
     // partitions' dispatcher threads, as
     // well as cluster dispatcher thread.
-
-    bslmt::Mutex d_appKeysLock;
-    // Mutex to protect access to
-    // 'd_appKeysVec' and its elements.
-    // Note that when acquiring this lock,
-    // *if* 'd_storagesLock' needs to be
-    // acquired as well, 'd_storagesLock'
-    // must be acquired before
-    // 'd_appKeysLock' in order to respect
-    // hierarchy of locks and avoid
-    // deadlock.  Also note that it is not
-    // necessary to acquire one when
-    // acquiring the other.
-
-    AppKeysVec d_appKeysVec;
-    // Vector of set of AppKeys which are
-    // currently active.  Vector is indexed
-    // on the partitionId, and the inner
-    // set contains a unique list of
-    // appKeys of virtual storages of the
-    // physical storages assigned to that
-    // partition.  Contains appKeys for
-    // *both* in-memory as well as
-    // file-backed 'physical' storages.
-    // Note that the corresponding virtual
-    // storages are owned by the physical
-    // storage.  Also note that
-    // 'd_appKeysLock' must be held while
-    // accessing this container and any of
-    // its elements, because they are
-    // accessed from partitions' dispatcher
-    // threads as well as cluster
-    // dispatcher threads.
 
     RecurringEventHandle d_storageMonitorEventHandle;
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -1197,32 +1197,6 @@ void ClusterUtil::registerQueueInfo(ClusterState*           clusterState,
     queueAssigningCb(uri, false);  // processingPendingRequests
 }
 
-void ClusterUtil::populateAppInfos(AppInfos*                  appInfos,
-                                   const mqbconfm::QueueMode& domainConfig)
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(appInfos && appInfos->empty());
-
-    if (domainConfig.isFanoutValue()) {
-        const bsl::vector<bsl::string>& cfgAppIds =
-            domainConfig.fanout().appIDs();
-        bsl::unordered_set<mqbu::StorageKey> appKeys;
-
-        for (bsl::vector<bsl::string>::const_iterator cit = cfgAppIds.begin();
-             cit != cfgAppIds.end();
-             ++cit) {
-            mqbu::StorageKey appKey;
-            mqbs::StorageUtil::generateStorageKey(&appKey, &appKeys, *cit);
-
-            appInfos->insert(AppInfo(*cit, appKey));
-        }
-    }
-    else {
-        appInfos->insert(AppInfo(bmqp::ProtocolUtil::k_DEFAULT_APP_ID,
-                                 mqbi::QueueEngine::k_DEFAULT_APP_KEY));
-    }
-}
-
 void ClusterUtil::populateAppInfos(
     bsl::vector<bmqp_ctrlmsg::AppIdInfo>* appInfos,
     const mqbconfm::QueueMode&            domainConfig)

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -276,8 +276,6 @@ struct ClusterUtil {
 
     /// Generate appKeys based on the appIds in the specified `domainConfig`
     /// and populate them into the specified `appIdInfos`.
-    static void populateAppInfos(AppInfos*                  appIdInfos,
-                                 const mqbconfm::QueueMode& domainConfig);
     static void
     populateAppInfos(bsl::vector<bmqp_ctrlmsg::AppIdInfo>* appIdInfos,
                      const mqbconfm::QueueMode&            domainConfig);

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -143,8 +143,6 @@ void StorageManager::recoveredQueuesCb(int                    partitionId,
     StorageUtil::recoveredQueuesCb(&d_storages[partitionId],
                                    &d_storagesLock,
                                    d_fileStores[partitionId].get(),
-                                   &d_appKeysVec[partitionId],
-                                   &d_appKeysLock,
                                    d_domainFactory_p,
                                    &d_unrecognizedDomainsLock,
                                    &d_unrecognizedDomains[partitionId],
@@ -3357,8 +3355,6 @@ StorageManager::StorageManager(
 , d_partitionPrimaryStatusCb(partitionPrimaryStatusCb)
 , d_storagesLock()
 , d_storages(allocator)
-, d_appKeysLock()
-, d_appKeysVec(allocator)
 , d_partitionInfoVec(allocator)
 , d_partitionFSMVec(allocator)
 , d_bufferedPrimaryStatusAdvisoryInfosVec(allocator)
@@ -3391,7 +3387,6 @@ StorageManager::StorageManager(
     d_unrecognizedDomains.resize(partitionCfg.numPartitions());
     d_fileStores.resize(partitionCfg.numPartitions());
     d_storages.resize(partitionCfg.numPartitions());
-    d_appKeysVec.resize(partitionCfg.numPartitions());
     d_partitionInfoVec.resize(partitionCfg.numPartitions());
     d_bufferedPrimaryStatusAdvisoryInfosVec.resize(
         partitionCfg.numPartitions(),
@@ -3678,8 +3673,6 @@ void StorageManager::registerQueue(
                                &d_storages[partitionId],
                                &d_storagesLock,
                                d_fileStores[partitionId].get(),
-                               &d_appKeysVec[partitionId],
-                               &d_appKeysLock,
                                &d_allocators,
                                processorForPartition(partitionId),
                                uri,
@@ -3735,15 +3728,12 @@ int StorageManager::updateQueuePrimary(const bmqt::Uri&        uri,
         &d_storages[partitionId],
         &d_storagesLock,
         d_fileStores[partitionId].get(),
-        &d_appKeysVec[partitionId],
-        &d_appKeysLock,
         d_clusterData_p->identity().description(),
         uri,
         queueKey,
         partitionId,
         addedIdKeyPairs,
-        removedIdKeyPairs,
-        true);  // isCSLMode
+        removedIdKeyPairs);
 }
 
 void StorageManager::registerQueueReplica(int                     partitionId,
@@ -3805,8 +3795,6 @@ void StorageManager::unregisterQueueReplica(int              partitionId,
             &d_storages[partitionId],
             &d_storagesLock,
             d_fileStores[partitionId].get(),
-            &d_appKeysVec[partitionId],
-            &d_appKeysLock,
             d_clusterData_p->identity().description(),
             partitionId,
             uri,
@@ -3842,15 +3830,12 @@ void StorageManager::updateQueueReplica(int                     partitionId,
                                  static_cast<int*>(0),
                                  &d_storages[partitionId],
                                  &d_storagesLock,
-                                 &d_appKeysVec[partitionId],
-                                 &d_appKeysLock,
                                  d_domainFactory_p,
                                  d_clusterData_p->identity().description(),
                                  partitionId,
                                  uri,
                                  queueKey,
                                  appIdKeyPairs,
-                                 true,  // isCSLMode
                                  domain,
                                  allowDuplicate));
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -285,8 +285,7 @@ class StorageManager
     mutable bslmt::Mutex d_storagesLock;
     // Mutex to protect access to
     // 'd_storages' and its elements.  See
-    // comments for 'd_storages' and
-    // 'd_appKeysLock' variables as well.
+    // comments for 'd_storages'.
 
     StorageSpMapVec d_storages;
     // Vector of (CanonicalQueueUri ->
@@ -302,41 +301,6 @@ class StorageManager
     // well as cluster dispatcher thread.
     //
     // THREAD: Protected by 'd_storagesLock'.
-
-    bslmt::Mutex d_appKeysLock;
-    // Mutex to protect access to
-    // 'd_appKeysVec' and its elements.
-    // Note that when acquiring this lock,
-    // *if* 'd_storagesLock' needs to be
-    // acquired as well, 'd_storagesLock'
-    // must be acquired before
-    // 'd_appKeysLock' in order to respect
-    // hierarchy of locks and avoid
-    // deadlock.  Also note that it is not
-    // necessary to acquire one when
-    // acquiring the other.
-
-    AppKeysVec d_appKeysVec;
-    // Vector of set of AppKeys which are
-    // currently active.  Vector is indexed
-    // on the partitionId, and the inner
-    // set contains a unique list of
-    // appKeys of virtual storages of the
-    // physical storages assigned to that
-    // partition.  Contains appKeys for
-    // *both* in-memory as well as
-    // file-backed 'physical' storages.
-    // Note that the corresponding virtual
-    // storages are owned by the physical
-    // storage.  Also note that
-    // 'd_appKeysLock' must be held while
-    // accessing this container and any of
-    // its elements, because they are
-    // accessed from partitions' dispatcher
-    // threads as well as cluster
-    // dispatcher threads.
-    //
-    // THREAD: Protected by 'd_appKeysLock'
 
     PartitionInfoVec d_partitionInfoVec;
     // Vector of 'PartitionInfo' indexed by

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -182,14 +182,11 @@ void StorageUtil::updateQueuePrimaryDispatched(
     mqbs::ReplicatedStorage*                                        storage,
     bslmt::Mutex*      storagesLock,
     mqbs::FileStore*   fs,
-    AppKeys*           appKeys,
-    bslmt::Mutex*      appKeysLock,
     const bsl::string& clusterDescription,
     int                partitionId,
     const AppInfos&    addedIdKeyPairs,
     const AppInfos&    removedIdKeyPairs,
-    bool               isFanout,
-    bool               isCSLMode)
+    bool               isFanout)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -204,26 +201,20 @@ void StorageUtil::updateQueuePrimaryDispatched(
     // Simply forward to 'updateQueuePrimaryRaw'.
     updateQueuePrimaryRaw(storage,
                           fs,
-                          appKeys,
-                          appKeysLock,
                           clusterDescription,
                           partitionId,
                           addedIdKeyPairs,
                           removedIdKeyPairs,
-                          isFanout,
-                          isCSLMode);
+                          isFanout);
 }
 
 int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
                                        mqbs::FileStore*         fs,
-                                       AppKeys*                 appKeys,
-                                       bslmt::Mutex*            appKeysLock,
                                        const bsl::string& clusterDescription,
                                        int                partitionId,
                                        const AppInfos&    addedIdKeyPairs,
                                        const AppInfos&    removedIdKeyPairs,
-                                       bool               isFanout,
-                                       bool               isCSLMode)
+                                       bool               isFanout)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -232,7 +223,6 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
     BSLS_ASSERT_SAFE(fs);
     BSLS_ASSERT_SAFE(fs->inDispatcherThread());
     BSLS_ASSERT_SAFE(storage);
-    BSLS_ASSERT_SAFE(appKeys);
 
     int                 rc        = 0;
     bsls::Types::Uint64 timestamp = bdlt::EpochUtil::convertToTimeT64(
@@ -264,13 +254,10 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
         storage->addQueueOpRecordHandle(handle);
 
         rc = addVirtualStoragesInternal(storage,
-                                        appKeys,
-                                        appKeysLock,
                                         addedIdKeyPairs,
                                         clusterDescription,
                                         partitionId,
-                                        isFanout,
-                                        isCSLMode);
+                                        isFanout);
         if (0 != rc) {
             return rc;  // RETURN
         }
@@ -316,8 +303,6 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
             storage->addQueueOpRecordHandle(handle);
 
             rc = removeVirtualStorageInternal(storage,
-                                              appKeys,
-                                              appKeysLock,
                                               cit->second,
                                               partitionId);
             if (0 != rc) {
@@ -362,20 +347,16 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
 
 int StorageUtil::addVirtualStoragesInternal(
     mqbs::ReplicatedStorage* storage,
-    AppKeys*                 appKeys,
-    bslmt::Mutex*            appKeysLock,
     const AppInfos&          appIdKeyPairs,
     const bsl::string&       clusterDescription,
     int                      partitionId,
-    bool                     isFanout,
-    bool                     isCSLMode)
+    bool                     isFanout)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(0 <= partitionId);
     BSLS_ASSERT_SAFE(storage);
-    BSLS_ASSERT_SAFE(appKeys);
 
     enum {
         rc_SUCCESS                          = 0,
@@ -383,29 +364,14 @@ int StorageUtil::addVirtualStoragesInternal(
         rc_VIRTUAL_STORAGE_CREATION_FAILURE = -2
     };
 
-    bslmt::LockGuard<bslmt::Mutex> appLockGuard(appKeysLock);  // LOCK
-
     int                rc = -1;
     bmqu::MemOutStream errorDesc;
     if (isFanout) {
-        // Register appKeys with 'appKeys' and then with the underlying
-        // physical 'storage'.
+        // Register appKeys with with the underlying physical 'storage'.
 
         for (AppInfosCIter cit = appIdKeyPairs.begin();
              cit != appIdKeyPairs.end();
              ++cit) {
-            AppKeysInsertRc irc = appKeys->insert(cit->second);
-            if (!irc.second && isCSLMode) {
-                BALL_LOG_WARN << clusterDescription << " Partition ["
-                              << partitionId << "]: AppKey [" << cit->second
-                              << "] already exists, while attempting to add "
-                              << "appId [" << cit->first << "], for queue ["
-                              << storage->queueUri() << "], queueKey ["
-                              << storage->queueKey() << "].";
-
-                return rc_APP_KEY_COLLISION;  // RETURN
-            }
-
             if (0 != (rc = storage->addVirtualStorage(errorDesc,
                                                       cit->first,
                                                       cit->second))) {
@@ -435,9 +401,7 @@ int StorageUtil::addVirtualStoragesInternal(
 }
 
 int StorageUtil::removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
-                                              AppKeys*                 appKeys,
-                                              bslmt::Mutex* appKeysLock,
-                                              const mqbu::StorageKey& appKey,
+                                              const mqbu::StorageKey&  appKey,
                                               int partitionId)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
@@ -445,30 +409,15 @@ int StorageUtil::removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(0 <= partitionId);
     BSLS_ASSERT_SAFE(storage);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(!appKey.isNull());
     // We should never have to remove a default appKey (for non-fanout queues)
     BSLS_ASSERT_SAFE(appKey != mqbi::QueueEngine::k_DEFAULT_APP_KEY);
 
-    enum {
-        rc_SUCCESS                        = 0,
-        rc_VIRTUAL_STORAGE_DOES_NOT_EXIST = -1,
-        rc_APP_KEY_NOT_PRESENT            = -2
-    };
-
-    bslmt::LockGuard<bslmt::Mutex> appLockGuard(appKeysLock);  // LOCK
+    enum { rc_SUCCESS = 0, rc_VIRTUAL_STORAGE_DOES_NOT_EXIST = -1 };
 
     bool existed = storage->removeVirtualStorage(appKey);
     if (!existed) {
         return rc_VIRTUAL_STORAGE_DOES_NOT_EXIST;  // RETURN
-    }
-
-    if (1 != appKeys->erase(appKey)) {
-        // This appKey is not present in the global data structure of appKeys.
-        // This really means that this node is out of sync with the cluster
-        // state.
-
-        return rc_APP_KEY_NOT_PRESENT;  // RETURN
     }
 
     return rc_SUCCESS;
@@ -1380,8 +1329,6 @@ void StorageUtil::recoveredQueuesCb(
     StorageSpMap*                storageMap,
     bslmt::Mutex*                storagesLock,
     mqbs::FileStore*             fs,
-    AppKeys*                     appKeys,
-    bslmt::Mutex*                appKeysLock,
     mqbi::DomainFactory*         domainFactory,
     bslmt::Mutex*                unrecognizedDomainsLock,
     DomainQueueMessagesCountMap* unrecognizedDomains,
@@ -1395,7 +1342,6 @@ void StorageUtil::recoveredQueuesCb(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(storageMap);
     BSLS_ASSERT_SAFE(fs);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(unrecognizedDomainsLock);
     BSLS_ASSERT_SAFE(unrecognizedDomains && unrecognizedDomains->empty());
     BSLS_ASSERT_SAFE(0 <= partitionId);
@@ -1430,9 +1376,7 @@ void StorageUtil::recoveredQueuesCb(
     // 'mqbi::Domain'.  Additionally, also ensure that if a fanout queue has
     // appId/appKey pairs associated with it, they are unique.  We don't have
     // a global list of AppIds (in fact, we can't have that, because AppIds can
-    // clash), so we check uniqueness of AppIds only for a given queue.  But we
-    // do have a global unique list of AppKeys ('appKeys'), so we check each
-    // queue's AppKey against that list.
+    // clash), so we check uniqueness of AppIds only for a given queue.
 
     for (QueueKeyInfoMapConstIter qit = queueKeyInfoMap.begin();
          qit != queueKeyInfoMap.end();
@@ -1470,29 +1414,6 @@ void StorageUtil::recoveredQueuesCb(
                         << "recovered queue [" << uri << "], " << "queueKey ["
                         << qit->first << "]. AppId [" << *(appIdsIrc.first)
                         << "]. AppKey [" << p.second << "]."
-                        << BMQTSK_ALARMLOG_END;
-                    mqbu::ExitUtil::terminate(
-                        mqbu::ExitCode::e_RECOVERY_FAILURE);
-                    // EXIT
-                }
-
-                bslmt::LockGuard<bslmt::Mutex> appLockGuard(appKeysLock);
-                // LOCK
-
-                AppKeysInsertRc appKeysIrc = appKeys->insert(p.second);
-                if (!appKeysIrc.second && !isCSLMode) {
-                    // Duplicate AppKey.  Error in non-csl mode.  In CSL mode,
-                    // this can occur because this queue (and thus its appIds &
-                    // appKeys) could be assigned at node startup, via
-                    // CQH::onQueueAssigned ->
-                    // StorageMgr::register/UpdateQueueReplica.
-                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
-                        << clusterDescription << ": Partition [" << partitionId
-                        << "]: "
-                        << "encountered a duplicate AppKey while processing "
-                        << "recovered queue [" << uri << "], queueKey ["
-                        << qit->first << "]. AppKey [" << *(appKeysIrc.first)
-                        << "]. AppId [" << p.first << "]."
                         << BMQTSK_ALARMLOG_END;
                     mqbu::ExitUtil::terminate(
                         mqbu::ExitCode::e_RECOVERY_FAILURE);
@@ -2237,13 +2158,11 @@ void StorageUtil::shutdown(int                              partitionId,
     latch->arrive();
 }
 
-mqbu::StorageKey StorageUtil::generateAppKey(AppKeys*           appKeys,
-                                             bslmt::Mutex*      appKeysLock,
-                                             const bsl::string& appId)
+mqbu::StorageKey
+StorageUtil::generateAppKey(bsl::unordered_set<mqbu::StorageKey>* appKeys,
+                            const bsl::string&                    appId)
 {
     // executed by *QUEUE_DISPATCHER* thread or by *CLUSTER DISPATCHER* thread.
-
-    bslmt::LockGuard<bslmt::Mutex> guard(appKeysLock);  // LOCK
 
     mqbu::StorageKey appKey;
     mqbs::StorageUtil::generateStorageKey(&appKey, appKeys, appId);
@@ -2259,8 +2178,6 @@ void StorageUtil::registerQueue(
     StorageSpMap*                            storageMap,
     bslmt::Mutex*                            storagesLock,
     mqbs::FileStore*                         fs,
-    AppKeys*                                 appKeys,
-    bslmt::Mutex*                            appKeysLock,
     bmqma::CountingAllocatorStore*           allocators,
     const mqbi::Dispatcher::ProcessorHandle& processor,
     const bmqt::Uri&                         uri,
@@ -2278,7 +2195,6 @@ void StorageUtil::registerQueue(
     BSLS_ASSERT_SAFE(dispatcher->inDispatcherThread(cluster));
     BSLS_ASSERT_SAFE(storageMap);
     BSLS_ASSERT_SAFE(fs);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(allocators);
     BSLS_ASSERT_SAFE(uri.isValid());
     BSLS_ASSERT_SAFE(
@@ -2390,14 +2306,11 @@ void StorageUtil::registerQueue(
                     storageSp.get(),
                     storagesLock,
                     fs,
-                    appKeys,
-                    appKeysLock,
                     clusterDescription,
                     partitionId,
                     addedAppInfos,
                     removedAppInfos,
-                    domain->config().mode().isFanoutValue(),
-                    cluster->isCSLModeEnabled()));
+                    domain->config().mode().isFanoutValue()));
 
             dispatcher->dispatchEvent(queueEvent,
                                       mqbi::DispatcherClientType::e_QUEUE,
@@ -2460,13 +2373,13 @@ void StorageUtil::registerQueue(
             const mqbconfm::QueueModeFanout& fanoutMode = queueMode.fanout();
             const bsl::vector<bsl::string>&  cfgAppIds  = fanoutMode.appIDs();
 
+            // TODO: use allocator once this is 'StorageManager'
+            bsl::unordered_set<mqbu::StorageKey>             appKeys;
             typedef bsl::vector<bsl::string>::const_iterator ConstIter;
 
             for (ConstIter citer = cfgAppIds.begin(); citer != cfgAppIds.end();
                  ++citer) {
-                mqbu::StorageKey appKey = generateAppKey(appKeys,
-                                                         appKeysLock,
-                                                         *citer);
+                mqbu::StorageKey appKey = generateAppKey(&appKeys, *citer);
 
                 rc = storageSp->addVirtualStorage(errorDesc, *citer, appKey);
 
@@ -2660,15 +2573,12 @@ void StorageUtil::unregisterQueueDispatched(
 int StorageUtil::updateQueuePrimary(StorageSpMap*           storageMap,
                                     bslmt::Mutex*           storagesLock,
                                     mqbs::FileStore*        fs,
-                                    AppKeys*                appKeys,
-                                    bslmt::Mutex*           appKeysLock,
                                     const bsl::string&      clusterDescription,
                                     const bmqt::Uri&        uri,
                                     const mqbu::StorageKey& queueKey,
                                     int                     partitionId,
                                     const AppInfos&         addedIdKeyPairs,
-                                    const AppInfos&         removedIdKeyPairs,
-                                    bool                    isCSLMode)
+                                    const AppInfos&         removedIdKeyPairs)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -2676,7 +2586,6 @@ int StorageUtil::updateQueuePrimary(StorageSpMap*           storageMap,
     BSLS_ASSERT_SAFE(fs);
     BSLS_ASSERT_SAFE(fs->inDispatcherThread());
     BSLS_ASSERT_SAFE(storageMap);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(0 <= partitionId);
 
     if (addedIdKeyPairs.empty() && removedIdKeyPairs.empty()) {
@@ -2705,14 +2614,11 @@ int StorageUtil::updateQueuePrimary(StorageSpMap*           storageMap,
 
     return updateQueuePrimaryRaw(storageSp.get(),
                                  fs,
-                                 appKeys,
-                                 appKeysLock,
                                  clusterDescription,
                                  partitionId,
                                  addedIdKeyPairs,
                                  removedIdKeyPairs,
-                                 true,  // isFanout
-                                 isCSLMode);
+                                 true);  // isFanout
 }
 
 void StorageUtil::registerQueueReplicaDispatched(
@@ -2881,8 +2787,6 @@ void StorageUtil::unregisterQueueReplicaDispatched(
     StorageSpMap*           storageMap,
     bslmt::Mutex*           storagesLock,
     mqbs::FileStore*        fs,
-    AppKeys*                appKeys,
-    bslmt::Mutex*           appKeysLock,
     const bsl::string&      clusterDescription,
     int                     partitionId,
     const bmqt::Uri&        uri,
@@ -2896,7 +2800,6 @@ void StorageUtil::unregisterQueueReplicaDispatched(
     BSLS_ASSERT_SAFE(fs);
     BSLS_ASSERT_SAFE(fs->inDispatcherThread());
     BSLS_ASSERT_SAFE(storageMap);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(0 <= partitionId);
     BSLS_ASSERT_SAFE(uri.isValid());
     BSLS_ASSERT_SAFE(!queueKey.isNull());
@@ -2998,11 +2901,7 @@ void StorageUtil::unregisterQueueReplicaDispatched(
         rs->purge(appKey);
     }
 
-    int rc = removeVirtualStorageInternal(rs,
-                                          appKeys,
-                                          appKeysLock,
-                                          appKey,
-                                          partitionId);
+    int rc = removeVirtualStorageInternal(rs, appKey, partitionId);
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("REPLICATION")
             << clusterDescription << " Partition [" << partitionId
@@ -3031,15 +2930,12 @@ void StorageUtil::updateQueueReplicaDispatched(
     int*                    status,
     StorageSpMap*           storageMap,
     bslmt::Mutex*           storagesLock,
-    AppKeys*                appKeys,
-    bslmt::Mutex*           appKeysLock,
     mqbi::DomainFactory*    domainFactory,
     const bsl::string&      clusterDescription,
     int                     partitionId,
     const bmqt::Uri&        uri,
     const mqbu::StorageKey& queueKey,
     const AppInfos&         appIdKeyPairs,
-    bool                    isCSLMode,
     mqbi::Domain*           domain,
     bool                    allowDuplicate)
 {
@@ -3048,7 +2944,6 @@ void StorageUtil::updateQueueReplicaDispatched(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(0 <= partitionId);
     BSLS_ASSERT_SAFE(storageMap);
-    BSLS_ASSERT_SAFE(appKeys);
     BSLS_ASSERT_SAFE(domainFactory);
     BSLS_ASSERT_SAFE(uri.isValid());
     BSLS_ASSERT_SAFE(!queueKey.isNull());
@@ -3093,13 +2988,10 @@ void StorageUtil::updateQueueReplicaDispatched(
 
     int rc = addVirtualStoragesInternal(
         storage,
-        appKeys,
-        appKeysLock,
         appIdKeyPairs,
         clusterDescription,
         partitionId,
-        domain->config().mode().isFanoutValue(),
-        isCSLMode);
+        domain->config().mode().isFanoutValue());
     if (rc != 0) {
         if (!allowDuplicate) {
             bmqu::Printer<AppInfos> printer(&appIdKeyPairs);

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -181,9 +181,8 @@ struct StorageUtil {
     /// Load into the specified `addedAppInfos` and
     /// `removedAppInfos` the appId/key pairs which have been added and
     /// removed respectively for the specified `storage` based on the
-    /// specified `newAppInfos` or `cfgAppIds`, as well as the
-    /// specified `isCSLMode` mode.  Return true if there are any added or
-    /// removed appId/key pairs, false otherwise.
+    /// specified `newAppInfos`.  Return true if there are any added or removed
+    /// appId/key pairs, false otherwise.
     ///
     /// THREAD: Executed by the cluster dispatcher thread.
     static bool loadUpdatedAppInfos(AppInfos* addedAppInfos,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -109,9 +109,6 @@ struct StorageUtil {
     typedef mqbi::StorageManager::AppIdsIter     AppIdsIter;
     typedef mqbi::StorageManager::AppIdsInsertRc AppIdsInsertRc;
 
-    typedef mqbi::StorageManager::AppKeys         AppKeys;
-    typedef mqbi::StorageManager::AppKeysInsertRc AppKeysInsertRc;
-
     typedef mqbi::StorageManager::StorageSp             StorageSp;
     typedef mqbi::StorageManager::StorageSpMap          StorageSpMap;
     typedef mqbi::StorageManager::StorageSpMapVec       StorageSpMapVec;
@@ -185,10 +182,8 @@ struct StorageUtil {
     /// `removedAppInfos` the appId/key pairs which have been added and
     /// removed respectively for the specified `storage` based on the
     /// specified `newAppInfos` or `cfgAppIds`, as well as the
-    /// specified `isCSLMode` mode.  If new app keys are generated, load
-    /// them into the specified `appKeys`.  If the optionally specified
-    /// `appKeysLock` is provided, lock it.  Return true if there are any
-    /// added or removed appId/key pairs, false otherwise.
+    /// specified `isCSLMode` mode.  Return true if there are any added or
+    /// removed appId/key pairs, false otherwise.
     ///
     /// THREAD: Executed by the cluster dispatcher thread.
     static bool loadUpdatedAppInfos(AppInfos* addedAppInfos,
@@ -211,14 +206,11 @@ struct StorageUtil {
         mqbs::ReplicatedStorage*                 storage,
         bslmt::Mutex*                            storagesLock,
         mqbs::FileStore*                         fs,
-        AppKeys*                                 appKeys,
-        bslmt::Mutex*                            appKeysLock,
         const bsl::string&                       clusterDescription,
         int                                      partitionId,
         const AppInfos&                          addedIdKeyPairs,
         const AppInfos&                          removedIdKeyPairs,
-        bool                                     isFanout,
-        bool                                     isCSLMode);
+        bool                                     isFanout);
 
     /// StorageManager's storages lock must be locked before calling this
     /// method.
@@ -226,29 +218,21 @@ struct StorageUtil {
     /// THREAD: Executed by the Queue's dispatcher thread.
     static int updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
                                      mqbs::FileStore*         fs,
-                                     AppKeys*                 appKeys,
-                                     bslmt::Mutex*            appKeysLock,
                                      const bsl::string& clusterDescription,
                                      int                partitionId,
                                      const AppInfos&    addedIdKeyPairs,
                                      const AppInfos&    removedIdKeyPairs,
-                                     bool               isFanout,
-                                     bool               isCSLMode);
+                                     bool               isFanout);
 
     static int
     addVirtualStoragesInternal(mqbs::ReplicatedStorage* storage,
-                               AppKeys*                 appKeys,
-                               bslmt::Mutex*            appKeysLock,
                                const AppInfos&          appIdKeyPairs,
                                const bsl::string&       clusterDescription,
                                int                      partitionId,
-                               bool                     isFanout,
-                               bool                     isCSLMode);
+                               bool                     isFanout);
 
     static int removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
-                                            AppKeys*                 appKeys,
-                                            bslmt::Mutex* appKeysLock,
-                                            const mqbu::StorageKey& appKey,
+                                            const mqbu::StorageKey&  appKey,
                                             int partitionId);
 
     /// Load the list of queue storages on the partition from the specified
@@ -558,8 +542,6 @@ struct StorageUtil {
     recoveredQueuesCb(StorageSpMap*                storageMap,
                       bslmt::Mutex*                storagesLock,
                       mqbs::FileStore*             fs,
-                      AppKeys*                     appKeys,
-                      bslmt::Mutex*                appKeysLock,
                       mqbi::DomainFactory*         domainFactory,
                       bslmt::Mutex*                unrecognizedDomainsLock,
                       DomainQueueMessagesCountMap* unrecognizedDomains,
@@ -607,12 +589,11 @@ struct StorageUtil {
                          const mqbcfg::ClusterDefinition& clusterConfig);
 
     /// Return a unique appKey for the specified `appId` for a queue, and
-    /// load the appKey into the specified `appKeys` while locking the
-    /// optionally specified `appKeysLock`.  This routine can be invoked by
-    /// any thread.
-    static mqbu::StorageKey generateAppKey(AppKeys*           appKeys,
-                                           bslmt::Mutex*      appKeysLock,
-                                           const bsl::string& appId);
+    /// load the appKey into the specified `appKeys`.  This routine can be
+    /// invoked by any thread.
+    static mqbu::StorageKey
+    generateAppKey(bsl::unordered_set<mqbu::StorageKey>* appKeys,
+                   const bsl::string&                    appId);
 
     /// Register a queue with the specified `uri`, `queueKey` and
     /// `partitionId`, having the specified `appIdKeyPairs`, and belonging to
@@ -626,8 +607,6 @@ struct StorageUtil {
                   StorageSpMap*                            storageMap,
                   bslmt::Mutex*                            storagesLock,
                   mqbs::FileStore*                         fs,
-                  AppKeys*                                 appKeys,
-                  bslmt::Mutex*                            appKeysLock,
                   bmqma::CountingAllocatorStore*           allocators,
                   const mqbi::Dispatcher::ProcessorHandle& processor,
                   const bmqt::Uri&                         uri,
@@ -660,15 +639,12 @@ struct StorageUtil {
     static int updateQueuePrimary(StorageSpMap*           storageMap,
                                   bslmt::Mutex*           storagesLock,
                                   mqbs::FileStore*        fs,
-                                  AppKeys*                appKeys,
-                                  bslmt::Mutex*           appKeysLock,
                                   const bsl::string&      clusterDescription,
                                   const bmqt::Uri&        uri,
                                   const mqbu::StorageKey& queueKey,
                                   int                     partitionId,
                                   const AppInfos&         addedIdKeyPairs,
-                                  const AppInfos&         removedIdKeyPairs,
-                                  bool                    isCSLMode);
+                                  const AppInfos&         removedIdKeyPairs);
 
     static void
     registerQueueReplicaDispatched(int*                 status,
@@ -689,8 +665,6 @@ struct StorageUtil {
                                      StorageSpMap*      storageMap,
                                      bslmt::Mutex*      storagesLock,
                                      mqbs::FileStore*   fs,
-                                     AppKeys*           appKeys,
-                                     bslmt::Mutex*      appKeysLock,
                                      const bsl::string& clusterDescription,
                                      int                partitionId,
                                      const bmqt::Uri&   uri,
@@ -702,15 +676,12 @@ struct StorageUtil {
     updateQueueReplicaDispatched(int*                    status,
                                  StorageSpMap*           storageMap,
                                  bslmt::Mutex*           storagesLock,
-                                 AppKeys*                appKeys,
-                                 bslmt::Mutex*           appKeysLock,
                                  mqbi::DomainFactory*    domainFactory,
                                  const bsl::string&      clusterDescription,
                                  int                     partitionId,
                                  const bmqt::Uri&        uri,
                                  const mqbu::StorageKey& queueKey,
                                  const AppInfos&         addedIdKeyPairs,
-                                 bool                    isCSLMode,
                                  mqbi::Domain*           domain = 0,
                                  bool allowDuplicate            = false);
 

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -176,15 +176,6 @@ class StorageManager {
     typedef AppIds::const_iterator          AppIdsConstIter;
     typedef bsl::pair<AppIdsIter, bool>     AppIdsInsertRc;
 
-    typedef bsl::unordered_set<mqbu::StorageKey> AppKeys;
-    typedef AppKeys::iterator                    AppKeysIter;
-    typedef AppKeys::const_iterator              AppKeysConstIter;
-    typedef bsl::pair<AppKeysIter, bool>         AppKeysInsertRc;
-
-    typedef bsl::vector<AppKeys>       AppKeysVec;
-    typedef AppKeysVec::iterator       AppKeysVecIter;
-    typedef AppKeysVec::const_iterator AppKeysVecConstIter;
-
     typedef bsl::shared_ptr<mqbs::ReplicatedStorage> StorageSp;
 
     /// Map of QueueUri -> ReplicatedStorageSp


### PR DESCRIPTION
Because ClusterStateManager generates AppKeys (outside of  StorageManager), it cannot use 
`StorageManager::d_appKeysVec`  
Moreover, the functionality of `d_appKeysVec` (verifying uniqueness) is a duplicate of `VirtualStorageCatalog`
