### PR TITLE
Fix[bmqa]: Remove unused `Session::impl()` function

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -1159,13 +1159,6 @@ class Session : public AbstractSession {
     /// been started.
     int configureMessageDumping(const bslstl::StringRef& command)
         BSLS_KEYWORD_OVERRIDE;
-
-    /// Internal
-    ///--------
-
-    /// Do *NOT* use.  Internal function, reserved for BlazingMQ internal
-    /// usage.
-    void* impl();
 };
 
 // ============================================================================
@@ -1179,11 +1172,6 @@ class Session : public AbstractSession {
 inline int Session::confirmMessage(const Message& message)
 {
     return confirmMessage(message.confirmationCookie());
-}
-
-inline void* Session::impl()
-{
-    return &d_impl;
 }
 
 }  // close package namespace


### PR DESCRIPTION
This function is not used within the BlazingMQ code, and exposes publically the PIMPL implementation that is used by `bmqa::Session`. Because we do not use this function, and because it is part of the public (documented!) API, users could break our session invariants. This patch removes this function from the API.  While this is a breaking change, we do not want any user to be using this function, so we should be okay with breaking them.