### PR TITLE
Refactor[mqba]: Remove unused `d_scriptTimestamp` from domain resolver cache

### DIFF
--- a/src/groups/mqb/mqba/mqba_domainresolver.h
+++ b/src/groups/mqb/mqba/mqba_domainresolver.h
@@ -114,10 +114,6 @@ class DomainResolver {
         mqbconfm::DomainResolver d_data;
         // Cached response data.
 
-        bdlt::Datetime d_scriptTimestamp;
-        // Last modification timestamp of the script
-        // at the time this data was generated.
-
         bdlt::Datetime d_cfgDirTimestamp;
         // Last modification timestamp of the config
         // directory at the time this data was


### PR DESCRIPTION
This patch removes a a `bdlt::Datetime` leftover from a time when BlazingMQ domain configuration generation was more dynamic.  This field in each cache entry is unused now.