### PR TITLE
Fix[schemagen]: Double quote to prevent globbing and work splitting

### DIFF
--- a/src/python/bin/schemagen
+++ b/src/python/bin/schemagen
@@ -46,13 +46,13 @@ cd "${python_root}"
 function copyright_black {
     echo "$copyright
 
-$(cat $1)" > $1
-    black -q $1
+$(cat "$1")" > "$1"
+    black -q "$1"
 }
 
 function generate {
     xsdata generate --package blazingmq.schemas "$1"
-    copyright_black $2
+    copyright_black "$2"
 }
 
 generate "${blazingmq_root}/src/groups/mqb/mqbcfg/mqbcfg.xsd" blazingmq/schemas/mqbcfg.py

--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -1,3 +1,4 @@
+black @ git+https://github.com/psf/black
 boofuzz
 crc32c
 docker


### PR DESCRIPTION
This patch fixes the shellcheck CI failures SC2086 introduced by b39062018c2ef3e6b793aef8fb0e217401bbc642.
