### PR TITLE
fix PushStream & VirtualStorage ordinal

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -130,9 +130,8 @@ void PushStreamIterator::removeCurrentElement()
     d_currentElement = d_currentElement->next();
     ++d_currentOrdinal;
 
-    d_owner_p->remove(del);
-    d_owner_p->destroy(del, true);
-    // doKeepGuid because of the d_iterator
+    d_owner_p->remove(del, false);
+    // cannot erase the GUID because of the d_iterator
 
     if (d_iterator->second.numElements() == 0) {
         BSLS_ASSERT_SAFE(d_currentElement == 0);
@@ -291,9 +290,8 @@ bool VirtualPushStreamIterator::advance()
 
     d_currentElement = d_currentElement->nextInApp();
 
-    d_owner_p->remove(del);
-    d_owner_p->destroy(del, false);
-    // do not keep Guid
+    d_owner_p->remove(del, true);
+    // can erase GUID
 
     if (atEnd()) {
         return false;

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -58,8 +58,7 @@ static void test1_basic()
                                                      itApp);
 
     ps.add(element);
-    ps.remove(element);
-    ps.destroy(element, false);
+    ps.remove(element, true);
 }
 
 static void test2_iterations()
@@ -183,10 +182,8 @@ static void test2_iterations()
         ASSERT(vit.atEnd());
     }
 
-    ps.remove(element2);
-    ps.destroy(element2, false);
-    ps.remove(element3);
-    ps.destroy(element3, false);
+    ps.remove(element2, true);
+    ps.remove(element3, true);
 }
 
 // ============================================================================

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -599,7 +599,8 @@ struct QueueEngineUtil_AppsDeliveryContext {
 
   private:
     Consumers                         d_consumers;
-    bool                              d_isReady;
+    int                               d_numApps;
+    int                               d_numStops;  // Apps not moving
     mqbi::StorageIterator*            d_currentMessage;
     mqbi::Queue*                      d_queue_p;
     bsl::optional<bsls::Types::Int64> d_timeDelta;
@@ -625,9 +626,6 @@ struct QueueEngineUtil_AppsDeliveryContext {
     // CREATORS
     QueueEngineUtil_AppsDeliveryContext(mqbi::Queue*      queue,
                                         bslma::Allocator* allocator);
-
-    /// Start delivery cycle(s).
-    void start();
 
     /// Prepare the context to process next message.
     /// Return `true` if the delivery can continue iterating dataStream
@@ -661,6 +659,9 @@ struct QueueEngineUtil_AppsDeliveryContext {
 
     /// Return `true` if there is at least one delivery target selected.
     bool isEmpty() const;
+
+    /// Return `true` if not all Apps are at capacity or there are no Apps.
+    bool haveProgress() const;
 
     bsls::Types::Int64 timeDelta();
 };

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -580,8 +580,6 @@ void RelayQueueEngine::deliverMessages()
     //   1. End of storage; or
     //   2. All subStreams return 'e_NO_CAPACITY_ALL'
 
-    d_appsDeliveryContext.start();
-
     while (d_appsDeliveryContext.reset(d_storageIter_mp.get())) {
         // Assume, all Apps need to deliver (some may be at capacity)
         unsigned int numApps = d_storageIter_mp->numApps();
@@ -604,14 +602,13 @@ void RelayQueueEngine::deliverMessages()
 
                 d_storageIter_mp->removeCurrentElement();
             }
-
-            if (d_appsDeliveryContext.processApp(*app, i)) {
+            else if (d_appsDeliveryContext.processApp(*app, i)) {
                 // The current element has made it either to delivery or
-                // putAside or resumerPoint and it can be removed
+                // putAside and it can be removed
                 d_storageIter_mp->removeCurrentElement();
             }
-            // Else, the current element has made it to resumerPoint and
-            // it cannot be removed
+            // Else, the current element has made it to resumePoint and it
+            // cannot be removed.
         }
         d_appsDeliveryContext.deliverMessage();
     }
@@ -1919,14 +1916,22 @@ void RelayQueueEngine::storePush(mqbi::StorageMessageAttributes* attributes,
 void RelayQueueEngine::beforeOneAppRemoved(unsigned int upstreamSubQueueId)
 {
     while (!d_storageIter_mp->atEnd()) {
-        if (d_storageIter_mp->numApps() > 1) {
+        const int numApps = d_storageIter_mp->numApps();
+        if (numApps > 1) {
             // Removal of App's elements will not invalidate 'd_storageIter_mp'
             break;
         }
+        if (numApps == 1) {
+            const PushStream::Element* element = d_storageIter_mp->element(0);
+            if (element->app().d_app->upstreamSubQueueId() !=
+                upstreamSubQueueId) {
+                break;
+            }
+        }
+        else {
+            BSLS_ASSERT_SAFE(numApps == 0);
 
-        const PushStream::Element* element = d_storageIter_mp->element(0);
-        if (element->app().d_app->upstreamSubQueueId() != upstreamSubQueueId) {
-            break;
+            // The case when 'advance' does not follow 'removeCurrentElement'
         }
 
         d_storageIter_mp->advance();

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1276,7 +1276,6 @@ void RootQueueEngine::afterNewMessage(
         d_queueState_p->queue()));
 
     // Deliver new messages to active (alive and capable to deliver) consumers
-    d_appsDeliveryContext.start();
 
     while (d_appsDeliveryContext.reset(d_storageIter_mp.get())) {
         // Assume, all Apps need to deliver (some may be at capacity)

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -422,9 +422,10 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
         appOrdinal = d_nextOrdinal++;
     }
     else {
-        appOrdinal = d_availableOrdinals.front();
+        AvailableOrdinals::const_iterator first = d_availableOrdinals.cbegin();
+        appOrdinal                              = *first;
         // There is no conflict because everything 'appOrdinal' was removed.
-        d_availableOrdinals.pop_front();
+        d_availableOrdinals.erase(first);
     }
 
     BSLS_ASSERT_SAFE(appOrdinal <= d_virtualStorages.size());
@@ -468,7 +469,7 @@ bool VirtualStorageCatalog::removeVirtualStorage(
         removeAll(appKey);
 
         const VirtualStorage& vs = *it->value();
-        d_availableOrdinals.push_back(vs.ordinal());
+        d_availableOrdinals.insert(vs.ordinal());
 
         if (d_queue_p) {
             BSLS_ASSERT_SAFE(d_queue_p->queueEngine());

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -86,7 +86,7 @@ class VirtualStorageCatalog {
     typedef bsl::shared_ptr<VirtualStorage> VirtualStorageSp;
 
     /// List of available ordinal values for Virtual Storages.
-    typedef bsl::list<Ordinal> AvailableOrdinals;
+    typedef bsl::set<Ordinal> AvailableOrdinals;
 
     /// appKey -> virtualStorage
     typedef bmqc::


### PR DESCRIPTION
Fixing bugs related to the Monolithic Storage  

1) VS ordinal recycling ([this](https://github.com/bloomberg/blazingmq/blob/e86bea84c894c70c19da5f12a69b28953ae20471/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp#L430) assert)
2) Empty `PushStream::Element` in `RelayQueueEngine::beforeMessageRemoved` ([this](https://github.com/bloomberg/blazingmq/blob/e86bea84c894c70c19da5f12a69b28953ae20471/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp#L197) assert)