### PR TITLE
CI: rebuild deps cache from the main branch nightly

### DIFF
--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -6,6 +6,10 @@ on:
       cache_key:
         description: "GH Actions Cache key associated with the built dependencies"
         value: ${{ jobs.build_dependencies.outputs.cache_key }}
+  schedule:
+    # Rebuild dependencies cache from the "main" branch at the beginning of a new day,
+    # so it is accessible from other branches' PRs
+    - cron: "10 0 * * *"
 
 concurrency:
   group: deps-${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Caches generated from non-default branches are not cross-accessible, so it has to be done from the main branch.

We will do it at `0:10 UTC` at the beginning of a new day.