### PR TITLE
Fix: handle appKey conflicts

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -2210,6 +2210,9 @@ void Cluster::onRecoveryStatusDispatched(
                 BSLS_ASSERT_SAFE(itMp->storage()->partitionId() ==
                                  static_cast<int>(pid));
 
+                // TODO:  wrong thread to call 'loadVirtualStorageDetails'
+                // but 'onRecoveryStatusDispatched' should not be concurrent
+                // with any of 'add/removeVirtualStorage' calls.
                 AppInfos appIdInfos;
                 itMp->storage()->loadVirtualStorageDetails(&appIdInfos);
 

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -239,13 +239,12 @@ void QueueState::loadInternals(mqbcmd::QueueState* out) const
                      appIdKeyPairs.cbegin();
                  cit != appIdKeyPairs.cend();
                  ++cit, ++i) {
-                const mqbi::Storage::AppInfo& p      = *cit;
-                virtualStorages[i].appId()           = p.first;
+                virtualStorages[i].appId() = cit->first;
                 os.reset();
-                os << p.second;
+                os << cit->second;
                 virtualStorages[i].appKey()      = os.str();
                 virtualStorages[i].numMessages() = d_storage_mp->numMessages(
-                    p.second);
+                    cit->second);
             }
         }
     }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1604,16 +1604,14 @@ void RelayQueueEngine::loadInternals(mqbcmd::QueueEngine* out) const
                  appIdKeyPairs.cbegin();
              cit != appIdKeyPairs.cend();
              ++cit) {
-            const mqbi::Storage::AppInfo& p = *cit;
-
             subStreams.resize(subStreams.size() + 1);
             mqbcmd::RelayQueueEngineSubStream& subStream = subStreams.back();
-            subStream.appId()                            = p.first;
+            subStream.appId()                            = cit->first;
             bmqu::MemOutStream appKey;
-            appKey << p.second;
+            appKey << cit->second;
             subStream.appKey()      = appKey.str();
             subStream.numMessages() = d_queueState_p->storage()->numMessages(
-                p.second);
+                cit->second);
         }
     }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -499,7 +499,7 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
         for (AppInfosCIter citer = removedAppIds.begin();
              citer != removedAppIds.end();
              ++citer) {
-            const AppInfosCIter appIdInfoCIter = appIdInfos.find(*citer);
+            const AppInfosCIter appIdInfoCIter = appIdInfos.find(citer->first);
             if (appIdInfoCIter == appIdInfos.cend()) {
                 return rc_APPID_NOT_FOUND;  // RETURN
             }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3639,7 +3639,7 @@ void StorageManager::initializeQueueKeyInfoMap(
             for (AppInfosCIter appIdCit = csQinfo.appInfos().cbegin();
                  appIdCit != csQinfo.appInfos().cend();
                  ++appIdCit) {
-                qinfo.addAppInfo(*appIdCit);
+                qinfo.addAppInfo(appIdCit);
             }
 
             d_queueKeyInfoMapVec.at(csQinfo.partitionId())
@@ -3650,12 +3650,11 @@ void StorageManager::initializeQueueKeyInfoMap(
     d_isQueueKeyInfoMapVecInitialized = true;
 }
 
-void StorageManager::registerQueue(
-    const bmqt::Uri&                   uri,
-    const mqbu::StorageKey&            queueKey,
-    int                                partitionId,
-    const bsl::unordered_set<AppInfo>& appIdKeyPairs,
-    mqbi::Domain*                      domain)
+void StorageManager::registerQueue(const bmqt::Uri&        uri,
+                                   const mqbu::StorageKey& queueKey,
+                                   int                     partitionId,
+                                   const AppInfos&         appIdKeyPairs,
+                                   mqbi::Domain*           domain)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -809,10 +809,10 @@ class StorageManager BSLS_KEYWORD_FINAL
     ///
     /// THREAD: Executed by the Client's dispatcher thread.
     void registerQueue(const bmqt::Uri&                   uri,
-                       const mqbu::StorageKey&            queueKey,
-                       int                                partitionId,
-                       const bsl::unordered_set<AppInfo>& appIdKeyPairs,
-                       mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
+                               const mqbu::StorageKey& queueKey,
+                               int                     partitionId,
+                               const AppInfos&         appIdKeyPairs,
+                               mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
 
     /// Synchronously unregister the queue with the specified `uri` from the
     /// specified `partitionId`.

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -808,11 +808,11 @@ class StorageManager BSLS_KEYWORD_FINAL
     /// associated queue storage created.
     ///
     /// THREAD: Executed by the Client's dispatcher thread.
-    void registerQueue(const bmqt::Uri&                   uri,
-                               const mqbu::StorageKey& queueKey,
-                               int                     partitionId,
-                               const AppInfos&         appIdKeyPairs,
-                               mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
+    void registerQueue(const bmqt::Uri&        uri,
+                       const mqbu::StorageKey& queueKey,
+                       int                     partitionId,
+                       const AppInfos&         appIdKeyPairs,
+                       mqbi::Domain*           domain) BSLS_KEYWORD_OVERRIDE;
 
     /// Synchronously unregister the queue with the specified `uri` from the
     /// specified `partitionId`.

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -155,12 +155,12 @@ void StorageUtil::loadAddedAndRemovedEntries(
     loadDifference(removedEntries, existingEntries, newEntries);
 }
 
-bool StorageUtil::loadUpdatedAppInfos(AppInfos* addedAppInfos,
-                                      AppInfos* removedAppInfos,
-                                      const mqbs::ReplicatedStorage& storage,
+bool StorageUtil::loadUpdatedAppInfos(AppInfos*       addedAppInfos,
+                                      AppInfos*       removedAppInfos,
+                                      const AppInfos& existingAppInfos,
                                       const AppInfos& newAppInfos)
 {
-    // executed by the *CLUSTER DISPATCHER* thread
+    // executed by the *QUEUE_DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(addedAppInfos);
@@ -180,9 +180,6 @@ bool StorageUtil::loadUpdatedAppInfos(AppInfos* addedAppInfos,
     // B and C, and add D.  This routine takes care of that, by retrieving the
     // list of newly added and removed appIds, and then invoking 'updateQueue'
     // in the appropriate thread.
-
-    AppInfos existingAppInfos;
-    storage.loadVirtualStorageDetails(&existingAppInfos);
 
     loadAddedAndRemovedEntries(addedAppInfos,
                                removedAppInfos,
@@ -294,7 +291,7 @@ void StorageUtil::updateQueuePrimaryDispatched(
 
     bool hasUpdate = loadUpdatedAppInfos(&addedAppInfos,
                                          &removedAppInfos,
-                                         *storage,
+                                         existingAppInfos,
                                          appIdKeyPairs);
     if (!hasUpdate) {
         // No update needed for AppId/Key pairs.

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -189,14 +189,14 @@ struct StorageUtil {
 
     /// Load into the specified `addedAppInfos` and
     /// `removedAppInfos` the appId/key pairs which have been added and
-    /// removed respectively for the specified `storage` based on the
+    /// removed respectively for the specified `existingAppInfos` based on the
     /// specified `newAppInfos`.  Return true if there are any added or removed
     /// appId/key pairs, false otherwise.
     ///
-    /// THREAD: Executed by the cluster dispatcher thread.
-    static bool loadUpdatedAppInfos(AppInfos* addedAppInfos,
-                                    AppInfos* removedAppInfos,
-                                    const mqbs::ReplicatedStorage& storage,
+    /// THREAD: Executed by the queue dispatcher thread.
+    static bool loadUpdatedAppInfos(AppInfos*       addedAppInfos,
+                                    AppInfos*       removedAppInfos,
+                                    const AppInfos& existingAppInfos,
                                     const AppInfos& newAppInfos);
 
     /// THREAD: Executed by the Queue's dispatcher thread.

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -87,7 +87,7 @@ class ClusterStateManager {
 
     /// Pair of (appId, appKey)
     typedef bsl::pair<bsl::string, mqbu::StorageKey> AppInfo;
-    typedef bsl::unordered_set<AppInfo>              AppInfos;
+    typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
     typedef AppInfos::const_iterator                 AppInfosCIter;
 
     struct QueueAssignmentResult {

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -377,10 +377,9 @@ class Storage {
 
     /// `AppInfo` is an alias for an (appId, appKey) pairing
     /// representing unique virtual storage identification.
-    typedef bsl::pair<bsl::string, mqbu::StorageKey> AppInfo;
 
     /// `AppInfos` is an alias for a set of pairs of appId and appKey
-    typedef bsl::unordered_set<AppInfo> AppInfos;
+    typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
 
     typedef bmqc::Array<mqbu::StorageKey,
                         bmqp::Protocol::k_SUBID_ARRAY_STATIC_LEN>

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -375,10 +375,7 @@ class Storage {
   public:
     // PUBLIC TYPES
 
-    /// `AppInfo` is an alias for an (appId, appKey) pairing
-    /// representing unique virtual storage identification.
-
-    /// `AppInfos` is an alias for a set of pairs of appId and appKey
+    /// `AppInfos` is an alias for a map [appId] -> appKey
     typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
 
     typedef bmqc::Array<mqbu::StorageKey,

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -167,7 +167,6 @@ class StorageManagerIterator {
 class StorageManager {
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo   AppInfo;
     typedef mqbi::Storage::AppInfos  AppInfos;
     typedef AppInfos::const_iterator AppInfosCIter;
 

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -272,7 +272,6 @@ class DataStoreConfigQueueInfo {
   public:
     // TYPES
     typedef mqbi::Storage::AppInfos AppInfos;
-    typedef AppInfos::const_iterator AppInfo;
 
   private:
     // DATA

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -271,9 +271,8 @@ struct DataStoreRecordKeyLess {
 class DataStoreConfigQueueInfo {
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo AppInfo;
-
     typedef mqbi::Storage::AppInfos AppInfos;
+    typedef AppInfos::const_iterator AppInfo;
 
   private:
     // DATA
@@ -299,7 +298,7 @@ class DataStoreConfigQueueInfo {
 
     void setPartitionId(int value);
 
-    void addAppInfo(const AppInfo& value);
+    void addAppInfo(const AppInfos::const_iterator& value);
 
     // ACCESSORS
     const bsl::string& canonicalQueueUri() const;
@@ -334,8 +333,6 @@ class DataStoreConfig {
     typedef Records::iterator RecordIterator;
 
     typedef Records::const_iterator RecordConstIterator;
-
-    typedef mqbi::Storage::AppInfo AppInfo;
 
     typedef mqbi::Storage::AppInfos AppInfos;
 
@@ -541,8 +538,6 @@ class DataStore : public mqbi::DispatcherClient {
 
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo AppInfo;
-
     typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef DataStoreConfig::QueueKeyInfoMap QueueKeyInfoMap;
@@ -891,9 +886,10 @@ inline void DataStoreConfigQueueInfo::setPartitionId(int value)
     d_partitionId = value;
 }
 
-inline void DataStoreConfigQueueInfo::addAppInfo(const AppInfo& value)
+inline void
+DataStoreConfigQueueInfo::addAppInfo(const AppInfos::const_iterator& value)
 {
-    d_appIdKeyPairs.insert(value);
+    d_appIdKeyPairs.emplace(value->first, value->second);
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -131,8 +131,6 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
 
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo AppInfo;
-
     typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef ReplicatedStorage::RecordHandles RecordHandles;

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2067,7 +2067,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             FileStoreProtocol::k_HASH_LENGTH,
                         appIdsAreaLen);
 
-                    AppInfos appIdKeyPairs;
+                    AppInfos appIdKeyPairs(d_allocator_p);
                     FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
                                                         appIdsBlock,
                                                         numAppIds);
@@ -2075,8 +2075,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
                          cit != appIdKeyPairs.cend();
                          ++cit) {
-                        const AppInfo& p = *cit;
-                        if (0 == deletedAppKeysOffsets.count(p.second)) {
+                        if (0 == deletedAppKeysOffsets.count(cit->second)) {
                             // This appKey is not deleted.  Add it to the list
                             // of 'alive' appId/appKey pairs for this queue.
                             // Note that we don't check for appId/appKey
@@ -2084,15 +2083,16 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             // StorageMgr because we have recovered all
                             // appId/appKey pairs by that time.
 
-                            qinfo.addAppInfo(p);
+                            qinfo.addAppInfo(cit);
 
-                            BALL_LOG_INFO
-                                << partitionDesc()
-                                << "Recovered appId/appKey pair ['" << p.first
-                                << "' (" << p.second << ")] in QueueOp ["
-                                << queueOpType << "] record for queue ["
-                                << qinfo.canonicalQueueUri()
-                                << "] with queue key [" << queueKey << "].";
+                            BALL_LOG_INFO << partitionDesc()
+                                          << "Recovered appId/appKey pair ['"
+                                          << cit->first << "' (" << cit->second
+                                          << ")] in QueueOp [" << queueOpType
+                                          << "] record for queue ["
+                                          << qinfo.canonicalQueueUri()
+                                          << "] with queue key [" << queueKey
+                                          << "].";
                         }
                     }
                 }
@@ -5720,13 +5720,12 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
         for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
              cit != appIdKeyPairs.cend();
              ++cit, ++i) {
-            const AppInfo& appIdKeyPair = *cit;
-            BSLS_ASSERT_SAFE(!appIdKeyPair.first.empty());
-            BSLS_ASSERT_SAFE(!appIdKeyPair.second.isNull());
+            BSLS_ASSERT_SAFE(!cit->first.empty());
+            BSLS_ASSERT_SAFE(!cit->second.isNull());
             appIdWords[i] = bmqp::ProtocolUtil::calcNumWordsAndPadding(
                 &appIdPaddings[i],
-                appIdKeyPair.first.length());
-            totalLength += sizeof(AppIdHeader) + appIdKeyPair.first.length() +
+                cit->first.length());
+            totalLength += sizeof(AppIdHeader) + cit->first.length() +
                            appIdPaddings[i] +
                            FileStoreProtocol::k_HASH_LENGTH;  // for AppKey
         }

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -209,7 +209,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     typedef DataStoreConfig::QueueKeyInfoMapConstIter QueueKeyInfoMapConstIter;
     typedef DataStoreConfig::QueueKeyInfoMapInsertRc  QueueKeyInfoMapInsertRc;
 
-    typedef mqbi::Storage::AppInfo  AppInfo;
     typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef StorageCollectionUtil::StoragesMap         StoragesMap;

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
@@ -331,10 +331,9 @@ int FileStoreProtocolUtil::calculateMd5Digest(
 }
 
 void FileStoreProtocolUtil::loadAppInfos(
-    bsl::unordered_set<bsl::pair<bsl::string, mqbu::StorageKey> >*
-                       appIdKeyPairs,
-    const MemoryBlock& appIdsBlock,
-    unsigned int       numAppIds)
+    bsl::unordered_map<bsl::string, mqbu::StorageKey>* appIdKeyPairs,
+    const MemoryBlock&                                 appIdsBlock,
+    unsigned int                                       numAppIds)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(appIdKeyPairs);

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
@@ -108,11 +108,10 @@ struct FileStoreProtocolUtil {
                                   const bmqu::BlobPosition& startPos,
                                   unsigned int              length);
 
-    static void
-    loadAppInfos(bsl::unordered_set<bsl::pair<bsl::string, mqbu::StorageKey> >*
-                                    appIdKeyPairs,
-                 const MemoryBlock& appIdsBlock,
-                 unsigned int       numAppIds);
+    static void loadAppInfos(
+        bsl::unordered_map<bsl::string, mqbu::StorageKey>* appIdKeyPairs,
+        const MemoryBlock&                                 appIdsBlock,
+        unsigned int                                       numAppIds);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
@@ -517,8 +517,7 @@ static void test4_loadAppInfos()
 //   loadAppInfos()
 // ------------------------------------------------------------------------
 {
-    typedef bsl::pair<bsl::string, mqbu::StorageKey> AppInfo;
-    typedef bsl::unordered_set<AppInfo>              AppInfos;
+    typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
 
     {
         // No appIds.
@@ -666,9 +665,9 @@ static void test4_loadAppInfos()
                         appHash,
                         mqbs::FileStoreProtocol::k_HASH_LENGTH);
 
-            expectedAppInfos.emplace(AppInfo(
+            expectedAppInfos.emplace(
                 bsl::string(appId, bmqtst::TestHelperUtil::allocator()),
-                appKey));
+                appKey);
             offset += mqbs::FileStoreProtocol::k_HASH_LENGTH;
         }
         // Test.

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -167,8 +167,6 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
 
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo AppInfo;
-
     typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef ReplicatedStorage::RecordHandles RecordHandles;

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -75,8 +75,6 @@ class VirtualStorageCatalog {
 
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfo AppInfo;
-
     typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef unsigned int Ordinal;


### PR DESCRIPTION
1.  Refactor thread-unsafe `mqbi::Storage::loadVirtualStorageDetails` call on the cluster thread.
2.  appId is the only key for `mqbi::Storage::AppInfos`
3.  Workaround for the appKeys conflict (CSL vs. Qlist)