### PR TITLE
Fix[MQB]: respect protocol file size limits

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1341,7 +1341,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
+        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;  // RETURN
     }
 
     if (mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD <
@@ -1351,7 +1351,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
+        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;  // RETURN
     }
 
     if (mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD <
@@ -1361,7 +1361,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;
+        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;  // RETURN
     }
 
     int rc = mqbc::StorageUtil::validatePartitionDirectory(partitionCfg,

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1320,7 +1320,10 @@ int StorageManager::start(bsl::ostream& errorDescription)
         rc_RECOVERY_MANAGER_FAILURE       = -2,
         rc_FILE_STORE_OPEN_FAILURE        = -3,
         rc_FILE_STORE_RECOVERY_FAILURE    = -4,
-        rc_NOT_ENOUGH_DISK_SPACE          = -5
+        rc_NOT_ENOUGH_DISK_SPACE          = -5,
+        rc_OVERFLOW_MAX_DATA_FILE_SIZE    = -6,
+        rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE = -7,
+        rc_OVERFLOW_MAX_QLIST_FILE_SIZE   = -8
     };
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
@@ -1329,6 +1332,37 @@ int StorageManager::start(bsl::ostream& errorDescription)
     // For convenience:
     const mqbcfg::PartitionConfig& partitionCfg =
         d_clusterConfig.partitionConfig();
+
+    // Validate file size limits before checking the available disk space
+    if (partitionCfg.maxDataFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxDataFileSize ("
+                       << partitionCfg.maxDataFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
+    }
+
+    if (partitionCfg.maxJournalFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxJournalFileSize ("
+                       << partitionCfg.maxJournalFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
+    }
+
+    if (partitionCfg.maxQlistFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxQlistFileSize ("
+                       << partitionCfg.maxQlistFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;
+    }
 
     int rc = mqbc::StorageUtil::validatePartitionDirectory(partitionCfg,
                                                            errorDescription);

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1334,8 +1334,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         d_clusterConfig.partitionConfig();
 
     // Validate file size limits before checking the available disk space
-    if (partitionCfg.maxDataFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD <
+        partitionCfg.maxDataFileSize()) {
         BALL_LOG_ERROR << "Configured maxDataFileSize ("
                        << partitionCfg.maxDataFileSize()
                        << ") exceeds the protocol limit ("
@@ -1344,8 +1344,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
     }
 
-    if (partitionCfg.maxJournalFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD <
+        partitionCfg.maxJournalFileSize()) {
         BALL_LOG_ERROR << "Configured maxJournalFileSize ("
                        << partitionCfg.maxJournalFileSize()
                        << ") exceeds the protocol limit ("
@@ -1354,8 +1354,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
     }
 
-    if (partitionCfg.maxQlistFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD <
+        partitionCfg.maxQlistFileSize()) {
         BALL_LOG_ERROR << "Configured maxQlistFileSize ("
                        << partitionCfg.maxQlistFileSize()
                        << ") exceeds the protocol limit ("

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3479,8 +3479,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         d_clusterConfig.partitionConfig();
 
     // Validate file size limits before checking the available disk space
-    if (partitionCfg.maxDataFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD <
+        partitionCfg.maxDataFileSize()) {
         BALL_LOG_ERROR << "Configured maxDataFileSize ("
                        << partitionCfg.maxDataFileSize()
                        << ") exceeds the protocol limit ("
@@ -3489,8 +3489,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
     }
 
-    if (partitionCfg.maxJournalFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD <
+        partitionCfg.maxJournalFileSize()) {
         BALL_LOG_ERROR << "Configured maxJournalFileSize ("
                        << partitionCfg.maxJournalFileSize()
                        << ") exceeds the protocol limit ("
@@ -3499,8 +3499,8 @@ int StorageManager::start(bsl::ostream& errorDescription)
         return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
     }
 
-    if (partitionCfg.maxQlistFileSize() >
-        mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD) {
+    if (mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD <
+        partitionCfg.maxQlistFileSize()) {
         BALL_LOG_ERROR << "Configured maxQlistFileSize ("
                        << partitionCfg.maxQlistFileSize()
                        << ") exceeds the protocol limit ("

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3452,12 +3452,23 @@ int StorageManager::start(bsl::ostream& errorDescription)
     BSLS_ASSERT_SAFE(d_dispatcher_p->inDispatcherThread(d_cluster_p));
 
     enum RcEnum {
-        // Value for the various RC error categories
+        // Value for the various RC error categories.
+        // RESERVED returned code is not used here, but kept for consistency
+        // with `mqbblp::StorageManager::start` return code:
+        // - rc_THREAD_POOL_START_FAILURE = rc_FILE_STORE_OPEN_FAILURE
+        // - rc_RESERVED                  = rc_FILE_STORE_RECOVERY_FAILURE
+        // TODO: `mqbblp::StorageManager` is used in non-FSM mode only, if/when
+        //       we support only FSM, we can remove these RESERVED codes
+        //       together with `mqbblp::StorageManager`.
         rc_SUCCESS                        = 0,
         rc_PARTITION_LOCATION_NONEXISTENT = -1,
-        rc_NOT_ENOUGH_DISK_SPACE          = -2,
+        rc_RECOVERY_MANAGER_FAILURE       = -2,
         rc_THREAD_POOL_START_FAILURE      = -3,
-        rc_RECOVERY_MANAGER_FAILURE       = -4
+        rc_RESERVED                       = -4,
+        rc_NOT_ENOUGH_DISK_SPACE          = -5,
+        rc_OVERFLOW_MAX_DATA_FILE_SIZE    = -6,
+        rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE = -7,
+        rc_OVERFLOW_MAX_QLIST_FILE_SIZE   = -8
     };
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
@@ -3466,6 +3477,37 @@ int StorageManager::start(bsl::ostream& errorDescription)
     // For convenience:
     const mqbcfg::PartitionConfig& partitionCfg =
         d_clusterConfig.partitionConfig();
+
+    // Validate file size limits before checking the available disk space
+    if (partitionCfg.maxDataFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxDataFileSize ("
+                       << partitionCfg.maxDataFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
+    }
+
+    if (partitionCfg.maxJournalFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxJournalFileSize ("
+                       << partitionCfg.maxJournalFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
+    }
+
+    if (partitionCfg.maxQlistFileSize() >
+        mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD) {
+        BALL_LOG_ERROR << "Configured maxQlistFileSize ("
+                       << partitionCfg.maxQlistFileSize()
+                       << ") exceeds the protocol limit ("
+                       << mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD
+                       << ")";
+        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;
+    }
 
     int rc = StorageUtil::validatePartitionDirectory(partitionCfg,
                                                      errorDescription);

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3486,7 +3486,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;
+        return rc_OVERFLOW_MAX_DATA_FILE_SIZE;  // RETURN
     }
 
     if (mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD <
@@ -3496,7 +3496,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;
+        return rc_OVERFLOW_MAX_JOURNAL_FILE_SIZE;  // RETURN
     }
 
     if (mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD <
@@ -3506,7 +3506,7 @@ int StorageManager::start(bsl::ostream& errorDescription)
                        << ") exceeds the protocol limit ("
                        << mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD
                        << ")";
-        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;
+        return rc_OVERFLOW_MAX_QLIST_FILE_SIZE;  // RETURN
     }
 
     int rc = StorageUtil::validatePartitionDirectory(partitionCfg,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -2969,10 +2969,10 @@ static void test19_fileSizesHardLimits()
             if (rc == 0) {
                 storageManager.stop();
             }
-            ASSERT_EQ_D("line: " << line << ", expected failure: "
-                                 << expectFailure << ", rc: " << rc,
-                        expectFailure,
-                        (rc != 0));
+            BMQTST_ASSERT_EQ_D("line: " << line << ", expected failure: "
+                                        << expectFailure << ", rc: " << rc,
+                               expectFailure,
+                               (rc != 0));
         }
     };
 

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -63,10 +63,10 @@
 //                                                        or 32GiB - 8B
 //               (See also: mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD)
 //       Max Journal file size..........................: 17179869180 bytes
-//                                                        or 16GiB - 8B
+//                                                        or 16GiB - 4B
 //            (See also: mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD)
 //       Max Qlist file size............................: 17179869180 bytes
-//                                                        or 16GiB - 8B
+//                                                        or 16GiB - 4B
 //              (See also: mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD)
 //       Max Journal Record size........................: 1020 bytes
 //       Max Journal Record types.......................: 15

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -60,13 +60,13 @@
 //       Max QlistFileHeader size.......................: 1020 bytes
 //       Max QueueRecordHeader size.....................: 1020 bytes
 //       Max Data file size.............................: 34359738360 bytes
-//                                                        or 32GB - 8B
+//                                                        or 32GiB - 8B
 //               (See also: mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD)
 //       Max Journal file size..........................: 17179869180 bytes
-//                                                        or 16GB - 8B
+//                                                        or 16GiB - 8B
 //            (See also: mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD)
 //       Max Qlist file size............................: 17179869180 bytes
-//                                                        or 16GB - 8B
+//                                                        or 16GiB - 8B
 //              (See also: mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD)
 //       Max Journal Record size........................: 1020 bytes
 //       Max Journal Record types.......................: 15

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -59,12 +59,15 @@
 //       Max JournalFileHeader size.....................: 1020 bytes
 //       Max QlistFileHeader size.......................: 1020 bytes
 //       Max QueueRecordHeader size.....................: 1020 bytes
-//       Max Data file size.............................: 32GB
-//                               (courtesy MessageRecord.d_messageOffsetDwords)
-//       Max Journal file size..........................: 16GB
-//                          (courtesy bmqp::StorageHeader.d_journalOffsetWords)
-//       Max Qlist file size............................: 16GB
-//                         (courtesy QueueOpRecord.d_queueUriRecordOffsetWords)
+//       Max Data file size.............................: 34359738360 bytes
+//                                                        or 32GB - 8B
+//               (See also: mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD)
+//       Max Journal file size..........................: 17179869180 bytes
+//                                                        or 16GB - 8B
+//            (See also: mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD)
+//       Max Qlist file size............................: 17179869180 bytes
+//                                                        or 16GB - 8B
+//              (See also: mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD)
 //       Max Journal Record size........................: 1020 bytes
 //       Max Journal Record types.......................: 15
 //
@@ -159,6 +162,21 @@ struct FileStoreProtocol {
 
     static const int k_NUM_FILES_PER_PARTITION = 3;
     // Number of files per partition (data, journal & qlist)
+
+    /// The unsigned 32-bit `mqbs::MessageRecord::d_messageOffsetDwords` allows
+    /// to address at most `((2 ^ 32) - 1) * 8` byte offset
+    static const bsls::Types::Uint64 k_MAX_DATA_FILE_SIZE_HARD =
+        34359738360ULL;
+
+    /// The unsigned 32-bit `bmqp::StorageHeader::d_journalOffsetWords` allows
+    /// to address at most `((2 ^ 32) - 1) * 4` byte offset
+    static const bsls::Types::Uint64 k_MAX_JOURNAL_FILE_SIZE_HARD =
+        17179869180ULL;
+
+    /// The unsigned 32-bit `mqbs::QueueOpRecord::d_queueUriRecordOffsetWords`
+    /// allows to address at most `((2 ^ 32) - 1) * 4` byte offset
+    static const bsls::Types::Uint64 k_MAX_QLIST_FILE_SIZE_HARD =
+        17179869180ULL;
 
     static const char* k_DATA_FILE_EXTENSION;
 

--- a/src/groups/mqb/mqbs/mqbs_filestoreset.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreset.h
@@ -27,6 +27,7 @@
 // a 'mqbs::FileStore' and some associated attributes.
 
 // MQB
+#include <mqbs_filestoreprotocol.h>
 
 // BDE
 #include <bsl_iostream.h>
@@ -74,28 +75,28 @@ class FileStoreSet BSLS_CPP11_FINAL {
 
     // MANIPULATORS
     // FileStoreSet& operator=(const FileStoreSet&);
-    FileStoreSet& setDataFile(const bsl::string& value);
-    FileStoreSet& setDataFileSize(bsls::Types::Int64 value);
-    FileStoreSet& setJournalFile(const bsl::string& value);
-    FileStoreSet& setJournalFileSize(bsls::Types::Int64 value);
-    FileStoreSet& setQlistFile(const bsl::string& value);
 
     /// Set the corresponding attribute to the specified `value` and return
     /// a reference offering modifiable access to this object.
-    FileStoreSet& setQlistFileSize(bsls::Types::Int64 value);
+    FileStoreSet& setDataFile(const bsl::string& value);
+    FileStoreSet& setDataFileSize(bsls::Types::Uint64 value);
+    FileStoreSet& setJournalFile(const bsl::string& value);
+    FileStoreSet& setJournalFileSize(bsls::Types::Uint64 value);
+    FileStoreSet& setQlistFile(const bsl::string& value);
+    FileStoreSet& setQlistFileSize(bsls::Types::Uint64 value);
 
     /// Reset the members of this object.
     void reset();
 
     // ACCESSORS
-    const bsl::string& dataFile() const;
-    bsls::Types::Int64 dataFileSize() const;
-    const bsl::string& journalFile() const;
-    bsls::Types::Int64 journalFileSize() const;
-    const bsl::string& qlistFile() const;
 
     /// Get the value of the corresponding attribute.
-    bsls::Types::Int64 qlistFileSize() const;
+    const bsl::string& dataFile() const;
+    bsls::Types::Uint64 dataFileSize() const;
+    const bsl::string& journalFile() const;
+    bsls::Types::Uint64 journalFileSize() const;
+    const bsl::string& qlistFile() const;
+    bsls::Types::Uint64 qlistFileSize() const;
 
     /// Write a human-readable string representation of this object to the
     /// specified output `stream`, and return a reference to `stream`.
@@ -156,8 +157,12 @@ inline FileStoreSet& FileStoreSet::setDataFile(const bsl::string& value)
     return *this;
 }
 
-inline FileStoreSet& FileStoreSet::setDataFileSize(bsls::Types::Int64 value)
+inline FileStoreSet& FileStoreSet::setDataFileSize(bsls::Types::Uint64 value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(value <=
+                     mqbs::FileStoreProtocol::k_MAX_DATA_FILE_SIZE_HARD);
+
     d_dataFileSize = value;
     return *this;
 }
@@ -168,8 +173,13 @@ inline FileStoreSet& FileStoreSet::setJournalFile(const bsl::string& value)
     return *this;
 }
 
-inline FileStoreSet& FileStoreSet::setJournalFileSize(bsls::Types::Int64 value)
+inline FileStoreSet&
+FileStoreSet::setJournalFileSize(bsls::Types::Uint64 value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(value <=
+                     mqbs::FileStoreProtocol::k_MAX_JOURNAL_FILE_SIZE_HARD);
+
     d_journalFileSize = value;
     return *this;
 }
@@ -180,8 +190,12 @@ inline FileStoreSet& FileStoreSet::setQlistFile(const bsl::string& value)
     return *this;
 }
 
-inline FileStoreSet& FileStoreSet::setQlistFileSize(bsls::Types::Int64 value)
+inline FileStoreSet& FileStoreSet::setQlistFileSize(bsls::Types::Uint64 value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(value <=
+                     mqbs::FileStoreProtocol::k_MAX_QLIST_FILE_SIZE_HARD);
+
     d_qlistFileSize = value;
     return *this;
 }
@@ -192,7 +206,7 @@ inline const bsl::string& FileStoreSet::dataFile() const
     return d_dataFile;
 }
 
-inline bsls::Types::Int64 FileStoreSet::dataFileSize() const
+inline bsls::Types::Uint64 FileStoreSet::dataFileSize() const
 {
     return d_dataFileSize;
 }
@@ -202,7 +216,7 @@ inline const bsl::string& FileStoreSet::journalFile() const
     return d_journalFile;
 }
 
-inline bsls::Types::Int64 FileStoreSet::journalFileSize() const
+inline bsls::Types::Uint64 FileStoreSet::journalFileSize() const
 {
     return d_journalFileSize;
 }
@@ -212,7 +226,7 @@ inline const bsl::string& FileStoreSet::qlistFile() const
     return d_qlistFile;
 }
 
-inline bsls::Types::Int64 FileStoreSet::qlistFileSize() const
+inline bsls::Types::Uint64 FileStoreSet::qlistFileSize() const
 {
     return d_qlistFileSize;
 }


### PR DESCRIPTION
Before this PR, it was possible to set a file size not complaint to the protocol limitations. In this case, the cluster will work until it gets the first offset overflow, and then crash.

This PR:
- Adds precise pre-calculated constants for DATA, JOURNAL, QLIST file sizes hard limits.
- Adds the 1st line of checks in `mqbblp::StorageManager::start` (for non-FSM) and `mqbc::StorageManager::start` (for FSM) to gracefully return a failure RC on file size overflow.
- Adds the 2nd line of checks (asserts in `FileStoreSet::setDataFileSize` etc), they should be never triggered in a normal workflow but left here just to be sure.
- Improves consistency of RCs returned from [`mqbblp`/`mqbc`]`::StorageManager::start`
- Adds UT to check file size hard limits for `mqbc::StorageManager` (there are no UTs for `mqbblp::StorageManager`).

The error logs look like this:
```
06DEC2024_00:29:20.649 25904:8394919744 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_storagemanager.cpp:3485 MQBC.STORAGEMANAGER Configured maxDataFileSize (34359738361) exceeds the protocol limit (34359738360) 

06DEC2024_00:29:20.649 25904:8394919744 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_storagemanager.cpp:3495 MQBC.STORAGEMANAGER Configured maxJournalFileSize (17179869181) exceeds the protocol limit (17179869180) 

06DEC2024_00:29:20.649 25904:8394919744 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_storagemanager.cpp:3505 MQBC.STORAGEMANAGER Configured maxQlistFileSize (17179869181) exceeds the protocol limit (17179869180) 

06DEC2024_00:29:20.649 25904:8394919744 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_storagemanager.cpp:3485 MQBC.STORAGEMANAGER Configured maxDataFileSize (8796093020160) exceeds the protocol limit (34359738360) 
```