### PR TITLE
fix: check for ASSIGNED state when loadQueuesInfo

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -2193,6 +2193,10 @@ void ClusterUtil::loadQueuesInfo(bsl::vector<bmqp_ctrlmsg::QueueInfo>* out,
         for (UriToQueueInfoMapCIter qCit = queuesInfoPerDomain.cbegin();
              qCit != queuesInfoPerDomain.cend();
              ++qCit) {
+            if (qCit->second->state() != ClusterStateQueueInfo::k_ASSIGNED) {
+                continue;  // CONTINUE
+            }
+
             bmqp_ctrlmsg::QueueInfo queueInfo;
             queueInfo.uri()         = qCit->second->uri().asString();
             queueInfo.partitionId() = qCit->second->partitionId();


### PR DESCRIPTION
Fixing the cause for assertion failure `mqbc_clusterutil.cpp:2200 Assertion failed: !qCit->second->key().isNull()`