### PR TITLE
Feat[bmq, mqb]: Support TLS listeners

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -105,6 +105,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libgtest-dev \
             libz-dev
       - name: Install cached non packaged dependencies
         if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -320,6 +320,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libgtest-dev \
             libz-dev \
             autoconf \
             libtool

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -59,6 +59,7 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libgmock-dev \
+            libgtest-dev \
             libz-dev
 
       - name: Fetch & build non packaged dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,3 @@ settings.json
 
 # Symlink from 'src/applications/bmqbrkr/run'
 src/applications/bmqbrkr/etc/etc
-
-# 'sim_cpp11_features.pl' backups
-*.bak

--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -69,7 +69,7 @@ fi
 
 # :: Optionally install prerequisites :::::::::::::::::::::::::::::::::::::::::
 
-REQ_PKGS=(cmake flex bison google-benchmark googletest ninja pkg-config zlib)
+REQ_PKGS=(cmake flex bison google-benchmark googletest ninja openssl pkg-config zlib)
 
 if $INSTALL_DEPS; then
     if ! command -v brew >/dev/null 2>&1; then
@@ -91,7 +91,7 @@ mkdir -p "${DIR_THIRDPARTY}"
 DIR_BUILD="${DIR_BUILD:-${DIR_ROOT}/build}"
 mkdir -p "${DIR_BUILD}"
 
-DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}}"
+DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}/install}"
 mkdir -p "${DIR_INSTALL}"
 
 

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -6,7 +6,7 @@ echo -e "Before running this script, install the following prerequisites, if not
         "by executing the following commands:\n"                                               \
         "sudo apt update && sudo apt -y install ca-certificates\n"                             \
         "sudo apt install -y --no-install-recommends"                                          \
-        "autoconf automake build-essential gdb cmake ninja-build pkg-config bison libfl-dev libbenchmark-dev libgmock-dev libtool libz-dev"
+        "autoconf automake build-essential gdb cmake ninja-build pkg-config bison libfl-dev libbenchmark-dev libgmock-dev libgtest-dev libtool libz-dev"
 
 # :: Parse and validate arguments :::::::::::::::::::::::::::::::::::::::::::::
 print_usage_and_exit_with_error() {
@@ -59,7 +59,7 @@ mkdir -p "${DIR_THIRDPARTY}"
 DIR_BUILD="${DIR_BUILD:-${DIR_ROOT}/build}"
 mkdir -p "${DIR_BUILD}"
 
-DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}}"
+DIR_INSTALL="${DIR_INSTALL:-${DIR_ROOT}/install}"
 mkdir -p "${DIR_INSTALL}"
 
 # :: Clone dependencies :::::::::::::::::::::::::::::::::::::::::::::::::::::::

--- a/bin/codegen.sh
+++ b/bin/codegen.sh
@@ -3,7 +3,7 @@
 #
 # This script is not able to be run by non-Bloomberg developers as it relies on internal tooling.
 
-COPYRIGHT="// Copyright 2025 Bloomberg Finance L.P.
+readonly COPYRIGHT="// Copyright 2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the \"License\");
@@ -18,6 +18,7 @@ COPYRIGHT="// Copyright 2025 Bloomberg Finance L.P.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 "
+readonly CODEGEN="${CODEGEN:-}"
 
 codegen() {
   local dir=$1
@@ -49,14 +50,24 @@ codegen() {
   done
 }
 
+usage() {
+  echo "Usage: codegen.sh <schema-name>\
+  Valid schema names include: [ m_bmqtool, bmqp_ctrlmsg, bmqstm, mqbcfg, mqbcmd, mqbconf ]"\ >&2
+}
+
 main() {
   set -eux
 
-  if [[ -z "${CODEGEN+}" ]]; then
+  if [[ -z "${CODEGEN}" ]]; then
     echo "This script is not able to be run by non-Bloomberg developers as it relies on \
 internal tooling. Please open an issue if you are an open-source contributor \
 in need of code generation. If you are a Bloomberg developer, please rerun this \
 script with the CODEGEN enviornment variable set to the internal codegen tool." >&2
+    exit 1
+  fi
+
+  if [[ -z "${1+x}" ]]; then
+    usage
     exit 1
   fi
 
@@ -80,7 +91,7 @@ script with the CODEGEN enviornment variable set to the internal codegen tool." 
       codegen ./src/groups/mqb/mqbconfm mqbconf.xsd messages
       ;;
     *)
-      echo "Unrecognized/missing codegen target" >&2
+      usage
       exit 1
       ;;
   esac

--- a/bin/gen-tls-certs.sh
+++ b/bin/gen-tls-certs.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+#
+# This scripts generates:
+#  - root CA certificate
+#  - server certificate and keystore
+#  - client keys
+#
+# Based off of
+#   https://github.com/confluentinc/librdkafka/blob/master/tests/gen-ssl-certs.sh
+
+OP="$1"
+CA_CERT="$2"
+PFX="$3"
+HOST="$4"
+
+C=NN
+ST=NN
+L=NN
+O=NN
+OU=NN
+CN="$HOST"
+ 
+
+# Password
+PASS="secret"
+
+# Cert validity, in days
+VALIDITY=10000
+
+set -e
+
+export LC_ALL=C
+
+if [[ $OP == "ca" && -n "$CA_CERT" && -n "$3" ]]; then
+    CN="$3"
+    openssl req -new -x509 -keyout "${CA_CERT}.key" -out "${CA_CERT}" -days $VALIDITY -passin "pass:$PASS" -passout "pass:$PASS" <<EOF
+${C}
+${ST}
+${L}
+${O}
+${OU}
+${CN}
+$USER@${CN}
+.
+.
+EOF
+
+
+
+elif [[ $OP == "server" && -n "$CA_CERT" && -n "$PFX" && -n "$CN" ]]; then
+    HOST_CERT_CONFIG_PATH="${PFX}host_cert.cnf"
+    HOST_PRIVATE_RSA_KEY_PATH="${PFX}host_private_key_rsa.pem"
+    HOST_PRIVATE_KEY_PATH="${PFX}private_key.pem"
+    HOST_CSR_PATH="${PFX}host_csr.pem"
+    HOST_CERT_PATH="${PFX}host_cert.pem"
+    HOST_CERT_CHAIN_PATH="${PFX}client_${CN}.pem"
+
+    # Create the CA cert config file
+    echo "Setting up host certs..."
+
+    cat <<EOF > "${HOST_CERT_CONFIG_PATH}"
+[req]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+req_extensions      = v3_req
+prompt              = no
+[req_distinguished_name]
+C   = ${C}
+ST  = ${ST}
+L   = ${L}
+O   = ${O}
+CN  = ${CN}
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1  = ${CN}
+DNS.2  = localhost.
+EOF
+
+    #Step 1
+    echo "############ Generating key"
+    openssl genrsa -out "${HOST_PRIVATE_RSA_KEY_PATH}" 2048
+    openssl pkcs8 -nocrypt -topk8 -v1 PBE-SHA1-RC4-128 -inform pem -outform pem -in "${HOST_PRIVATE_RSA_KEY_PATH}" -out "${HOST_PRIVATE_KEY_PATH}"
+	
+    #Step 2
+    echo "############ Generate the CSR"
+    openssl req -nodes -new -extensions v3_req -sha256 -config "${HOST_CERT_CONFIG_PATH}" -key "${HOST_PRIVATE_KEY_PATH}" -out "${HOST_CSR_PATH}"
+    
+    #Step 3
+    echo "############ Generate the cert"
+    openssl x509 -req -in "${HOST_CSR_PATH}" -CA "${CA_CERT}" -CAkey "${CA_CERT}.key" -CAcreateserial -out "${HOST_CERT_PATH}" -days ${VALIDITY} -sha256 -extensions v3_req -extfile "${HOST_CERT_CONFIG_PATH}" -passin "pass:${PASS}"
+    
+    cat "${HOST_CERT_PATH}" > "${HOST_CERT_CHAIN_PATH}"
+
+
+elif [[ $OP == "client" && -n "$CA_CERT" && -n "$PFX" && -n "$CN" ]]; then
+
+# Standard OpenSSL keys
+	echo "############ Generating key"
+	openssl genrsa -nodes -passout "pass:${PASS}" -out "${PFX}client.key" 2048 
+	
+	echo "############ Generating request"
+	openssl req -passin "pass:${PASS}" -passout "pass:${PASS}" -key "${PFX}client.key" -new -out "${PFX}client.req" \
+		<<EOF
+$C
+$ST
+$L
+$O
+$OU
+$CN
+.
+$PASS
+.
+EOF
+
+	echo "########### Signing key"
+	openssl x509 -req -passin "pass:${PASS}" -in "${PFX}client.req" -CA "${CA_CERT}" -CAkey "${CA_CERT}.key" -CAcreateserial -out "${PFX}client.pem" -days ${VALIDITY}
+
+
+else
+    echo "Usage: $0 ca <ca-cert-file> <CN>"
+    echo "       $0 server|client <ca-cert-file> <file_prefix> <hostname>"
+    echo ""
+    exit 1
+fi
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get update && \
     libfl-dev \
     libbenchmark-dev \
     libgmock-dev \
+    libgtest-dev \
+    liblz4-dev \
+    libssl-dev \
     libz-dev \
     libssl-dev \
     && apt clean \
@@ -51,10 +54,19 @@ FROM docker.io/ubuntu:24.04
 
 COPY --from=builder /bmq /usr/local
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    openssl
+
 RUN groupadd bmq \
     && useradd bmq --home /var/local/bmq --system --gid bmq --shell /usr/bin/bash
 USER bmq
 WORKDIR /var/local/bmq
-RUN mkdir -p logs storage/archive
+COPY bin/gen-tls-certs.sh gen-tls-certs.sh
+
+RUN mkdir -p logs storage/archive certs && \
+    cd certs && \
+    ../gen-tls-certs.sh ca ca-cert dummy && \
+    ../gen-tls-certs.sh server ca-cert broker_ dummy
 
 CMD [ "/bin/bash" ]

--- a/docker/cluster/config/bmqbrkrcfg.json
+++ b/docker/cluster/config/bmqbrkrcfg.json
@@ -86,11 +86,27 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    },
+                    {
+                        "name": "TLSListener",
+                        "port": 30115,
+                        "tls": true
+                    }
             }
         },
         "bmqconfConfig": {
             "cacheTTLSeconds": 30
+        },
+        "tlsConfig": {
+            "certificateAuthority": "/var/local/bmq/certs/ca-cert",
+            "certificate": "/var/local/bmq/certs/broker_host_cert.pem",
+            "key": "/var/local/bmq/certs/broker_private_key.pem"
         }
     }
 }

--- a/docker/sanitizers/build_sanitizer.sh
+++ b/docker/sanitizers/build_sanitizer.sh
@@ -60,6 +60,10 @@ apt-get install -qy --no-install-recommends \
     libfl-dev \
     pkg-config \
     python3.12-venv \
+    liblz4-dev \
+    libssl-dev \
+    libz-dev \
+    libzstd-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Install prerequisites for LLVM: latest cmake version, Ubuntu apt repository contains stale version

--- a/docker/single-node/config/bmqbrkrcfg.json
+++ b/docker/single-node/config/bmqbrkrcfg.json
@@ -86,11 +86,28 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    },
+                    {
+                        "name": "TLSListener",
+                        "port": 30115,
+                        "tls": true
+                    }
+                ]
             }
         },
         "bmqconfConfig": {
             "cacheTTLSeconds": 30
+        },
+        "tlsConfig": {
+            "certificateAuthority": "/var/local/bmq/certs/ca-cert",
+            "certificate": "/var/local/bmq/certs/broker_host_cert.pem",
+            "key": "/var/local/bmq/certs/broker_private_key.pem"
         }
     }
 }

--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -1,88 +1,9 @@
 # This module provides functions to support generating test targets compatible
 # with BlazingMQ CI.
 #
-# add_bmq_test( TARGET )
+# bmq_add_application_test( TARGET )
 
 include_guard()
-
-# :: bmq_add_test :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-# This function searches for the test drivers of a UOR-style TARGET within the
-# `tests` directory of each package. For each component, it generates a target
-# named ${UOR_component}.t for each component found.
-function(bmq_add_test target)
-  cmake_parse_arguments(PARSE_ARGV 1
-    ""
-    "SKIP_TESTS;NO_GEN_BDE_METADATA;NO_EMIT_PKG_CONFIG_FILE;COMPAT"
-    "SOURCE_DIR"
-    "CUSTOM_PACKAGES")
-
-  find_package(BdeBuildSystem REQUIRED)
-
-  # Get the name of the unit from the target
-  get_target_property(uor_name ${target} NAME)
-
-  # Use the current source directory if none is specified
-  if(NOT _SOURCE_DIR)
-    set(_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-
-  # Check that BDE metadata exists and load it
-  if(NOT DEFINED ${uor_name}_PACKAGES)
-    if(EXISTS ${_SOURCE_DIR}/group)
-      bbs_read_metadata(GROUP ${uor_name}
-        SOURCE_DIR ${_SOURCE_DIR}
-        CUSTOM_PACKAGES "${_CUSTOM_PACKAGES}")
-    else()
-      if(EXISTS ${_SOURCE_DIR}/package)
-        bbs_read_metadata(PACKAGE ${uor_name}
-          SOURCE_DIR ${_SOURCE_DIR})
-      endif()
-    endif()
-  endif()
-
-  # Each package in the groups
-  if(${uor_name}_PACKAGES)
-    foreach(pkg ${${uor_name}_PACKAGES})
-      bbs_configure_target_tests(${pkg}
-        SOURCES ${${pkg}_TEST_SOURCES}
-        TEST_DEPS ${${pkg}_DEPENDS}
-        ${${pkg}_TEST_DEPENDS}
-        ${${uor_name}_PCDEPS}
-        ${${uor_name}_TEST_PCDEPS}
-        LABELS "unit;all" ${target} ${pkg})
-    endforeach()
-
-    set(import_test_deps ON)
-
-    foreach(pkg ${${uor_name}_PACKAGES})
-      if(${pkg}_TEST_TARGETS)
-        if(NOT TARGET ${target}.t)
-          add_custom_target(${target}.t)
-        endif()
-
-        add_dependencies(${target}.t ${${pkg}_TEST_TARGETS})
-
-        if(import_test_deps)
-          # Import UOR test dependencies only once and only if we have at least
-          # one generated test target
-          bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
-          set(import_test_deps OFF)
-        endif()
-      endif()
-    endforeach()
-  else()
-    # Configure standalone library ( no packages ) and tests from BDE metadata
-    bbs_configure_target_tests(${target}
-      SOURCES ${${uor_name}_TEST_SOURCES}
-      TEST_DEPS ${${uor_name}_PCDEPS}
-      ${${uor_name}_TEST_PCDEPS}
-      LABELS "unit;all" ${target})
-
-    if(${target}_TEST_TARGETS)
-      bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
-    endif()
-  endif()
-endfunction()
 
 # :: bmq_add_application_test :::::::::::::::::::::::::::::::::::::::::::::::::
 # This function searches for the test drivers of an 'application' TARGET.  It

--- a/etc/cmake/BmqPackageProvider.cmake
+++ b/etc/cmake/BmqPackageProvider.cmake
@@ -22,5 +22,6 @@ macro(setup_package_provider)
 
         find_package(GTest CONFIG REQUIRED)
         add_library(gmock ALIAS GTest::gmock)
+        add_library(gtest ALIAS GTest::gtest)
     endif()
 endmacro()

--- a/etc/cmake/TargetBMQStyleUor.cmake
+++ b/etc/cmake/TargetBMQStyleUor.cmake
@@ -59,7 +59,6 @@ function(target_bmq_style_uor TARGET)
   add_library(${TARGET}-flags INTERFACE IMPORTED)
 
   bbs_setup_target_uor(${TARGET}
-    SKIP_TESTS
     PRIVATE_PACKAGES "${_PRIVATE_PACKAGES}")
 
   get_target_property(uor_name ${TARGET} NAME)
@@ -84,9 +83,6 @@ function(target_bmq_style_uor TARGET)
       target_link_libraries(${pkg}-iface PUBLIC ${TARGET}-flags)
     endforeach()
   endif()
-
-  include(BMQTest)
-  bmq_add_test(${TARGET} COMPAT)
 endfunction()
 
 # :: bmq_install_target_headers ::::::::::::::::::::::::::::::::::::::::::::::::

--- a/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
+++ b/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
@@ -86,7 +86,14 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    }
+                ]
             }
         },
         "bmqconfConfig": {

--- a/src/applications/bmqtool/bmqtool.m.cpp
+++ b/src/applications/bmqtool/bmqtool.m.cpp
@@ -204,6 +204,18 @@ static bool parseArgs(Parameters* parameters, int argc, const char* argv[])
          "address and port of the broker",
          balcl::TypeInfo(&params.broker()),
          balcl::OccurrenceInfo(params.broker())},
+        {"tls-authority",
+         "tlsAuthority",
+         "Path to the certificate authority FILE for TLS mode."
+         "The empty string value means that TLS is disabled, "
+         "non-empty string value means that TLS is enabled",
+         balcl::TypeInfo(&params.tlsAuthority()),
+         balcl::OccurrenceInfo(params.tlsAuthority())},
+        {"tls-versions",
+         "tlsVersions",
+         "TLS protocol versions, has effect only in TLS mode",
+         balcl::TypeInfo(&params.tlsVersions()),
+         balcl::OccurrenceInfo(params.tlsVersions())},
         {"q|queueuri",
          "uri",
          "URI of the queue (for auto/syschk modes)",

--- a/src/applications/bmqtool/bmqtoolcmd.xsd
+++ b/src/applications/bmqtool/bmqtoolcmd.xsd
@@ -223,6 +223,8 @@
     <sequence>
       <element name='mode'                     type='string'  default="cli"/>
       <element name='broker'                   type='string'  default="tcp://localhost:30114"/>
+      <element name='tlsAuthority'             type='string'  default=""/>
+      <element name='tlsVersions'              type='string'  default="TLSv1.3"/>
       <element name='queueUri'                 type='string'  default=""/>
       <element name='queueFlags'               type='string'  default=""/>
       <element name='latency'                  type='string'  default="none"/>

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -596,6 +596,11 @@ int Application::initialize()
                                     d_parameters.authnData()));
     }
 
+    if (!d_parameters.tlsAuthority().empty()) {
+        options.configureTls(d_parameters.tlsAuthority(),
+                             d_parameters.tlsVersions());
+    }
+
     // Create the session
     if (d_parameters.noSessionEventHandler()) {
         d_session_mp.load(new (*d_allocator_p)

--- a/src/applications/bmqtool/m_bmqtool_messages.cpp
+++ b/src/applications/bmqtool/m_bmqtool_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2026 Bloomberg Finance L.P.
+// Copyright 2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -4312,6 +4312,11 @@ const char CommandLineParameters::DEFAULT_INITIALIZER_MODE[] = "cli";
 const char CommandLineParameters::DEFAULT_INITIALIZER_BROKER[] =
     "tcp://localhost:30114";
 
+const char CommandLineParameters::DEFAULT_INITIALIZER_TLS_AUTHORITY[] = "";
+
+const char CommandLineParameters::DEFAULT_INITIALIZER_TLS_VERSIONS[] =
+    "TLSv1.3";
+
 const char CommandLineParameters::DEFAULT_INITIALIZER_QUEUE_URI[] = "";
 
 const char CommandLineParameters::DEFAULT_INITIALIZER_QUEUE_FLAGS[] = "";
@@ -4378,6 +4383,16 @@ const bdlat_AttributeInfo CommandLineParameters::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_BROKER,
      "broker",
      sizeof("broker") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_TLS_AUTHORITY,
+     "tlsAuthority",
+     sizeof("tlsAuthority") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_TLS_VERSIONS,
+     "tlsVersions",
+     sizeof("tlsVersions") - 1,
      "",
      bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_QUEUE_URI,
@@ -4521,7 +4536,7 @@ const bdlat_AttributeInfo CommandLineParameters::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 CommandLineParameters::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 29; ++i) {
+    for (int i = 0; i < 31; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             CommandLineParameters::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -4540,6 +4555,10 @@ const bdlat_AttributeInfo* CommandLineParameters::lookupAttributeInfo(int id)
     case ATTRIBUTE_ID_MODE: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MODE];
     case ATTRIBUTE_ID_BROKER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BROKER];
+    case ATTRIBUTE_ID_TLS_AUTHORITY:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_AUTHORITY];
+    case ATTRIBUTE_ID_TLS_VERSIONS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_VERSIONS];
     case ATTRIBUTE_ID_QUEUE_URI:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUE_URI];
     case ATTRIBUTE_ID_QUEUE_FLAGS:
@@ -4606,6 +4625,8 @@ CommandLineParameters::CommandLineParameters(bslma::Allocator* basicAllocator)
 , d_messageProperties(basicAllocator)
 , d_mode(DEFAULT_INITIALIZER_MODE, basicAllocator)
 , d_broker(DEFAULT_INITIALIZER_BROKER, basicAllocator)
+, d_tlsAuthority(DEFAULT_INITIALIZER_TLS_AUTHORITY, basicAllocator)
+, d_tlsVersions(DEFAULT_INITIALIZER_TLS_VERSIONS, basicAllocator)
 , d_queueUri(DEFAULT_INITIALIZER_QUEUE_URI, basicAllocator)
 , d_queueFlags(DEFAULT_INITIALIZER_QUEUE_FLAGS, basicAllocator)
 , d_latency(DEFAULT_INITIALIZER_LATENCY, basicAllocator)
@@ -4642,6 +4663,8 @@ CommandLineParameters::CommandLineParameters(
 , d_messageProperties(original.d_messageProperties, basicAllocator)
 , d_mode(original.d_mode, basicAllocator)
 , d_broker(original.d_broker, basicAllocator)
+, d_tlsAuthority(original.d_tlsAuthority, basicAllocator)
+, d_tlsVersions(original.d_tlsVersions, basicAllocator)
 , d_queueUri(original.d_queueUri, basicAllocator)
 , d_queueFlags(original.d_queueFlags, basicAllocator)
 , d_latency(original.d_latency, basicAllocator)
@@ -4679,6 +4702,8 @@ CommandLineParameters::CommandLineParameters(
   d_messageProperties(bsl::move(original.d_messageProperties)),
   d_mode(bsl::move(original.d_mode)),
   d_broker(bsl::move(original.d_broker)),
+  d_tlsAuthority(bsl::move(original.d_tlsAuthority)),
+  d_tlsVersions(bsl::move(original.d_tlsVersions)),
   d_queueUri(bsl::move(original.d_queueUri)),
   d_queueFlags(bsl::move(original.d_queueFlags)),
   d_latency(bsl::move(original.d_latency)),
@@ -4713,6 +4738,8 @@ CommandLineParameters::CommandLineParameters(CommandLineParameters&& original,
 , d_messageProperties(bsl::move(original.d_messageProperties), basicAllocator)
 , d_mode(bsl::move(original.d_mode), basicAllocator)
 , d_broker(bsl::move(original.d_broker), basicAllocator)
+, d_tlsAuthority(bsl::move(original.d_tlsAuthority), basicAllocator)
+, d_tlsVersions(bsl::move(original.d_tlsVersions), basicAllocator)
 , d_queueUri(bsl::move(original.d_queueUri), basicAllocator)
 , d_queueFlags(bsl::move(original.d_queueFlags), basicAllocator)
 , d_latency(bsl::move(original.d_latency), basicAllocator)
@@ -4754,6 +4781,8 @@ CommandLineParameters::operator=(const CommandLineParameters& rhs)
     if (this != &rhs) {
         d_mode                     = rhs.d_mode;
         d_broker                   = rhs.d_broker;
+        d_tlsAuthority             = rhs.d_tlsAuthority;
+        d_tlsVersions              = rhs.d_tlsVersions;
         d_queueUri                 = rhs.d_queueUri;
         d_queueFlags               = rhs.d_queueFlags;
         d_latency                  = rhs.d_latency;
@@ -4794,6 +4823,8 @@ CommandLineParameters::operator=(CommandLineParameters&& rhs)
     if (this != &rhs) {
         d_mode                     = bsl::move(rhs.d_mode);
         d_broker                   = bsl::move(rhs.d_broker);
+        d_tlsAuthority             = bsl::move(rhs.d_tlsAuthority);
+        d_tlsVersions              = bsl::move(rhs.d_tlsVersions);
         d_queueUri                 = bsl::move(rhs.d_queueUri);
         d_queueFlags               = bsl::move(rhs.d_queueFlags);
         d_latency                  = bsl::move(rhs.d_latency);
@@ -4831,6 +4862,8 @@ void CommandLineParameters::reset()
 {
     d_mode                  = DEFAULT_INITIALIZER_MODE;
     d_broker                = DEFAULT_INITIALIZER_BROKER;
+    d_tlsAuthority          = DEFAULT_INITIALIZER_TLS_AUTHORITY;
+    d_tlsVersions           = DEFAULT_INITIALIZER_TLS_VERSIONS;
     d_queueUri              = DEFAULT_INITIALIZER_QUEUE_URI;
     d_queueFlags            = DEFAULT_INITIALIZER_QUEUE_FLAGS;
     d_latency               = DEFAULT_INITIALIZER_LATENCY;
@@ -4871,6 +4904,8 @@ bsl::ostream& CommandLineParameters::print(bsl::ostream& stream,
     printer.start();
     printer.printAttribute("mode", this->mode());
     printer.printAttribute("broker", this->broker());
+    printer.printAttribute("tlsAuthority", this->tlsAuthority());
+    printer.printAttribute("tlsVersions", this->tlsVersions());
     printer.printAttribute("queueUri", this->queueUri());
     printer.printAttribute("queueFlags", this->queueFlags());
     printer.printAttribute("latency", this->latency());
@@ -6889,3 +6924,7 @@ const char* Command::selectionName() const
 }
 }  // close package namespace
 }  // close enterprise namespace
+
+// GENERATED BY BLP_BAS_CODEGEN_2026.03.05
+// USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
+// --noIdent --package m_bmqtool --msgComponent messages bmqtoolcmd.xsd

--- a/src/applications/bmqtool/m_bmqtool_messages.h
+++ b/src/applications/bmqtool/m_bmqtool_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2026 Bloomberg Finance L.P.
+// Copyright 2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,6 +46,7 @@
 
 #include <bsl_iosfwd.h>
 #include <bsl_limits.h>
+#include <bsl_type_traits.h>
 
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -5263,6 +5264,8 @@ class CommandLineParameters {
     bsl::vector<MessageProperty> d_messageProperties;
     bsl::string                  d_mode;
     bsl::string                  d_broker;
+    bsl::string                  d_tlsAuthority;
+    bsl::string                  d_tlsVersions;
     bsl::string                  d_queueUri;
     bsl::string                  d_queueFlags;
     bsl::string                  d_latency;
@@ -5299,67 +5302,71 @@ class CommandLineParameters {
     enum {
         ATTRIBUTE_ID_MODE                       = 0,
         ATTRIBUTE_ID_BROKER                     = 1,
-        ATTRIBUTE_ID_QUEUE_URI                  = 2,
-        ATTRIBUTE_ID_QUEUE_FLAGS                = 3,
-        ATTRIBUTE_ID_LATENCY                    = 4,
-        ATTRIBUTE_ID_LATENCY_REPORT             = 5,
-        ATTRIBUTE_ID_DUMP_MSG                   = 6,
-        ATTRIBUTE_ID_CONFIRM_MSG                = 7,
-        ATTRIBUTE_ID_EVENT_SIZE                 = 8,
-        ATTRIBUTE_ID_MSG_SIZE                   = 9,
-        ATTRIBUTE_ID_POST_RATE                  = 10,
-        ATTRIBUTE_ID_EVENTS_COUNT               = 11,
-        ATTRIBUTE_ID_MAX_UNCONFIRMED            = 12,
-        ATTRIBUTE_ID_POST_INTERVAL              = 13,
-        ATTRIBUTE_ID_VERBOSITY                  = 14,
-        ATTRIBUTE_ID_LOG_FORMAT                 = 15,
-        ATTRIBUTE_ID_MEMORY_DEBUG               = 16,
-        ATTRIBUTE_ID_THREADS                    = 17,
-        ATTRIBUTE_ID_SHUTDOWN_GRACE             = 18,
-        ATTRIBUTE_ID_NO_SESSION_EVENT_HANDLER   = 19,
-        ATTRIBUTE_ID_STORAGE                    = 20,
-        ATTRIBUTE_ID_LOG                        = 21,
-        ATTRIBUTE_ID_SEQUENTIAL_MESSAGE_PATTERN = 22,
-        ATTRIBUTE_ID_MESSAGE_PROPERTIES         = 23,
-        ATTRIBUTE_ID_SUBSCRIPTIONS              = 24,
-        ATTRIBUTE_ID_AUTO_PUB_SUB_MODULO        = 25,
-        ATTRIBUTE_ID_TIMEOUT_SEC                = 26,
-        ATTRIBUTE_ID_AUTHN_MECHANISM            = 27,
-        ATTRIBUTE_ID_AUTHN_DATA                 = 28
+        ATTRIBUTE_ID_TLS_AUTHORITY              = 2,
+        ATTRIBUTE_ID_TLS_VERSIONS               = 3,
+        ATTRIBUTE_ID_QUEUE_URI                  = 4,
+        ATTRIBUTE_ID_QUEUE_FLAGS                = 5,
+        ATTRIBUTE_ID_LATENCY                    = 6,
+        ATTRIBUTE_ID_LATENCY_REPORT             = 7,
+        ATTRIBUTE_ID_DUMP_MSG                   = 8,
+        ATTRIBUTE_ID_CONFIRM_MSG                = 9,
+        ATTRIBUTE_ID_EVENT_SIZE                 = 10,
+        ATTRIBUTE_ID_MSG_SIZE                   = 11,
+        ATTRIBUTE_ID_POST_RATE                  = 12,
+        ATTRIBUTE_ID_EVENTS_COUNT               = 13,
+        ATTRIBUTE_ID_MAX_UNCONFIRMED            = 14,
+        ATTRIBUTE_ID_POST_INTERVAL              = 15,
+        ATTRIBUTE_ID_VERBOSITY                  = 16,
+        ATTRIBUTE_ID_LOG_FORMAT                 = 17,
+        ATTRIBUTE_ID_MEMORY_DEBUG               = 18,
+        ATTRIBUTE_ID_THREADS                    = 19,
+        ATTRIBUTE_ID_SHUTDOWN_GRACE             = 20,
+        ATTRIBUTE_ID_NO_SESSION_EVENT_HANDLER   = 21,
+        ATTRIBUTE_ID_STORAGE                    = 22,
+        ATTRIBUTE_ID_LOG                        = 23,
+        ATTRIBUTE_ID_SEQUENTIAL_MESSAGE_PATTERN = 24,
+        ATTRIBUTE_ID_MESSAGE_PROPERTIES         = 25,
+        ATTRIBUTE_ID_SUBSCRIPTIONS              = 26,
+        ATTRIBUTE_ID_AUTO_PUB_SUB_MODULO        = 27,
+        ATTRIBUTE_ID_TIMEOUT_SEC                = 28,
+        ATTRIBUTE_ID_AUTHN_MECHANISM            = 29,
+        ATTRIBUTE_ID_AUTHN_DATA                 = 30
     };
 
-    enum { NUM_ATTRIBUTES = 29 };
+    enum { NUM_ATTRIBUTES = 31 };
 
     enum {
         ATTRIBUTE_INDEX_MODE                       = 0,
         ATTRIBUTE_INDEX_BROKER                     = 1,
-        ATTRIBUTE_INDEX_QUEUE_URI                  = 2,
-        ATTRIBUTE_INDEX_QUEUE_FLAGS                = 3,
-        ATTRIBUTE_INDEX_LATENCY                    = 4,
-        ATTRIBUTE_INDEX_LATENCY_REPORT             = 5,
-        ATTRIBUTE_INDEX_DUMP_MSG                   = 6,
-        ATTRIBUTE_INDEX_CONFIRM_MSG                = 7,
-        ATTRIBUTE_INDEX_EVENT_SIZE                 = 8,
-        ATTRIBUTE_INDEX_MSG_SIZE                   = 9,
-        ATTRIBUTE_INDEX_POST_RATE                  = 10,
-        ATTRIBUTE_INDEX_EVENTS_COUNT               = 11,
-        ATTRIBUTE_INDEX_MAX_UNCONFIRMED            = 12,
-        ATTRIBUTE_INDEX_POST_INTERVAL              = 13,
-        ATTRIBUTE_INDEX_VERBOSITY                  = 14,
-        ATTRIBUTE_INDEX_LOG_FORMAT                 = 15,
-        ATTRIBUTE_INDEX_MEMORY_DEBUG               = 16,
-        ATTRIBUTE_INDEX_THREADS                    = 17,
-        ATTRIBUTE_INDEX_SHUTDOWN_GRACE             = 18,
-        ATTRIBUTE_INDEX_NO_SESSION_EVENT_HANDLER   = 19,
-        ATTRIBUTE_INDEX_STORAGE                    = 20,
-        ATTRIBUTE_INDEX_LOG                        = 21,
-        ATTRIBUTE_INDEX_SEQUENTIAL_MESSAGE_PATTERN = 22,
-        ATTRIBUTE_INDEX_MESSAGE_PROPERTIES         = 23,
-        ATTRIBUTE_INDEX_SUBSCRIPTIONS              = 24,
-        ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO        = 25,
-        ATTRIBUTE_INDEX_TIMEOUT_SEC                = 26,
-        ATTRIBUTE_INDEX_AUTHN_MECHANISM            = 27,
-        ATTRIBUTE_INDEX_AUTHN_DATA                 = 28
+        ATTRIBUTE_INDEX_TLS_AUTHORITY              = 2,
+        ATTRIBUTE_INDEX_TLS_VERSIONS               = 3,
+        ATTRIBUTE_INDEX_QUEUE_URI                  = 4,
+        ATTRIBUTE_INDEX_QUEUE_FLAGS                = 5,
+        ATTRIBUTE_INDEX_LATENCY                    = 6,
+        ATTRIBUTE_INDEX_LATENCY_REPORT             = 7,
+        ATTRIBUTE_INDEX_DUMP_MSG                   = 8,
+        ATTRIBUTE_INDEX_CONFIRM_MSG                = 9,
+        ATTRIBUTE_INDEX_EVENT_SIZE                 = 10,
+        ATTRIBUTE_INDEX_MSG_SIZE                   = 11,
+        ATTRIBUTE_INDEX_POST_RATE                  = 12,
+        ATTRIBUTE_INDEX_EVENTS_COUNT               = 13,
+        ATTRIBUTE_INDEX_MAX_UNCONFIRMED            = 14,
+        ATTRIBUTE_INDEX_POST_INTERVAL              = 15,
+        ATTRIBUTE_INDEX_VERBOSITY                  = 16,
+        ATTRIBUTE_INDEX_LOG_FORMAT                 = 17,
+        ATTRIBUTE_INDEX_MEMORY_DEBUG               = 18,
+        ATTRIBUTE_INDEX_THREADS                    = 19,
+        ATTRIBUTE_INDEX_SHUTDOWN_GRACE             = 20,
+        ATTRIBUTE_INDEX_NO_SESSION_EVENT_HANDLER   = 21,
+        ATTRIBUTE_INDEX_STORAGE                    = 22,
+        ATTRIBUTE_INDEX_LOG                        = 23,
+        ATTRIBUTE_INDEX_SEQUENTIAL_MESSAGE_PATTERN = 24,
+        ATTRIBUTE_INDEX_MESSAGE_PROPERTIES         = 25,
+        ATTRIBUTE_INDEX_SUBSCRIPTIONS              = 26,
+        ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO        = 27,
+        ATTRIBUTE_INDEX_TIMEOUT_SEC                = 28,
+        ATTRIBUTE_INDEX_AUTHN_MECHANISM            = 29,
+        ATTRIBUTE_INDEX_AUTHN_DATA                 = 30
     };
 
     // CONSTANTS
@@ -5368,6 +5375,10 @@ class CommandLineParameters {
     static const char DEFAULT_INITIALIZER_MODE[];
 
     static const char DEFAULT_INITIALIZER_BROKER[];
+
+    static const char DEFAULT_INITIALIZER_TLS_AUTHORITY[];
+
+    static const char DEFAULT_INITIALIZER_TLS_VERSIONS[];
 
     static const char DEFAULT_INITIALIZER_QUEUE_URI[];
 
@@ -5518,6 +5529,14 @@ class CommandLineParameters {
 
     bsl::string& broker();
     // Return a reference to the modifiable "Broker" attribute of this
+    // object.
+
+    bsl::string& tlsAuthority();
+    // Return a reference to the modifiable "TlsAuthority" attribute of
+    // this object.
+
+    bsl::string& tlsVersions();
+    // Return a reference to the modifiable "TlsVersions" attribute of this
     // object.
 
     bsl::string& queueUri();
@@ -5677,6 +5696,14 @@ class CommandLineParameters {
     const bsl::string& broker() const;
     // Return a reference offering non-modifiable access to the "Broker"
     // attribute of this object.
+
+    const bsl::string& tlsAuthority() const;
+    // Return a reference offering non-modifiable access to the
+    // "TlsAuthority" attribute of this object.
+
+    const bsl::string& tlsVersions() const;
+    // Return a reference offering non-modifiable access to the
+    // "TlsVersions" attribute of this object.
 
     const bsl::string& queueUri() const;
     // Return a reference offering non-modifiable access to the "QueueUri"
@@ -10651,6 +10678,8 @@ void CommandLineParameters::hashAppendImpl(
     using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->mode());
     hashAppend(hashAlgorithm, this->broker());
+    hashAppend(hashAlgorithm, this->tlsAuthority());
+    hashAppend(hashAlgorithm, this->tlsVersions());
     hashAppend(hashAlgorithm, this->queueUri());
     hashAppend(hashAlgorithm, this->queueFlags());
     hashAppend(hashAlgorithm, this->latency());
@@ -10684,6 +10713,8 @@ inline bool
 CommandLineParameters::isEqualTo(const CommandLineParameters& rhs) const
 {
     return this->mode() == rhs.mode() && this->broker() == rhs.broker() &&
+           this->tlsAuthority() == rhs.tlsAuthority() &&
+           this->tlsVersions() == rhs.tlsVersions() &&
            this->queueUri() == rhs.queueUri() &&
            this->queueFlags() == rhs.queueFlags() &&
            this->latency() == rhs.latency() &&
@@ -10726,6 +10757,18 @@ int CommandLineParameters::manipulateAttributes(t_MANIPULATOR& manipulator)
     }
 
     ret = manipulator(&d_broker, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BROKER]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_tlsAuthority,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_AUTHORITY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_tlsVersions,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_VERSIONS]);
     if (ret) {
         return ret;
     }
@@ -10913,6 +10956,15 @@ int CommandLineParameters::manipulateAttribute(t_MANIPULATOR& manipulator,
         return manipulator(&d_broker,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BROKER]);
     }
+    case ATTRIBUTE_ID_TLS_AUTHORITY: {
+        return manipulator(
+            &d_tlsAuthority,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_AUTHORITY]);
+    }
+    case ATTRIBUTE_ID_TLS_VERSIONS: {
+        return manipulator(&d_tlsVersions,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_VERSIONS]);
+    }
     case ATTRIBUTE_ID_QUEUE_URI: {
         return manipulator(&d_queueUri,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUE_URI]);
@@ -11058,6 +11110,16 @@ inline bsl::string& CommandLineParameters::mode()
 inline bsl::string& CommandLineParameters::broker()
 {
     return d_broker;
+}
+
+inline bsl::string& CommandLineParameters::tlsAuthority()
+{
+    return d_tlsAuthority;
+}
+
+inline bsl::string& CommandLineParameters::tlsVersions()
+{
+    return d_tlsVersions;
 }
 
 inline bsl::string& CommandLineParameters::queueUri()
@@ -11207,6 +11269,18 @@ int CommandLineParameters::accessAttributes(t_ACCESSOR& accessor) const
     }
 
     ret = accessor(d_broker, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BROKER]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_tlsAuthority,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_AUTHORITY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_tlsVersions,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_VERSIONS]);
     if (ret) {
         return ret;
     }
@@ -11385,6 +11459,14 @@ int CommandLineParameters::accessAttribute(t_ACCESSOR& accessor, int id) const
         return accessor(d_broker,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BROKER]);
     }
+    case ATTRIBUTE_ID_TLS_AUTHORITY: {
+        return accessor(d_tlsAuthority,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_AUTHORITY]);
+    }
+    case ATTRIBUTE_ID_TLS_VERSIONS: {
+        return accessor(d_tlsVersions,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_VERSIONS]);
+    }
     case ATTRIBUTE_ID_QUEUE_URI: {
         return accessor(d_queueUri,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUE_URI]);
@@ -11524,6 +11606,16 @@ inline const bsl::string& CommandLineParameters::mode() const
 inline const bsl::string& CommandLineParameters::broker() const
 {
     return d_broker;
+}
+
+inline const bsl::string& CommandLineParameters::tlsAuthority() const
+{
+    return d_tlsAuthority;
+}
+
+inline const bsl::string& CommandLineParameters::tlsVersions() const
+{
+    return d_tlsVersions;
 }
 
 inline const bsl::string& CommandLineParameters::queueUri() const
@@ -12623,6 +12715,6 @@ inline bool Command::isUndefinedValue() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.02.05
+// GENERATED BY BLP_BAS_CODEGEN_2026.03.05
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package m_bmqtool --msgComponent messages bmqtoolcmd.xsd

--- a/src/applications/bmqtool/m_bmqtool_parameters.cpp
+++ b/src/applications/bmqtool/m_bmqtool_parameters.cpp
@@ -253,18 +253,39 @@ bool ParametersLatency::isValid(const bsl::string* str, bsl::ostream& stream)
 // ================
 
 Parameters::Parameters(bslma::Allocator* allocator)
-: d_broker(allocator)
+: d_mode(ParametersMode::Value::e_CLI)
+, d_broker(allocator)
 , d_queueUri(allocator)
 , d_qlistFilePath(allocator)
 , d_journalFilePath(allocator)
 , d_dataFilePath(allocator)
+, d_sequentialMessagePattern(allocator)
+, d_queueFlags(0)
+, d_latency(ParametersLatency::Value::e_NONE)
 , d_latencyReportPath(allocator)
 , d_logFilePath(allocator)
+, d_dumpMsg(false)
+, d_confirmMsg(false)
+, d_eventSize(0)
+, d_msgSize(0)
+, d_postRate(0)
+, d_postInterval(0)
+, d_eventsCount(0)
+, d_maxUnconfirmedMsgs(0)
+, d_maxUnconfirmedBytes(0)
+, d_verbosity(ParametersVerbosity::Value::e_INFO)
+, d_logFormat(allocator)
+, d_numProcessingThreads(0)
+, d_shutdownGrace(0)
+, d_noSessionEventHandler(false)
+, d_memoryDebug(false)
 , d_messageProperties(allocator)
 , d_subscriptions(allocator)
 , d_autoIncrementedField(allocator)
 , d_authnMechanism(allocator)
 , d_authnData(allocator)
+, d_tlsAuthority(allocator)
+, d_tlsVersions(allocator)
 {
     CommandLineParameters params(allocator);
     const bool            rc = from(bsl::cerr, params);
@@ -311,6 +332,8 @@ Parameters::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     printer.printAttribute("messageProperties", d_messageProperties);
     printer.printAttribute("subscriptions", d_subscriptions);
     printer.printAttribute("timeout", d_timeout);
+    printer.printAttribute("tlsAuthority", d_tlsAuthority);
+    printer.printAttribute("tlsVersions", d_tlsVersions);
     printer.end();
 
     return stream;
@@ -423,6 +446,8 @@ bool Parameters::from(bsl::ostream&                stream,
     setTimeout(timeout);
     setAuthnMechanism(params.authnMechanism());
     setAuthnData(params.authnData());
+    setTlsAuthority(params.tlsAuthority());
+    setTlsVersions(params.tlsVersions());
 
     return true;
 }

--- a/src/applications/bmqtool/m_bmqtool_parameters.h
+++ b/src/applications/bmqtool/m_bmqtool_parameters.h
@@ -285,7 +285,14 @@ class Parameters {
     // authentication callback is set.
 
     bsl::string d_authnData;
+
     // Authentication data/credentials string.
+    /// A path to the FILE, containing concatenation of known certificates
+    /// the client can use to reference as its certificate store.
+    bsl::string d_tlsAuthority;
+
+    /// A string with a comma-separated list of supported TLS versions.
+    bsl::string d_tlsVersions;
 
   public:
     // CREATORS
@@ -326,6 +333,8 @@ class Parameters {
     Parameters& setTimeout(const bsls::TimeInterval& value);
     Parameters& setAuthnMechanism(const bsl::string& value);
     Parameters& setAuthnData(const bsl::string& value);
+    Parameters& setTlsAuthority(const bsl::string& value);
+    Parameters& setTlsVersions(const bsl::string& value);
 
     // Set the corresponding member to the specified 'value' and return a
     // reference offering modifiable access to this object.
@@ -390,6 +399,8 @@ class Parameters {
     const bsl::string&                  authnData() const;
 
     const char* autoPubSubPropertyName() const;
+    const bsl::string&                  tlsAuthority() const;
+    const bsl::string&                  tlsVersions() const;
 };
 
 // FREE OPERATORS
@@ -609,7 +620,18 @@ inline Parameters& Parameters::setAutoPubSubModulo(int autoPubSubModulo)
 inline Parameters& Parameters::setTimeout(const bsls::TimeInterval& value)
 {
     d_timeout = value;
+    return *this;
+}
 
+inline Parameters& Parameters::setTlsAuthority(const bsl::string& value)
+{
+    d_tlsAuthority = value;
+    return *this;
+}
+
+inline Parameters& Parameters::setTlsVersions(const bsl::string& value)
+{
+    d_tlsVersions = value;
     return *this;
 }
 
@@ -790,6 +812,16 @@ inline const bsl::string& Parameters::authnMechanism() const
 inline const bsl::string& Parameters::authnData() const
 {
     return d_authnData;
+}
+
+inline const bsl::string& Parameters::tlsAuthority() const
+{
+    return d_tlsAuthority;
+}
+
+inline const bsl::string& Parameters::tlsVersions() const
+{
+    return d_tlsVersions;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqex/bmqex_bindutil.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil.h
@@ -151,12 +151,16 @@
 #include <bsls_compilerfeatures.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
-#define COMPILING_BMQEX_BINDUTIL_H
-#include <bmqex_bindutil_cpp03.h>
-#undef COMPILING_BMQEX_BINDUTIL_H
+
+# define COMPILING_BMQEX_BINDUTIL_H
+# include <bmqex_bindutil_cpp03.h>
+# undef COMPILING_BMQEX_BINDUTIL_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -166,7 +170,7 @@ namespace bmqex {
 // struct BindUtil_DummyNullaryFunction
 // ====================================
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
 /// Provides a dummy nullary function object which result type is the same
 /// as the result type of the specified `FUNCTION` when invoked with
@@ -253,7 +257,7 @@ class BindUtil_BindWrapper {
     typename ExecutionUtil::ExecuteResult<POLICY, FUNCTION>::Type
     operator()() const;
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
 
     /// Call `ExecutionUtil::execute(p, bsl::move(f2))` and return the
     /// result of that operation, where `p` is the contained execution
@@ -371,7 +375,7 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()() const
     return ExecutionUtil::execute(d_policy, d_function.object());
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
 template <class POLICY, class FUNCTION>
 template <class ARG1, class... ARGS>
 inline typename ExecutionUtil::ExecuteResult<
@@ -418,7 +422,8 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
+
 #include <bsl_type_traits.h>
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_bindutil.cpp
 
 #define INCLUDED_BMQEX_BINDUTIL_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_BINDUTIL_CPP)
+#endif // defined(COMPILING_BMQEX_BINDUTIL_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
 
 #ifdef COMPILING_BMQEX_BINDUTIL_H
@@ -60,57 +60,49 @@ namespace bmqex {
 
 template <class FUNCTION
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
-          ,
-          class ARGS_0 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_0 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
-          ,
-          class ARGS_1 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_1 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-          ,
-          class ARGS_2 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_2 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-          ,
-          class ARGS_3 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_3 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-          ,
-          class ARGS_4 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_4 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-          ,
-          class ARGS_5 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_5 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-          ,
-          class ARGS_6 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_6 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-          ,
-          class ARGS_7 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_7 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class ARGS_8 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_8 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class = BSLS_COMPILERFEATURES_NILT>
+        , class = BSLS_COMPILERFEATURES_NILT>
 struct BindUtil_DummyNullaryFunction;
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 template <class FUNCTION>
 struct BindUtil_DummyNullaryFunction<FUNCTION> {
+
     typedef typename bsl::invoke_result<FUNCTION>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -119,193 +111,205 @@ struct BindUtil_DummyNullaryFunction<FUNCTION> {
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 template <class FUNCTION, class ARGS_1>
 struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1> {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS_1>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-template <class FUNCTION, class ARGS_1, class ARGS_2>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-template <class FUNCTION, class ARGS_1, class ARGS_2, class ARGS_3>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2, ARGS_3> {
-    typedef typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3>::type
-        ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4>::
-            type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5> {
-    typedef typename bsl::
-        invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4, ARGS_5>::type
-            ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 9
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8,
-                                     ARGS_9> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8,
-                                        ARGS_9>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8,
+                                               ARGS_9> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8,
+                                                  ARGS_9>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -317,7 +321,9 @@ struct BindUtil_DummyNullaryFunction<FUNCTION,
 
 template <class FUNCTION, class... ARGS>
 struct BindUtil_DummyNullaryFunction {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS...>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -407,8 +413,9 @@ class BindUtil_BindWrapper {
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-    operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type
+        operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 0
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
@@ -424,7 +431,8 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
-    template <class ARG1, class ARGS_1, class ARGS_2>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -438,7 +446,9 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
-    template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -454,11 +464,10 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -476,12 +485,11 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -501,13 +509,12 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -529,14 +536,13 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -560,15 +566,14 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -594,8 +599,8 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class ARG1, class... ARGS>
     typename ExecutionUtil::ExecuteResult<
@@ -722,18 +727,19 @@ inline typename ExecutionUtil::ExecuteResult<
     BindUtil_DummyNullaryFunction<FUNCTION,
                                   typename bsl::decay<ARG1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-        ResultType;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type ResultType;
 
-    return ExecutionUtil::execute(
-        d_policy,
-        bdlf::BindUtil::bindR<ResultType>(d_function.object(),
-                                          bslmf::Util::forward<ARG1>(arg1)));
+    return ExecutionUtil::execute(d_policy,
+                                  bdlf::BindUtil::bindR<ResultType>(
+                                      d_function.object(),
+                                      bslmf::Util::forward<ARG1>(arg1)));
 }
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 0
 
@@ -746,8 +752,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS_1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -766,7 +773,8 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 2
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -774,9 +782,10 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_1>::type,
                                   typename bsl::decay<ARGS_2>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -797,7 +806,9 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 3
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -806,10 +817,11 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_2>::type,
                                   typename bsl::decay<ARGS_3>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -832,7 +844,10 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 4
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -842,11 +857,12 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_3>::type,
                                   typename bsl::decay<ARGS_4>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -871,12 +887,11 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 5
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -887,12 +902,13 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_4>::type,
                                   typename bsl::decay<ARGS_5>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -919,13 +935,12 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 6
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -937,13 +952,14 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_5>::type,
                                   typename bsl::decay<ARGS_6>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -972,14 +988,13 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 7
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -992,14 +1007,15 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_6>::type,
                                   typename bsl::decay<ARGS_7>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1030,15 +1046,14 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 8
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -1052,15 +1067,16 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_7>::type,
                                   typename bsl::decay<ARGS_8>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1102,8 +1118,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS>::type...> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                                BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1142,8 +1159,9 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_BINDUTIL_H)
-#error Not valid except when included from bmqex_bindutil.h
-#endif  // ! defined(COMPILING_BMQEX_BINDUTIL_H)
+#else // if ! defined(DEFINED_BMQEX_BINDUTIL_H)
+# error Not valid except when included from bmqex_bindutil.h
+#endif // ! defined(COMPILING_BMQEX_BINDUTIL_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_BINDUTIL_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_BINDUTIL_CPP03)
+

--- a/src/groups/bmq/bmqex/bmqex_future.h
+++ b/src/groups/bmq/bmqex/bmqex_future.h
@@ -148,12 +148,16 @@
 #include <bsls_timeinterval.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_future.h
-#define COMPILING_BMQEX_FUTURE_H
-#include <bmqex_future_cpp03.h>
-#undef COMPILING_BMQEX_FUTURE_H
+
+# define COMPILING_BMQEX_FUTURE_H
+# include <bmqex_future_cpp03.h>
+# undef COMPILING_BMQEX_FUTURE_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -952,7 +956,7 @@ class FutureSharedState {
     /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Atomically initialize the stored value as if by direct-non-list-
     /// initializing an object of type `R` with 'bsl::forward<ARGS>(
@@ -1665,7 +1669,7 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
     emplaceValue(bslmf::MovableRefUtil::move(value));
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(ARGS&&... args)
@@ -1903,7 +1907,8 @@ inline void bmqex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
+
 #include <bsl_type_traits.h>
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_future.cpp
 
 #define INCLUDED_BMQEX_FUTURE_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_FUTURE_CPP)
+#endif // defined(COMPILING_BMQEX_FUTURE_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_future.h
 
 #ifdef COMPILING_BMQEX_FUTURE_H
@@ -857,20 +857,26 @@ class FutureSharedState {
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -963,8 +969,8 @@ class FutureSharedState {
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
@@ -1648,7 +1654,6 @@ inline FutureSharedState<R>::~FutureSharedState()
     default: {
         // Unreachable code, but makes the compiler happy.
         BSLS_ASSERT(false);
-        BSLS_ASSERT_INVOKE_NORETURN("");
     }
     }
 }
@@ -1677,7 +1682,8 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
 #endif
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 0
 template <class R>
-inline void FutureSharedState<R>::emplaceValue()
+inline void FutureSharedState<R>::emplaceValue(
+                               )
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1701,9 +1707,8 @@ inline void FutureSharedState<R>::emplaceValue()
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 1
 template <class R>
 template <class ARGS_1>
-inline void
-FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                       args_1)
+inline void FutureSharedState<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1727,10 +1732,11 @@ FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 2
 template <class R>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1755,11 +1761,13 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 3
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1785,12 +1793,15 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 4
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1817,13 +1828,17 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 5
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1858,12 +1873,12 @@ template <class ARGS_1,
           class ARGS_5,
           class ARGS_6>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1900,13 +1915,13 @@ template <class ARGS_1,
           class ARGS_6,
           class ARGS_7>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1945,14 +1960,14 @@ template <class ARGS_1,
           class ARGS_7,
           class ARGS_8>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1993,15 +2008,15 @@ template <class ARGS_1,
           class ARGS_8,
           class ARGS_9>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2037,7 +2052,7 @@ inline void FutureSharedState<R>::emplaceValue(
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2272,8 +2287,9 @@ inline void bmqex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_FUTURE_H)
-#error Not valid except when included from bmqex_future.h
-#endif  // ! defined(COMPILING_BMQEX_FUTURE_H)
+#else // if ! defined(DEFINED_BMQEX_FUTURE_H)
+# error Not valid except when included from bmqex_future.h
+#endif // ! defined(COMPILING_BMQEX_FUTURE_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_FUTURE_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_FUTURE_CPP03)
+

--- a/src/groups/bmq/bmqex/bmqex_promise.h
+++ b/src/groups/bmq/bmqex/bmqex_promise.h
@@ -89,12 +89,16 @@
 #include <bsls_systemclocktype.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_promise.h
+
 # define COMPILING_BMQEX_PROMISE_H
 # include <bmqex_promise_cpp03.h>
-#undef COMPILING_BMQEX_PROMISE_H
+# undef COMPILING_BMQEX_PROMISE_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -198,7 +202,7 @@ class Promise {
     /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Atomically store a value into the shared state as if by direct-non-
     /// list-initializing an object of type `R` with 'bsl::forward<ARGS>(
@@ -509,7 +513,7 @@ inline void Promise<R>::setValue(bslmf::MovableRef<R> value)
     d_sharedState->setValue(bslmf::MovableRefUtil::move(value));
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class R>
 template <class... ARGS>
 inline void Promise<R>::emplaceValue(ARGS&&... args)
@@ -719,6 +723,6 @@ inline void bmqex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_promise.cpp
 
 #define INCLUDED_BMQEX_PROMISE_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_PROMISE_CPP)
+#endif // defined(COMPILING_BMQEX_PROMISE_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:15 2025
+// Generated on Wed Mar 25 20:05:12 2026
 // Command line: sim_cpp11_features.pl bmqex_promise.h
 
 #ifdef COMPILING_BMQEX_PROMISE_H
@@ -162,20 +162,26 @@ class Promise {
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -268,8 +274,8 @@ class Promise {
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
@@ -577,7 +583,8 @@ inline void Promise<R>::setValue(bslmf::MovableRef<R> value)
 #endif
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 0
 template <class R>
-inline void Promise<R>::emplaceValue()
+inline void Promise<R>::emplaceValue(
+                               )
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -588,8 +595,8 @@ inline void Promise<R>::emplaceValue()
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 1
 template <class R>
 template <class ARGS_1>
-inline void Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                         args_1)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -599,10 +606,11 @@ inline void Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 2
 template <class R>
-template <class ARGS_1, class ARGS_2>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+template <class ARGS_1,
+          class ARGS_2>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -613,11 +621,13 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 3
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -629,12 +639,15 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 4
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -647,13 +660,17 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 5
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -673,13 +690,13 @@ template <class ARGS_1,
           class ARGS_4,
           class ARGS_5,
           class ARGS_6>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -701,14 +718,14 @@ template <class ARGS_1,
           class ARGS_5,
           class ARGS_6,
           class ARGS_7>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -732,15 +749,15 @@ template <class ARGS_1,
           class ARGS_6,
           class ARGS_7,
           class ARGS_8>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -766,16 +783,16 @@ template <class ARGS_1,
           class ARGS_7,
           class ARGS_8,
           class ARGS_9>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -796,8 +813,8 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 // forwarding in some compilers.
 template <class R>
 template <class... ARGS>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void Promise<R>::emplaceValue(
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -1004,8 +1021,9 @@ inline void bmqex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_PROMISE_H)
-#error Not valid except when included from bmqex_promise.h
-#endif  // ! defined(COMPILING_BMQEX_PROMISE_H)
+#else // if ! defined(DEFINED_BMQEX_PROMISE_H)
+# error Not valid except when included from bmqex_promise.h
+#endif // ! defined(COMPILING_BMQEX_PROMISE_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_PROMISE_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_PROMISE_CPP03)
+

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -14,16 +14,21 @@
 // limitations under the License.
 
 // bmqimp_application.cpp                                             -*-C++-*-
+#include <ball_log.h>
 #include <bmqimp_application.h>
 
-#include <bmqscm_version.h>
 // BMQ
 #include <bmqex_executionpolicy.h>
 #include <bmqex_systemexecutor.h>
 #include <bmqimp_authenticatedchannelfactory.h>
 #include <bmqimp_negotiatedchannelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_channelutil.h>
 #include <bmqio_connectoptions.h>
+#include <bmqio_reconnectingchannelfactory.h>
+#include <bmqio_resolvingchannelfactory.h>
+#include <bmqio_statchannel.h>
+#include <bmqio_statchannelfactory.h>
 #include <bmqio_status.h>
 #include <bmqio_tcpendpoint.h>
 #include <bmqma_countingallocatorutil.h>
@@ -35,10 +40,11 @@
 #include <bmqsys_threadutil.h>
 #include <bmqsys_time.h>
 #include <bmqt_resultcode.h>
+#include <bmqt_sessionoptions.h>
+#include <bmqt_tlsprotocolversion.h>
 #include <bmqt_uri.h>
-#include <bmqu_blob.h>
-#include <bmqu_memoutstream.h>
-#include <bmqu_printutil.h>
+#include <bmqu_stringutil.h>
+#include <bmqvt_valueorerror.h>
 
 // BDE
 #include <bdlb_scopeexit.h>
@@ -54,6 +60,8 @@
 #include <bsl_limits.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
+#include <bsla_unreachable.h>
+#include <bsla_unused.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslmt_lockguard.h>
@@ -140,6 +148,180 @@ ntcCreateInterfaceConfig(const bmqt::SessionOptions& sessionOptions,
     return config;
 }
 
+/// Convert a `bmqt::ProtocolVersion::Value` into its equivalent
+/// `ntca::EncryptionMethod::Value` value.
+///
+/// @param version A TLS protocol version value
+ntca::EncryptionMethod::Value
+toNtcEncryptionMethod(bmqt::TlsProtocolVersion::Value version)
+{
+    switch (version) {
+    case bmqt::TlsProtocolVersion::e_TLS1_3: {
+        return ntca::EncryptionMethod::e_TLS_V1_3;
+    } break;
+    default:
+        BSLS_ASSERT_OPT(false && "Missing conversion case");
+        BSLA_UNREACHABLE;
+    }
+}
+
+/// Get the minimum TLS version specified in the set of specified TLS
+/// versions.
+///
+/// Currently, only `TLSv1.3` is supported, and the empty set results
+/// in an error.
+///
+/// @param versions A set of versions to find the minimum in
+///
+/// @returns The minimum version found or bsl::nullopt if the set is empty
+bsl::optional<bmqt::TlsProtocolVersion::Value> findMinTlsVersion(
+    const bsl::unordered_set<bmqt::TlsProtocolVersion::Value>& versions)
+{
+    bsl::optional<bmqt::TlsProtocolVersion::Value> result;
+    if (versions.empty()) {
+        return result;
+    }
+
+    // We only support TLS v1.3
+    result.emplace(bmqt::TlsProtocolVersion::e_TLS1_3);
+    return result;
+}
+
+bmqio::ChannelFactoryPipeline makeChannelFactoryPipeline(
+    bslma::Allocator*                           allocator,
+    bdlbb::BlobBufferFactory*                   blobBufferFactory,
+    bdlmt::EventScheduler*                      scheduler,
+    NegotiatedChannelFactoryConfig::BlobSpPool* blobSpPool,
+    const bmqt::SessionOptions&                 sessionOptions,
+    const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+                                            statContextCreator,
+    const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage)
+{
+    typedef bmqio::ChannelFactoryPipeline::ChannelFactorySP ChannelFactorySP;
+
+    struct Builders {
+        static ChannelFactorySP
+        resolvingChannelFactory(bslma::Allocator* allocator,
+                                ChannelFactorySP& prev)
+        {
+            return bsl::allocate_shared<bmqio::ResolvingChannelFactory>(
+                allocator,
+                bmqio::ResolvingChannelFactoryConfig(
+                    prev.get(),
+                    bmqex::ExecutionPolicyUtil::oneWay()
+                        .alwaysBlocking()
+                        .useExecutor(bmqex::SystemExecutor())));
+        }
+
+        static ChannelFactorySP
+        reconnectingChannelFactory(bslma::Allocator*      allocator,
+                                   ChannelFactorySP&      prev,
+                                   bdlmt::EventScheduler* scheduler)
+        {
+            return bsl::allocate_shared<bmqio::ReconnectingChannelFactory>(
+                allocator,
+                bmqio::ReconnectingChannelFactoryConfig(prev.get(),
+                                                        scheduler));
+        }
+
+        static ChannelFactorySP statChannelFactory(
+            bslma::Allocator* allocator,
+            ChannelFactorySP& prev,
+            const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+                statContextCreator)
+        {
+            return bsl::allocate_shared<bmqio::StatChannelFactory>(
+                allocator,
+                bmqio::StatChannelFactoryConfig(prev.get(),
+                                                statContextCreator));
+        }
+
+        static ChannelFactorySP authenticatedChannelFactory(
+            bslma::Allocator*                              allocator,
+            ChannelFactorySP&                              prev,
+            bdlmt::EventScheduler*                         scheduler,
+            const bmqt::SessionOptions::AuthnCredentialCb& credentialCb,
+            const bsls::TimeInterval&                      connectTimeout,
+            AuthenticatedChannelFactoryConfig::BlobSpPool* blobSpPool)
+        {
+            return bsl::allocate_shared<AuthenticatedChannelFactory>(
+                allocator,
+                AuthenticatedChannelFactoryConfig(prev.get(),
+                                                  scheduler,
+                                                  credentialCb,
+                                                  connectTimeout,
+                                                  blobSpPool));
+        }
+
+        static ChannelFactorySP negotiatedChannelFactory(
+            bslma::Allocator*                           allocator,
+            ChannelFactorySP&                           prev,
+            const bmqp_ctrlmsg::NegotiationMessage&     negotiationMessage,
+            const bsls::TimeInterval&                   negotiationTimeout,
+            NegotiatedChannelFactoryConfig::BlobSpPool* blobSpPool)
+        {
+            return bsl::allocate_shared<NegotiatedChannelFactory>(
+                allocator,
+                NegotiatedChannelFactoryConfig(prev.get(),
+                                               negotiationMessage,
+                                               negotiationTimeout,
+                                               blobSpPool));
+        }
+    };
+
+    bsl::shared_ptr<bmqio::NtcChannelFactory> channelFactory =
+        bsl::make_shared<bmqio::NtcChannelFactory>(
+            ntcCreateInterfaceConfig(sessionOptions, allocator),
+            blobBufferFactory,
+            allocator);
+
+    // Check if we should use TLS sessions or not
+    if (sessionOptions.isTlsSession()) {
+        ntca::EncryptionClientOptions                  options;
+        bsl::optional<bmqt::TlsProtocolVersion::Value> minTlsVersion =
+            findMinTlsVersion(sessionOptions.protocolVersions());
+
+        BSLS_ASSERT(minTlsVersion.has_value());
+
+        options.setMinMethod(toNtcEncryptionMethod(minTlsVersion.value()));
+        options.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+        options.setAuthentication(ntca::EncryptionAuthentication::e_VERIFY);
+        options.addAuthorityFile(sessionOptions.certificateAuthority());
+
+        channelFactory->configureEncryptionClient(options);
+    }
+
+    using bdlf::PlaceHolders::_1;
+    bmqio::ChannelFactoryPipeline::Builder builder(allocator);
+    return builder.add(channelFactory)
+        .addWith(bdlf::BindUtil::bind(Builders::resolvingChannelFactory,
+                                      allocator,
+                                      _1))
+        .addWith(bdlf::BindUtil::bind(Builders::reconnectingChannelFactory,
+                                      allocator,
+                                      _1,
+                                      scheduler))
+        .addWith(bdlf::BindUtil::bind(Builders::statChannelFactory,
+                                      allocator,
+                                      _1,
+                                      bsl::cref(statContextCreator)))
+        .addWith(
+            bdlf::BindUtil::bind(Builders::authenticatedChannelFactory,
+                                 allocator,
+                                 _1,
+                                 bsl::cref(sessionOptions.authnCredentialCb()),
+                                 bsl::cref(sessionOptions.connectTimeout()),
+                                 blobSpPool))
+        .addWith(
+            bdlf::BindUtil::bind(Builders::negotiatedChannelFactory,
+                                 allocator,
+                                 _1,
+                                 bsl::cref(negotiationMessage),
+                                 bsl::cref(sessionOptions.connectTimeout()),
+                                 blobSpPool))
+        .build();
+}
+
 }  // close unnamed namespace
 
 // -------------------------
@@ -224,7 +406,15 @@ void Application::readCb(
             // Application received a broker response to an re-authentication
             // request.  The callback function `channelStateCallback` should
             // only be called for failed cases.
-            d_authenticatedChannelFactory.processAuthenticationEvent(
+
+            // TODO(tfoxhall): This is a code smell to me, the factory should
+            // probably only be responsible for making channels. Handling
+            // request logic should probably be elsewhere.
+            AuthenticatedChannelFactory* authenticatedChannelFactory_p =
+                d_channelFactoryPipeline.get<AuthenticatedChannelFactory>();
+            BSLS_ASSERT(authenticatedChannelFactory_p);
+
+            authenticatedChannelFactory_p->processAuthenticationEvent(
                 event,
                 bdlf::BindUtil::bindS(&d_allocator,
                                       &Application::channelStateCallback,
@@ -343,8 +533,7 @@ void Application::brokerSessionStopped(
         // This code assumes that there is no need to stop both factories upon
         // e_START_FAILURE.
         // If we wanted that, we would need another event.
-        d_reconnectingChannelFactory.stop();
-        d_channelFactory.stop();
+        d_channelFactoryPipeline.stop();
     }
 
     d_scheduler.cancelAllEventsAndWait();
@@ -367,34 +556,11 @@ bmqt::GenericResult::Enum Application::startChannel()
     BSLS_ASSERT_SAFE(d_brokerSession.state() ==
                      bmqimp::BrokerSession::State::e_STARTING);
 
-    int rc = 0;
-
-    // Start the channel factories.
-    rc = d_channelFactory.start();
-    if (rc != 0) {
-        BALL_LOG_ERROR << id() << "Failed to start channelFactory [rc: " << rc
-                       << "]";
-        return bmqt::GenericResult::e_UNKNOWN;  // RETURN
-    }
-    bdlb::ScopeExitAny tcpScopeGuard(
-        bdlf::BindUtil::bind(&bmqio::NtcChannelFactory::stop,
-                             &d_channelFactory));
-
-    rc = d_reconnectingChannelFactory.start();
-    if (rc != 0) {
-        BALL_LOG_ERROR << id()
-                       << "Failed to start reconnectingChannelFactory [rc: "
-                       << rc << "]";
-        return bmqt::GenericResult::e_UNKNOWN;  // RETURN
-    }
-    bdlb::ScopeExitAny reconnectingScopeGuard(
-        bdlf::BindUtil::bind(&bmqio::ReconnectingChannelFactory::stop,
-                             &d_reconnectingChannelFactory));
-
-    // Connect to the broker.
+    // TODO: Add ScopedAttribute for Application::id()
+    // 1. Prepare and validate connection parameters
     bmqio::TCPEndpoint endpoint(d_sessionOptions.brokerUri());
     if (!endpoint) {
-        BALL_LOG_ERROR << id() << "Invalid brokerURI '"
+        BALL_LOG_ERROR << id() << "Invalid brokerUri '"
                        << d_sessionOptions.brokerUri() << "'";
         return bmqt::GenericResult::e_INVALID_ARGUMENT;  // RETURN
     }
@@ -406,14 +572,27 @@ bmqt::GenericResult::Enum Application::startChannel()
     bsls::TimeInterval attemptInterval;
     attemptInterval.setTotalMilliseconds(k_RECONNECT_INTERVAL_MS);
 
-    bmqio::Status         status(&d_allocator);
     bmqio::ConnectOptions options(&d_allocator);
     options.setEndpoint(out.str())
         .setNumAttempts(k_RECONNECT_COUNT)
         .setAttemptInterval(attemptInterval)
         .setAutoReconnect(true);
 
-    d_negotiatedChannelFactory.connect(
+    // 2. Start channelFactoryPipeline
+    const int rc = d_channelFactoryPipeline.start();
+    if (rc != 0) {
+        BALL_LOG_ERROR << "Failed to start channelFactoryPipeline [rc: " << rc
+                       << "]";
+        return bmqt::GenericResult::e_UNKNOWN;  // RETURN
+    }
+
+    bdlb::ScopeExitAny pipelineScopeGuard(
+        bdlf::BindUtil::bind(&bmqio::ChannelFactoryPipeline::stop,
+                             &d_channelFactoryPipeline));
+
+    // 3. Connect to the broker
+    bmqio::Status status(&d_allocator);
+    d_channelFactoryPipeline.connect(
         &status,
         &d_connectHandle_mp,
         options,
@@ -447,8 +626,7 @@ bmqt::GenericResult::Enum Application::startChannel()
             bdlf::MemFnUtil::memFn(&Application::snapshotStats, this));
     }
 
-    reconnectingScopeGuard.release();
-    tcpScopeGuard.release();
+    pipelineScopeGuard.release();
 
     return bmqt::GenericResult::e_SUCCESS;
 }
@@ -603,45 +781,17 @@ Application::Application(
       bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
                                          d_allocators.get("BlobSpPool")))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC, &d_allocator)
-, d_channelFactory(ntcCreateInterfaceConfig(sessionOptions, &d_allocator),
-                   &d_blobBufferFactory,
-                   &d_allocator)
-, d_resolvingChannelFactory(
-      bmqio::ResolvingChannelFactoryConfig(
-          &d_channelFactory,
-          bmqex::ExecutionPolicyUtil::oneWay().alwaysBlocking().useExecutor(
-              bmqex::SystemExecutor()),
-          allocator),
-      allocator)
-, d_reconnectingChannelFactory(
-      bmqio::ReconnectingChannelFactoryConfig(&d_resolvingChannelFactory,
-                                              &d_scheduler,
-                                              allocator),
-      allocator)
-, d_statChannelFactory(
-      bmqio::StatChannelFactoryConfig(
-          &d_reconnectingChannelFactory,
-          bdlf::BindUtil::bind(&Application::channelStatContextCreator,
-                               this,
-                               bdlf::PlaceHolders::_1,   // channel
-                               bdlf::PlaceHolders::_2),  // handle
-          allocator),
-      allocator)
-, d_authenticatedChannelFactory(
-      AuthenticatedChannelFactoryConfig(&d_statChannelFactory,
-                                        &d_scheduler,
-                                        sessionOptions.authnCredentialCb(),
-                                        sessionOptions.connectTimeout(),
-                                        d_blobSpPool_sp.get(),
-                                        allocator),
-      allocator)
-, d_negotiatedChannelFactory(
-      NegotiatedChannelFactoryConfig(&d_authenticatedChannelFactory,
-                                     negotiationMessage,
-                                     sessionOptions.connectTimeout(),
-                                     d_blobSpPool_sp.get(),
-                                     allocator),
-      allocator)
+, d_channelFactoryPipeline(makeChannelFactoryPipeline(
+      &d_allocator,
+      &d_blobBufferFactory,
+      &d_scheduler,
+      d_blobSpPool_sp.get(),
+      sessionOptions,
+      bdlf::BindUtil::bind(&Application::channelStatContextCreator,
+                           this,
+                           bdlf::PlaceHolders::_1,   // channel
+                           bdlf::PlaceHolders::_2),  // handle
+      negotiationMessage))
 , d_connectHandle_mp()
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,

--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -35,7 +35,6 @@
 // Thread safe.
 
 // BMQ
-
 #include <bmqimp_authenticatedchannelfactory.h>
 #include <bmqimp_brokersession.h>
 #include <bmqimp_eventqueue.h>
@@ -46,6 +45,7 @@
 
 #include <bmqio_channel.h>
 #include <bmqio_channelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_ntcchannelfactory.h>
 #include <bmqio_reconnectingchannelfactory.h>
 #include <bmqio_resolvingchannelfactory.h>
@@ -127,17 +127,8 @@ class Application {
     /// Scheduler
     bdlmt::EventScheduler d_scheduler;
 
-    bmqio::NtcChannelFactory d_channelFactory;
-
-    bmqio::ResolvingChannelFactory d_resolvingChannelFactory;
-
-    bmqio::ReconnectingChannelFactory d_reconnectingChannelFactory;
-
-    bmqio::StatChannelFactory d_statChannelFactory;
-
-    AuthenticatedChannelFactory d_authenticatedChannelFactory;
-
-    NegotiatedChannelFactory d_negotiatedChannelFactory;
+    /// The stack of channel factories used for customizing connection/listening logic
+    bmqio::ChannelFactoryPipeline d_channelFactoryPipeline;
 
     ChannelFactoryOpHandleMp d_connectHandle_mp;
 

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
@@ -462,5 +462,15 @@ void AuthenticatedChannelFactory::connect(bmqio::Status*               status,
             bdlf::PlaceHolders::_3));  // channel
 }
 
+int AuthenticatedChannelFactory::start()
+{
+    return 0;
+}
+
+void AuthenticatedChannelFactory::stop()
+{
+    // NOTHING
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.h
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.h
@@ -205,6 +205,13 @@ class AuthenticatedChannelFactory : public bmqio::ChannelFactory {
     processAuthenticationEvent(const bmqp::Event&                     event,
                                const ResultCallback&                  cb,
                                const bsl::shared_ptr<bmqio::Channel>& channel);
+
+    /// Enable this factory to start creating connections.
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop this factory from creating connections and clean up any pending
+    /// connections.
+    void stop() BSLS_KEYWORD_OVERRIDE;
 };
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.cpp
@@ -16,11 +16,11 @@
 // bmqimp_negotiatedchannelfactory.cpp                                -*-C++-*-
 #include <bmqimp_negotiatedchannelfactory.h>
 
-#include <bmqscm_version.h>
 // BMQ
 #include <bmqp_event.h>
 #include <bmqp_protocol.h>
 #include <bmqp_schemaeventbuilder.h>
+#include <bmqscm_version.h>
 
 #include <bmqio_channelutil.h>
 #include <bmqu_blob.h>
@@ -394,6 +394,16 @@ void NegotiatedChannelFactory::connect(bmqio::Status*               status,
                              bdlf::PlaceHolders::_1,    // event
                              bdlf::PlaceHolders::_2,    // status
                              bdlf::PlaceHolders::_3));  // channel
+}
+
+int NegotiatedChannelFactory::start()
+{
+    return d_config.d_baseFactory_p->start();
+}
+
+void NegotiatedChannelFactory::stop()
+{
+    d_config.d_baseFactory_p->stop();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
+++ b/src/groups/bmq/bmqimp/bmqimp_negotiatedchannelfactory.h
@@ -80,6 +80,11 @@ class NegotiatedChannelFactoryConfig {
                                    bslma::UsesBslmaAllocator)
 
     // CREATORS
+
+    /// @brief Create a configuration for building a NegotiatedChannelFactory.
+    ///
+    /// @pre base != NULL
+    /// @pre bufferFactory != NULL
     NegotiatedChannelFactoryConfig(
         bmqio::ChannelFactory*                  base,
         const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage,
@@ -90,6 +95,9 @@ class NegotiatedChannelFactoryConfig {
     NegotiatedChannelFactoryConfig(
         const NegotiatedChannelFactoryConfig& original,
         bslma::Allocator*                     basicAllocator = 0);
+
+    // ACCESSORS
+    bslma::Allocator* allocator() const;
 };
 
 // ==============================
@@ -167,6 +175,9 @@ class NegotiatedChannelFactory : public bmqio::ChannelFactory {
     ~NegotiatedChannelFactory() BSLS_KEYWORD_OVERRIDE;
 
   public:
+    // ACCESSORS
+    bslma::Allocator* allocator() const;
+
     // MANIPULATORS
     void listen(bmqio::Status*               status,
                 bslma::ManagedPtr<OpHandle>* handle,
@@ -177,7 +188,35 @@ class NegotiatedChannelFactory : public bmqio::ChannelFactory {
                  bslma::ManagedPtr<OpHandle>* handle,
                  const bmqio::ConnectOptions& options,
                  const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    /// Start the base channel factory.
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the base channel factory.
+    void stop() BSLS_KEYWORD_OVERRIDE;
 };
+
+// ============================================================================
+//                             INLINE DEFINITIONS
+// ============================================================================
+
+// ====================================
+// class NegotiatedChannelFactoryConfig
+// ====================================
+
+inline bslma::Allocator* NegotiatedChannelFactoryConfig::allocator() const
+{
+    return d_allocator_p;
+}
+
+// ==============================
+// class NegotiatedChannelFactory
+// ==============================
+
+inline bslma::Allocator* NegotiatedChannelFactory::allocator() const
+{
+    return d_config.allocator();
+}
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqio/bmqio_channelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_channelfactory.h
@@ -188,6 +188,13 @@ class ChannelFactory {
                          bslma::ManagedPtr<OpHandle>* handle,
                          const ConnectOptions&        options,
                          const ResultCallback&        cb) = 0;
+
+    /// Enable this factory to start creating connections.
+    virtual int start() = 0;
+
+    /// Stop this factory from creating connections and clean up any pending
+    /// connections.
+    virtual void stop() = 0;
 };
 
 }  // close package namespace

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.cpp
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.cpp
@@ -1,0 +1,150 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqio_channelfactorypipeline.h>
+
+namespace BloombergLP {
+namespace bmqio {
+
+ChannelFactoryPipeline::Builder::Builder()
+: d_pipeline()
+{
+}
+
+ChannelFactoryPipeline::Builder::Builder(const allocator_type& allocator)
+: d_pipeline(allocator)
+{
+}
+
+ChannelFactoryPipeline::Builder::Builder(bslmf::MovableRef<Builder> other)
+    BSLS_KEYWORD_NOEXCEPT
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline),
+             MoveUtil::access(other).d_pipeline.get_allocator())
+{
+}
+
+ChannelFactoryPipeline::Builder::Builder(bslmf::MovableRef<Builder> other,
+                                         const allocator_type&      allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline), allocator)
+{
+}
+
+ChannelFactoryPipeline::Builder::allocator_type
+ChannelFactoryPipeline::Builder::get_allocator() const
+{
+    return d_pipeline.get_allocator();
+}
+
+void ChannelFactoryPipeline::Builder::reset()
+{
+    d_pipeline.clear();
+}
+
+ChannelFactoryPipeline::Builder&
+ChannelFactoryPipeline::Builder::add(const ChannelFactorySP& channelFactory)
+{
+    BSLS_ASSERT(channelFactory != NULL);
+
+    d_pipeline.push_back(channelFactory);
+
+    return *this;
+}
+
+ChannelFactoryPipeline::Builder&
+ChannelFactoryPipeline::Builder::addWith(const ChannelFactoryBuilder& builder)
+{
+    ChannelFactorySP last;
+    if (!d_pipeline.empty()) {
+        last = d_pipeline.back();
+    }
+    ChannelFactorySP channelFactory = builder(last);
+    add(channelFactory);
+
+    return *this;
+}
+
+ChannelFactoryPipeline ChannelFactoryPipeline::Builder::build()
+{
+    ChannelFactoryPipeline pipeline(MoveUtil::move(*this), get_allocator());
+    reset();
+    return pipeline;
+}
+
+size_t ChannelFactoryPipeline::Builder::size() const
+{
+    return d_pipeline.size();
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<ChannelFactoryPipeline> other) BSLS_KEYWORD_NOEXCEPT
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline),
+             MoveUtil::access(other).get_allocator())
+{
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<ChannelFactoryPipeline> other,
+    const allocator_type&                     allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline), allocator)
+{
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<Builder> builder,
+    const allocator_type&      allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(builder).d_pipeline), allocator)
+{
+}
+
+ChannelFactoryPipeline::allocator_type
+ChannelFactoryPipeline::get_allocator() const
+{
+    return d_pipeline.get_allocator();
+}
+
+const ChannelFactoryPipeline::ChannelFactorySP&
+ChannelFactoryPipeline::top() const
+{
+    return d_pipeline.back();
+}
+
+void ChannelFactoryPipeline::listen(bmqio::Status*               status,
+                                    bslma::ManagedPtr<OpHandle>* handle,
+                                    const bmqio::ListenOptions&  options,
+                                    const ResultCallback&        cb)
+{
+    top()->listen(status, handle, options, cb);
+}
+
+void ChannelFactoryPipeline::connect(bmqio::Status*               status,
+                                     bslma::ManagedPtr<OpHandle>* handle,
+                                     const bmqio::ConnectOptions& options,
+                                     const ResultCallback&        cb)
+{
+    top()->connect(status, handle, options, cb);
+}
+
+int ChannelFactoryPipeline::start()
+{
+    return top()->start();
+}
+
+void ChannelFactoryPipeline::stop()
+{
+    top()->stop();
+}
+
+}
+}

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
@@ -1,0 +1,358 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqio_channelfactorypipeline.h>
+
+// BMQ
+#include <bmqio_channelfactory.h>
+#include <bmqio_connectoptions.h>
+#include <bmqio_listenoptions.h>
+#include <bmqio_testchannelfactory.h>
+
+// BDE
+#include <bslmf_movableref.h>
+
+// TEST_DRIVER
+#include <bmqtst_testhelper.h>
+#include <bsls_assert.h>
+#include <bsls_asserttestexception.h>
+#include <bslstl_sharedptr.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+
+namespace {
+
+class MockChannelFactory : public bmqio::ChannelFactory {
+  public:
+    MOCK_METHOD(void,
+                listen,
+                (bmqio::Status * status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ListenOptions&  options,
+                 const ResultCallback&        cb),
+                (BSLS_KEYWORD_OVERRIDE));
+    MOCK_METHOD(void,
+                connect,
+                (bmqio::Status * status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ConnectOptions& options,
+                 const ResultCallback&        cb),
+                (BSLS_KEYWORD_OVERRIDE));
+    MOCK_METHOD(int, start, (), (BSLS_KEYWORD_OVERRIDE));
+    MOCK_METHOD(void, stop, (), (BSLS_KEYWORD_OVERRIDE));
+};
+
+class WrappedChannelFactory : public bmqio::ChannelFactory {
+  private:
+    bmqio::ChannelFactory* d_wrapped;
+
+  public:
+    WrappedChannelFactory(bmqio::ChannelFactory* wrapped)
+    : d_wrapped(wrapped)
+    {
+        BSLS_ASSERT(d_wrapped != NULL);
+    }
+
+    void listen(bmqio::Status*               status,
+                bslma::ManagedPtr<OpHandle>* handle,
+                const bmqio::ListenOptions&  options,
+                const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE
+    {
+        d_wrapped->listen(status, handle, options, cb);
+    }
+
+    void connect(bmqio::Status*               status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ConnectOptions& options,
+                 const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE
+    {
+        d_wrapped->connect(status, handle, options, cb);
+    }
+
+    int start() BSLS_KEYWORD_OVERRIDE { return 0; }
+
+    void stop() BSLS_KEYWORD_OVERRIDE {}
+};
+}
+
+// ========================================================================
+//                                  TESTS
+// ------------------------------------------------------------------------
+
+class ChannelFactoryPipelineBuilderTest : public ::testing::Test {
+  protected:
+    ChannelFactoryPipelineBuilderTest() {}
+
+    typedef bsl::allocator<unsigned char> allocator_type;
+
+    allocator_type get_allocator() const
+    {
+        return bmqtst::TestHelperUtil::allocator();
+    }
+};
+
+TEST_F(ChannelFactoryPipelineBuilderTest, breathingTest)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(get_allocator());
+}
+
+TEST_F(ChannelFactoryPipelineBuilderTest, add)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(get_allocator());
+    builder.add(
+        bsl::allocate_shared<bmqio::TestChannelFactory>(get_allocator()));
+
+    EXPECT_EQ(1, builder.size());
+}
+
+TEST_F(ChannelFactoryPipelineBuilderTest, addWith)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(get_allocator());
+
+    struct FactoryFunctor {
+        allocator_type allocator;
+
+        bsl::shared_ptr<bmqio::ChannelFactory>
+        operator()(bsl::shared_ptr<bmqio::ChannelFactory> prev) const
+        {
+            EXPECT_TRUE(NULL == prev);
+            return bsl::allocate_shared<bmqio::TestChannelFactory>(allocator);
+        }
+    };
+
+    FactoryFunctor func{get_allocator()};
+
+    builder.addWith(func);
+
+    EXPECT_EQ(1, builder.size());
+}
+
+TEST_F(ChannelFactoryPipelineBuilderTest, addWithFails)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(get_allocator());
+
+    struct FactoryFunctor {
+        bsl::shared_ptr<bmqio::ChannelFactory>
+        operator()(bsl::shared_ptr<bmqio::ChannelFactory> prev) const
+        {
+            return NULL;
+        }
+    };
+
+    FactoryFunctor func;
+
+    // This is a contract failure.
+    EXPECT_THROW(builder.addWith(func), bsls::AssertTestException);
+}
+
+TEST_F(ChannelFactoryPipelineBuilderTest, addWithPrev)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(get_allocator());
+
+    struct FactoryFunctor {
+        allocator_type allocator;
+
+        bsl::shared_ptr<bmqio::ChannelFactory>
+        operator()(bsl::shared_ptr<bmqio::ChannelFactory> prev) const
+        {
+            return bsl::allocate_shared<bmqio::TestChannelFactory>(allocator);
+        }
+    };
+
+    FactoryFunctor func{get_allocator()};
+
+    builder.addWith(func);
+
+    ASSERT_EQ(1, builder.size());
+}
+
+TEST_F(ChannelFactoryPipelineBuilderTest, canMove)
+{
+    bmqio::ChannelFactoryPipeline::Builder builder(
+        (bmqtst::TestHelperUtil::allocator()));
+    bmqio::ChannelFactoryPipeline::Builder builder2 =
+        bslmf::MovableRefUtil::move(builder);
+}
+
+class ChannelFactoryPipelineTest : public ::testing::Test {
+  protected:
+    ChannelFactoryPipelineTest()
+    : d_builder(get_allocator())
+    {
+    }
+
+    typedef bsl::allocator<unsigned char> allocator_type;
+
+    allocator_type get_allocator() const
+    {
+        return bmqtst::TestHelperUtil::allocator();
+    }
+
+    bmqio::ChannelFactoryPipeline::Builder::ChannelFactoryBuilder
+    wrappedFactoryBuilder() const
+    {
+        struct Builder {
+            allocator_type allocator;
+
+            bsl::shared_ptr<bmqio::ChannelFactory>
+            operator()(bsl::shared_ptr<bmqio::ChannelFactory> prev) const
+            {
+                return bsl::allocate_shared<WrappedChannelFactory>(allocator,
+                                                                   prev.get());
+            }
+        };
+
+        return Builder{get_allocator()};
+    }
+
+    bmqio::ChannelFactoryPipeline::Builder d_builder;
+};
+
+TEST_F(ChannelFactoryPipelineTest, breathingTest)
+{
+    bmqio::ChannelFactoryPipeline pipeline = d_builder.build();
+}
+
+TEST_F(ChannelFactoryPipelineTest, listenFollowsChain)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+    bmqio::Status                                      status;
+    bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> handle;
+    bmqio::ListenOptions                               options;
+    const bmqio::ChannelFactory::ResultCallback        cb;
+
+    using ::testing::_;
+    using ::testing::Address;
+
+    EXPECT_CALL(*mockFactory,
+                listen(&status, &handle, Address(&options), Address(&cb)));
+
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory).addWith(wrappedFactoryBuilder()).build();
+
+    pipeline.listen(&status, &handle, options, cb);
+}
+
+TEST_F(ChannelFactoryPipelineTest, connectFollowsChain)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+    bmqio::Status                                      status;
+    bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> handle;
+    bmqio::ConnectOptions                              options;
+    const bmqio::ChannelFactory::ResultCallback        cb;
+
+    using ::testing::_;
+    using ::testing::Address;
+
+    EXPECT_CALL(*mockFactory,
+                connect(&status, &handle, Address(&options), Address(&cb)));
+
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory).addWith(wrappedFactoryBuilder()).build();
+
+    pipeline.connect(&status, &handle, options, cb);
+}
+
+TEST_F(ChannelFactoryPipelineTest, startGoesFromTopToBottom)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory1 =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+    bsl::shared_ptr<MockChannelFactory> mockFactory2 =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+
+    using ::testing::InSequence;
+    using ::testing::Invoke;
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*mockFactory2, start())
+            .WillRepeatedly(
+                Invoke(mockFactory1.get(), &MockChannelFactory::start));
+        EXPECT_CALL(*mockFactory1, start());
+    }
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory1).add(mockFactory2).build();
+
+    pipeline.start();
+}
+
+TEST_F(ChannelFactoryPipelineTest, stopGoesFromTopToBottom)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory1 =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+    bsl::shared_ptr<MockChannelFactory> mockFactory2 =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+
+    using ::testing::InSequence;
+    using ::testing::Invoke;
+
+    {
+        InSequence seq;
+        EXPECT_CALL(*mockFactory2, stop())
+            .WillRepeatedly(
+                Invoke(mockFactory1.get(), &MockChannelFactory::stop));
+        EXPECT_CALL(*mockFactory1, stop());
+    }
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory1).add(mockFactory2).build();
+
+    pipeline.stop();
+}
+
+TEST_F(ChannelFactoryPipelineTest, getFindsChannelFactorySubtype)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory).build();
+
+    MockChannelFactory* result = pipeline.get<MockChannelFactory>();
+
+    EXPECT_EQ(result, mockFactory.get());
+}
+
+TEST_F(ChannelFactoryPipelineTest, getDoesntFindNonexistantSubtype)
+{
+    bsl::shared_ptr<MockChannelFactory> mockFactory =
+        bsl::allocate_shared<MockChannelFactory>(get_allocator());
+
+    bmqio::ChannelFactoryPipeline pipeline =
+        d_builder.add(mockFactory).build();
+
+    int* result = pipeline.get<int>();
+
+    EXPECT_EQ(result, NULL);
+}
+
+// ========================================================================
+//                                  MAIN
+// ------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bmqtst::TestHelperUtil::testStatus() = RUN_ALL_TESTS();
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.h
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.h
@@ -1,0 +1,180 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_BMQIO_CHANNELFACTORYPIPELINE
+#define INCLUDED_BMQIO_CHANNELFACTORYPIPELINE
+
+#include <bmqio_channelfactory.h>
+
+#include <bsl_memory.h>
+#include <bsl_vector.h>
+#include <bslmf_movableref.h>
+#include <bslstl_sharedptr.h>
+
+namespace BloombergLP {
+namespace bmqio {
+
+class ChannelFactoryPipeline_Impl {};
+
+class ChannelFactoryPipeline : public bmqio::ChannelFactory {
+  private:
+    // PRIVATE TYPES
+    typedef bslmf::MovableRefUtil MoveUtil;
+
+  public:
+    // TYPES
+    typedef bsl::shared_ptr<bmqio::ChannelFactory> ChannelFactorySP;
+
+    /// A builder class for constructing `ChannelFactoryPipelines`.
+    class Builder {
+      private:
+        // PRIVATE DATA
+        bsl::vector<ChannelFactorySP> d_pipeline;
+
+        // FRIENDS
+        friend class ChannelFactoryPipeline;
+
+      public:
+        /// The allocator type.
+        typedef bsl::allocator<unsigned char> allocator_type;
+
+        /// A builder for channel factories.
+        typedef bsl::function<ChannelFactorySP(ChannelFactorySP&)>
+            ChannelFactoryBuilder;
+
+        // CONSTRUCTORS
+
+        // Create an empty pipeline builder.
+        Builder();
+        explicit Builder(const allocator_type& allocator);
+        Builder(bslmf::MovableRef<Builder> other) BSLS_KEYWORD_NOEXCEPT;
+        Builder(bslmf::MovableRef<Builder> other,
+                const allocator_type&      allocator);
+
+      private:
+        // PRIVATE CONSTRUCTORS
+
+        Builder(const Builder& other) BSLS_KEYWORD_DELETED;
+        Builder& operator=(const Builder& other) BSLS_KEYWORD_DELETED;
+
+      public:
+        // ACESSORS
+
+        allocator_type get_allocator() const;
+
+        // MANIPULATORS
+
+        /// Resets the pipeline builder to the empty state, as on construction
+        void reset();
+
+        /// Add a `ChannelFactory` as the next step in the pipeline.
+        ///
+        /// @pre `channelFactory` must not be null.
+        Builder& add(const ChannelFactorySP& channelFactory);
+
+        /// Add a `ChannelFactory` as the next step in the pipeline,
+        /// constructed from the provided factory. The parameter is a reference
+        /// to the previous factory in the pipeline. If there are no factories
+        /// in the pipeline, the parameter is NULL.
+        ///
+        /// @pre `builder(previous)` must not return null
+        Builder& addWith(const ChannelFactoryBuilder& builder);
+
+        /// Construct a `ChannelFactoryPipeline` using `this` and
+        /// `get_allocator()`
+        ChannelFactoryPipeline build();
+
+        /// Get the current size of the pipeline.
+        size_t size() const;
+    };
+
+  private:
+    // PRIVATE DATA
+    bsl::vector<ChannelFactorySP> d_pipeline;
+
+  public:
+    // TYPES
+
+    /// The allocator type.
+    typedef bsl::allocator<unsigned char> allocator_type;
+
+    ChannelFactoryPipeline(bslmf::MovableRef<ChannelFactoryPipeline> other)
+        BSLS_KEYWORD_NOEXCEPT;
+
+    ChannelFactoryPipeline(bslmf::MovableRef<ChannelFactoryPipeline> other,
+                           const allocator_type& allocator);
+
+    ChannelFactoryPipeline(bslmf::MovableRef<Builder> builder,
+                           const allocator_type& allocator = allocator_type());
+
+  private:
+    // PRIVATE CONSTRUCTORS
+
+    ChannelFactoryPipeline(const ChannelFactoryPipeline& other)
+        BSLS_KEYWORD_DELETED;
+
+    // PRIVATE ACCESSORS
+
+    /// Get the top of the stack of channel factories.
+    const ChannelFactorySP& top() const;
+
+  public:
+    // ACESSORS
+
+    allocator_type get_allocator() const;
+
+    // MANIPULATORS
+
+    void listen(bmqio::Status*               status,
+                bslma::ManagedPtr<OpHandle>* handle,
+                const bmqio::ListenOptions&  options,
+                const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    void connect(bmqio::Status*               status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ConnectOptions& options,
+                 const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    void stop() BSLS_KEYWORD_OVERRIDE;
+
+    /// Search the channel factory stack for a ChannelFactory matching subtype
+    /// T. If no such type is found, return NULL.
+    ///
+    /// @pre The behavior is undefined unless T is a unique subtype among all
+    /// `ChannelFactory` objects managed by this object.
+    template <typename T>
+    T* get();
+};
+
+template <typename T>
+inline T* ChannelFactoryPipeline::get()
+{
+    for (bsl::vector<ChannelFactorySP>::iterator it  = d_pipeline.begin(),
+                                                 end = d_pipeline.end();
+         it != end;
+         ++it) {
+        T* test = dynamic_cast<T*>(it->get());
+        if (test != NULL) {
+            return test;
+        }
+    }
+    return NULL;
+}
+
+}
+}
+#endif

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.h
@@ -34,8 +34,8 @@
 #include <bmqvt_propertybag.h>
 
 // NTC
-#include <ntcf_system.h>
-#include <ntci_streamsocket.h>
+#include <ntca_upgradeoptions.h>
+#include <ntci_interface.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -47,6 +47,7 @@
 #include <bsl_list.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
@@ -287,6 +288,11 @@ class NtcChannel : public bmqio::Channel,
     /// Notify using the specified `status` and remove each existing reader.
     void drainReaders(const bmqio::Status& status);
 
+    /// @brief Process the upgradeServer of this socket to TLS
+    void processUpgrade(const bsl::shared_ptr<ntci::Upgradable>& upgradable,
+                        const ntca::UpgradeEvent&                upgradeEvent,
+                        const ntci::UpgradeFunction&             cb);
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(NtcChannel, bslma::UsesBslmaAllocator)
@@ -410,6 +416,24 @@ class NtcChannel : public bmqio::Channel,
 
     /// Set the write queue high watermark to the specified `highWatermark`.
     void setWriteQueueHighWatermark(int highWatermark);
+
+    /// Assume the TLS server role and begin upgrading the socket from
+    /// being unencrypted to being encrypted with TLS. Invoke the specified
+    /// `upgradeCallback` when the socket has completed upgrading to TLS.
+    int
+    upgrade(bmqio::Status*                                 status,
+            const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
+            const ntca::UpgradeOptions&                    options,
+            const ntci::UpgradeFunction&                   upgradeCallback);
+
+    /// Assume the TLS client role and begin upgrading the socket from
+    /// being unencrypted to being encrypted with TLS. Invoke the specified
+    /// `upgradeCallback` when the socket has completed upgrading to TLS.
+    int
+    upgrade(bmqio::Status*                                 status,
+            const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
+            const ntca::UpgradeOptions&                    options,
+            const ntci::UpgradeFunction&                   upgradeCallback);
 
     // ACCESSORS
 

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
@@ -17,9 +17,9 @@
 #include <bmqio_ntcchannelfactory.h>
 
 #include <bmqscm_version.h>
+
 // NTF
 #include <ntcf_system.h>
-#include <ntsf_system.h>
 
 // BDE
 #include <ball_log.h>
@@ -107,6 +107,28 @@ void NtcChannelFactory::processListenerResult(
                                << AddressFormatter(alias.get()) << " to "
                                << alias->peerUri() << " registered"
                                << BALL_LOG_END;
+
+                // Check if we need to upgrade the connection to TLS
+                if (d_encryptionServer_sp) {
+                    bmqio::Status upgradeStatus;
+                    const int     rc = alias->upgrade(
+                        &upgradeStatus,
+                        d_encryptionServer_sp,
+                        d_upgradeOptions,
+                        bdlf::BindUtil::bind(
+                            &NtcChannelFactory::processUpgrade,
+                            this,
+                            event,
+                            status,
+                            alias,
+                            bdlf::PlaceHolders::_1,  // upgradable
+                            bdlf::PlaceHolders::_2,  // upgradeEvent
+                            callback));
+                    if (rc != 0) {
+                        callback(event, upgradeStatus, channel);
+                    }
+                    return;  // RETURN
+                }
             }
         }
     }
@@ -120,6 +142,7 @@ void NtcChannelFactory::processChannelResult(
     const bsl::shared_ptr<bmqio::Channel>&       channel,
     const bmqio::ChannelFactory::ResultCallback& callback)
 {
+    // Result callback for connect
     BALL_LOG_TRACE << "NTC factory event " << event << " status " << status
                    << BALL_LOG_END;
 
@@ -130,8 +153,56 @@ void NtcChannelFactory::processChannelResult(
             if (alias) {
                 d_createSignaler(alias, alias);
             }
+
+            // Check if we need to upgrade the connection to TLS
+            if (d_encryptionClient_sp) {
+                bmqio::Status upgradeStatus;
+                const int     rc = alias->upgrade(
+                    &upgradeStatus,
+                    d_encryptionClient_sp,
+                    d_upgradeOptions,
+                    bdlf::BindUtil::bind(
+                        &NtcChannelFactory::processUpgrade,
+                        this,
+                        event,
+                        status,
+                        alias,
+                        bdlf::PlaceHolders::_1,  // upgradable
+                        bdlf::PlaceHolders::_2,  // upgradeEvent
+                        callback));
+                if (rc != 0) {
+                    callback(event, upgradeStatus, channel);
+                }
+
+                return;  // RETURN
+            }
         }
     }
+
+    callback(event, status, channel);
+}
+
+void NtcChannelFactory::processUpgrade(
+    bmqio::ChannelFactoryEvent::Enum             event,
+    const bmqio::Status&                         status,
+    const bsl::shared_ptr<bmqio::NtcChannel>&    channel,
+    const bsl::shared_ptr<ntci::Upgradable>&     upgradable,
+    const ntca::UpgradeEvent&                    upgradeEvent,
+    const bmqio::ChannelFactory::ResultCallback& callback)
+{
+    if (upgradeEvent.isError()) {
+        BALL_LOG_ERROR << "Received error during TLS negotiation: "
+                       << upgradeEvent;
+        bmqio::Status st(bmqio::StatusCategory::e_GENERIC_ERROR);
+        channel->close(st);
+        callback(ChannelFactoryEvent::e_CONNECT_FAILED, st, channel);
+        return;  // RETURN
+    }
+
+    // Note: the `upgradable` object is the channel's underlying stream socket.
+    // This signaler is the only way that we can communicate to observers what
+    // the status of the upgrade is.
+    d_upgradeSignaler(channel, upgradable, upgradeEvent);
 
     callback(event, status, channel);
 }
@@ -150,6 +221,10 @@ NtcChannelFactory::NtcChannelFactory(
 , d_validator(false)
 , d_resourceMonitor(false)
 , d_isInterfaceStarted(false)
+, d_encryptionServer_sp()
+, d_encryptionClient_sp()
+, d_upgradeSignaler(basicAllocator)
+, d_upgradeOptions()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
@@ -167,6 +242,10 @@ NtcChannelFactory::NtcChannelFactory(
 , d_validator(false)
 , d_resourceMonitor(false)
 , d_isInterfaceStarted(false)
+, d_encryptionServer_sp()
+, d_encryptionClient_sp()
+, d_upgradeSignaler(basicAllocator)
+, d_upgradeOptions()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     bsl::shared_ptr<bdlbb::BlobBufferFactory> blobBufferFactory_sp(
@@ -194,7 +273,7 @@ NtcChannelFactory::~NtcChannelFactory()
     BSLS_ASSERT_OPT(d_channels.length() == 0);
     BSLS_ASSERT_OPT(d_createSignaler.slotCount() == 0);
     BSLS_ASSERT_OPT(d_limitSignaler.slotCount() == 0);
-    BSLS_ASSERT_OPT(!d_interface_sp);
+    BSLS_ASSERT_OPT(d_upgradeSignaler.slotCount() == 0);
 }
 
 // MANIPULATORS
@@ -257,6 +336,7 @@ void NtcChannelFactory::stop()
 
     d_createSignaler.disconnectAllSlots();
     d_limitSignaler.disconnectAllSlots();
+    d_upgradeSignaler.disconnectAllSlots();
 
     BALL_LOG_TRACE << "NTC factory has stopped" << BALL_LOG_END;
 }
@@ -410,9 +490,14 @@ bdlmt::SignalerConnection NtcChannelFactory::onLimit(const LimitFn& cb)
     return d_limitSignaler.connect(cb);
 }
 
+bdlmt::SignalerConnection NtcChannelFactory::onUpgrade(const UpgradeFn& cb)
+{
+    return d_upgradeSignaler.connect(cb);
+}
+
 int NtcChannelFactory::lookupChannel(
     bsl::shared_ptr<bmqio::NtcChannel>* result,
-    int                                 channelId)
+    int                                 channelId) const
 {
     return d_channels.find(channelId, result);
 }
@@ -453,6 +538,72 @@ int NtcChannelFactory::addChannel(
 {
     d_resourceMonitor.acquire();
     return d_channels.add(channel);
+}
+
+void NtcChannelFactory::setEncryptionServer(
+    const EncryptionServerSp& encryptionServer)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_encryptionServer_sp = encryptionServer;
+}
+
+ntsa::Error NtcChannelFactory::configureEncryptionServer(
+    const ntca::EncryptionServerOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_interface_sp->createEncryptionServer(&d_encryptionServer_sp,
+                                                  options,
+                                                  d_allocator_p);
+}
+
+void NtcChannelFactory::setEncryptionClient(
+    const EncryptionClientSp& encryptionClient)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_encryptionClient_sp = encryptionClient;
+}
+
+ntsa::Error NtcChannelFactory::configureEncryptionClient(
+    const ntca::EncryptionClientOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_interface_sp->createEncryptionClient(&d_encryptionClient_sp,
+                                                  options,
+                                                  d_allocator_p);
+}
+
+void NtcChannelFactory::setUpgradeOptions(const ntca::UpgradeOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_upgradeOptions = options;
+}
+
+// ACCESSORS
+
+const ntci::EncryptionServer& NtcChannelFactory::encryptionServer() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return *d_encryptionServer_sp;
+}
+
+const ntci::EncryptionClient& NtcChannelFactory::encryptionClient() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return *d_encryptionClient_sp;
+}
+
+const ntca::UpgradeOptions& NtcChannelFactory::upgradeOptions() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_upgradeOptions;
 }
 
 // ----------------------------

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
@@ -38,6 +38,7 @@
 // NTF
 #include <ntca_interfaceconfig.h>
 #include <ntci_interface.h>
+#include <ntci_upgradecallback.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -80,6 +81,21 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// been reached.
     typedef bsl::function<LimitFnType> LimitFn;
 
+    /// This typedef defines the signature of a function invoked when a
+    /// channel has been upgraded
+    typedef void
+    UpgradeFnType(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                  const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                  const ntca::UpgradeEvent&                 event);
+
+    /// This typedef defines a function invoked when a channel has been
+    /// upgraded.
+    typedef bsl::function<UpgradeFnType> UpgradeFn;
+
+    typedef bsl::shared_ptr<ntci::EncryptionServer> EncryptionServerSp;
+
+    typedef bsl::shared_ptr<ntci::EncryptionClient> EncryptionClientSp;
+
   private:
     // PRIVATE TYPES
 
@@ -111,6 +127,10 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     bmqu::AtomicValidator            d_validator;
     bmqu::AtomicValidator            d_resourceMonitor;
     bsls::AtomicBool                 d_isInterfaceStarted;
+    EncryptionServerSp               d_encryptionServer_sp;
+    EncryptionClientSp               d_encryptionClient_sp;
+    bdlmt::Signaler<UpgradeFnType>   d_upgradeSignaler;
+    ntca::UpgradeOptions             d_upgradeOptions;
     bslma::Allocator*                d_allocator_p;
 
   private:
@@ -164,6 +184,14 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// @return Catalog handle for the added channel.
     int addChannel(const bsl::shared_ptr<bmqio::NtcChannel>& channel);
 
+    /// Process a TLS upgrade
+    void processUpgrade(bmqio::ChannelFactoryEvent::Enum          event,
+                        const bmqio::Status&                      status,
+                        const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                        const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                        const ntca::UpgradeEvent&                 upgradeEvent,
+                        const bmqio::ChannelFactory::ResultCallback& callback);
+
   public:
     // PUBLIC TYPES
 
@@ -199,12 +227,12 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
 
     /// Start the channel factory. Return 0 on success and a non-zero value
     /// otherwise.
-    int start();
+    int start() BSLS_KEYWORD_OVERRIDE;
 
     /// Stop the channel factory. Note that the behavior is undefined unless
     /// the thread calling this function is the same thread that called
     /// `start()` and is not one of the I/O threads used by this object.
-    void stop();
+    void stop() BSLS_KEYWORD_OVERRIDE;
 
     /// Listen for connections according to the specified `options` (whose
     /// meaning is implementation-defined), and invoke the specified `cb`
@@ -213,6 +241,9 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// this operation.  Return `e_SUCCESS` on success or a failure
     /// StatusCategory on error, populating the optionally-specified
     /// `status` with more detailed error information.
+    ///
+    /// If `encryptionServer()` is not null, the listener will use it to
+    /// upgrade to a TLS connection.
     void listen(Status*                      status,
                 bslma::ManagedPtr<OpHandle>* handle,
                 const ListenOptions&         options,
@@ -232,6 +263,9 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// `options.autoReconnect()` is `true` and the implementing
     /// `ChannelFactory` doesn't provide this behavior, it must fail the
     /// connection immediately.
+    ///
+    /// If `encryptionClient()` is not null, the connection will use it to
+    /// upgrade to a TLS connection.
     void connect(Status*                      status,
                  bslma::ManagedPtr<OpHandle>* handle,
                  const ConnectOptions&        options,
@@ -247,18 +281,72 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// used to unregister the callback.
     bdlmt::SignalerConnection onLimit(const LimitFn& cb);
 
+    /// Register the specified `cb` to be invoked when a channel is
+    /// upgraded. Return a `bdlmt::SignalerConnection` object than can be
+    /// used to unregister the callback.
+    bdlmt::SignalerConnection onUpgrade(const UpgradeFn& cb);
+
     /// Load into the specified `result` the channel having the specified
     /// `channelId`. Return 0 on success and a non-zero value otherwise.
     int lookupChannel(bsl::shared_ptr<bmqio::NtcChannel>* result,
-                      int                                 channelId);
+                      int                                 channelId) const;
 
     /// Invoke the specified `visitor` once for every currently active
     /// channel managed by this object.  The `visitor` will be invoked with
-    /// a single argument, `const bsl::shared_ptr<bmqio::NtzChannel>&`.
+    /// a single argument, `const bsl::shared_ptr<bmqio::NtcChannel>&`.
     /// Note that it is unspecified whether channels created or closed
     /// during the execution of this function will be included.
     template <typename VISITOR>
     void visitChannels(VISITOR& visitor);
+
+    /// @brief Modify the factory's encryption server.
+    ///
+    /// The behavior is undefined unless this channel factory
+    /// is stopped.
+    void setEncryptionServer(const EncryptionServerSp& encryptionServer);
+
+    /// @brief Initailze this factory's encryption server using `options`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    ntsa::Error
+    configureEncryptionServer(const ntca::EncryptionServerOptions& options);
+
+    /// @brief Modify this factory's encryption client.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    void setEncryptionClient(const EncryptionClientSp& encryptionClient);
+
+    /// @brief Initailze this factory's encryption server using `options`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    ntsa::Error
+    configureEncryptionClient(const ntca::EncryptionClientOptions& options);
+
+    /// @brief Modify the upgrade options used for listener and connect
+    /// operations. The default value is the default initialized
+    /// `ntca::UpgradeOptions`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    void setUpgradeOptions(const ntca::UpgradeOptions& options);
+
+    // ACCESSORS
+
+    /// @brief Access the factory's encryption server.
+    ///
+    /// The behavior of is undefined unless the encryption client was
+    /// initialized with either `configureEncryptionServer` or
+    /// `setEncryptionServer`.
+    const ntci::EncryptionServer& encryptionServer() const;
+
+    /// @brief Access this factory's encryption client.
+    ///
+    /// The behavior of is undefined unless the encryption client was
+    /// initialized with either `configureEncryptionClient` or
+    /// `setEncryptionClient`.
+    const ntci::EncryptionClient& encryptionClient() const;
+
+    /// @brief Access this factory's upgrade options.
+    const ntca::UpgradeOptions& upgradeOptions() const;
 };
 
 // ============================

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
@@ -16,11 +16,15 @@
 // bmqio_ntcchannelfactory.t.cpp                                      -*-C++-*-
 #include <bmqio_ntcchannelfactory.h>
 
-#include <bmqu_blob.h>
-
+// NTC
+#include <ntca_upgradeevent.h>
+#include <ntca_upgradeoptions.h>
 #include <ntcf_system.h>
-#include <ntsf_system.h>
+#include <ntci_interface.h>
+#include <ntci_upgradable.h>
+#include <ntsa_distinguishedname.h>
 
+// BDE
 #include <ball_filteringobserver.h>
 #include <ball_loggermanager.h>
 #include <ball_testobserver.h>
@@ -32,13 +36,18 @@
 #include <bdlf_bind.h>
 #include <bsl_deque.h>
 #include <bsl_memory.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
 #include <bsla_annotations.h>
+#include <bslma_allocator.h>
 #include <bslmt_latch.h>
 #include <bslmt_threadutil.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
 
+// BMQ
 #include <bmqtst_testhelper.h>
+#include <bmqu_blob.h>
 #include <bsl_iostream.h>
 #include <bsl_map.h>
 
@@ -81,6 +90,110 @@ static bool ballFilter(const bsl::string&      messageSubstring,
     return !bdlb::StringRefUtil::strstr(record.fixedFields().messageRef(),
                                         messageSubstring)
                 .isEmpty();
+}
+
+namespace {
+
+// ==========================
+// class Tester_UpgradeCbInfo
+// ==========================
+
+/// Arguments used in a call to a `NtcChannelFactory::onUpgrade` handler.
+struct UpgradeCbInfo {
+    // DATA
+    bsl::shared_ptr<ntci::Upgradable> d_upgradable;
+    ntca::UpgradeEvent                d_event;
+
+    typedef bsl::allocator<> allocator_type;
+
+    // CREATORS
+    UpgradeCbInfo(allocator_type allocator)
+    : d_upgradable()
+    , d_event(bslma::AllocatorUtil::adapt(allocator))
+    {
+        // NOTHING
+    }
+
+    UpgradeCbInfo(BSLA_MAYBE_UNUSED const UpgradeCbInfo& original,
+                  allocator_type                         allocator)
+    : d_upgradable()
+    , d_event(bslma::AllocatorUtil::adapt(allocator))
+    {
+        // NOTHING
+    }
+};
+
+///
+class ChannelUpgradeHandler {
+  public:
+    typedef bsl::map<int, UpgradeCbInfo> ChannelMap;
+    typedef bsl::allocator<>             allocator_type;
+
+  private:
+    mutable bslmt::Mutex d_mutex;
+    ChannelMap           d_channelMap;
+
+  public:
+    explicit ChannelUpgradeHandler(allocator_type allocator)
+    : d_mutex()
+    , d_channelMap(allocator)
+    {
+    }
+
+    /// Record the upgrade event and associate it with a channel based on its
+    /// ID.
+    void onUpgrade(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                   const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                   const ntca::UpgradeEvent&                 event)
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        BMQTST_ASSERT_D("Channel was attempted to upgrade multiple times",
+                        !d_channelMap.contains(channel->channelId()));
+
+        UpgradeCbInfo& upgradeInfo = d_channelMap[channel->channelId()];
+        upgradeInfo.d_upgradable   = upgradable;
+        upgradeInfo.d_event        = event;
+    }
+
+    /// Check that each upgrade was successful. Otherwise, fail the test.
+    void checkAll() const
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        bsl::for_each(d_channelMap.cbegin(),
+                      d_channelMap.cend(),
+                      ChannelUpgradeHandler::checkChannelMapEntry);
+    }
+
+    /// Return the number of upgrade events
+    bsl::size_t upgradeCounts() const { return d_channelMap.size(); }
+
+    /// Create a callback function that references this handler
+    bsl::function<void(const bsl::shared_ptr<bmqio::NtcChannel>&,
+                       const bsl::shared_ptr<ntci::Upgradable>&,
+                       const ntca::UpgradeEvent&)>
+    makeOnUpgradeCb()
+    {
+        return bdlf::BindUtil::bindS(
+            bslma::AllocatorUtil::adapt(d_channelMap.get_allocator()),
+            &ChannelUpgradeHandler::onUpgrade,
+            this,
+            bdlf::PlaceHolders::_1,
+            bdlf::PlaceHolders::_2,
+            bdlf::PlaceHolders::_3);
+    }
+
+  private:
+    /// Check if the upgrade event contained in `value` was completed,
+    /// otherwise fail the test.
+    static void checkChannelMapEntry(const ChannelMap::value_type& value)
+    {
+        BMQTST_ASSERT_D("Channel upgrade failed",
+                        value.second.d_event.isComplete());
+    }
+};
+
 }
 
 // CONSTANTS
@@ -196,6 +309,7 @@ struct Tester_HandleInfo {
     bsl::shared_ptr<ChannelFactory::OpHandle> d_handle;
     bsl::deque<Tester_ResultCbInfo>           d_resultCbCalls;
     int                                       d_listenPort;
+    bsl::deque<UpgradeCbInfo>                 d_upgradeCbCalls;
 
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(Tester_HandleInfo,
@@ -206,6 +320,7 @@ struct Tester_HandleInfo {
     : d_handle()
     , d_resultCbCalls(basicAllocator)
     , d_listenPort(-1)
+    , d_upgradeCbCalls(basicAllocator)
     {
         // NOTHING
     }
@@ -215,6 +330,7 @@ struct Tester_HandleInfo {
     : d_handle(original.d_handle)
     , d_resultCbCalls(original.d_resultCbCalls, basicAllocator)
     , d_listenPort(original.d_listenPort)
+    , d_upgradeCbCalls(original.d_upgradeCbCalls, basicAllocator)
     {
         // NOTHING
     }
@@ -259,16 +375,25 @@ class Tester {
     typedef bsl::shared_ptr<NtcChannel>        NtcChannelPtr;
     typedef bsl::deque<NtcChannelPtr>          PreCreateCbCallList;
 
+  private:
     // DATA
-    bslma::Allocator*                    d_allocator_p;
-    bdlbb::PooledBlobBufferFactory       d_blobBufferFactory;
-    bsl::shared_ptr<ball::TestObserver>  d_ballObserver;
-    ChannelMap                           d_channelMap;
-    HandleMap                            d_handleMap;
-    PreCreateCbCallList                  d_preCreateCbCalls;
-    bool                                 d_setPreCreateCb;
-    bslma::ManagedPtr<NtcChannelFactory> d_object;
-    bslmt::Mutex                         d_mutex;
+    bslma::Allocator*                            d_allocator_p;
+    bdlbb::PooledBlobBufferFactory               d_blobBufferFactory;
+    bsl::shared_ptr<ball::TestObserver>          d_ballObserver;
+    ChannelMap                                   d_channelMap;
+    HandleMap                                    d_handleMap;
+    PreCreateCbCallList                          d_preCreateCbCalls;
+    bool                                         d_setPreCreateCb;
+    bool                                         d_setEncryptionServer;
+    bool                                         d_setEncryptionClient;
+    bslma::ManagedPtr<NtcChannelFactory>         d_object;
+    bslmt::Mutex                                 d_mutex;
+    bsl::shared_ptr<ntci::Interface>             d_interface;
+    bsl::shared_ptr<ntci::EncryptionCertificate> d_authorityCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         d_authorityPrivateKey;
+    bsl::shared_ptr<ntci::EncryptionCertificate> d_serverCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         d_serverPrivateKey;
+    bsl::shared_ptr<ntci::EncryptionClient>      d_encryptionClient;
 
     // PRIVATE MANIPULATORS
 
@@ -277,6 +402,11 @@ class Tester {
                   ChannelFactoryEvent::Enum       event,
                   const Status&                   status,
                   const bsl::shared_ptr<Channel>& channel);
+
+    /// Push an upgrade event onto the list of observed upgrade events
+    void recordUpgrade(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                       const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                       const ntca::UpgradeEvent&                 event);
 
     /// `channelPreCreationCb` passed to the NtcChannelFactory, if we're
     /// asked to pass one
@@ -304,6 +434,17 @@ class Tester {
     /// Destroy the object being tested and reset all supporting objects.
     void destroy();
 
+    /// Initialize the root authority certificate for the server and client.
+    void initEncryptionAuthority();
+
+    /// Initialize the server certificate and private key and configure the
+    /// channel factory to use it for upgrading listeners.
+    void initEncryptionServer();
+
+    /// Initialize the client encryption settings and configure the
+    /// channel factory to use it for upgrading connections.
+    void initEncryptionClient();
+
     // NOT IMPLEMENTED
     Tester(const Tester&);
     Tester& operator=(const Tester&);
@@ -322,6 +463,16 @@ class Tester {
     /// the next time `init` is called to the specified `value`.  By default
     /// this is `false`.
     void setPreCreateCb(bool value);
+
+    /// Set whether an `encryptionServer` will be set on the
+    /// `NtcChannelFactory` the next time `init` is called to the specified
+    /// `value`.  By default this is `false`.
+    void setEncryptionServer(bool value);
+
+    /// Set whether an `encryptionClient` will be set on the
+    /// `NtcChannelFactory` the next time `init` is called to the specified
+    /// `value`.  By default this is `false`.
+    void setEncryptionClient(bool value);
 
     /// Find and return a free port by opening and dropping a handle.
     /// Note that the found port might become occupied in an unlikely event of
@@ -546,6 +697,12 @@ void Tester::channelWatermarkCb(const bsl::string&         channelName,
 
 void Tester::destroy()
 {
+    d_serverPrivateKey.reset();
+    d_serverCertificate.reset();
+    d_authorityPrivateKey.reset();
+    d_authorityCertificate.reset();
+
+    d_interface.reset();
     d_preCreateCbCalls.clear();
 
     if (d_object) {
@@ -565,12 +722,20 @@ void Tester::destroy()
 Tester::Tester(bslma::Allocator* basicAllocator)
 : d_allocator_p(bslma::Default::allocator(basicAllocator))
 , d_blobBufferFactory(0xFFFF, basicAllocator)
+, d_ballObserver()
 , d_channelMap(basicAllocator)
 , d_handleMap(basicAllocator)
 , d_preCreateCbCalls(basicAllocator)
 , d_setPreCreateCb(false)
+, d_setEncryptionServer(false)
+, d_setEncryptionClient(false)
 , d_object()
 , d_mutex()
+, d_interface()
+, d_authorityCertificate()
+, d_authorityPrivateKey()
+, d_serverCertificate()
+, d_serverPrivateKey()
 {
 }
 
@@ -583,6 +748,16 @@ Tester::~Tester()
 void Tester::setPreCreateCb(bool value)
 {
     d_setPreCreateCb = value;
+}
+
+void Tester::setEncryptionServer(bool value)
+{
+    d_setEncryptionServer = value;
+}
+
+void Tester::setEncryptionClient(bool value)
+{
+    d_setEncryptionClient = value;
 }
 
 int Tester::findFreeEphemeralPort()
@@ -603,6 +778,138 @@ int Tester::findFreeEphemeralPort()
     return port;
 }
 
+void Tester::initEncryptionAuthority()
+{
+    if (d_authorityCertificate && d_authorityPrivateKey) {
+        // Authority root has already been initialized, no need to set it again
+        return;
+    }
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         authorityPrivateKey;
+
+    // Generate the certificate and private key of a trusted authority.
+
+    ntsa::DistinguishedName authorityIdentity(d_allocator_p);
+    authorityIdentity["CN"] = "Authority";
+    authorityIdentity["O"]  = "Bloomberg LP";
+
+    ntsa::Error error = d_interface->generateKey(&authorityPrivateKey,
+                                                 ntca::EncryptionKeyOptions(),
+                                                 d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    ntca::EncryptionCertificateOptions authorityCertificateOptions;
+    authorityCertificateOptions.setAuthority(true);
+
+    error = d_interface->generateCertificate(&authorityCertificate,
+                                             authorityIdentity,
+                                             authorityPrivateKey,
+                                             authorityCertificateOptions,
+                                             d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    d_authorityCertificate.swap(authorityCertificate);
+    d_authorityPrivateKey.swap(authorityPrivateKey);
+}
+
+void Tester::initEncryptionServer()
+{
+    if (d_serverCertificate && d_serverPrivateKey) {
+        // Authority root has already been initialized, no need to set it again
+        return;
+    }
+
+    // Ensure the authority is initialized as its our root of trust
+    initEncryptionAuthority();
+
+    // Create an encryption server and configure the encryption server to
+    // accept upgrades to TLS 1.3 and higher, to cryptographically identify
+    // itself using the server certificate previously generated, to encrypt
+    // data using the server private key previously generated, and to not
+    // require identification from the client.
+    bsl::shared_ptr<ntci::EncryptionCertificate> serverCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         serverPrivateKey;
+
+    // Generate the certificate and private key of the server, signed
+    // by the trusted authority.
+
+    ntsa::DistinguishedName serverIdentity(d_allocator_p);
+    serverIdentity["CN"] = "Server";
+    serverIdentity["O"]  = "Bloomberg LP";
+
+    ntsa::Error error = d_interface->generateKey(&serverPrivateKey,
+                                                 ntca::EncryptionKeyOptions(),
+                                                 d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    error = d_interface->generateCertificate(
+        &serverCertificate,
+        serverIdentity,
+        serverPrivateKey,
+        d_authorityCertificate,
+        d_authorityPrivateKey,
+        ntca::EncryptionCertificateOptions(),
+        d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    ntca::EncryptionServerOptions encryptionServerOptions;
+    encryptionServerOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionServerOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    encryptionServerOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_NONE);
+
+    {
+        bsl::vector<char> identityData(d_allocator_p);
+        serverCertificate->encode(&identityData);
+        encryptionServerOptions.setIdentityData(identityData);
+    }
+
+    {
+        bsl::vector<char> privateKeyData(d_allocator_p);
+        serverPrivateKey->encode(&privateKeyData);
+        encryptionServerOptions.setPrivateKeyData(privateKeyData);
+    }
+
+    // Let the channel factory use the certificate for upgrading incoming
+    // connections
+    error = object().configureEncryptionServer(encryptionServerOptions);
+
+    d_serverCertificate.swap(serverCertificate);
+    d_serverPrivateKey.swap(serverPrivateKey);
+
+    BMQTST_ASSERT(!error);
+}
+
+void Tester::initEncryptionClient()
+{
+    ntsa::Error error;
+
+    initEncryptionAuthority();
+
+    // Create an encryption client and configure the encryption client to
+    // request upgrades using TLS 1.2 require identification from the
+    // server, and to trust the certificate authority previously generated
+    // to verify the authenticity of the server.
+    ntca::EncryptionClientOptions encryptionClientOptions;
+    encryptionClientOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionClientOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    encryptionClientOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_VERIFY);
+
+    {
+        bsl::vector<char> authorityData(d_allocator_p);
+        d_authorityCertificate->encode(&authorityData);
+        encryptionClientOptions.addAuthorityData(authorityData);
+    }
+
+    // Let the channel factory use the certificate for upgrading outgoing
+    // connections
+    error = object().configureEncryptionClient(encryptionClientOptions);
+
+    BMQTST_ASSERT(!error);
+}
+
 void Tester::init(int line)
 {
     destroy();
@@ -610,9 +917,17 @@ void Tester::init(int line)
     ntca::InterfaceConfig interfaceConfig;
     interfaceConfig.setThreadName("test");
 
-    d_object.load(new (*d_allocator_p) NtcChannelFactory(interfaceConfig,
-                                                         &d_blobBufferFactory,
-                                                         d_allocator_p),
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> blobBufferFactory_sp(
+        &d_blobBufferFactory,
+        bslstl::SharedPtrNilDeleter(),
+        d_allocator_p);
+
+    d_interface = ntcf::System::createInterface(interfaceConfig,
+                                                blobBufferFactory_sp,
+                                                d_allocator_p);
+
+    d_object.load(new (*d_allocator_p)
+                      NtcChannelFactory(d_interface, d_allocator_p),
                   d_allocator_p);
 
     if (d_setPreCreateCb) {
@@ -620,6 +935,12 @@ void Tester::init(int line)
                                                 this,
                                                 bdlf::PlaceHolders::_1,
                                                 bdlf::PlaceHolders::_2));
+    }
+    if (d_setEncryptionServer) {
+        initEncryptionServer();
+    }
+    if (d_setEncryptionClient) {
+        initEncryptionClient();
     }
 
     int ret = d_object->start();
@@ -1076,6 +1397,106 @@ NtcChannelFactory& Tester::object()
 // ============================================================================
 //                                    TESTS
 // ----------------------------------------------------------------------------
+
+static void test9_tlsClientFailsOnPlaintextServer()
+// ------------------------------------------------------------------------
+// PRE CREATION CB TEST
+//
+// Concerns:
+//  a) An attempt to connect to a plaintext server with a TLS channel will fail
+//  b) An attempt to connect to a TLS server with a plaintext channel will fail
+//  c) A failed attempt to connect from a plaintext client doesn't cause a TLS
+//  listener to close
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("Upgrade Channel Cb Test");
+
+    Tester t(bmqtst::TestHelperUtil::allocator());
+
+    // Use TLS for both connections and listeners
+    t.setEncryptionServer(true);
+
+    // Concern 'a'
+    t.init(L_);
+
+    {
+        ChannelUpgradeHandler upgradeCounter(
+            bmqtst::TestHelperUtil::allocator());
+
+        // Register a way to record upgrade events
+        t.object().onUpgrade(upgradeCounter.makeOnUpgradeCb());
+
+        // Shorten the timeout interval
+        ntca::UpgradeOptions upgradeOptions;
+        bsls::TimeInterval   deadline = bdlt::CurrentTime::now();
+        // 5ms doesn't seem to interfere with the success test case, so this
+        // should be sufficient enough
+        deadline.addMilliseconds(5);
+        upgradeOptions.setDeadline(deadline);
+        t.object().setUpgradeOptions(upgradeOptions);
+
+        BMQTST_ASSERT_EQ(0, t.object().start());
+    }
+
+    t.listen(L_, "listenHandle0", "127.0.0.1:5001", StatusCategory::e_SUCCESS);
+    t.connect(L_,
+              "connectHandle0",
+              "listenHandle0",
+              StatusCategory::e_SUCCESS);
+
+    t.checkResultCallback(L_,
+                          "listenHandle0",
+                          ChannelFactoryEvent::e_CONNECT_FAILED,
+                          StatusCategory::e_GENERIC_ERROR);
+    t.checkNoResultCallback(L_, "channelHandle0");
+}
+
+static void test8_upgradeChannelTest()
+// ------------------------------------------------------------------------
+// PRE CREATION CB TEST
+//
+// Concerns:
+//  a) 'upgradeChannelCb' is called for every channel upgraded
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("Upgrade Channel Cb Test");
+
+    Tester t(bmqtst::TestHelperUtil::allocator());
+
+    // Use TLS for both connections and listeners
+    t.setEncryptionServer(true);
+    t.setEncryptionClient(true);
+
+    // Concern 'a'
+    t.init(L_);
+
+    ChannelUpgradeHandler upgradeCounter(bmqtst::TestHelperUtil::allocator());
+
+    // Register a way to record upgrade events
+    t.object().onUpgrade(upgradeCounter.makeOnUpgradeCb());
+
+    // Create a TLS channel
+    t.listen(L_, "listenHandle", "127.0.0.1:5001", StatusCategory::e_SUCCESS);
+    t.connect(L_, "connectHandle", "listenHandle", StatusCategory::e_SUCCESS);
+    t.connect(L_, "connectHandle2", "listenHandle", StatusCategory::e_SUCCESS);
+
+    // Confirm the channel was successfully created
+    t.checkResultCallback(L_, "listenHandle", "listenChannel");
+    t.checkResultCallback(L_, "connectHandle", "connectChannel");
+    t.checkResultCallback(L_, "connectHandle2", "connectChannel2");
+
+    // We expect each connect/listen pair to have received a successful
+    // upgrade event
+    upgradeCounter.checkAll();
+    BMQTST_ASSERT_EQ_D("Unexpected number of channel upgrades",
+                       4UL,
+                       upgradeCounter.upgradeCounts());
+
+    // Confirm the upgrade didn't mess up the received message
+    t.writeChannel(L_, "listenChannel", "abcdef");
+    t.readChannel(L_, "connectChannel", "abcdef");
+}
+
 static void test7_checkMultithreadListen()
 {
     bmqtst::TestHelper::printTestName("Check Multithread Listen Test");
@@ -1371,7 +1792,7 @@ static void test1_breathingTest()
     t.init(L_);
 
     // Listen and connect work
-    t.listen(L_, "listenHandle", "127.0.0.1:0");
+    t.listen(L_, "listenHandle", "127.0.0.1:5001");
     t.connect(L_, "connectHandle", "listenHandle");
 
     t.checkResultCallback(L_, "listenHandle", "listenChannel");
@@ -1406,9 +1827,10 @@ static void test1_breathingTest()
 
 int main(int argc, char* argv[])
 {
+    bmqtst::TestHelperUtil::verbosityLevel() = 1;
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    // ntcf::System::initialize();
+    ntcf::SystemGuard systemGuard(ntscfg::Signal::e_PIPE);
 
     switch (_testCase) {
     case 0:
@@ -1419,13 +1841,13 @@ int main(int argc, char* argv[])
     case 5: test5_visitChannelsTest(); break;
     case 6: test6_preCreationCbTest(); break;
     case 7: test7_checkMultithreadListen(); break;
+    case 8: test8_upgradeChannelTest(); break;
+    case 9: test9_tlsClientFailsOnPlaintextServer(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    // ntcf::System::exit();
 
     TEST_EPILOG(0);
 }

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
@@ -473,6 +473,10 @@ ReconnectingChannelFactory::~ReconnectingChannelFactory()
 
 int ReconnectingChannelFactory::start()
 {
+    int rc = d_config.d_base_p->start();
+    if (rc != 0) {
+        return rc;
+    }
     d_validator.reset();  // Support multiple 'start'
     return 0;
 }
@@ -495,6 +499,8 @@ void ReconnectingChannelFactory::stop()
          ++iter) {
         iter->second->cancel();
     }
+
+    d_config.d_base_p->stop();
 }
 
 void ReconnectingChannelFactory::listen(Status*                      status,

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
@@ -297,10 +297,10 @@ class ReconnectingChannelFactory : public ChannelFactory {
     ~ReconnectingChannelFactory() BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
-    int start();
+    int start() BSLS_KEYWORD_OVERRIDE;
 
     /// Cancel any pending reconnect attempts.
-    void stop();
+    void stop() BSLS_KEYWORD_OVERRIDE;
 
     // ChannelFactory
 

--- a/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.cpp
@@ -215,6 +215,16 @@ void ResolvingChannelFactory::connect(Status*                      status,
                              bdlf::PlaceHolders::_3));  // channel
 }
 
+int ResolvingChannelFactory::start()
+{
+    return d_config.d_baseFactory_p->start();
+}
+
+void ResolvingChannelFactory::stop()
+{
+    return d_config.d_baseFactory_p->stop();
+}
+
 // ----------------------------------
 // struct ResolvingChannelFactoryUtil
 // ----------------------------------

--- a/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.h
@@ -254,6 +254,10 @@ class ResolvingChannelFactory : public ChannelFactory {
                  bslma::ManagedPtr<OpHandle>* handle,
                  const ConnectOptions&        options,
                  const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    void stop() BSLS_KEYWORD_OVERRIDE;
 };
 
 // ==================================

--- a/src/groups/bmq/bmqio/bmqio_statchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_statchannelfactory.cpp
@@ -207,6 +207,18 @@ void StatChannelFactory::connect(Status*                      status,
                              bdlf::PlaceHolders::_3));  // channel
 }
 
+int StatChannelFactory::start()
+{
+    // Pass through
+    return d_config.d_baseFactory_p->start();
+}
+
+void StatChannelFactory::stop()
+{
+    // Pass through
+    d_config.d_baseFactory_p->stop();
+}
+
 // -----------------------------
 // struct StatChannelFactoryUtil
 // -----------------------------

--- a/src/groups/bmq/bmqio/bmqio_statchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_statchannelfactory.h
@@ -226,6 +226,12 @@ class StatChannelFactory : public ChannelFactory {
                  bslma::ManagedPtr<OpHandle>* handle,
                  const ConnectOptions&        options,
                  const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    /// Start the base channel factory.
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the base channel factory.
+    void stop() BSLS_KEYWORD_OVERRIDE;
 };
 
 // =============================

--- a/src/groups/bmq/bmqio/bmqio_testchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_testchannelfactory.cpp
@@ -148,5 +148,14 @@ void TestChannelFactory::connect(Status*                      status,
     }
 }
 
+int TestChannelFactory::start()
+{
+    return 0;
+}
+
+void TestChannelFactory::stop()
+{
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqio/bmqio_testchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_testchannelfactory.h
@@ -204,6 +204,8 @@ class TestChannelFactory : public ChannelFactory {
                  bslma::ManagedPtr<OpHandle>* handle,
                  const ConnectOptions&        options,
                  const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+    int  start() BSLS_KEYWORD_OVERRIDE;
+    void stop() BSLS_KEYWORD_OVERRIDE;
 };
 
 }  // close package namespace

--- a/src/groups/bmq/bmqio/package/bmqio.dep
+++ b/src/groups/bmq/bmqio/package/bmqio.dep
@@ -3,5 +3,6 @@ bmqscm
 bmqst
 bmqsys
 bmqt
+bmqtst
 bmqu
 bmqvt

--- a/src/groups/bmq/bmqio/package/bmqio.mem
+++ b/src/groups/bmq/bmqio/package/bmqio.mem
@@ -1,6 +1,7 @@
 bmqio_basechannelpartialimp
 bmqio_channel
 bmqio_channelfactory
+bmqio_channelfactorypipeline
 bmqio_channelutil
 bmqio_connectoptions
 bmqio_decoratingchannelpartialimp

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
@@ -18,8 +18,13 @@
 
 #include <bmqscm_version.h>
 // BDE
+#include <bdlb_string.h>
+#include <bdls_filesystemutil.h>
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
+
+// BMQ
+#include <bmqu_stringutil.h>
 
 namespace BloombergLP {
 namespace bmqt {
@@ -29,6 +34,8 @@ namespace bmqt {
 // --------------------
 
 const char SessionOptions::k_BROKER_DEFAULT_URI[] = "tcp://localhost:30114";
+
+const char SessionOptions::k_DEFAULT_TLS_PROTOCOL_VERSIONS[] = "TLSv1.3";
 
 SessionOptions::SessionOptions(bslma::Allocator* allocator)
 : d_brokerUri(k_BROKER_DEFAULT_URI, allocator)
@@ -46,6 +53,8 @@ SessionOptions::SessionOptions(bslma::Allocator* allocator)
 , d_eventQueueHighWatermark(2 * 1000)
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
 , d_authnCredentialCb()
+, d_certificateAuthority(allocator)
+, d_protocolVersions(allocator)
 , d_hostHealthMonitor_sp()
 , d_dtContext_sp()
 , d_dtTracer_sp()
@@ -72,6 +81,8 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 , d_eventQueueHighWatermark(other.eventQueueHighWatermark())
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
 , d_authnCredentialCb(other.authnCredentialCb())
+, d_certificateAuthority(other.certificateAuthority(), allocator)
+, d_protocolVersions(other.protocolVersions(), allocator)
 , d_hostHealthMonitor_sp(other.hostHealthMonitor())
 , d_dtContext_sp(other.traceContext())
 , d_dtTracer_sp(other.tracer())
@@ -79,6 +90,44 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 , d_channelWriteTimeout(other.d_channelWriteTimeout)
 {
     // NOTHING
+}
+
+SessionOptions&
+SessionOptions::configureTls(bsl::string_view certificateAuthority,
+                             bsl::string_view versions)
+{
+    d_certificateAuthority = certificateAuthority;
+    d_protocolVersions.clear();
+
+    bsl::vector<bsl::string_view> vs =
+        bmqu::StringUtil::strTokenizeRef(versions, ", \t");
+    for (bsl::vector<bsl::string_view>::const_iterator it  = vs.cbegin(),
+                                                       end = vs.cend();
+         it != end;
+         ++it) {
+        TlsProtocolVersion::Value version;
+
+        if (TlsProtocolVersion::fromAscii(&version, *it)) {
+            d_protocolVersions.insert(version);
+        }
+        else {
+            BSLS_ASSERT_OPT(false && "Unrecognized protocol version");
+        }
+    }
+
+    // TODO(tfoxhall): Asserts are a terrible way to do validation here but
+    // this seems to be the approach taken for the entire SessionOptions class.
+    BSLS_ASSERT_OPT(bdls::FilesystemUtil::exists(d_certificateAuthority));
+    BSLS_ASSERT_OPT(!d_protocolVersions.empty() &&
+                    "At least one TLS protocol version must be specified");
+
+    return *this;
+}
+
+SessionOptions&
+SessionOptions::configureTls(bsl::string_view certificateAuthority)
+{
+    return configureTls(certificateAuthority, k_DEFAULT_TLS_PROTOCOL_VERSIONS);
 }
 
 bsl::ostream& SessionOptions::print(bsl::ostream& stream,
@@ -117,6 +166,10 @@ bsl::ostream& SessionOptions::print(bsl::ostream& stream,
                            d_hostHealthMonitor_sp != NULL);
     printer.printAttribute("hasDistributedTracing", d_dtTracer_sp != NULL);
     printer.printAttribute("userAgentPrefix", d_userAgentPrefix);
+    printer.printAttribute("certificateAuthority", d_certificateAuthority);
+    printer.printAttribute("protocolVersions",
+                           d_protocolVersions.cbegin(),
+                           d_protocolVersions.cend());
     printer.end();
 
     return stream;

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -131,6 +131,7 @@
 
 // BMQ
 #include <bmqt_authncredential.h>
+#include <bmqt_tlsprotocolversion.h>
 
 // BDE
 #include <bdlb_chartype.h>
@@ -141,6 +142,7 @@
 #include <bsl_memory.h>
 #include <bsl_optional.h>
 #include <bsl_string.h>
+#include <bsl_unordered_set.h>
 #include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
@@ -197,6 +199,9 @@ class SessionOptions {
 
     static const unsigned int k_CHANNEL_WRITE_DEFAULT_TIMEOUT_SEC = 5;
 
+    /// Default supported TLS versions in this client.
+    static const char k_DEFAULT_TLS_PROTOCOL_VERSIONS[];
+
   private:
     // DATA
 
@@ -244,6 +249,12 @@ class SessionOptions {
     /// data) for authenticating with the broker. If not set, the session will
     /// not authenticate with the broker.
     AuthnCredentialCb d_authnCredentialCb;
+
+    /// Path of the certificate authority
+    bsl::string d_certificateAuthority;
+
+    /// Supported TLS versions
+    bsl::unordered_set<TlsProtocolVersion::Value> d_protocolVersions;
 
     bsl::shared_ptr<bmqpi::HostHealthMonitor> d_hostHealthMonitor_sp;
 
@@ -359,6 +370,20 @@ class SessionOptions {
     /// Zero means no blocking.
     SessionOptions& setChannelWriteTimeout(const bsls::TimeInterval& value);
 
+    /// Set the TLS certificate authority to the specified
+    /// 'certificateAuthority'. Set the TLS protocol versions to the specified
+    /// 'versions'. Return this SessionOptions object reference.
+    ///
+    /// @pre The `versions` string must contain at least one TLS version.
+    SessionOptions& configureTls(bsl::string_view certificateAuthority,
+                                 bsl::string_view versions);
+
+    /// Set the TLS certificate authority to the specified
+    /// 'certificateAuthority'. Set the supported TLS protocol versions to the
+    /// default supported TLS versions. Return this SessionOptions object
+    /// reference.
+    SessionOptions& configureTls(bsl::string_view certificateAuthority);
+
     // ACCESSORS
 
     /// Get the broker URI.
@@ -407,6 +432,16 @@ class SessionOptions {
 
     int eventQueueLowWatermark() const;
     int eventQueueHighWatermark() const;
+
+    /// @brief Get the configured certificate authority file path.
+    const bsl::string& certificateAuthority() const;
+
+    /// @brief Get the configured supported TLS protocol versions.
+    const bsl::unordered_set<TlsProtocolVersion::Value>&
+    protocolVersions() const;
+
+    /// @brief Return true if this session will be configured for TLS.
+    bool isTlsSession() const;
 
     /// DEPRECATED: This parameter is no longer relevant and will be removed
     /// in future release of libbmq.
@@ -698,6 +733,22 @@ inline int SessionOptions::eventQueueHighWatermark() const
     return d_eventQueueHighWatermark;
 }
 
+inline const bsl::string& SessionOptions::certificateAuthority() const
+{
+    return d_certificateAuthority;
+}
+
+inline const bsl::unordered_set<TlsProtocolVersion::Value>&
+SessionOptions::protocolVersions() const
+{
+    return d_protocolVersions;
+}
+
+inline bool SessionOptions::isTlsSession() const
+{
+    return !protocolVersions().empty();
+}
+
 inline int SessionOptions::eventQueueSize() const
 {
     return d_eventQueueSize;
@@ -736,7 +787,9 @@ inline bool bmqt::operator==(const bmqt::SessionOptions& lhs,
            lhs.hostHealthMonitor() == rhs.hostHealthMonitor() &&
            lhs.traceContext() == rhs.traceContext() &&
            lhs.tracer() == rhs.tracer() &&
-           lhs.userAgentPrefix() == rhs.userAgentPrefix();
+           lhs.userAgentPrefix() == rhs.userAgentPrefix() &&
+           lhs.certificateAuthority() == rhs.certificateAuthority() &&
+           lhs.protocolVersions() == rhs.protocolVersions();
 }
 
 inline bool bmqt::operator!=(const bmqt::SessionOptions& lhs,
@@ -756,7 +809,9 @@ inline bool bmqt::operator!=(const bmqt::SessionOptions& lhs,
            lhs.hostHealthMonitor() != rhs.hostHealthMonitor() ||
            lhs.traceContext() != rhs.traceContext() ||
            lhs.tracer() != rhs.tracer() ||
-           lhs.userAgentPrefix() != rhs.userAgentPrefix();
+           lhs.userAgentPrefix() != rhs.userAgentPrefix() ||
+           lhs.certificateAuthority() != rhs.certificateAuthority() ||
+           lhs.protocolVersions() != rhs.protocolVersions();
 }
 
 inline bsl::ostream& bmqt::operator<<(bsl::ostream&               stream,

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
@@ -26,6 +26,7 @@
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
+#include <bslstl_unorderedset.h>
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -66,7 +67,7 @@ static void test2_printTest()
         "closeQueueTimeout = 300 eventQueueLowWatermark = 50 "
         "eventQueueHighWatermark = 2000 hasAuthnCredentialCb = false "
         "hasHostHealthMonitor = false hasDistributedTracing = false "
-        "userAgentPrefix = \"\" ]";
+        "userAgentPrefix = \"\" certificateAuthority = \"\" protocolVersions = [ ] ]";
     bmqtst::TestHelper::printTestName("PRINT");
     PV("Testing print");
     bmqu::MemOutStream stream(bmqtst::TestHelperUtil::allocator());
@@ -84,10 +85,15 @@ static void test2_printTest()
 
 static void test3_setterGetterAndCopyTest()
 {
+    bslma::Allocator* allocator = bmqtst::TestHelperUtil::allocator();
     bmqtst::TestHelper::printTestName("SETTER GETTER");
+    // Default allocator use is actually pretty normal
+    // Used in configureTls
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
     PVV("Setter getter test");
     // Create default sessionOptions
-    bmqt::SessionOptions obj(bmqtst::TestHelperUtil::allocator());
+    bmqt::SessionOptions obj(allocator);
 
     PVV("Checking setter and getter for brokerUri");
     const char* const brokerUri = "tcp://localhost:30115";
@@ -171,6 +177,19 @@ static void test3_setterGetterAndCopyTest()
     obj.setUserAgentPrefix(userAgentPrefix);
     BMQTST_ASSERT_EQ(obj.userAgentPrefix(), userAgentPrefix);
 
+    PVV("Checking setter and getter for configureTls");
+    BMQTST_ASSERT(!obj.isTlsSession());
+    BMQTST_ASSERT(obj.certificateAuthority().empty());
+    BMQTST_ASSERT(obj.protocolVersions().empty());
+    const char* const certificatePath = "/tmp/test";
+    const char* const tlsVersions     = "TLSv1.3";
+    bsl::unordered_set<bmqt::TlsProtocolVersion::Value> expectedVersions(
+        allocator);
+    expectedVersions.insert(bmqt::TlsProtocolVersion::e_TLS1_3);
+    obj.configureTls(certificatePath, tlsVersions);
+    BMQTST_ASSERT_EQ(obj.certificateAuthority(), certificatePath);
+    BMQTST_ASSERT_EQ(obj.protocolVersions(), expectedVersions);
+
     PVV("Copy constructor test");
     bmqt::SessionOptions objCopy(obj, bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(objCopy.brokerUri(), brokerUri);
@@ -186,6 +205,8 @@ static void test3_setterGetterAndCopyTest()
     BMQTST_ASSERT_EQ(objCopy.eventQueueHighWatermark(),
                      eventQueueHighWatermark);
     BMQTST_ASSERT_EQ(objCopy.userAgentPrefix(), userAgentPrefix);
+    BMQTST_ASSERT_EQ(objCopy.certificateAuthority(), certificatePath);
+    BMQTST_ASSERT_EQ(objCopy.protocolVersions(), expectedVersions);
 }
 // ============================================================================
 //                                 MAIN PROGRAM

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.cpp
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_sessionoptions.cpp                                            -*-C++-*-
+#include <bmqt_tlsprotocolversion.h>
+
+// BMQ
+#include <bmqscm_version.h>
+#include <bmqt_resultcode.h>
+#include <bmqu_stringutil.h>
+
+// BDE
+#include <bdlb_string.h>
+#include <bdls_filesystemutil.h>
+#include <bslim_printer.h>
+#include <bslma_allocator.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// =========================
+// struct TlsProtocolVersion
+// =========================
+
+bsl::ostream& TlsProtocolVersion::print(bsl::ostream&             stream,
+                                        TlsProtocolVersion::Value value,
+                                        int                       level,
+                                        int spacesPerLevel)
+{
+    if (stream.bad()) {
+        return stream;  // RETURN
+    }
+
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printValue(TlsProtocolVersion::toAscii(value));
+    printer.end();
+
+    return stream;
+}
+
+const char* TlsProtocolVersion::toAscii(TlsProtocolVersion::Value value)
+{
+    // Use openssl compatible string representation
+    switch (value) {
+    case e_TLS1_3: return "TLSv1.3";
+    default: return "(* UNKNOWN *)";
+    }
+}
+
+bool TlsProtocolVersion::fromAscii(TlsProtocolVersion::Value* out,
+                                   const bslstl::StringRef&   str)
+{
+#define CHECKVALUE(M)                                                         \
+    if (bdlb::String::areEqualCaseless(toAscii(TlsProtocolVersion::e_##M),    \
+                                       str.data(),                            \
+                                       str.length())) {                       \
+        *out = TlsProtocolVersion::e_##M;                                     \
+        return true;                                                          \
+    }
+
+    CHECKVALUE(TLS1_3);
+
+    // Invalid string
+    return false;
+
+#undef CHECKVALUE
+}
+
+// =============================
+// struct TlsProtocolVersionUtil
+// =============================
+
+GenericResult::Enum TlsProtocolVersionUtil::parseMinTlsVersion(
+    TlsProtocolVersion::Value* outMinVersion,
+    const bsl::string&         versions)
+{
+    BSLS_ASSERT(outMinVersion);
+
+    bsl::vector<bslstl::StringRef> vs =
+        bmqu::StringUtil::strTokenizeRef(versions, ", \t");
+    for (size_t i = 0; i < vs.size(); i++) {
+        bmqt::TlsProtocolVersion::Value version;
+
+        if (TlsProtocolVersion::fromAscii(&version, vs[i])) {
+            // We only support TLS v1.3
+            if (version == TlsProtocolVersion::e_TLS1_3) {
+                *outMinVersion = version;
+                return GenericResult::e_SUCCESS;
+            }
+        }
+    }
+
+    return GenericResult::e_INVALID_ARGUMENT;
+}
+
+}
+}

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.g.cpp
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.g.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqt_tlsprotocolversion.h>
+
+// BMQ
+#include <bmqt_resultcode.h>
+#include <bmqu_memoutstream.h>
+
+// BDE
+#include <bsl_algorithm.h>
+
+// TEST_DRIVER
+#include <bmqtst_testhelper.h>
+#include <bslstl_iterator.h>
+#include <gtest/gtest.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+
+namespace {
+}
+
+TEST(TlsProtocolVersion, printRepresentation)
+{
+    struct TestCase {
+        bmqt::TlsProtocolVersion::Value d_input;
+        const char*                     d_expected;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
+            bmqt::TlsProtocolVersion::print(out, testCase.d_input, 0, -1);
+            bsl::string printed(out.str(),
+                                bmqtst::TestHelperUtil::allocator());
+            EXPECT_STREQ(testCase.d_expected, printed.c_str());
+        }
+    };
+
+    TestCase k_DATA[] = {
+        {bmqt::TlsProtocolVersion::e_TLS1_3, "[ \"TLSv1.3\" ]"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, fromAsciiInvertsToAscii)
+{
+    struct TestCase {
+        bmqt::TlsProtocolVersion::Value d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value converted;
+            bool result = bmqt::TlsProtocolVersion::fromAscii(
+                &converted,
+                bmqt::TlsProtocolVersion::toAscii(testCase.d_input));
+            EXPECT_TRUE(result);
+            EXPECT_EQ(testCase.d_input, converted);
+        }
+    };
+
+    TestCase k_DATA[] = {{bmqt::TlsProtocolVersion::e_TLS1_3}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, toAsciiInvertsFromAscii)
+{
+    struct TestCase {
+        const char* d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value converted;
+            EXPECT_TRUE(bmqt::TlsProtocolVersion::fromAscii(&converted,
+                                                            testCase.d_input));
+            EXPECT_STREQ(testCase.d_input,
+                         bmqt::TlsProtocolVersion::toAscii(converted));
+        }
+    };
+
+    TestCase k_DATA[] = {{"TLSv1.3"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, badAsciiGivesErrorCode)
+{
+    bmqt::TlsProtocolVersion::Value out;
+    bool result = bmqt::TlsProtocolVersion::fromAscii(&out, "garbage");
+    EXPECT_FALSE(result);
+}
+
+TEST(TlsProtocolVersionUtil, parsesMinTlsVersion)
+{
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    struct TestCase {
+        const char*                     d_input;
+        bmqt::TlsProtocolVersion::Value d_expected;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value out;
+            bmqt::TlsProtocolVersionUtil::parseMinTlsVersion(&out,
+                                                             testCase.d_input);
+            EXPECT_EQ(testCase.d_expected, out);
+        }
+    };
+
+    TestCase k_DATA[] = {
+        {"TLSv1.3", bmqt::TlsProtocolVersion::e_TLS1_3},
+        {"TLSv1.3,TLSv1.3", bmqt::TlsProtocolVersion::e_TLS1_3},
+        {"garbage,TLSv.13", bmqt::TlsProtocolVersion::e_TLS1_3}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersionUtil, badVersionStringGivesErrorCode)
+{
+    struct TestCase {
+        const char* d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value out;
+            int rc = bmqt::TlsProtocolVersionUtil::parseMinTlsVersion(
+                &out,
+                testCase.d_input);
+            EXPECT_NE(0, rc)
+                << "Value parsed successfully: " << testCase.d_input;
+        }
+    };
+
+    TestCase k_DATA[] = {{"garbage"}, {""}, {",,,"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+// ========================================================================
+//                                  MAIN
+// ========================================================================
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bmqtst::TestHelperUtil::testStatus() = RUN_ALL_TESTS();
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.h
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.h
@@ -1,0 +1,92 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_tlsprotocol_version.h                                        -*-C++-*-
+#ifndef INCLUDED_BMQT_TLSPROTOCOLVERSION
+#define INCLUDED_BMQT_TLSPROTOCOLVERSION
+
+///@PURPOSE: Provide a set of helpers for parsing TLS related config values.
+///
+///@CLASSES:
+///  bmqu::TlsProtocolVersion: Struct containing enums representing TLS
+///  protocol versions.
+//
+//   bmqu::TlsProtocolVersionUtil: Utility struct for processing TLS protocol
+///  config values.
+///
+///@DESCRIPTION: 'bmqt::TlsProtocolVersion'
+///
+/// Functionality
+/// -------------
+/// TBD: Comment about Default vs Initial value -- assert vs safe mode
+///
+/// Usage
+/// -----
+/// This section illustrates the intended use of this component.
+///
+//// Example 1: TBD:
+////- - - - - - - -
+/// TBD:
+
+#include <bmqt_resultcode.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// ======================
+// struct TlsProtocolVersion
+// ======================
+
+struct TlsProtocolVersion {
+    enum Value { e_TLS1_3 };
+
+    // CLASS METHODS
+    static bsl::ostream& print(bsl::ostream&             stream,
+                               TlsProtocolVersion::Value value,
+                               int                       level          = 0,
+                               int                       spacesPerLevel = 4);
+
+    static const char* toAscii(TlsProtocolVersion::Value value);
+
+    static bool fromAscii(TlsProtocolVersion::Value* out,
+                          const bslstl::StringRef&   str);
+};
+
+// ============================
+// class TlsProtocolVersionUtil
+// ============================
+
+/// Helper struct for parsing TLS config values.
+struct TlsProtocolVersionUtil {
+    /// Parse the minimum TLS version specified in the TLS config string.
+    ///
+    /// TLS version strings are comma separated values of TLS versions.
+    /// Currently, only `TLSv1.3` is supported. Invalid values are ignored,
+    /// and the empty string results in an error.
+    ///
+    /// @param[out] outMinVersion The location to store the minimum version
+    /// parsed
+    /// @param versions A comma separated string of versions
+    ///
+    /// @returns Zero on success
+    static GenericResult::Enum
+    parseMinTlsVersion(TlsProtocolVersion::Value* outMinVersion,
+                       const bsl::string&         versions);
+};
+
+}
+}
+
+#endif

--- a/src/groups/bmq/bmqt/package/bmqt.mem
+++ b/src/groups/bmq/bmqt/package/bmqt.mem
@@ -12,5 +12,6 @@ bmqt_resultcode
 bmqt_sessioneventtype
 bmqt_sessionoptions
 bmqt_subscription
+bmqt_tlsprotocolversion
 bmqt_uri
 bmqt_version

--- a/src/groups/bmq/bmqt/package/mwct.mem
+++ b/src/groups/bmq/bmqt/package/mwct.mem
@@ -1,3 +1,0 @@
-bmqt_propertybag
-bmqt_rcdescriptionerror
-bmqt_valueorerror

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -687,7 +687,7 @@
         static void run()                                                     \
         {                                                                     \
             FIXTURE##NAME test;                                               \
-            bmqtst::TestHelper::printTestName(#NAME);                         \
+            bmqtst::TestHelper::printTestName(#FIXTURE "::" #NAME);           \
             test.SetUp();                                                     \
             test.body();                                                      \
             test.TearDown();                                                  \

--- a/src/groups/bmq/bmqu/bmqu_managedcallback.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback.h
@@ -94,12 +94,16 @@
 #include <bsls_compilerfeatures.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
+
 # define COMPILING_BMQU_MANAGEDCALLBACK_H
 # include <bmqu_managedcallback_cpp03.h>
-#undef COMPILING_BMQU_MANAGEDCALLBACK_H
+# undef COMPILING_BMQU_MANAGEDCALLBACK_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -153,7 +157,7 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
     /// call a destructor for it and set this object empty.
     void reset();
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
     /// Construct a callback object of the specified CALLBACK_TYPE in this
     /// objects' reusable buffer, with the specified `args` passed to its
     /// constructor.  The buffer must be empty before construction, it is
@@ -267,7 +271,7 @@ inline void ManagedCallback::operator()() const
     (*reinterpret_cast<const CallbackFunctor*>(d_callbackBuffer.data()))();
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class CALLBACK_TYPE, class... ARGS>
 inline void ManagedCallback::createInplace(ARGS&&... args)
 {
@@ -280,6 +284,6 @@ inline void ManagedCallback::createInplace(ARGS&&... args)
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.cpp
 
 #define INCLUDED_BMQU_MANAGEDCALLBACK_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_MANAGEDCALLBACK_CPP)
+#endif // defined(COMPILING_BMQU_MANAGEDCALLBACK_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
 
 #ifdef COMPILING_BMQU_MANAGEDCALLBACK_H
@@ -99,8 +99,7 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A
-#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A                                 \
-    BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
+#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
 #endif
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 0
     template <class CALLBACK_TYPE>
@@ -113,24 +112,26 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 2
-    template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 3
-    template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 4
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -138,12 +139,11 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 4
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 5
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -152,13 +152,12 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 5
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 6
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -168,14 +167,13 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 6
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 7
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -186,15 +184,14 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 7
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 8
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7,
+                                   class ARGS_8>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -206,16 +203,15 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 8
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 9
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8,
-              class ARGS_9>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7,
+                                   class ARGS_8,
+                                   class ARGS_9>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -228,8 +224,8 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
     template <class CALLBACK_TYPE, class... ARGS>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
@@ -347,216 +343,258 @@ inline void ManagedCallback::operator()() const
 #define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B
-#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B                                 \
-    BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
+#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
 #endif
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 0
 template <class CALLBACK_TYPE>
-inline void ManagedCallback::createInplace()
+inline void ManagedCallback::createInplace(
+                               )
 {
-    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE();
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                           );
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 0
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 1
 template <class CALLBACK_TYPE, class ARGS_1>
-inline void
-ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                   args_1)
+inline void ManagedCallback::createInplace(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 1
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 2
-template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 2
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 3
-template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 3
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 4
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 4
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 5
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 5
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 6
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 6
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 7
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 7
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 8
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7,
+                               class ARGS_8>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 8
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 9
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7,
+                               class ARGS_8,
+                               class ARGS_9>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_9, args_9));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_9,
+                                          args_9));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 9
 
@@ -564,11 +602,12 @@ inline void ManagedCallback::createInplace(
 // The generated code below is a workaround for the absence of perfect
 // forwarding in some compilers.
 template <class CALLBACK_TYPE, class... ARGS>
-inline void
-ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void ManagedCallback::createInplace(
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                           BSLS_COMPILERFEATURES_FORWARD(ARGS,
+                                           args)...);
 }
 // }}} END GENERATED CODE
 #endif
@@ -576,8 +615,9 @@ ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_MANAGEDCALLBACK_H)
-#error Not valid except when included from bmqu_managedcallback.h
-#endif  // ! defined(COMPILING_BMQU_MANAGEDCALLBACK_H)
+#else // if ! defined(DEFINED_BMQU_MANAGEDCALLBACK_H)
+# error Not valid except when included from bmqu_managedcallback.h
+#endif // ! defined(COMPILING_BMQU_MANAGEDCALLBACK_H)
 
-#endif  // ! defined(INCLUDED_BMQU_MANAGEDCALLBACK_CPP03)
+#endif // ! defined(INCLUDED_BMQU_MANAGEDCALLBACK_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
@@ -44,12 +44,16 @@
 #include <bsls_performancehint.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
-#define COMPILING_BMQU_OBJECTPLACEHOLDER_H
-#include <bmqu_objectplaceholder_cpp03.h>
-#undef COMPILING_BMQU_OBJECTPLACEHOLDER_H
+
+# define COMPILING_BMQU_OBJECTPLACEHOLDER_H
+# include <bmqu_objectplaceholder_cpp03.h>
+# undef COMPILING_BMQU_OBJECTPLACEHOLDER_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -190,7 +194,7 @@ class ObjectPlaceHolder {
 
   public:
     // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Initialize this placeholder with an object of the specified `TYPE`
     /// constructed from the specified `args` arguments.  Specify an
@@ -386,7 +390,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 }
 
 // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
@@ -469,6 +473,6 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.cpp
 
 #define INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_OBJECTPLACEHOLDER_CPP)
+#endif // defined(COMPILING_BMQU_OBJECTPLACEHOLDER_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
 
 #ifdef COMPILING_BMQU_OBJECTPLACEHOLDER_H
@@ -186,8 +186,7 @@ class ObjectPlaceHolder {
 #define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A
-#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A                               \
-    BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 0
@@ -198,139 +197,136 @@ class ObjectPlaceHolder {
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
     template <class TYPE, class ARGS_1>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
-    template <class TYPE, class ARGS_1, class ARGS_2>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
-    template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8,
-              class ARGS_9>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class TYPE, class... ARGS>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
 #endif
 
@@ -524,8 +520,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 #define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B
-#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B                               \
-    BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 0
@@ -539,7 +534,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(object, allocator);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator);
 
     objectGuard.release();
 }
@@ -548,10 +544,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 1
 template <size_t SIZE>
 template <class TYPE, class ARGS_1>
-inline void
-ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
-                                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                          args_1)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -559,10 +553,10 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1));
 
     objectGuard.release();
 }
@@ -570,11 +564,11 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 2
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -582,11 +576,12 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2));
 
     objectGuard.release();
 }
@@ -594,12 +589,13 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 3
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -607,12 +603,14 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3));
 
     objectGuard.release();
 }
@@ -620,13 +618,15 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 4
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -634,13 +634,16 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4));
 
     objectGuard.release();
 }
@@ -648,19 +651,17 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 5
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -668,14 +669,18 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5));
 
     objectGuard.release();
 }
@@ -683,21 +688,19 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 6
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -705,15 +708,20 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6));
 
     objectGuard.release();
 }
@@ -721,23 +729,21 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 7
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -745,16 +751,22 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7));
 
     objectGuard.release();
 }
@@ -762,25 +774,23 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 8
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -788,17 +798,24 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8));
 
     objectGuard.release();
 }
@@ -806,27 +823,25 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 9
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8,
+                      class ARGS_9>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -834,18 +849,26 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_9, args_9));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_9,
+                                          args_9));
 
     objectGuard.release();
 }
@@ -857,9 +880,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -867,10 +889,10 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                           BSLS_COMPILERFEATURES_FORWARD(ARGS,
+                                           args)...);
 
     objectGuard.release();
 }
@@ -935,8 +957,9 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_OBJECTPLACEHOLDER_H)
-#error Not valid except when included from bmqu_objectplaceholder.h
-#endif  // ! defined(COMPILING_BMQU_OBJECTPLACEHOLDER_H)
+#else // if ! defined(DEFINED_BMQU_OBJECTPLACEHOLDER_H)
+# error Not valid except when included from bmqu_objectplaceholder.h
+#endif // ! defined(COMPILING_BMQU_OBJECTPLACEHOLDER_H)
 
-#endif  // ! defined(INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03)
+#endif // ! defined(INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_operationchain.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain.h
@@ -191,12 +191,16 @@
 #endif
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
+
 # define COMPILING_BMQU_OPERATIONCHAIN_H
 # include <bmqu_operationchain_cpp03.h>
-#undef COMPILING_BMQU_OPERATIONCHAIN_H
+# undef COMPILING_BMQU_OPERATIONCHAIN_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {
@@ -301,7 +305,7 @@ class OperationChain_CompletionCallbackWrapper {
 
   public:
     // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Invoke the associated completion callback with the specified `args`
     /// arguments and notify the associated operation chain. Propagate any
@@ -806,7 +810,7 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 }
 
 // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class CO_CALLBACK>
 template <class... ARGS>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
@@ -1021,6 +1025,6 @@ inline void bmqu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_operationchain.cpp
 
 #define INCLUDED_BMQU_OPERATIONCHAIN_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_OPERATIONCHAIN_CPP)
+#endif // defined(COMPILING_BMQU_OPERATIONCHAIN_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jun 18 14:44:06 2025
+// Generated on Wed Mar 25 20:05:02 2026
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
 
 #ifdef COMPILING_BMQU_OPERATIONCHAIN_H
@@ -163,20 +163,26 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const;
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const;
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -269,8 +275,8 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const;
@@ -784,11 +790,12 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 #endif
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 0
 template <class CO_CALLBACK>
-inline void
-OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()() const
+inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
+    ) const
 {
     try {
-        bslmf::Util::moveIfSupported((*d_coCallback_p))();
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            );
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -820,15 +827,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 2
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -841,17 +849,19 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 3
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -864,7 +874,10 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 4
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -872,11 +885,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -889,7 +902,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 5
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -898,12 +915,12 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -931,13 +948,13 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -967,14 +984,14 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1006,15 +1023,15 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1048,16 +1065,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8),
-                               bslmf::Util::forward<ARGS_9>(args_9));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8),
+            bslmf::Util::forward<ARGS_9>(args_9));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1283,8 +1300,9 @@ inline void bmqu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_OPERATIONCHAIN_H)
-#error Not valid except when included from bmqu_operationchain.h
-#endif  // ! defined(COMPILING_BMQU_OPERATIONCHAIN_H)
+#else // if ! defined(DEFINED_BMQU_OPERATIONCHAIN_H)
+# error Not valid except when included from bmqu_operationchain.h
+#endif // ! defined(COMPILING_BMQU_OPERATIONCHAIN_H)
 
-#endif  // ! defined(INCLUDED_BMQU_OPERATIONCHAIN_CPP03)
+#endif // ! defined(INCLUDED_BMQU_OPERATIONCHAIN_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_stringutil.h
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.h
@@ -82,6 +82,9 @@ struct StringUtil {
     static bsl::vector<bslstl::StringRef>
     strTokenizeRef(const bsl::string& str, const bslstl::StringRef& delims);
 
+    static bsl::vector<bsl::string_view>
+    strTokenizeRef(bsl::string_view str, bsl::string_view delims);
+
     /// Return true if the specified string `str` matches the specified
     /// `pattern`.  `pattern` may include Unix file matching wildcards `*`
     /// and `?`, representing respectively 0 to n characters and exactly 1

--- a/src/groups/bmq/group/bmq.t.dep
+++ b/src/groups/bmq/group/bmq.t.dep
@@ -1,2 +1,4 @@
 benchmark
 bmq
+gmock
+gtest

--- a/src/groups/mqb/group/mqb.t.dep
+++ b/src/groups/mqb/group/mqb.t.dep
@@ -1,3 +1,4 @@
 benchmark
-mqb
 bmq
+gtest
+mqb

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -17,6 +17,7 @@
 #include <mqba_application.h>
 
 #include <mqbscm_version.h>
+
 // MQB
 #include <mqba_authenticator.h>
 #include <mqba_configprovider.h>

--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -87,6 +87,7 @@
         advertiseSubscriptions.: temporarily control use of ConfigureStream in SDK
         routeCommandTimeoutMs: maximum amount of time to wait for a routed command's response
         authentication.......: configuration for authentication
+        tlsConfig............: optional configuration for TLS
       </documentation>
     </annotation>
     <sequence>
@@ -109,7 +110,9 @@
       <element name='configureStream'      type='boolean' default='false'/>
       <element name='advertiseSubscriptions' type='boolean' default='false'/>
       <element name='routeCommandTimeoutMs' type='int' default='3000'/>
+      <!-- TODO: authn should have minOccurs='0' -->
       <element name='authentication'       type='tns:AuthenticatorConfig'/>
+      <element name="tlsConfig"            type='tns:TlsConfig' minOccurs='0'/>
     </sequence>
   </complexType>
 
@@ -288,12 +291,15 @@
         The IPv4 address this listener will accept connections on.
       port.................:
         The port this listener will accept connections on.
+      tls..................:
+        Use TLS on this interface.
       </documentation>
     </annotation>
     <sequence>
       <element name='name'                type='string'/>
       <element name='address'             type='string' default='0.0.0.0'/>
       <element name='port'                type='int'/>
+      <element name='tls'   type='boolean' default='false'/>
     </sequence>
   </complexType>
 
@@ -428,6 +434,30 @@
       <element name='doubleVal' type='double'/>
       <element name='stringVal' type='string'/>
     </choice>
+  </complexType>
+
+    <complexType name='TlsConfig'>
+    <annotation>
+      <documentation>
+        certificateAuthority.:
+            A path to the FILE, containing concatenation of known certificates
+            the server can use to reference as its certificate store.
+        certificate..........:
+            A path to the FILE, containing the certificate the broker will use
+            to identify itself to other clients.
+        key..................:
+            A path to the FILE, containing the private key that the broker uses
+            to read the certificate.
+        versions.............:
+            A string with a comma-separated list of supported protocol versions.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name='certificateAuthority' type='string'/>
+      <element name='certificate'          type='string'/>
+      <element name='key'                  type='string'/>
+      <element name='versions'             type='string' default='TLSv1.3'/>
+    </sequence>
   </complexType>
 
   <!-- ========================================================================

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // mqbcfg_messages.cpp            *DO NOT EDIT*            @generated -*-C++-*-
 
 #include <mqbcfg_messages.h>
@@ -3090,6 +3091,8 @@ const char TcpInterfaceListener::CLASS_NAME[] = "TcpInterfaceListener";
 
 const char TcpInterfaceListener::DEFAULT_INITIALIZER_ADDRESS[] = "0.0.0.0";
 
+const bool TcpInterfaceListener::DEFAULT_INITIALIZER_TLS = false;
+
 const bdlat_AttributeInfo TcpInterfaceListener::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_NAME,
      "name",
@@ -3105,14 +3108,19 @@ const bdlat_AttributeInfo TcpInterfaceListener::ATTRIBUTE_INFO_ARRAY[] = {
      "port",
      sizeof("port") - 1,
      "",
-     bdlat_FormattingMode::e_DEC}};
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_TLS,
+     "tls",
+     sizeof("tls") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
 TcpInterfaceListener::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             TcpInterfaceListener::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -3132,6 +3140,7 @@ const bdlat_AttributeInfo* TcpInterfaceListener::lookupAttributeInfo(int id)
     case ATTRIBUTE_ID_ADDRESS:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ADDRESS];
     case ATTRIBUTE_ID_PORT: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT];
+    case ATTRIBUTE_ID_TLS: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS];
     default: return 0;
     }
 }
@@ -3142,6 +3151,7 @@ TcpInterfaceListener::TcpInterfaceListener(bslma::Allocator* basicAllocator)
 : d_name(basicAllocator)
 , d_address(DEFAULT_INITIALIZER_ADDRESS, basicAllocator)
 , d_port()
+, d_tls(DEFAULT_INITIALIZER_TLS)
 {
 }
 
@@ -3151,6 +3161,7 @@ TcpInterfaceListener::TcpInterfaceListener(
 : d_name(original.d_name, basicAllocator)
 , d_address(original.d_address, basicAllocator)
 , d_port(original.d_port)
+, d_tls(original.d_tls)
 {
 }
 
@@ -3159,7 +3170,8 @@ TcpInterfaceListener::TcpInterfaceListener(
 TcpInterfaceListener::TcpInterfaceListener(TcpInterfaceListener&& original)
     noexcept : d_name(bsl::move(original.d_name)),
                d_address(bsl::move(original.d_address)),
-               d_port(bsl::move(original.d_port))
+               d_port(bsl::move(original.d_port)),
+               d_tls(bsl::move(original.d_tls))
 {
 }
 
@@ -3168,6 +3180,7 @@ TcpInterfaceListener::TcpInterfaceListener(TcpInterfaceListener&& original,
 : d_name(bsl::move(original.d_name), basicAllocator)
 , d_address(bsl::move(original.d_address), basicAllocator)
 , d_port(bsl::move(original.d_port))
+, d_tls(bsl::move(original.d_tls))
 {
 }
 #endif
@@ -3185,6 +3198,7 @@ TcpInterfaceListener::operator=(const TcpInterfaceListener& rhs)
         d_name    = rhs.d_name;
         d_address = rhs.d_address;
         d_port    = rhs.d_port;
+        d_tls     = rhs.d_tls;
     }
 
     return *this;
@@ -3199,6 +3213,7 @@ TcpInterfaceListener::operator=(TcpInterfaceListener&& rhs)
         d_name    = bsl::move(rhs.d_name);
         d_address = bsl::move(rhs.d_address);
         d_port    = bsl::move(rhs.d_port);
+        d_tls     = bsl::move(rhs.d_tls);
     }
 
     return *this;
@@ -3210,6 +3225,7 @@ void TcpInterfaceListener::reset()
     bdlat_ValueTypeFunctions::reset(&d_name);
     d_address = DEFAULT_INITIALIZER_ADDRESS;
     bdlat_ValueTypeFunctions::reset(&d_port);
+    d_tls = DEFAULT_INITIALIZER_TLS;
 }
 
 // ACCESSORS
@@ -3223,6 +3239,167 @@ bsl::ostream& TcpInterfaceListener::print(bsl::ostream& stream,
     printer.printAttribute("name", this->name());
     printer.printAttribute("address", this->address());
     printer.printAttribute("port", this->port());
+    printer.printAttribute("tls", this->tls());
+    printer.end();
+    return stream;
+}
+
+// ---------------
+// class TlsConfig
+// ---------------
+
+// CONSTANTS
+
+const char TlsConfig::CLASS_NAME[] = "TlsConfig";
+
+const char TlsConfig::DEFAULT_INITIALIZER_VERSIONS[] = "TLSv1.3";
+
+const bdlat_AttributeInfo TlsConfig::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_CERTIFICATE_AUTHORITY,
+     "certificateAuthority",
+     sizeof("certificateAuthority") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_CERTIFICATE,
+     "certificate",
+     sizeof("certificate") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_KEY,
+     "key",
+     sizeof("key") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_VERSIONS,
+     "versions",
+     sizeof("versions") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo* TlsConfig::lookupAttributeInfo(const char* name,
+                                                          int nameLength)
+{
+    for (int i = 0; i < 4; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            TlsConfig::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo* TlsConfig::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_CERTIFICATE_AUTHORITY:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY];
+    case ATTRIBUTE_ID_CERTIFICATE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE];
+    case ATTRIBUTE_ID_KEY: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_KEY];
+    case ATTRIBUTE_ID_VERSIONS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSIONS];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+TlsConfig::TlsConfig(bslma::Allocator* basicAllocator)
+: d_certificateAuthority(basicAllocator)
+, d_certificate(basicAllocator)
+, d_key(basicAllocator)
+, d_versions(DEFAULT_INITIALIZER_VERSIONS, basicAllocator)
+{
+}
+
+TlsConfig::TlsConfig(const TlsConfig&  original,
+                     bslma::Allocator* basicAllocator)
+: d_certificateAuthority(original.d_certificateAuthority, basicAllocator)
+, d_certificate(original.d_certificate, basicAllocator)
+, d_key(original.d_key, basicAllocator)
+, d_versions(original.d_versions, basicAllocator)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+TlsConfig::TlsConfig(TlsConfig&& original) noexcept
+: d_certificateAuthority(bsl::move(original.d_certificateAuthority)),
+  d_certificate(bsl::move(original.d_certificate)),
+  d_key(bsl::move(original.d_key)),
+  d_versions(bsl::move(original.d_versions))
+{
+}
+
+TlsConfig::TlsConfig(TlsConfig&& original, bslma::Allocator* basicAllocator)
+: d_certificateAuthority(bsl::move(original.d_certificateAuthority),
+                         basicAllocator)
+, d_certificate(bsl::move(original.d_certificate), basicAllocator)
+, d_key(bsl::move(original.d_key), basicAllocator)
+, d_versions(bsl::move(original.d_versions), basicAllocator)
+{
+}
+#endif
+
+TlsConfig::~TlsConfig()
+{
+}
+
+// MANIPULATORS
+
+TlsConfig& TlsConfig::operator=(const TlsConfig& rhs)
+{
+    if (this != &rhs) {
+        d_certificateAuthority = rhs.d_certificateAuthority;
+        d_certificate          = rhs.d_certificate;
+        d_key                  = rhs.d_key;
+        d_versions             = rhs.d_versions;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+TlsConfig& TlsConfig::operator=(TlsConfig&& rhs)
+{
+    if (this != &rhs) {
+        d_certificateAuthority = bsl::move(rhs.d_certificateAuthority);
+        d_certificate          = bsl::move(rhs.d_certificate);
+        d_key                  = bsl::move(rhs.d_key);
+        d_versions             = bsl::move(rhs.d_versions);
+    }
+
+    return *this;
+}
+#endif
+
+void TlsConfig::reset()
+{
+    bdlat_ValueTypeFunctions::reset(&d_certificateAuthority);
+    bdlat_ValueTypeFunctions::reset(&d_certificate);
+    bdlat_ValueTypeFunctions::reset(&d_key);
+    d_versions = DEFAULT_INITIALIZER_VERSIONS;
+}
+
+// ACCESSORS
+
+bsl::ostream&
+TlsConfig::print(bsl::ostream& stream, int level, int spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("certificateAuthority",
+                           this->certificateAuthority());
+    printer.printAttribute("certificate", this->certificate());
+    printer.printAttribute("key", this->key());
+    printer.printAttribute("versions", this->versions());
     printer.end();
     return stream;
 }
@@ -6962,6 +7139,11 @@ const bdlat_AttributeInfo AppConfig::ATTRIBUTE_INFO_ARRAY[] = {
      "authentication",
      sizeof("authentication") - 1,
      "",
+     bdlat_FormattingMode::e_DEFAULT},
+    {ATTRIBUTE_ID_TLS_CONFIG,
+     "tlsConfig",
+     sizeof("tlsConfig") - 1,
+     "",
      bdlat_FormattingMode::e_DEFAULT}};
 
 // CLASS METHODS
@@ -6969,7 +7151,7 @@ const bdlat_AttributeInfo AppConfig::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo* AppConfig::lookupAttributeInfo(const char* name,
                                                           int nameLength)
 {
-    for (int i = 0; i < 19; ++i) {
+    for (int i = 0; i < 20; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             AppConfig::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -7023,6 +7205,8 @@ const bdlat_AttributeInfo* AppConfig::lookupAttributeInfo(int id)
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROUTE_COMMAND_TIMEOUT_MS];
     case ATTRIBUTE_ID_AUTHENTICATION:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTHENTICATION];
+    case ATTRIBUTE_ID_TLS_CONFIG:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_CONFIG];
     default: return 0;
     }
 }
@@ -7037,6 +7221,7 @@ AppConfig::AppConfig(bslma::Allocator* basicAllocator)
 , d_hostDataCenter(basicAllocator)
 , d_latencyMonitorDomain(DEFAULT_INITIALIZER_LATENCY_MONITOR_DOMAIN,
                          basicAllocator)
+, d_tlsConfig(basicAllocator)
 , d_stats(basicAllocator)
 , d_plugins(basicAllocator)
 , d_networkInterfaces(basicAllocator)
@@ -7061,6 +7246,7 @@ AppConfig::AppConfig(const AppConfig&  original,
 , d_hostTags(original.d_hostTags, basicAllocator)
 , d_hostDataCenter(original.d_hostDataCenter, basicAllocator)
 , d_latencyMonitorDomain(original.d_latencyMonitorDomain, basicAllocator)
+, d_tlsConfig(original.d_tlsConfig, basicAllocator)
 , d_stats(original.d_stats, basicAllocator)
 , d_plugins(original.d_plugins, basicAllocator)
 , d_networkInterfaces(original.d_networkInterfaces, basicAllocator)
@@ -7086,6 +7272,7 @@ AppConfig::AppConfig(AppConfig&& original) noexcept
   d_hostTags(bsl::move(original.d_hostTags)),
   d_hostDataCenter(bsl::move(original.d_hostDataCenter)),
   d_latencyMonitorDomain(bsl::move(original.d_latencyMonitorDomain)),
+  d_tlsConfig(bsl::move(original.d_tlsConfig)),
   d_stats(bsl::move(original.d_stats)),
   d_plugins(bsl::move(original.d_plugins)),
   d_networkInterfaces(bsl::move(original.d_networkInterfaces)),
@@ -7111,6 +7298,7 @@ AppConfig::AppConfig(AppConfig&& original, bslma::Allocator* basicAllocator)
 , d_hostDataCenter(bsl::move(original.d_hostDataCenter), basicAllocator)
 , d_latencyMonitorDomain(bsl::move(original.d_latencyMonitorDomain),
                          basicAllocator)
+, d_tlsConfig(bsl::move(original.d_tlsConfig), basicAllocator)
 , d_stats(bsl::move(original.d_stats), basicAllocator)
 , d_plugins(bsl::move(original.d_plugins), basicAllocator)
 , d_networkInterfaces(bsl::move(original.d_networkInterfaces), basicAllocator)
@@ -7156,6 +7344,7 @@ AppConfig& AppConfig::operator=(const AppConfig& rhs)
         d_advertiseSubscriptions = rhs.d_advertiseSubscriptions;
         d_routeCommandTimeoutMs  = rhs.d_routeCommandTimeoutMs;
         d_authentication         = rhs.d_authentication;
+        d_tlsConfig              = rhs.d_tlsConfig;
     }
 
     return *this;
@@ -7185,6 +7374,7 @@ AppConfig& AppConfig::operator=(AppConfig&& rhs)
         d_advertiseSubscriptions = bsl::move(rhs.d_advertiseSubscriptions);
         d_routeCommandTimeoutMs  = bsl::move(rhs.d_routeCommandTimeoutMs);
         d_authentication         = bsl::move(rhs.d_authentication);
+        d_tlsConfig              = bsl::move(rhs.d_tlsConfig);
     }
 
     return *this;
@@ -7212,6 +7402,7 @@ void AppConfig::reset()
     d_advertiseSubscriptions = DEFAULT_INITIALIZER_ADVERTISE_SUBSCRIPTIONS;
     d_routeCommandTimeoutMs  = DEFAULT_INITIALIZER_ROUTE_COMMAND_TIMEOUT_MS;
     bdlat_ValueTypeFunctions::reset(&d_authentication);
+    bdlat_ValueTypeFunctions::reset(&d_tlsConfig);
 }
 
 // ACCESSORS
@@ -7243,6 +7434,7 @@ AppConfig::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     printer.printAttribute("routeCommandTimeoutMs",
                            this->routeCommandTimeoutMs());
     printer.printAttribute("authentication", this->authentication());
+    printer.printAttribute("tlsConfig", this->tlsConfig());
     printer.end();
     return stream;
 }

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.h
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // mqbcfg_messages.h             *DO NOT EDIT*             @generated -*-C++-*-
 #ifndef INCLUDED_MQBCFG_MESSAGES
 #define INCLUDED_MQBCFG_MESSAGES
@@ -115,6 +116,9 @@ class TcpClusterNodeConnection;
 }
 namespace mqbcfg {
 class TcpInterfaceListener;
+}
+namespace mqbcfg {
+class TlsConfig;
 }
 namespace mqbcfg {
 class VirtualClusterInformation;
@@ -5067,37 +5071,45 @@ class TcpInterfaceListener {
     // name.................: A name to associate this listener to.
     // address..............: The IPv4 address this listener will accept
     // connections on.  port.................: The port this listener will
-    // accept connections on.
+    // accept connections on.  tls..................: Use TLS on this
+    // interface.
 
     // INSTANCE DATA
     bsl::string d_name;
     bsl::string d_address;
     int         d_port;
+    bool        d_tls;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
     void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
+
+    bool isEqualTo(const TcpInterfaceListener& rhs) const;
 
   public:
     // TYPES
     enum {
         ATTRIBUTE_ID_NAME    = 0,
         ATTRIBUTE_ID_ADDRESS = 1,
-        ATTRIBUTE_ID_PORT    = 2
+        ATTRIBUTE_ID_PORT    = 2,
+        ATTRIBUTE_ID_TLS     = 3
     };
 
-    enum { NUM_ATTRIBUTES = 3 };
+    enum { NUM_ATTRIBUTES = 4 };
 
     enum {
         ATTRIBUTE_INDEX_NAME    = 0,
         ATTRIBUTE_INDEX_ADDRESS = 1,
-        ATTRIBUTE_INDEX_PORT    = 2
+        ATTRIBUTE_INDEX_PORT    = 2,
+        ATTRIBUTE_INDEX_TLS     = 3
     };
 
     // CONSTANTS
     static const char CLASS_NAME[];
 
     static const char DEFAULT_INITIALIZER_ADDRESS[];
+
+    static const bool DEFAULT_INITIALIZER_TLS;
 
     static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
 
@@ -5204,6 +5216,9 @@ class TcpInterfaceListener {
     // Return a reference to the modifiable "Port" attribute of this
     // object.
 
+    bool& tls();
+    // Return a reference to the modifiable "Tls" attribute of this object.
+
     // ACCESSORS
     bsl::ostream&
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
@@ -5258,6 +5273,9 @@ class TcpInterfaceListener {
     int port() const;
     // Return the value of the "Port" attribute of this object.
 
+    bool tls() const;
+    // Return the value of the "Tls" attribute of this object.
+
     // HIDDEN FRIENDS
     friend bool operator==(const TcpInterfaceListener& lhs,
                            const TcpInterfaceListener& rhs)
@@ -5265,8 +5283,7 @@ class TcpInterfaceListener {
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.name() == rhs.name() && lhs.address() == rhs.address() &&
-               lhs.port() == rhs.port();
+        return lhs.isEqualTo(rhs);
     }
 
     friend bool operator!=(const TcpInterfaceListener& lhs,
@@ -5305,6 +5322,261 @@ BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::TcpInterfaceListener>
 : bsl::true_type {};
+
+namespace mqbcfg {
+
+// ===============
+// class TlsConfig
+// ===============
+
+class TlsConfig {
+    // certificateAuthority.: A path to the FILE, containing concatenation of
+    // known certificates the server can use to reference as its certificate
+    // store.  certificate..........: A path to the FILE, containing the
+    // certificate the broker will use to identify itself to other clients.
+    // key..................: A path to the FILE, containing the private key
+    // that the broker uses to read the certificate.  versions.............: A
+    // string with a comma-separated list of supported protocol versions.
+
+    // INSTANCE DATA
+    bsl::string d_certificateAuthority;
+    bsl::string d_certificate;
+    bsl::string d_key;
+    bsl::string d_versions;
+
+    // PRIVATE ACCESSORS
+    template <typename t_HASH_ALGORITHM>
+    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
+
+    bool isEqualTo(const TlsConfig& rhs) const;
+
+  public:
+    // TYPES
+    enum {
+        ATTRIBUTE_ID_CERTIFICATE_AUTHORITY = 0,
+        ATTRIBUTE_ID_CERTIFICATE           = 1,
+        ATTRIBUTE_ID_KEY                   = 2,
+        ATTRIBUTE_ID_VERSIONS              = 3
+    };
+
+    enum { NUM_ATTRIBUTES = 4 };
+
+    enum {
+        ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY = 0,
+        ATTRIBUTE_INDEX_CERTIFICATE           = 1,
+        ATTRIBUTE_INDEX_KEY                   = 2,
+        ATTRIBUTE_INDEX_VERSIONS              = 3
+    };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const char DEFAULT_INITIALIZER_VERSIONS[];
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit TlsConfig(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'TlsConfig' having the default value.  Use
+    // the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+
+    TlsConfig(const TlsConfig& original, bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'TlsConfig' having the value of the
+    // specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    TlsConfig(TlsConfig&& original) noexcept;
+    // Create an object of type 'TlsConfig' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+
+    TlsConfig(TlsConfig&& original, bslma::Allocator* basicAllocator);
+    // Create an object of type 'TlsConfig' having the value of the
+    // specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+    // Use the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+#endif
+
+    ~TlsConfig();
+    // Destroy this object.
+
+    // MANIPULATORS
+    TlsConfig& operator=(const TlsConfig& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    TlsConfig& operator=(TlsConfig&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    bsl::string& certificateAuthority();
+    // Return a reference to the modifiable "CertificateAuthority"
+    // attribute of this object.
+
+    bsl::string& certificate();
+    // Return a reference to the modifiable "Certificate" attribute of this
+    // object.
+
+    bsl::string& key();
+    // Return a reference to the modifiable "Key" attribute of this object.
+
+    bsl::string& versions();
+    // Return a reference to the modifiable "Versions" attribute of this
+    // object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    const bsl::string& certificateAuthority() const;
+    // Return a reference offering non-modifiable access to the
+    // "CertificateAuthority" attribute of this object.
+
+    const bsl::string& certificate() const;
+    // Return a reference offering non-modifiable access to the
+    // "Certificate" attribute of this object.
+
+    const bsl::string& key() const;
+    // Return a reference offering non-modifiable access to the "Key"
+    // attribute of this object.
+
+    const bsl::string& versions() const;
+    // Return a reference offering non-modifiable access to the "Versions"
+    // attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const TlsConfig& lhs, const TlsConfig& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.isEqualTo(rhs);
+    }
+
+    friend bool operator!=(const TlsConfig& lhs, const TlsConfig& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream& stream, const TlsConfig& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM& hashAlg, const TlsConfig& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for 'TlsConfig'.
+    {
+        object.hashAppendImpl(hashAlg);
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::TlsConfig);
+template <>
+struct bdlat_UsesDefaultValueFlag<mqbcfg::TlsConfig> : bsl::true_type {};
 
 namespace mqbcfg {
 
@@ -10384,28 +10656,30 @@ class AppConfig {
     // ConfigureQueue advertiseSubscriptions.: temporarily control use of
     // ConfigureStream in SDK routeCommandTimeoutMs: maximum amount of time to
     // wait for a routed command's response authentication.......:
-    // configuration for authentication
+    // configuration for authentication tlsConfig............: optional
+    // configuration for TLS
 
     // INSTANCE DATA
-    bsl::string         d_brokerInstanceName;
-    bsl::string         d_etcDir;
-    bsl::string         d_hostName;
-    bsl::string         d_hostTags;
-    bsl::string         d_hostDataCenter;
-    bsl::string         d_latencyMonitorDomain;
-    StatsConfig         d_stats;
-    Plugins             d_plugins;
-    NetworkInterfaces   d_networkInterfaces;
-    MessagePropertiesV2 d_messagePropertiesV2;
-    DispatcherConfig    d_dispatcherConfig;
-    BmqconfConfig       d_bmqconfConfig;
-    AuthenticatorConfig d_authentication;
-    int                 d_brokerVersion;
-    int                 d_configVersion;
-    int                 d_logsObserverMaxSize;
-    int                 d_routeCommandTimeoutMs;
-    bool                d_configureStream;
-    bool                d_advertiseSubscriptions;
+    bsl::string                    d_brokerInstanceName;
+    bsl::string                    d_etcDir;
+    bsl::string                    d_hostName;
+    bsl::string                    d_hostTags;
+    bsl::string                    d_hostDataCenter;
+    bsl::string                    d_latencyMonitorDomain;
+    bdlb::NullableValue<TlsConfig> d_tlsConfig;
+    StatsConfig                    d_stats;
+    Plugins                        d_plugins;
+    NetworkInterfaces              d_networkInterfaces;
+    MessagePropertiesV2            d_messagePropertiesV2;
+    DispatcherConfig               d_dispatcherConfig;
+    BmqconfConfig                  d_bmqconfConfig;
+    AuthenticatorConfig            d_authentication;
+    int                            d_brokerVersion;
+    int                            d_configVersion;
+    int                            d_logsObserverMaxSize;
+    int                            d_routeCommandTimeoutMs;
+    bool                           d_configureStream;
+    bool                           d_advertiseSubscriptions;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
@@ -10434,10 +10708,11 @@ class AppConfig {
         ATTRIBUTE_ID_CONFIGURE_STREAM         = 15,
         ATTRIBUTE_ID_ADVERTISE_SUBSCRIPTIONS  = 16,
         ATTRIBUTE_ID_ROUTE_COMMAND_TIMEOUT_MS = 17,
-        ATTRIBUTE_ID_AUTHENTICATION           = 18
+        ATTRIBUTE_ID_AUTHENTICATION           = 18,
+        ATTRIBUTE_ID_TLS_CONFIG               = 19
     };
 
-    enum { NUM_ATTRIBUTES = 19 };
+    enum { NUM_ATTRIBUTES = 20 };
 
     enum {
         ATTRIBUTE_INDEX_BROKER_INSTANCE_NAME     = 0,
@@ -10458,7 +10733,8 @@ class AppConfig {
         ATTRIBUTE_INDEX_CONFIGURE_STREAM         = 15,
         ATTRIBUTE_INDEX_ADVERTISE_SUBSCRIPTIONS  = 16,
         ATTRIBUTE_INDEX_ROUTE_COMMAND_TIMEOUT_MS = 17,
-        ATTRIBUTE_INDEX_AUTHENTICATION           = 18
+        ATTRIBUTE_INDEX_AUTHENTICATION           = 18,
+        ATTRIBUTE_INDEX_TLS_CONFIG               = 19
     };
 
     // CONSTANTS
@@ -10639,6 +10915,10 @@ class AppConfig {
     // Return a reference to the modifiable "Authentication" attribute of
     // this object.
 
+    bdlb::NullableValue<TlsConfig>& tlsConfig();
+    // Return a reference to the modifiable "TlsConfig" attribute of this
+    // object.
+
     // ACCESSORS
     bsl::ostream&
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
@@ -10754,6 +11034,10 @@ class AppConfig {
     const AuthenticatorConfig& authentication() const;
     // Return a reference offering non-modifiable access to the
     // "Authentication" attribute of this object.
+
+    const bdlb::NullableValue<TlsConfig>& tlsConfig() const;
+    // Return a reference offering non-modifiable access to the "TlsConfig"
+    // attribute of this object.
 
     // HIDDEN FRIENDS
     friend bool operator==(const AppConfig& lhs, const AppConfig& rhs)
@@ -15566,6 +15850,14 @@ void TcpInterfaceListener::hashAppendImpl(
     hashAppend(hashAlgorithm, this->name());
     hashAppend(hashAlgorithm, this->address());
     hashAppend(hashAlgorithm, this->port());
+    hashAppend(hashAlgorithm, this->tls());
+}
+
+inline bool
+TcpInterfaceListener::isEqualTo(const TcpInterfaceListener& rhs) const
+{
+    return this->name() == rhs.name() && this->address() == rhs.address() &&
+           this->port() == rhs.port() && this->tls() == rhs.tls();
 }
 
 // CLASS METHODS
@@ -15591,6 +15883,11 @@ int TcpInterfaceListener::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
+    ret = manipulator(&d_tls, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -15612,6 +15909,9 @@ int TcpInterfaceListener::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_PORT: {
         return manipulator(&d_port,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    }
+    case ATTRIBUTE_ID_TLS: {
+        return manipulator(&d_tls, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS]);
     }
     default: return NOT_FOUND;
     }
@@ -15648,6 +15948,11 @@ inline int& TcpInterfaceListener::port()
     return d_port;
 }
 
+inline bool& TcpInterfaceListener::tls()
+{
+    return d_tls;
+}
+
 // ACCESSORS
 template <typename t_ACCESSOR>
 int TcpInterfaceListener::accessAttributes(t_ACCESSOR& accessor) const
@@ -15665,6 +15970,11 @@ int TcpInterfaceListener::accessAttributes(t_ACCESSOR& accessor) const
     }
 
     ret = accessor(d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_tls, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS]);
     if (ret) {
         return ret;
     }
@@ -15687,6 +15997,9 @@ int TcpInterfaceListener::accessAttribute(t_ACCESSOR& accessor, int id) const
     }
     case ATTRIBUTE_ID_PORT: {
         return accessor(d_port, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PORT]);
+    }
+    case ATTRIBUTE_ID_TLS: {
+        return accessor(d_tls, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS]);
     }
     default: return NOT_FOUND;
     }
@@ -15721,6 +16034,223 @@ inline const bsl::string& TcpInterfaceListener::address() const
 inline int TcpInterfaceListener::port() const
 {
     return d_port;
+}
+
+inline bool TcpInterfaceListener::tls() const
+{
+    return d_tls;
+}
+
+// ---------------
+// class TlsConfig
+// ---------------
+
+// PRIVATE ACCESSORS
+template <typename t_HASH_ALGORITHM>
+void TlsConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
+{
+    using bslh::hashAppend;
+    hashAppend(hashAlgorithm, this->certificateAuthority());
+    hashAppend(hashAlgorithm, this->certificate());
+    hashAppend(hashAlgorithm, this->key());
+    hashAppend(hashAlgorithm, this->versions());
+}
+
+inline bool TlsConfig::isEqualTo(const TlsConfig& rhs) const
+{
+    return this->certificateAuthority() == rhs.certificateAuthority() &&
+           this->certificate() == rhs.certificate() &&
+           this->key() == rhs.key() && this->versions() == rhs.versions();
+}
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int TlsConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(
+        &d_certificateAuthority,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_certificate,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_key, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_KEY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_versions,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSIONS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int TlsConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_CERTIFICATE_AUTHORITY: {
+        return manipulator(
+            &d_certificateAuthority,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY]);
+    }
+    case ATTRIBUTE_ID_CERTIFICATE: {
+        return manipulator(&d_certificate,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE]);
+    }
+    case ATTRIBUTE_ID_KEY: {
+        return manipulator(&d_key, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_KEY]);
+    }
+    case ATTRIBUTE_ID_VERSIONS: {
+        return manipulator(&d_versions,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSIONS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int TlsConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                   const char*    name,
+                                   int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline bsl::string& TlsConfig::certificateAuthority()
+{
+    return d_certificateAuthority;
+}
+
+inline bsl::string& TlsConfig::certificate()
+{
+    return d_certificate;
+}
+
+inline bsl::string& TlsConfig::key()
+{
+    return d_key;
+}
+
+inline bsl::string& TlsConfig::versions()
+{
+    return d_versions;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int TlsConfig::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(
+        d_certificateAuthority,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_certificate,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_key, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_KEY]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_versions, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSIONS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int TlsConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_CERTIFICATE_AUTHORITY: {
+        return accessor(
+            d_certificateAuthority,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE_AUTHORITY]);
+    }
+    case ATTRIBUTE_ID_CERTIFICATE: {
+        return accessor(d_certificate,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CERTIFICATE]);
+    }
+    case ATTRIBUTE_ID_KEY: {
+        return accessor(d_key, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_KEY]);
+    }
+    case ATTRIBUTE_ID_VERSIONS: {
+        return accessor(d_versions,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_VERSIONS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int TlsConfig::accessAttribute(t_ACCESSOR& accessor,
+                               const char* name,
+                               int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline const bsl::string& TlsConfig::certificateAuthority() const
+{
+    return d_certificateAuthority;
+}
+
+inline const bsl::string& TlsConfig::certificate() const
+{
+    return d_certificate;
+}
+
+inline const bsl::string& TlsConfig::key() const
+{
+    return d_key;
+}
+
+inline const bsl::string& TlsConfig::versions() const
+{
+    return d_versions;
 }
 
 // -------------------------------
@@ -20425,6 +20955,7 @@ void AppConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
     hashAppend(hashAlgorithm, this->advertiseSubscriptions());
     hashAppend(hashAlgorithm, this->routeCommandTimeoutMs());
     hashAppend(hashAlgorithm, this->authentication());
+    hashAppend(hashAlgorithm, this->tlsConfig());
 }
 
 inline bool AppConfig::isEqualTo(const AppConfig& rhs) const
@@ -20447,7 +20978,8 @@ inline bool AppConfig::isEqualTo(const AppConfig& rhs) const
            this->configureStream() == rhs.configureStream() &&
            this->advertiseSubscriptions() == rhs.advertiseSubscriptions() &&
            this->routeCommandTimeoutMs() == rhs.routeCommandTimeoutMs() &&
-           this->authentication() == rhs.authentication();
+           this->authentication() == rhs.authentication() &&
+           this->tlsConfig() == rhs.tlsConfig();
 }
 
 // CLASS METHODS
@@ -20577,6 +21109,12 @@ int AppConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
+    ret = manipulator(&d_tlsConfig,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_CONFIG]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -20675,6 +21213,10 @@ int AppConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
         return manipulator(
             &d_authentication,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTHENTICATION]);
+    }
+    case ATTRIBUTE_ID_TLS_CONFIG: {
+        return manipulator(&d_tlsConfig,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_CONFIG]);
     }
     default: return NOT_FOUND;
     }
@@ -20789,6 +21331,11 @@ inline int& AppConfig::routeCommandTimeoutMs()
 inline AuthenticatorConfig& AppConfig::authentication()
 {
     return d_authentication;
+}
+
+inline bdlb::NullableValue<TlsConfig>& AppConfig::tlsConfig()
+{
+    return d_tlsConfig;
 }
 
 // ACCESSORS
@@ -20913,6 +21460,12 @@ int AppConfig::accessAttributes(t_ACCESSOR& accessor) const
         return ret;
     }
 
+    ret = accessor(d_tlsConfig,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_CONFIG]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -21006,6 +21559,10 @@ int AppConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_AUTHENTICATION: {
         return accessor(d_authentication,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTHENTICATION]);
+    }
+    case ATTRIBUTE_ID_TLS_CONFIG: {
+        return accessor(d_tlsConfig,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TLS_CONFIG]);
     }
     default: return NOT_FOUND;
     }
@@ -21120,6 +21677,11 @@ inline int AppConfig::routeCommandTimeoutMs() const
 inline const AuthenticatorConfig& AppConfig::authentication() const
 {
     return d_authentication;
+}
+
+inline const bdlb::NullableValue<TlsConfig>& AppConfig::tlsConfig() const
+{
+    return d_tlsConfig;
 }
 
 // ------------------------

--- a/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.g.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.g.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// mqbcfg_tcpinterfaceconfigvalidator.t.cpp                           -*-C++-*-
+// mqbcfg_tcpinterfaceconfigvalidator.g.cpp                           -*-C++-*-
 #include <mqbcfg_tcpinterfaceconfigvalidator.h>
 
 // MQB
@@ -28,39 +28,27 @@
 #include <bsla_annotations.h>
 #include <bsls_asserttest.h>
 
+// GTest
+#include <gtest/gtest.h>
+
 using namespace BloombergLP;
 
-struct TcpInterfaceConfigValidatorTest : bmqtst::Test {
-    // CREATORS
-    TcpInterfaceConfigValidatorTest();
-    ~TcpInterfaceConfigValidatorTest() BSLS_KEYWORD_OVERRIDE;
-};
+class TcpInterfaceConfigValidatorTest : public ::testing::Test {};
 
-TcpInterfaceConfigValidatorTest::TcpInterfaceConfigValidatorTest()
+TEST_F(TcpInterfaceConfigValidatorTest, breathingTest)
 {
-    // NOTHING
+    EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK, 0);
 }
 
-TcpInterfaceConfigValidatorTest::~TcpInterfaceConfigValidatorTest()
-{
-    // NOTHING
-}
-
-BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, breathingTest)
-{
-    BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK, 0);
-}
-
-BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, emptyConfigIsValid)
+TEST_F(TcpInterfaceConfigValidatorTest, emptyConfigIsValid)
 {
     mqbcfg::TcpInterfaceConfigValidator validator;
     mqbcfg::TcpInterfaceConfig          config;
 
-    BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK,
-                     validator(config));
+    EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_OK, validator(config));
 }
 
-BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, nonUniqueNamesAreInvalid)
+TEST_F(TcpInterfaceConfigValidatorTest, nonUniqueNamesAreInvalid)
 {
     mqbcfg::TcpInterfaceConfigValidator validator;
     mqbcfg::TcpInterfaceConfig          config;
@@ -77,11 +65,11 @@ BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, nonUniqueNamesAreInvalid)
         listener.name() = "Test";
     }
 
-    BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_NAME,
-                     validator(config));
+    EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_NAME,
+              validator(config));
 }
 
-BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, nonUniquePortsAreInvalid)
+TEST_F(TcpInterfaceConfigValidatorTest, nonUniquePortsAreInvalid)
 {
     mqbcfg::TcpInterfaceConfigValidator validator;
     mqbcfg::TcpInterfaceConfig          config;
@@ -100,11 +88,11 @@ BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, nonUniquePortsAreInvalid)
         listener.port() = 8000;
     }
 
-    BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_PORT,
-                     validator(config));
+    EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_DUPLICATE_PORT,
+              validator(config));
 }
 
-BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
+TEST_F(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
 {
     mqbcfg::TcpInterfaceConfigValidator validator;
 
@@ -113,8 +101,8 @@ BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
         mqbcfg::TcpInterfaceListener& listener =
             config.listeners().emplace_back();
         listener.port() = 0x10000;
-        BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
-                         validator(config));
+        EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
+                  validator(config));
     }
 
     {
@@ -122,8 +110,8 @@ BMQTST_TEST_F(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
         mqbcfg::TcpInterfaceListener& listener =
             config.listeners().emplace_back();
         listener.port() = -1;
-        BMQTST_ASSERT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
-                         validator(config));
+        EXPECT_EQ(mqbcfg::TcpInterfaceConfigValidator::k_PORT_RANGE,
+                  validator(config));
     }
 }
 
@@ -135,7 +123,9 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqtst::runTest(_testCase);
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bmqtst::TestHelperUtil::testStatus() = RUN_ALL_TESTS();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -41,25 +41,33 @@
 // BMQ
 #include <bmqex_executionutil.h>
 #include <bmqex_systemexecutor.h>
+#include <bmqio_channelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_channelutil.h>
 #include <bmqio_connectoptions.h>
 #include <bmqio_ntcchannel.h>
 #include <bmqio_ntcchannelfactory.h>
+#include <bmqio_reconnectingchannelfactory.h>
 #include <bmqio_resolveutil.h>
 #include <bmqio_statchannel.h>
+#include <bmqio_statchannelfactory.h>
+#include <bmqio_status.h>
 #include <bmqio_tcpendpoint.h>
 #include <bmqp_event.h>
 #include <bmqp_protocol.h>
 #include <bmqp_protocolutil.h>
 #include <bmqsys_threadutil.h>
 #include <bmqsys_time.h>
+#include <bmqt_sessionoptions.h>
 #include <bmqu_blob.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
+#include <bmqu_stringutil.h>
 #include <bmqu_weakmemfn.h>
 
 // BDE
 #include <ball_log.h>
+#include <bdlb_pairutil.h>
 #include <bdlb_scopeexit.h>
 #include <bdlb_string.h>
 #include <bdlf_bind.h>
@@ -70,7 +78,9 @@
 #include <bsl_cstdlib.h>
 #include <bsl_iostream.h>
 #include <bsl_limits.h>
+#include <bsl_memory.h>
 #include <bsl_utility.h>
+#include <bsl_vector.h>
 #include <bsla_annotations.h>
 #include <bslalg_swaputil.h>
 #include <bslmf_movableref.h>
@@ -84,7 +94,8 @@
 #include <bsls_types.h>
 
 // NTC
-#include <bsl_vector.h>
+#include <ntca_encryptionmethod.h>
+#include <ntcf_system.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
 
@@ -229,14 +240,6 @@ bool isClientOrProxy(const mqbnet::Session* session)
     return mqbnet::ClusterUtil::isClientOrProxy(session->negotiationMessage());
 }
 
-void stopChannelFactory(bmqio::ChannelFactory* channelFactory)
-{
-    bmqio::NtcChannelFactory* factory =
-        dynamic_cast<bmqio::NtcChannelFactory*>(channelFactory);
-    BSLS_ASSERT_SAFE(factory);
-    factory->stop();
-}
-
 /// A predicate functor for comparing a [mqbcfg::TcpInterfaceListener] by their
 /// `port()` member.
 struct PortMatcher {
@@ -252,6 +255,124 @@ struct PortMatcher {
         return listener.port() == d_port;
     }
 };
+
+ntsa::Error
+loadTlsConfig(bsl::shared_ptr<ntci::EncryptionServer>* encryptionServer,
+              ntci::Interface*                         interface,
+              const mqbcfg::TlsConfig&                 tlsConfig)
+{
+    BSLS_ASSERT_SAFE(interface != NULL);
+
+    // We only support TLS 1.3
+    // TODO(tfoxhall): Implement a parser for versions
+    bsl::vector<bslstl::StringRef> vs =
+        bmqu::StringUtil::strTokenizeRef(tlsConfig.versions(), ", \t");
+    for (size_t i = 0; i < vs.size(); i++) {
+        bmqt::TlsProtocolVersion::Value version;
+
+        if (bmqt::TlsProtocolVersion::fromAscii(&version, vs[i])) {
+            if (version != bmqt::TlsProtocolVersion::e_TLS1_3) {
+                return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+            }
+        }
+    }
+
+    ntca::EncryptionServerOptions encryptionServerOptions;
+    // Set the minimum version to TLS 1.3
+    encryptionServerOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionServerOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    // Disable client side authentication (mTLS)
+    encryptionServerOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_NONE);
+
+    encryptionServerOptions.setIdentityFile(tlsConfig.certificate());
+    encryptionServerOptions.setPrivateKeyFile(tlsConfig.key());
+    encryptionServerOptions.addAuthorityFile(tlsConfig.certificateAuthority());
+
+    return interface->createEncryptionServer(encryptionServer,
+                                             encryptionServerOptions);
+}
+
+/// Helpers for building ChannelFactoryPipeline's
+struct ChannelFactoryBuilders {
+    typedef bmqio::ChannelFactoryPipeline::ChannelFactorySP ChannelFactorySP;
+
+    static bsl::shared_ptr<bmqio::NtcChannelFactory>
+    ntcChannelFactory(bslma::Allocator*                       allocator,
+                      const bsl::shared_ptr<ntci::Interface>& interface)
+    {
+        bsl::shared_ptr<bmqio::NtcChannelFactory> factory =
+            bsl::allocate_shared<bmqio::NtcChannelFactory>(allocator,
+                                                           interface);
+        factory->onCreate(bdlf::BindUtil::bind(&ntcChannelPreCreation,
+                                               bdlf::PlaceHolders::_1,
+                                               bdlf::PlaceHolders::_2));
+        return factory;
+    }
+
+    static bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory(
+        bslma::Allocator*                              allocator,
+        const bsl::shared_ptr<ntci::Interface>&        interface,
+        const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer)
+    {
+        BSLS_ASSERT(encryptionServer);
+        bsl::shared_ptr<bmqio::NtcChannelFactory> factory =
+            ChannelFactoryBuilders::ntcChannelFactory(allocator, interface);
+        factory->setEncryptionServer(encryptionServer);
+
+        return factory;
+    }
+
+    static ChannelFactorySP
+    resolvingChannelFactory(bslma::Allocator*               allocator,
+                            ChannelFactorySP&               prev,
+                            const bmqex::SequentialContext& resolutionContext)
+    {
+        return bsl::allocate_shared<bmqio::ResolvingChannelFactory>(
+            allocator,
+            bmqio::ResolvingChannelFactoryConfig(
+                prev.get(),
+                bmqex::ExecutionPolicyUtil::oneWay()
+                    .neverBlocking()
+                    .useExecutor(resolutionContext.executor()))
+                .resolutionFn(bdlf::BindUtil::bind(
+                    &monitoredDNSResolution,
+                    bdlf::PlaceHolders::_1,   // resolvedUri
+                    bdlf::PlaceHolders::_2))  // channel
+        );
+    }
+
+    static ChannelFactorySP
+    reconnectingChannelFactory(bslma::Allocator*      allocator,
+                               ChannelFactorySP&      prev,
+                               bdlmt::EventScheduler* scheduler)
+    {
+        return bsl::allocate_shared<bmqio::ReconnectingChannelFactory>(
+            allocator,
+            bmqio::ReconnectingChannelFactoryConfig(prev.get(), scheduler)
+                .setReconnectIntervalFn(bdlf::BindUtil::bind(
+                    &bmqio::ReconnectingChannelFactoryUtil::
+                        defaultConnectIntervalFn,
+                    bdlf::PlaceHolders::_1,        // interval
+                    bdlf::PlaceHolders::_2,        // options
+                    bdlf::PlaceHolders::_3,        // timeSinceLastAttempt
+                    bsls::TimeInterval(3 * 60.0),  // resetReconnectTime
+                    bsls::TimeInterval(30.0)))     // maxInterval
+        );
+    }
+
+    static ChannelFactorySP statChannelFactory(
+        bslma::Allocator* allocator,
+        ChannelFactorySP& prev,
+        const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+            statContextCreator)
+    {
+        return bsl::allocate_shared<bmqio::StatChannelFactory>(
+            allocator,
+            bmqio::StatChannelFactoryConfig(prev.get(), statContextCreator));
+    }
+};
+
 }  // close unnamed namespace
 
 // -----------------------------------------
@@ -285,6 +406,12 @@ struct TCPSessionFactory_OperationContext {
     // that will be set for the
     // 'InitialConnectionContext::resultState' passed to the
     // 'Negotiator::negotiate'.
+
+    /// True if the session is TLS enabled.
+    bool d_isTls;
+
+    /// Name for the TCP interface the operation is associated with.
+    bsl::string d_interfaceName;
 };
 
 // -----------------------
@@ -745,21 +872,11 @@ void TCPSessionFactory::channelStateCallback(
                                       d_allocator_p);
             channel->close(closeStatus);
         }
-        else {
-            {  // Save begin session timestamp
-               // TODO: it's possible to store this timestamp directly in one
-               // of the bmqio::Channel implementations, so we don't need a
-               // mutex synchronization for them at all.
-                bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
-                d_timestampMap[channel.get()] =
-                    bmqsys::Time::highResolutionTimer();
-            }  // close mutex lock guard // UNLOCK
 
-            // Keep track of active channels, for logging purposes
-            ++d_nbActiveChannels;
+        // Keep track of active channels, for logging purposes
+        ++d_nbActiveChannels;
 
-            handleInitialConnection(channel, context);
-        }
+        handleInitialConnection(channel, context);
     } break;
     case bmqio::ChannelFactoryEvent::e_CONNECT_ATTEMPT_FAILED: {
         // Nothing
@@ -842,8 +959,8 @@ void TCPSessionFactory::onClose(const bsl::shared_ptr<bmqio::Channel>& channel,
     if (!channelInfo) {
         // We register to the close event as soon as the channel is up;
         // however, we insert in the d_channels only upon successful
-        // negotiation; therefore a failed to negotiate channel (like during
-        // intrusion testing) would trigger this trace.
+        // negotiation; therefore a failed to negotiate channel (like
+        // during intrusion testing) would trigger this trace.
         BALL_LOG_INFO << "#TCP_UNEXPECTED_STATE "
                       << "TCPSessionFactory '" << d_config.name()
                       << "': OnClose channel for an unknown channel '"
@@ -1053,11 +1170,9 @@ TCPSessionFactory::TCPSessionFactory(
 , d_authenticator_p(authenticator)
 , d_negotiator_p(negotiator)
 , d_statController_p(statController)
-, d_tcpChannelFactory_mp()
 , d_resolutionContext(allocator)
-, d_resolvingChannelFactory_mp()
-, d_reconnectingChannelFactory_mp()
-, d_statChannelFactory_mp()
+, d_channelFactoryPipeline_mp()
+, d_tlsChannelFactoryPipeline_mp()
 , d_threadName(allocator)
 , d_nbActiveChannels(0)
 , d_nbOpenClients(0)
@@ -1073,6 +1188,7 @@ TCPSessionFactory::TCPSessionFactory(
 , d_isListening(false)
 , d_listenContexts(allocator)
 , d_timestampMap(allocator)
+, d_encryptionServer_sp()
 , d_allocator_p(allocator)
 {
     // PRECONDITIONS
@@ -1155,30 +1271,15 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
 
     ntca::InterfaceConfig interfaceConfig = ntcCreateInterfaceConfig(d_config);
 
-    bslma::ManagedPtr<bmqio::NtcChannelFactory> channelFactory;
-    channelFactory.load(new (*d_allocator_p)
-                            bmqio::NtcChannelFactory(interfaceConfig,
-                                                     d_blobBufferFactory_p,
-                                                     d_allocator_p),
-                        d_allocator_p);
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> blobBufferFactory_sp(
+        d_blobBufferFactory_p,
+        bslstl::SharedPtrNilDeleter(),
+        d_allocator_p);
 
-    channelFactory->onCreate(bdlf::BindUtil::bind(&ntcChannelPreCreation,
-                                                  bdlf::PlaceHolders::_1,
-                                                  bdlf::PlaceHolders::_2));
-
-    rc = channelFactory->start();
-    if (rc != 0) {
-        errorDescription << "Failed starting channel pool for "
-                         << "TCPSessionFactory '" << d_config.name()
-                         << "' [rc: " << rc << "]";
-        return rc;  // RETURN
-    }
-
-    d_tcpChannelFactory_mp = channelFactory;
-
-    bdlb::ScopeExitAny tcpScopeGuard(
-        bdlf::BindUtil::bind(&stopChannelFactory,
-                             d_tcpChannelFactory_mp.get()));
+    bsl::shared_ptr<ntci::Interface> interface = ntcf::System::createInterface(
+        interfaceConfig,
+        blobBufferFactory_sp,
+        d_allocator_p);
 
     bslmt::ThreadAttributes attributes =
         bmqsys::ThreadUtil::defaultAttributes();
@@ -1186,62 +1287,98 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
     rc = d_resolutionContext.start(attributes);
     BSLS_ASSERT_SAFE(rc == 0);
 
-    d_resolvingChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::ResolvingChannelFactory(
-            bmqio::ResolvingChannelFactoryConfig(
-                d_tcpChannelFactory_mp.get(),
-                bmqex::ExecutionPolicyUtil::oneWay()
-                    .neverBlocking()
-                    .useExecutor(d_resolutionContext.executor()),
-                d_allocator_p)
-                .resolutionFn(bdlf::BindUtil::bind(
-                    &monitoredDNSResolution,
-                    bdlf::PlaceHolders::_1,    // resolvedUri
-                    bdlf::PlaceHolders::_2)),  // channel
-            d_allocator_p),
-        d_allocator_p);
+    bmqio::StatChannelFactoryConfig::StatContextCreatorFn statContextCreator(
+        bdlf::BindUtil::bind(&TCPSessionFactory::channelStatContextCreator,
+                             this,
+                             bdlf::PlaceHolders::_1,  // channel
+                             bdlf::PlaceHolders::_2)  // handle
+    );
 
-    d_reconnectingChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::ReconnectingChannelFactory(
-            bmqio::ReconnectingChannelFactoryConfig(
-                d_resolvingChannelFactory_mp.get(),
-                d_scheduler_p,
-                d_allocator_p)
-                .setReconnectIntervalFn(bdlf::BindUtil::bind(
-                    &bmqio::ReconnectingChannelFactoryUtil ::
-                        defaultConnectIntervalFn,
-                    bdlf::PlaceHolders::_1,        // interval
-                    bdlf::PlaceHolders::_2,        // options
-                    bdlf::PlaceHolders::_3,        // timeSinceLastAttempt
-                    bsls::TimeInterval(3 * 60.0),  // resetReconnectTime
-                    bsls::TimeInterval(30.0))),    // maxInterval
-            d_allocator_p),
-        d_allocator_p);
+    typedef bmqio::ChannelFactoryPipeline::Builder::ChannelFactoryBuilder
+        ChannelFactoryBuilder;
 
-    rc = d_reconnectingChannelFactory_mp->start();
-    if (rc != 0) {
-        errorDescription << "Failed starting reconnecting channel factory for "
-                         << "TCPSessionFactory '" << d_config.name()
-                         << "' [rc: " << rc << "]";
-        return rc;  // RETURN
+    bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory =
+        ChannelFactoryBuilders::ntcChannelFactory(d_allocator_p, interface);
+    ChannelFactoryBuilder resolvingChannelFactoryBuilder =
+        bdlf::BindUtil::bind(ChannelFactoryBuilders::resolvingChannelFactory,
+                             d_allocator_p,
+                             bdlf::PlaceHolders::_1,
+                             bsl::cref(d_resolutionContext));
+    ChannelFactoryBuilder reconnectingChannelFactoryBuilder =
+        bdlf::BindUtil::bind(
+            ChannelFactoryBuilders::reconnectingChannelFactory,
+            d_allocator_p,
+            bdlf::PlaceHolders::_1,
+            d_scheduler_p);
+    ChannelFactoryBuilder statChannelFactoryBuilder = bdlf::BindUtil::bind(
+        ChannelFactoryBuilders::statChannelFactory,
+        d_allocator_p,
+        bdlf::PlaceHolders::_1,
+        statContextCreator);
+
+    {
+        bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
+            channelFactoryPipeline_mp = bslma::ManagedPtrUtil::allocateManaged<
+                bmqio::ChannelFactoryPipeline>(
+                d_allocator_p,
+                bslmf::MovableRefUtil::move(
+                    bmqio::ChannelFactoryPipeline::Builder(d_allocator_p)
+                        .add(ntcChannelFactory)
+                        .addWith(resolvingChannelFactoryBuilder)
+                        .addWith(reconnectingChannelFactoryBuilder)
+                        .addWith(statChannelFactoryBuilder)));
+
+        rc = channelFactoryPipeline_mp->start();
+        if (rc != 0) {
+            errorDescription << "Failed starting channel pool for "
+                             << "TCPSessionFactory '" << d_config.name()
+                             << "' [rc: " << rc << "]";
+            return rc;  // RETURN
+        }
+
+        d_channelFactoryPipeline_mp = channelFactoryPipeline_mp;
     }
 
-    bdlb::ScopeExitAny reconnectingScopeGuard(
-        bdlf::BindUtil::bind(&bmqio::ReconnectingChannelFactory::stop,
-                             d_reconnectingChannelFactory_mp.get()));
+    // TLS channel factory pipeline
+    const mqbcfg::AppConfig& appConfig = mqbcfg::BrokerConfig::get();
+    if (appConfig.tlsConfig().has_value()) {
+        ntsa::Error err = loadTlsConfig(&d_encryptionServer_sp,
+                                        interface.get(),
+                                        *appConfig.tlsConfig());
 
-    d_statChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::StatChannelFactory(
-            bmqio::StatChannelFactoryConfig(
-                d_reconnectingChannelFactory_mp.get(),
-                bdlf::BindUtil::bind(
-                    &TCPSessionFactory::channelStatContextCreator,
-                    this,
-                    bdlf::PlaceHolders::_1,   // channel
-                    bdlf::PlaceHolders::_2),  // handle
-                d_allocator_p),
-            d_allocator_p),
-        d_allocator_p);
+        if (err) {
+            errorDescription << "Failed to load the TLS configuration "
+                             << "TCPSessionFactory '" << d_config.name()
+                             << "' [err: " << err << "]";
+            return err.code();  // RETURN
+        }
+
+        bsl::shared_ptr<bmqio::ChannelFactory> tlsChannelFactory =
+            ChannelFactoryBuilders::ntcChannelFactory(d_allocator_p,
+                                                      interface,
+                                                      d_encryptionServer_sp);
+        bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
+            tlsChannelFactoryPipeline_mp =
+                bslma::ManagedPtrUtil::allocateManaged<
+                    bmqio::ChannelFactoryPipeline>(
+                    d_allocator_p,
+                    bslmf::MovableRefUtil::move(
+                        bmqio::ChannelFactoryPipeline::Builder(d_allocator_p)
+                            .add(tlsChannelFactory)
+                            .addWith(resolvingChannelFactoryBuilder)
+                            .addWith(reconnectingChannelFactoryBuilder)
+                            .addWith(statChannelFactoryBuilder)));
+
+        rc = tlsChannelFactoryPipeline_mp->start();
+        if (rc != 0) {
+            errorDescription << "Failed starting channel pool for "
+                             << "TCPSessionFactory '" << d_config.name()
+                             << "' [rc: " << rc << "]";
+            return rc;  // RETURN
+        }
+
+        d_tlsChannelFactoryPipeline_mp = tlsChannelFactoryPipeline_mp;
+    }
 
     if (d_config.heartbeatIntervalMs() != 0) {
         BALL_LOG_INFO
@@ -1272,9 +1409,6 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
                   << "successfully started";
 
     d_isStarted = true;
-
-    reconnectingScopeGuard.release();
-    tcpScopeGuard.release();
 
     return 0;
 }
@@ -1372,7 +1506,8 @@ void TCPSessionFactory::closeClients()
                        << "timed out while waiting for clients to close"
                        << ", remaining clients: " << d_nbOpenClients;
 
-        // Invalidate the remaining sessions before stopping all Dispatchers.
+        // Invalidate the remaining sessions before stopping all
+        // Dispatchers.
 
         for (size_t i = 0; i < clients.size(); ++i) {
             bsl::shared_ptr<Session> session = clients[i].lock();
@@ -1406,12 +1541,12 @@ void TCPSessionFactory::stop()
     d_resolutionContext.stop();
     d_resolutionContext.join();
 
-    if (d_reconnectingChannelFactory_mp) {
-        d_reconnectingChannelFactory_mp->stop();
+    if (d_tlsChannelFactoryPipeline_mp) {
+        d_tlsChannelFactoryPipeline_mp->stop();
     }
 
-    if (d_tcpChannelFactory_mp) {
-        stopChannelFactory(d_tcpChannelFactory_mp.get());
+    if (d_channelFactoryPipeline_mp) {
+        d_channelFactoryPipeline_mp->stop();
     }
 
     // Wait for all sessions to have been destroyed
@@ -1457,20 +1592,10 @@ void TCPSessionFactory::stop()
     d_mutex.unlock();
 
     // DESTROY
-    // We destroy the channel factories here for symmetry since it's created in
-    // 'start'.
-    if (d_statChannelFactory_mp) {
-        d_statChannelFactory_mp.clear();
-    }
-    if (d_reconnectingChannelFactory_mp) {
-        d_reconnectingChannelFactory_mp.clear();
-    }
-    if (d_resolvingChannelFactory_mp) {
-        d_resolvingChannelFactory_mp.clear();
-    }
-    if (d_tcpChannelFactory_mp) {
-        d_tcpChannelFactory_mp.clear();
-    }
+    // We destroy the channel factories here for symmetry since they're
+    // created in 'start'.
+    d_tlsChannelFactoryPipeline_mp.reset();
+    d_channelFactoryPipeline_mp.reset();
 
     BALL_LOG_INFO << "Stopped TCPSessionFactory '" << d_config.name() << "'";
 }
@@ -1495,6 +1620,8 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
     context->d_resultCb      = resultCallback;
     context->d_isIncoming    = true;
     context->d_resultState_p = 0;
+    context->d_isTls         = listener.tls();
+    context->d_interfaceName = listener.name();
 
     bdlma::LocalSequentialAllocator<64> localAlloc(d_allocator_p);
     bmqu::MemOutStream                  endpoint(&localAlloc);
@@ -1504,7 +1631,12 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
 
     bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> listeningHandle_mp;
     bmqio::Status                                      status;
-    d_statChannelFactory_mp->listen(
+    bmqio::ChannelFactory*                             channelFactory =
+        listener.tls() ? d_tlsChannelFactoryPipeline_mp.get()
+                                                   : d_channelFactoryPipeline_mp.get();
+    BSLS_ASSERT_OPT(channelFactory != NULL);
+
+    channelFactory->listen(
         &status,
         &listeningHandle_mp,
         listenOptions,
@@ -1545,6 +1677,7 @@ int TCPSessionFactory::connect(const bslstl::StringRef& endpoint,
     context->d_resultCb      = resultCallback;
     context->d_isIncoming    = false;
     context->d_resultState_p = resultState;
+    context->d_isTls         = false;
 
     if (negotiationUserData) {
         context->d_negotiationUserData_sp = *negotiationUserData;
@@ -1562,7 +1695,7 @@ int TCPSessionFactory::connect(const bslstl::StringRef& endpoint,
         .setAutoReconnect(shouldAutoReconnect);
 
     bmqio::Status status;
-    d_statChannelFactory_mp->connect(
+    d_channelFactoryPipeline_mp->connect(
         &status,
         0,  // no handle ..
         options,
@@ -1591,34 +1724,17 @@ int TCPSessionFactory::connect(const bslstl::StringRef& endpoint,
 bool TCPSessionFactory::setNodeWriteQueueWatermarks(const Session& session)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_tcpChannelFactory_mp);
     BSLS_ASSERT_SAFE(d_config.nodeLowWatermark() > 0);
     BSLS_ASSERT_SAFE(d_config.nodeLowWatermark() <=
                      d_config.nodeHighWatermark());
 
-    int channelId;
+    bsl::shared_ptr<bmqio::NtcChannel> ntcChannel =
+        bsl::dynamic_pointer_cast<bmqio::NtcChannel>(session.channel());
 
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
-            !session.channel()->properties().load(
-                &channelId,
-                k_CHANNEL_PROPERTY_CHANNEL_ID))) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        BALL_LOG_ERROR << "TCPSessionFactory '" << d_config.name() << "' "
-                       << "failed to get channel id out of '"
-                       << session.description() << "'";
-        return false;  // RETURN
-    }
-
-    bmqio::NtcChannelFactory* factory =
-        dynamic_cast<bmqio::NtcChannelFactory*>(d_tcpChannelFactory_mp.get());
-    BSLS_ASSERT_SAFE(factory);
-
-    bsl::shared_ptr<bmqio::NtcChannel> ntcChannel;
-    int rc = factory->lookupChannel(&ntcChannel, channelId);
-    if (rc != 0) {
+    if (ntcChannel == NULL) {
         BALL_LOG_ERROR << "TCPSessionFactory '" << d_config.name() << "' "
                        << "failed to set watermarks for '"
-                       << session.description() << "' [rc: " << rc << "]";
+                       << session.description() << "'";
         return false;  // RETURN
     }
 

--- a/src/integration-tests/conftest.py
+++ b/src/integration-tests/conftest.py
@@ -30,15 +30,8 @@ import blazingmq.util.logging as bul
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
 from blazingmq.dev.it.testhooks import PHASE_REPORT_KEY
 
-# pylint: disable=unused-import, wrong-import-position
-from blazingmq.dev.it.fixtures import (
-    single_node,
-    multi_node,
-    cluster,
-    fsm_single_node,
-    fsm_multi_node,
-    fsm_cluster,
-)
+# Load the fixtures defined in the BlazingMQ support library
+pytest_plugins = "blazingmq.dev.it.fixtures"
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)

--- a/src/integration-tests/pytest.ini
+++ b/src/integration-tests/pytest.ini
@@ -19,3 +19,5 @@ markers =
     flakey
     eventual_consistency
     strong_consistency
+    tls
+certificate_generator = ../../bin/gen-tls-certs.sh

--- a/src/integration-tests/test_admin_client.py
+++ b/src/integration-tests/test_admin_client.py
@@ -127,8 +127,13 @@ def expect_same_structure(
             assert expected.check(entry), path
         else:
             assert isinstance(expected, int)
-            if entry != expected:
-                raise RuntimeError(f"Path: {path}, {entry} != {expected} (expected)")
+            assert entry == expected, (
+                path,
+                "Actual value:",
+                entry,
+                "Expected value:",
+                expected,
+            )
 
 
 def test_breathing(
@@ -166,7 +171,11 @@ def test_breathing(
     broker_config_str = admin.send_admin("brokerconfig dump")
     broker_config = json.loads(broker_config_str)
 
-    assert broker_config["networkInterfaces"]["tcpInterface"]["port"] == port
+    listeners = broker_config["networkInterfaces"]["tcpInterface"].get("listeners")
+    if listeners is not None:
+        assert listeners[0]["port"] == port
+    else:
+        assert broker_config["networkInterfaces"]["tcpInterface"]["port"] == port
 
     # Stop the admin session
     admin.stop()

--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -20,7 +20,7 @@ This suite of test cases exercises connection losses.
 import json
 import re
 from time import sleep
-from typing import Dict
+from typing import Dict, List
 
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
@@ -198,7 +198,7 @@ def test_force_leader_primary_divergence(
         res = admin.send_admin(
             f"CLUSTERS CLUSTER {cluster.config.name} STORAGE SUMMARY"
         )
-        primaries: [str] = []
+        primaries: List[str] = []
         try:
             for line in res.splitlines():
                 mm = re.search(r"Primary Node.*\[(.+), \d+\]", line)

--- a/src/integration-tests/test_graceful_shutdown.py
+++ b/src/integration-tests/test_graceful_shutdown.py
@@ -44,7 +44,10 @@ def multi_cluster_config(
         "otherCluster",
         nodes=[
             configurator.broker(
-                "localhost", next(port_allocator), f"{dc}{i}", data_center=dc
+                name=f"{dc}{i}",
+                tcp_host="localhost",
+                tcp_port=next(port_allocator),
+                data_center=dc,
             )
             for dc in ("east", "west")
             for i in (3, 4)

--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -39,6 +39,9 @@ import tempfile
 from enum import IntEnum
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Tuple
+from dataclasses import dataclass
+import subprocess
+
 import psutil
 
 import pytest
@@ -51,7 +54,7 @@ import blazingmq.util.logging as bul
 from blazingmq.dev.it.cluster import Cluster
 from blazingmq.dev.it.tweaks import tweak  # pylint: disable=unused-import
 from blazingmq.dev.it.tweaks import TWEAK_ATTRIBUTE, Tweak
-from blazingmq.dev.it.util import internal_use
+from blazingmq.dev.it.util import internal_use, chdir
 from blazingmq.dev.paths import paths
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
 from blazingmq.dev.reserveport import reserve_port, reserve_port_pool
@@ -246,7 +249,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
                 ):
                     try:
                         log_file_path.unlink()
-                    except:
+                    except FileNotFoundError:
                         pass
 
             on_exit.callback(remove_log_file_handler)
@@ -439,7 +442,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
 
                     try:
                         cluster.stop()
-                    except:
+                    except RuntimeError:
                         if not get_option_ini(
                             request.config, "bmq_tolerate_dirty_shutdown"
                         ):
@@ -513,6 +516,30 @@ class ForwardProxyConnection(ProxyConnection):
 WorkspaceConfigurator = Callable[..., None]
 
 
+class Tls(IntEnum):
+    NONE = 0
+    HOST = 1
+
+    @property
+    def suffix(self) -> str:
+        return ["", "_tls"][self]
+
+    @property
+    def marks(self):
+        return [
+            [],
+            # TODO(tfoxhall): Figure out how to add a new mark
+            [pytest.mark.tls],
+        ][self]
+
+
+@dataclass(frozen=True)
+class CertificateBundle:
+    certificate_authority: Path
+    host_certificate: Path
+    host_key: Path
+
+
 ###############################################################################
 # single node cluster
 
@@ -537,16 +564,43 @@ def add_test_domains(cluster: cfg.Cluster):
             )
 
 
+def app_tls_config(certificate_bundle: CertificateBundle) -> mqbcfg.TlsConfig:
+    return mqbcfg.TlsConfig(
+        certificate_authority=str(certificate_bundle.certificate_authority),
+        certificate=str(certificate_bundle.host_certificate),
+        key=str(certificate_bundle.host_key),
+    )
+
+
 def single_node_cluster_config(
-    configurator: cfg.Configurator, port_allocator: Iterator[int], mode: Mode
+    configurator: cfg.Configurator,
+    port_allocator: Iterator[int],
+    mode: Mode,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ):
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is None:
+        raise ValueError("A TLS config is required when TLS is enabled")
+
     mode.tweak(configurator.proto.cluster)
+    if is_tls_enabled:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     broker = configurator.broker(
         name="single",
-        tcp_host="localhost",
-        tcp_port=next(port_allocator),
         data_center="single_node",
+        listeners=[
+            mqbcfg.TcpInterfaceListener(
+                name="localhost",
+                port=next(port_allocator),
+                tls=is_tls_enabled,
+                address="localhost",
+            ),
+        ],
+        tls_config=tls_config,
     )
 
     cluster = configurator.cluster(name="itCluster", nodes=[broker])
@@ -582,17 +636,41 @@ def multi_node_cluster_config(
     configurator: cfg.Configurator,
     port_allocator: Iterator[int],
     mode: Mode,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ) -> None:
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is None:
+        raise ValueError("A TLS config is required when TLS is enabled")
+
     mode.tweak(configurator.proto.cluster)
+    if is_tls_enabled:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
-                tcp_port=next(port_allocator),
                 data_center=data_center,
+                listeners=[
+                    mqbcfg.TcpInterfaceListener(
+                        name="localhost",
+                        port=next(port_allocator),
+                        tls=is_tls_enabled,
+                        address="localhost",
+                    ),
+                    mqbcfg.TcpInterfaceListener(
+                        name="BROKER",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
+                ],
+                tls_config=tls_config,
+                inter_broker_listener="BROKER",
             )
             for data_center in ("east", "west")
             for broker in ("1", "2")
@@ -604,9 +682,16 @@ def multi_node_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
-            tcp_port=next(port_allocator),
+            listeners=[
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
+            ],
             data_center=data_center,
+            tls_config=tls_config,
         ).proxy(cluster)
 
 
@@ -715,7 +800,8 @@ def multi_interface_cluster_config(
     configurator: cfg.Configurator,
     port_allocator: Iterator[int],
     mode: Mode,
-    listener_count: int,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ) -> None:
     """A factory for cluster configurations containing multiple open TCP interfaces.
 
@@ -734,22 +820,34 @@ def multi_interface_cluster_config(
             minimum number of listeners is 1.
     """
     mode.tweak(configurator.proto.cluster)
-
-    assert listener_count > 0
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is not None:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
-                tcp_port=-1,
-                listeners=[("BROKER", next(port_allocator))]
-                + [
-                    (f"listener{i}", next(port_allocator))
-                    for i in range(listener_count - 1)
+                listeners=[
+                    mqbcfg.TcpInterfaceListener(
+                        name="localhost",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
+                    mqbcfg.TcpInterfaceListener(
+                        name="BROKER",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
                 ],
                 data_center=data_center,
+                tls_config=tls_config,
+                inter_broker_listener="BROKER",
             )
             for data_center in ("east", "west")
             for broker in ("1", "2")
@@ -761,18 +859,28 @@ def multi_interface_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
-            tcp_port=-1,
             listeners=[
-                (f"listener{i}", next(port_allocator)) for i in range(listener_count)
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost1",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost2",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
             ],
             data_center=data_center,
+            tls_config=tls_config,
         ).proxy(cluster)
 
 
 multi_interface_cluster_params = [
     pytest.param(
-        functools.partial(multi_interface_cluster_config, mode=mode, listener_count=2),
+        functools.partial(multi_interface_cluster_config, mode=mode),
         id=f"multi_interface{mode.suffix}",
         marks=[
             pytest.mark.integrationtest,
@@ -809,13 +917,14 @@ def virtual_cluster_config(
     mode: Mode,
 ) -> None:
     mode.tweak(configurator.proto.cluster)
+    tcp_host = "localhost"
 
     final_cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
+                tcp_host=tcp_host,
                 tcp_port=next(port_allocator),
                 data_center=data_center,
             )
@@ -830,7 +939,7 @@ def virtual_cluster_config(
         nodes=[
             configurator.broker(
                 name=f"{data_center}v",
-                tcp_host="localhost",
+                tcp_host=tcp_host,
                 tcp_port=next(port_allocator),
                 data_center=data_center,
             )
@@ -842,7 +951,7 @@ def virtual_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
+            tcp_host=tcp_host,
             tcp_port=next(port_allocator),
             data_center=data_center,
         ).proxy(cluster)
@@ -971,3 +1080,127 @@ def fsm_cluster(request):
 @pytest.fixture(params=fsm_multi_cluster_params)
 def fsm_multi_cluster(request):
     yield from cluster_fixture(request, request.param)
+
+
+###############################################################################
+# TLS Cluster Config
+
+
+def generate_certificate_bundle(
+    generator: Path,
+    ca_cert: str,
+    prefix: str,
+    host: str,
+    path: Path,
+) -> CertificateBundle:
+    """Generate a certificate authority and a host certificate in the current directory.
+
+    Args:
+        generator: A path to an executable program that can generate certificates and
+            CAs. See gen-tls-certs.sh for more information on the interface.
+        ca_cert: The name of the certificate authority.
+        prefix: A prefix used to for naming the generated files
+        host: The hostname for the host certificate to use.
+
+    Returns:
+        A CertificateBundle object containing the paths to the generate certificate
+        authority and host certificate.
+    """
+    with chdir(path):
+        subprocess.run([generator, "ca", ca_cert, prefix], check=True)
+        subprocess.run([generator, "server", ca_cert, prefix, host], check=True)
+        return CertificateBundle(
+            certificate_authority=path / ca_cert,
+            host_certificate=path / f"{prefix}host_cert.pem",
+            host_key=path / f"{prefix}private_key.pem",
+        )
+
+
+@pytest.fixture()
+def certificate_bundle(tmp_path, request):
+    """Provide a certificate bundle for use in the current test session.
+
+    This fixture depends on a certificate generator script to be available, which can be
+    specified with the --certificate-generator option.
+    """
+    cert_generator = Path(request.config.getini("certificate_generator")).resolve()
+    return generate_certificate_bundle(
+        cert_generator,
+        ca_cert="ca-cert",
+        prefix="broker_",
+        host="dummy",
+        path=tmp_path,
+    )
+
+
+tls_single_cluster_params = [
+    pytest.param(
+        functools.partial(single_node_cluster_config, mode=mode, tls=Tls.HOST),
+        id=f"single_node_tls{mode.suffix}",
+        marks=[
+            pytest.mark.integrationtest,
+            pytest.mark.pr_integrationtest,
+            pytest.mark.single,
+            pytest.mark.tls,
+            *Mode.FSM.marks,
+        ],
+    )
+    for mode in Mode.__members__.values()
+]
+
+
+@pytest.fixture(params=tls_single_cluster_params)
+def tls_single_cluster(request, certificate_bundle):
+    print("Certificate bundle:", certificate_bundle)
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=certificate_bundle)
+    )
+
+
+tls_multi_cluster_params = [
+    pytest.param(
+        functools.partial(multi_node_cluster_config, mode=mode, tls=Tls.HOST),
+        id=f"multi_node_tls{mode.suffix}",
+        marks=[
+            pytest.mark.integrationtest,
+            pytest.mark.pr_integrationtest,
+            pytest.mark.multi,
+            pytest.mark.tls,
+            *Mode.FSM.marks,
+        ],
+    )
+    for mode in Mode.__members__.values()
+]
+
+
+@pytest.fixture(params=tls_multi_cluster_params)
+def tls_multi_cluster(request):
+    yield from cluster_fixture(request, request.param)
+
+
+@pytest.fixture(params=tls_single_cluster_params + tls_multi_cluster_params)
+def tls_cluster(request, certificate_bundle):
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=certificate_bundle)
+    )
+
+
+def pytest_addoption(parser):
+    help_ = "script for generating certificates"
+    parser.addini("certificate_generator", help_, type="string", default=".")
+
+
+@pytest.fixture(
+    params=single_node_cluster_params
+    + multi_node_cluster_params
+    + tls_single_cluster_params
+    + tls_multi_cluster_params
+)
+def plain_and_tls_cluster(request, certificate_bundle):
+    if request.param.keywords.get("tls", Tls.NONE) != Tls.NONE:
+        bundle = certificate_bundle
+    else:
+        bundle = None
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=bundle)
+    )

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -27,12 +27,16 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, List, NamedTuple
+from typing import Any, Callable, Dict, Optional, List, NamedTuple, Tuple
 
 from blazingmq.dev.it.process import bmqproc
 from blazingmq.dev.it.process.bmqproc import BMQProcess
 
-from blazingmq.dev.it.testconstants import *
+from blazingmq.dev.it.testconstants import (
+    URI_BROADCAST,
+    URI_FANOUT,
+    URI_PRIORITY,
+)
 from blazingmq.dev.it.util import internal_use, ListContextManager, Queue
 
 Message = namedtuple("Message", "guid, uri, correlationId, payload")
@@ -98,10 +102,10 @@ class Client(BMQProcess):
     def __init__(
         self,
         name,
-        broker: (str, int),
+        broker: Tuple[str, int],
         tool_path: Path,
-        options=None,
-        dump_messages=True,
+        options: Optional[str] = None,
+        dump_messages: bool = True,
         **kwargs,
     ):
         if options is None:

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -620,6 +620,11 @@ class TweakFactory:
 
                         port = Port()
 
+                        class Tls(metaclass=TweakMetaclass):
+                            def __call__(self, value: bool) -> Callable: ...
+
+                        tls = Tls()
+
                         def __call__(self, value: None) -> Callable: ...
 
                     listeners = Listeners()
@@ -850,6 +855,42 @@ class TweakFactory:
                 ) -> Callable: ...
 
             authentication = Authentication()
+
+            class TlsConfig(metaclass=TweakMetaclass):
+                class CertificateAuthority(metaclass=TweakMetaclass):
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
+
+                certificate_authority = CertificateAuthority()
+
+                class Certificate(metaclass=TweakMetaclass):
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
+
+                certificate = Certificate()
+
+                class Key(metaclass=TweakMetaclass):
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
+
+                key = Key()
+
+                class Versions(metaclass=TweakMetaclass):
+                    def __call__(
+                        self, value: typing.Union[str, NoneType]
+                    ) -> Callable: ...
+
+                versions = Versions()
+
+                def __call__(
+                    self,
+                    value: typing.Union[blazingmq.schemas.mqbcfg.TlsConfig, NoneType],
+                ) -> Callable: ...
+
+            tls_config = TlsConfig()
 
             def __call__(
                 self, value: typing.Union[blazingmq.schemas.mqbcfg.AppConfig, NoneType]

--- a/src/python/blazingmq/dev/it/util.py
+++ b/src/python/blazingmq/dev/it/util.py
@@ -25,6 +25,7 @@ import logging
 import random
 import string
 import time
+import os
 
 from typing import List, Optional, TypeVar
 from typing import TYPE_CHECKING
@@ -170,3 +171,20 @@ class ListContextManager(List[_T]):
     def __exit__(self, *args):
         for item in self.__reversed__():
             item.__exit__(*args)
+
+
+class chdir(contextlib.AbstractContextManager):
+    """Non thread-safe context manager to change the current working directory."""
+
+    # Backported from upstream python
+
+    def __init__(self, path):
+        self.path = path
+        self._old_cwd = []
+
+    def __enter__(self):
+        self._old_cwd.append(os.getcwd())
+        os.chdir(self.path)
+
+    def __exit__(self, *excinfo):
+        os.chdir(self._old_cwd.pop())

--- a/src/python/blazingmq/schemas/mqbcfg.py
+++ b/src/python/blazingmq/schemas/mqbcfg.py
@@ -1103,8 +1103,12 @@ class TcpInterfaceListener:
 
     name.................:
     A name to associate this listener to.
+    address..............:
+    The IPv4 address this listener will accept connections on.
     port.................:
     The port this listener will accept connections on.
+    tls..................:
+    Use TLS on this interface.
     """
 
     name: Optional[str] = field(
@@ -1115,7 +1119,74 @@ class TcpInterfaceListener:
             "required": True,
         },
     )
+    address: str = field(
+        default="0.0.0.0",
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
     port: Optional[int] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    tls: bool = field(
+        default=False,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+
+
+@dataclass
+class TlsConfig:
+    """certificateAuthority.:
+
+    A path to the FILE, containing concatenation of known certificates
+    the server can use to reference as its certificate store.
+    certificate..........:
+    A path to the FILE, containing the certificate the broker will use
+    to identify itself to other clients.
+    key..................:
+    A path to the FILE, containing the private key that the broker uses
+    to read the certificate.
+    versions.............:
+    A string with a comma-separated list of supported protocol versions.
+    """
+
+    certificate_authority: Optional[str] = field(
+        default=None,
+        metadata={
+            "name": "certificateAuthority",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    certificate: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    key: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    versions: Optional[str] = field(
         default=None,
         metadata={
             "type": "Element",
@@ -2164,6 +2235,7 @@ class AppConfig:
     advertiseSubscriptions.: temporarily control use of ConfigureStream in SDK
     routeCommandTimeoutMs: maximum amount of time to wait for a routed command's response
     authentication.......: configuration for authentication
+    tlsConfig............: optional configuration for TLS
     """
 
     broker_instance_name: Optional[str] = field(
@@ -2332,6 +2404,14 @@ class AppConfig:
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,
+        },
+    )
+    tls_config: Optional[TlsConfig] = field(
+        default=None,
+        metadata={
+            "name": "tlsConfig",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
         },
     )
 


### PR DESCRIPTION
Added
=====

- TLS configuration in broker config
- Helper script for generating test certs and CAs
- TLS options for NtcChannel
- Loading certificates and authority data specified from bmqbrkrcfg.json
- SessionOptions to bmq package for configuring client sessions
- --tls-authority and --tls-version options to bmqtool to configure session options
- Client sessions will now require broker TLS sessions when TLS protocol versions are specified
- Create CertificateStore component for bmqio
- Integration tests for TLS

Changed
=======

- Update ntf-core and bde dependencies