### PR TITLE
Fix: handling no leader case

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -5551,10 +5551,6 @@ void ClusterQueueHelper::deconfigureUri(
         }
         BSLS_ASSERT(pinfo.primaryNode() == contextSp->d_peer);
     }
-    else {
-        BSLS_ASSERT(d_clusterData_p->electorInfo().leaderNode() ==
-                    contextSp->d_peer);
-    }
 
     // Primary is active; send configure-queue request, wait for response,
     // send close-queue request


### PR DESCRIPTION
Not asserting leader in `deconfigureUri`
Since deconfiguring is async, leader can disappear before `deconfigureUri`.

(If queue cannot deconfigure, it is controlled by it's state.)