### PR TITLE
Fix: bug in queue admin command validation

### DIFF
--- a/src/groups/mqb/mqbcmd/mqbcmd_parseutil.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_parseutil.cpp
@@ -442,7 +442,7 @@ int parseDomainQueue(DomainQueue*  queue,
 
     const bslstl::StringRef subcommand = next();
 
-    if (name.empty()) {
+    if (subcommand.empty()) {
         *error = "DOMAINS DOMAIN <name> QUEUE <queue_name> command must have "
                  "a subcommand, such as PURGE, INTERNALS, or LIST.";
         return -1;  // RETURN


### PR DESCRIPTION
**Describe your changes**
Fuzz tests caught this; the `if` block is never being executed.

