### PR TITLE
Fix[Storagetool]: use bsl::optional for `Parameters::Range` class members

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filters.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filters.h
@@ -44,7 +44,7 @@ class Filters {
   private:
     // DATA
     bsl::unordered_set<mqbu::StorageKey> d_queueKeys;
-    const Parameters::Range              d_range;
+    const Parameters::Range&             d_range;
 
   public:
     // CREATORS

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.h
@@ -48,7 +48,7 @@ namespace m_bmqstoragetool {
 class LessThanLowerBoundFn {
   private:
     // PRIVATE DATA
-    const Parameters::Range d_range;
+    const Parameters::Range& d_range;
 
   public:
     // CREATORS

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -868,7 +868,6 @@ static void test11_searchMessagesByTimestamp()
     Parameters params(bmqtst::TestHelperUtil::allocator());
     params.d_range.d_timestampGt = ts1;
     params.d_range.d_timestampLt = ts2;
-    params.d_range.d_type        = Parameters::Range::e_TIMESTAMP;
 
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
@@ -1244,7 +1243,6 @@ static void test15_timestampSearchTest()
         BMQTST_ASSERT_EQ(journalFileIt.nextRecord(), 1);
 
         Parameters::Range range;
-        range.d_type        = Parameters::Range::e_TIMESTAMP;
         range.d_timestampGt = ts;
         LessThanLowerBoundFn lessThanLowerBoundFn(range);
 
@@ -1277,10 +1275,9 @@ static void test15_timestampSearchTest()
         // specified iterator, which is initially forward
         BMQTST_ASSERT_GT(journalFileIt.recordHeader().timestamp(), ts1);
 
-        Parameters::Range range;
-        range.d_type        = Parameters::Range::e_TIMESTAMP;
-        range.d_timestampGt = ts1;
-        LessThanLowerBoundFn lessThanLowerBoundFn(range);
+        Parameters::Range range1;
+        range1.d_timestampGt = ts1;
+        LessThanLowerBoundFn lessThanLowerBoundFn(range1);
 
         BMQTST_ASSERT_EQ(
             m_bmqstoragetool::moveToLowerBound(&journalFileIt,
@@ -1291,9 +1288,10 @@ static void test15_timestampSearchTest()
         // Find record with higher timestamp than the record pointed by the
         // specified iterator, which is initially forward
         BMQTST_ASSERT_LT(journalFileIt.recordHeader().timestamp(), ts2);
-        range.d_timestampGt = ts2;
+        Parameters::Range range2;
+        range2.d_timestampGt = ts2;
 
-        LessThanLowerBoundFn lessThanLowerBoundFn2(range);
+        LessThanLowerBoundFn lessThanLowerBoundFn2(range2);
         BMQTST_ASSERT_EQ(
             m_bmqstoragetool::moveToLowerBound(&journalFileIt,
                                                lessThanLowerBoundFn2),
@@ -1335,7 +1333,6 @@ static void test15_timestampSearchTest()
         BMQTST_ASSERT_EQ(journalFileIt.nextRecord(), 1);
 
         Parameters::Range range;
-        range.d_type        = Parameters::Range::e_TIMESTAMP;
         range.d_timestampGt = ts;
         LessThanLowerBoundFn lessThanLowerBoundFn(range);
 
@@ -1359,7 +1356,6 @@ static void test15_timestampSearchTest()
         BMQTST_ASSERT_EQ(journalFileIt.nextRecord(), 1);
 
         Parameters::Range range;
-        range.d_type        = Parameters::Range::e_TIMESTAMP;
         range.d_timestampGt = ts;
         LessThanLowerBoundFn lessThanLowerBoundFn(range);
 
@@ -1439,7 +1435,6 @@ static void test16_sequenceNumberLowerBoundTest()
         BMQTST_ASSERT_EQ(journalFileIt.nextRecord(), 1);
 
         Parameters::Range range;
-        range.d_type     = Parameters::Range::e_SEQUENCE_NUM;
         range.d_seqNumGt = seqNumGt;
         LessThanLowerBoundFn lessThanLowerBoundFn(range);
 
@@ -1476,7 +1471,6 @@ static void test16_sequenceNumberLowerBoundTest()
 
         CompositeSequenceNumber seqNumGt(1, k_NUM_RECORDS);
         Parameters::Range       range;
-        range.d_type     = Parameters::Range::e_SEQUENCE_NUM;
         range.d_seqNumGt = seqNumGt;
         LessThanLowerBoundFn lessThanLowerBoundFn(range);
 
@@ -1518,7 +1512,6 @@ static void test17_searchMessagesBySequenceNumbersRange()
     Parameters params(bmqtst::TestHelperUtil::allocator());
     params.d_range.d_seqNumGt = seqNumGt;
     params.d_range.d_seqNumLt = seqNumLt;
-    params.d_range.d_type     = Parameters::Range::e_SEQUENCE_NUM;
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
         new (*bmqtst::TestHelperUtil::allocator())
@@ -1591,7 +1584,6 @@ static void test18_searchMessagesByOffsetsRange()
     Parameters params(bmqtst::TestHelperUtil::allocator());
     params.d_range.d_offsetGt = offsetGt;
     params.d_range.d_offsetLt = offsetLt;
-    params.d_range.d_type     = Parameters::Range::e_OFFSET;
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
         new (*bmqtst::TestHelperUtil::allocator())
@@ -1666,7 +1658,6 @@ static void test19_searchQueueOpRecords()
     params.d_processRecordTypes.d_queueOp = true;
     params.d_range.d_offsetGt             = offsetGt;
     params.d_range.d_offsetLt             = offsetLt;
-    params.d_range.d_type                 = Parameters::Range::e_OFFSET;
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
         new (*bmqtst::TestHelperUtil::allocator())
@@ -1743,7 +1734,6 @@ static void test20_searchJournalOpRecords()
     params.d_processRecordTypes.d_journalOp = true;
     params.d_range.d_offsetGt               = offsetGt;
     params.d_range.d_offsetLt               = offsetLt;
-    params.d_range.d_type                   = Parameters::Range::e_OFFSET;
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
         new (*bmqtst::TestHelperUtil::allocator())
@@ -1821,7 +1811,6 @@ static void test21_searchAllTypesRecords()
     params.d_processRecordTypes.d_journalOp = true;
     params.d_range.d_offsetGt               = offsetGt;
     params.d_range.d_offsetLt               = offsetLt;
-    params.d_range.d_type                   = Parameters::Range::e_OFFSET;
     // Prepare file manager
     bslma::ManagedPtr<FileManager> fileManager(
         new (*bmqtst::TestHelperUtil::allocator())

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "m_bmqstoragetool_compositesequencenumber.h"
 #include <m_bmqstoragetool_parameters.h>
 
 // BMQ
@@ -322,11 +323,10 @@ bool CommandLineArguments::isValidFileName(const bsl::string* fileName,
 }
 
 Parameters::Range::Range()
-: d_type(Range::e_NONE)
-, d_timestampGt(0)
-, d_timestampLt(0)
-, d_offsetGt(0)
-, d_offsetLt(0)
+: d_timestampGt()
+, d_timestampLt()
+, d_offsetGt()
+, d_offsetLt()
 , d_seqNumGt()
 , d_seqNumLt()
 {
@@ -400,27 +400,28 @@ Parameters::Parameters(const CommandLineArguments& arguments,
 
     // Set search range type and values if present
     if (arguments.d_timestampLt || arguments.d_timestampGt) {
-        d_range.d_type        = Range::e_TIMESTAMP;
         d_range.d_timestampLt = static_cast<bsls::Types::Uint64>(
             arguments.d_timestampLt);
         d_range.d_timestampGt = static_cast<bsls::Types::Uint64>(
             arguments.d_timestampGt);
     }
     else if (arguments.d_offsetLt || arguments.d_offsetGt) {
-        d_range.d_type     = Range::e_OFFSET;
         d_range.d_offsetLt = static_cast<bsls::Types::Uint64>(
             arguments.d_offsetLt);
         d_range.d_offsetGt = static_cast<bsls::Types::Uint64>(
             arguments.d_offsetGt);
     }
     else if (!arguments.d_seqNumLt.empty() || !arguments.d_seqNumGt.empty()) {
-        d_range.d_type = Range::e_SEQUENCE_NUM;
         bmqu::MemOutStream errorDescr(allocator);
         if (!arguments.d_seqNumLt.empty()) {
-            d_range.d_seqNumLt.fromString(errorDescr, arguments.d_seqNumLt);
+            d_range.d_seqNumLt = CompositeSequenceNumber().fromString(
+                errorDescr,
+                arguments.d_seqNumLt);
         }
         if (!arguments.d_seqNumGt.empty()) {
-            d_range.d_seqNumGt.fromString(errorDescr, arguments.d_seqNumGt);
+            d_range.d_seqNumGt = CompositeSequenceNumber().fromString(
+                errorDescr,
+                arguments.d_seqNumGt);
         }
     }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
@@ -40,6 +40,7 @@
 
 // BDE
 #include <bsl_iosfwd.h>
+#include <bsl_optional.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
 #include <bsls_types.h>
@@ -131,29 +132,20 @@ struct Parameters {
 
     /// VST representing search range parameters
     struct Range {
-        // PUBLIC TYPES
-        enum Type {
-            e_NONE         = 0,
-            e_TIMESTAMP    = 1,
-            e_SEQUENCE_NUM = 2,
-            e_OFFSET       = 3
-        };
-
         // PUBLIC DATA
-        /// Range type
-        Type d_type;
+
         /// Filter messages greater than timestamp value
-        bsls::Types::Uint64 d_timestampGt;
+        bsl::optional<bsls::Types::Uint64> d_timestampGt;
         /// Filter messages less than timestamp value
-        bsls::Types::Uint64 d_timestampLt;
+        bsl::optional<bsls::Types::Uint64> d_timestampLt;
         /// Filter messages greater than offset value
-        bsls::Types::Uint64 d_offsetGt;
+        bsl::optional<bsls::Types::Uint64> d_offsetGt;
         /// Filter messages less than offset value
-        bsls::Types::Uint64 d_offsetLt;
+        bsl::optional<bsls::Types::Uint64> d_offsetLt;
         /// Filter messages greater than sequence number
-        CompositeSequenceNumber d_seqNumGt;
+        bsl::optional<CompositeSequenceNumber> d_seqNumGt;
         /// Filter messages less than sequence number
-        CompositeSequenceNumber d_seqNumLt;
+        bsl::optional<CompositeSequenceNumber> d_seqNumLt;
 
         // CREATORS
         /// Default constructor

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
@@ -147,33 +147,27 @@ bsl::shared_ptr<SearchResult> SearchResultFactory::createSearchResult(
                            alloc);
     }
 
-    // Add TimestampDecorator if 'timestampLt' is given and value type is
-    // `e_TIMESTAMP`.
-    if (params->d_range.d_type == Parameters::Range::e_TIMESTAMP &&
-        params->d_range.d_timestampLt > 0) {
+    // Add TimestampDecorator if 'timestampLt' is given.
+    if (params->d_range.d_timestampLt) {
         searchResult.reset(new (*alloc) SearchResultTimestampDecorator(
                                searchResult,
-                               params->d_range.d_timestampLt,
+                               params->d_range.d_timestampLt.value(),
                                alloc),
                            alloc);
     }
-    else if (params->d_range.d_type == Parameters::Range::e_OFFSET &&
-             params->d_range.d_offsetLt > 0) {
-        // Add OffsetDecorator if 'offsetLt' is given and value type is
-        // `e_OFFSET`.
+    else if (params->d_range.d_offsetLt) {
+        // Add OffsetDecorator if 'offsetLt' is given.
         searchResult.reset(new (*alloc) SearchResultOffsetDecorator(
                                searchResult,
-                               params->d_range.d_offsetLt,
+                               params->d_range.d_offsetLt.value(),
                                alloc),
                            alloc);
     }
-    else if (params->d_range.d_type == Parameters::Range::e_SEQUENCE_NUM &&
-             params->d_range.d_seqNumLt.isSet()) {
-        // Add SequenceNumberDecorator if 'seqNumLt' is given and value type is
-        // `e_SEQUENCE_NUM`.
+    else if (params->d_range.d_seqNumLt) {
+        // Add SequenceNumberDecorator if 'seqNumLt' is given.
         searchResult.reset(new (*alloc) SearchResultSequenceNumberDecorator(
                                searchResult,
-                               params->d_range.d_seqNumLt,
+                               params->d_range.d_seqNumLt.value(),
                                alloc),
                            alloc);
     }


### PR DESCRIPTION
Addressing postponed review comment https://github.com/bloomberg/blazingmq/pull/508#discussion_r1869935596 - use `bsl::optional` for `Range` class members.