### PR TITLE
Fix[BMQ,MQB]: ensure Solaris build

### DIFF
--- a/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
+++ b/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
@@ -38,14 +38,16 @@ static bool parseArgs(CommandLineArguments& arguments,
 {
     bool showHelp = false;
 
+    bsl::vector<bsl::string> defaultRecordType(allocator);
+    defaultRecordType.push_back(CommandLineArguments::k_MESSAGE_TYPE);
+
     balcl::OptionInfo specTable[] = {
         {"r|record-type",
          "record type",
          "record type to search {message|queue-op|journal-op}",
          balcl::TypeInfo(&arguments.d_recordType,
                          CommandLineArguments::isValidRecordType),
-         balcl::OccurrenceInfo(bsl::vector<bsl::string>(
-             {CommandLineArguments::k_MESSAGE_TYPE}))},
+         balcl::OccurrenceInfo(defaultRecordType)},
         {"journal-path",
          "journal path",
          "'*'-ended file path pattern, where the tool will try to find "

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -924,7 +924,7 @@ static void test12_printMessagesDetailsTest()
     bmqtst::TestHelper::printTestName("PRINT MESSAGE DETAILS TEST");
 
 #if defined(BSLS_PLATFORM_OS_SOLARIS)
-    s_ignoreCheckDefAlloc = true;
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
     // Disable default allocator check for this test until we can debug
     // it on Solaris
 #endif

--- a/src/groups/bmq/bmqa/bmqa_message.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.t.cpp
@@ -166,7 +166,7 @@ static void test2_validPushMessagePrint()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -192,7 +192,7 @@ static void test2_validPushMessagePrint()
                      bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(peb.eventSize()));
@@ -256,7 +256,7 @@ static void test3_messageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -290,7 +290,7 @@ static void test3_messageProperties()
     bdlbb::BlobUtil::append(&payload, buffer, bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
 
     // Add SubQueueInfo option
@@ -432,7 +432,7 @@ static void test4_subscriptionHandle()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         4 * 1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -459,7 +459,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PushEventBuilder
-        bmqp::PushEventBuilder peb(&blobSpPool,
+        bmqp::PushEventBuilder peb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(0, peb.messageCount());
 
@@ -525,7 +525,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PushEventBuilder
-        bmqp::PushEventBuilder peb(&blobSpPool,
+        bmqp::PushEventBuilder peb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(0, peb.messageCount());
 
@@ -573,7 +573,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder builder(&blobSpPool,
+        bmqp::PutEventBuilder builder(blobSpPool.get(),
                                       bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(0, builder.messageCount());
 
@@ -614,7 +614,7 @@ static void test4_subscriptionHandle()
             bmqtst::TestHelperUtil::allocator());
 
         // Create AckEventBuilder
-        bmqp::AckEventBuilder builder(&blobSpPool,
+        bmqp::AckEventBuilder builder(blobSpPool.get(),
                                       bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(0, builder.messageCount());
 

--- a/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
@@ -167,11 +167,11 @@ static void test2_ackMesageIteratorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder builder(&blobSpPool,
+    bmqp::AckEventBuilder builder(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<AckData>  messages(bmqtst::TestHelperUtil::allocator());
 
@@ -234,11 +234,11 @@ static void test3_putMessageIteratorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder builder(&blobSpPool,
+    bmqp::PutEventBuilder builder(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<PutData>  messages(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -823,6 +823,9 @@ class MockSession : public AbstractSession {
         bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
         BlobSpPool;
 
+    /// Shared pointer to a pool of shared pointers to Blobs
+    typedef bsl::shared_ptr<BlobSpPool> BlobSpPoolSp;
+
     /// Aligned buffer holding the two key hash map
     typedef bsls::AlignedBuffer<k_MAX_SIZEOF_BMQC_TWOKEYHASHMAP>
         TwoKeyHashMapBuffer;
@@ -1035,8 +1038,8 @@ class MockSession : public AbstractSession {
     /// Buffer factory used to build Blobs with `d_blobSpPool`
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
 
-    /// Pool of shared pointers to blobs
-    BlobSpPool d_blobSpPool;
+    /// Shared pointer to the pool of shared pointers to blobs
+    BlobSpPoolSp d_blobSpPool_sp;
 
     /// Event handler (set only in asynchronous mode)
     bslma::ManagedPtr<SessionEventHandler> d_eventHandler_mp;

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -553,7 +553,7 @@ Application::Application(
 , d_channelsTip(&d_allocator)
 , d_blobBufferFactory(sessionOptions.blobBufferSize(),
                       d_allocators.get("BlobBufferFactory"))
-, d_blobSpPool(
+, d_blobSpPool_sp(
       bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
                                          d_allocators.get("BlobSpPool")))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC, &d_allocator)
@@ -584,13 +584,13 @@ Application::Application(
       NegotiatedChannelFactoryConfig(&d_statChannelFactory,
                                      negotiationMessage,
                                      sessionOptions.connectTimeout(),
-                                     &d_blobSpPool,
+                                     d_blobSpPool_sp.get(),
                                      allocator),
       allocator)
 , d_connectHandle_mp()
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,
-                  &d_blobSpPool,
+                  d_blobSpPool_sp.get(),
                   d_sessionOptions,
                   eventHandlerCB,
                   bdlf::MemFnUtil::memFn(&Application::stateCb, this),

--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -81,6 +81,7 @@ class Application {
   public:
     // PUBLIC TYPES
     typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+    typedef bmqp::BlobPoolUtil::BlobSpPoolSp BlobSpPoolSp;
 
   private:
     // PRIVATE TYPES
@@ -118,8 +119,8 @@ class Application {
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
     // Factory for blob buffers
 
-    /// Pool of shared pointers to blobs.
-    BlobSpPool d_blobSpPool;
+    /// Shared pointer to the pool of shared pointers to blobs.
+    BlobSpPoolSp d_blobSpPool_sp;
 
     bdlmt::EventScheduler d_scheduler;
     // Scheduler
@@ -324,7 +325,7 @@ inline bool Application::isStarted() const
 
 inline Application::BlobSpPool* Application::blobSpPool()
 {
-    return &d_blobSpPool;
+    return d_blobSpPool_sp.get();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -774,7 +774,7 @@ static void test6_comparisonOperatorTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -818,8 +818,8 @@ static void test6_comparisonOperatorTest()
     PV("Configure as MesageEvent");
     bmqimp::Event obj3(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqimp::Event obj4(&bufferFactory, bmqtst::TestHelperUtil::allocator());
-    obj3.configureAsMessageEvent(&blobSpPool);
-    obj4.configureAsMessageEvent(&blobSpPool);
+    obj3.configureAsMessageEvent(blobSpPool.get());
+    obj4.configureAsMessageEvent(blobSpPool.get());
 
     // NOTE: Message event can not be equal. Is it expected?
     BMQTST_ASSERT(obj3 != obj4);
@@ -1112,7 +1112,7 @@ static void test8_putEventBuilder()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1145,7 +1145,7 @@ static void test8_putEventBuilder()
 
     // Create PutEventBuilder
     bmqimp::Event obj(&bufferFactory, bmqtst::TestHelperUtil::allocator());
-    obj.configureAsMessageEvent(&blobSpPool);
+    obj.configureAsMessageEvent(blobSpPool.get());
     bmqp::PutEventBuilder& builder = *(obj.putEventBuilder());
 
     builder.startMessage();
@@ -1569,7 +1569,7 @@ static void test12_upgradeDowngradeMessageEvent()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1578,7 +1578,7 @@ static void test12_upgradeDowngradeMessageEvent()
     bmqimp::Event obj(&bufferFactory, bmqtst::TestHelperUtil::allocator());
 
     // 2. Configure event as message event in WRITE mode.
-    obj.configureAsMessageEvent(&blobSpPool);
+    obj.configureAsMessageEvent(blobSpPool.get());
     BMQTST_ASSERT_EQ(bmqimp::Event::MessageEventMode::e_WRITE,
                      obj.messageEventMode());
 

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
@@ -260,11 +260,11 @@ static void test2_capacityTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder         builder(&blobSpPool,
+    bmqp::PutEventBuilder         builder(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bmqimp::EventQueue::EventPool eventPool(
         bdlf::BindUtil::bind(&poolCreateEvent,
@@ -568,11 +568,11 @@ static void test6_workingStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder         builder(&blobSpPool,
+    bmqp::PutEventBuilder         builder(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bmqimp::EventQueue::EventPool eventPool(
         bdlf::BindUtil::bind(&poolCreateEvent,

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -141,7 +141,7 @@ struct Tester BSLS_CPP11_FINAL {
     // various builders
 
     /// Blob shared pointer pool used in event builders.
-    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPoolSp d_blobSpPool_sp;
 
     bmqp::PushEventBuilder d_pushEventBuilder;
     // PUSH event builder
@@ -336,11 +336,12 @@ Tester::Tester(bslma::Allocator* allocator)
 , d_nextCorrelationId(0)
 , d_time(0, 0)
 , d_bufferFactory(1024, allocator)
-, d_blobSpPool(bmqp::BlobPoolUtil::createBlobPool(&d_bufferFactory, allocator))
-, d_pushEventBuilder(&d_blobSpPool, allocator)
-, d_ackEventBuilder(&d_blobSpPool, allocator)
-, d_putEventBuilder(&d_blobSpPool, allocator)
-, d_confirmEventBuilder(&d_blobSpPool, allocator)
+, d_blobSpPool_sp(
+      bmqp::BlobPoolUtil::createBlobPool(&d_bufferFactory, allocator))
+, d_pushEventBuilder(d_blobSpPool_sp.get(), allocator)
+, d_ackEventBuilder(d_blobSpPool_sp.get(), allocator)
+, d_putEventBuilder(d_blobSpPool_sp.get(), allocator)
+, d_confirmEventBuilder(d_blobSpPool_sp.get(), allocator)
 , d_allocator_p(allocator)
 {
     bmqsys::Time::initialize(

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
@@ -595,11 +595,11 @@ static void test9_pushStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
     bmqt::Uri   uri(k_URI, bmqtst::TestHelperUtil::allocator());
@@ -713,11 +713,11 @@ static void test10_putStatsTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder peb(&blobSpPool,
+    bmqp::PutEventBuilder peb(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bmqt::Uri             uri(k_URI, bmqtst::TestHelperUtil::allocator());
     bmqimp::QueueManager::QueueSp  queueSp;

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
@@ -270,8 +270,13 @@ void Tester::init()
     ntca::InterfaceConfig config = ntcCreateInterfaceConfig(d_allocator_p);
     config.setThreadName("test");
 
+    // Solaris: disambiguate by using the expected interface type
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> bufferFactory_sp =
+        bsl::static_pointer_cast<bdlbb::BlobBufferFactory>(
+            d_blobBufferFactory_sp);
+
     d_interface_sp    = ntcf::System::createInterface(config,
-                                                   d_blobBufferFactory_sp,
+                                                   bufferFactory_sp,
                                                    d_allocator_p);
     ntsa::Error error = d_interface_sp->start();
     BMQTST_ASSERT_EQ(error, ntsa::Error::e_OK);

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
@@ -41,10 +41,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::AckEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::AckEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.appendMessage(0, 1, bmqt::MessageGUID(), 1);

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.t.cpp
@@ -142,11 +142,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder obj(&blobSpPool,
+    bmqp::AckEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -173,11 +173,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder obj(&blobSpPool,
+    bmqp::AckEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -196,11 +196,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder obj(&blobSpPool,
+    bmqp::AckEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
 
@@ -232,11 +232,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder obj(&blobSpPool,
+    bmqp::AckEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -292,11 +292,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::AckEventBuilder obj(&blobSpPool,
+    bmqp::AckEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
@@ -51,15 +51,13 @@ BlobPoolUtil::createBlobPool(bdlbb::BlobBufferFactory* blobBufferFactory_p,
 
     bslma::Allocator* alloc = bslma::Default::allocator(allocator);
 
-    return bsl::shared_ptr<BlobSpPool>(
-        new BlobSpPool(
-            bdlf::BindUtil::bind(&createBlob,
-                                 blobBufferFactory_p,
-                                 bdlf::PlaceHolders::_1,   // arena
-                                 bdlf::PlaceHolders::_2),  // allocator
-            k_BLOB_POOL_GROWTH_STRATEGY,
-            alloc),
-        alloc);
+    return bsl::allocate_shared<BlobSpPool>(
+        alloc,
+        bdlf::BindUtil::bind(&createBlob,
+                             blobBufferFactory_p,
+                             bdlf::PlaceHolders::_1,   // arena
+                             bdlf::PlaceHolders::_2),  // allocator
+        k_BLOB_POOL_GROWTH_STRATEGY);
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_blobpoolutil.cpp
@@ -42,20 +42,24 @@ void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
 // class BlobPoolUtil
 // ------------------
 
-BlobPoolUtil::BlobSpPool
+BlobPoolUtil::BlobSpPoolSp
 BlobPoolUtil::createBlobPool(bdlbb::BlobBufferFactory* blobBufferFactory_p,
                              bslma::Allocator*         allocator)
 {
     // PRECONDITIONS
     BSLS_ASSERT(blobBufferFactory_p);
 
-    return BlobSpPool(
-        bdlf::BindUtil::bind(&createBlob,
-                             blobBufferFactory_p,
-                             bdlf::PlaceHolders::_1,   // arena
-                             bdlf::PlaceHolders::_2),  // allocator
-        k_BLOB_POOL_GROWTH_STRATEGY,
-        bslma::Default::allocator(allocator));
+    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
+
+    return bsl::shared_ptr<BlobSpPool>(
+        new BlobSpPool(
+            bdlf::BindUtil::bind(&createBlob,
+                                 blobBufferFactory_p,
+                                 bdlf::PlaceHolders::_1,   // arena
+                                 bdlf::PlaceHolders::_2),  // allocator
+            k_BLOB_POOL_GROWTH_STRATEGY,
+            alloc),
+        alloc);
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_blobpoolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_blobpoolutil.h
@@ -35,7 +35,7 @@ namespace BloombergLP {
 namespace bmqp {
 
 struct BlobPoolUtil {
-    // TYPES
+    // PUBLIC TYPES
 
     /// Pool of shared pointers to Blobs
     typedef bdlcc::SharedObjectPool<
@@ -44,12 +44,15 @@ struct BlobPoolUtil {
         bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
         BlobSpPool;
 
+    /// Shared pointer to the pool of shared pointers to Blobs
+    typedef bsl::shared_ptr<BlobSpPool> BlobSpPoolSp;
+
     // CLASS METHODS
 
-    /// Create a blob shared pointer pool, using the specified
-    /// `blobBufferFactory_p`.  Use the optionally specified `allocator`
-    /// for memory allocations.
-    static BlobSpPool
+    /// Create a pool of shared pointers to blobs, using the specified
+    /// `blobBufferFactory_p`, and return it as a shared pointer.
+    /// Use the optionally specified `allocator` for memory allocations.
+    static BlobSpPoolSp
     createBlobPool(bdlbb::BlobBufferFactory* blobBufferFactory_p,
                    bslma::Allocator*         allocator = 0);
 };

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.h
@@ -41,10 +41,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::ConfirmEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::ConfirmEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages, from same or different queue
 //  builder.appendMessage(k_QUEUEID1, k_SUBQUEUEID1, bmqt::MessageGUID());

--- a/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmeventbuilder.t.cpp
@@ -139,11 +139,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::ConfirmEventBuilder obj(&blobSpPool,
+    bmqp::ConfirmEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -170,11 +170,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::ConfirmEventBuilder obj(&blobSpPool,
+    bmqp::ConfirmEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -193,11 +193,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::ConfirmEventBuilder obj(&blobSpPool,
+    bmqp::ConfirmEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
 
@@ -229,11 +229,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::ConfirmEventBuilder obj(&blobSpPool,
+    bmqp::ConfirmEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -291,11 +291,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::ConfirmEventBuilder obj(&blobSpPool,
+    bmqp::ConfirmEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>         messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_event.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_event.t.cpp
@@ -528,7 +528,7 @@ static void test4_eventLoading()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -548,7 +548,7 @@ static void test4_eventLoading()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << "encoding");
 
-        bmqp::SchemaEventBuilder obj(&blobSpPool,
+        bmqp::SchemaEventBuilder obj(blobSpPool.get(),
                                      test.d_encodingType,
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -595,7 +595,7 @@ static void test4_eventLoading()
     }
 
     {
-        bmqp::SchemaEventBuilder obj(&blobSpPool,
+        bmqp::SchemaEventBuilder obj(blobSpPool.get(),
                                      bmqp::EncodingType::e_BER,
                                      bmqtst::TestHelperUtil::allocator());
         BSLS_ASSERT_OPT(obj.blob()->length() == 0);

--- a/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.t.cpp
@@ -251,12 +251,12 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::PushEventBuilder pushEventBuilder(
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>      data(bmqtst::TestHelperUtil::allocator());
     int                    payloadLength    = 0;
@@ -321,7 +321,7 @@ static void test1_breathingTest()
         &eventInfos,
         event,
         &bufferFactory,
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(rc, 0);
     BMQTST_ASSERT_EQ(eventInfos.size(), 1u);
@@ -456,12 +456,12 @@ static void test2_flattenExplodesEvent()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::PushEventBuilder pushEventBuilder(
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>      data(bmqtst::TestHelperUtil::allocator());
     int                    payloadLength  = 0;
@@ -499,7 +499,7 @@ static void test2_flattenExplodesEvent()
         &eventInfos,
         event,
         &bufferFactory,
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(rc, 0);
     BMQTST_ASSERT_EQ(eventInfos.size(), 2u);
@@ -690,14 +690,14 @@ static void test3_flattenWithMessageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::MessageProperties msgProperties(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob             appData(bmqtst::TestHelperUtil::allocator());
     bmqp::PushEventBuilder  pushEventBuilder(
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     bmqt::EventBuilderResult::Enum result;
     int                            payloadLength    = 0;
@@ -778,7 +778,7 @@ static void test3_flattenWithMessageProperties()
         &eventInfos,
         event,
         &bufferFactory,
-        &blobSpPool,
+        blobSpPool.get(),
         bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(rc, 0);
     BMQTST_ASSERT_EQ(eventInfos.size(), 1U);

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.t.cpp
@@ -864,14 +864,14 @@ static void test11_parseMessageProperties()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::MessageProperties in(bmqtst::TestHelperUtil::allocator());
     encode(&in);
     const int             queueId = 4;
-    bmqp::PutEventBuilder peb(&blobSpPool,
+    bmqp::PutEventBuilder peb(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
@@ -40,10 +40,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::PushEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::PushEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.packMessage("hello", 5, 0, bmqt::MessageGUID());

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
@@ -273,7 +273,7 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -296,7 +296,7 @@ static void test1_breathingTest()
                      bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(peb.eventSize()));
@@ -401,7 +401,7 @@ static void test2_buildEventBackwardsCompatibility()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -424,7 +424,7 @@ static void test2_buildEventBackwardsCompatibility()
                      bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(peb.eventSize()));
@@ -530,7 +530,7 @@ static void test3_buildEventWithPackedOption()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -549,7 +549,7 @@ static void test3_buildEventWithPackedOption()
                      bsl::strlen(buffer));
 
     // Create PushEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(peb.eventSize()));
@@ -646,11 +646,11 @@ static void test4_buildEventWithMultipleMessages()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
 
     bsl::vector<Data> data(bmqtst::TestHelperUtil::allocator());
@@ -770,7 +770,7 @@ static void test5_buildEventWithPayloadTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -794,7 +794,7 @@ static void test5_buildEventWithPayloadTooBig()
                      bigMsgPayload.length());
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(peb.eventSize()));
@@ -894,7 +894,7 @@ static void test6_buildEventWithImplicitPayload()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -903,7 +903,7 @@ static void test6_buildEventWithImplicitPayload()
     const int flags = bmqp::PushHeaderFlags::e_IMPLICIT_PAYLOAD;
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder         peb(&blobSpPool,
+    bmqp::PushEventBuilder         peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
     bmqt::EventBuilderResult::Enum rc = peb.packMessage(
         queueId,
@@ -980,7 +980,7 @@ static void test7_buildEventOptionTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1004,7 +1004,7 @@ static void test7_buildEventOptionTooBig()
     generateSubQueueInfos(&subQueueInfos, numSubQueueInfos);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
 
     // Add option larger than maximum allowed
@@ -1164,7 +1164,7 @@ static void test8_buildEventTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1184,7 +1184,7 @@ static void test8_buildEventTooBig()
     bdlbb::BlobUtil::append(&validPayload1, s.c_str(), validLen);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder peb(&blobSpPool,
+    bmqp::PushEventBuilder peb(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
 
     // Add message with valid payload size
@@ -1256,7 +1256,7 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1273,7 +1273,7 @@ static void testN1_decodeFromFile()
     bdlbb::BlobUtil::append(&payloadBlob, k_PAYLOAD, k_PAYLOAD_LEN);
 
     // Create PutEventBuilder
-    bmqp::PushEventBuilder obj(&blobSpPool,
+    bmqp::PushEventBuilder obj(blobSpPool.get(),
                                bmqtst::TestHelperUtil::allocator());
 
     // Pack one msg

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.h
@@ -40,10 +40,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::PutEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::PutEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages
 //  // (Error handling omitted below for brevity)

--- a/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puteventbuilder.t.cpp
@@ -217,7 +217,7 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -261,7 +261,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -490,7 +490,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -725,7 +725,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -975,7 +975,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -1212,7 +1212,7 @@ static void test1_breathingTest()
         BSLS_ASSERT_OPT(k_NUM_PROPERTIES == msgProps.numProperties());
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -1432,7 +1432,7 @@ static void test1_breathingTest()
         PVV("DO NOT USE COMPRESSION FOR RELAYED PUT MESSAGES");
 
         // Create PutEventBuilder
-        bmqp::PutEventBuilder obj(&blobSpPool,
+        bmqp::PutEventBuilder obj(blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
         bmqu::MemOutStream error(bmqtst::TestHelperUtil::allocator());
@@ -1686,11 +1686,11 @@ static void test2_manipulators_one()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     // Properties.
@@ -1846,7 +1846,7 @@ static void test3_eventTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1868,7 +1868,7 @@ static void test3_eventTooBig()
                 bigMsgPayload.length());
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     obj.startMessage();
@@ -1962,11 +1962,11 @@ static void test4_manipulators_two()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder          obj(&blobSpPool,
+    bmqp::PutEventBuilder          obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   k_NUM_MSGS = 1000;
@@ -2051,11 +2051,11 @@ static void test5_putEventWithZeroLengthMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>     data(bmqtst::TestHelperUtil::allocator());
 
@@ -2106,7 +2106,7 @@ static void test6_emptyBuilder()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -2128,7 +2128,7 @@ static void test6_emptyBuilder()
 
     const char* k_PAYLOAD = "abcdefghijklmnopqrstuvwxyz";
 
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     BMQTST_ASSERT_EQ(obj.unpackedMessageSize(), 0);
@@ -2201,7 +2201,7 @@ static void test7_multiplePackMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -2242,7 +2242,7 @@ static void test7_multiplePackMessage()
     BMQTST_ASSERT_EQ(k_NUM_PROPERTIES, msgProps.numProperties());
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     BMQTST_ASSERT_EQ(obj.crc32c(), 0U);
@@ -2452,7 +2452,7 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -2496,7 +2496,7 @@ static void testN1_decodeFromFile()
         bmqp::PutHeaderFlags::e_MESSAGE_PROPERTIES);
 
     // Create PutEventBuilder
-    bmqp::PutEventBuilder obj(&blobSpPool,
+    bmqp::PutEventBuilder obj(blobSpPool.get(),
                               bmqtst::TestHelperUtil::allocator());
 
     obj.startMessage();

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.h
@@ -42,10 +42,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::RecoveryEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::RecoveryEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.appendMessage(0, 1, bmqt::MessageGUID(), 1);

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
@@ -115,7 +115,7 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -130,7 +130,7 @@ static void test1_breathingTest()
 
     // Create RecoveryEventBuilder.
 
-    bmqp::RecoveryEventBuilder reb(&blobSpPool,
+    bmqp::RecoveryEventBuilder reb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(sizeof(bmqp::EventHeader),
                      static_cast<size_t>(reb.eventSize()));
@@ -211,11 +211,11 @@ static void test2_multipleMessagesTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RecoveryEventBuilder     reb(&blobSpPool,
+    bmqp::RecoveryEventBuilder     reb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -299,11 +299,11 @@ static void test3_eventTooBigTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RecoveryEventBuilder reb(&blobSpPool,
+    bmqp::RecoveryEventBuilder reb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
     bsl::string                bigChunk(bmqtst::TestHelperUtil::allocator());
     bigChunk.resize(bmqp::RecoveryHeader::k_MAX_PAYLOAD_SIZE_SOFT + 4, 'a');
@@ -396,11 +396,11 @@ static void test4_emptyPayloadTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RecoveryEventBuilder reb(&blobSpPool,
+    bmqp::RecoveryEventBuilder reb(blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<char> chunkBufferSp(

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.h
@@ -41,10 +41,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::RejectEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::RejectEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages, from same or different queue
 //  builder.appendMessage(k_QUEUEID1, k_SUBQUEUEID1, bmqt::MessageGUID(), 5);

--- a/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_rejecteventbuilder.t.cpp
@@ -139,11 +139,11 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RejectEventBuilder obj(&blobSpPool,
+    bmqp::RejectEventBuilder obj(blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -170,11 +170,11 @@ static void test2_multiMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RejectEventBuilder obj(&blobSpPool,
+    bmqp::RejectEventBuilder obj(blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -193,11 +193,11 @@ static void test3_reset()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RejectEventBuilder obj(&blobSpPool,
+    bmqp::RejectEventBuilder obj(blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
 
@@ -229,11 +229,11 @@ static void test4_capacity()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RejectEventBuilder obj(&blobSpPool,
+    bmqp::RejectEventBuilder obj(blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator());
 
     PVV("Computing max message");
@@ -291,11 +291,11 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         256,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
-    bmqp::RejectEventBuilder obj(&blobSpPool,
+    bmqp::RejectEventBuilder obj(blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>        messages(bmqtst::TestHelperUtil::allocator());
     bdlbb::Blob outBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -112,7 +112,7 @@ class TestContext {
     bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
 
     /// Blob pool used to provide blobs to event builders.
-    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPoolSp d_blobSpPool_sp;
 
     TestClock d_testClock;
     // Pointer to struct to initialize system time
@@ -204,13 +204,13 @@ class TestContext {
 
 TestContext::TestContext(bool lateResponseMode, bslma::Allocator* allocator)
 : d_blobBufferFactory(1024, allocator)
-, d_blobSpPool(
+, d_blobSpPool_sp(
       bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory, allocator))
 , d_testClock(allocator)
 , d_scheduler(d_testClock.d_scheduler)
 , d_testChannel(allocator)
 , d_requestManager(bmqp::EventType::e_CONTROL,
-                   &d_blobSpPool,
+                   d_blobSpPool_sp.get(),
                    &d_scheduler,
                    lateResponseMode,
                    allocator)
@@ -386,7 +386,7 @@ static void test1_creatorsTest()
     bdlbb::PooledBlobBufferFactory blobBufferFactory(
         4096,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &blobBufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -398,7 +398,7 @@ static void test1_creatorsTest()
 
         BMQTST_ASSERT_SAFE_FAIL(
             ReqManagerType(bmqp::EventType::e_CONTROL,
-                           &blobSpPool,
+                           blobSpPool.get(),
                            &scheduler,
                            false,  // late response mode is off
                            bmqtst::TestHelperUtil::allocator()));
@@ -411,14 +411,14 @@ static void test1_creatorsTest()
 
         BMQTST_ASSERT_PASS(
             ReqManagerType(bmqp::EventType::e_CONTROL,
-                           &blobSpPool,
+                           blobSpPool.get(),
                            &scheduler,
                            false,  // late response mode is off
                            bmqtst::TestHelperUtil::allocator()));
 
         BMQTST_ASSERT_PASS(
             ReqManagerType(bmqp::EventType::e_CONTROL,
-                           &blobSpPool,
+                           blobSpPool.get(),
                            &scheduler,
                            false,  // late response mode is off
                            bmqex::SystemExecutor(),
@@ -426,7 +426,7 @@ static void test1_creatorsTest()
 
         BMQTST_ASSERT_PASS(
             ReqManagerType(bmqp::EventType::e_CONTROL,
-                           &blobSpPool,
+                           blobSpPool.get(),
                            &scheduler,
                            false,  // late response mode is off
                            bmqex::SystemExecutor(),

--- a/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemaeventbuilder.t.cpp
@@ -58,7 +58,7 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -78,7 +78,7 @@ static void test1_breathingTest()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << "encoding");
 
-        bmqp::SchemaEventBuilder obj(&blobSpPool,
+        bmqp::SchemaEventBuilder obj(blobSpPool.get(),
                                      test.d_encodingType,
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -288,7 +288,7 @@ static void testN1_decodeFromFile()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -308,7 +308,7 @@ static void testN1_decodeFromFile()
         const Test& test = k_DATA[idx];
         PVV(test.d_line << ": Testing " << test.d_encodingType << " encoding");
 
-        bmqp::SchemaEventBuilder obj(&blobSpPool,
+        bmqp::SchemaEventBuilder obj(blobSpPool.get(),
                                      test.d_encodingType,
                                      bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.h
@@ -42,10 +42,10 @@
 /// Usage
 ///-----
 //..
-//  bdlbb::PooledBlobBufferFactory bufferFactory(1024, s_allocator_p);
-//  bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+//  bdlbb::PooledBlobBufferFactory   bufferFactory(1024, s_allocator_p);
+//  bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
 //        bmqp::BlobPoolUtil::createBlobPool(&bufferFactory, s_allocator_p));
-//  bmqp::StorageEventBuilder builder(&blobSpPool, d_allocator_p);
+//  bmqp::StorageEventBuilder builder(blobSpPool.get(), d_allocator_p);
 //
 //  // Append multiple messages
 //  builder.packMessage(...);

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
@@ -187,7 +187,7 @@ static void test1_breathingTest()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -202,7 +202,7 @@ static void test1_breathingTest()
     // Create StorageEventBuilder
     bmqp::StorageEventBuilder seb(1,  // storage protocol version
                                   bmqp::EventType::e_STORAGE,
-                                  &blobSpPool,
+                                  blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(seb.eventSize(),
                      static_cast<int>(sizeof(bmqp::EventHeader)));
@@ -295,14 +295,14 @@ static void test2_storageEventHavingMultipleMessages()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
 
     bmqp::StorageEventBuilder      seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &blobSpPool,
+                                  blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -396,7 +396,7 @@ static void test3_packMessage_payloadTooBig()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -410,7 +410,7 @@ static void test3_packMessage_payloadTooBig()
 
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &blobSpPool,
+                                  blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
     bsl::string               bigPayload(bmqtst::TestHelperUtil::allocator());
     bigPayload.resize(bmqp::StorageHeader::k_MAX_PAYLOAD_SIZE_SOFT + 4, 'a');
@@ -536,13 +536,13 @@ static void test4_packMessageRaw()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::StorageEventBuilder      sebA(k_SPV,
                                    bmqp::EventType::e_STORAGE,
-                                   &blobSpPool,
+                                   blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
     bsl::vector<Data>              data(bmqtst::TestHelperUtil::allocator());
     const size_t                   NUM_MSGS = 1000;
@@ -571,7 +571,7 @@ static void test4_packMessageRaw()
     // Iterate over event 'A', and create event 'B' using 'packMessageRaw'.
     bmqp::StorageEventBuilder sebB(k_SPV,
                                    bmqp::EventType::e_STORAGE,
-                                   &blobSpPool,
+                                   blobSpPool.get(),
                                    bmqtst::TestHelperUtil::allocator());
 
     while (1 == iterA.next() && dataIndex < NUM_MSGS) {
@@ -681,13 +681,13 @@ static void test5_packMessageRaw_emptyMessage()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &blobSpPool,
+                                  blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
     bdlbb::Blob emptyBlob(&bufferFactory, bmqtst::TestHelperUtil::allocator());
@@ -728,7 +728,7 @@ static void test6_packMessageRaw_invalidPosition()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         1024,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -736,7 +736,7 @@ static void test6_packMessageRaw_invalidPosition()
                              bmqtst::TestHelperUtil::allocator());
     bmqp::StorageEventBuilder seb(k_SPV,
                                   bmqp::EventType::e_STORAGE,
-                                  &blobSpPool,
+                                  blobSpPool.get(),
                                   bmqtst::TestHelperUtil::allocator());
 
     // 1.

--- a/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.h
@@ -209,6 +209,14 @@ class AlarmLog : public ball::ObserverAdapter {
     /// will be dumped to stderr with respects to rate-controlled logic.
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
+
+    /// Note: this member is overriden to get rid of the "hides the virtual
+    ///       function" warning.
+    inline void publish(const bsl::shared_ptr<const ball::Record>& record,
+                        const ball::Context& context) BSLS_KEYWORD_OVERRIDE
+    {
+        publish(*record, context);
+    }
 };
 
 }  // close package namespace

--- a/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
@@ -239,6 +239,14 @@ class ConsoleObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
+    /// Note: this member is overriden to get rid of the "hides the virtual
+    ///       function" warning.
+    inline void publish(const bsl::shared_ptr<const ball::Record>& record,
+                        const ball::Context& context) BSLS_KEYWORD_OVERRIDE
+    {
+        publish(*record, context);
+    }
+
     // ACCESSORS
 
     /// Return the currently set severity threshold of this object.

--- a/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
@@ -166,6 +166,14 @@ class SyslogObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
+    /// Note: this member is overriden to get rid of the "hides the virtual
+    ///       function" warning.
+    inline void publish(const bsl::shared_ptr<const ball::Record>& record,
+                        const ball::Context& context) BSLS_KEYWORD_OVERRIDE
+    {
+        publish(*record, context);
+    }
+
     // ACCESSORS
 
     /// Return the currently set severity threshold of this object.

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
@@ -145,6 +145,14 @@ class ScopedLogObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
+    /// Note: this member is overriden to get rid of the "hides the virtual
+    ///       function" warning.
+    inline void publish(const bsl::shared_ptr<const ball::Record>& record,
+                        const ball::Context& context) BSLS_KEYWORD_OVERRIDE
+    {
+        publish(*record, context);
+    }
+
   public:
     // ACCESSORS
 

--- a/src/groups/bmq/bmqu/bmqu_blobiterator.h
+++ b/src/groups/bmq/bmqu/bmqu_blobiterator.h
@@ -135,11 +135,6 @@ class BlobIterator {
     /// referring to a valid value.
     const char& operator*() const;
 
-    /// Return a pointer to the byte being referred to by this
-    /// iterator.  The behavior is undefined if this iterator isn't
-    /// referring to a valid value.
-    const char* operator->() const;
-
     /// Return `true` if this `BlobIterator` has reached its end.
     bool atEnd() const;
 
@@ -282,11 +277,6 @@ inline bool BlobIterator::operator!=(const BlobIterator& rhs) const
 inline const char& BlobIterator::operator*() const
 {
     return d_blob_p->buffer(d_pos.buffer()).data()[d_pos.byte()];
-}
-
-inline const char* BlobIterator::operator->() const
-{
-    return &**this;
 }
 
 inline bool BlobIterator::atEnd() const

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -925,7 +925,7 @@ void Domain::removeDomainReset()
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
 
     d_state            = e_PREREMOVE;
-    d_teardownRemoveCb = nullptr;
+    d_teardownRemoveCb = bsl::nullptr_t();
 }
 
 void Domain::removeDomainComplete()

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -422,7 +422,7 @@ bool ClusterState::unassignQueue(const bmqt::Uri& uri)
 
     domIt->second->queuesInfo().erase(cit);
     if (domIt->second->queuesInfo().empty()) {
-        domIt->second->setDomain(nullptr);
+        domIt->second->setDomain(NULL);
     }
 
     // POSTCONDITIONS

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -67,14 +67,14 @@ Channel::Channel(bdlbb::BlobBufferFactory* blobBufferFactory,
                  bslma::Allocator*         allocator)
 : d_allocators(allocator)
 , d_allocator_p(d_allocators.get("Channel"))
-, d_blobSpPool(
+, d_blobSpPool_sp(
       bmqp::BlobPoolUtil::createBlobPool(blobBufferFactory,
                                          d_allocators.get("BlobSpPool")))
-, d_putBuilder(&d_blobSpPool, d_allocator_p)
-, d_pushBuilder(&d_blobSpPool, d_allocator_p)
-, d_ackBuilder(&d_blobSpPool, d_allocator_p)
-, d_confirmBuilder(&d_blobSpPool, d_allocator_p)
-, d_rejectBuilder(&d_blobSpPool, d_allocator_p)
+, d_putBuilder(d_blobSpPool_sp.get(), d_allocator_p)
+, d_pushBuilder(d_blobSpPool_sp.get(), d_allocator_p)
+, d_ackBuilder(d_blobSpPool_sp.get(), d_allocator_p)
+, d_confirmBuilder(d_blobSpPool_sp.get(), d_allocator_p)
+, d_rejectBuilder(d_blobSpPool_sp.get(), d_allocator_p)
 , d_itemPool(sizeof(Item),
              bsls::BlockGrowth::BSLS_CONSTANT,
              d_allocators.get("ItemPool"))

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -127,7 +127,7 @@ class Channel {
         bdlcc::SingleConsumerQueue<bslma::ManagedPtr<Item> > >
         ItemQueue;
 
-    typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+    typedef bmqp::BlobPoolUtil::BlobSpPoolSp BlobSpPoolSp;
 
     /// Const references to everything needed to writeBufferedItem PUT.
     /// This is template parameter to generalized writing code.
@@ -370,7 +370,7 @@ class Channel {
     /// Counting allocator
     bslma::Allocator* d_allocator_p;
 
-    BlobSpPool d_blobSpPool;
+    BlobSpPoolSp d_blobSpPool_sp;
 
     bmqp::PutEventBuilder d_putBuilder;
 

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -740,7 +740,7 @@ static void test1_write()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -752,31 +752,31 @@ static void test1_write()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
-                                 &blobSpPool,
+                                 blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
-                                        blobSpPool,
+                                        *blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannel>(testChannel));
@@ -830,7 +830,7 @@ static void test2_highWatermark()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -842,35 +842,35 @@ static void test2_highWatermark()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
-                                 &blobSpPool,
+                                 blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
-                                        blobSpPool,
+                                        *blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<PseudoBuilder>            control(channel,
                                   bufferFactory,
-                                  blobSpPool,
+                                  *blobSpPool,
                                   bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     bslmt::Barrier phase1(6 + 1);
@@ -947,7 +947,7 @@ static void test3_highWatermarkInWriteCb()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -959,31 +959,31 @@ static void test3_highWatermarkInWriteCb()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
-                                 &blobSpPool,
+                                 blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
-                                        blobSpPool,
+                                        *blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     bslmt::Barrier phase1(5 + 1);
@@ -1064,7 +1064,7 @@ static void test4_controlBlob()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1076,31 +1076,31 @@ static void test4_controlBlob()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
-                                 &blobSpPool,
+                                 blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     Tester<bmqp::PutEventBuilder>     put(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::PushEventBuilder>    push(channel,
                                         bufferFactory,
-                                        blobSpPool,
+                                        *blobSpPool,
                                         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::AckEventBuilder>     ack(channel,
                                       bufferFactory,
-                                      blobSpPool,
+                                      *blobSpPool,
                                       bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::ConfirmEventBuilder> confirm(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
     Tester<bmqp::RejectEventBuilder> reject(
         channel,
         bufferFactory,
-        blobSpPool,
+        *blobSpPool,
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
@@ -1113,7 +1113,7 @@ static void test4_controlBlob()
 
     // cannot assert 'writeCalls().size() == 0' because of auto-flushing
 
-    bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
+    bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool->getObject();
     bdlbb::BlobBuffer blobBuffer;
 
     bufferFactory.allocate(&blobBuffer);
@@ -1157,7 +1157,7 @@ static void test5_reconnect()
     bdlbb::PooledBlobBufferFactory bufferFactory(
         k_BUFFER_SIZE,
         bmqtst::TestHelperUtil::allocator());
-    bmqp::BlobPoolUtil::BlobSpPool blobSpPool(
+    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
         bmqp::BlobPoolUtil::createBlobPool(
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator()));
@@ -1169,14 +1169,14 @@ static void test5_reconnect()
         new (*bmqtst::TestHelperUtil::allocator())
             bmqio::TestChannelEx(channel,
                                  &bufferFactory,
-                                 &blobSpPool,
+                                 blobSpPool.get(),
                                  bmqtst::TestHelperUtil::allocator()),
         bmqtst::TestHelperUtil::allocator());
 
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
 
     {
-        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool->getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);
@@ -1198,7 +1198,7 @@ static void test5_reconnect()
     testChannel->setWriteStatus(bmqio::StatusCategory::e_CONNECTION);
 
     {
-        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool->getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);
@@ -1218,7 +1218,7 @@ static void test5_reconnect()
     testChannel->setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
 
     {
-        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool.getObject();
+        bsl::shared_ptr<bdlbb::Blob> payload_sp = blobSpPool->getObject();
         bdlbb::BlobBuffer blobBuffer;
 
         bufferFactory.allocate(&blobBuffer);

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -123,7 +123,7 @@ class TestContext {
     // Buffer factory provided to the various builders
 
     /// Blob shared pointer pool used in event builders.
-    bmqp::BlobPoolUtil::BlobSpPool d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPoolSp d_blobSpPool_sp;
 
     ReqManagerTypeSp d_requestManager;
     // RequestManager object under testing
@@ -236,7 +236,7 @@ class TestContext {
 
 TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
 : d_blobBufferFactory(1024, allocator)
-, d_blobSpPool(
+, d_blobSpPool_sp(
       bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
                                          bmqtst::TestHelperUtil::allocator()))
 , d_requestManager(0)
@@ -266,7 +266,7 @@ TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
 
     d_requestManager = bsl::make_shared<ReqManagerType>(
         bmqp::EventType::e_CONTROL,
-        &d_blobSpPool,
+        d_blobSpPool_sp.get(),
         &d_cluster_mp->_scheduler(),
         false,  // lateResponseMode
         d_allocator_p);

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -299,7 +299,7 @@ class MockDataStore : public mqbs::DataStore {
         *options = d_options.at(id);
     }
 
-    mqbi::Dispatcher* dispatcher() BSLS_KEYWORD_OVERRIDE { return nullptr; }
+    mqbi::Dispatcher* dispatcher() BSLS_KEYWORD_OVERRIDE { return NULL; }
 
     mqbi::DispatcherClientData& dispatcherClientData() BSLS_KEYWORD_OVERRIDE
     {
@@ -314,7 +314,7 @@ class MockDataStore : public mqbs::DataStore {
 
     const mqbi::Dispatcher* dispatcher() const BSLS_KEYWORD_OVERRIDE
     {
-        return nullptr;
+        return NULL;
     }
 
     const mqbi::DispatcherClientData&

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -142,7 +142,7 @@ struct Tester {
     bdlbb::PooledBlobBufferFactory         d_bufferFactory;
     bsl::string                            d_clusterLocation;
     bsl::string                            d_clusterArchiveLocation;
-    bmqp::BlobPoolUtil::BlobSpPool         d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPoolSp       d_blobSpPool_sp;
     mqbcfg::PartitionConfig                d_partitionCfg;
     mqbcfg::ClusterDefinition              d_clusterCfg;
     bsl::vector<mqbcfg::ClusterNode>       d_clusterNodesCfg;
@@ -167,7 +167,7 @@ struct Tester {
     , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_clusterLocation(location, bmqtst::TestHelperUtil::allocator())
     , d_clusterArchiveLocation(location, bmqtst::TestHelperUtil::allocator())
-    , d_blobSpPool(bmqp::BlobPoolUtil::createBlobPool(
+    , d_blobSpPool_sp(bmqp::BlobPoolUtil::createBlobPool(
           &d_bufferFactory,
           bmqtst::TestHelperUtil::allocator()))
     , d_partitionCfg(bmqtst::TestHelperUtil::allocator())
@@ -264,7 +264,7 @@ struct Tester {
                                          &d_dispatcher,
                                          d_cluster_mp.get(),
                                          &d_clusterStats,
-                                         &d_blobSpPool,
+                                         d_blobSpPool_sp.get(),
                                          &d_statePool,
                                          &d_miscWorkThreadPool,
                                          false,  // isCSLModeEnabled

--- a/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
@@ -165,8 +165,7 @@ inline bmqst::StatContext* BrokerStats::statContext()
 }
 
 template <>
-inline void
-BrokerStats::onEvent<BrokerStats::EventType::Enum::e_CLIENT_CREATED>()
+inline void BrokerStats::onEvent<BrokerStats::EventType::e_CLIENT_CREATED>()
 {
     BSLS_ASSERT_SAFE(d_statContext_p && "initialize was not called");
 
@@ -174,8 +173,7 @@ BrokerStats::onEvent<BrokerStats::EventType::Enum::e_CLIENT_CREATED>()
 }
 
 template <>
-inline void
-BrokerStats::onEvent<BrokerStats::EventType::Enum::e_CLIENT_DESTROYED>()
+inline void BrokerStats::onEvent<BrokerStats::EventType::e_CLIENT_DESTROYED>()
 {
     BSLS_ASSERT_SAFE(d_statContext_p && "initialize was not called");
 
@@ -183,8 +181,7 @@ BrokerStats::onEvent<BrokerStats::EventType::Enum::e_CLIENT_DESTROYED>()
 }
 
 template <>
-inline void
-BrokerStats::onEvent<BrokerStats::EventType::Enum::e_QUEUE_CREATED>()
+inline void BrokerStats::onEvent<BrokerStats::EventType::e_QUEUE_CREATED>()
 {
     BSLS_ASSERT_SAFE(d_statContext_p && "initialize was not called");
 
@@ -192,8 +189,7 @@ BrokerStats::onEvent<BrokerStats::EventType::Enum::e_QUEUE_CREATED>()
 }
 
 template <>
-inline void
-BrokerStats::onEvent<BrokerStats::EventType::Enum::e_QUEUE_DESTROYED>()
+inline void BrokerStats::onEvent<BrokerStats::EventType::e_QUEUE_DESTROYED>()
 {
     BSLS_ASSERT_SAFE(d_statContext_p && "initialize was not called");
 

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -418,32 +418,28 @@ inline bmqst::StatContext* ClusterNodeStats::statContext()
 }
 
 template <>
-inline void
-ClusterNodeStats::onEvent<ClusterNodeStats::EventType::Enum::e_ACK>(
+inline void ClusterNodeStats::onEvent<ClusterNodeStats::EventType::e_ACK>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     d_statContext_mp->adjustValue(ClusterNodeStatsIndex::e_STAT_ACK, 1);
 }
 
 template <>
-inline void
-ClusterNodeStats::onEvent<ClusterNodeStats::EventType::Enum::e_CONFIRM>(
+inline void ClusterNodeStats::onEvent<ClusterNodeStats::EventType::e_CONFIRM>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     d_statContext_mp->adjustValue(ClusterNodeStatsIndex::e_STAT_CONFIRM, 1);
 }
 
 template <>
-inline void
-ClusterNodeStats::onEvent<ClusterNodeStats::EventType::Enum::e_PUSH>(
+inline void ClusterNodeStats::onEvent<ClusterNodeStats::EventType::e_PUSH>(
     bsls::Types::Int64 value)
 {
     d_statContext_mp->adjustValue(ClusterNodeStatsIndex::e_STAT_PUSH, value);
 }
 
 template <>
-inline void
-ClusterNodeStats::onEvent<ClusterNodeStats::EventType::Enum::e_PUT>(
+inline void ClusterNodeStats::onEvent<ClusterNodeStats::EventType::e_PUT>(
     bsls::Types::Int64 value)
 {
     d_statContext_mp->adjustValue(ClusterNodeStatsIndex::e_STAT_PUT, value);

--- a/src/groups/mqb/mqbstat/mqbstat_domainstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_domainstats.h
@@ -157,7 +157,7 @@ inline bmqst::StatContext* DomainStats::statContext()
 }
 
 template <>
-inline void DomainStats::onEvent<DomainStats::EventType::Enum::e_CFG_MSGS>(
+inline void DomainStats::onEvent<DomainStats::EventType::e_CFG_MSGS>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -165,7 +165,7 @@ inline void DomainStats::onEvent<DomainStats::EventType::Enum::e_CFG_MSGS>(
 }
 
 template <>
-inline void DomainStats::onEvent<DomainStats::EventType::Enum::e_CFG_BYTES>(
+inline void DomainStats::onEvent<DomainStats::EventType::e_CFG_BYTES>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -173,7 +173,7 @@ inline void DomainStats::onEvent<DomainStats::EventType::Enum::e_CFG_BYTES>(
 }
 
 template <>
-inline void DomainStats::onEvent<DomainStats::EventType::Enum::e_QUEUE_COUNT>(
+inline void DomainStats::onEvent<DomainStats::EventType::e_QUEUE_COUNT>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -527,8 +527,7 @@ inline bmqst::StatContext* QueueStatsDomain::statContext()
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ACK>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_ACK>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -536,8 +535,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ACK>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ACK_TIME>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_ACK_TIME>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -545,8 +543,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ACK_TIME>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_NACK>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_NACK>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -555,8 +552,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_NACK>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CONFIRM>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_CONFIRM>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -566,7 +562,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CONFIRM>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CONFIRM_TIME>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_CONFIRM_TIME>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -575,8 +571,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CONFIRM_TIME>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_REJECT>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_REJECT>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -586,7 +581,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_REJECT>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_QUEUE_TIME>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_QUEUE_TIME>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -594,8 +589,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_QUEUE_TIME>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PUSH>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_PUSH>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -603,8 +597,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PUSH>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PUT>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_PUT>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -613,7 +606,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PUT>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ADD_MESSAGE>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_ADD_MESSAGE>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -631,7 +624,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_ADD_MESSAGE>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_DEL_MESSAGE>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_DEL_MESSAGE>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -641,7 +634,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_DEL_MESSAGE>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_GC_MESSAGE>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_GC_MESSAGE>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -649,8 +642,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_GC_MESSAGE>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PURGE>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_PURGE>(
     BSLS_ANNOTATION_UNUSED bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -670,7 +662,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_PURGE>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CHANGE_ROLE>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_CHANGE_ROLE>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -678,8 +670,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CHANGE_ROLE>(
 }
 
 template <>
-inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CFG_MSGS>(
+inline void QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_CFG_MSGS>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -688,7 +679,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CFG_MSGS>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CFG_BYTES>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_CFG_BYTES>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -697,7 +688,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_CFG_BYTES>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_NO_SC_MESSAGE>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_NO_SC_MESSAGE>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");
@@ -706,7 +697,7 @@ QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_NO_SC_MESSAGE>(
 
 template <>
 inline void
-QueueStatsDomain::onEvent<QueueStatsDomain::EventType::Enum::e_UPDATE_HISTORY>(
+QueueStatsDomain::onEvent<QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
     bsls::Types::Int64 value)
 {
     BSLS_ASSERT_SAFE(d_statContext_mp && "initialize was not called");


### PR DESCRIPTION
1. Fix return value optimization problem with Solaris in `bmqp::BlobPoolUtil::createBlobPool`, by returning a shared pointer to the blob pool. The choice of shared pointer type is made to do it compatible with resource manager PR: https://github.com/bloomberg/blazingmq/pull/499
2. Update all places where blob shared pointer pool is used.
3. `bmqstoragetool`: remove incompatible initializer list usage.
4. `bmqio_ntcchannel.t`: disambiguate argument for `ntcf::System::createInterface` call.
5. Logger classes: explicitly implement `publish` override to get rid of a warning.
6. `bmqu::BlobIterator` remove unused `const char* operator->() const;` that produces a compilation warning `Warning: Questionable (non-class) return type for BloombergLP::bmqu::BlobIterator::operator->() const.`
7. Replace unrecognized `nullptr` usage by `NULL` or `bsl::nullptr_t()` where applicable.
8. `mqbstat`: pass enum template arguments in a way acceptable by Solaris compiler (`BrokerStats::EventType::Enum::e_CLIENT_DESTROYED` -> `BrokerStats::EventType::e_CLIENT_DESTROYED`).
9. storage tool: set allocator flag via `bmqtst::TestHelperUtil::ignoreCheckDefAlloc()`