### PR TITLE
Feat: CQH calls Queue::getHandle

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -177,7 +177,6 @@ ClusterQueueHelper::OpenQueueContext::OpenQueueContext(
 , d_callback(callback)
 {
     BSLS_ASSERT_SAFE(domain);
-    // NOTHING
 }
 
 ClusterQueueHelper::OpenQueueContext::~OpenQueueContext()
@@ -811,6 +810,8 @@ void ClusterQueueHelper::processPendingContexts(
 void ClusterQueueHelper::assignUpstreamSubqueueId(
     const OpenQueueContextSp& context)
 {
+    BSLS_ASSERT_SAFE(context);
+
     QueueLiveState&   info  = context->queueContext()->d_liveQInfo;
     const bsl::string appId = bmqp::QueueUtil::extractAppId(
         context->d_handleParameters);
@@ -863,7 +864,9 @@ void ClusterQueueHelper::processOpenQueueRequest(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(context);
     BSLS_ASSERT_SAFE(isQueueAssigned(*(context->queueContext())));
+
     // At this time, the Queue must have been assigned an id/partition.
 
     if (d_cluster_p->isRemote()) {
@@ -927,6 +930,7 @@ void ClusterQueueHelper::sendOpenQueueRequest(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(context);
 
     QueueLiveState& qinfo = context->queueContext()->d_liveQInfo;
     const int       pid   = context->queueContext()->partitionId();
@@ -1101,6 +1105,7 @@ void ClusterQueueHelper::onOpenQueueResponse(
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT_SAFE(requestContext->request().choice().isOpenQueueValue());
+    BSLS_ASSERT_SAFE(context);
 
     BALL_LOG_INFO << d_cluster_p->description() << ": on OpenQueueResponse "
                   << "from " << responder->nodeDescription() << ": "
@@ -1855,6 +1860,7 @@ bool ClusterQueueHelper::createQueue(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(context);
 
     const bmqp_ctrlmsg::QueueHandleParameters& parameters =
         openQueueResponse.originalRequest().handleParameters();

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -222,9 +222,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         // messages or handles or both).
         bsls::Types::Int64 d_queueExpirationTimestampMs;
 
+        bsl::vector<bsl::shared_ptr<OpenQueueContext> > d_pending;
         // List of all open queue pending contexts which are awaiting for a
         // next step on the queue (assignment, ...).
-        bsl::vector<OpenQueueContext> d_pending;
 
         // Number of in flight contexts, that is the number of contexts for
         // which `d_callback` has not yet been called. Note that this may be
@@ -326,10 +326,25 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         /// (@bbref{bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID} if unassigned)
         unsigned int d_upstreamSubQueueId;
 
-        /// Callback to invoke when the queue is opened (whether success or
-        /// failure).
+        bsl::shared_ptr<mqbi::QueueHandleRequesterContext> d_clientContext;
+
         mqbi::Cluster::OpenQueueCallback d_callback;
+        // Callback to invoke when the queue is
+        // opened (whether success or failure).
+
+        OpenQueueContext(
+            mqbi::Domain*                              domain,
+            const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
+            const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>&
+                                                    clientContext,
+            const mqbi::Cluster::OpenQueueCallback& callback);
+
+        ~OpenQueueContext();
+
+        void setQueueContext(QueueContext* queueContext);
     };
+
+    typedef bsl::shared_ptr<OpenQueueContext> OpenQueueContextSp;
 
     /// Structure representing all information and context associated to a
     /// queue, whether the queue is opened, being opened, or just aware due
@@ -451,7 +466,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
 
     /// Get the next subQueueId for a subStream of the queue corresponding
     /// to the specified `context`.
-    unsigned int getNextSubQueueId(OpenQueueContext* context);
+    unsigned int getNextSubQueueId(const OpenQueueContextSp& context);
 
     /// Invoked after the specified `partitionId` gets assigned to the
     /// specified `primary` with the specified `status`.  Note that null is
@@ -511,14 +526,14 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// `context`: that is, depending on the cluster mode and queue
     /// assignment, either send an open queue request or create the queue.
     /// The queue must have been assigned at this point.
-    void processOpenQueueRequest(const OpenQueueContext& context);
+    void processOpenQueueRequest(const OpenQueueContextSp& context);
 
     /// Send an open queue request for the queue and its associated
     /// parameter as contained in the specified `context` to the primary
     /// node in charge of the queue.  The queue must have been assigned at
     /// this point, and the current machine must either be a proxy, or not
     /// the primary of the queue.
-    void sendOpenQueueRequest(const OpenQueueContext& context);
+    void sendOpenQueueRequest(const OpenQueueContextSp& context);
 
     /// Send an open queue request for the queue and its associated
     /// parameters as contained in the specified `requestContext` to the
@@ -538,14 +553,14 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// queue has already been opened with the appId in the `context`,
     /// assign the upstream subQueueId which was previously generated for
     /// that appId.  Otherwise, generate and assign new unique id.
-    void assignUpstreamSubqueueId(OpenQueueContext* context);
+    void assignUpstreamSubqueueId(const OpenQueueContextSp& context);
 
     /// Response callback of an open queue request, in the specified
     /// `context` and with the request and its associated response in the
     /// specified `requestContext`.
     void
     onOpenQueueResponse(const RequestManagerType::RequestSp& requestContext,
-                        const OpenQueueContext&              context,
+                        const OpenQueueContextSp&            context,
                         mqbnet::ClusterNode*                 responder);
 
     /// Response callback of an open queue request, that was sent due to the
@@ -592,7 +607,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// this method is invoked at the primary node; for every other node,
     /// `upstreamNode` will represent the node to which open-queue request
     /// was sent.
-    bool createQueue(const OpenQueueContext&                context,
+    bool createQueue(const OpenQueueContextSp&              context,
                      const bmqp_ctrlmsg::OpenQueueResponse& openQueueResponse,
                      mqbnet::ClusterNode*                   upstreamNode);
 
@@ -652,11 +667,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     void onGetQueueHandle(
         const bmqp_ctrlmsg::Status&                      status,
         mqbi::QueueHandle*                               queueHandle,
+        const OpenQueueContextSp&                        context,
         const bmqp_ctrlmsg::OpenQueueResponse&           openQueueResponse,
-        const mqbi::Domain::OpenQueueConfirmationCookie& confirmationCookie,
-        const bmqp_ctrlmsg::ControlMessage&              request,
-        mqbc::ClusterNodeSession*                        requester,
-        const int                                        peerInstanceId);
+        const mqbi::Domain::OpenQueueConfirmationCookie& confirmationCookie);
 
     /// Callback invoked in response to an open queue request to the domain
     /// (in the specified `request`).  If the specified `status` is SUCCESS,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -328,9 +328,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
 
         bsl::shared_ptr<mqbi::QueueHandleRequesterContext> d_clientContext;
 
+        /// Callback to invoke when the queue is
+        /// opened (whether success or failure).
         mqbi::Cluster::OpenQueueCallback d_callback;
-        // Callback to invoke when the queue is
-        // opened (whether success or failure).
 
         // NOT IMPLEMENTED
         OpenQueueContext(const OpenQueueContext&) BSLS_CPP11_DELETED;

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -332,6 +332,13 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         // Callback to invoke when the queue is
         // opened (whether success or failure).
 
+        // NOT IMPLEMENTED
+        OpenQueueContext(const OpenQueueContext&) BSLS_CPP11_DELETED;
+
+        /// Copy constructor and assignment operator are not implemented.
+        OpenQueueContext&
+        operator=(const OpenQueueContext&) BSLS_CPP11_DELETED;
+
         OpenQueueContext(
             mqbi::Domain*                              domain,
             const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
@@ -342,6 +349,8 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         ~OpenQueueContext();
 
         void setQueueContext(QueueContext* queueContext);
+
+        QueueContext* queueContext() const;
     };
 
     typedef bsl::shared_ptr<OpenQueueContext> OpenQueueContextSp;

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -204,7 +204,7 @@ void Domain::onOpenQueueResponse(
     --d_pendingRequests;
     if (status.category() == bmqp_ctrlmsg::StatusCategory::E_SUCCESS) {
         // VALIDATION: The queue must exist at this point, i.e., have been
-        //             registered.FE(
+        //             registered.
         BSLS_ASSERT_SAFE(queuehandle);
         BSLS_ASSERT_SAFE(queuehandle->queue());
         BSLS_ASSERT_SAFE(lookupQueue(0, queuehandle->queue()->uri()) == 0);

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -88,7 +88,7 @@ namespace mqbblp {
 // ============
 
 /// Domain implementation
-class Domain : public mqbi::Domain {
+class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBBLP.DOMAIN");

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -88,8 +88,7 @@ namespace mqbblp {
 // ============
 
 /// Domain implementation
-class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain,
-                                  public mqbc::ClusterStateObserver {
+class Domain : public mqbi::Domain {
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBBLP.DOMAIN");
@@ -188,43 +187,13 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain,
     /// `confirmationCookie` to propagate the result to the requester.
     void onOpenQueueResponse(
         const bmqp_ctrlmsg::Status&                       status,
-        mqbi::Queue*                                      queue,
+        mqbi::QueueHandle*                                queuehandle,
         const bmqp_ctrlmsg::OpenQueueResponse&            openQueueResponse,
         const mqbi::Cluster::OpenQueueConfirmationCookie& confirmationCookie,
-        const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>&
-                                                   clientContext,
-        const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-        const mqbi::Domain::OpenQueueCallback&     callback);
-
-    /// Update the list of authorized appIds by adding the specified
-    /// `addedAppIds` and removing the specified `removedAppIds`.
-    void updateAuthorizedAppIds(const AppInfos& addedAppIds,
-                                const AppInfos& removedAppIds = AppInfos());
+        const mqbi::Domain::OpenQueueCallback&            callback);
 
     // PRIVATE MANIPULATORS
     //   (virtual: mqbc::ClusterStateObserver)
-
-    /// Callback invoked when a queue with the specified `info` gets
-    /// assigned to the cluster.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    void
-    onQueueAssigned(const bsl::shared_ptr<mqbc::ClusterStateQueueInfo>& info)
-        BSLS_KEYWORD_OVERRIDE;
-
-    /// Callback invoked when a queue with the specified `uri` belonging to
-    /// the specified `domain` is updated with the optionally specified
-    /// `addedAppIds` and `removedAppIds`.  If the specified `uri` is empty,
-    /// the appId updates are applied to the entire `domain` instead.
-    ///
-    /// Note: The `uri` could belong to a different domain than this one, in
-    ///       which case this queue update is ignored.
-    void onQueueUpdated(const bmqt::Uri&   uri,
-                        const bsl::string& domain,
-                        const AppInfos&    addedAppIds,
-                        const AppInfos&    removedAppIds = AppInfos())
-        BSLS_KEYWORD_OVERRIDE;
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -224,7 +224,7 @@ class Cluster : public DispatcherClient {
     /// above).
     typedef bsl::function<void(
         const bmqp_ctrlmsg::Status&            status,
-        Queue*                                 queue,
+        QueueHandle*                           queueHandle,
         const bmqp_ctrlmsg::OpenQueueResponse& openQueueResponse,
         const OpenQueueConfirmationCookie&     confirmationCookie)>
         OpenQueueCallback;

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -214,7 +214,7 @@ class Cluster : public DispatcherClient {
 
     /// Signature of the callback passed to the `openQueue()` method: if the
     /// specified `status` is SUCCESS, the operation was a success and the
-    /// specified `queue` contains the resulting queue, and the specified
+    /// specified `queueHandle` contains the queue handle, and the specified
     /// `openQueueResponse` contains the upstream response (if applicable,
     /// otherwise an injected response having valid routing configuration);
     /// otherwise `status` contains the category, error code and description

--- a/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py
+++ b/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py
@@ -40,7 +40,8 @@ options:
   -m {all,pull,push}, --mode {all,pull,push}
                         prometheus mode
   --no-docker           don't run Prometheus in docker, assume it is running on localhost
- """
+
+"""
 __test__ = False  # This is not for pytest.
 
 import argparse

--- a/src/python/blazingmq/dev/fuzztest/__init__.py
+++ b/src/python/blazingmq/dev/fuzztest/__init__.py
@@ -253,7 +253,7 @@ def make_put_message() -> BoofuzzSequence:
         math=lambda x: x // NumBytes.WORD,
     )
 
-    guid = b"\x00\x00\x00\x00\x05\x78\x8D\xAE\xD4\xB8\xCA\x12\xAE\xF3\x2D\xCE"
+    guid = b"\x00\x00\x00\x00\x05\x78\x8d\xae\xd4\xb8\xca\x12\xae\xf3\x2d\xce"
 
     message_components = [
         boofuzz.BitField(name="options_size", width=3 * NumBits.BYTE),
@@ -302,7 +302,7 @@ def make_confirm_message() -> BoofuzzSequence:
     Constructs boofuzz structures representing ConfirmMessage.
     """
 
-    guid = b"\x00\x00\x00\x00\x05\x78\x8D\xAE\xD4\xB8\xCA\x12\xAE\xF3\x2D\xCE"
+    guid = b"\x00\x00\x00\x00\x05\x78\x8d\xae\xd4\xb8\xca\x12\xae\xf3\x2d\xce"
 
     message_components = [
         boofuzz.BitField(

--- a/src/python/blazingmq/util/test/logging_test.py
+++ b/src/python/blazingmq/util/test/logging_test.py
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test suite for blazingmq.util.logging.
-"""
+"""Test suite for blazingmq.util.logging."""
 
 from logging import DEBUG, INFO, getLogger
 from unittest.mock import patch


### PR DESCRIPTION
For the upcoming Dynamic Apps feature, we need `ClusterQueueHelper` to be the caller of `Queue::getHandle` (and inspect the status to make Dynamic Apps updates if necessary).
So, instead of `Domain` calling `Queue::getHandle` after `Cluster::openQueue`, it is the `Cluster` (`ClusterQueueHelper`) calling `Queue::getHandle` as part of `Cluster::openQueue`.

Roughly, the sequence looks like this:
```
    //  CQH::processPeerOpenQueueRequest  QueueSessionManager::processOpenQueue
    //              \                       /
    //               V                     V
    //              DomainFactory::createDomain
    //              /                      \
    //             V                        V
    //  CQH::onGetDomain                  QueueSessionManager::onDomainOpenCb
    //          |                           /
    //          V                          /
    //      CQH::onGetDomainDispatched    /
    //                      \            /
    //                       V          V
    //                      Domain::openQueue
    //                              |
    //                              V
    //                          Cluster::openQueue
    //                              |
    //                              V
    //                              CQH::openQueue
    //                                      \
    //                                       V
    //                                  Queue::getHandle
    //                                      /
    //                                     V
    //                              CQH::onGetQueueHandle. (future Dynamic Apps work)
    //                                    /
    //                                   V
    //                      Domain::onOpenQueueResponse
    //                        /                 \
    //                       V                   V
    //  CQH::onGetQueueHandleDispatched     QueueSessionManager::onQueueOpenCb
    //
    ```