### PR TITLE
Fix[python]: default set together CSL and FSM flags

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -152,11 +152,15 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
         // 1. Fetch the cluster definition
         const mqbcfg::ClusterDefinition& clusterDefinition =
             *clusterDefinitionIter;
-        if (clusterDefinition.clusterAttributes().isFSMWorkflow() &&
-            !clusterDefinition.clusterAttributes().isCSLModeEnabled()) {
-            errorDescription << "Cluster ('" << name
-                             << "') has incompatible CSL and FSM modes, not "
-                                "creating cluster.";
+        if (clusterDefinition.clusterAttributes().isFSMWorkflow() !=
+            clusterDefinition.clusterAttributes().isCSLModeEnabled()) {
+            // CSL and FSM must be both true or both false, other combinations
+            // are not supported
+            errorDescription << "Cluster ('" << name << "') has incompatible CSL ("
+                             << clusterDefinition.clusterAttributes().isCSLModeEnabled()
+                             << ") and FSM ("
+                             << clusterDefinition.clusterAttributes().isFSMWorkflow()
+                             << ") modes, not creating cluster.";
             return (rc * 10) + rc_FETCH_DEFINITION_FAILED;  // RETURN
         }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -156,11 +156,12 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
             clusterDefinition.clusterAttributes().isCSLModeEnabled()) {
             // CSL and FSM must be both true or both false, other combinations
             // are not supported
-            errorDescription << "Cluster ('" << name << "') has incompatible CSL ("
-                             << clusterDefinition.clusterAttributes().isCSLModeEnabled()
-                             << ") and FSM ("
-                             << clusterDefinition.clusterAttributes().isFSMWorkflow()
-                             << ") modes, not creating cluster.";
+            errorDescription
+                << "Cluster ('" << name << "') has incompatible CSL ("
+                << clusterDefinition.clusterAttributes().isCSLModeEnabled()
+                << ") and FSM ("
+                << clusterDefinition.clusterAttributes().isFSMWorkflow()
+                << ") modes, not creating cluster.";
             return (rc * 10) + rc_FETCH_DEFINITION_FAILED;  // RETURN
         }
 

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -305,7 +305,7 @@ def _cluster_definition_partial_prototype(partition_config: mqbcfg.PartitionConf
             ack_window_size=500,
         ),
         cluster_attributes=mqbcfg.ClusterAttributes(
-            is_cslmode_enabled=True, is_fsmworkflow=False
+            is_cslmode_enabled=True, is_fsmworkflow=True
         ),
         cluster_monitor_config=mqbcfg.ClusterMonitorConfig(
             max_time_leader=15,


### PR DESCRIPTION
Default flags combination `CSL = True, FSM = False` is not supported
