### PR TITLE
FIX[MQB]: race in admin domain remove

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -673,18 +673,14 @@ class Cluster : public mqbi::Cluster,
     /// Load the cluster state to the specified `out` object.
     void loadClusterStatus(mqbcmd::ClusterResult* out) BSLS_KEYWORD_OVERRIDE;
 
-    /// Purge queues in this cluster on a given domain.
-    void
-    purgeQueueOnDomain(mqbcmd::ClusterResult* result,
-                       const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
-
-    /// Force GC queues in this cluster on a given domain.
-    int gcQueueOnDomain(mqbcmd::ClusterResult* result,
-                        const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
+    /// Purge and force GC queues in this cluster on a given domain.
+    void purgeAndGCQueueOnDomain(mqbcmd::ClusterResult* result,
+                                 const bsl::string&     domainName)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Executed by dispatcher thread.
-    void gcQueueOnDomainDispatched(mqbcmd::ClusterResult* result,
-                                   const bsl::string&     domainName);
+    void purgeAndGCQueueOnDomainDispatched(mqbcmd::ClusterResult* result,
+                                           const bsl::string&     domainName);
 
     // MANIPULATORS
     //   (virtual: mqbnet::SessionEventProcessor)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -1342,27 +1342,14 @@ void ClusterProxy::loadClusterStatus(mqbcmd::ClusterResult* out)
     loadQueuesInfo(&clusterProxyStatus.queuesInfo());
 }
 
-void ClusterProxy::purgeQueueOnDomain(
+void ClusterProxy::purgeAndGCQueueOnDomain(
     mqbcmd::ClusterResult*       result,
     BSLS_ANNOTATION_UNUSED const bsl::string& domainName)
 {
-    bmqu::MemOutStream os;
-    os << "MockCluster::gcQueueOnDomain not implemented!";
-    result->makeError().message() = os.str();
-}
-
-int ClusterProxy::gcQueueOnDomain(
-    mqbcmd::ClusterResult*       result,
-    BSLS_ANNOTATION_UNUSED const bsl::string& domainName)
-{
-    // exected by *ANY* thread
-
     bdlma::LocalSequentialAllocator<256> localAllocator(d_allocator_p);
     bmqu::MemOutStream                   os(&localAllocator);
-    os << "GC Queue not supported on a Proxy.";
+    os << "Purge and GC queue not supported on a Proxy.";
     result->makeError().message() = os.str();
-
-    return 0;
 }
 
 // MANIPULATORS

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -539,14 +539,10 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
     /// Load the cluster state in the specified `out` object.
     void loadClusterStatus(mqbcmd::ClusterResult* out) BSLS_KEYWORD_OVERRIDE;
 
-    /// Purge queues in this cluster on a given domain.
-    void
-    purgeQueueOnDomain(mqbcmd::ClusterResult* result,
-                       const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
-
-    /// Force GC queues in this cluster on a given domain.
-    int gcQueueOnDomain(mqbcmd::ClusterResult* result,
-                        const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
+    /// Purge and force GC queues in this cluster on a given domain.
+    void purgeAndGCQueueOnDomain(mqbcmd::ClusterResult* result,
+                                 const bsl::string&     domainName)
+        BSLS_KEYWORD_OVERRIDE;
 
     void getPrimaryNodes(int*                               rc,
                          bsl::ostream&                      errorDescription,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -1089,6 +1089,8 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     int gcExpiredQueues(bool               immediate  = false,
                         const bsl::string& domainName = "");
 
+    bool hasActiveQueue(const bsl::string& domainName);
+
     /// Start executing multi-step processing of StopRequest or CLOSING node
     /// advisory received from the specified `clusterNode`.   In the case of
     /// StopRequest the specified `request` references the request; in the

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -112,14 +112,9 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain,
         e_STARTED  = 0,
         e_STOPPING = 1,
         e_STOPPED  = 2,
-        // Used for teardownRemove function
-        e_REMOVING = 3,
-        e_REMOVED  = 4,
-        // Used as flags to indicate
-        // the start and finish of
-        // the first round for DOMAINS REMOVE
-        e_PREREMOVE  = 5,
-        e_POSTREMOVE = 6,
+        // indicate the start of the
+        // first round of DOMAINS REMOVE
+        e_REMOVING = 3
     };
 
   private:
@@ -337,13 +332,6 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain,
     processCommand(mqbcmd::DomainResult*        result,
                    const mqbcmd::DomainCommand& command) BSLS_KEYWORD_OVERRIDE;
 
-    /// Mark the state of domain to be PREREMOVE
-    void removeDomainReset() BSLS_KEYWORD_OVERRIDE;
-
-    /// Mark the state of domain to be POSTREMOVE,
-    /// indicating the first round of DOMAINS REMOVE is completed
-    void removeDomainComplete() BSLS_KEYWORD_OVERRIDE;
-
     // ACCESSORS
 
     /// Load into the specified `out` the queue corresponding to the
@@ -381,8 +369,8 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain,
         const BSLS_KEYWORD_OVERRIDE;
 
     /// Check the state of the queues in this domain, return false if there's
-    /// queues opened or opening.
-    bool tryRemove() const BSLS_KEYWORD_OVERRIDE;
+    /// queues opened or opening, or if the domain is closed or closing.
+    bool tryRemove() BSLS_KEYWORD_OVERRIDE;
 
     /// Check the state of the domain, return true if the first round
     /// of DOMAINS REMOVE is completed

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -448,9 +448,6 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
 
     /// Return the Schema Leaner associated with this queue.
     bmqp::SchemaLearner& schemaLearner() const BSLS_KEYWORD_OVERRIDE;
-
-    /// Return true if there's queue handle and they're actively used.
-    bool hasActiveHandle() const BSLS_KEYWORD_OVERRIDE;
 };
 
 // ============================================================================
@@ -600,11 +597,6 @@ inline const mqbi::Dispatcher* Queue::dispatcher() const
 inline bmqp::SchemaLearner& Queue::schemaLearner() const
 {
     return d_schemaLearner;
-}
-
-inline bool Queue::hasActiveHandle() const
-{
-    return d_state.handleCatalog().handlesCount() != 0;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -421,8 +421,9 @@ bool ClusterState::unassignQueue(const bmqt::Uri& uri)
     }
 
     domIt->second->queuesInfo().erase(cit);
+
     if (domIt->second->queuesInfo().empty()) {
-        domIt->second->setDomain(NULL);
+        d_domainStates.erase(domIt);
     }
 
     // POSTCONDITIONS

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -371,13 +371,9 @@ class Cluster : public DispatcherClient {
     /// Load the cluster state to the specified `out` object.
     virtual void loadClusterStatus(mqbcmd::ClusterResult* out) = 0;
 
-    /// Purge queues in this cluster on a given domain.
-    virtual void purgeQueueOnDomain(mqbcmd::ClusterResult* result,
-                                    const bsl::string&     domainName) = 0;
-
-    /// Force GC queues in this cluster on a given domain.
-    virtual int gcQueueOnDomain(mqbcmd::ClusterResult* result,
-                                const bsl::string&     domainName) = 0;
+    /// Purge and force GC queues in this cluster on a given domain.
+    virtual void purgeAndGCQueueOnDomain(mqbcmd::ClusterResult* result,
+                                         const bsl::string& domainName) = 0;
 
     // ACCESSORS
 

--- a/src/groups/mqb/mqbi/mqbi_domain.h
+++ b/src/groups/mqb/mqbi/mqbi_domain.h
@@ -185,13 +185,6 @@ class Domain {
     virtual int processCommand(mqbcmd::DomainResult*        result,
                                const mqbcmd::DomainCommand& command) = 0;
 
-    /// Mark the state of domain to be PREREMOVE
-    virtual void removeDomainReset() = 0;
-
-    /// Mark the state of domain to be POSTREMOVE,
-    /// indicating the first round of DOMAINS REMOVE is completed
-    virtual void removeDomainComplete() = 0;
-
     // ACCESSORS
 
     /// Load into the specified `out` the queue corresponding to the
@@ -229,8 +222,8 @@ class Domain {
         bmqp_ctrlmsg::RoutingConfiguration* config) const = 0;
 
     /// Check the state of the queues in this domain, return false if there's
-    /// queues opened or opening.
-    virtual bool tryRemove() const = 0;
+    /// queues opened or opening, or if the domain is closed or closing.
+    virtual bool tryRemove() = 0;
 
     /// Check the state of the domain, return true if the first round
     /// of DOMAINS REMOVE is completed

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -956,9 +956,6 @@ class Queue : public DispatcherClient {
 
     /// Return the Schema Leaner associated with this queue.
     virtual bmqp::SchemaLearner& schemaLearner() const = 0;
-
-    /// Return true if there's queue handle and they're actively used.
-    virtual bool hasActiveHandle() const = 0;
 };
 
 // ========================

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -489,23 +489,13 @@ void Cluster::loadClusterStatus(mqbcmd::ClusterResult* out)
     out->makeClusterStatus();
 }
 
-void Cluster::purgeQueueOnDomain(
+void Cluster::purgeAndGCQueueOnDomain(
     mqbcmd::ClusterResult*       result,
     BSLS_ANNOTATION_UNUSED const bsl::string& domainName)
 {
     bmqu::MemOutStream os;
-    os << "MockCluster::gcQueueOnDomain not implemented!";
+    os << "MockCluster::purgeAndGCQueueOnDomain not implemented!";
     result->makeError().message() = os.str();
-}
-
-int Cluster::gcQueueOnDomain(
-    mqbcmd::ClusterResult*       result,
-    BSLS_ANNOTATION_UNUSED const bsl::string& domainName)
-{
-    bmqu::MemOutStream os;
-    os << "MockCluster::gcQueueOnDomain not implemented!";
-    result->makeError().message() = os.str();
-    return -1;
 }
 
 // MANIPULATORS

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -402,14 +402,10 @@ class Cluster : public mqbi::Cluster {
     /// Load the cluster state to the specified `out` object.
     void loadClusterStatus(mqbcmd::ClusterResult* out) BSLS_KEYWORD_OVERRIDE;
 
-    /// Purge queues in this cluster on a given domain.
-    void
-    purgeQueueOnDomain(mqbcmd::ClusterResult* result,
-                       const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
-
-    /// Force GC queues in this cluster on a given domain.
-    int gcQueueOnDomain(mqbcmd::ClusterResult* result,
-                        const bsl::string& domainName) BSLS_KEYWORD_OVERRIDE;
+    /// Purge and force GC queues in this cluster on a given domain.
+    void purgeAndGCQueueOnDomain(mqbcmd::ClusterResult* result,
+                                 const bsl::string&     domainName)
+        BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
     //   (specific to mqbmock::Cluster)

--- a/src/groups/mqb/mqbmock/mqbmock_domain.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_domain.cpp
@@ -155,16 +155,6 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
     return -1;
 }
 
-void Domain::removeDomainReset()
-{
-    BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
-}
-
-void Domain::removeDomainComplete()
-{
-    BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
-}
-
 int Domain::lookupQueue(bsl::shared_ptr<mqbi::Queue>* out,
                         const bmqt::Uri&              uri) const
 {
@@ -236,7 +226,7 @@ void Domain::loadRoutingConfiguration(
     // NOTHING
 }
 
-bool Domain::tryRemove() const
+bool Domain::tryRemove()
 {
     BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
     return true;

--- a/src/groups/mqb/mqbmock/mqbmock_domain.h
+++ b/src/groups/mqb/mqbmock/mqbmock_domain.h
@@ -211,13 +211,6 @@ class Domain : public mqbi::Domain {
     processCommand(mqbcmd::DomainResult*        result,
                    const mqbcmd::DomainCommand& command) BSLS_KEYWORD_OVERRIDE;
 
-    /// Mark the state of domain to be PREREMOVE
-    void removeDomainReset() BSLS_KEYWORD_OVERRIDE;
-
-    /// Mark the state of domain to be POSTREMOVE,
-    /// indicating the first round of DOMAINS REMOVE is completed
-    void removeDomainComplete() BSLS_KEYWORD_OVERRIDE;
-
     /// Load into the specified `out`, if `out` is not 0, the queue
     /// corresponding to the specified `uri`, if found. Return 0 on success,
     /// or a non-zero return code otherwise.
@@ -254,7 +247,7 @@ class Domain : public mqbi::Domain {
 
     /// Check the state of the queues in this domain, return false if there's
     /// queues opened or opening.
-    bool tryRemove() const BSLS_KEYWORD_OVERRIDE;
+    bool tryRemove() BSLS_KEYWORD_OVERRIDE;
 
     /// Check the state of the domain, return true if the first round
     /// of DOMAINS REMOVE is completed

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -527,13 +527,6 @@ bmqp::SchemaLearner& Queue::schemaLearner() const
     return d_schemaLearner;
 }
 
-bool Queue::hasActiveHandle() const
-{
-    BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
-
-    return false;
-}
-
 // -------------------
 // class HandleFactory
 // -------------------

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -430,9 +430,6 @@ class Queue : public mqbi::Queue {
     /// Return the Schema Leaner associated with this queue.
     bmqp::SchemaLearner& schemaLearner() const BSLS_KEYWORD_OVERRIDE;
 
-    /// Return true if there's queue handle and they're actively used.
-    bool hasActiveHandle() const BSLS_KEYWORD_OVERRIDE;
-
     // ACCESSORS
     //   (specific to mqbi::MockQueue)
 };


### PR DESCRIPTION
1. Check queue open status in cluster thread to prevent race when checking if the queue is actively used
2. Consolidate purge and GC since they're both called in cluster thread
3. Decide whether or not to call d_teardownCb based on function pointer being nullptr or not, since d_state can be rewritten when shutdown is called after DOMAINS REMOVE
4. Remove e_REMOVING and e_REMOVED since these states are not necessary
when we check if d_teardownRemoveCb is assigned to decide whether to call it
5. Change e_PREREMOVE to e_REMOVING
6. Replace the use of e_POSTREMOVE to e_STOPPED since there's a chance the state of a domain could be changed to e_POSTREMOVE after e_STOPPING in a late unregisterQueue
7. Explicitly invalidate a SharedResource of DomainManage. Commented in the code for the reason