### PR TITLE
fix: always update CSL on QueueUpdateAdvisory

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -70,16 +70,21 @@ void ClusterStateManager::onCommit(
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT_SAFE(advisory.choice().isClusterMessageValue());
 
-    // NOTE: Even when using old workflow, we still apply all advisories to the
-    // CSL. We just don't invoke the commit callbacks.
-    if (!d_clusterConfig.clusterAttributes().isCSLModeEnabled()) {
-        return;  // RETURN
-    }
-
     if (status != mqbc::ClusterStateLedgerCommitStatus::e_SUCCESS) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
                        << ": Failed to commit advisory: " << advisory
                        << ", with status '" << status << "'";
+        return;  // RETURN
+    }
+
+    const bmqp_ctrlmsg::ClusterMessage& clusterMessage =
+        advisory.choice().clusterMessage();
+
+    // NOTE: Even when using old workflow, we still apply all advisories to the
+    // CSL. We just don't invoke the commit callbacks.
+    // Make an exception for QueueUpdateAdvisory
+    if (!d_clusterConfig.clusterAttributes().isCSLModeEnabled() &&
+        !clusterMessage.choice().isQueueUpdateAdvisoryValue()) {
         return;  // RETURN
     }
 
@@ -94,8 +99,6 @@ void ClusterStateManager::onCommit(
                   << ": Committed advisory: " << advisory << ", with status '"
                   << status << "'";
 
-    const bmqp_ctrlmsg::ClusterMessage& clusterMessage =
-        advisory.choice().clusterMessage();
     mqbc::ClusterUtil::apply(d_state_p, clusterMessage, *d_clusterData_p);
 }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -1286,29 +1286,6 @@ void ClusterUtil::registerAppId(ClusterData*        clusterData,
 
             queueUpdate.addedAppIds().push_back(appIdInfo);
             queueAdvisory.queueUpdates().push_back(queueUpdate);
-
-            if (!clusterData->cluster().isCSLModeEnabled()) {
-                // In CSL mode, we update the queue to ClusterState upon CSL
-                // commit callback of QueueUpdateAdvisory.
-
-                // In non-CSL mode this is the shortcut to call Primary CQH
-                // instead of waiting for the quorum of acks in the ledger.
-
-                AppInfos addedApps(allocator);
-                mqbc::ClusterUtil::parseQueueInfo(&addedApps,
-                                                  queueUpdate.addedAppIds(),
-                                                  allocator);
-
-                BSLA_MAYBE_UNUSED const int assignRc =
-                    clusterState.updateQueue(queueUpdate.uri(),
-                                             queueUpdate.domain(),
-                                             addedApps,
-                                             AppInfos(allocator));
-                BSLS_ASSERT_SAFE(assignRc == 0);
-
-                BALL_LOG_INFO << clusterData->cluster().description()
-                              << ": Queue updated: " << queueAdvisory;
-            }
         }
     }
 
@@ -1436,29 +1413,6 @@ void ClusterUtil::unregisterAppId(ClusterData*        clusterData,
                                << qinfoCit->second->uri() << "'.";
 
                 return;  // RETURN
-            }
-
-            if (!clusterData->cluster().isCSLModeEnabled()) {
-                // In CSL mode, we update the queue to ClusterState upon CSL
-                // commit callback of QueueUpdateAdvisory.
-
-                // In non-CSL mode this is the shortcut to call Primary CQH
-                // instead of waiting for the quorum of acks in the ledger.
-
-                AppInfos removedApps(allocator);
-                mqbc::ClusterUtil::parseQueueInfo(&removedApps,
-                                                  queueUpdate.removedAppIds(),
-                                                  allocator);
-
-                BSLA_MAYBE_UNUSED const int assignRc =
-                    clusterState.updateQueue(queueUpdate.uri(),
-                                             queueUpdate.domain(),
-                                             AppInfos(allocator),
-                                             removedApps);
-                BSLS_ASSERT_SAFE(assignRc == 0);
-
-                BALL_LOG_INFO << clusterData->cluster().description()
-                              << ": Queue updated: " << queueAdvisory;
             }
         }
     }


### PR DESCRIPTION
1) After [#469](https://github.com/bloomberg/blazingmq/pull/469), Primaries use ClusterState (instead of Domain config) when opening queue.  
2) In legacy mode, Replicas do not update ClusterState upon QueueUpdateAdvisory from Primary (App Registration).  (They do upon QueueAssignmentAdvisory).
3) If an App is added (to Domain config) to an existing queue, and then a Replica becomes Primary and receives OpenQueue request, it will detect the difference between the exiting storage (with the App) and the current ClusterState (without the App).  The new Primary then will remove the storage for the App and abort upon the assert in `RootQueueEngine::initializeAppId` - `#QUEUE_STORAGE_NOTFOUND Virtual storage does not exist for AppId`

One way of fixing this is to allow CSL apply QueueUpdateAdvisory commits in legacy mode (this PR)
Another would be to add `processQueueUpdateAdvisory` symmetrically to `processQueueAssignmentAdvisory`

Best way is to apply CSL commits unconditionally.
