### PR TITLE
fix: Not delivering old data to new Apps

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
@@ -105,8 +105,8 @@
 #include <bsl_cstddef.h>
 #include <bsl_stdexcept.h>
 #include <bsl_utility.h>
+#include <bslalg_hasstliterators.h>
 #include <bslalg_scalarprimitives.h>
-#include <bslalg_typetraithasstliterators.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bslma_usesbslmaallocator.h>
@@ -717,11 +717,13 @@ class OrderedHashMap {
     /// maintained by this container, or the `end` iterator if this
     /// containeris empty.
     const_iterator begin() const;
+    const_iterator cbegin() const;
 
     /// Return an iterator providing non-modifiable access to the
     /// past-the-end element in the sequence of `value_type` objects
     /// maintained by this container.
     const_iterator end() const;
+    const_iterator cend() const;
 
     /// Return a local iterator providing non-modifiable access to the first
     /// `value_type` object in the sequence of `value_type` objects of the
@@ -730,6 +732,7 @@ class OrderedHashMap {
     /// bucket is empty.  The behavior is undefined unless 'index <
     /// bucket_count()'.
     const_local_iterator begin(size_t index) const;
+    const_local_iterator cbegin(size_t index) const;
 
     /// Return a local iterator providing non-modifiable access to the
     /// past-the-end element in the sequence of `value_type` objects of the
@@ -737,6 +740,7 @@ class OrderedHashMap {
     /// maintained by this container.  The behavior is undefined unless
     /// `index < bucket_count()`.
     const_local_iterator end(size_t index) const;
+    const_local_iterator cend(size_t index) const;
 
     /// Return the index of the bucket, in the array of buckets maintained
     /// by this container, where values having the specified `key` would be
@@ -1541,7 +1545,21 @@ OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::begin() const
 
 template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
 inline typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_iterator
+OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::cbegin() const
+{
+    return const_iterator(d_sentinel_p->nextInList());
+}
+
+template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
+inline typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_iterator
 OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::end() const
+{
+    return const_iterator(d_sentinel_p);
+}
+
+template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
+inline typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_iterator
+OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::cend() const
 {
     return const_iterator(d_sentinel_p);
 }
@@ -1558,7 +1576,25 @@ inline
 template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
 inline
     typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_local_iterator
+    OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::cbegin(size_t index) const
+{
+    BSLS_ASSERT_SAFE(index < d_bucketArraySize);
+    return const_local_iterator(d_bucketArray_p + index);
+}
+
+template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
+inline
+    typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_local_iterator
     OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::end(size_t index) const
+{
+    BSLS_ASSERT_SAFE(index < d_bucketArraySize);
+    return const_local_iterator(d_bucketArray_p + index, 0);
+}
+
+template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
+inline
+    typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::const_local_iterator
+    OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::cend(size_t index) const
 {
     BSLS_ASSERT_SAFE(index < d_bucketArraySize);
     return const_local_iterator(d_bucketArray_p + index, 0);

--- a/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
@@ -106,6 +106,7 @@
 #include <bsl_stdexcept.h>
 #include <bsl_utility.h>
 #include <bslalg_scalarprimitives.h>
+#include <bslalg_typetraithasstliterators.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bslma_usesbslmaallocator.h>
@@ -683,8 +684,7 @@ class OrderedHashMap {
     /// is `true` if a new value was inserted, and `false` if the value was
     /// already present.  Note that this method requires that the (template
     /// parameter) types `KEY` and `VALUE` both be "copy-constructible".
-    template <class SOURCE_TYPE>
-    bsl::pair<iterator, bool> insert(const SOURCE_TYPE& value);
+    bsl::pair<iterator, bool> insert(const VALUE_TYPE& value);
 
     /// Insert the specified `value` into this container at the beginning of
     /// the underlying sequential list if the key (the `first` element) of a
@@ -698,8 +698,7 @@ class OrderedHashMap {
     /// inserted, and `false` if the value was already present.  Note that
     /// this method requires that the (template parameter) types `KEY` and
     /// `VALUE` both be "copy-constructible".
-    template <class SOURCE_TYPE>
-    bsl::pair<iterator, bool> rinsert(const SOURCE_TYPE& value);
+    bsl::pair<iterator, bool> rinsert(const VALUE_TYPE& value);
 
     // void reserve(int numElements);
     // Increase the number of buckets of this set to a quantity such that
@@ -1475,11 +1474,10 @@ OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::find(const key_type& key)
 }
 
 template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
-template <class SOURCE_TYPE>
 inline bsl::pair<
     typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::iterator,
     bool>
-OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::insert(const SOURCE_TYPE& value)
+OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::insert(const VALUE_TYPE& value)
 {
     Bucket* bucket    = getBucketForKey(get_key(value));
     Link*   foundLink = 0;
@@ -1507,11 +1505,10 @@ OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::insert(const SOURCE_TYPE& value)
 }
 
 template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
-template <class SOURCE_TYPE>
 inline bsl::pair<
     typename OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::iterator,
     bool>
-OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::rinsert(const SOURCE_TYPE& value)
+OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::rinsert(const VALUE_TYPE& value)
 {
     Bucket* bucket    = getBucketForKey(get_key(value));
     Link*   foundLink = 0;
@@ -1629,6 +1626,15 @@ OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE>::get_allocator() const
 }
 
 }  // close package namespace
+
+namespace bslalg {
+
+template <class KEY, class VALUE, class HASH, class VALUE_TYPE>
+struct HasStlIterators<bmqc::OrderedHashMap<KEY, VALUE, HASH, VALUE_TYPE> >
+: bsl::true_type {};
+
+}  // close namespace bslalg
+
 }  // close enterprise namespace
 
 #endif

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -4332,8 +4332,8 @@ void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
                     ->domain());
         }
 
-        for (AppInfosCIter cit = removedAppIds.begin();
-             cit != removedAppIds.end();
+        for (AppInfosCIter cit = removedAppIds.cbegin();
+             cit != removedAppIds.cend();
              ++cit) {
             if (!d_clusterState_p->isSelfPrimary(partitionId) || queue == 0) {
                 // Note: In non-CSL mode, the queue deletion callback is

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -4332,8 +4332,8 @@ void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
                     ->domain());
         }
 
-        for (AppInfosCIter cit = removedAppIds.cbegin();
-             cit != removedAppIds.cend();
+        for (AppInfosCIter cit = removedAppIds.begin();
+             cit != removedAppIds.end();
              ++cit) {
             if (!d_clusterState_p->isSelfPrimary(partitionId) || queue == 0) {
                 // Note: In non-CSL mode, the queue deletion callback is

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -103,7 +103,7 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     typedef QueueMap::iterator       QueueMapIter;
     typedef QueueMap::const_iterator QueueMapCIter;
 
-    typedef mqbi::Storage::AppInfos  AppInfos;
+    typedef mqbc::ClusterState::AppInfos AppInfos;
     typedef AppInfos::const_iterator AppInfosCIter;
 
     enum DomainState {

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -424,7 +424,6 @@ BMQTST_TEST_F(Test, putAliveIdleSendAliveTwoSubstreams)
 {
     bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
                                           bmqtst::TestHelperUtil::allocator());
-    size_t                    expectedLogRecords = 0U;
 
     const bsls::Types::Int64 k_MAX_IDLE_TIME = 10;
 
@@ -439,6 +438,8 @@ BMQTST_TEST_F(Test, putAliveIdleSendAliveTwoSubstreams)
     bmqu::MemOutStream errorDescription(bmqtst::TestHelperUtil::allocator());
     d_storage.addVirtualStorage(errorDescription, id1, key1);
     d_storage.addVirtualStorage(errorDescription, id2, key2);
+
+    size_t expectedLogRecords = logObserver.records().size();
 
     d_monitor.registerSubStream(id1);
     d_monitor.registerSubStream(id2);

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -242,8 +242,8 @@ void QueueState::loadInternals(mqbcmd::QueueState* out) const
 
             size_t i = 0;
             for (mqbi::Storage::AppInfos::const_iterator cit =
-                     appIdKeyPairs.begin();
-                 cit != appIdKeyPairs.end();
+                     appIdKeyPairs.cbegin();
+                 cit != appIdKeyPairs.cend();
                  ++cit, ++i) {
                 virtualStorages[i].appId() = cit->first;
                 os.reset();

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -242,8 +242,8 @@ void QueueState::loadInternals(mqbcmd::QueueState* out) const
 
             size_t i = 0;
             for (mqbi::Storage::AppInfos::const_iterator cit =
-                     appIdKeyPairs.cbegin();
-                 cit != appIdKeyPairs.cend();
+                     appIdKeyPairs.begin();
+                 cit != appIdKeyPairs.end();
                  ++cit, ++i) {
                 virtualStorages[i].appId() = cit->first;
                 os.reset();

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1617,8 +1617,8 @@ void RelayQueueEngine::loadInternals(mqbcmd::QueueEngine* out) const
         subStreams.reserve(appIdKeyPairs.size());
 
         for (mqbi::Storage::AppInfos::const_iterator cit =
-                 appIdKeyPairs.begin();
-             cit != appIdKeyPairs.end();
+                 appIdKeyPairs.cbegin();
+             cit != appIdKeyPairs.cend();
              ++cit) {
             subStreams.resize(subStreams.size() + 1);
             mqbcmd::RelayQueueEngineSubStream& subStream = subStreams.back();

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1107,7 +1107,11 @@ mqbi::QueueHandle* RelayQueueEngine::getHandle(
     BSLS_ASSERT_SAFE(app);
 
     if (!app->isAuthorized()) {
-        app->authorize();
+        if (app->authorize()) {
+            BALL_LOG_INFO << "Queue '" << d_queueState_p->uri()
+                          << "' authorized App '" << downstreamInfo.appId()
+                          << "' with ordinal " << app->ordinal() << ".";
+        }
     }
 
     queueHandle->registerSubStream(
@@ -1613,8 +1617,8 @@ void RelayQueueEngine::loadInternals(mqbcmd::QueueEngine* out) const
         subStreams.reserve(appIdKeyPairs.size());
 
         for (mqbi::Storage::AppInfos::const_iterator cit =
-                 appIdKeyPairs.cbegin();
-             cit != appIdKeyPairs.cend();
+                 appIdKeyPairs.begin();
+             cit != appIdKeyPairs.end();
              ++cit) {
             subStreams.resize(subStreams.size() + 1);
             mqbcmd::RelayQueueEngineSubStream& subStream = subStreams.back();
@@ -1888,10 +1892,10 @@ bool RelayQueueEngine::checkForDuplicate(const App_State*         app,
     if (d_queueState_p->domain()->cluster()->isRemote()) {
         d_realStorageIter_mp->reset(msgGUID);
         if (!d_realStorageIter_mp->atEnd()) {
-            mqbi::AppMessage& appState = d_realStorageIter_mp->appMessageState(
-                app->ordinal());
+            const mqbi::AppMessage& appView =
+                d_realStorageIter_mp->appMessageView(app->ordinal());
 
-            if (appState.isPushing()) {
+            if (appView.isPushing()) {
                 BMQ_LOGTHROTTLE_INFO()
                     << "Remote queue: " << d_queueState_p->uri()
                     << " (id: " << d_queueState_p->id() << ", App '"
@@ -1931,16 +1935,13 @@ void RelayQueueEngine::storePush(
                 result != mqbi::StorageResult::e_SUCCESS)) {
             BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
 
-            if (result != mqbi::StorageResult::e_GUID_NOT_UNIQUE ||
-                isOutOfOrder) {
-                BMQ_LOGTHROTTLE_INFO()
-                    << d_queueState_p->uri() << " failed to store GUID ["
-                    << msgGUID << "], result = " << result;
-            }
-            // A redelivery PUSH for one App in the presence of another App
-            // can result in 'e_GUID_NOT_UNIQUE'.
+            BMQ_LOGTHROTTLE_INFO()
+                << d_queueState_p->uri() << " failed to store GUID ["
+                << msgGUID << "], result = " << result;
         }
         else {
+            BSLS_ASSERT_SAFE(dataStreamMessage);
+
             // Reusing previously cached ordinals.
             for (bmqp::Protocol::SubQueueInfosArray::const_iterator cit =
                      subscriptions.begin();

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -740,7 +740,7 @@ void RemoteQueue::onHandleReleased(
                         d_state_p->storage()->hasVirtualStorage(appId,
                                                                 &appKey);
                     BSLS_ASSERT_SAFE(hasVirtualStorage);
-                    d_state_p->storage()->removeVirtualStorage(appKey);
+                    d_state_p->storage()->removeVirtualStorage(appKey, false);
 
                     (void)
                         hasVirtualStorage;  // Compiler happiness in opt build
@@ -750,7 +750,8 @@ void RemoteQueue::onHandleReleased(
                          d_state_p->handleParameters().flags())) {
                 // Lost last reader in non-fanout mode
                 d_state_p->storage()->removeVirtualStorage(
-                    mqbi::QueueEngine::k_DEFAULT_APP_KEY);
+                    mqbi::QueueEngine::k_DEFAULT_APP_KEY,
+                    false);
                 d_state_p->storage()->removeAll(mqbu::StorageKey::k_NULL_KEY);
             }
         }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1865,8 +1865,8 @@ void RootQueueEngine::afterAppIdRegistered(
         return;  // RETURN;
     }
 
-    for (mqbi::Storage::AppInfos::const_iterator cit = addedAppIds.begin();
-         cit != addedAppIds.end();
+    for (mqbi::Storage::AppInfos::const_iterator cit = addedAppIds.cbegin();
+         cit != addedAppIds.cend();
          ++cit) {
         // We need to handle 2 scenarios here: a consumer with the specified
         // 'appId' may have already opened the queue, or otherwise.
@@ -1915,8 +1915,8 @@ void RootQueueEngine::afterAppIdUnregistered(
         return;  // RETURN
     }
 
-    for (mqbi::Storage::AppInfos::const_iterator cit = removedAppIds.begin();
-         cit != removedAppIds.end();
+    for (mqbi::Storage::AppInfos::const_iterator cit = removedAppIds.cbegin();
+         cit != removedAppIds.cend();
          ++cit) {
         const bsl::string& appId = cit->first;
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1865,8 +1865,8 @@ void RootQueueEngine::afterAppIdRegistered(
         return;  // RETURN;
     }
 
-    for (mqbi::Storage::AppInfos::const_iterator cit = addedAppIds.cbegin();
-         cit != addedAppIds.cend();
+    for (mqbi::Storage::AppInfos::const_iterator cit = addedAppIds.begin();
+         cit != addedAppIds.end();
          ++cit) {
         // We need to handle 2 scenarios here: a consumer with the specified
         // 'appId' may have already opened the queue, or otherwise.
@@ -1915,11 +1915,10 @@ void RootQueueEngine::afterAppIdUnregistered(
         return;  // RETURN
     }
 
-    for (mqbi::Storage::AppInfos::const_iterator cit = removedAppIds.cbegin();
-         cit != removedAppIds.cend();
+    for (mqbi::Storage::AppInfos::const_iterator cit = removedAppIds.begin();
+         cit != removedAppIds.end();
          ++cit) {
-        const bsl::string&      appId  = cit->first;
-        const mqbu::StorageKey& appKey = cit->second;
+        const bsl::string& appId = cit->first;
 
         Apps::iterator iter = d_apps.find(appId);
         BSLS_ASSERT_SAFE(iter != d_apps.end());
@@ -1929,19 +1928,8 @@ void RootQueueEngine::afterAppIdUnregistered(
         // we still keep the app but invalidate the authorization
         iter->second->unauthorize();
 
-        // Do a best effort to confirm the messages and remove the storage.  If
-        // either fails, just log the condition.
-
-        const mqbi::StorageResult::Enum rc =
-            d_queueState_p->storage()->removeAll(appKey);
-        if (rc != mqbi::StorageResult::e_SUCCESS) {
-            BALL_LOG_WARN << "#QUEUE_APPID_UNREGISTER_FAILURE "
-                          << "Failed to unregister appId '" << appId
-                          << "', appKey '" << appKey << "' of queue '"
-                          << d_queueState_p->queue()->description()
-                          << "' [reason: " << mqbi::StorageResult::toAscii(rc)
-                          << "]";
-        }
+        // There is no need to purge the storage.  'removeVirtualStorage' will
+        // do that.
 
         d_consumptionMonitor.unregisterSubStream(appId);
     }
@@ -1966,17 +1954,31 @@ void RootQueueEngine::registerStorage(const bsl::string&      appId,
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->dispatcher()->inDispatcherThread(
         d_queueState_p->queue()));
 
-    BALL_LOG_INFO << "Local queue: " << d_queueState_p->uri()
-                  << " (id: " << d_queueState_p->id()
-                  << ") now has storage: [App Id: " << appId
-                  << ", key: " << appKey << ", ordinal: " << appOrdinal << "]";
-
     Apps::iterator iter = d_apps.find(appId);
     BSLS_ASSERT_SAFE(iter != d_apps.end());
 
-    iter->second->authorize(appKey, appOrdinal);
+    AppState& app = *iter->second;
 
-    d_consumptionMonitor.registerSubStream(appId);
+    if (app.isAuthorized()) {
+        BSLS_ASSERT_SAFE(appKey == app.appKey());
+
+        BALL_LOG_INFO << "Local queue: " << d_queueState_p->uri()
+                      << " (id: " << d_queueState_p->id()
+                      << ") changing [App Id: " << appId << ", key: " << appKey
+                      << ", ordinal: " << app.ordinal()
+                      << "] to [ordinal: " << appOrdinal << "]";
+    }
+    else {
+        BALL_LOG_INFO << "Local queue: " << d_queueState_p->uri()
+                      << " (id: " << d_queueState_p->id()
+                      << ") now has storage: [App Id: " << appId
+                      << ", key: " << appKey << ", ordinal: " << appOrdinal
+                      << "]";
+
+        d_consumptionMonitor.registerSubStream(appId);
+    }
+
+    iter->second->authorize(appKey, appOrdinal);
 }
 
 void RootQueueEngine::unregisterStorage(

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -33,19 +33,19 @@ namespace mqbc {
 // class ClusterStateQueueInfo
 // ---------------------------
 
-bool operator==(const ClusterStateQueueInfo::AppInfos& lhs,
-                const ClusterStateQueueInfo::AppInfos& rhs)
+bool ClusterStateQueueInfo::hasTheSameAppIds(const AppInfos& appInfos) const
 {
     // This ignores the order
 
-    if (lhs.size() != rhs.size()) {
-        return false;
+    if (d_appInfos.size() != appInfos.size()) {
+        return false;  // RETURN
     }
-    typedef mqbi::Storage::AppInfos::const_iterator Iter;
 
-    for (Iter iter = lhs.begin(); iter != lhs.end(); ++iter) {
-        if (rhs.count(iter->first) != 1) {
-            return false;
+    for (AppInfos::const_iterator cit = d_appInfos.cbegin();
+         cit != d_appInfos.cend();
+         ++cit) {
+        if (appInfos.count(cit->first) != 1) {
+            return false;  // RETURN
         }
     }
 
@@ -574,8 +574,8 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
         }
 
         AppInfos& appIdInfos = iter->second->appInfos();
-        for (AppInfosCIter citer = addedAppIds.begin();
-             citer != addedAppIds.end();
+        for (AppInfosCIter citer = addedAppIds.cbegin();
+             citer != addedAppIds.cend();
              ++citer) {
             if (!appIdInfos.insert(*citer).second) {
                 return rc_APPID_ALREADY_EXISTS;  // RETURN
@@ -586,7 +586,7 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
              citer != removedAppIds.end();
              ++citer) {
             const AppInfosCIter appIdInfoCIter = appIdInfos.find(citer->first);
-            if (appIdInfoCIter == appIdInfos.end()) {
+            if (appIdInfoCIter == appIdInfos.cend()) {
                 return rc_APPID_NOT_FOUND;  // RETURN
             }
             appIdInfos.erase(appIdInfoCIter);

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -33,6 +33,25 @@ namespace mqbc {
 // class ClusterStateQueueInfo
 // ---------------------------
 
+bool operator==(const ClusterStateQueueInfo::AppInfos& lhs,
+                const ClusterStateQueueInfo::AppInfos& rhs)
+{
+    // This ignores the order
+
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+    typedef mqbi::Storage::AppInfos::const_iterator Iter;
+
+    for (Iter iter = lhs.begin(); iter != lhs.end(); ++iter) {
+        if (rhs.count(iter->first) != 1) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 bsl::ostream& ClusterStateQueueInfo::print(bsl::ostream& stream,
                                            int           level,
                                            int           spacesPerLevel) const
@@ -555,8 +574,8 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
         }
 
         AppInfos& appIdInfos = iter->second->appInfos();
-        for (AppInfosCIter citer = addedAppIds.cbegin();
-             citer != addedAppIds.cend();
+        for (AppInfosCIter citer = addedAppIds.begin();
+             citer != addedAppIds.end();
              ++citer) {
             if (!appIdInfos.insert(*citer).second) {
                 return rc_APPID_ALREADY_EXISTS;  // RETURN
@@ -567,7 +586,7 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
              citer != removedAppIds.end();
              ++citer) {
             const AppInfosCIter appIdInfoCIter = appIdInfos.find(citer->first);
-            if (appIdInfoCIter == appIdInfos.cend()) {
+            if (appIdInfoCIter == appIdInfos.end()) {
                 return rc_APPID_NOT_FOUND;  // RETURN
             }
             appIdInfos.erase(appIdInfoCIter);

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -289,6 +289,14 @@ class ClusterStateQueueInfo {
     /// undefined unless `isValid()` returns true.
     bsl::ostream&
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+
+    /// Return `true` if the specified `appInfos` object contains the same
+    /// AppIds (excluding the appKeys) as this object.  Return false otherwise.
+    bool hasTheSameAppIds(const AppInfos& appInfos) const;
+
+    /// Return `true` if the specified `rhs` object contains the same state
+    /// as this object excluding the appKeys.  Return false otherwise.
+    bool isEquivalent(const ClusterStateQueueInfo& rhs) const;
 };
 
 // FREE OPERATORS
@@ -302,24 +310,6 @@ bsl::ostream& operator<<(bsl::ostream&                stream,
 /// a reference to the modifiable `stream`.
 bsl::ostream& operator<<(bsl::ostream&                      stream,
                          ClusterStateQueueInfo::State::Enum value);
-
-/// Return `true` if the specified `rhs` object contains the value of the
-/// same type as contained in the specified `lhs` object and the value
-/// itself is the same in both objects, return false otherwise.
-bool operator==(const ClusterStateQueueInfo& lhs,
-                const ClusterStateQueueInfo& rhs);
-
-/// Return `false` if the specified `rhs` object contains the value of the
-/// same type as contained in the specified `lhs` object and the value
-/// itself is the same in both objects, return `true` otherwise.
-bool operator!=(const ClusterStateQueueInfo& lhs,
-                const ClusterStateQueueInfo& rhs);
-
-bool operator==(const ClusterStateQueueInfo::AppInfos& lhs,
-                const ClusterStateQueueInfo::AppInfos& rhs);
-
-bool operator!=(const ClusterStateQueueInfo::AppInfos& lhs,
-                const ClusterStateQueueInfo::AppInfos& rhs);
 
 // ==========================
 // class ClusterStateObserver
@@ -947,6 +937,14 @@ inline bool ClusterStateQueueInfo::pendingUnassignment() const
     return d_state == State::k_UNASSIGNING;
 }
 
+inline bool
+ClusterStateQueueInfo::isEquivalent(const ClusterStateQueueInfo& rhs) const
+{
+    return uri() == rhs.uri() && key() == rhs.key() &&
+           partitionId() == rhs.partitionId() &&
+           hasTheSameAppIds(rhs.appInfos()) && state() == rhs.state();
+}
+
 // ------------------
 // class ClusterState
 // ------------------
@@ -1221,20 +1219,6 @@ mqbc::operator<<(bsl::ostream&                            stream,
                  mqbc::ClusterStateQueueInfo::State::Enum value)
 {
     return mqbc::ClusterStateQueueInfo::State::print(stream, value, 0, -1);
-}
-
-inline bool mqbc::operator==(const ClusterStateQueueInfo& lhs,
-                             const ClusterStateQueueInfo& rhs)
-{
-    return lhs.uri() == rhs.uri() && lhs.key() == rhs.key() &&
-           lhs.partitionId() == rhs.partitionId() &&
-           lhs.appInfos() == rhs.appInfos() && lhs.state() == rhs.state();
-}
-
-inline bool mqbc::operator!=(const ClusterStateQueueInfo& lhs,
-                             const ClusterStateQueueInfo& rhs)
-{
-    return !(lhs == rhs);
 }
 
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -315,6 +315,12 @@ bool operator==(const ClusterStateQueueInfo& lhs,
 bool operator!=(const ClusterStateQueueInfo& lhs,
                 const ClusterStateQueueInfo& rhs);
 
+bool operator==(const ClusterStateQueueInfo::AppInfos& lhs,
+                const ClusterStateQueueInfo::AppInfos& rhs);
+
+bool operator!=(const ClusterStateQueueInfo::AppInfos& lhs,
+                const ClusterStateQueueInfo::AppInfos& rhs);
+
 // ==========================
 // class ClusterStateObserver
 // ==========================

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -1086,7 +1086,7 @@ void ClusterUtil::registerQueueInfo(ClusterState*           clusterState,
             BSLS_ASSERT_SAFE(qs->uri() == uri);
 
             if ((qs->partitionId() == partitionId) &&
-                (qs->key() == queueKey) && (qs->appInfos() == appInfos)) {
+                (qs->key() == queueKey) && qs->hasTheSameAppIds(appInfos)) {
                 // All good.. nothing to update.
                 return;  // RETURN
             }
@@ -1263,8 +1263,8 @@ void ClusterUtil::registerAppId(ClusterData*        clusterData,
 
             bsl::unordered_set<mqbu::StorageKey> appKeys;
             const AppInfos& appInfos = qinfoCit->second->appInfos();
-            for (AppInfosCIter appInfoCit = appInfos.begin();
-                 appInfoCit != appInfos.end();
+            for (AppInfosCIter appInfoCit = appInfos.cbegin();
+                 appInfoCit != appInfos.cend();
                  ++appInfoCit) {
                 if (appInfoCit->first == appId) {
                     BALL_LOG_ERROR << "Failed to register appId '" << appId
@@ -1390,8 +1390,8 @@ void ClusterUtil::unregisterAppId(ClusterData*        clusterData,
 
             bool            appIdFound = false;
             const AppInfos& appInfos   = qinfoCit->second->appInfos();
-            for (AppInfosCIter appInfoCit = appInfos.begin();
-                 appInfoCit != appInfos.end();
+            for (AppInfosCIter appInfoCit = appInfos.cbegin();
+                 appInfoCit != appInfos.cend();
                  ++appInfoCit) {
                 if (appInfoCit->first == appId) {
                     // Populate AppInfo
@@ -1632,7 +1632,7 @@ int ClusterUtil::validateState(bsl::ostream&       errorDescription,
     bsl::vector<ClusterStatePartitionInfo> incorrectPartitions;
     for (size_t i = 0; i < state.partitions().size(); ++i) {
         const ClusterStatePartitionInfo& stateInfo = state.partitions()[i];
-        int                              pid       = i;
+        const int                        pid       = i;
         BSLS_ASSERT_SAFE(stateInfo.partitionId() == pid);
 
         const ClusterStatePartitionInfo& referenceInfo =
@@ -1678,7 +1678,7 @@ int ClusterUtil::validateState(bsl::ostream&       errorDescription,
         for (size_t i = 0; i < state.partitions().size(); ++i) {
             const ClusterStatePartitionInfo& referenceInfo =
                 reference.partitions()[i];
-            int pid = i;
+            const int pid = i;
             BSLS_ASSERT_SAFE(referenceInfo.partitionId() == pid);
             bdlb::Print::newlineAndIndent(out, level + 1);
             out << "Partition [" << pid
@@ -1727,7 +1727,7 @@ int ClusterUtil::validateState(bsl::ostream&       errorDescription,
                     citer->second;
                 const bsl::shared_ptr<ClusterStateQueueInfo>& referenceInfo =
                     refCiter->second;
-                if (*info != *referenceInfo) {
+                if (!info->isEquivalent(*referenceInfo)) {
                     // Incorrect queue information
                     incorrectQueues.push_back(
                         bsl::make_pair(info, referenceInfo));
@@ -2139,8 +2139,8 @@ void ClusterUtil::loadQueuesInfo(bsl::vector<bmqp_ctrlmsg::QueueInfo>* out,
             BSLS_ASSERT_SAFE(!qCit->second->key().isNull());
             qCit->second->key().loadBinary(&queueInfo.key());
 
-            for (AppInfosCIter appIdCit = qCit->second->appInfos().begin();
-                 appIdCit != qCit->second->appInfos().end();
+            for (AppInfosCIter appIdCit = qCit->second->appInfos().cbegin();
+                 appIdCit != qCit->second->appInfos().cend();
                  ++appIdCit) {
                 bmqp_ctrlmsg::AppIdInfo appIdInfo;
                 appIdInfo.appId() = appIdCit->first;

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3675,13 +3675,13 @@ void StorageManager::initializeQueueKeyInfoMap(
             BSLS_ASSERT_SAFE(cit->second);
             const ClusterStateQueueInfo& csQinfo = *(cit->second);
 
-            mqbs::DataStoreConfigQueueInfo qinfo;
+            mqbs::DataStoreConfigQueueInfo qinfo(true);
             qinfo.setCanonicalQueueUri(csQinfo.uri().asString());
             qinfo.setPartitionId(csQinfo.partitionId());
-            for (AppInfosCIter appIdCit = csQinfo.appInfos().cbegin();
-                 appIdCit != csQinfo.appInfos().cend();
+            for (AppInfosCIter appIdCit = csQinfo.appInfos().begin();
+                 appIdCit != csQinfo.appInfos().end();
                  ++appIdCit) {
-                qinfo.addAppInfo(appIdCit);
+                qinfo.addAppInfo(appIdCit->first, appIdCit->second);
             }
 
             d_queueKeyInfoMapVec.at(csQinfo.partitionId())

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3678,8 +3678,8 @@ void StorageManager::initializeQueueKeyInfoMap(
             mqbs::DataStoreConfigQueueInfo qinfo(true);
             qinfo.setCanonicalQueueUri(csQinfo.uri().asString());
             qinfo.setPartitionId(csQinfo.partitionId());
-            for (AppInfosCIter appIdCit = csQinfo.appInfos().begin();
-                 appIdCit != csQinfo.appInfos().end();
+            for (AppInfosCIter appIdCit = csQinfo.appInfos().cbegin();
+                 appIdCit != csQinfo.appInfos().cend();
                  ++appIdCit) {
                 qinfo.addAppInfo(appIdCit->first, appIdCit->second);
             }

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -82,8 +82,8 @@ bool StorageUtil::loadDifference(mqbi::Storage::AppInfos*       result,
                                  bool                           findConflicts)
 {
     bool noConflicts = true;
-    for (mqbi::Storage::AppInfos::const_iterator cit = baseSet.begin();
-         cit != baseSet.end();
+    for (mqbi::Storage::AppInfos::const_iterator cit = baseSet.cbegin();
+         cit != baseSet.cend();
          ++cit) {
         mqbi::Storage::AppInfos::const_iterator match = subtractionSet.find(
             cit->first);
@@ -1502,14 +1502,14 @@ void StorageUtil::recoveredQueuesCb(
         }
 
         if (qinfo.appIdKeyPairs().size() != 1 ||
-            qinfo.appIdKeyPairs().begin()->second !=
+            qinfo.appIdKeyPairs().cbegin()->second !=
                 bmqp::ProtocolUtil::k_DEFAULT_APP_ID) {
             // This is a fanout queue
             AppIds appIds;
 
             for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator cit =
-                     qinfo.appIdKeyPairs().begin();
-                 cit != qinfo.appIdKeyPairs().end();
+                     qinfo.appIdKeyPairs().cbegin();
+                 cit != qinfo.appIdKeyPairs().cend();
                  ++cit) {
                 AppIdsInsertRc appIdsIrc = appIds.insert(cit->second);
                 if (false == appIdsIrc.second) {
@@ -1654,8 +1654,8 @@ void StorageUtil::recoveredQueuesCb(
                 BSLS_ASSERT_SAFE(partitionId == rstorage->partitionId());
 
                 for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator
-                         ait = appIdKeyPairs.begin();
-                     ait != appIdKeyPairs.end();
+                         ait = appIdKeyPairs.cbegin();
+                     ait != appIdKeyPairs.cend();
                      ++ait) {
                     BSLA_MAYBE_UNUSED const bsl::string& appId = ait->second;
                     BSLA_MAYBE_UNUSED const mqbu::StorageKey& appKey =
@@ -1789,8 +1789,8 @@ void StorageUtil::recoveredQueuesCb(
         int                rc;
         if (domain->config().mode().isFanoutValue()) {
             for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator ait =
-                     appIdKeyPairs.begin();
-                 ait != appIdKeyPairs.end();
+                     appIdKeyPairs.cbegin();
+                 ait != appIdKeyPairs.cend();
                  ++ait) {
                 const bsl::string&      appId  = ait->second;
                 const mqbu::StorageKey& appKey = ait->first;
@@ -2009,7 +2009,7 @@ void StorageUtil::recoveredQueuesCb(
             const mqbs::DataStoreRecordKey current(handle.sequenceNum(),
                                                    handle.primaryLeaseId());
 
-            unsigned int numGhosts = infoMapCit->second.advanceAndCount(
+            const unsigned int numGhosts = infoMapCit->second.advanceAndCount(
                 current);
             BSLS_ASSERT_SAFE(numGhosts < refCount);
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -82,14 +82,14 @@ bool StorageUtil::loadDifference(mqbi::Storage::AppInfos*       result,
                                  bool                           findConflicts)
 {
     bool noConflicts = true;
-    for (mqbi::Storage::AppInfos::const_iterator cit = baseSet.cbegin();
-         cit != baseSet.cend();
+    for (mqbi::Storage::AppInfos::const_iterator cit = baseSet.begin();
+         cit != baseSet.end();
          ++cit) {
         mqbi::Storage::AppInfos::const_iterator match = subtractionSet.find(
             cit->first);
 
         if (subtractionSet.end() == match) {
-            result->emplace(cit->first, cit->second);
+            result->insert(bsl::make_pair(cit->first, cit->second));
         }
         else if (findConflicts && match->second != cit->second) {
             BALL_LOG_ERROR << "appId [" << cit->first
@@ -378,32 +378,10 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
         for (AppInfosCIter cit = removedIdKeyPairs.begin();
              cit != removedIdKeyPairs.end();
              ++cit) {
-            // Write QueueDeletionRecord to data store for removed appIds.
-            //
-            // TODO_CSL Do not write this record when we logically delete the
-            // QLIST file
-
-            mqbs::DataStoreRecordHandle handle;
-            rc = fs->writeQueueDeletionRecord(&handle,
-                                              storage->queueKey(),
-                                              cit->second,
-                                              timestamp);
-            if (0 != rc) {
-                BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                    << clusterDescription << ": Partition [" << partitionId
-                    << "] failed to write QueueDeletionRecord for queue ["
-                    << storage->queueUri() << "], queueKey ["
-                    << storage->queueKey() << "], appId [" << cit->first
-                    << "], appKey [" << cit->second << "], rc: " << rc
-                    << BMQTSK_ALARMLOG_END;
-                return rc;  // RETURN
-            }
-
-            storage->addQueueOpRecordHandle(handle);
-
             rc = removeVirtualStorageInternal(storage,
                                               cit->second,
-                                              partitionId);
+                                              partitionId,
+                                              true);  // asPrimary
             if (0 != rc) {
                 BALL_LOG_ERROR
                     << clusterDescription << " Partition [" << partitionId
@@ -501,7 +479,8 @@ int StorageUtil::addVirtualStoragesInternal(
 
 int StorageUtil::removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
                                               const mqbu::StorageKey&  appKey,
-                                              int partitionId)
+                                              int  partitionId,
+                                              bool asPrimary)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -514,7 +493,7 @@ int StorageUtil::removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
 
     enum { rc_SUCCESS = 0, rc_VIRTUAL_STORAGE_DOES_NOT_EXIST = -1 };
 
-    bool existed = storage->removeVirtualStorage(appKey);
+    bool existed = storage->removeVirtualStorage(appKey, asPrimary);
     if (!existed) {
         return rc_VIRTUAL_STORAGE_DOES_NOT_EXIST;  // RETURN
     }
@@ -1523,15 +1502,16 @@ void StorageUtil::recoveredQueuesCb(
         }
 
         if (qinfo.appIdKeyPairs().size() != 1 ||
-            qinfo.appIdKeyPairs().cbegin()->first !=
+            qinfo.appIdKeyPairs().begin()->second !=
                 bmqp::ProtocolUtil::k_DEFAULT_APP_ID) {
             // This is a fanout queue
             AppIds appIds;
 
-            for (AppInfos::const_iterator cit = qinfo.appIdKeyPairs().cbegin();
-                 cit != qinfo.appIdKeyPairs().cend();
+            for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator cit =
+                     qinfo.appIdKeyPairs().begin();
+                 cit != qinfo.appIdKeyPairs().end();
                  ++cit) {
-                AppIdsInsertRc appIdsIrc = appIds.insert(cit->first);
+                AppIdsInsertRc appIdsIrc = appIds.insert(cit->second);
                 if (false == appIdsIrc.second) {
                     // Duplicate AppId.
 
@@ -1638,7 +1618,8 @@ void StorageUtil::recoveredQueuesCb(
          ++qit) {
         const mqbu::StorageKey&               queueKey = qit->first;
         const mqbs::DataStoreConfigQueueInfo& qinfo    = qit->second;
-        const AppInfos&      appIdKeyPairs             = qinfo.appIdKeyPairs();
+        const mqbs::DataStoreConfigQueueInfo::AppInfos& appIdKeyPairs =
+            qinfo.appIdKeyPairs();
         const bmqt::Uri      queueUri(qinfo.canonicalQueueUri());
         BSLS_ASSERT_SAFE(queueUri.isValid());
 
@@ -1672,12 +1653,13 @@ void StorageUtil::recoveredQueuesCb(
                 BSLS_ASSERT_SAFE(queueKey == rstorage->queueKey());
                 BSLS_ASSERT_SAFE(partitionId == rstorage->partitionId());
 
-                for (AppInfosCIter ait = appIdKeyPairs.begin();
+                for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator
+                         ait = appIdKeyPairs.begin();
                      ait != appIdKeyPairs.end();
                      ++ait) {
-                    BSLA_MAYBE_UNUSED const bsl::string& appId = ait->first;
+                    BSLA_MAYBE_UNUSED const bsl::string& appId = ait->second;
                     BSLA_MAYBE_UNUSED const mqbu::StorageKey& appKey =
-                        ait->second;
+                        ait->first;
 
                     BSLS_ASSERT_SAFE(!appKey.isNull());
                     BSLS_ASSERT_SAFE(!appId.empty());
@@ -1806,11 +1788,12 @@ void StorageUtil::recoveredQueuesCb(
         bmqu::MemOutStream errorDesc;
         int                rc;
         if (domain->config().mode().isFanoutValue()) {
-            for (AppInfosCIter ait = appIdKeyPairs.begin();
+            for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator ait =
+                     appIdKeyPairs.begin();
                  ait != appIdKeyPairs.end();
                  ++ait) {
-                const bsl::string&      appId  = ait->first;
-                const mqbu::StorageKey& appKey = ait->second;
+                const bsl::string&      appId  = ait->second;
+                const mqbu::StorageKey& appKey = ait->first;
 
                 BSLS_ASSERT_SAFE(!appKey.isNull());
                 BSLS_ASSERT_SAFE(!appId.empty());
@@ -1883,7 +1866,7 @@ void StorageUtil::recoveredQueuesCb(
     typedef DataStoreRecordHandles::iterator DataStoreRecordHandlesIter;
 
     mqbs::FileStoreIterator fsIt(fs);
-    DataStoreRecordHandles  recordsToPurge;
+    DataStoreRecordHandles  recordsToPurge;  // TODO: allocator
 
     bsls::Types::Uint64 lastStrongConsistencySequenceNum    = 0;
     unsigned int        lastStrongConsistencyPrimaryLeaseId = 0;
@@ -1913,8 +1896,8 @@ void StorageUtil::recoveredQueuesCb(
             confirmReason = confRec.reason();
         }
         else if (mqbs::RecordType::e_QUEUE_OP == fsIt.type()) {
-            // TODO_CSL When we logically delete the QLIST file, will we still
-            // load QueueOp records here?
+            // TODO_CSL When we logically delete the QLIST file, we do not need
+            // 'e_DELETION/e_ADDITION' for Apps but we still need 'e_PURGE'
             mqbs::QueueOpRecord qOpRec;
             fsIt.loadQueueOpRecord(&qOpRec);
             queueKey    = qOpRec.queueKey();
@@ -1986,8 +1969,8 @@ void StorageUtil::recoveredQueuesCb(
             }
         }
 
-        // TODO_CSL When we logically delete the QLIST file, will we still
-        // do this here?
+        // TODO_CSL When we logically delete the QLIST file, we do not need
+        // 'e_DELETION' / 'e_ADDITION' for Apps but we still need 'e_PURGE'
         if (mqbs::RecordType::e_QUEUE_OP == fsIt.type()) {
             BSLS_ASSERT_SAFE(guid.isUnset());
             BSLS_ASSERT_SAFE(mqbs::QueueOpType::e_UNDEFINED != queueOpType);
@@ -2019,10 +2002,27 @@ void StorageUtil::recoveredQueuesCb(
             // even if indicated by the storage record.
         }
         else if (mqbs::RecordType::e_MESSAGE == fsIt.type()) {
+            QueueKeyInfoMapConstIter infoMapCit = queueKeyInfoMap.find(
+                queueKey);
+            BSLS_ASSERT_SAFE(infoMapCit != queueKeyInfoMap.end());
+
+            const mqbs::DataStoreRecordKey current(handle.sequenceNum(),
+                                                   handle.primaryLeaseId());
+
+            unsigned int numGhosts = infoMapCit->second.advanceAndCount(
+                current);
+            BSLS_ASSERT_SAFE(numGhosts < refCount);
+
+            BALL_LOG_INFO << clusterDescription << " Partition ["
+                          << partitionId << "]: Adjusting queueUri ["
+                          << infoMapCit->second.canonicalQueueUri()
+                          << "], queueKey [" << queueKey << ", current "
+                          << current << "] for " << numGhosts << " ghosts.";
+
             BSLS_ASSERT_SAFE(false == guid.isUnset());
             rs->processMessageRecord(guid,
                                      fs->getMessageLenRaw(handle),
-                                     refCount,
+                                     refCount - numGhosts,
                                      handle);
             if (isStrongConsistency) {
                 lastStrongConsistencySequenceNum    = handle.sequenceNum();
@@ -2064,6 +2064,12 @@ void StorageUtil::recoveredQueuesCb(
 
     fs->setLastStrongConsistency(lastStrongConsistencyPrimaryLeaseId,
                                  lastStrongConsistencySequenceNum);
+
+    // Calculate offsets
+    for (StorageSpMapIter it = storageMap->begin(); it != storageMap->end();
+         ++it) {
+        it->second->calibrate();
+    }
 }
 
 void StorageUtil::dumpUnknownRecoveredDomains(
@@ -2512,7 +2518,7 @@ void StorageUtil::registerQueue(
                  ++citer) {
                 mqbu::StorageKey appKey = generateAppKey(&appKeys, *citer);
 
-                appIdKeyPairsToUse.emplace(bsl::make_pair(*citer, appKey));
+                appIdKeyPairsToUse.insert(bsl::make_pair(*citer, appKey));
 
                 int rc = storageSp->addVirtualStorage(errorDesc,
                                                       *citer,
@@ -3050,11 +3056,9 @@ void StorageUtil::unregisterQueueReplicaDispatched(
     }
 
     // A specific appId is being deleted.
-    if (isCSLMode) {
-        rs->purge(appKey);
-    }
+    // No explicit 'purge', storage takes care of that when removing App
 
-    int rc = removeVirtualStorageInternal(rs, appKey, partitionId);
+    int rc = removeVirtualStorageInternal(rs, appKey, partitionId, false);
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("REPLICATION")
             << clusterDescription << " Partition [" << partitionId

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -237,7 +237,8 @@ struct StorageUtil {
 
     static int removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
                                             const mqbu::StorageKey&  appKey,
-                                            int partitionId);
+                                            int  partitionId,
+                                            bool asPrimary);
 
     /// Load the list of queue storages on the partition from the specified
     /// `fileStores` having the specified `partitionId` into the

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -37,6 +37,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqc_orderedhashmap.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_uri.h>
 
@@ -86,9 +87,9 @@ class ClusterStateManager {
         AfterPartitionPrimaryAssignmentCb;
 
     /// Pair of (appId, appKey)
-    typedef bsl::pair<bsl::string, mqbu::StorageKey> AppInfo;
-    typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
-    typedef AppInfos::const_iterator                 AppInfosCIter;
+    typedef bsl::pair<bsl::string, mqbu::StorageKey>            AppInfo;
+    typedef bmqc::OrderedHashMap<bsl::string, mqbu::StorageKey> AppInfos;
+    typedef AppInfos::const_iterator                            AppInfosCIter;
 
     struct QueueAssignmentResult {
         enum Enum {

--- a/src/groups/mqb/mqbi/mqbi_storage.cpp
+++ b/src/groups/mqb/mqbi/mqbi_storage.cpp
@@ -168,4 +168,29 @@ Storage::~Storage()
 }
 
 }  // close package namespace
+
+bsl::ostream&
+bmqu::operator<<(bsl::ostream&                                 stream,
+                 const bmqu::Printer<mqbi::Storage::AppInfos>& printer)
+{
+    stream << "{";
+
+    typedef mqbi::Storage::AppInfos::const_iterator Iter;
+
+    Iter begin = printer.obj().begin();
+    Iter end   = printer.obj().end();
+    for (Iter iter = begin; iter != end; ++iter) {
+        if (iter != begin) {
+            stream << ", ";
+        }
+
+        stream << bmqu::Printer<bsl::string>(&iter->first) << ":"
+               << bmqu::Printer<mqbu::StorageKey>(&iter->second);
+    }
+
+    stream << "}";
+
+    return stream;
+}
+
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -564,7 +564,9 @@ class Storage {
                                   const bsl::string&      appId,
                                   const mqbu::StorageKey& appKey) = 0;
 
-    /// Remove the virtual storage identified by the specified `appKey`.
+    /// Remove the virtual storage identified by the specified `appKey`.  The
+    /// specified `asPrimary` indicates if this storage need to write Purge
+    /// record in the case of persistent storage.
     /// Return true if a virtual storage with `appKey` was found and
     /// deleted, false if a virtual storage with `appKey` does not exist.
     /// Behavior is undefined unless `appKey` is non-null.  Note that this

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -40,6 +40,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqc_orderedhashmap.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_messageguid.h>
 #include <bmqt_uri.h>
@@ -271,15 +272,26 @@ struct DataStoreRecordKeyLess {
 class DataStoreConfigQueueInfo {
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfos AppInfos;
+    typedef bmqc::OrderedHashMap<mqbu::StorageKey, bsl::string>   AppInfos;
+    typedef bsl::multimap<DataStoreRecordKey, DataStoreRecordKey> PurgeOps;
+    typedef PurgeOps::const_iterator                              PurgeOp;
+    typedef bsl::unordered_map<mqbu::StorageKey, PurgeOp>         Ghosts;
 
   private:
     // DATA
+    bool d_isCSL;
+
     bsl::string d_canonicalUri;
 
     int d_partitionId;
 
     AppInfos d_appIdKeyPairs;
+
+    /// Ghosts are Apps which got removed before the current recovery.
+    Ghosts d_ghosts;
+
+    /// Second pass will cache the sequence of Purge intervals for Ghosts
+    mutable PurgeOps d_purgeOps;
 
   public:
     // TRAITS
@@ -287,7 +299,8 @@ class DataStoreConfigQueueInfo {
                                    bslma::UsesBslmaAllocator)
 
     // CREATORS
-    explicit DataStoreConfigQueueInfo(bslma::Allocator* basicAllocator = 0);
+    explicit DataStoreConfigQueueInfo(bool              isCSL,
+                                      bslma::Allocator* basicAllocator = 0);
 
     DataStoreConfigQueueInfo(const DataStoreConfigQueueInfo& other,
                              bslma::Allocator* basicAllocator = 0);
@@ -297,7 +310,23 @@ class DataStoreConfigQueueInfo {
 
     void setPartitionId(int value);
 
-    void addAppInfo(const AppInfos::const_iterator& value);
+    /// Save the specified `appId` and the specified `appKey` as a valid App
+    /// for which a Storage will be created.  If the same key was specified in
+    /// a previous `addPurgeOp` call, remove the App from the cache of Ghost
+    /// Apps.
+    void addAppInfo(const bsl::string& appId, const mqbu::StorageKey& appKey);
+
+    /// Cache the Purge interval from the specified `start` to the specified
+    /// `end` for the specified `key` unless the `key` was specified in a
+    /// previous `addAppInfo` call.
+    void addPurgeOp(const mqbu::StorageKey&   key,
+                    const DataStoreRecordKey& start,
+                    const DataStoreRecordKey& end);
+
+    /// Return the number of previously cached Purge intervals which contain
+    /// the specified `current` message.  Erase all Purge intervals for which
+    /// there ends is less than the `current`.
+    unsigned int advanceAndCount(const DataStoreRecordKey& current) const;
 
     // ACCESSORS
     const bsl::string& canonicalQueueUri() const;
@@ -594,10 +623,11 @@ class DataStore : public mqbi::DispatcherClient {
                                          bsls::Types::Uint64     timestamp,
                                          bool isNewQueue) = 0;
 
-    virtual int writeQueuePurgeRecord(DataStoreRecordHandle*  handle,
-                                      const mqbu::StorageKey& queueKey,
-                                      const mqbu::StorageKey& appKey,
-                                      bsls::Types::Uint64     timestamp) = 0;
+    virtual int writeQueuePurgeRecord(DataStoreRecordHandle*       handle,
+                                      const mqbu::StorageKey&      queueKey,
+                                      const mqbu::StorageKey&      appKey,
+                                      bsls::Types::Uint64          timestamp,
+                                      const DataStoreRecordHandle& start) = 0;
 
     virtual int writeQueueDeletionRecord(DataStoreRecordHandle*  handle,
                                          const mqbu::StorageKey& queueKey,
@@ -857,19 +887,26 @@ DataStoreRecordKeyLess::operator()(const DataStoreRecordKey& lhs,
 
 // CREATORS
 inline DataStoreConfigQueueInfo::DataStoreConfigQueueInfo(
+    bool              isCSL,
     bslma::Allocator* basicAllocator)
-: d_canonicalUri(basicAllocator)
+: d_isCSL(isCSL)
+, d_canonicalUri(basicAllocator)
 , d_partitionId(DataStore::k_INVALID_PARTITION_ID)
 , d_appIdKeyPairs(basicAllocator)
+, d_ghosts(basicAllocator)
+, d_purgeOps(basicAllocator)
 {
 }
 
 inline DataStoreConfigQueueInfo::DataStoreConfigQueueInfo(
     const DataStoreConfigQueueInfo& other,
     bslma::Allocator*               basicAllocator)
-: d_canonicalUri(other.d_canonicalUri, basicAllocator)
+: d_isCSL(other.d_isCSL)
+, d_canonicalUri(other.d_canonicalUri, basicAllocator)
 , d_partitionId(other.d_partitionId)
 , d_appIdKeyPairs(other.d_appIdKeyPairs, basicAllocator)
+, d_ghosts(other.d_ghosts, basicAllocator)
+, d_purgeOps(other.d_purgeOps, basicAllocator)
 {
 }
 
@@ -883,12 +920,6 @@ DataStoreConfigQueueInfo::setCanonicalQueueUri(const bsl::string& value)
 inline void DataStoreConfigQueueInfo::setPartitionId(int value)
 {
     d_partitionId = value;
-}
-
-inline void
-DataStoreConfigQueueInfo::addAppInfo(const AppInfos::const_iterator& value)
-{
-    d_appIdKeyPairs.emplace(value->first, value->second);
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -653,7 +653,7 @@ FileBackedStorage::writePurgeRecordImpl(bool                        alsoDelete,
                                         const mqbu::StorageKey&     appKey,
                                         const DataStoreRecordHandle start)
 {
-    bsls::Types::Uint64 timestamp = bdlt::EpochUtil::convertToTimeT64(
+    const bsls::Types::Uint64 timestamp = bdlt::EpochUtil::convertToTimeT64(
         bdlt::CurrentTime::utc());
     DataStoreRecordHandle handle;
     int                   rc = d_store_p->writeQueuePurgeRecord(&handle,
@@ -1060,7 +1060,7 @@ void FileBackedStorage::addQueueOpRecordHandle(
     d_queueOpRecordHandles.push_back(handle);
 }
 
-bool FileBackedStorage::purge(const mqbu::StorageKey& appKey)
+void FileBackedStorage::purge(const mqbu::StorageKey& appKey)
 {
     purgeCommon(appKey);
 
@@ -1078,8 +1078,6 @@ bool FileBackedStorage::purge(const mqbu::StorageKey& appKey)
 
         queue()->queueEngine()->afterQueuePurged(appId, appKey);
     }
-
-    return true;
 }
 
 void FileBackedStorage::selectForAutoConfirming(

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -70,9 +70,8 @@ void FileBackedStorage::purgeCommon(const mqbu::StorageKey& appKey)
     // to be purged, otherwise only the virtual storage associated with the
     // specified 'appKey'.
 
-    d_virtualStorageCatalog.removeAll(appKey);
-
     if (appKey.isNull()) {
+        d_virtualStorageCatalog.removeAll();
         // Remove all records from the physical storage as well.
 
         for (RecordHandleMapConstIter it = d_handles.begin();
@@ -94,6 +93,9 @@ void FileBackedStorage::purgeCommon(const mqbu::StorageKey& appKey)
         d_queueStats_sp
             ->onEvent<mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
                 d_handles.historySize());
+    }
+    else {
+        d_virtualStorageCatalog.removeAll(appKey);
     }
 }
 
@@ -341,14 +343,22 @@ FileBackedStorage::put(mqbi::StorageMessageAttributes*     attributes,
     // if we keep `irc` (like we keep 'DataStoreRecordHandle').
 
     if (d_autoConfirms.empty()) {
-        d_virtualStorageCatalog.put(msgGUID, msgSize, out);
+        d_virtualStorageCatalog.put(
+            msgGUID,
+            msgSize,
+            d_virtualStorageCatalog.numVirtualStorages(),
+            out);
     }
     else {
         mqbi::DataStreamMessage* dataStreamMessage = 0;
         if (out == 0) {
             out = &dataStreamMessage;
         }
-        d_virtualStorageCatalog.put(msgGUID, msgSize, out);
+        d_virtualStorageCatalog.put(
+            msgGUID,
+            msgSize,
+            d_virtualStorageCatalog.numVirtualStorages(),
+            out);
 
         // Move auto confirms to the data record
         for (AutoConfirms::const_iterator it = d_autoConfirms.begin();
@@ -574,19 +584,83 @@ FileBackedStorage::remove(const bmqt::MessageGUID& msgGUID, int* msgSize)
 mqbi::StorageResult::Enum
 FileBackedStorage::removeAll(const mqbu::StorageKey& appKey)
 {
-    bsl::string appId;
+    mqbi::StorageResult::Enum rc;
+
     if (!appKey.isNull()) {
-        if (!d_virtualStorageCatalog.hasVirtualStorage(appKey, &appId)) {
-            return mqbi::StorageResult::e_APPKEY_NOT_FOUND;  // RETURN
+        rc = d_virtualStorageCatalog.purge(
+            appKey,
+            bdlf::BindUtil::bind(&FileBackedStorage::writeAppPurgeRecord,
+                                 this,
+                                 false,
+                                 bdlf::PlaceHolders::_1,
+                                 bdlf::PlaceHolders::_2));
+        if (d_handles.empty()) {
+            d_isEmpty.storeRelaxed(1);
+        }
+    }
+    else {
+        rc = writeQueuePurgeRecord();
+        if (mqbi::StorageResult::e_SUCCESS == rc) {
+            purgeCommon(mqbu::StorageKey::k_NULL_KEY);
+
+            d_isEmpty.storeRelaxed(1);
+
+            return mqbi::StorageResult::e_SUCCESS;  // RETURN
         }
     }
 
+    d_queueStats_sp
+        ->onEvent<mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
+            d_handles.historySize());
+
+    return rc;
+}
+
+bool FileBackedStorage::removeVirtualStorage(const mqbu::StorageKey& appKey,
+                                             bool                    asPrimary)
+{
+    BSLS_ASSERT_SAFE(!appKey.isNull());
+
+    VirtualStorageCatalog::PurgeCallback cb;
+
+    if (asPrimary) {
+        cb = bdlf::BindUtil::bind(&FileBackedStorage::writeAppPurgeRecord,
+                                  this,
+                                  true,
+                                  bdlf::PlaceHolders::_1,
+                                  bdlf::PlaceHolders::_2);
+    }
+
+    mqbi::StorageResult::Enum rc =
+        d_virtualStorageCatalog.removeVirtualStorage(appKey, cb);
+
+    if (d_handles.empty()) {
+        d_isEmpty.storeRelaxed(1);
+    }
+
+    return mqbi::StorageResult::e_SUCCESS == rc;
+}
+
+mqbi::StorageResult::Enum FileBackedStorage::writeQueuePurgeRecord()
+{
+    return writePurgeRecordImpl(false,
+                                mqbu::StorageKey::k_NULL_KEY,
+                                DataStoreRecordHandle());
+}
+
+mqbi::StorageResult::Enum
+FileBackedStorage::writePurgeRecordImpl(bool                        alsoDelete,
+                                        const mqbu::StorageKey&     appKey,
+                                        const DataStoreRecordHandle start)
+{
+    bsls::Types::Uint64 timestamp = bdlt::EpochUtil::convertToTimeT64(
+        bdlt::CurrentTime::utc());
     DataStoreRecordHandle handle;
-    int                   rc = d_store_p->writeQueuePurgeRecord(
-        &handle,
-        d_queueKey,
-        appKey,
-        bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()));
+    int                   rc = d_store_p->writeQueuePurgeRecord(&handle,
+                                              d_queueKey,
+                                              appKey,
+                                              timestamp,
+                                              start);
 
     if (0 != rc) {
         return mqbi::StorageResult::e_WRITE_FAILURE;  // RETURN
@@ -594,30 +668,43 @@ FileBackedStorage::removeAll(const mqbu::StorageKey& appKey)
 
     d_queueOpRecordHandles.push_back(handle);
 
-    if (appKey.isNull()) {
-        purgeCommon(appKey);  // or 'mqbu::StorageKey::k_NULL_KEY'
-        flushStorage();
-        d_isEmpty.storeRelaxed(1);
+    if (alsoDelete) {
+        // Write QueueDeletionRecord to data store for removed appIds.
+        //
+        // TODO_CSL Do not write this record when we logically delete the
+        // QLIST file
 
-        return mqbi::StorageResult::e_SUCCESS;  // RETURN
+        rc = d_store_p->writeQueueDeletionRecord(&handle,
+                                                 d_queueKey,
+                                                 appKey,
+                                                 timestamp);
+        if (0 != rc) {
+            return mqbi::StorageResult::e_WRITE_FAILURE;  // RETURN
+        }
+
+        d_queueOpRecordHandles.push_back(handle);
     }
-
-    // A specific appKey is being purged.
-
-    d_virtualStorageCatalog.removeAll(appKey);
-    // This will call back 'releaseRef'
 
     flushStorage();
 
-    if (d_handles.empty()) {
-        d_isEmpty.storeRelaxed(1);
-    }
-
-    d_queueStats_sp
-        ->onEvent<mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
-            d_handles.historySize());
-
     return mqbi::StorageResult::e_SUCCESS;
+}
+
+mqbi::StorageResult::Enum FileBackedStorage::writeAppPurgeRecord(
+    bool                                             alsoDelete,
+    const mqbu::StorageKey&                          appKey,
+    const VirtualStorageCatalog::DataStreamIterator& first)
+{
+    // double lookup
+    RecordHandleMap::iterator itRecord = d_handles.find(first->first);
+    BSLS_ASSERT_SAFE(itRecord != d_handles.end());
+
+    DataStoreRecordHandle     start;  // !isValid()
+    const RecordHandlesArray& handles = itRecord->second.d_array;
+    BSLS_ASSERT(!handles.empty());
+    start = handles[0];
+
+    return writePurgeRecordImpl(alsoDelete, appKey, start);
 }
 
 void FileBackedStorage::flushStorage()
@@ -774,7 +861,7 @@ void FileBackedStorage::processMessageRecord(
         irc.first->second.d_refCount = refCount;
 
         if (d_autoConfirms.empty()) {
-            d_virtualStorageCatalog.put(guid, msgLen);
+            d_virtualStorageCatalog.put(guid, msgLen, refCount);
         }
         else {
             if (!d_currentlyAutoConfirming.isUnset()) {
@@ -782,6 +869,8 @@ void FileBackedStorage::processMessageRecord(
                     mqbi::DataStreamMessage* dataStreamMessage = 0;
                     d_virtualStorageCatalog.put(guid,
                                                 msgLen,
+                                                refCount +
+                                                    d_autoConfirms.size(),
                                                 &dataStreamMessage);
 
                     // Move auto confirms to the data record
@@ -959,10 +1048,11 @@ void FileBackedStorage::addQueueOpRecordHandle(
 {
     BSLS_ASSERT_SAFE(handle.isValid());
 
+    // The first Record must be 'e_CREATION'
 #ifdef BSLS_ASSERT_SAFE_IS_ACTIVE
-    if (!d_queueOpRecordHandles.empty()) {
+    if (d_queueOpRecordHandles.empty()) {
         QueueOpRecord rec;
-        d_store_p->loadQueueOpRecordRaw(&rec, d_queueOpRecordHandles[0]);
+        d_store_p->loadQueueOpRecordRaw(&rec, handle);
         BSLS_ASSERT_SAFE(QueueOpType::e_CREATION == rec.type());
     }
 #endif
@@ -970,7 +1060,7 @@ void FileBackedStorage::addQueueOpRecordHandle(
     d_queueOpRecordHandles.push_back(handle);
 }
 
-void FileBackedStorage::purge(const mqbu::StorageKey& appKey)
+bool FileBackedStorage::purge(const mqbu::StorageKey& appKey)
 {
     purgeCommon(appKey);
 
@@ -988,6 +1078,8 @@ void FileBackedStorage::purge(const mqbu::StorageKey& appKey)
 
         queue()->queueEngine()->afterQueuePurged(appId, appKey);
     }
+
+    return true;
 }
 
 void FileBackedStorage::selectForAutoConfirming(
@@ -1024,6 +1116,11 @@ void FileBackedStorage::setPrimary()
     d_queueStats_sp
         ->onEvent<mqbstat::QueueStatsDomain::EventType::e_CHANGE_ROLE>(
             mqbstat::QueueStatsDomain::Role::e_PRIMARY);
+}
+
+void FileBackedStorage::calibrate()
+{
+    d_virtualStorageCatalog.calibrate();
 }
 
 void FileBackedStorage::clearSelection()

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -226,15 +226,29 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// Clear the state created by 'selectForAutoConfirming'.
     void clearSelection();
 
+    /// Write QueuePurgeRecord to the persistent data store for the App with
+    /// specified `appKey`.  The specified `first` references the first (the
+    /// oldest) message for this App.  If the specified `alsoDelete` is `true`,
+    /// follow by writing QueueDeletionRecord.
     mqbi::StorageResult::Enum writeAppPurgeRecord(
         bool                                             alsoDelete,
         const mqbu::StorageKey&                          appKey,
         const VirtualStorageCatalog::DataStreamIterator& first);
+
+    /// Write QueuePurgeRecord to the persistent data store for the entire
+    /// queue.
     mqbi::StorageResult::Enum writeQueuePurgeRecord();
+
+    /// Write QueuePurgeRecord to the persistent data store for with the
+    /// specified `appKey`.  If the `appKey` is `mqbu::StorageKey::k_NULL_KEY`,
+    /// the QueuePurgeRecord applies to the entire queue.  Otherwise, the
+    /// specified `start` references the first (the  oldest) message for the
+    /// App with the `appKey`.
     mqbi::StorageResult::Enum
     writePurgeRecordImpl(bool                        alsoDelete,
                          const mqbu::StorageKey&     appKey,
                          const DataStoreRecordHandle start);
+
     // PRIVATE ACCESSORS
 
     /// Callback function called by `d_capacityMeter` to log appllications
@@ -512,7 +526,9 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
                       const bsl::string&      appId,
                       const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
-    /// Remove the virtual storage identified by the specified `appKey`.
+    /// Remove the virtual storage identified by the specified `appKey`.  The
+    /// specified `asPrimary` indicates if this storage need to write Purge
+    /// record in the case of persistent storage.
     /// Return true if a virtual storage with `appKey` was found and
     /// deleted, false if a virtual storage with `appKey` does not exist.
     /// Behavior is undefined unless `appKey` is non-null.  Note that this
@@ -540,7 +556,7 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     void addQueueOpRecordHandle(const DataStoreRecordHandle& handle)
         BSLS_KEYWORD_OVERRIDE;
 
-    bool purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
+    void purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
     void selectForAutoConfirming(const bmqt::MessageGUID& msgGUID)
         BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -352,7 +352,9 @@ class MockDataStore : public mqbs::DataStore {
     int writeQueuePurgeRecord(mqbs::DataStoreRecordHandle*,
                               const mqbu::StorageKey&,
                               const mqbu::StorageKey&,
-                              bsls::Types::Uint64) BSLS_KEYWORD_OVERRIDE
+                              bsls::Types::Uint64,
+                              const mqbs::DataStoreRecordHandle&)
+        BSLS_KEYWORD_OVERRIDE
     {
         return 0;
     }
@@ -442,10 +444,11 @@ class MockDataStore : public mqbs::DataStore {
     {
     }
 
-    void loadQueueOpRecordRaw(mqbs::QueueOpRecord*,
+    void loadQueueOpRecordRaw(mqbs::QueueOpRecord* rec,
                               const mqbs::DataStoreRecordHandle&) const
         BSLS_KEYWORD_OVERRIDE
     {
+        rec->setType(mqbs::QueueOpType::e_CREATION);
     }
 
     unsigned int getMessageLenRaw(const mqbs::DataStoreRecordHandle&) const
@@ -1128,14 +1131,14 @@ BMQTST_TEST_F(Test, removeVirtualStorage)
     storage.addVirtualStorage(errDescription, k_APP_ID2, k_APP_KEY2);
 
     // Verify removal
-    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY1));
+    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY1, true));
     BMQTST_ASSERT(!storage.hasVirtualStorage(k_APP_KEY1, &dummyAppId));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 1);
 
-    BMQTST_ASSERT(!storage.removeVirtualStorage(k_APP_KEY3));
+    BMQTST_ASSERT(!storage.removeVirtualStorage(k_APP_KEY3, true));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 1);
 
-    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY2));
+    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY2, true));
     BMQTST_ASSERT(!storage.hasVirtualStorage(k_APP_KEY2, &dummyAppId));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 0);
 }

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1830,7 +1830,6 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         DataStoreRecordKey(rec.startSequenceNumber(),
                                            rec.startPrimaryLeaseId()),
                         key);
-                    // Skip "empty" App PURGE - the one with empty range
                 }
 
                 DataStoreRecord    record(RecordType::e_QUEUE_OP,
@@ -2104,8 +2103,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                                         appIdsBlock,
                                                         numAppIds);
 
-                    for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
-                         cit != appIdKeyPairs.end();
+                    for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
+                         cit != appIdKeyPairs.cend();
                          ++cit) {
                         if (0 == deletedAppKeysOffsets.count(cit->second)) {
                             // This appKey is not deleted.  Add it to the list
@@ -2414,8 +2413,6 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 deletedGuids.erase(delGuidIter);
                 continue;  // CONTINUE
             }
-
-            // TODO: apply all Apps purge ops, including deleted Apps
 
             // The message needs to be recovered as it is an outstanding one.
             // Check various fields in the message header etc as well as the
@@ -4403,8 +4400,8 @@ int FileStore::writeQueueCreationRecord(
             BALL_LOG_OUTPUT_STREAM << ", queue [" << quri << "]"
                                    << ", with [" << appIdKeyPairs.size()
                                    << "] appId/appKey pairs ";
-            for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
-                 cit != appIdKeyPairs.end();
+            for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
+                 cit != appIdKeyPairs.cend();
                  ++cit) {
                 BALL_LOG_OUTPUT_STREAM << " [" << cit->first << ", "
                                        << cit->second << "]";
@@ -5754,8 +5751,8 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
                       queueUri.asString().length() + queueUriPadding +
                       FileStoreProtocol::k_HASH_LENGTH;
         size_t i = 0;
-        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
-             cit != appIdKeyPairs.end();
+        for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
+             cit != appIdKeyPairs.cend();
              ++cit, ++i) {
             BSLS_ASSERT_SAFE(!cit->first.empty());
             BSLS_ASSERT_SAFE(!cit->second.isNull());
@@ -5862,8 +5859,8 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
 
         // 3) Append AppIds and AppKeys
         size_t i = 0;
-        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
-             cit != appIdKeyPairs.end();
+        for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
+             cit != appIdKeyPairs.cend();
              ++cit, ++i) {
             // Append AppIdHeader.
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -945,8 +945,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&          errorDescription,
     }
 
     // Close file set as it is in read mode.
-    close(*fileSetSp,
-          false);  // flush
+    close(*fileSetSp, false);  // flush
 
     // Re-open in write mode, grow & map (do not delete on failure).
     bmqu::MemOutStream errorDesc;
@@ -1158,6 +1157,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
     BSLS_ASSERT_SAFE(journalIt.isReverseMode());
 
     // First pass.
+    // Populate 'queueKeyInfoMap' while skipping deleted queues
     int rc = 0;
     while ((rc = journalIt.nextRecord()) == 1) {
         const RecordHeader& recHeader = journalIt.recordHeader();
@@ -1289,6 +1289,9 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 }
             }
             else {
+                // TODO_CSL: Remove this block.
+                // CSL does not need 'e_DELETION' for Apps
+
                 StorageKeysOffsetsInsertRc irc = deletedAppKeysOffsets.insert(
                     bsl::make_pair(appKey, journalIt.recordOffset()));
 
@@ -1326,6 +1329,9 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             continue;  // CONTINUE
         }
         else if (QueueOpType::e_ADDITION == queueOpType) {
+            // TODO_CSL: Remove this block.
+            // CSL does not need 'e_ADDITION' for Apps
+
             // No need to keep track of appIds/appKeys in the 1st pass.  It
             // will be done in 2nd pass.  Just perform some basic validation.
 
@@ -1434,7 +1440,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 // 'QueueOpType::e_ADDITION' as well).
 
                 QueueKeyInfoMapInsertRc insertRc = queueKeyInfoMap->insert(
-                    bsl::make_pair(queueKey, DataStoreConfigQueueInfo()));
+                    bsl::make_pair(queueKey, DataStoreConfigQueueInfo(false)));
                 insertRc.first->second.setPartitionId(d_config.partitionId());
 
                 if (false == insertRc.second) {
@@ -1758,6 +1764,14 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
             }
             else if (QueueOpType::e_PURGE == queueOpType) {
+                DataStoreRecordKey key(sequenceNum, primaryLeaseId);
+
+                BALL_LOG_INFO << partitionDesc() << "PurgeOp for " << appKey
+                              << " from "
+                              << DataStoreRecordKey(rec.startSequenceNumber(),
+                                                    rec.startPrimaryLeaseId())
+                              << " to " << key;
+
                 StorageKeysOffsetsConstIter queueIt =
                     deletedQueueKeysOffsets.find(queueKey);
 
@@ -1770,8 +1784,10 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         continue;  // CONTINUE
                     }
                 }
+                QueueKeyInfoMap::iterator iter = queueKeyInfoMap->find(
+                    queueKey);
 
-                if (0 == queueKeyInfoMap->count(queueKey)) {
+                if (iter == queueKeyInfoMap->end()) {
                     if (d_isFSMWorkflow) {
                         BALL_LOG_ERROR
                             << partitionDesc()
@@ -1801,7 +1817,22 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     purgedQueueKeys.insert(queueKey);
                 }
 
-                DataStoreRecordKey key(sequenceNum, primaryLeaseId);
+                else {
+                    BALL_LOG_INFO
+                        << partitionDesc() << "Adding PurgeOp for " << appKey
+                        << " from "
+                        << DataStoreRecordKey(rec.startSequenceNumber(),
+                                              rec.startPrimaryLeaseId())
+                        << " to " << key;
+
+                    iter->second.addPurgeOp(
+                        appKey,
+                        DataStoreRecordKey(rec.startSequenceNumber(),
+                                           rec.startPrimaryLeaseId()),
+                        key);
+                    // Skip "empty" App PURGE - the one with empty range
+                }
+
                 DataStoreRecord    record(RecordType::e_QUEUE_OP,
                                        jit->recordOffset());
                 d_records.rinsert(bsl::make_pair(key, record));
@@ -1973,6 +2004,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
 
                 QueueKeyInfoMap::iterator iter = queueKeyInfoMap->find(
                     queueKey);
+
                 if (!d_isFSMWorkflow &&
                     QueueOpType::e_ADDITION == queueOpType &&
                     iter == queueKeyInfoMap->end()) {
@@ -2072,8 +2104,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                                         appIdsBlock,
                                                         numAppIds);
 
-                    for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
-                         cit != appIdKeyPairs.cend();
+                    for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
+                         cit != appIdKeyPairs.end();
                          ++cit) {
                         if (0 == deletedAppKeysOffsets.count(cit->second)) {
                             // This appKey is not deleted.  Add it to the list
@@ -2083,7 +2115,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             // StorageMgr because we have recovered all
                             // appId/appKey pairs by that time.
 
-                            qinfo.addAppInfo(cit);
+                            qinfo.addAppInfo(cit->first, cit->second);
 
                             BALL_LOG_INFO << partitionDesc()
                                           << "Recovered appId/appKey pair ['"
@@ -2382,6 +2414,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 deletedGuids.erase(delGuidIter);
                 continue;  // CONTINUE
             }
+
+            // TODO: apply all Apps purge ops, including deleted Apps
 
             // The message needs to be recovered as it is an outstanding one.
             // Check various fields in the message header etc as well as the
@@ -3409,7 +3443,9 @@ int FileStore::writeQueueOpRecord(DataStoreRecordHandle*  handle,
                                   const mqbu::StorageKey& queueKey,
                                   const mqbu::StorageKey& appKey,
                                   QueueOpType::Enum       queueOpFlag,
-                                  bsls::Types::Uint64     timestamp)
+                                  bsls::Types::Uint64     timestamp,
+                                  unsigned int            startPrimaryLeaseId,
+                                  bsls::Types::Uint64     startSequenceNum)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(handle);
@@ -3472,6 +3508,8 @@ int FileStore::writeQueueOpRecord(DataStoreRecordHandle*  handle,
         .setSequenceNumber(++d_sequenceNum)
         .setTimestamp(timestamp);
     qRec->setQueueKey(queueKey).setType(queueOpFlag);
+    qRec->setStartSequenceNumber(startSequenceNum);
+    qRec->setStartPrimaryLeaseId(startPrimaryLeaseId);
 
     if (!appKey.isNull()) {
         qRec->setAppKey(appKey);
@@ -4365,8 +4403,8 @@ int FileStore::writeQueueCreationRecord(
             BALL_LOG_OUTPUT_STREAM << ", queue [" << quri << "]"
                                    << ", with [" << appIdKeyPairs.size()
                                    << "] appId/appKey pairs ";
-            for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
-                 cit != appIdKeyPairs.cend();
+            for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
+                 cit != appIdKeyPairs.end();
                  ++cit) {
                 BALL_LOG_OUTPUT_STREAM << " [" << cit->first << ", "
                                        << cit->second << "]";
@@ -5716,8 +5754,8 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
                       queueUri.asString().length() + queueUriPadding +
                       FileStoreProtocol::k_HASH_LENGTH;
         size_t i = 0;
-        for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
-             cit != appIdKeyPairs.cend();
+        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
+             cit != appIdKeyPairs.end();
              ++cit, ++i) {
             BSLS_ASSERT_SAFE(!cit->first.empty());
             BSLS_ASSERT_SAFE(!cit->second.isNull());
@@ -5824,8 +5862,8 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
 
         // 3) Append AppIds and AppKeys
         size_t i = 0;
-        for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
-             cit != appIdKeyPairs.cend();
+        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
+             cit != appIdKeyPairs.end();
              ++cit, ++i) {
             // Append AppIdHeader.
 
@@ -5911,16 +5949,29 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
     return rc_SUCCESS;
 }
 
-int FileStore::writeQueuePurgeRecord(DataStoreRecordHandle*  handle,
-                                     const mqbu::StorageKey& queueKey,
-                                     const mqbu::StorageKey& appKey,
-                                     bsls::Types::Uint64     timestamp)
+int FileStore::writeQueuePurgeRecord(DataStoreRecordHandle*       handle,
+                                     const mqbu::StorageKey&      queueKey,
+                                     const mqbu::StorageKey&      appKey,
+                                     bsls::Types::Uint64          timestamp,
+                                     const DataStoreRecordHandle& start)
 {
+    unsigned int        startPrimaryLeaseId = 0;
+    bsls::Types::Uint64 startSequenceNum    = 0;
+
+    if (!appKey.isNull()) {
+        BSLS_ASSERT_SAFE(start.isValid());
+
+        startPrimaryLeaseId = start.primaryLeaseId();
+        startSequenceNum    = start.sequenceNum();
+    }
+
     return writeQueueOpRecord(handle,
                               queueKey,
                               appKey,
                               QueueOpType::e_PURGE,
-                              timestamp);
+                              timestamp,
+                              startPrimaryLeaseId,
+                              startSequenceNum);
 }
 
 int FileStore::writeQueueDeletionRecord(DataStoreRecordHandle*  handle,
@@ -5932,7 +5983,9 @@ int FileStore::writeQueueDeletionRecord(DataStoreRecordHandle*  handle,
                               queueKey,
                               appKey,
                               QueueOpType::e_DELETION,
-                              timestamp);
+                              timestamp,
+                              0,
+                              0);
 }
 
 int FileStore::writeConfirmRecord(DataStoreRecordHandle*   handle,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -511,12 +511,17 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
     /// Write a QUEUE_OP record to the journal with the specified
     /// `queueKey`, optional `appKey`, `timestamp`, `opValue` and `subValue`
-    /// to the journal.  Return zero on success, non-zero value otherwise.
+    /// to the journal.  If the specified `start` is set, it specifies the
+    /// beginning of the range for which this QUEUE_OP applies; otherwise, the
+    /// range includes all records.
+    /// Return zero on success, non-zero value otherwise.
     int writeQueueOpRecord(DataStoreRecordHandle*  handle,
                            const mqbu::StorageKey& queueKey,
                            const mqbu::StorageKey& appKey,
                            QueueOpType::Enum       queueOpFlag,
-                           bsls::Types::Uint64     timestamp);
+                           bsls::Types::Uint64     timestamp,
+                           unsigned int            startPrimaryLeaseId,
+                           bsls::Types::Uint64     startSequenceNum);
 
     /// Rollover over the specified `record` from `oldFileSet` to the
     /// `newFileSet`, and if it is a message record, update the counter of
@@ -777,11 +782,12 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                                  bsls::Types::Uint64     timestamp,
                                  bool isNewQueue) BSLS_KEYWORD_OVERRIDE;
 
-    int
-    writeQueuePurgeRecord(DataStoreRecordHandle*  handle,
-                          const mqbu::StorageKey& queueKey,
-                          const mqbu::StorageKey& appKey,
-                          bsls::Types::Uint64 timestamp) BSLS_KEYWORD_OVERRIDE;
+    int writeQueuePurgeRecord(DataStoreRecordHandle*       handle,
+                              const mqbu::StorageKey&      queueKey,
+                              const mqbu::StorageKey&      appKey,
+                              bsls::Types::Uint64          timestamp,
+                              const DataStoreRecordHandle& start)
+        BSLS_KEYWORD_OVERRIDE;
 
     int writeQueueDeletionRecord(DataStoreRecordHandle*  handle,
                                  const mqbu::StorageKey& queueKey,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -511,9 +511,9 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
     /// Write a QUEUE_OP record to the journal with the specified
     /// `queueKey`, optional `appKey`, `timestamp`, `opValue` and `subValue`
-    /// to the journal.  If the specified `start` is set, it specifies the
-    /// beginning of the range for which this QUEUE_OP applies; otherwise, the
-    /// range includes all records.
+    /// to the journal.  If the specified `startPrimaryLeaseId` and
+    /// `startSequenceNum` are set, they specify the beginning of the range for
+    /// which this QUEUE_OP applies; otherwise, the range includes all records.
     /// Return zero on success, non-zero value otherwise.
     int writeQueueOpRecord(DataStoreRecordHandle*  handle,
                            const mqbu::StorageKey& queueKey,

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -92,15 +92,6 @@ typedef bsl::pair<mqbs::DataStoreRecordHandle, Record> HandleRecordPair;
 
 // FUNCTIONS
 
-/// Create a new blob at the specified `arena` address, using the specified
-/// `bufferFactory` and `allocator`.
-void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
-                void*                     arena,
-                bslma::Allocator*         allocator)
-{
-    new (arena) bdlbb::Blob(bufferFactory, allocator);
-}
-
 void queueCreationCb(int*                    status,
                      int                     partitionId,
                      const bmqt::Uri&        uri,
@@ -658,7 +649,8 @@ struct Tester {
                 rc = fs->writeQueuePurgeRecord(&handle,
                                                rec.d_queueKey,
                                                mqbu::StorageKey(),
-                                               rec.d_timestamp);
+                                               rec.d_timestamp,
+                                               mqbs::DataStoreRecordHandle());
                 if (0 != rc) {
                     bsl::cout << "Error writing QueuePurgeRecord, rc: " << rc
                               << bsl::endl;

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -1718,11 +1718,11 @@ struct QueueOpRecord {
     //   +---------------+---------------+---------------+---------------+
     //   |                   QueueUriRecordOffsetWords                   |
     //   +---------------+---------------+---------------+---------------+
-    //   |                           Reserved                            |
+    //   |          Start of the range Sequence Number Upper Bits        |
     //   +---------------+---------------+---------------+---------------+
-    //   |                           Reserved                            |
+    //   |          Start of the range Sequence Number Lower Bits        |
     //   +---------------+---------------+---------------+---------------+
-    //   |                           Reserved                            |
+    //   |          Start of the range Primary Lease Id                  |
     //   +---------------+---------------+---------------+---------------+
     //   |                           Reserved                            |
     //   +---------------+---------------+---------------+---------------+
@@ -1760,7 +1760,13 @@ struct QueueOpRecord {
 
     bdlb::BigEndianUint32 d_queueUriRecordOffsetWords;
 
-    char d_reserved2[16];
+    bdlb::BigEndianUint32 d_startSequenceNumberUpper;
+
+    bdlb::BigEndianUint32 d_startSequenceNumberLower;
+
+    bdlb::BigEndianUint32 d_startPrimaryLeaseId;
+
+    char d_reserved2[4];
 
     bdlb::BigEndianUint32 d_magic;
 
@@ -1783,6 +1789,9 @@ struct QueueOpRecord {
 
     QueueOpRecord& setQueueUriRecordOffsetWords(unsigned int value);
 
+    QueueOpRecord& setStartSequenceNumber(bsls::Types::Uint64 value);
+    QueueOpRecord& setStartPrimaryLeaseId(unsigned int value);
+
     QueueOpRecord& setMagic(unsigned int value);
 
     // ACCESSORS
@@ -1797,6 +1806,10 @@ struct QueueOpRecord {
     QueueOpType::Enum type() const;
 
     unsigned int queueUriRecordOffsetWords() const;
+
+    bsls::Types::Uint64 startSequenceNumber() const;
+
+    unsigned int startPrimaryLeaseId() const;
 
     unsigned int magic() const;
 
@@ -2993,6 +3006,21 @@ QueueOpRecord::setQueueUriRecordOffsetWords(unsigned int value)
     return *this;
 }
 
+inline QueueOpRecord&
+QueueOpRecord::setStartSequenceNumber(bsls::Types::Uint64 value)
+{
+    bmqp::Protocol::split(&d_startSequenceNumberUpper,
+                          &d_startSequenceNumberLower,
+                          value);
+    return *this;
+}
+
+inline QueueOpRecord& QueueOpRecord::setStartPrimaryLeaseId(unsigned int value)
+{
+    d_startPrimaryLeaseId = value;
+    return *this;
+}
+
 inline QueueOpRecord& QueueOpRecord::setMagic(unsigned int value)
 {
     d_magic = value;
@@ -3028,6 +3056,17 @@ inline QueueOpType::Enum QueueOpRecord::type() const
 inline unsigned int QueueOpRecord::queueUriRecordOffsetWords() const
 {
     return d_queueUriRecordOffsetWords;
+}
+
+inline bsls::Types::Uint64 QueueOpRecord::startSequenceNumber() const
+{
+    return bmqp::Protocol::combine(d_startSequenceNumberUpper,
+                                   d_startSequenceNumberLower);
+}
+
+inline unsigned int QueueOpRecord::startPrimaryLeaseId() const
+{
+    return d_startPrimaryLeaseId;
 }
 
 inline unsigned int QueueOpRecord::magic() const

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -1738,6 +1738,8 @@ struct QueueOpRecord {
     //  QueueUriRecordOffsetWords..: Offset (in WORDS) of the QueueUriRecord in
     //                               the QLIST file.  Valid only if
     //                               QueueOpType == CREATION or ADDITION.
+    //  Start of the range         : The oldest message affected by PURGE.
+    //                               Valid when QueueOpType == PURGE only.
     //  Magic......................: Magic word
     //..
     //

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
@@ -372,6 +372,8 @@ void printRecord(bsl::ostream& stream, const mqbs::QueueOpRecord& rec)
         mqbs::QueueOpType::e_ADDITION == rec.type()) {
         fields.push_back("QLIST OffsetWords");
     }
+    fields.push_back("StartPrimaryLeaseId");
+    fields.push_back("StartSequenceNumber");
 
     bmqu::MemOutStream queueKeyStr, appKeyStr;
     queueKeyStr << rec.queueKey();
@@ -402,6 +404,7 @@ void printRecord(bsl::ostream& stream, const mqbs::QueueOpRecord& rec)
         mqbs::QueueOpType::e_ADDITION == rec.type()) {
         printer << rec.queueUriRecordOffsetWords();
     }
+    printer << rec.startPrimaryLeaseId() << rec.startSequenceNumber();
 
     stream << "\n";
 }

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
@@ -331,14 +331,12 @@ int FileStoreProtocolUtil::calculateMd5Digest(
 }
 
 void FileStoreProtocolUtil::loadAppInfos(
-    bsl::unordered_map<bsl::string, mqbu::StorageKey>* appIdKeyPairs,
-    const MemoryBlock&                                 appIdsBlock,
-    unsigned int                                       numAppIds)
+    mqbi::Storage::AppInfos* appIdKeyPairs,
+    const MemoryBlock&       appIdsBlock,
+    unsigned int             numAppIds)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(appIdKeyPairs);
-
-    appIdKeyPairs->reserve(numAppIds);
 
     // 'appIdsAreaBegin' should point to the beginning of 1st 'AppIdHeader'.
     unsigned int offset = 0;
@@ -351,12 +349,12 @@ void FileStoreProtocolUtil::loadAppInfos(
         const char* appIdBegin = appIdsBlock.base() + offset +
                                  sizeof(AppIdHeader);
 
-        appIdKeyPairs->emplace(
+        appIdKeyPairs->insert(bsl::make_pair(
             bsl::string(appIdBegin,
                         paddedLen - appIdBegin[paddedLen - 1],
                         appIdKeyPairs->get_allocator()),
             mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
-                             appIdBegin + paddedLen));
+                             appIdBegin + paddedLen)));
 
         // Move to beginning of next AppIdHeader.
         offset += sizeof(AppIdHeader) + paddedLen +

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
@@ -28,8 +28,8 @@
 // file store protocol, in the 'mqbs::FileStoreProtocolUtil' namespace.
 
 // MQB
-
 #include <mqbconfm_messages.h>
+#include <mqbi_storage.h>
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_mappedfiledescriptor.h>
 #include <mqbu_storagekey.h>
@@ -108,10 +108,9 @@ struct FileStoreProtocolUtil {
                                   const bmqu::BlobPosition& startPos,
                                   unsigned int              length);
 
-    static void loadAppInfos(
-        bsl::unordered_map<bsl::string, mqbu::StorageKey>* appIdKeyPairs,
-        const MemoryBlock&                                 appIdsBlock,
-        unsigned int                                       numAppIds);
+    static void loadAppInfos(mqbi::Storage::AppInfos* appIdKeyPairs,
+                             const MemoryBlock&       appIdsBlock,
+                             unsigned int             numAppIds);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
@@ -517,7 +517,7 @@ static void test4_loadAppInfos()
 //   loadAppInfos()
 // ------------------------------------------------------------------------
 {
-    typedef bsl::unordered_map<bsl::string, mqbu::StorageKey> AppInfos;
+    typedef mqbi::Storage::AppInfos AppInfos;
 
     {
         // No appIds.
@@ -665,9 +665,9 @@ static void test4_loadAppInfos()
                         appHash,
                         mqbs::FileStoreProtocol::k_HASH_LENGTH);
 
-            expectedAppInfos.emplace(
+            expectedAppInfos.insert(bsl::make_pair(
                 bsl::string(appId, bmqtst::TestHelperUtil::allocator()),
-                appKey);
+                appKey));
             offset += mqbs::FileStoreProtocol::k_HASH_LENGTH;
         }
         // Test.
@@ -679,7 +679,12 @@ static void test4_loadAppInfos()
                                                   numAppIds);
 
         BMQTST_ASSERT_EQ(static_cast<size_t>(numAppIds), appIdKeyPairs.size());
-        BMQTST_ASSERT_EQ(appIdKeyPairs, expectedAppInfos);
+
+        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
+             cit != appIdKeyPairs.end();
+             ++cit) {
+            BMQTST_ASSERT_EQ(expectedAppInfos.count(cit->first), 1);
+        }
 
         bmqtst::TestHelperUtil::allocator()->deallocate(p);
     }

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -623,14 +623,12 @@ void InMemoryStorage::addQueueOpRecordHandle(
     d_queueOpRecordHandles.push_back(handle);
 }
 
-bool InMemoryStorage::purge(
+void InMemoryStorage::purge(
     BSLS_ANNOTATION_UNUSED const mqbu::StorageKey& appKey)
 {
     // Replicated in-memory storage is not yet supported.
 
     BSLS_ASSERT_OPT(false && "Invalid operation on in-memory storage");
-
-    return false;
 }
 
 void InMemoryStorage::setPrimary()

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -406,7 +406,8 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     // 'errorDescription' with a brief reason in case of failure.  Behavior
     // is undefined unless 'appId' is non-empty and 'appKey' is non-null.
 
-    /// Remove the virtual storage identified by the specified `appKey`.
+    /// Remove the virtual storage identified by the specified `appKey`.  The
+    /// specified `asPrimary` applies to persistent storage types only.
     /// Return true if a virtual storage with `appKey` was found and
     /// deleted, false if a virtual storage with `appKey` does not exist.
     /// Behavior is undefined unless `appKey` is non-null.  Note that this
@@ -547,7 +548,7 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     void addQueueOpRecordHandle(const DataStoreRecordHandle& handle)
         BSLS_KEYWORD_OVERRIDE;
 
-    bool purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
+    void purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
     virtual void setPrimary() BSLS_KEYWORD_OVERRIDE;
 

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -412,8 +412,8 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// Behavior is undefined unless `appKey` is non-null.  Note that this
     /// method will delete the virtual storage, and any reference to it will
     /// become invalid after this method returns.
-    bool
-    removeVirtualStorage(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
+    bool removeVirtualStorage(const mqbu::StorageKey& appKey,
+                              bool asPrimary) BSLS_KEYWORD_OVERRIDE;
 
     void selectForAutoConfirming(const bmqt::MessageGUID& msgGUID)
         BSLS_KEYWORD_OVERRIDE;
@@ -547,9 +547,13 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     void addQueueOpRecordHandle(const DataStoreRecordHandle& handle)
         BSLS_KEYWORD_OVERRIDE;
 
-    void purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
+    bool purge(const mqbu::StorageKey& appKey) BSLS_KEYWORD_OVERRIDE;
 
     virtual void setPrimary() BSLS_KEYWORD_OVERRIDE;
+
+    /// Calculate offsets of all Apps (after recovery) in the data stream.
+    /// An App offset is the number of messages older than the App.
+    virtual void calibrate() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
     //   (virtual mqbs::ReplicatedStorage)
@@ -674,11 +678,14 @@ inline int InMemoryStorage::addVirtualStorage(bsl::ostream& errorDescription,
 }
 
 inline bool
-InMemoryStorage::removeVirtualStorage(const mqbu::StorageKey& appKey)
+InMemoryStorage::removeVirtualStorage(const mqbu::StorageKey& appKey, bool)
 {
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
-    return d_virtualStorageCatalog.removeVirtualStorage(appKey);
+    mqbi::StorageResult::Enum rc =
+        d_virtualStorageCatalog.removeVirtualStorage(appKey);
+
+    return mqbi::StorageResult::e_SUCCESS == rc;
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -787,14 +787,14 @@ BMQTST_TEST_F(Test, removeVirtualStorage)
     storage.addVirtualStorage(errDescription, k_APP_ID2, k_APP_KEY2);
 
     // Verify removal
-    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY1));
+    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY1, true));
     BMQTST_ASSERT(!storage.hasVirtualStorage(k_APP_KEY1, &dummyAppId));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 1);
 
-    BMQTST_ASSERT(!storage.removeVirtualStorage(k_APP_KEY3));
+    BMQTST_ASSERT(!storage.removeVirtualStorage(k_APP_KEY3, true));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 1);
 
-    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY2));
+    BMQTST_ASSERT(storage.removeVirtualStorage(k_APP_KEY2, true));
     BMQTST_ASSERT(!storage.hasVirtualStorage(k_APP_KEY2, &dummyAppId));
     BMQTST_ASSERT_EQ(storage.numVirtualStorages(), 0);
 }

--- a/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
@@ -96,10 +96,14 @@ class ReplicatedStorage : public mqbi::Storage {
     /// If `appKey` is null, purge the physical as well as all virtual
     /// storages.  Note that this routine is supposed to be invoked at
     /// replica nodes, and the record will not be replicated to peer nodes.
-    virtual void purge(const mqbu::StorageKey& appKey) = 0;
+    virtual bool purge(const mqbu::StorageKey& appKey) = 0;
 
-    // Notify the storage of node role set to primary
+    /// Notify the storage of node role set to primary
     virtual void setPrimary() = 0;
+
+    /// Calculate offsets of all Apps (after recovery) in the data stream.
+    /// An App offset is the number of messages older than the App.
+    virtual void calibrate() = 0;
 
     // ACCESSORS
 

--- a/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_replicatedstorage.h
@@ -96,7 +96,7 @@ class ReplicatedStorage : public mqbi::Storage {
     /// If `appKey` is null, purge the physical as well as all virtual
     /// storages.  Note that this routine is supposed to be invoked at
     /// replica nodes, and the record will not be replicated to peer nodes.
-    virtual bool purge(const mqbu::StorageKey& appKey) = 0;
+    virtual void purge(const mqbu::StorageKey& appKey) = 0;
 
     /// Notify the storage of node role set to primary
     virtual void setPrimary() = 0;

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.h
@@ -102,7 +102,7 @@ class VirtualStorage {
     // Cumulative count of all messages _removed_ from this App
     // The owner 'VirtualStorageCatalog' keeps track of all messages
 
-    const unsigned int d_ordinal;
+    unsigned int d_ordinal;
     // The ordinal to locate corresponding state in 'DataStreamMessage'
 
   private:
@@ -128,6 +128,7 @@ class VirtualStorage {
                    const bsl::string&      appId,
                    const mqbu::StorageKey& appKey,
                    unsigned int            ordinal,
+                   bsls::Types::Int64      numMessagesSoFar,
                    bslma::Allocator*       allocator);
 
     /// Destructor.
@@ -168,12 +169,19 @@ class VirtualStorage {
     mqbi::StorageResult::Enum
     remove(mqbi::DataStreamMessage* dataStreamMessage);
 
+    bool remove(mqbi::DataStreamMessage* dataStreamMessage,
+                unsigned int             replacingOrdinal);
+
     /// Observe removal of this App from the specified 'dataStreamMessage' by
     /// GC and update bytes and messages counts if needed.
     void onGC(const mqbi::DataStreamMessage& dataStreamMessage);
 
     /// Reset bytes and messages counts as in the case of purging all Apps.
     void resetStats();
+
+    void replaceOrdinal(unsigned int replacingOrdinal);
+
+    void setNumRemoved(bsls::Types::Int64 numRemoved);
 };
 
 // =====================

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -102,7 +102,7 @@ VirtualStorageCatalog::VirtualStorageCatalog(mqbi::Storage*    storage,
 , d_numMessages(0)
 , d_defaultAppMessage(bmqp::RdaInfo())
 , d_defaultNonApplicableAppMessage(bmqp::RdaInfo())
-, d_areOrdinalsContinuous(true)
+, d_isProxy(true)
 , d_queue_p(0)
 , d_allocator_p(allocator)
 {
@@ -165,7 +165,7 @@ VirtualStorageCatalog::put(const bmqt::MessageGUID&  msgGUID,
 
     if (!insertResult.second) {
         // Duplicate GUID
-        if (!d_areOrdinalsContinuous) {
+        if (!d_isProxy) {
             // A proxy can receive subsequent PUSH messages for the same GUID
             // but different apps
             BSLS_ASSERT_SAFE(refCount <= d_ordinals.size());
@@ -359,7 +359,7 @@ bsls::Types::Int64 VirtualStorageCatalog::seek(DataStreamIterator*   it,
 
     itData = d_dataStream.begin();
 
-    if (!d_areOrdinalsContinuous) {
+    if (!d_isProxy) {
         return 0;
     }
 
@@ -444,8 +444,10 @@ VirtualStorageCatalog::purgeImpl(VirtualStorage*     vs,
                        "storage.";
             }
             else if (result == mqbi::StorageResult::e_NON_ZERO_REFERENCES) {
+                // Not logging this case.
             }
             else if (result == mqbi::StorageResult::e_SUCCESS) {
+                // Not logging this case.
             }
             else {
                 BMQTSK_ALARMLOG_ALARM("STORAGE_PURGE_ERROR")
@@ -495,7 +497,7 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
 
     Ordinal appOrdinal;
 
-    if (d_availableOrdinals.empty() || d_areOrdinalsContinuous) {
+    if (d_availableOrdinals.empty() || d_isProxy) {
         // Replicas or Primary
         // Grow ordinals
         appOrdinal = d_ordinals.size();
@@ -560,7 +562,7 @@ VirtualStorageCatalog::removeVirtualStorage(const mqbu::StorageKey& appKey,
     VirtualStorageSp replacing;
     unsigned int     replacingOrdinal = removingOrdinal;
 
-    if (d_areOrdinalsContinuous) {
+    if (d_isProxy) {
         replacing        = d_ordinals.back();
         replacingOrdinal = replacing->ordinal();
         BSLS_ASSERT_SAFE(replacingOrdinal + 1 == d_ordinals.size());
@@ -598,7 +600,7 @@ VirtualStorageCatalog::removeVirtualStorage(const mqbu::StorageKey& appKey,
                                                     removingOrdinal);
     }
 
-    if (d_areOrdinalsContinuous) {
+    if (d_isProxy) {
         if (removingOrdinal != replacingOrdinal) {
             // Replacement
 

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -97,17 +97,20 @@ VirtualStorageCatalog::VirtualStorageCatalog(mqbi::Storage*    storage,
 : d_storage_p(storage)
 , d_virtualStorages(allocator)
 , d_availableOrdinals(allocator)
-, d_nextOrdinal(0)
 , d_dataStream(allocator)
 , d_totalBytes(0)
 , d_numMessages(0)
-, d_defaultAppMessage(defaultAppMessage().d_rdaInfo)
+, d_defaultAppMessage(bmqp::RdaInfo())
+, d_defaultNonApplicableAppMessage(bmqp::RdaInfo())
+, d_areOrdinalsContinuous(true)
 , d_queue_p(0)
 , d_allocator_p(allocator)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(storage);
     BSLS_ASSERT_SAFE(allocator);
+
+    d_defaultNonApplicableAppMessage.setRemovedState();
 }
 
 VirtualStorageCatalog::~VirtualStorageCatalog()
@@ -145,41 +148,45 @@ VirtualStorageCatalog::get(const bmqt::MessageGUID& msgGUID)
     return it;
 }
 
-void VirtualStorageCatalog::setup(mqbi::DataStreamMessage* data)
-{
-    // The only case for subsequent resize is proxy receiving subsequent PUSH
-    // messages for the same GUID and different apps
-    if (data->d_apps.size() < d_nextOrdinal) {
-        data->d_apps.resize(d_nextOrdinal, defaultAppMessage());
-    }
-}
-
 mqbi::StorageResult::Enum
 VirtualStorageCatalog::put(const bmqt::MessageGUID&  msgGUID,
                            int                       msgSize,
+                           unsigned int              refCount,
                            mqbi::DataStreamMessage** out)
 {
     bsl::pair<VirtualStorage::DataStreamIterator, bool> insertResult =
-        d_dataStream.insert(
-            bsl::make_pair(msgGUID,
-                           mqbi::DataStreamMessage(msgSize, d_allocator_p)));
+        d_dataStream.insert(bsl::make_pair(
+            msgGUID,
+            mqbi::DataStreamMessage(refCount, msgSize, d_allocator_p)));
+
+    mqbi::StorageResult::Enum result = mqbi::StorageResult::e_SUCCESS;
+
+    mqbi::DataStreamMessage& dataStreamMessage = insertResult.first->second;
 
     if (!insertResult.second) {
         // Duplicate GUID
-        return mqbi::StorageResult::e_GUID_NOT_UNIQUE;  // RETURN
-    }
+        if (!d_areOrdinalsContinuous) {
+            // A proxy can receive subsequent PUSH messages for the same GUID
+            // but different apps
+            BSLS_ASSERT_SAFE(refCount <= d_ordinals.size());
 
-    d_totalBytes += msgSize;
-    ++d_numMessages;
+            dataStreamMessage.d_numApps = refCount;
+        }
+        result = mqbi::StorageResult::e_GUID_NOT_UNIQUE;
+    }
+    else {
+        d_totalBytes += msgSize;
+        ++d_numMessages;
+    }
 
     if (out) {
         // The auto-confirm case when we need to update App states.
-        *out = &insertResult.first->second;
+        *out = &dataStreamMessage;
 
         setup(*out);
     }
 
-    return mqbi::StorageResult::e_SUCCESS;  // RETURN
+    return result;
 }
 
 bslma::ManagedPtr<mqbi::StorageIterator>
@@ -316,79 +323,151 @@ VirtualStorageCatalog::gc(const bmqt::MessageGUID& msgGUID)
     return mqbi::StorageResult::e_SUCCESS;
 }
 
-mqbi::StorageResult::Enum
-VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
+void VirtualStorageCatalog::removeAll()
 {
-    if (!appKey.isNull()) {
-        VirtualStoragesIter itVs = d_virtualStorages.findByKey2(appKey);
-        BSLS_ASSERT_SAFE(itVs != d_virtualStorages.end());
+    for (VirtualStoragesIter it = d_virtualStorages.begin();
+         it != d_virtualStorages.end();
+         ++it) {
+        it->value()->resetStats();
+    }
+    d_dataStream.clear();
+    d_numMessages = 0;
+    d_totalBytes  = 0;
+}
 
-        for (DataStreamIterator itData = d_dataStream.begin();
-             itData != d_dataStream.end();) {
-            mqbi::StorageResult::Enum result = mqbi::StorageResult::e_SUCCESS;
+void VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
+{
+    BSLS_ASSERT_SAFE(!appKey.isNull());
 
-            mqbi::DataStreamMessage* data = &itData->second;
-            setup(data);
+    VirtualStoragesIter itVs = d_virtualStorages.findByKey2(appKey);
+    BSLS_ASSERT_SAFE(itVs != d_virtualStorages.end());
+    VirtualStorage* vs = itVs->value().get();
 
-            if (itVs->value()->remove(data) ==
-                mqbi::StorageResult::e_SUCCESS) {
-                // The 'data' was not already removed or confirmed.
-                result = d_storage_p->releaseRef(itData->first);
+    DataStreamIterator itData;
+    bsls::Types::Int64 total = d_dataStream.size();
+    if (seek(&itData, vs) < total) {
+        purgeImpl(vs, itData, numVirtualStorages());
+    }
+}
+
+bsls::Types::Int64 VirtualStorageCatalog::seek(DataStreamIterator*   it,
+                                               const VirtualStorage* vs)
+{
+    BSLS_ASSERT_SAFE(vs);
+
+    DataStreamIterator& itData = *it;  // alias
+
+    itData = d_dataStream.begin();
+
+    if (!d_areOrdinalsContinuous) {
+        return 0;
+    }
+
+    bsls::Types::Int64 result = 0;
+    for (; itData != d_dataStream.end(); ++itData, ++result) {
+        const mqbi::DataStreamMessage& data    = itData->second;
+        const unsigned int             numApps = data.d_numApps;
+
+        if (vs->ordinal() < numApps) {
+            break;  // BREAK
+        }
+        // else 'dataStreamMessage' is older than this VirtualStorage
+    }
+
+    return result;
+}
+
+mqbi::StorageResult::Enum
+VirtualStorageCatalog::purge(const mqbu::StorageKey& appKey,
+                             const PurgeCallback&    cb)
+{
+    BSLS_ASSERT_SAFE(!appKey.isNull());
+
+    VirtualStoragesConstIter it = d_virtualStorages.findByKey2(appKey);
+    if (it == d_virtualStorages.end()) {
+        return mqbi::StorageResult::e_APPKEY_NOT_FOUND;
+    }
+
+    VirtualStorage*    vs = it->value().get();
+    DataStreamIterator itData;
+    bsls::Types::Int64 total = d_dataStream.size();
+
+    if (seek(&itData, vs) < total) {
+        if (cb) {
+            mqbi::StorageResult::Enum rc = cb(appKey, itData);
+            if (mqbi::StorageResult::e_SUCCESS != rc) {
+                return rc;
             }
+        }
 
-            if (result == mqbi::StorageResult::e_ZERO_REFERENCES) {
-                itData = d_dataStream.erase(itData);
+        purgeImpl(vs, itData, numVirtualStorages());
+    }
+
+    return mqbi::StorageResult::e_SUCCESS;
+}
+
+mqbi::StorageResult::Enum
+VirtualStorageCatalog::purgeImpl(VirtualStorage*     vs,
+                                 DataStreamIterator& itData,
+                                 unsigned int        replacingOrdinal)
+{
+    BSLS_ASSERT_SAFE(!d_ordinals.empty());
+
+    while (itData != d_dataStream.end()) {
+        const bmqt::MessageGUID& msgGUID           = itData->first;
+        mqbi::DataStreamMessage* dataStreamMessage = &itData->second;
+
+        mqbi::StorageResult::Enum result = mqbi::StorageResult::e_SUCCESS;
+
+        // Must call 'seek' before 'purge'
+        setup(dataStreamMessage);
+
+        if (vs->remove(dataStreamMessage, replacingOrdinal)) {
+            // The 'data' was not already removed or confirmed.
+            result = d_storage_p->releaseRef(msgGUID);
+        }
+
+        if (result == mqbi::StorageResult::e_ZERO_REFERENCES) {
+            itData = d_dataStream.erase(itData);
+        }
+        else {
+            if (result == mqbi::StorageResult::e_GUID_NOT_FOUND) {
+                BALL_LOG_WARN
+                    << "#STORAGE_PURGE_ERROR " << "Partition ["
+                    << d_storage_p->partitionId() << "]"
+                    << ": Attempting to purge GUID '" << msgGUID
+                    << "' from virtual storage with appId '" << vs->appId()
+                    << "' & appKey '" << vs->appKey() << "' for queue '"
+                    << d_storage_p->queueUri() << "' & queueKey '"
+                    << d_storage_p->queueKey()
+                    << "', but GUID does not exist in the underlying "
+                       "storage.";
+            }
+            else if (result == mqbi::StorageResult::e_NON_ZERO_REFERENCES) {
+            }
+            else if (result == mqbi::StorageResult::e_SUCCESS) {
             }
             else {
-                if (result == mqbi::StorageResult::e_GUID_NOT_FOUND) {
-                    BALL_LOG_WARN
-                        << "#STORAGE_PURGE_ERROR " << "Partition ["
-                        << d_storage_p->partitionId() << "]"
-                        << ": Attempting to purge GUID '" << itData->first
-                        << "' from virtual storage with appId '"
-                        << itVs->value()->appId() << "' & appKey '" << appKey
-                        << "' for queue '" << d_storage_p->queueUri()
-                        << "' & queueKey '" << d_storage_p->queueKey()
-                        << "', but GUID does not exist in the underlying "
-                           "storage.";
-                }
-                else if (result ==
-                         mqbi::StorageResult::e_NON_ZERO_REFERENCES) {
-                }
-                else if (result == mqbi::StorageResult::e_SUCCESS) {
-                }
-                else {
-                    BMQTSK_ALARMLOG_ALARM("STORAGE_PURGE_ERROR")
-                        << "Partition [" << d_storage_p->partitionId() << "]"
-                        << ": Attempting to purge GUID '" << itData->first
-                        << "' from virtual storage with appId '"
-                        << itVs->value()->appId() << "' & appKey '" << appKey
-                        << "] for queue '" << d_storage_p->queueUri()
-                        << "' & queueKey '" << d_storage_p->queueKey()
-                        << "', with invalid context (refCount is already "
-                           "zero)."
-                        << BMQTSK_ALARMLOG_END;
-                }
-                ++itData;
+                BMQTSK_ALARMLOG_ALARM("STORAGE_PURGE_ERROR")
+                    << "Partition [" << d_storage_p->partitionId() << "]"
+                    << ": Attempting to purge GUID '" << msgGUID
+                    << "' from virtual storage with appId '" << vs->appId()
+                    << "' & appKey '" << vs->appKey() << "] for queue '"
+                    << d_storage_p->queueUri() << "' & queueKey '"
+                    << d_storage_p->queueKey()
+                    << "', with invalid context (refCount is already "
+                       "zero)."
+                    << BMQTSK_ALARMLOG_END;
             }
-        }
-
-        if (queue()) {
-            queue()->stats()->onEvent(
-                mqbstat::QueueStatsDomain::EventType::e_PURGE,
-                0,
-                itVs->key1());
+            ++itData;
         }
     }
-    else {
-        for (VirtualStoragesIter it = d_virtualStorages.begin();
-             it != d_virtualStorages.end();
-             ++it) {
-            it->value()->resetStats();
-        }
-        d_dataStream.clear();
-        d_numMessages = 0;
-        d_totalBytes  = 0;
+
+    if (queue()) {
+        queue()->stats()->onEvent(
+            mqbstat::QueueStatsDomain::EventType::e_PURGE,
+            0,
+            vs->appId());
     }
 
     return mqbi::StorageResult::e_SUCCESS;
@@ -416,11 +495,14 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
 
     Ordinal appOrdinal;
 
-    // Ordinals ever grow.
-    if (d_availableOrdinals.empty()) {
-        appOrdinal = d_nextOrdinal++;
+    if (d_availableOrdinals.empty() || d_areOrdinalsContinuous) {
+        // Replicas or Primary
+        // Grow ordinals
+        appOrdinal = d_ordinals.size();
+        d_ordinals.resize(appOrdinal + 1);
     }
     else {
+        // Proxy. Recycle ordinal.
         AvailableOrdinals::const_iterator first = d_availableOrdinals.cbegin();
         appOrdinal                              = *first;
         // There is no conflict because everything 'appOrdinal' was removed.
@@ -435,8 +517,17 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
                       appId,
                       appKey,
                       appOrdinal,
+                      d_numMessages,
                       d_allocator_p);
     d_virtualStorages.insert(appId, appKey, vsp);
+
+    d_ordinals[appOrdinal] = vsp;
+
+    BALL_LOG_INFO << "Adding VirtualStorage for appId '" << vsp->appId()
+                  << "' & appKey '" << vsp->appKey() << "' for queue '"
+                  << d_storage_p->queueUri() << "' & queueKey '"
+                  << d_storage_p->queueKey() << "', with ordinal "
+                  << vsp->ordinal();
 
     if (d_queue_p) {
         BSLS_ASSERT_SAFE(d_queue_p->queueEngine());
@@ -448,42 +539,91 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
     return 0;
 }
 
-bool VirtualStorageCatalog::removeVirtualStorage(
-    const mqbu::StorageKey& appKey)
+mqbi::StorageResult::Enum
+VirtualStorageCatalog::removeVirtualStorage(const mqbu::StorageKey& appKey,
+                                            const PurgeCallback&    cb)
 {
-    if (appKey.isNull()) {
-        // Make sure there is no AppMessage in the pending states
-        removeAll(appKey);
-
-        // Remove all virtual storages
-        d_virtualStorages.clear();
-        d_availableOrdinals.clear();
-        d_nextOrdinal = 0;
-        return true;  // RETURN
-    }
+    BSLS_ASSERT_SAFE(!appKey.isNull());
 
     VirtualStoragesConstIter it = d_virtualStorages.findByKey2(appKey);
-    if (it != d_virtualStorages.end()) {
-        // Make sure there is no AppMessage in the pending states
-        removeAll(appKey);
-
-        const VirtualStorage& vs = *it->value();
-        d_availableOrdinals.insert(vs.ordinal());
-
-        if (d_queue_p) {
-            BSLS_ASSERT_SAFE(d_queue_p->queueEngine());
-            // QueueEngines use the key to look up the id
-
-            d_queue_p->queueEngine()->unregisterStorage(vs.appId(),
-                                                        appKey,
-                                                        vs.ordinal());
-        }
-
-        d_virtualStorages.erase(it);
-        return true;  // RETURN
+    if (it == d_virtualStorages.end()) {
+        return mqbi::StorageResult::e_APPKEY_NOT_FOUND;
     }
 
-    return false;
+    // Make sure there is no AppMessage in the pending states
+
+    BSLS_ASSERT_SAFE(!d_ordinals.empty());
+
+    VirtualStorage*    removing        = it->value().get();
+    const unsigned int removingOrdinal = removing->ordinal();
+
+    VirtualStorageSp replacing;
+    unsigned int     replacingOrdinal = removingOrdinal;
+
+    if (d_areOrdinalsContinuous) {
+        replacing        = d_ordinals.back();
+        replacingOrdinal = replacing->ordinal();
+        BSLS_ASSERT_SAFE(replacingOrdinal + 1 == d_ordinals.size());
+    }
+
+    BALL_LOG_INFO << "Removing VirtualStorage with appId '"
+                  << removing->appId() << "' & appKey '" << removing->appKey()
+                  << "' for queue '" << d_storage_p->queueUri()
+                  << "' & queueKey '" << d_storage_p->queueKey()
+                  << "'. Replacing " << removingOrdinal << " with "
+                  << replacingOrdinal;
+
+    // Replace [vs->ordinal()] with [maxVirtualStorageSpOrdinal]
+
+    DataStreamIterator itData;
+    bsls::Types::Int64 total = d_dataStream.size();
+
+    if (seek(&itData, removing) < total) {
+        if (cb) {
+            mqbi::StorageResult::Enum rc = cb(appKey, itData);
+            if (mqbi::StorageResult::e_SUCCESS != rc) {
+                return rc;
+            }
+        }
+    }
+
+    purgeImpl(removing, itData, replacingOrdinal);
+
+    if (d_queue_p) {
+        BSLS_ASSERT_SAFE(d_queue_p->queueEngine());
+        // QueueEngines use the key to look up the id
+
+        d_queue_p->queueEngine()->unregisterStorage(removing->appId(),
+                                                    appKey,
+                                                    removingOrdinal);
+    }
+
+    if (d_areOrdinalsContinuous) {
+        if (removingOrdinal != replacingOrdinal) {
+            // Replacement
+
+            d_ordinals[removingOrdinal] = replacing;
+            replacing->replaceOrdinal(removingOrdinal);
+
+            if (d_queue_p) {
+                BSLS_ASSERT_SAFE(d_queue_p->queueEngine());
+                d_queue_p->queueEngine()->registerStorage(
+                    replacing->appId(),
+                    replacing->appKey(),
+                    replacing->ordinal());
+            }
+        }
+
+        d_ordinals.resize(d_ordinals.size() - 1);
+    }
+    else {
+        d_availableOrdinals.insert(removingOrdinal);
+        d_ordinals[removingOrdinal].reset();
+    }
+
+    d_virtualStorages.erase(it);
+
+    return mqbi::StorageResult::e_SUCCESS;
 }
 
 VirtualStorage*
@@ -513,6 +653,16 @@ void VirtualStorageCatalog::autoConfirm(
     BSLS_ASSERT_SAFE(it != d_virtualStorages.end());
 
     it->value()->confirm(dataStreamMessage);
+}
+
+void VirtualStorageCatalog::calibrate()
+{
+    for (VirtualStoragesIter it = d_virtualStorages.begin();
+         it != d_virtualStorages.end();
+         ++it) {
+        DataStreamIterator itData;
+        it->value()->setNumRemoved(seek(&itData, it->value().get()));
+    }
 }
 
 // ACCESSORS
@@ -574,7 +724,35 @@ void VirtualStorageCatalog::loadVirtualStorageDetails(AppInfos* buffer) const
          cit != d_virtualStorages.end();
          ++cit) {
         BSLS_ASSERT_SAFE(cit->key2() == cit->value()->appKey());
-        buffer->emplace(bsl::make_pair(cit->key1(), cit->key2()));
+        buffer->insert(bsl::make_pair(cit->key1(), cit->key2()));
+    }
+}
+
+void VirtualStorageCatalog::setup(mqbi::DataStreamMessage* data) const
+{
+    // The only case for subsequent resize is proxy receiving subsequent PUSH
+    // messages for the same GUID and different apps
+    const unsigned int numApps = data->d_numApps;
+    if (data->d_apps.size() < numApps) {
+        data->d_apps.resize(numApps, defaultAppMessage());
+    }
+}
+
+const mqbi::AppMessage& VirtualStorageCatalog::appMessageView(
+    const mqbi::DataStreamMessage& dataStreamMessage,
+    unsigned int                   ordinal) const
+{
+    const unsigned int numApps = dataStreamMessage.d_numApps;
+
+    if (ordinal < numApps) {
+        if (dataStreamMessage.d_apps.size() > ordinal) {
+            return dataStreamMessage.app(ordinal);
+        }
+        return d_defaultAppMessage;
+    }
+    else {
+        // The message is older than the App associated with the 'appOrdinal'
+        return d_defaultNonApplicableAppMessage;
     }
 }
 

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -101,6 +101,11 @@ class VirtualStorageCatalog {
     /// Access to the DataStream
     typedef VirtualStorage::DataStream::iterator DataStreamIterator;
 
+    typedef bsl::function<mqbi::StorageResult::Enum(
+        const mqbu::StorageKey&   appKey,
+        const DataStreamIterator& first)>
+        PurgeCallback;
+
   private:
     // DATA
     /// Physical storage underlying all virtual storages known to this object
@@ -113,7 +118,7 @@ class VirtualStorageCatalog {
     AvailableOrdinals d_availableOrdinals;
 
     /// Monotonically increasing value to generate new ordinal.
-    Ordinal d_nextOrdinal;
+    bsl::vector<VirtualStorageSp> d_ordinals;
 
     /// The DataStream tracking all Apps states.
     VirtualStorage::DataStream d_dataStream;
@@ -121,11 +126,23 @@ class VirtualStorageCatalog {
     /// Cumulative count of all bytes.
     bsls::Types::Int64 d_totalBytes;
 
-    /// Cumulative count of all messages.
+    /// Cumulative count of all messages (including removed upon all confirms).
     bsls::Types::Int64 d_numMessages;
 
     /// The default App state
     mqbi::AppMessage d_defaultAppMessage;
+
+    /// The default fastForwarded App state
+    mqbi::AppMessage d_defaultNonApplicableAppMessage;
+
+    /// When Ordinal are Continuous, comparing Apps and messages is possible by
+    /// comparing message initial refCount and App ordinal.  If message is
+    /// older, its refCount <= ordinal.  That, of course, requires special
+    /// handling when removing ordinal (we need to scan messages anyway to
+    /// purge) and when recovering messages after adding and removing an App.
+    /// For the former, see 'VirtualStorageCatalog::removeVirtualStorage'.
+    /// For the latter, see `mqbs::DataStoreConfigQueueInfo::Ghosts`.
+    bool d_areOrdinalsContinuous;
 
     /// This could be null if a local or remote
     /// queue instance has not been created.
@@ -139,6 +156,10 @@ class VirtualStorageCatalog {
     VirtualStorageCatalog(const VirtualStorageCatalog&);  // = delete
     VirtualStorageCatalog&
     operator=(const VirtualStorageCatalog&);  // = delete
+
+    mqbi::StorageResult::Enum purgeImpl(VirtualStorage*     vs,
+                                        DataStreamIterator& itData,
+                                        unsigned int        replacingOrdinal);
 
   public:
     // TRAITS
@@ -170,14 +191,12 @@ class VirtualStorageCatalog {
     /// specified 'msgGUID' and allocate space for all Apps states if needed.
     DataStreamIterator get(const bmqt::MessageGUID& msgGUID);
 
-    /// Allocate space for all Apps states in the specified 'data' if needed.
-    void setup(mqbi::DataStreamMessage* data);
-
     /// Save the message having the specified 'msgGUID' and 'msgSize' to the
     /// DataStream.  If the specified 'out' is not '0', allocate space for all
     /// Apps states and load the created object into the 'out'.
     mqbi::StorageResult::Enum put(const bmqt::MessageGUID&  msgGUID,
                                   int                       msgSize,
+                                  unsigned int              refCount,
                                   mqbi::DataStreamMessage** out = 0);
 
     /// Get an iterator for items stored in the DataStream identified by the
@@ -220,9 +239,24 @@ class VirtualStorageCatalog {
     mqbi::StorageResult::Enum confirm(const bmqt::MessageGUID& msgGUID,
                                       const mqbu::StorageKey&  appKey);
 
-    /// If the specified 'appKey' is null, erase the entire DataStream;
-    /// otherwise, erase all states of the App corresponding to the 'appKey'.
-    mqbi::StorageResult::Enum removeAll(const mqbu::StorageKey& appKey);
+    /// Update all states of the App corresponding to the 'appKey' as purged.
+    /// This does not affect the underlying `DataStore`.
+    void removeAll(const mqbu::StorageKey& appKey);
+
+    /// Erase the entire DataStream;
+    /// This does not affect the underlying `DataStore`.
+    void removeAll();
+
+    /// Prepare to update all states of the App corresponding to the 'appKey'
+    /// as purged.  Invoke the specified the `cb` and if it returns
+    /// `e_SUCCESS`, proceed with the update.
+    mqbi::StorageResult::Enum purge(const mqbu::StorageKey& appKey,
+                                    const PurgeCallback&    cb);
+
+    /// Return the number of messages in the datastream which are older than
+    /// the specified `vs`.  Load into the specified `it` the iterator pointing
+    /// either to the first newer message or to the end of the datastream.
+    bsls::Types::Int64 seek(DataStreamIterator* it, const VirtualStorage* vs);
 
     /// Create, if it doesn't exist already, a virtual storage instance with
     /// the specified 'appId' and 'appKey'.  Return zero upon success and a
@@ -237,7 +271,9 @@ class VirtualStorageCatalog {
     /// all Virtual Storage instances; erase all states of the App
     /// corresponding to the 'appKey' and remove the corresponding Virtual
     /// Storage instance.
-    bool removeVirtualStorage(const mqbu::StorageKey& appKey);
+    mqbi::StorageResult::Enum
+    removeVirtualStorage(const mqbu::StorageKey& appKey,
+                         const PurgeCallback&    cb = PurgeCallback());
 
     /// Return the Virtual Storage instance corresponding to the specified
     /// 'appKey'.
@@ -251,7 +287,14 @@ class VirtualStorageCatalog {
     /// Set the default RDA according to the specified 'maxDeliveryAttempts'.
     void setDefaultRda(int maxDeliveryAttempts);
 
+    /// Proxies do not support Ordinals Continuity.
+    void setDiscontinuousOrdinals();
+
     void setQueue(mqbi::Queue* queue);
+
+    /// Calculate offsets of all Apps (after recovery) in the data stream.
+    /// An App offset is the number of messages older than the App.
+    void calibrate();
 
     // ACCESSORS
 
@@ -291,6 +334,13 @@ class VirtualStorageCatalog {
     const mqbi::AppMessage& defaultAppMessage() const;
 
     mqbi::Queue* queue() const;
+
+    /// Allocate space for all Apps states in the specified 'data' if needed.
+    void setup(mqbi::DataStreamMessage* data) const;
+
+    const mqbi::AppMessage&
+    appMessageView(const mqbi::DataStreamMessage& dataStreamMessage,
+                   unsigned int                   ordinal) const;
 };
 
 // ============================================================================
@@ -309,6 +359,11 @@ inline void VirtualStorageCatalog::setDefaultRda(int maxDeliveryAttempts)
     else {
         d_defaultAppMessage.d_rdaInfo.setUnlimited();
     }
+}
+
+inline void VirtualStorageCatalog::setDiscontinuousOrdinals()
+{
+    d_areOrdinalsContinuous = false;
 }
 
 inline void VirtualStorageCatalog::setQueue(mqbi::Queue* queue)


### PR DESCRIPTION
Scenario I.  Not enough confirms.  "Stuck" message.
-----------------------------------------------------

0.  Domain with at least 2 apps {`a1`, `a2`}
1.  Post `m1`.  `refCount == 2`
2.  Delete `a1` app
3.  Restart broker
4.  Open `a1` consumer, no data
5.  Open `a2` consumer, receive `m1`, confirm `m1`
6.  `m1` is still in the storage

This is because the restart does not notify storage about `a1` deletion.
Without restart, 5. will delete `m1` from the storage because 2. decrements `m1` refCount in memory (not in Journal, where it is always `2`) 

Scenario II.  Too many confirms
--------------------------------

0.  Domain with 1 apps `a1`
1.  Post `m1`.  `refCount == 1`
2.  Add an app `a2`
3.  Open `a1` consumer, receive `m1`
4.  Open `a2` consumer, receive `m1` (wrong `refCount`!)  
5.  `a1` confirms
6.  `a2` confirms.  Failure [reason: `GUID_NOT_FOUND`]


Solution.

---------

Not to deliver existing data to newly added App.  And do that upon restart as well!

The chronology of message/App events should be available in memory.  No need to store this information

This chronology can be restored in `recoveredQueuesCb` which iterates all existing data and app records in the Journal.