### PR TITLE
Fix mqbblp::RecoveryManager: Clear sync peer promptly

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1770,7 +1770,7 @@ void ClusterOrchestrator::processPrimaryStatusAdvisory(
     // TBD: may need to review the order of invoking these routines.
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " PartitionId [" << primaryAdv.partitionId()
+                  << " Partition [" << primaryAdv.partitionId()
                   << "]: received primary status advisory: " << primaryAdv
                   << ", from: " << source->nodeDescription();
 

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -1430,12 +1430,17 @@ void RecoveryManager::onPartitionPrimarySyncStatus(int partitionId, int status)
         &primarySyncCtx.primarySyncStatusEventHandle());
 
     primarySyncCtx.partitionPrimarySyncCb()(partitionId, status);
-    primarySyncCtx.setPrimarySyncPeer(0);
 
     if (primarySyncCtx.fileTransferInfo().areFilesMapped()) {
         // Don't clear the 'primarySyncCtx' at this time because files are
         // still mapped.  It will be cleaned up when the chunk deleter
         // eventually invokes 'partitionSyncCleanupDispatched' routine.
+
+        // However, we have already received all sync data chunks from the sync
+        // peer, so we can reset our sync peer to *null*.  This prevents false
+        // alarm of primary sync failure if that peer happens to go down before
+        // 'partitionSyncCleanupDispatched' is invoked.
+        primarySyncCtx.setPrimarySyncPeer(0);
 
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -1417,10 +1417,20 @@ void RecoveryManager::onPartitionPrimarySyncStatus(int partitionId, int status)
     PrimarySyncContext& primarySyncCtx = d_primarySyncContexts[partitionId];
     BSLS_ASSERT_SAFE(primarySyncCtx.primarySyncInProgress());
 
+    BALL_LOG_INFO << d_clusterData_p->identity().description()
+                  << "For Partition [" << partitionId
+                  << "], primary sync returned with status: " << status
+                  << ".  Resetting primary sync peer from "
+                  << (primarySyncCtx.syncPeer()
+                          ? primarySyncCtx.syncPeer()->nodeDescription()
+                          : "** null **")
+                  << " to ** null **.";
+
     d_clusterData_p->scheduler().cancelEventAndWait(
         &primarySyncCtx.primarySyncStatusEventHandle());
 
     primarySyncCtx.partitionPrimarySyncCb()(partitionId, status);
+    primarySyncCtx.setPrimarySyncPeer(0);
 
     if (primarySyncCtx.fileTransferInfo().areFilesMapped()) {
         // Don't clear the 'primarySyncCtx' at this time because files are

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -796,13 +796,15 @@ void StorageManager::processPartitionSyncEventDispatched(
             return;  // RETURN
         }
 
-        if (source != d_recoveryManager_mp->primarySyncPeer(partitionId)) {
+        mqbnet::ClusterNode* syncPeer = d_recoveryManager_mp->primarySyncPeer(
+            partitionId);
+        if (source != syncPeer) {
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
                            << " Partition [" << partitionId
                            << "]: received a partition sync event from: "
                            << source->nodeDescription()
                            << ", while partition-sync peer is: "
-                           << source->nodeDescription();
+                           << syncPeer->nodeDescription();
             return;  // RETURN
         }
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -470,7 +470,7 @@ FileBackedStorage::releaseRef(const bmqt::MessageGUID& guid)
 
         if (0 != rc) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << "PartitionId [" << partitionId() << "] failed to write "
+                << "Partition [" << partitionId() << "] failed to write "
                 << "DELETION record for GUID: " << guid << ", for queue '"
                 << d_queueUri << "', queueKey '" << d_queueKey
                 << "' while attempting to purge the message, rc: " << rc

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -342,7 +342,7 @@ VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
             else {
                 if (result == mqbi::StorageResult::e_GUID_NOT_FOUND) {
                     BALL_LOG_WARN
-                        << "#STORAGE_PURGE_ERROR " << "PartitionId ["
+                        << "#STORAGE_PURGE_ERROR " << "Partition ["
                         << d_storage_p->partitionId() << "]"
                         << ": Attempting to purge GUID '" << itData->first
                         << "' from virtual storage with appId '"
@@ -359,7 +359,7 @@ VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
                 }
                 else {
                     BMQTSK_ALARMLOG_ALARM("STORAGE_PURGE_ERROR")
-                        << "PartitionId [" << d_storage_p->partitionId() << "]"
+                        << "Partition [" << d_storage_p->partitionId() << "]"
                         << ": Attempting to purge GUID '" << itData->first
                         << "' from virtual storage with appId '"
                         << itVs->value()->appId() << "' & appKey '" << appKey


### PR DESCRIPTION
See internal ticket 178057288

Clearing sync peer promptly prevents [this failure condition](https://bbgithub.dev.bloomberg.com/BMQ/blazingmq-mirror/blob/85fa14b429195474314a4fc1675b5bc923099a6e/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp#L666-L667) to trigger when the sync peer node goes down after sync with that peer is already complete. Otherwise, we will call `onPartitionPrimarySyncStatus(partitionId, -1 /* status */);` and fail [this assert](https://bbgithub.dev.bloomberg.com/BMQ/blazingmq-mirror/blob/85fa14b429195474314a4fc1675b5bc923099a6e/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp#L368-L369) later on because primary is already active.