### PR TITLE
Fix[IT]: CSL+FSM together or both disabled; rollback new python features

### DIFF
--- a/src/integration-tests/pytest.ini
+++ b/src/integration-tests/pytest.ini
@@ -14,6 +14,5 @@ markers =
     single
     multi
     legacy_mode
-    csl_mode
     fsm_mode
     flakey

--- a/src/integration-tests/run-tests
+++ b/src/integration-tests/run-tests
@@ -11,7 +11,7 @@
 # =====
 #   ./run-tests
 #   ./run-tests "legacy_mode"
-#   ./run-tests "not csl_mode"
+#   ./run-tests "not fsm_mode"
 #   ./run-tests "legacy_mode or fsm_mode"
 #   export BLAZINGMQ_IT_PRESET="fsm_mode" && ./run-tests
 

--- a/src/python/blazingmq/dev/it/README.md
+++ b/src/python/blazingmq/dev/it/README.md
@@ -370,9 +370,8 @@ Tests can be selected using keywords (using the `-k` switch) and/or markers
 | `pr_integrationtest`    | integration tests to be run as part of a Jenkins PR (currently all tests) |
 | `single`                | tests that use a local cluster fixture                                    |
 | `multi`                 | tests that use a 4-node, 2-proxy cluster fixture                          |
-| `legacy_mode`           | choice between: legacy, CSL, FSM                                          |
-| `csl_mode`              | choice between: legacy, CSL, FSM                                          |
-| `fsm_mode`              | choice between: legacy, CSL, FSM                                          |
+| `legacy_mode`           | choice between: legacy, FSM (with CSL)                                    |
+| `fsm_mode`              | choice between: legacy, FSM (with CSL)                                    |
 | `flakey`                | tests that occasionally fail; excluded from the Jenkins PR check          |
 
 ### Erroneous Exits

--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -453,22 +453,21 @@ def break_before_test(request, cluster):
 
 class Mode(IntEnum):
     LEGACY = 0
-    CSL = 1
-    FSM = 2
+    FSM = 1
 
     def tweak(self, cluster: mqbcfg.ClusterDefinition):
-        cluster.cluster_attributes.is_cslmode_enabled = self >= Mode.CSL
+        # CSL and FSM settings must be either both enabled or both disabled
+        cluster.cluster_attributes.is_cslmode_enabled = self == Mode.FSM
         cluster.cluster_attributes.is_fsmworkflow = self == Mode.FSM
 
     @property
     def suffix(self) -> str:
-        return ["", "_csl", "_fsm"][self]
+        return ["", "_fsm"][self]
 
     @property
     def marks(self):
         return [
             [pytest.mark.legacy_mode],
-            [pytest.mark.csl_mode],
             [pytest.mark.fsm_mode],
         ][self]
 

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -41,8 +41,8 @@ Message = namedtuple("Message", "guid, uri, correlationId, payload")
 
 
 class CommandResult(NamedTuple):
-    error_code: int | None
-    matches: List[re.Match | None] | None
+    error_code: Optional[int]
+    matches: Optional[List[Optional[re.Match]]]
 
 
 blocktimeout = 15
@@ -378,7 +378,7 @@ class Client(BMQProcess):
 
     def confirm(
         self, uri, guid, block=None, succeed=None, no_except=None
-    ) -> int | None:
+    ) -> Optional[int]:
         command = _build_command(f'confirm uri="{uri}" guid="{guid}"', {}, {})
         with internal_use(self):
             res = self._command_helper(

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -40,7 +40,6 @@ class TweakFactory:
     class Broker:
         class TaskConfig(metaclass=TweakMetaclass):
             class AllocatorType(metaclass=TweakMetaclass):
-
                 def __call__(
                     self,
                     value: typing.Union[
@@ -51,14 +50,12 @@ class TweakFactory:
             allocator_type = AllocatorType()
 
             class AllocationLimit(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             allocation_limit = AllocationLimit()
 
             class LogController(metaclass=TweakMetaclass):
                 class FileName(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -66,7 +63,6 @@ class TweakFactory:
                 file_name = FileName()
 
                 class FileMaxAgeDays(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -74,7 +70,6 @@ class TweakFactory:
                 file_max_age_days = FileMaxAgeDays()
 
                 class RotationBytes(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -82,7 +77,6 @@ class TweakFactory:
                 rotation_bytes = RotationBytes()
 
                 class LogfileFormat(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -90,7 +84,6 @@ class TweakFactory:
                 logfile_format = LogfileFormat()
 
                 class ConsoleFormat(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -98,7 +91,6 @@ class TweakFactory:
                 console_format = ConsoleFormat()
 
                 class LoggingVerbosity(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -106,13 +98,11 @@ class TweakFactory:
                 logging_verbosity = LoggingVerbosity()
 
                 class BslsLogSeverityThreshold(metaclass=TweakMetaclass):
-
                     def __call__(self, value: str) -> Callable: ...
 
                 bsls_log_severity_threshold = BslsLogSeverityThreshold()
 
                 class ConsoleSeverityThreshold(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -120,20 +110,17 @@ class TweakFactory:
                 console_severity_threshold = ConsoleSeverityThreshold()
 
                 class Categories(metaclass=TweakMetaclass):
-
                     def __call__(self, value: None) -> Callable: ...
 
                 categories = Categories()
 
                 class Syslog(metaclass=TweakMetaclass):
                     class Enabled(metaclass=TweakMetaclass):
-
                         def __call__(self, value: bool) -> Callable: ...
 
                     enabled = Enabled()
 
                     class AppName(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -141,7 +128,6 @@ class TweakFactory:
                     app_name = AppName()
 
                     class LogFormat(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -149,7 +135,6 @@ class TweakFactory:
                     log_format = LogFormat()
 
                     class Verbosity(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -182,61 +167,51 @@ class TweakFactory:
 
         class AppConfig(metaclass=TweakMetaclass):
             class BrokerInstanceName(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             broker_instance_name = BrokerInstanceName()
 
             class BrokerVersion(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             broker_version = BrokerVersion()
 
             class ConfigVersion(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             config_version = ConfigVersion()
 
             class EtcDir(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             etc_dir = EtcDir()
 
             class HostName(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_name = HostName()
 
             class HostTags(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_tags = HostTags()
 
             class HostDataCenter(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             host_data_center = HostDataCenter()
 
             class IsRunningOnDev(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[bool, NoneType]) -> Callable: ...
 
             is_running_on_dev = IsRunningOnDev()
 
             class LogsObserverMaxSize(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             logs_observer_max_size = LogsObserverMaxSize()
 
             class LatencyMonitorDomain(metaclass=TweakMetaclass):
-
                 def __call__(self, value: str) -> Callable: ...
 
             latency_monitor_domain = LatencyMonitorDomain()
@@ -244,7 +219,6 @@ class TweakFactory:
             class DispatcherConfig(metaclass=TweakMetaclass):
                 class Sessions(metaclass=TweakMetaclass):
                     class NumProcessors(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -253,7 +227,6 @@ class TweakFactory:
 
                     class ProcessorConfig(metaclass=TweakMetaclass):
                         class QueueSize(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -261,7 +234,6 @@ class TweakFactory:
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -269,7 +241,6 @@ class TweakFactory:
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -297,7 +268,6 @@ class TweakFactory:
 
                 class Queues(metaclass=TweakMetaclass):
                     class NumProcessors(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -306,7 +276,6 @@ class TweakFactory:
 
                     class ProcessorConfig(metaclass=TweakMetaclass):
                         class QueueSize(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -314,7 +283,6 @@ class TweakFactory:
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -322,7 +290,6 @@ class TweakFactory:
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -350,7 +317,6 @@ class TweakFactory:
 
                 class Clusters(metaclass=TweakMetaclass):
                     class NumProcessors(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -359,7 +325,6 @@ class TweakFactory:
 
                     class ProcessorConfig(metaclass=TweakMetaclass):
                         class QueueSize(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -367,7 +332,6 @@ class TweakFactory:
                         queue_size = QueueSize()
 
                         class QueueSizeLowWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -375,7 +339,6 @@ class TweakFactory:
                         queue_size_low_watermark = QueueSizeLowWatermark()
 
                         class QueueSizeHighWatermark(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -412,63 +375,53 @@ class TweakFactory:
 
             class Stats(metaclass=TweakMetaclass):
                 class SnapshotInterval(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 snapshot_interval = SnapshotInterval()
 
                 class Plugins(metaclass=TweakMetaclass):
                     class Name(metaclass=TweakMetaclass):
-
                         def __call__(self, value: str) -> Callable: ...
 
                     name = Name()
 
                     class QueueSize(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     queue_size = QueueSize()
 
                     class QueueHighWatermark(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     queue_high_watermark = QueueHighWatermark()
 
                     class QueueLowWatermark(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     queue_low_watermark = QueueLowWatermark()
 
                     class PublishInterval(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     publish_interval = PublishInterval()
 
                     class NamespacePrefix(metaclass=TweakMetaclass):
-
                         def __call__(self, value: str) -> Callable: ...
 
                     namespace_prefix = NamespacePrefix()
 
                     class Hosts(metaclass=TweakMetaclass):
-
                         def __call__(self, value: None) -> Callable: ...
 
                     hosts = Hosts()
 
                     class InstanceId(metaclass=TweakMetaclass):
-
                         def __call__(self, value: str) -> Callable: ...
 
                     instance_id = InstanceId()
 
                     class PrometheusSpecific(metaclass=TweakMetaclass):
                         class Mode(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: blazingmq.schemas.mqbcfg.ExportMode
                             ) -> Callable: ...
@@ -476,13 +429,11 @@ class TweakFactory:
                         mode = Mode()
 
                         class Host(metaclass=TweakMetaclass):
-
                             def __call__(self, value: str) -> Callable: ...
 
                         host = Host()
 
                         class Port(metaclass=TweakMetaclass):
-
                             def __call__(self, value: int) -> Callable: ...
 
                         port = Port()
@@ -503,13 +454,11 @@ class TweakFactory:
 
                 class Printer(metaclass=TweakMetaclass):
                     class PrintInterval(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     print_interval = PrintInterval()
 
                     class File(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -517,7 +466,6 @@ class TweakFactory:
                     file = File()
 
                     class MaxAgeDays(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -525,13 +473,11 @@ class TweakFactory:
                     max_age_days = MaxAgeDays()
 
                     class RotateBytes(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     rotate_bytes = RotateBytes()
 
                     class RotateDays(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     rotate_days = RotateDays()
@@ -555,25 +501,21 @@ class TweakFactory:
             class NetworkInterfaces(metaclass=TweakMetaclass):
                 class Heartbeats(metaclass=TweakMetaclass):
                     class Client(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     client = Client()
 
                     class DownstreamBroker(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     downstream_broker = DownstreamBroker()
 
                     class UpstreamBroker(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     upstream_broker = UpstreamBroker()
 
                     class ClusterPeer(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     cluster_peer = ClusterPeer()
@@ -589,7 +531,6 @@ class TweakFactory:
 
                 class TcpInterface(metaclass=TweakMetaclass):
                     class Name(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -597,7 +538,6 @@ class TweakFactory:
                     name = Name()
 
                     class Port(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -605,7 +545,6 @@ class TweakFactory:
                     port = Port()
 
                     class IoThreads(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -613,13 +552,11 @@ class TweakFactory:
                     io_threads = IoThreads()
 
                     class MaxConnections(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     max_connections = MaxConnections()
 
                     class LowWatermark(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -627,7 +564,6 @@ class TweakFactory:
                     low_watermark = LowWatermark()
 
                     class HighWatermark(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[int, NoneType]
                         ) -> Callable: ...
@@ -635,26 +571,22 @@ class TweakFactory:
                     high_watermark = HighWatermark()
 
                     class NodeLowWatermark(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     node_low_watermark = NodeLowWatermark()
 
                     class NodeHighWatermark(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     node_high_watermark = NodeHighWatermark()
 
                     class HeartbeatIntervalMs(metaclass=TweakMetaclass):
-
                         def __call__(self, value: int) -> Callable: ...
 
                     heartbeat_interval_ms = HeartbeatIntervalMs()
 
                     class Listeners(metaclass=TweakMetaclass):
                         class Name(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[str, NoneType]
                             ) -> Callable: ...
@@ -662,7 +594,6 @@ class TweakFactory:
                         name = Name()
 
                         class Port(metaclass=TweakMetaclass):
-
                             def __call__(
                                 self, value: typing.Union[int, NoneType]
                             ) -> Callable: ...
@@ -693,7 +624,6 @@ class TweakFactory:
 
             class BmqconfConfig(metaclass=TweakMetaclass):
                 class CacheTtlseconds(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -711,13 +641,11 @@ class TweakFactory:
 
             class Plugins(metaclass=TweakMetaclass):
                 class Libraries(metaclass=TweakMetaclass):
-
                     def __call__(self, value: None) -> Callable: ...
 
                 libraries = Libraries()
 
                 class Enabled(metaclass=TweakMetaclass):
-
                     def __call__(self, value: None) -> Callable: ...
 
                 enabled = Enabled()
@@ -731,19 +659,16 @@ class TweakFactory:
 
             class MessagePropertiesV2(metaclass=TweakMetaclass):
                 class AdvertiseV2Support(metaclass=TweakMetaclass):
-
                     def __call__(self, value: bool) -> Callable: ...
 
                 advertise_v2_support = AdvertiseV2Support()
 
                 class MinCppSdkVersion(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 min_cpp_sdk_version = MinCppSdkVersion()
 
                 class MinJavaSdkVersion(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 min_java_sdk_version = MinJavaSdkVersion()
@@ -758,13 +683,11 @@ class TweakFactory:
             message_properties_v2 = MessagePropertiesV2()
 
             class ConfigureStream(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             configure_stream = ConfigureStream()
 
             class AdvertiseSubscriptions(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             advertise_subscriptions = AdvertiseSubscriptions()
@@ -777,7 +700,6 @@ class TweakFactory:
 
     class Domain:
         class Name(metaclass=TweakMetaclass):
-
             def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
         name = Name()
@@ -785,13 +707,11 @@ class TweakFactory:
         class Mode(metaclass=TweakMetaclass):
             class Fanout(metaclass=TweakMetaclass):
                 class AppIds(metaclass=TweakMetaclass):
-
                     def __call__(self, value: None) -> Callable: ...
 
                 app_ids = AppIds()
 
                 class PublishAppIdMetrics(metaclass=TweakMetaclass):
-
                     def __call__(self, value: bool) -> Callable: ...
 
                 publish_app_id_metrics = PublishAppIdMetrics()
@@ -806,7 +726,6 @@ class TweakFactory:
             fanout = Fanout()
 
             class Priority(metaclass=TweakMetaclass):
-
                 def __call__(
                     self,
                     value: typing.Union[
@@ -817,7 +736,6 @@ class TweakFactory:
             priority = Priority()
 
             class Broadcast(metaclass=TweakMetaclass):
-
                 def __call__(
                     self,
                     value: typing.Union[
@@ -836,7 +754,6 @@ class TweakFactory:
         class Storage(metaclass=TweakMetaclass):
             class DomainLimits(metaclass=TweakMetaclass):
                 class Messages(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -844,13 +761,11 @@ class TweakFactory:
                 messages = Messages()
 
                 class MessagesWatermarkRatio(metaclass=TweakMetaclass):
-
                     def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 messages_watermark_ratio = MessagesWatermarkRatio()
 
                 class Bytes(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -858,7 +773,6 @@ class TweakFactory:
                 bytes = Bytes()
 
                 class BytesWatermarkRatio(metaclass=TweakMetaclass):
-
                     def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 bytes_watermark_ratio = BytesWatermarkRatio()
@@ -872,7 +786,6 @@ class TweakFactory:
 
             class QueueLimits(metaclass=TweakMetaclass):
                 class Messages(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -880,13 +793,11 @@ class TweakFactory:
                 messages = Messages()
 
                 class MessagesWatermarkRatio(metaclass=TweakMetaclass):
-
                     def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 messages_watermark_ratio = MessagesWatermarkRatio()
 
                 class Bytes(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[int, NoneType]
                     ) -> Callable: ...
@@ -894,7 +805,6 @@ class TweakFactory:
                 bytes = Bytes()
 
                 class BytesWatermarkRatio(metaclass=TweakMetaclass):
-
                     def __call__(self, value: decimal.Decimal) -> Callable: ...
 
                 bytes_watermark_ratio = BytesWatermarkRatio()
@@ -908,7 +818,6 @@ class TweakFactory:
 
             class Config(metaclass=TweakMetaclass):
                 class InMemory(metaclass=TweakMetaclass):
-
                     def __call__(
                         self,
                         value: typing.Union[
@@ -919,7 +828,6 @@ class TweakFactory:
                 in_memory = InMemory()
 
                 class FileBacked(metaclass=TweakMetaclass):
-
                     def __call__(
                         self,
                         value: typing.Union[
@@ -946,38 +854,32 @@ class TweakFactory:
         storage = Storage()
 
         class MaxConsumers(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         max_consumers = MaxConsumers()
 
         class MaxProducers(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         max_producers = MaxProducers()
 
         class MaxQueues(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         max_queues = MaxQueues()
 
         class MsgGroupIdConfig(metaclass=TweakMetaclass):
             class Rebalance(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             rebalance = Rebalance()
 
             class MaxGroups(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_groups = MaxGroups()
 
             class TtlSeconds(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             ttl_seconds = TtlSeconds()
@@ -992,32 +894,27 @@ class TweakFactory:
         msg_group_id_config = MsgGroupIdConfig()
 
         class MaxIdleTime(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         max_idle_time = MaxIdleTime()
 
         class MessageTtl(metaclass=TweakMetaclass):
-
             def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
         message_ttl = MessageTtl()
 
         class MaxDeliveryAttempts(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         max_delivery_attempts = MaxDeliveryAttempts()
 
         class DeduplicationTimeMs(metaclass=TweakMetaclass):
-
             def __call__(self, value: int) -> Callable: ...
 
         deduplication_time_ms = DeduplicationTimeMs()
 
         class Consistency(metaclass=TweakMetaclass):
             class Eventual(metaclass=TweakMetaclass):
-
                 def __call__(
                     self,
                     value: typing.Union[
@@ -1028,7 +925,6 @@ class TweakFactory:
             eventual = Eventual()
 
             class Strong(metaclass=TweakMetaclass):
-
                 def __call__(
                     self,
                     value: typing.Union[
@@ -1047,14 +943,12 @@ class TweakFactory:
 
         class Subscriptions(metaclass=TweakMetaclass):
             class AppId(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             app_id = AppId()
 
             class Expression(metaclass=TweakMetaclass):
                 class Version(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: blazingmq.schemas.mqbconf.ExpressionVersion
                     ) -> Callable: ...
@@ -1062,7 +956,6 @@ class TweakFactory:
                 version = Version()
 
                 class Text(metaclass=TweakMetaclass):
-
                     def __call__(
                         self, value: typing.Union[str, NoneType]
                     ) -> Callable: ...
@@ -1082,26 +975,22 @@ class TweakFactory:
 
     class Cluster:
         class Name(metaclass=TweakMetaclass):
-
             def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
         name = Name()
 
         class Nodes(metaclass=TweakMetaclass):
             class Id(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             id = Id()
 
             class Name(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             name = Name()
 
             class DataCenter(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             data_center = DataCenter()
@@ -1109,7 +998,6 @@ class TweakFactory:
             class Transport(metaclass=TweakMetaclass):
                 class Tcp(metaclass=TweakMetaclass):
                     class Endpoint(metaclass=TweakMetaclass):
-
                         def __call__(
                             self, value: typing.Union[str, NoneType]
                         ) -> Callable: ...
@@ -1140,116 +1028,97 @@ class TweakFactory:
 
         class PartitionConfig(metaclass=TweakMetaclass):
             class NumPartitions(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             num_partitions = NumPartitions()
 
             class Location(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             location = Location()
 
             class ArchiveLocation(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[str, NoneType]) -> Callable: ...
 
             archive_location = ArchiveLocation()
 
             class MaxDataFileSize(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_data_file_size = MaxDataFileSize()
 
             class MaxJournalFileSize(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_journal_file_size = MaxJournalFileSize()
 
             class MaxQlistFileSize(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_qlist_file_size = MaxQlistFileSize()
 
             class Preallocate(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             preallocate = Preallocate()
 
             class MaxArchivedFileSets(metaclass=TweakMetaclass):
-
                 def __call__(self, value: typing.Union[int, NoneType]) -> Callable: ...
 
             max_archived_file_sets = MaxArchivedFileSets()
 
             class PrefaultPages(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             prefault_pages = PrefaultPages()
 
             class FlushAtShutdown(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             flush_at_shutdown = FlushAtShutdown()
 
             class SyncConfig(metaclass=TweakMetaclass):
                 class StartupRecoveryMaxDurationMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 startup_recovery_max_duration_ms = StartupRecoveryMaxDurationMs()
 
                 class MaxAttemptsStorageSync(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 max_attempts_storage_sync = MaxAttemptsStorageSync()
 
                 class StorageSyncReqTimeoutMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 storage_sync_req_timeout_ms = StorageSyncReqTimeoutMs()
 
                 class MasterSyncMaxDurationMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 master_sync_max_duration_ms = MasterSyncMaxDurationMs()
 
                 class PartitionSyncStateReqTimeoutMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_state_req_timeout_ms = PartitionSyncStateReqTimeoutMs()
 
                 class PartitionSyncDataReqTimeoutMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_data_req_timeout_ms = PartitionSyncDataReqTimeoutMs()
 
                 class StartupWaitDurationMs(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 startup_wait_duration_ms = StartupWaitDurationMs()
 
                 class FileChunkSize(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 file_chunk_size = FileChunkSize()
 
                 class PartitionSyncEventSize(metaclass=TweakMetaclass):
-
                     def __call__(self, value: int) -> Callable: ...
 
                 partition_sync_event_size = PartitionSyncEventSize()
@@ -1271,7 +1140,6 @@ class TweakFactory:
         partition_config = PartitionConfig()
 
         class MasterAssignment(metaclass=TweakMetaclass):
-
             def __call__(
                 self,
                 value: typing.Union[
@@ -1283,55 +1151,46 @@ class TweakFactory:
 
         class Elector(metaclass=TweakMetaclass):
             class InitialWaitTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             initial_wait_timeout_ms = InitialWaitTimeoutMs()
 
             class MaxRandomWaitTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_random_wait_timeout_ms = MaxRandomWaitTimeoutMs()
 
             class ScoutingResultTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             scouting_result_timeout_ms = ScoutingResultTimeoutMs()
 
             class ElectionResultTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             election_result_timeout_ms = ElectionResultTimeoutMs()
 
             class HeartbeatBroadcastPeriodMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             heartbeat_broadcast_period_ms = HeartbeatBroadcastPeriodMs()
 
             class HeartbeatCheckPeriodMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             heartbeat_check_period_ms = HeartbeatCheckPeriodMs()
 
             class HeartbeatMissCount(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             heartbeat_miss_count = HeartbeatMissCount()
 
             class Quorum(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             quorum = Quorum()
 
             class LeaderSyncDelayMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             leader_sync_delay_ms = LeaderSyncDelayMs()
@@ -1345,73 +1204,61 @@ class TweakFactory:
 
         class QueueOperations(metaclass=TweakMetaclass):
             class OpenTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             open_timeout_ms = OpenTimeoutMs()
 
             class ConfigureTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             configure_timeout_ms = ConfigureTimeoutMs()
 
             class CloseTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             close_timeout_ms = CloseTimeoutMs()
 
             class ReopenTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             reopen_timeout_ms = ReopenTimeoutMs()
 
             class ReopenRetryIntervalMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             reopen_retry_interval_ms = ReopenRetryIntervalMs()
 
             class ReopenMaxAttempts(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             reopen_max_attempts = ReopenMaxAttempts()
 
             class AssignmentTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             assignment_timeout_ms = AssignmentTimeoutMs()
 
             class KeepaliveDurationMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             keepalive_duration_ms = KeepaliveDurationMs()
 
             class ConsumptionMonitorPeriodMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             consumption_monitor_period_ms = ConsumptionMonitorPeriodMs()
 
             class StopTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             stop_timeout_ms = StopTimeoutMs()
 
             class ShutdownTimeoutMs(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             shutdown_timeout_ms = ShutdownTimeoutMs()
 
             class AckWindowSize(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             ack_window_size = AckWindowSize()
@@ -1427,13 +1274,11 @@ class TweakFactory:
 
         class ClusterAttributes(metaclass=TweakMetaclass):
             class IsCslmodeEnabled(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             is_cslmode_enabled = IsCslmodeEnabled()
 
             class IsFsmworkflow(metaclass=TweakMetaclass):
-
                 def __call__(self, value: bool) -> Callable: ...
 
             is_fsmworkflow = IsFsmworkflow()
@@ -1449,49 +1294,41 @@ class TweakFactory:
 
         class ClusterMonitorConfig(metaclass=TweakMetaclass):
             class MaxTimeLeader(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_time_leader = MaxTimeLeader()
 
             class MaxTimeMaster(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_time_master = MaxTimeMaster()
 
             class MaxTimeNode(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_time_node = MaxTimeNode()
 
             class MaxTimeFailover(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             max_time_failover = MaxTimeFailover()
 
             class ThresholdLeader(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             threshold_leader = ThresholdLeader()
 
             class ThresholdMaster(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             threshold_master = ThresholdMaster()
 
             class ThresholdNode(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             threshold_node = ThresholdNode()
 
             class ThresholdFailover(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             threshold_failover = ThresholdFailover()
@@ -1507,25 +1344,21 @@ class TweakFactory:
 
         class MessageThrottleConfig(metaclass=TweakMetaclass):
             class LowThreshold(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             low_threshold = LowThreshold()
 
             class HighThreshold(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             high_threshold = HighThreshold()
 
             class LowInterval(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             low_interval = LowInterval()
 
             class HighInterval(metaclass=TweakMetaclass):
-
                 def __call__(self, value: int) -> Callable: ...
 
             high_interval = HighInterval()

--- a/src/python/blazingmq/dev/it/util.py
+++ b/src/python/blazingmq/dev/it/util.py
@@ -26,7 +26,7 @@ import random
 import string
 import time
 
-from typing import List, Generic, TypeVar
+from typing import List, Optional, TypeVar
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -145,7 +145,7 @@ class Queue:
     def list(self, *args, **kwargs):
         return self.client.list(self.uri, *args, **kwargs)
 
-    def confirm(self, *args, **kwargs) -> int | None:
+    def confirm(self, *args, **kwargs) -> Optional[int]:
         return self.client.confirm(self.uri, *args, **kwargs)
 
     def configure(self, *args, **kwargs):


### PR DESCRIPTION
- Rollback new python features (`int | None` with `|`-notation, replaced by `Optional[int]`) blocking us from launching ITs on older python versions
- Redo ITs launch presets, by allowing CSL+FSM together only or both disabled