### PR TITLE
Feat[bmq]: support exists(x) function in subscription expressions

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -386,11 +386,7 @@ bdld::Datum SimpleEvaluator::Exists::evaluate(EvaluationContext& context) const
     bdld::Datum value = context.d_propertiesReader->get(d_name,
                                                         context.d_allocator);
 
-    if (value.isError()) {
-        return bdld::Datum::createBoolean(false);
-    }
-
-    return bdld::Datum::createBoolean(true);
+    return bdld::Datum::createBoolean(!value.isError());
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -364,9 +364,9 @@ bdld::Datum SimpleEvaluator::Not::evaluate(EvaluationContext& context) const
     return bdld::Datum::createBoolean(!value.theBoolean());
 }
 
-// --------------------------
+// -----------------------------
 // class SimpleEvaluator::Exists
-// --------------------------
+// -----------------------------
 
 SimpleEvaluator::Exists::Exists(const bsl::string& name)
 : d_name(name)

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -364,5 +364,34 @@ bdld::Datum SimpleEvaluator::Not::evaluate(EvaluationContext& context) const
     return bdld::Datum::createBoolean(!value.theBoolean());
 }
 
+// --------------------------
+// class SimpleEvaluator::Exists
+// --------------------------
+
+SimpleEvaluator::Exists::Exists(const bsl::string& name)
+: d_name(name)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+SimpleEvaluator::Exists::Exists(bsl::string&& name) noexcept
+: d_name(bsl::move(name))
+{
+}
+#endif
+
+bdld::Datum SimpleEvaluator::Exists::evaluate(EvaluationContext& context) const
+{
+    bdld::Datum value = context.d_propertiesReader->get(d_name,
+                                                        context.d_allocator);
+
+    if (value.isError()) {
+        return bdld::Datum::createBoolean(false);
+    }
+
+    return bdld::Datum::createBoolean(true);
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -505,9 +505,9 @@ class SimpleEvaluator {
 
         // ACCESSORS
 
-        /// Evaluate `expression` passed to the constructor. If it is a
+        /// Evaluate `expression` passed to the constructor.  If it is a
         /// boolean, return the negated value as a boolean Datum.
-        /// Otherwise, set the error in the context to  e_TYPE, stop the
+        /// Otherwise, set the error in the context to e_TYPE, stop the
         /// evaluation, and return a null datum.
         bdld::Datum
         evaluate(EvaluationContext& context) const BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -478,6 +478,41 @@ class SimpleEvaluator {
         evaluate(EvaluationContext& context) const BSLS_KEYWORD_OVERRIDE;
     };
 
+    // ---
+    // Exists
+    // ---
+
+    class Exists : public Expression {
+      private:
+        // DATA
+
+        // The name of the property.
+        bsl::string d_name;
+
+      public:
+        // CREATORS
+
+        /// Create an object that evaluates property `name`, in the
+        /// evaluation context, as a boolean.
+        explicit Exists(const bsl::string& name);
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+        /// Create an object that evaluates property `name`, in the
+        /// evaluation context, as a boolean.
+        explicit Exists(bsl::string&& name) noexcept;
+#endif
+
+        // ACCESSORS
+
+        /// Evaluate `expression` passed to the constructor. If it is a
+        /// boolean, return the negated value as a boolean Datum.
+        /// Otherwise, set the error in the context to  e_TYPE, stop the
+        /// evaluation, and return a null datum.
+        bdld::Datum
+        evaluate(EvaluationContext& context) const BSLS_KEYWORD_OVERRIDE;
+    };
+
   private:
     // SimpleEvaluator(const SimpleEvaluator& other) BSLS_KEYWORD_DELETED;
     // SimpleEvaluator& operator=(const SimpleEvaluator& other)
@@ -549,6 +584,7 @@ class SimpleEvaluator {
     friend class SimpleEvaluatorScanner;  // for access to Expression hierarchy
     friend class CompilationContext;      // for access to ExpressionPtr
 };
+
 // ========================
 // class CompilationContext
 // ========================

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -478,9 +478,9 @@ class SimpleEvaluator {
         evaluate(EvaluationContext& context) const BSLS_KEYWORD_OVERRIDE;
     };
 
-    // ---
+    // ------
     // Exists
-    // ---
+    // ------
 
     class Exists : public Expression {
       private:

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -523,6 +523,9 @@ static void test3_evaluation()
         {"i_0 != -9223372036854775808", true},  // -(2 ** 63)
 
         // exists
+        // Note that we allow to set a message property with name `exists`.
+        // In this case the usage context defines whether it's a function call
+        // or a property value.
         {"exists(i_42)", true},
         {"exists(non_existing_property)", false},
         {"!exists(non_existing_property) || non_existing_property > 41", true},

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -55,6 +55,7 @@ class MockPropertiesReader : public PropertiesReader {
         d_map["i_42"]    = bdld::Datum::createInteger(42);
         d_map["i64_42"]  = bdld::Datum::createInteger64(42, allocator);
         d_map["s_foo"]   = bdld::Datum::createStringRef("foo", allocator);
+        d_map["exists"]  = bdld::Datum::createInteger(42);
     }
     // Destroy this object.
 
@@ -520,6 +521,14 @@ static void test3_evaluation()
         {"i_0 != -9223372036854775807", true},  // -(2 ** 63) + 1
         {"i_0 != 9223372036854775807", true},   // 2 ** 63 - 1
         {"i_0 != -9223372036854775808", true},  // -(2 ** 63)
+
+        // exists
+        {"exists(i_42)", true},
+        {"exists(non_existing_property)", false},
+        {"exists(i_42) && i_42 > 41", true},
+        {"exists(non_existing_property) && non_existing_property > 41", false},
+        {"exists == 42", true},
+        {"exists(exists)", true},
     };
     const TestParameters* testParametersEnd = testParameters +
                                               sizeof(testParameters) /

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -525,6 +525,7 @@ static void test3_evaluation()
         // exists
         {"exists(i_42)", true},
         {"exists(non_existing_property)", false},
+        {"!exists(non_existing_property) || non_existing_property > 41", true},
         {"exists(i_42) && i_42 > 41", true},
         {"exists(non_existing_property) && non_existing_property > 41", false},
         {"exists == 42", true},

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.l
@@ -32,6 +32,11 @@
 	return SimpleEvaluatorParser::make_FALSE();
 }
 
+"exists" {
+	updatePosition();
+	return SimpleEvaluatorParser::make_EXISTS(yytext);
+}
+
 [a-zA-Z][a-zA-Z0-9_.]* {
 	updatePosition();
 	return SimpleEvaluatorParser::make_PROPERTY(yytext);


### PR DESCRIPTION
[*Issue number of the reported bug or feature request: #<219>*](https://github.com/bloomberg/blazingmq/issues/219)

**Describe your changes**
- Added new function exists(x) to check if the variable x is defined in the current context

**Testing performed**
- Added various unit tests to cover exists(x)

**Additional context**
Created PR for the docs website update: https://github.com/bloomberg/blazingmq/pull/648