### PR TITLE
feat repair CSL on mismatch with Domain config

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -2848,10 +2848,15 @@ void Cluster::onDomainReconfigured(const mqbi::Domain&     domain,
         newDefn.mode().fanout().appIDs().cend(),
         d_allocator_p);
 
-    bsl::vector<bsl::string> addedIds(d_allocator_p);
-    bsl::vector<bsl::string> removedIds(d_allocator_p);
-    mqbc::StorageUtil::loadAddedAndRemovedEntries(&addedIds,
-                                                  &removedIds,
+    bsl::shared_ptr<bsl::vector<bsl::string> > addedIds(
+        new (*d_allocator_p) bsl::vector<bsl::string>(d_allocator_p),
+        d_allocator_p);
+    bsl::shared_ptr<bsl::vector<bsl::string> > removedIds(
+        new (*d_allocator_p) bsl::vector<bsl::string>(d_allocator_p),
+        d_allocator_p);
+
+    mqbc::StorageUtil::loadAddedAndRemovedEntries(addedIds.get(),
+                                                  removedIds.get(),
                                                   oldCfgAppIds,
                                                   newCfgAppIds);
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -289,6 +289,8 @@ void ClusterOrchestrator::registerQueueInfo(const bmqt::Uri& uri,
                                             const AppInfos&         appIdInfos,
                                             bool forceUpdate)
 {
+    // TODO_CSL: Legacy only.  Remove.
+
     // executed by the *DISPATCHER* thread
 
     // PRECONDITIONS
@@ -296,11 +298,22 @@ void ClusterOrchestrator::registerQueueInfo(const bmqt::Uri& uri,
     BSLS_ASSERT_SAFE(!d_cluster_p->isRemote());
     BSLS_ASSERT_SAFE(uri.isCanonical());
 
-    d_stateManager_mp->registerQueueInfo(uri,
-                                         partitionId,
-                                         queueKey,
-                                         appIdInfos,
-                                         forceUpdate);
+    bmqp_ctrlmsg::QueueInfo advisory(d_allocator_p);
+
+    advisory.uri()         = uri.canonical();
+    advisory.partitionId() = partitionId;
+    queueKey.loadBinary(&advisory.key());
+
+    advisory.appIds().resize(appIdInfos.size());
+    int i = 0;
+    for (AppInfos::const_iterator cit = appIdInfos.cbegin();
+         cit != appIdInfos.cend();
+         ++cit, ++i) {
+        advisory.appIds()[i].appId() = cit->first;
+        cit->second.loadBinary(&advisory.appIds()[i].appKey());
+    }
+
+    d_stateManager_mp->registerQueueInfo(advisory, forceUpdate);
 }
 
 void ClusterOrchestrator::onPartitionPrimaryStatusDispatched(
@@ -1934,26 +1947,19 @@ void ClusterOrchestrator::validateClusterStateLedger()
     d_stateManager_mp->validateClusterStateLedger();
 }
 
-void ClusterOrchestrator::registerAppId(bsl::string         appId,
-                                        const mqbi::Domain& domain)
+void ClusterOrchestrator::updateAppIds(const bsl::vector<bsl::string>& added,
+                                       const bsl::vector<bsl::string>& removed,
+                                       const bsl::string& domainName)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
 
-    d_stateManager_mp->registerAppId(appId, &domain);
-}
-
-void ClusterOrchestrator::unregisterAppId(bsl::string         appId,
-                                          const mqbi::Domain& domain)
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
-
-    d_stateManager_mp->unregisterAppId(appId, &domain);
+    d_stateManager_mp->updateAppIds(added,
+                                    removed,
+                                    domainName,
+                                    "");  // for all queues
 }
 
 void ClusterOrchestrator::onPartitionPrimaryStatus(int          partitionId,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1947,17 +1947,18 @@ void ClusterOrchestrator::validateClusterStateLedger()
     d_stateManager_mp->validateClusterStateLedger();
 }
 
-void ClusterOrchestrator::updateAppIds(const bsl::vector<bsl::string>& added,
-                                       const bsl::vector<bsl::string>& removed,
-                                       const bsl::string& domainName)
+void ClusterOrchestrator::updateAppIds(
+    const bsl::shared_ptr<const bsl::vector<bsl::string> >& added,
+    const bsl::shared_ptr<const bsl::vector<bsl::string> >& removed,
+    const bsl::string&                                      domainName)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
 
-    d_stateManager_mp->updateAppIds(added,
-                                    removed,
+    d_stateManager_mp->updateAppIds(*added,
+                                    *removed,
                                     domainName,
                                     "");  // for all queues
 }

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
@@ -489,11 +489,12 @@ class ClusterOrchestrator {
     void validateClusterStateLedger();
 
     /// Unregister the specified 'removed' and register the specified `added`
-    /// for the specified  `domain`.
+    /// for the specified  `domainName`.
     /// Invoked by @bbref{mqbblp::Cluster}.
-    void updateAppIds(const bsl::vector<bsl::string>& added,
-                      const bsl::vector<bsl::string>& removed,
-                      const bsl::string&              domainName);
+    void updateAppIds(
+        const bsl::shared_ptr<const bsl::vector<bsl::string> >& added,
+        const bsl::shared_ptr<const bsl::vector<bsl::string> >& removed,
+        const bsl::string&                                      domainName);
 
     /// Register a queue info for the queue with the specified `uri`,
     /// `partitionId`, `queueKey` and `appIdInfos`.  If the specified

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
@@ -488,21 +488,12 @@ class ClusterOrchestrator {
     /// IncoreCSL.
     void validateClusterStateLedger();
 
-    /// Invoked by @bbref{mqbblp::Cluster} to register a new `appId` for
-    /// `domain`.
-    ///
-    /// Note: As this function is dispatched from a separate thread, `appId`
-    ///       is taken by value to ensure it survives the lifetime of this
-    ///       function call.
-    void registerAppId(bsl::string appId, const mqbi::Domain& domain);
-
-    /// Invoked by @bbref{mqbblp::Cluster} to unregister an `appId` for
-    /// `domain`.
-    ///
-    /// Note: As this function is dispatched from a separate thread, `appId`
-    ///       is taken by value to ensure it survives the lifetime of this
-    ///       function call.
-    void unregisterAppId(bsl::string appId, const mqbi::Domain& domain);
+    /// Unregister the specified 'removed' and register the specified `added`
+    /// for the specified  `domain`.
+    /// Invoked by @bbref{mqbblp::Cluster}.
+    void updateAppIds(const bsl::vector<bsl::string>& added,
+                      const bsl::vector<bsl::string>& removed,
+                      const bsl::string&              domainName);
 
     /// Register a queue info for the queue with the specified `uri`,
     /// `partitionId`, `queueKey` and `appIdInfos`.  If the specified
@@ -511,6 +502,7 @@ class ClusterOrchestrator {
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
+    /// TODO_CSL: Legacy only.  Remove.
     void registerQueueInfo(const bmqt::Uri&        uri,
                            int                     partitionId,
                            const mqbu::StorageKey& queueKey,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -219,6 +219,7 @@ ClusterQueueHelper::QueueLiveState::QueueLiveState(bslma::Allocator* allocator)
 , d_numHandleCreationsInProgress(0)
 , d_queueExpirationTimestampMs(0)
 , d_pending(allocator)
+, d_pendingUpdates(allocator)
 , d_inFlight(0)
 {
     // NOTHING
@@ -235,6 +236,7 @@ ClusterQueueHelper::QueueLiveState::QueueLiveState(
 , d_numHandleCreationsInProgress(other.d_numHandleCreationsInProgress)
 , d_queueExpirationTimestampMs(other.d_queueExpirationTimestampMs)
 , d_pending(other.d_pending)
+, d_pendingUpdates(other.d_pendingUpdates)
 , d_inFlight(other.d_inFlight)
 {
     // NOTHING
@@ -794,11 +796,19 @@ void ClusterQueueHelper::processPendingContexts(
     //       caller typically would have checked for that already and 2) even
     //       if there are none, the below code will mostly be a no-op.
 
+    if (queueContext->d_liveQInfo.d_pending.empty()) {
+        return;  // RETURN
+    }
+
     // Swap the contexts to process them one by one and also clear the
     // pendingContexts of the queue info: they will be enqueued back, if
     // needed.
     bsl::vector<OpenQueueContextSp> contexts(d_allocator_p);
     contexts.swap(queueContext->d_liveQInfo.d_pending);
+
+    BALL_LOG_INFO << d_cluster_p->description() << ": Proceeding with "
+                  << contexts.size() << " associated pending contexts for '"
+                  << queueContext->uri() << "'";
 
     for (bsl::vector<OpenQueueContextSp>::iterator it = contexts.begin();
          it != contexts.end();
@@ -1849,6 +1859,44 @@ bool ClusterQueueHelper::createQueue(
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT_SAFE(context);
+    BSLS_ASSERT_SAFE(context->d_domain_p);
+    BSLS_ASSERT_SAFE(context->queueContext());
+
+    QueueContext*   queueContext = context->queueContext();
+    QueueLiveState& qinfo        = queueContext->d_liveQInfo;
+    const int       pid          = queueContext->partitionId();
+    const bool      isPrimary    = !d_cluster_p->isRemote() &&
+                           d_clusterState_p->isSelfPrimary(pid);
+    mqbi::Domain* domain = context->d_domain_p;
+
+    if (isPrimary) {
+        // Make sure the Cluster state and the domain config agrees.
+        // If there are missing/extra Apps, repair the Cluste state with a
+        // QueueUpdateAdvisory and wait for 'onQueueUpdated' to continue to
+        // 'registerQueue'.
+
+        bsl::vector<bsl::string> added(d_allocator_p);
+        bsl::vector<bsl::string> removed(d_allocator_p);
+
+        match(&added,
+              &removed,
+              *queueContext->d_stateQInfo_sp,
+              domain->config().mode());
+
+        if (!removed.empty() || !added.empty()) {
+            // Add to 'd_pending' before calling 'updateAppIds' which can be
+            // both synchronous (legacy) and asynchronous (CSL)
+            queueContext->d_liveQInfo.d_pending.push_back(context);
+
+            d_clusterStateManager_p->updateAppIds(added,
+                                                  removed,
+                                                  domain->name(),
+                                                  "");
+            // Cannot continue until 'onQueueUpdated'
+
+            return false;  // RETURN
+        }
+    }
 
     const bmqp_ctrlmsg::QueueHandleParameters& parameters =
         openQueueResponse.originalRequest().handleParameters();
@@ -1874,11 +1922,6 @@ bool ClusterQueueHelper::createQueue(
     bmqu::MemOutStream                         errorDescription(&la);
     bmqp_ctrlmsg::Status                       status;
 
-    QueueContext*   queueContext = context->queueContext();
-    QueueLiveState& qinfo        = queueContext->d_liveQInfo;
-    const int       pid          = queueContext->partitionId();
-    const bool      isPrimary    = !d_cluster_p->isRemote() &&
-                           d_clusterState_p->isSelfPrimary(pid);
     bsl::shared_ptr<mqbi::Queue> queue = createQueueFactory(errorDescription,
                                                             *context,
                                                             openQueueResponse);
@@ -1971,10 +2014,11 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(context.d_domain_p);
 
     QueueContext* queueContext = context.queueContext();
 
-    BSLS_ASSERT_SAFE(isQueueAssigned(*(queueContext)));
+    BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext));
     BSLS_ASSERT_SAFE(context.d_domain_p);
 
     const int pid = queueContext->partitionId();
@@ -3541,13 +3585,12 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
          cit != d_queues.cend();
          ++cit) {
         const QueueContextSp& queueContext = cit->second;
-
+        QueueLiveState&       liveQInfo    = queueContext->d_liveQInfo;
         if (allPartitions) {
             // Attempt to re-issue open-queue requests for all appropriate
             // queues across *all* partitions.
 
-            if (!queueContext->d_liveQInfo.d_queue_sp &&
-                queueContext->d_liveQInfo.d_inFlight == 0) {
+            if (!liveQInfo.d_queue_sp && liveQInfo.d_inFlight == 0) {
                 // Queue instance does not exist and self node is not waiting
                 // for any pending open-queue responses.  So there is no need
                 // to re-issue an open-queue request for this one.
@@ -3585,9 +3628,11 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
             BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext.get()));
             BSLS_ASSERT_SAFE(isQueuePrimaryAvailable(*queueContext.get()));
 
-            QueueLiveState& qinfo = queueContext->d_liveQInfo;
+            // TODO: verify the CSL if needed by comparing it with the Domain
+            // config
+            //  send QueueUpdateAdvisory and _wait_ for commit
 
-            if (qinfo.d_queue_sp) {
+            if (liveQInfo.d_queue_sp) {
                 if (isSelfPrimary) {
                     // We are assuming that it is not possible for a node to be
                     // primary, lose primary-ship and regain primary-ship;
@@ -3601,26 +3646,35 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                     // node creates a local queue instance (see
                     // 'createQueueFactory').
 
-                    d_storageManager_p->registerQueue(
-                        queueContext->uri(),
-                        queueContext->key(),
-                        queueContext->partitionId(),
-                        queueContext->d_stateQInfo_sp->appInfos(),
-                        qinfo.d_queue_sp->domain());
+                    bsl::vector<bsl::string> added(d_allocator_p);
+                    bsl::vector<bsl::string> removed(d_allocator_p);
+                    mqbi::Domain* domain = liveQInfo.d_queue_sp->domain();
 
-                    // Convert the queue from remote to local instance.
-                    queueContext->d_liveQInfo.d_queue_sp->convertToLocal();
-                    queueContext->d_liveQInfo.d_id =
-                        bmqp::QueueId::k_PRIMARY_QUEUE_ID;
+                    match(&added,
+                          &removed,
+                          *queueContext->d_stateQInfo_sp,
+                          domain->config().mode());
 
-                    if (!queueContext->d_liveQInfo.d_pending.empty()) {
-                        // Proceed with pending contexts, if any.
-                        BALL_LOG_INFO
-                            << d_cluster_p->description()
-                            << ": Proceeding with "
-                            << queueContext->d_liveQInfo.d_pending.size()
-                            << " associated pending contexts for '"
-                            << queueContext->uri() << "'";
+                    if (!removed.empty() || !added.empty()) {
+                        VoidFunctor park = bdlf::BindUtil::bind(
+                            &ClusterQueueHelper::convertToLocal,
+                            this,
+                            queueContext,
+                            domain);
+
+                        // Add to 'd_pending' before calling 'updateAppIds'
+                        // which can be both synchronous (legacy) and
+                        // asynchronous (CSL)
+                        liveQInfo.d_pendingUpdates.push_back(park);
+
+                        d_clusterStateManager_p->updateAppIds(added,
+                                                              removed,
+                                                              domain->name(),
+                                                              "");
+                        // Cannot continue until 'onQueueUpdated'
+                    }
+                    else {
+                        convertToLocal(queueContext, domain);
 
                         processPendingContexts(queueContext);
                     }
@@ -4295,8 +4349,9 @@ void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
     QueueContextMapIter qiter = d_queues.find(uri);
     BSLS_ASSERT_SAFE(qiter != d_queues.end());
 
-    mqbblp::Queue* queue       = qiter->second->d_liveQInfo.d_queue_sp.get();
-    const int      partitionId = qiter->second->partitionId();
+    QueueContext&  queueContext = *qiter->second;
+    mqbblp::Queue* queue        = queueContext.d_liveQInfo.d_queue_sp.get();
+    const int      partitionId  = queueContext.partitionId();
     BSLS_ASSERT_SAFE(partitionId != mqbs::DataStore::k_INVALID_PARTITION_ID);
 
     if (d_cluster_p->isCSLModeEnabled()) {
@@ -4308,25 +4363,24 @@ void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
             d_storageManager_p->updateQueueReplica(
                 partitionId,
                 uri,
-                qiter->second->key(),
+                queueContext.key(),
                 addedAppIds,
                 d_clusterState_p->domainStates()
                     .at(uri.qualifiedDomain())
                     ->domain());
         }
 
-        for (AppInfosCIter cit = removedAppIds.cbegin();
+        for (AppInfos::const_iterator cit = removedAppIds.cbegin();
              cit != removedAppIds.cend();
              ++cit) {
             if (!d_clusterState_p->isSelfPrimary(partitionId) || queue == 0) {
                 // Note: In non-CSL mode, the queue deletion callback is
                 // invoked at replica nodes when they receive a queue deletion
                 // record from the primary in the partition stream.
-                d_storageManager_p->unregisterQueueReplica(
-                    partitionId,
-                    uri,
-                    qiter->second->key(),
-                    cit->second);
+                d_storageManager_p->unregisterQueueReplica(partitionId,
+                                                           uri,
+                                                           queueContext.key(),
+                                                           cit->second);
             }
         }
     }
@@ -4351,6 +4405,28 @@ void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
     BALL_LOG_INFO << d_cluster_p->description() << ": Updated queue: " << uri
                   << ", addedAppIds: " << printer1
                   << ", removedAppIds: " << printer2;
+
+    // Resume open queue request(s) waiting for new App(s).
+    processPendingContexts(qiter->second);
+
+    if (queueContext.d_liveQInfo.d_pendingUpdates.empty()) {
+        return;  // RETURN
+    }
+
+    // Swap the contexts to process them one by one and also clear the
+    // pendingContexts of the queue info: they will be enqueued back, if
+    // needed.
+    bsl::vector<VoidFunctor> pending(d_allocator_p);
+    pending.swap(queueContext.d_liveQInfo.d_pendingUpdates);
+
+    BALL_LOG_INFO << d_cluster_p->description() << ": processing "
+                  << pending.size() << " pending Dynamic App.";
+
+    for (bsl::vector<VoidFunctor>::iterator it = pending.begin();
+         it != pending.end();
+         ++it) {
+        (*it)();
+    }
 }
 
 void ClusterQueueHelper::onUpstreamNodeChange(mqbnet::ClusterNode* node,
@@ -6099,16 +6175,27 @@ int ClusterQueueHelper::gcExpiredQueues(bool               immediate,
             continue;  // CONTINUE
         }
 
+        // With asynchronous CL repair, it is possible to have
+        // '0 == qinfo.d_queue_sp' while waiting for QueueUpdate
+
+        if (qinfo.d_numHandleCreationsInProgress) {
+            continue;  // CONTINUE
+        }
+        if (qinfo.d_numQueueHandles) {
+            continue;  // CONTINUE
+        }
+        if (!queueContextSp->d_liveQInfo.d_pending.empty()) {
+            continue;  // CONTINUE
+        }
+        if (queueContextSp->d_liveQInfo.d_inFlight) {
+            continue;  // CONTINUE
+        }
+
         if (0 == qinfo.d_queue_sp) {
             // Even though queue is assigned to an active primary node (self),
             // it is possible that queue instance does not exist.  This could
             // occur if this queue was recovered at startup and there have been
             // no clients for this queue.
-
-            BSLS_ASSERT_SAFE(0 == qinfo.d_numHandleCreationsInProgress);
-            BSLS_ASSERT_SAFE(0 == qinfo.d_numQueueHandles);
-            BSLS_ASSERT_SAFE(queueContextSp->d_liveQInfo.d_pending.empty());
-            BSLS_ASSERT_SAFE(0 == queueContextSp->d_liveQInfo.d_inFlight);
 
             if (immediate) {
                 queuesToGc.push_back(it);
@@ -6437,6 +6524,77 @@ void ClusterQueueHelper::loadState(
                 os.str();
             os.reset();
         }
+    }
+}
+
+void ClusterQueueHelper::convertToLocal(const QueueContextSp& queueContext,
+                                        mqbi::Domain*         domain)
+{
+    d_storageManager_p->registerQueue(
+        queueContext->uri(),
+        queueContext->key(),
+        queueContext->partitionId(),
+        queueContext->d_stateQInfo_sp->appInfos(),
+        domain);
+
+    // Convert the queue from remote to local instance.
+    queueContext->d_liveQInfo.d_queue_sp->convertToLocal();
+    queueContext->d_liveQInfo.d_id = bmqp::QueueId::k_PRIMARY_QUEUE_ID;
+}
+
+void ClusterQueueHelper::match(bsl::vector<bsl::string>*          added,
+                               bsl::vector<bsl::string>*          removed,
+                               const mqbc::ClusterStateQueueInfo& state,
+                               const mqbconfm::QueueMode&         domainConfig)
+{
+    // executed by the cluster *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(
+        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
+
+    BSLS_ASSERT_SAFE(added);
+    BSLS_ASSERT_SAFE(removed);
+
+    if (!domainConfig.isFanoutValue()) {
+        return;
+    }
+
+    bsl::unordered_set<bsl::string> inTheConfig(
+        domainConfig.fanout().appIDs().cbegin(),
+        domainConfig.fanout().appIDs().cend(),
+        d_allocator_p);
+
+    for (AppInfos::const_iterator citInTheState = state.appInfos().begin();
+         citInTheState != state.appInfos().end();
+         ++citInTheState) {
+        const bsl::string& appId = citInTheState->first;
+        bsl::unordered_set<bsl::string>::const_iterator citInTheConfig =
+            inTheConfig.find(appId);
+
+        if (citInTheConfig == inTheConfig.end()) {
+            // TODO: handle dynamic App
+            BALL_LOG_ERROR << d_cluster_p->description()
+                           << " removing extra App '" << appId
+                           << "' in the Cluster State of '" << state.uri()
+                           << "'";
+            removed->push_back(appId);
+        }
+        else {
+            inTheConfig.erase(citInTheConfig);
+        }
+    }
+    for (bsl::unordered_set<bsl::string>::const_iterator citInTheConfig =
+             inTheConfig.begin();
+         citInTheConfig != inTheConfig.end();
+         ++citInTheConfig) {
+        const bsl::string& appId = *citInTheConfig;
+        // TODO: handle dynamic App
+        BALL_LOG_ERROR << d_cluster_p->description() << " adding missing App '"
+                       << appId << "' in the Cluster State of '" << state.uri()
+                       << "'";
+
+        added->push_back(appId);
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -226,6 +226,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         // List of all open queue pending contexts which are awaiting for a
         // next step on the queue (assignment, ...).
 
+        bsl::vector<VoidFunctor> d_pendingUpdates;
+        // Operations pending QueueUpdate.
+
         // Number of in flight contexts, that is the number of contexts for
         // which `d_callback` has not yet been called. Note that this may be
         // different than `d_pending.size` because the `d_pending` vector
@@ -411,10 +414,6 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// QueueContextByIdMap[queueId] -> queueContext*; only used when remote
     /// queue which have a proper valid unique queueId.
     typedef bsl::unordered_map<int, QueueContext*> QueueContextByIdMap;
-
-    typedef AppInfos::const_iterator AppInfosCIter;
-
-    typedef mqbc::ClusterStateQueueInfo::AppInfos AppInfos;
 
   private:
     // DATA
@@ -880,6 +879,11 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
                            int                                 code,
                            const char*                         message);
 
+    bool setStopContext(const mqbnet::ClusterNode*          clusterNode,
+                        const bsl::shared_ptr<StopContext>& contextSp);
+
+    void convertToLocal(const QueueContextSp& queueContext,
+                        mqbi::Domain*         domain);
     // PRIVATE ACCESSORS
 
     /// Return true if for the specified `partitionId`, there is currently a
@@ -909,8 +913,12 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
                                  bsls::Types::Uint64*  genCount,
                                  int                   partitionId) const;
 
-    bool setStopContext(const mqbnet::ClusterNode*          clusterNode,
-                        const bsl::shared_ptr<StopContext>& contextSp);
+    /// Compare the specified `state` and `domainConfig` and populate the
+    //// specified `added` and `removed` with missing/extra Apps.
+    void match(bsl::vector<bsl::string>*          added,
+               bsl::vector<bsl::string>*          removed,
+               const mqbc::ClusterStateQueueInfo& state,
+               const mqbconfm::QueueMode&         domainConfig);
 
     // PRIVATE MANIPULATORS
     //   (virtual: mqbc::ClusterMembershipObserver)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -363,17 +363,13 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     assignQueue(const bmqt::Uri&      uri,
                 bmqp_ctrlmsg::Status* status = 0) BSLS_KEYWORD_OVERRIDE;
 
-    /// Register a queue info for the queue with the specified `uri`,
-    /// `partitionId`, `queueKey` and `appIdInfos`.  If the specified
-    /// `forceUpdate` flag is true, update queue info even if it is valid
-    /// but different from the specified `queueKey` and `partitionId`.
+    /// Register a queue info for the queue with the specified `advisory`.
+    /// If the specified `forceUpdate` flag is true, update queue info even if
+    /// it is valid but different from the specified `advisory`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void registerQueueInfo(const bmqt::Uri&        uri,
-                           int                     partitionId,
-                           const mqbu::StorageKey& queueKey,
-                           const AppInfos&         appIdInfos,
+    void registerQueueInfo(const bmqp_ctrlmsg::QueueInfo& advisory,
                            bool forceUpdate) BSLS_KEYWORD_OVERRIDE;
 
     /// Unassign the queue in the specified `advisory` by applying the
@@ -404,21 +400,15 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
             bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>())
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Register the specified `appId` for all queues in the specified
-    /// `domain`.
+    /// Unregister the specified 'removed' and register the specified `added`
+    /// for the specified  `domain` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void registerAppId(const bsl::string&  appId,
-                       const mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
-
-    /// Unregister the specified `appId` for all queues in the specified
-    /// `domain`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    void unregisterAppId(const bsl::string&  appId,
-                         const mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
+    void updateAppIds(const bsl::vector<bsl::string>& added,
+                      const bsl::vector<bsl::string>& removed,
+                      const bsl::string&              domainName,
+                      const bsl::string& uri) BSLS_KEYWORD_OVERRIDE;
 
     /// Invoked when a newly elected (i.e. passive) leader node initiates a
     /// sync with followers before transitioning to active leader.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -401,7 +401,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
         BSLS_KEYWORD_OVERRIDE;
 
     /// Unregister the specified 'removed' and register the specified `added`
-    /// for the specified  `domain` and optionally specified `uri`.
+    /// for the specified  `domainName` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
@@ -232,15 +232,6 @@ void QueueSessionManager::onQueueOpenCb(
 {
     // executed by *ANY* thread
 
-    // First step in this routine is to update the cookie with the queue handle
-    // if 'confirmationCookie' is valid.  If this open-queue request has
-    // succeeded, this client session object should eventually set
-    // 'confirmationCookie' to 0 (see 'onQueueOpenCbDispatched').
-
-    if (confirmationCookie) {
-        *confirmationCookie = queueHandle;
-    }
-
     bmqu::AtomicValidatorGuard guard(validator.get());
     if (!guard.isValid()) {
         // The session was destroyed before we received the response (see

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -445,7 +445,22 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// the specified `stream`.
     bsl::ostream& logAppSubscriptionInfo(bsl::ostream&     stream,
                                          const AppStateSp& appState) const;
+
+    const mqbconfm::Domain& config() const;
 };
+
+// ============================================================================
+//                           INLINE DEFINITIONS
+// ============================================================================
+
+// ----------------------
+// struct RootQueueEngine
+// ----------------------
+
+inline const mqbconfm::Domain& RootQueueEngine::config() const
+{
+    return d_queueState_p->queue()->domain()->config();
+}
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -2177,8 +2177,7 @@ bool StorageManager::isStorageEmpty(const bmqt::Uri& uri,
 
     return mqbc::StorageUtil::isStorageEmpty(&d_storagesLock,
                                              d_storages[partitionId],
-                                             uri,
-                                             partitionId);
+                                             uri);
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -257,7 +257,7 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
     /// Vector of `CanonicalQueueUri -> ReplicatedStorage` maps.  Vector is
     /// indexed by partitionId.  The maps contain *both* in-memory and
     /// file-backed storages.  Note that `d_storagesLock` must be held while
-    /// accessing nthis container and any of its elements (`URI -> Storage`
+    /// accessing this container and any of its elements (`URI -> Storage`
     /// maps), because they are accessed from partitions' dispatcher threads,
     /// as well as the cluster dispatcher thread.
     StorageSpMapVec d_storages;

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -35,8 +35,27 @@ namespace mqbc {
 // class ClusterStateQueueInfo
 // ---------------------------
 
+bool ClusterStateQueueInfo::containsDefaultAppIdOnly(const AppInfos& appInfos)
+{
+    if (appInfos.empty()) {
+        return true;  // RETURN
+    }
+
+    if (appInfos.size() == 1 &&
+        appInfos.count(bmqp::ProtocolUtil::k_DEFAULT_APP_ID) == 1) {
+        return true;  // RETURN
+    }
+
+    return false;
+}
+
 bool ClusterStateQueueInfo::hasTheSameAppIds(const AppInfos& appInfos) const
 {
+    if (containsDefaultAppIdOnly(d_appInfos) &&
+        containsDefaultAppIdOnly(appInfos)) {
+        return true;  // RETURN
+    }
+
     // This ignores the order
 
     if (d_appInfos.size() != appInfos.size()) {

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -73,6 +73,50 @@ bool ClusterStateQueueInfo::hasTheSameAppIds(const AppInfos& appInfos) const
     return true;
 }
 
+void ClusterStateQueueInfo::setApps(const bmqp_ctrlmsg::QueueInfo& advisory)
+{
+    d_appInfos.clear();
+
+    for (bsl::vector<bmqp_ctrlmsg::AppIdInfo>::const_iterator cit =
+             advisory.appIds().cbegin();
+         cit != advisory.appIds().cend();
+         ++cit) {
+        BSLS_ASSERT_SAFE(!cit->appId().empty());
+        BSLS_ASSERT_SAFE(!cit->appKey().empty());
+
+        d_appInfos.emplace(mqbi::ClusterStateManager::AppInfo(
+            bsl::string(cit->appId(), d_allocator_p),
+            mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                             cit->appKey().data())));
+    }
+}
+
+bool ClusterStateQueueInfo::equal(
+    const bmqp_ctrlmsg::QueueInfo& advisory) const
+{
+    if (partitionId() != advisory.partitionId()) {
+        return false;
+    }
+    if (key() != mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                                  advisory.key().data())) {
+        return false;
+    }
+
+    if (advisory.appIds().size() != appInfos().size()) {
+        return false;
+    }
+
+    for (bsl::vector<bmqp_ctrlmsg::AppIdInfo>::const_iterator cit =
+             advisory.appIds().cbegin();
+         cit != advisory.appIds().cend();
+         ++cit) {
+        if (!appInfos().contains(cit->appId())) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bsl::ostream& ClusterStateQueueInfo::print(bsl::ostream& stream,
                                            int           level,
                                            int           spacesPerLevel) const
@@ -414,15 +458,15 @@ ClusterState& ClusterState::updatePartitionNumActiveQueues(int partitionId,
     return *this;
 }
 
-bool ClusterState::assignQueue(const bmqt::Uri&        uri,
-                               const mqbu::StorageKey& key,
-                               int                     partitionId,
-                               const AppInfos&         appIdInfos)
+bool ClusterState::assignQueue(const bmqp_ctrlmsg::QueueInfo& advisory)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(cluster()->dispatcher()->inDispatcherThread(cluster()));
+
+    const bmqt::Uri& uri         = advisory.uri();
+    int              partitionId = advisory.partitionId();
 
     bool                  isNewAssignment = true;
     DomainStatesIter      domIt = domainStates().find(uri.qualifiedDomain());
@@ -443,12 +487,7 @@ bool ClusterState::assignQueue(const bmqt::Uri&        uri,
     if (queueIt == domIt->second->queuesInfo().end()) {
         QueueInfoSp queueInfo;
 
-        queueInfo.createInplace(d_allocator_p,
-                                uri,
-                                key,
-                                partitionId,
-                                appIdInfos,
-                                d_allocator_p);
+        queueInfo.createInplace(d_allocator_p, advisory, d_allocator_p);
 
         queueIt = domIt->second->queuesInfo().emplace(uri, queueInfo).first;
     }
@@ -468,8 +507,9 @@ bool ClusterState::assignQueue(const bmqt::Uri&        uri,
 
             updatePartitionQueueMapped(queueIt->second->partitionId(), -1);
         }
-        queueIt->second->setKey(key).setPartitionId(partitionId);
-        queueIt->second->appInfos() = appIdInfos;
+
+        queueIt->second->setKey(advisory).setPartitionId(partitionId);
+        queueIt->second->setApps(advisory);
     }
 
     // Set the queue as assigned
@@ -477,9 +517,12 @@ bool ClusterState::assignQueue(const bmqt::Uri&        uri,
 
     updatePartitionQueueMapped(partitionId, 1);
 
-    bmqu::Printer<AppInfos> printer(&appIdInfos);
-    BALL_LOG_INFO << "Cluster [" << d_cluster_p->name() << "]: "
-                  << "Assigning queue [" << uri << "], queueKey: [" << key
+    bmqu::Printer<bsl::vector<bmqp_ctrlmsg::AppIdInfo> > printer(
+        &advisory.appIds());
+    BALL_LOG_INFO << "Cluster [" << d_cluster_p->name()
+                  << "]: Assigning queue [" << uri << "], queueKey: ["
+                  << mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                                      advisory.key().data())
                   << "] to Partition [" << partitionId
                   << "] with appIdInfos: [" << printer
                   << "], isNewAssignment: " << isNewAssignment << ".";
@@ -568,10 +611,7 @@ void ClusterState::clearQueues()
     }
 }
 
-int ClusterState::updateQueue(const bmqt::Uri&   uri,
-                              const bsl::string& domain,
-                              const AppInfos&    addedAppIds,
-                              const AppInfos&    removedAppIds)
+int ClusterState::updateQueue(const bmqp_ctrlmsg::QueueInfoUpdate& update)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -585,6 +625,13 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
         rc_APPID_ALREADY_EXISTS = -2,
         rc_APPID_NOT_FOUND      = -3
     };
+
+    const bmqt::Uri&   uri    = update.uri();
+    const bsl::string& domain = update.domain();
+
+    // TODO: avoid this extra copy
+    AppInfos addedAppIds(d_allocator_p);
+    AppInfos removedAppIds(d_allocator_p);
 
     if (uri.isValid()) {
         BSLS_ASSERT_SAFE(uri.qualifiedDomain() == domain);
@@ -600,28 +647,48 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
         if (iter == domIt->second->queuesInfo().end()) {
             return rc_QUEUE_NOT_FOUND;  // RETURN
         }
+        AppInfos& appInfos = iter->second->appInfos();
 
-        AppInfos& appIdInfos = iter->second->appInfos();
-        for (AppInfosCIter citer = addedAppIds.cbegin();
-             citer != addedAppIds.cend();
+        for (bsl::vector<bmqp_ctrlmsg::AppIdInfo>::const_iterator citer =
+                 update.addedAppIds().cbegin();
+             citer != update.addedAppIds().cend();
              ++citer) {
-            if (!appIdInfos.insert(*citer).second) {
+            const AppInfo appInfo = bsl::make_pair(
+                citer->appId(),
+                mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                                 citer->appKey().data()));
+
+            if (!appInfos
+                     .emplace(citer->appId(),
+                              mqbu::StorageKey(
+                                  mqbu::StorageKey::BinaryRepresentation(),
+                                  citer->appKey().data()))
+                     .second) {
                 return rc_APPID_ALREADY_EXISTS;  // RETURN
             }
+            addedAppIds.emplace(appInfo);
         }
 
-        for (AppInfosCIter citer = removedAppIds.begin();
-             citer != removedAppIds.end();
+        for (bsl::vector<bmqp_ctrlmsg::AppIdInfo>::const_iterator citer =
+                 update.removedAppIds().cbegin();
+             citer != update.removedAppIds().cend();
              ++citer) {
-            const AppInfosCIter appIdInfoCIter = appIdInfos.find(citer->first);
-            if (appIdInfoCIter == appIdInfos.cend()) {
+            const AppInfo appInfo = bsl::make_pair(
+                citer->appId(),
+                mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                                 citer->appKey().data()));
+
+            if (appInfos.erase(citer->appId()) == 0) {
                 return rc_APPID_NOT_FOUND;  // RETURN
             }
-            appIdInfos.erase(appIdInfoCIter);
+
+            removedAppIds.emplace(appInfo);
         }
 
-        bmqu::Printer<AppInfos> printer1(&addedAppIds);
-        bmqu::Printer<AppInfos> printer2(&removedAppIds);
+        bmqu::Printer<bsl::vector<bmqp_ctrlmsg::AppIdInfo> > printer1(
+            &update.addedAppIds());
+        bmqu::Printer<bsl::vector<bmqp_ctrlmsg::AppIdInfo> > printer2(
+            &update.removedAppIds());
         BALL_LOG_INFO << "Cluster [" << d_cluster_p->name() << "]: "
                       << "Updating queue [" << uri << "], queueKey: ["
                       << iter->second->key() << "], partitionId: ["
@@ -630,10 +697,12 @@ int ClusterState::updateQueue(const bmqt::Uri&   uri,
                       << ", removedAppIds: " << printer2 << ".";
     }
     else {
-        // This update is for an entire domain, instead of any individual
+        // This update is for the entire domain, instead of any individual
         // queue.
-        bmqu::Printer<AppInfos> printer1(&addedAppIds);
-        bmqu::Printer<AppInfos> printer2(&removedAppIds);
+        bmqu::Printer<bsl::vector<bmqp_ctrlmsg::AppIdInfo> > printer1(
+            &update.addedAppIds());
+        bmqu::Printer<bsl::vector<bmqp_ctrlmsg::AppIdInfo> > printer2(
+            &update.removedAppIds());
         BALL_LOG_INFO << "Cluster [" << d_cluster_p->name() << "]: "
                       << "Updating domain: [" << domain
                       << "], addedAppIds: " << printer1

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -35,27 +35,8 @@ namespace mqbc {
 // class ClusterStateQueueInfo
 // ---------------------------
 
-bool ClusterStateQueueInfo::containsDefaultAppIdOnly(const AppInfos& appInfos)
-{
-    if (appInfos.empty()) {
-        return true;  // RETURN
-    }
-
-    if (appInfos.size() == 1 &&
-        appInfos.count(bmqp::ProtocolUtil::k_DEFAULT_APP_ID) == 1) {
-        return true;  // RETURN
-    }
-
-    return false;
-}
-
 bool ClusterStateQueueInfo::hasTheSameAppIds(const AppInfos& appInfos) const
 {
-    if (containsDefaultAppIdOnly(d_appInfos) &&
-        containsDefaultAppIdOnly(appInfos)) {
-        return true;  // RETURN
-    }
-
     // This ignores the order
 
     if (d_appInfos.size() != appInfos.size()) {
@@ -502,9 +483,9 @@ bool ClusterState::assignQueue(const bmqp_ctrlmsg::QueueInfo& advisory)
             // insists on re-assigning
             isNewAssignment = false;
 
-            if (queueIt->second->key() == key &&
-                queueIt->second->partitionId() == partitionId &&
-                queueIt->second->hasTheSameAppIds(appIdInfos)) {
+            ClusterStateQueueInfo fromAdvisory(advisory, d_allocator_p);
+
+            if (queueIt->second->isEquivalent(fromAdvisory)) {
                 // If queue info is unchanged, can simply return
                 return false;  // RETURN
             }

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -251,9 +251,8 @@ class ClusterStateQueueInfo {
     /// using the specified `allocator` for any memory allocation.
     ClusterStateQueueInfo(const bmqt::Uri& uri, bslma::Allocator* allocator);
 
-    /// Create a `mqbc::ClusterStateQueueInfo` with the specified `uri`,
-    /// `key`, `partitionId` and `appIdInfos` values.  Use the specified
-    /// `allocator` for any memory allocation.
+    /// Create a `mqbc::ClusterStateQueueInfo` with values from the specified
+    /// `advisory`.  Use the specified `allocator` for any memory allocation.
     ClusterStateQueueInfo(const bmqp_ctrlmsg::QueueInfo& advisory,
                           bslma::Allocator*              allocator);
 
@@ -621,8 +620,9 @@ class ClusterState {
     /// partitionsCount'.
     ClusterState& updatePartitionNumActiveQueues(int partitionId, int delta);
 
-    /// Assign the queue with the specified `uri` and `key` to the specified
-    /// `partitionId`, and register the specified `appIdInfos` to the queue.
+    /// Assign the queue with the values (such as `uri`, `key`, `partitionId`)
+    /// from the specified `queueInfo`, and register the `appIdInfos` from the
+    /// `queueInfo` to the queue.
     /// If the queue already appears in cluster state, return false.  Else,
     /// return true.
     ///
@@ -643,11 +643,12 @@ class ClusterState {
     /// cluster's dispatcher thread.
     void clearQueues();
 
-    /// Update the queue with the specified `uri` belonging to the specified
-    /// `domain` by registering the specified `addedAppIds` and
-    /// un-registering the specified `removedAppIds`.  If the specified
-    /// `uri` is empty, the appId updates are applied to the entire `domain`
-    /// instead.  Return 0 on success or a non-zero error code on failure.
+    /// Update the queue with the values in the specified `update`.  Queue must
+    /// have `uri` from the `update` and belong to the corresponding domain.
+    /// Registering the `addedAppIds` and un-registering the `removedAppIds`
+    /// from the `update` .  If the `uri` is empty, apply the update to the
+    /// entire `domain` instead.
+    /// Return 0 on success or a non-zero error code on failure.
     ///
     /// THREAD: This method should only be called from the associated
     /// cluster's dispatcher thread.

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -238,13 +238,6 @@ class ClusterStateQueueInfo {
     BSLMF_NESTED_TRAIT_DECLARATION(ClusterStateQueueInfo,
                                    bslma::UsesBslmaAllocator)
 
-    // CLASS METHODS
-
-    /// Return true if the specified `appInfos` semantically contains the
-    /// default appId only.  Note that having null appIds is treated as
-    /// equivalent to only having default appId.  Return false otherwise.
-    static bool containsDefaultAppIdOnly(const AppInfos& appInfos);
-
     // CREATORS
 
     /// Create a new `mqbc::ClusterStateQueueInfo` with the specified `uri`,

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -238,6 +238,13 @@ class ClusterStateQueueInfo {
     BSLMF_NESTED_TRAIT_DECLARATION(ClusterStateQueueInfo,
                                    bslma::UsesBslmaAllocator)
 
+    // CLASS METHODS
+
+    /// Return true if the specified `appInfos` semantically contains the
+    /// default appId only.  Note that having null appIds is treated as
+    /// equivalent to only having default appId.  Return false otherwise.
+    static bool containsDefaultAppIdOnly(const AppInfos& appInfos);
+
     // CREATORS
 
     /// Create a new `mqbc::ClusterStateQueueInfo` with the specified `uri`,

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1504,11 +1504,9 @@ ClusterStateManager::assignQueue(const bmqt::Uri&      uri,
                                           status);
 }
 
-void ClusterStateManager::registerQueueInfo(const bmqt::Uri& uri,
-                                            int              partitionId,
-                                            const mqbu::StorageKey& queueKey,
-                                            const AppInfos&         appIdInfos,
-                                            bool forceUpdate)
+void ClusterStateManager::registerQueueInfo(
+    const bmqp_ctrlmsg::QueueInfo& advisory,
+    bool                           forceUpdate)
 {
     // executed by the *DISPATCHER* thread
 
@@ -1517,10 +1515,7 @@ void ClusterStateManager::registerQueueInfo(const bmqt::Uri& uri,
 
     mqbc::ClusterUtil::registerQueueInfo(d_state_p,
                                          d_cluster_p,
-                                         uri,
-                                         partitionId,
-                                         queueKey,
-                                         appIdInfos,
+                                         advisory,
                                          forceUpdate);
 }
 
@@ -1569,38 +1564,26 @@ void ClusterStateManager::sendClusterState(
                                         partitions);
 }
 
-void ClusterStateManager::registerAppId(const bsl::string&  appId,
-                                        const mqbi::Domain* domain)
+void ClusterStateManager::updateAppIds(const bsl::vector<bsl::string>& added,
+                                       const bsl::vector<bsl::string>& removed,
+                                       const bsl::string& domainName,
+                                       const bsl::string& uri)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
-    BSLS_ASSERT_SAFE(domain);
+    BSLS_ASSERT_SAFE(!d_cluster_p->isRemote());
+    BSLS_ASSERT_SAFE(!domainName.empty());
 
-    mqbc::ClusterUtil::registerAppId(d_clusterData_p,
-                                     d_clusterStateLedger_mp.get(),
-                                     *d_state_p,
-                                     appId,
-                                     domain,
-                                     d_allocator_p);
-}
-
-void ClusterStateManager::unregisterAppId(const bsl::string&  appId,
-                                          const mqbi::Domain* domain)
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
-    BSLS_ASSERT_SAFE(domain);
-
-    mqbc::ClusterUtil::unregisterAppId(d_clusterData_p,
-                                       d_clusterStateLedger_mp.get(),
-                                       *d_state_p,
-                                       appId,
-                                       domain,
-                                       d_allocator_p);
+    mqbc::ClusterUtil::updateAppIds(d_clusterData_p,
+                                    d_clusterStateLedger_mp.get(),
+                                    *d_state_p,
+                                    added,
+                                    removed,
+                                    domainName,
+                                    uri,
+                                    d_allocator_p);
 }
 
 void ClusterStateManager::initiateLeaderSync(BSLS_ANNOTATION_UNUSED bool wait)

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -481,7 +481,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
         BSLS_KEYWORD_OVERRIDE;
 
     /// Unregister the specified 'removed' and register the specified `added`
-    /// for the specified  `domain` and optionally specified `uri`.
+    /// for the specified  `domainName` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -443,19 +443,13 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     assignQueue(const bmqt::Uri&      uri,
                 bmqp_ctrlmsg::Status* status = 0) BSLS_KEYWORD_OVERRIDE;
 
-    /// Register a queue info for the queue with the specified `uri`,
-    /// `partitionId`, `queueKey` and the optionally specified `appIdInfos`.
-    /// If no `appIdInfos` is specified, use the appId infos from the domain
-    /// config instead.  If the specified `forceUpdate` flag is true, update
-    /// queue info even if it is valid but different from the specified
-    /// `queueKey` and `partitionId`.
+    /// Register a queue info for the queue with the specified `advisory`.
+    /// If the specified `forceUpdate` flag is true, update queue info even if
+    /// it is valid but different from the specified `advisory`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void registerQueueInfo(const bmqt::Uri&        uri,
-                           int                     partitionId,
-                           const mqbu::StorageKey& queueKey,
-                           const AppInfos&         appIdInfos,
+    void registerQueueInfo(const bmqp_ctrlmsg::QueueInfo& advisory,
                            bool forceUpdate) BSLS_KEYWORD_OVERRIDE;
 
     /// Unassign the queue in the specified `advisory` by applying the
@@ -486,21 +480,15 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
             bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>())
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Register the specified `appId` for all queues in the specified
-    /// `domain`.
+    /// Unregister the specified 'removed' and register the specified `added`
+    /// for the specified  `domain` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void registerAppId(const bsl::string&  appId,
-                       const mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
-
-    /// Unregister the specified `appId` for all queues in the specified
-    /// `domain`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    void unregisterAppId(const bsl::string&  appId,
-                         const mqbi::Domain* domain) BSLS_KEYWORD_OVERRIDE;
+    void updateAppIds(const bsl::vector<bsl::string>& added,
+                      const bsl::vector<bsl::string>& removed,
+                      const bsl::string&              domainName,
+                      const bsl::string& uri) BSLS_KEYWORD_OVERRIDE;
 
     /// Invoked when a newly elected (i.e. passive) leader node initiates a
     /// sync with followers before transitioning to active leader.

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -353,18 +353,6 @@ bool populateQueueUpdate(bmqp_ctrlmsg::QueueUpdateAdvisory* queueAdvisory,
         queueUpdate.addedAppIds().size() == added.size()) {
         queueAdvisory->queueUpdates().push_back(queueUpdate);
 
-        if (!clusterState->cluster()->isCSLModeEnabled()) {
-            // In CSL mode, we update the queue to ClusterState upon CSL
-            // commit callback of QueueUpdateAdvisory.
-
-            // In non-CSL mode this is the shortcut to call Primary CQH
-            // instead of waiting for the quorum of acks in the ledger.
-
-            BSLA_MAYBE_UNUSED const int assignRc = clusterState->updateQueue(
-                queueUpdate);
-            BSLS_ASSERT_SAFE(assignRc == 0);
-        }
-
         return true;
     }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -134,8 +134,8 @@ struct ClusterUtil {
 
     /// Set the specified `uri` to have the `k_UNASSIGNING` state in the
     /// specified `clusterState`.
-    static void setPendingUnassignment(ClusterState*    clusterState,
-                                       const bmqt::Uri& uri);
+    static void setPendingUnassignment(const ClusterState* clusterState,
+                                       const bmqt::Uri&    uri);
 
     /// Load into the specified `message` the message encoded in the
     /// specified `eventBlob` using the specified `allocator`.
@@ -211,7 +211,7 @@ struct ClusterUtil {
         ClusterState*                          clusterState,
         ClusterData*                           clusterData,
         const bmqt::Uri&                       uri,
-        const mqbi::Domain*                    domain);
+        const mqbconfm::QueueMode&             config);
 
     /// Populate the specified `advisory` with information describing a
     /// queue unassignment of the specified `uri` having the specified `key`
@@ -258,13 +258,10 @@ struct ClusterUtil {
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    static void registerQueueInfo(ClusterState*           clusterState,
-                                  const mqbi::Cluster*    cluster,
-                                  const bmqt::Uri&        uri,
-                                  int                     partitionId,
-                                  const mqbu::StorageKey& queueKey,
-                                  const AppInfos&         appIdInfos,
-                                  bool                    forceUpdate);
+    static void registerQueueInfo(ClusterState*                  clusterState,
+                                  const mqbi::Cluster*           cluster,
+                                  const bmqp_ctrlmsg::QueueInfo& advisory,
+                                  bool                           forceUpdate);
 
     /// Generate appKeys based on the appIds in the specified `domainConfig`
     /// and populate them into the specified `appIdInfos`.
@@ -272,33 +269,16 @@ struct ClusterUtil {
     populateAppInfos(bsl::vector<bmqp_ctrlmsg::AppIdInfo>* appIdInfos,
                      const mqbconfm::QueueMode&            domainConfig);
 
-    /// Register the specified `appId` for all queues in the specified
-    /// `domain`, using the specified `clusterData` and `clusterState`.
-    /// Apply the corresponding queue update advisory to the specified
-    /// `ledger`.  Use the specified `allocator` for memory allocations.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    static void registerAppId(ClusterData*        clusterData,
-                              ClusterStateLedger* ledger,
-                              ClusterState&       clusterState,
-                              const bsl::string&  appId,
-                              const mqbi::Domain* domain,
-                              bslma::Allocator*   allocator);
-
-    /// Unregister the specified `appId` for all queues in the specified
-    /// `domain`, using the specified `clusterData` and `clusterState`.
-    /// Apply the corresponding queue update advisory to the specified
-    /// `ledger`.  Use the specified `allocator` for memory allocations.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    static void unregisterAppId(ClusterData*        clusterData,
-                                ClusterStateLedger* ledger,
-                                ClusterState&       clusterState,
-                                const bsl::string&  appId,
-                                const mqbi::Domain* domain,
-                                bslma::Allocator*   allocator);
+    /// Unregister the specified 'removed' and register the specified `added`
+    /// for the specified  `domainName` and the specified `uri`.
+    static void updateAppIds(ClusterData*                    clusterData,
+                             ClusterStateLedger*             ledger,
+                             ClusterState&                   clusterState,
+                             const bsl::vector<bsl::string>& added,
+                             const bsl::vector<bsl::string>& removed,
+                             const bsl::string&              domainName,
+                             const bsl::string&              uri,
+                             bslma::Allocator*               allocator);
 
     /// Send the current cluster state to follower nodes.  If the specified
     /// `sendPartitionPrimaryInfo` is true, the specified partition-primary
@@ -397,16 +377,6 @@ struct ClusterUtil {
     static int latestLedgerLSN(bmqp_ctrlmsg::LeaderMessageSequence* out,
                                const ClusterStateLedger&            ledger,
                                const ClusterData& clusterData);
-
-    /// Load into the specified `out` all `AppInfo` data from the specified
-    /// `queueInfo` using the specified `allocator`.
-    static void parseQueueInfo(mqbi::ClusterStateManager::AppInfos* out,
-                               const bmqp_ctrlmsg::QueueInfo&       queueInfo,
-                               bslma::Allocator*                    allocator);
-    static void
-    parseQueueInfo(mqbi::ClusterStateManager::AppInfos*        out,
-                   const bsl::vector<bmqp_ctrlmsg::AppIdInfo>& apps,
-                   bslma::Allocator*                           allocator);
 };
 
 // ============================================================================

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -202,8 +202,8 @@ struct ClusterUtil {
                                   bslma::Allocator*    allocator);
 
     /// Populate the specified `advisory` with information describing a
-    /// queue assignment of the specified `uri` living in the specified
-    /// `domain`, using the specified `clusterState`, `clusterData`.  Load into
+    /// queue assignment of the specified `uri` according to the specified
+    /// `config`, using the specified `clusterState`, `clusterData`.  Load into
     /// the specified `key` the unique queue key generated.
     static void populateQueueAssignmentAdvisory(
         bmqp_ctrlmsg::QueueAssignmentAdvisory* advisory,
@@ -248,13 +248,10 @@ struct ClusterUtil {
                 bslma::Allocator*     allocator,
                 bmqp_ctrlmsg::Status* status = 0);
 
-    /// Register a queue info for the queue with the specified `uri`,
-    /// `partitionId`, `queueKey` and the optionally specified `appIdInfos`
-    /// to the specified `clusterState` of the specified `cluster`.  If no
-    /// `appIdInfos` is specified, use the appId infos from the domain
-    /// config instead.  If the specified `forceUpdate` flag is true, update
-    /// queue info even if it is valid but different from the specified
-    /// `queueKey` and `partitionId`.
+    /// Register a queue info for the queue with the values in the specified
+    /// `advisory` to the specified `clusterState` of the specified `cluster`.
+    /// If the specified `forceUpdate` flag is true, update queue info even if
+    /// it is valid but different from the specified `advisory`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
@@ -270,7 +267,8 @@ struct ClusterUtil {
                      const mqbconfm::QueueMode&            domainConfig);
 
     /// Unregister the specified 'removed' and register the specified `added`
-    /// for the specified  `domainName` and the specified `uri`.
+    /// for the specified  `domainName` and the specified `uri`.  if the `uri`
+    /// is empty, update all queues in the domain.
     static void updateAppIds(ClusterData*                    clusterData,
                              ClusterStateLedger*             ledger,
                              ClusterState&                   clusterState,

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -75,14 +75,13 @@ struct Tester {
                       int                                 partitionId,
                       const mqbc::ClusterState::AppInfos& appIdInfos)
     {
-        bmqt::Uri                       uri(uriString, d_allocator_p);
+        bmqp_ctrlmsg::QueueInfo advisory(bmqtst::TestHelperUtil::allocator());
+
+        advisory.uri() = uriString;
+        key.loadBinary(&advisory.key());
+        advisory.partitionId() = partitionId;
         mqbc::ClusterState::QueueInfoSp queueInfo;
-        queueInfo.createInplace(d_allocator_p,
-                                uri,
-                                key,
-                                partitionId,
-                                appIdInfos,
-                                d_allocator_p);
+        queueInfo.createInplace(d_allocator_p, advisory, d_allocator_p);
         return queueInfo;
     }
 };

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4534,8 +4534,7 @@ bool StorageManager::isStorageEmpty(const bmqt::Uri& uri,
 
     return StorageUtil::isStorageEmpty(&d_storagesLock,
                                        d_storages[partitionId],
-                                       uri,
-                                       partitionId);
+                                       uri);
 }
 
 const mqbs::FileStore& StorageManager::fileStore(int partitionId) const

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -787,10 +787,12 @@ struct TestHelper {
             rec.d_timestamp,
             true);  // isNewQueue
 
-        d_cluster_mp->_state().assignQueue(uri_t,
-                                           queueKey,
-                                           partitionId,
-                                           mqbc::ClusterState::AppInfos());
+        bmqp_ctrlmsg::QueueInfo advisory(bmqtst::TestHelperUtil::allocator());
+
+        advisory.uri() = rec.d_uri;
+        queueKey.loadBinary(&advisory.key());
+        advisory.partitionId() = partitionId;
+        d_cluster_mp->_state().assignQueue(advisory);
 
         BSLS_ASSERT_OPT(rc == 0);
         return queueKey;

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -104,7 +104,7 @@ bool StorageUtil::loadDifference(mqbi::Storage::AppInfos*       result,
 }
 
 void StorageUtil::loadDifference(
-    bsl::unordered_set<bsl::string>*       result,
+    bsl::vector<bsl::string>*              result,
     const bsl::unordered_set<bsl::string>& baseSet,
     const bsl::unordered_set<bsl::string>& subtractionSet)
 {
@@ -113,7 +113,7 @@ void StorageUtil::loadDifference(
          cit != baseSet.cend();
          ++cit) {
         if (subtractionSet.end() == subtractionSet.find(*cit)) {
-            result->emplace(*cit);
+            result->push_back(*cit);
         }
     }
 }
@@ -139,8 +139,8 @@ bool StorageUtil::loadAddedAndRemovedEntries(
 }
 
 void StorageUtil::loadAddedAndRemovedEntries(
-    bsl::unordered_set<bsl::string>*       addedEntries,
-    bsl::unordered_set<bsl::string>*       removedEntries,
+    bsl::vector<bsl::string>*              addedEntries,
+    bsl::vector<bsl::string>*              removedEntries,
     const bsl::unordered_set<bsl::string>& existingEntries,
     const bsl::unordered_set<bsl::string>& newEntries)
 {
@@ -373,7 +373,7 @@ int StorageUtil::updateQueuePrimaryRaw(mqbs::ReplicatedStorage* storage,
     }
 
     if (!removedIdKeyPairs.empty()) {
-        for (AppInfosCIter cit = removedIdKeyPairs.begin();
+        for (AppInfos::const_iterator cit = removedIdKeyPairs.begin();
              cit != removedIdKeyPairs.end();
              ++cit) {
             rc = removeVirtualStorageInternal(storage,
@@ -444,7 +444,7 @@ int StorageUtil::addVirtualStoragesInternal(
     if (isFanout) {
         // Register appKeys with with the underlying physical 'storage'.
 
-        for (AppInfosCIter cit = appIdKeyPairs.begin();
+        for (AppInfos::const_iterator cit = appIdKeyPairs.begin();
              cit != appIdKeyPairs.end();
              ++cit) {
             if (0 != (rc = storage->addVirtualStorage(errorDesc,
@@ -795,14 +795,12 @@ int StorageUtil::processReplicationCommand(
 // FUNCTIONS
 bool StorageUtil::isStorageEmpty(bslmt::Mutex*       storagesLock,
                                  const StorageSpMap& storageMap,
-                                 const bmqt::Uri&    uri,
-                                 int                 partitionId)
+                                 const bmqt::Uri&    uri)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(uri.isValid());
-    BSLS_ASSERT_SAFE(0 <= partitionId);
 
     bslmt::LockGuard<bslmt::Mutex> guard(storagesLock);  // LOCK
 
@@ -2476,7 +2474,7 @@ void StorageUtil::registerQueue(const mqbi::Cluster*           cluster,
     AppInfos           appIdKeyPairsToUse;
     if (queueMode.isFanoutValue()) {
         if (cluster->isCSLModeEnabled() || !appIdKeyPairs.empty()) {
-            for (AppInfosCIter citer = appIdKeyPairs.begin();
+            for (AppInfos::const_iterator citer = appIdKeyPairs.begin();
                  citer != appIdKeyPairs.end();
                  ++citer) {
                 int rc = storageSp->addVirtualStorage(errorDesc,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -98,8 +98,7 @@ struct StorageUtil {
 
   private:
     // TYPES
-    typedef mqbi::StorageManager::AppInfos      AppInfos;
-    typedef mqbi::StorageManager::AppInfosCIter AppInfosCIter;
+    typedef mqbi::StorageManager::AppInfos AppInfos;
 
     typedef mqbi::StorageManager::AppIds         AppIds;
     typedef mqbi::StorageManager::AppIdsIter     AppIdsIter;
@@ -180,7 +179,7 @@ struct StorageUtil {
     /// Load into the specified `result` the list of elements present in
     /// `baseSet` which are not present in `subtractionSet`.
     static void
-    loadDifference(bsl::unordered_set<bsl::string>*       result,
+    loadDifference(bsl::vector<bsl::string>*              result,
                    const bsl::unordered_set<bsl::string>& baseSet,
                    const bsl::unordered_set<bsl::string>& subtractionSet);
 
@@ -389,20 +388,18 @@ struct StorageUtil {
     /// into the specified `removedEntries` the list of entries which are
     /// present in `existingEntries` but not in `newEntries`.
     static void loadAddedAndRemovedEntries(
-        bsl::unordered_set<bsl::string>*       addedEntries,
-        bsl::unordered_set<bsl::string>*       removedEntries,
+        bsl::vector<bsl::string>*              addedEntries,
+        bsl::vector<bsl::string>*              removedEntries,
         const bsl::unordered_set<bsl::string>& existingEntries,
         const bsl::unordered_set<bsl::string>& newEntries);
 
-    /// Return true if the queue having specified `uri` and assigned to the
-    /// specified `partitionId` has no messages in the specified
-    /// `storageMap`, false in any other case.  If the optionally specified
-    /// `storagesLock` is specified, lock it.  Behavior is undefined unless
-    /// this routine is invoked from cluster dispatcher thread.
+    /// Return true if the queue having specified `uri` has no messages in the
+    /// specified `storageMap`, false in any other case.  If the optionally
+    /// specified `storagesLock` is specified, lock it.  Behavior is undefined
+    /// unless this routine is invoked from cluster dispatcher thread.
     static bool isStorageEmpty(bslmt::Mutex*       storagesLock,
                                const StorageSpMap& storageMap,
-                               const bmqt::Uri&    uri,
-                               int                 partitionId);
+                               const bmqt::Uri&    uri);
 
     /// Callback scheduled by the Storage Manager to run every minute which
     /// monitors storage (disk space, archive clean up, etc), using the

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -193,20 +193,14 @@ class ClusterStateManager {
     virtual QueueAssignmentResult::Enum
     assignQueue(const bmqt::Uri& uri, bmqp_ctrlmsg::Status* status = 0) = 0;
 
-    /// Register a queue info for the queue with the specified `uri`,
-    /// `partitionId`, `queueKey` and the optionally specified `appIdInfos`.
-    /// If no `appIdInfos` is specified, use the appId infos from the domain
-    /// config instead.  If the specified `forceUpdate` flag is true, update
-    /// queue info even if it is valid but different from the specified
-    /// `queueKey` and `partitionId`.
+    /// Register a queue info for the queue with the specified `advisory`.
+    /// If the specified `forceUpdate` flag is true, update queue info even if
+    /// it is valid but different from the specified `advisory`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    virtual void registerQueueInfo(const bmqt::Uri&        uri,
-                                   int                     partitionId,
-                                   const mqbu::StorageKey& queueKey,
-                                   const AppInfos&         appIdInfos,
-                                   bool                    forceUpdate) = 0;
+    virtual void registerQueueInfo(const bmqp_ctrlmsg::QueueInfo& advisory,
+                                   bool forceUpdate) = 0;
 
     /// Unassign the queue in the specified `advisory` by applying the
     /// advisory to the cluster state ledger owned by this object.
@@ -235,21 +229,15 @@ class ClusterStateManager {
         const bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>& partitions =
             bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>()) = 0;
 
-    /// Register the specified `appId` for all queues in the specified
-    /// `domain`.
+    /// Unregister the specified 'removed' and register the specified `added`
+    /// for the specified  `domain` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    virtual void registerAppId(const bsl::string&  appId,
-                               const mqbi::Domain* domain) = 0;
-
-    /// Unregister the specified `appId` for all queues in the specified
-    /// `domain`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    virtual void unregisterAppId(const bsl::string&  appId,
-                                 const mqbi::Domain* domain) = 0;
+    virtual void updateAppIds(const bsl::vector<bsl::string>& added,
+                              const bsl::vector<bsl::string>& removed,
+                              const bsl::string&              domainName,
+                              const bsl::string&              uri) = 0;
 
     /// Invoked when a newly elected (i.e. passive) leader node initiates a
     /// sync with followers before transitioning to active leader.

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -230,7 +230,7 @@ class ClusterStateManager {
             bsl::vector<bmqp_ctrlmsg::PartitionPrimaryInfo>()) = 0;
 
     /// Unregister the specified 'removed' and register the specified `added`
-    /// for the specified  `domain` and optionally specified `uri`.
+    /// for the specified  `domainName` and optionally specified `uri`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -167,8 +167,7 @@ class StorageManagerIterator {
 class StorageManager {
   public:
     // TYPES
-    typedef mqbi::Storage::AppInfos  AppInfos;
-    typedef AppInfos::const_iterator AppInfosCIter;
+    typedef mqbi::Storage::AppInfos AppInfos;
 
     typedef bsl::unordered_set<bsl::string> AppIds;
     typedef AppIds::iterator                AppIdsIter;

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
@@ -178,8 +178,8 @@ void StoragePrintUtil::printRecoveredStorages(
         rs->loadVirtualStorageDetails(&appIdKeyPairs);
         BSLS_ASSERT_SAFE(numVS == appIdKeyPairs.size());
 
-        for (AppInfosCIter vit = appIdKeyPairs.begin();
-             vit != appIdKeyPairs.end();
+        for (AppInfos::const_iterator vit = appIdKeyPairs.cbegin();
+             vit != appIdKeyPairs.cend();
              ++vit) {
             BSLS_ASSERT_SAFE(rs->hasVirtualStorage(vit->second));
 

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.h
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.h
@@ -67,7 +67,6 @@ struct StoragePrintUtil {
   private:
     // PRIVATE TYPES
     typedef mqbi::StorageManager::AppInfos AppInfos;
-    typedef AppInfos::const_iterator       AppInfosCIter;
 
   public:
     // TYPES

--- a/src/integration-tests/test_appids.py
+++ b/src/integration-tests/test_appids.py
@@ -695,7 +695,7 @@ def test_csl_repair_after_stop(cluster: Cluster):
     producer.open(tc.URI_FANOUT_SC, flags=["write,ack"], succeed=True)
 
 
-def test_open_authorize_change_primary(multi_node: Cluster):
+def test_open_authorize_change_primary(multi_node: Cluster, domain_urls: tc.DomainUrls):
     """Add an App to Domain config of an existing queue, and then force a
     Replica to become new Primary.  Start new Consumer.  Make sure the Consumer
     receives previously posted data.

--- a/src/integration-tests/test_appids.py
+++ b/src/integration-tests/test_appids.py
@@ -680,9 +680,13 @@ def test_csl_repair_after_stop(cluster: Cluster):
 
     cluster.stop_nodes()
 
+    updated_app_ids = default_app_ids.copy()
+    updated_app_ids.remove("foo")
+    updated_app_ids.append("new1")
+
     cluster.config.domains[
         tc.DOMAIN_FANOUT_SC
-    ].definition.parameters.mode.fanout.app_ids = default_app_ids + ["new1"]
+    ].definition.parameters.mode.fanout.app_ids = updated_app_ids
 
     cluster.deploy_domains()
 

--- a/src/integration-tests/test_appids.py
+++ b/src/integration-tests/test_appids.py
@@ -665,7 +665,33 @@ def test_open_authorize_restart_from_non_FSM_to_FSM(
         )
 
 
-def test_open_authorize_change_primary(multi_node: Cluster, domain_urls: tc.DomainUrls):
+def test_csl_repair_after_stop(cluster: Cluster):
+    """Adding Apps to an existing queue in the absense of primary results in
+    the App missing in the CSL.  The CSL needs repair
+    """
+    proxies = cluster.proxy_cycle()
+
+    producer = next(proxies).create_client("producer")
+    producer.open(tc.URI_FANOUT_SC, flags=["write,ack"], succeed=True)
+
+    producer.post(tc.URI_FANOUT_SC, ["msg1"], block=True)
+
+    producer.close(tc.URI_FANOUT_SC, succeed=True)
+
+    cluster.stop_nodes()
+
+    cluster.config.domains[
+        tc.DOMAIN_FANOUT_SC
+    ].definition.parameters.mode.fanout.app_ids = default_app_ids + ["new1"]
+
+    cluster.deploy_domains()
+
+    cluster.start_nodes(wait_leader=True, wait_ready=True)
+
+    producer.open(tc.URI_FANOUT_SC, flags=["write,ack"], succeed=True)
+
+
+def test_open_authorize_change_primary(multi_node: Cluster):
     """Add an App to Domain config of an existing queue, and then force a
     Replica to become new Primary.  Start new Consumer.  Make sure the Consumer
     receives previously posted data.


### PR DESCRIPTION
We rely on Primary to pick new domain config, but if Primary fails, the new config does not make it to the CSL on existing Replica.
As the result new Primary may crash because domain config doe snot match CSL - 
- "#QUEUE_STORAGE_NOTFOUND Virtual storage does not exist for AppId "

