### PR TITLE
fix race between restoreState and onOpenQueueResponse [178106131]

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -1241,7 +1241,10 @@ inline bool ClusterQueueHelper::isQueuePrimaryAvailable(
         return queueContext.d_liveQInfo.d_id !=
                    bmqp::QueueId::k_UNASSIGNED_QUEUE_ID &&
                d_clusterData_p->electorInfo().leaderNode() != 0 &&
-               d_clusterData_p->electorInfo().leaderNode() != otherThan;
+               d_clusterData_p->electorInfo().leaderNode() != otherThan &&
+               d_clusterData_p->electorInfo().electorState() ==
+                   mqbnet::ElectorState::e_LEADER;
+
         // RETURN
     }
 


### PR DESCRIPTION
 Race between processing reopen request cancellation (due to disconnect) and reacting to new primary.  In the former, we assume that since we got cancellation, there is no primary and we buffer the request waiting for primary (which is already there).