### PR TITLE
Fix: m_bmqtool::Poster: remove unsafe format string passed

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -129,13 +129,16 @@ void PostingContext::postNext()
             }
 
             if (!d_parameters_p->sequentialMessagePattern().empty()) {
-                char buffer[128];
+                char buffer[16];
+                bsl::string messageData(d_allocator_p);
                 length = snprintf(
                     buffer,
                     sizeof(buffer),
-                    d_parameters_p->sequentialMessagePattern().c_str(),
+                    "%09d",
                     d_numMessagesPosted);
-                msg.setDataRef(buffer, length);
+                messageData = d_parameters_p->sequentialMessagePattern();
+                messageData.append(buffer);
+                msg.setDataRef(messageData.c_str(), messageData.length());
             }
             else {
                 // Insert latency if required...

--- a/src/applications/bmqtool/m_bmqtool_poster.cpp
+++ b/src/applications/bmqtool/m_bmqtool_poster.cpp
@@ -129,13 +129,12 @@ void PostingContext::postNext()
             }
 
             if (!d_parameters_p->sequentialMessagePattern().empty()) {
-                char buffer[16];
+                char        buffer[16];
                 bsl::string messageData(d_allocator_p);
-                length = snprintf(
-                    buffer,
-                    sizeof(buffer),
-                    "%09d",
-                    d_numMessagesPosted);
+                length      = snprintf(buffer,
+                                  sizeof(buffer),
+                                  "%09d",
+                                  d_numMessagesPosted);
                 messageData = d_parameters_p->sequentialMessagePattern();
                 messageData.append(buffer);
                 msg.setDataRef(messageData.c_str(), messageData.length());

--- a/src/integration-tests/test_puts_retransmission.py
+++ b/src/integration-tests/test_puts_retransmission.py
@@ -205,7 +205,6 @@ class TestPutsRetransmission:
                 + r"msg\s*"  # "msg"
                 + r"(\d+)"
             )  # %d
-            )
 
             re_confirm = re.compile(
                 "(?i)"  # case insensitive

--- a/src/integration-tests/test_puts_retransmission.py
+++ b/src/integration-tests/test_puts_retransmission.py
@@ -202,9 +202,8 @@ class TestPutsRetransmission:
                 + r" PUSH "  # PUSH
                 + re.escape(uri[0])  # queue url
                 + r"\|(.+)\|"  # |GUID|
-                + r"msg\s*"  # "msg"
-                + r"(\d+)\|"
-            )  # %d
+                + r"msg"  # "msg"
+            )
 
             re_confirm = re.compile(
                 "(?i)"  # case insensitive
@@ -409,7 +408,7 @@ class TestPutsRetransmission:
                 "--queueuri",
                 self.uri,
                 "--messagepattern",
-                "msg%10d|",
+                "msg",
                 f"--messageProperties={self.mps}",
                 "--log",
                 producer_log,

--- a/src/integration-tests/test_puts_retransmission.py
+++ b/src/integration-tests/test_puts_retransmission.py
@@ -202,7 +202,9 @@ class TestPutsRetransmission:
                 + r" PUSH "  # PUSH
                 + re.escape(uri[0])  # queue url
                 + r"\|(.+)\|"  # |GUID|
-                + r"msg"  # "msg"
+                + r"msg\s*"  # "msg"
+                + r"(\d+)"
+            )  # %d
             )
 
             re_confirm = re.compile(


### PR DESCRIPTION
Closes: #593

1. We remove `sequentialMessagePattern` from being passed as a format string by appending it with a mutable suffix for `d_numMessagesPosted`.
2. Remove the need for `%d` in the integration test file `test_puts_retransmission.py`.