### PR TITLE
Fix[MQB]: Select active node quickly when no cluster node in same DC

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
@@ -163,7 +163,7 @@ bool ClusterActiveNodeManager::findNewActiveNode()
          ++it) {
         mqbnet::ClusterNode* node = it->first;
         if (it->second.d_status == bmqp_ctrlmsg::NodeStatus::E_AVAILABLE &&
-            ((d_ignoreDataCenter || node->dataCenter() == d_dataCenter) ||
+            (d_ignoreDataCenter || node->dataCenter() == d_dataCenter ||
              d_dataCenter == "UNSPECIFIED")) {
             candidates.push_back(node);
         }

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
@@ -163,7 +163,7 @@ bool ClusterActiveNodeManager::findNewActiveNode()
          ++it) {
         mqbnet::ClusterNode* node = it->first;
         if (it->second.d_status == bmqp_ctrlmsg::NodeStatus::E_AVAILABLE &&
-            ((node->dataCenter() == d_dataCenter) ||
+            ((d_ignoreDataCenter || node->dataCenter() == d_dataCenter) ||
              d_dataCenter == "UNSPECIFIED")) {
             candidates.push_back(node);
         }
@@ -242,14 +242,19 @@ ClusterActiveNodeManager::ClusterActiveNodeManager(
 : d_description(description)
 , d_dataCenter(dataCenter)
 , d_activeNodeIt(d_nodes.end())
+, d_ignoreDataCenter(false)
 , d_useExtendedSelection(false)
 {
+    bool clusterHasNodeInLocalDC = false;
     for (mqbnet::Cluster::NodesList::const_iterator it = nodes.begin();
          it != nodes.end();
          ++it) {
         mqbnet::ClusterNode* node = *it;
         d_nodes[node].d_status    = bmqp_ctrlmsg::NodeStatus::E_UNAVAILABLE;
+        clusterHasNodeInLocalDC   = clusterHasNodeInLocalDC ||
+                                  d_dataCenter == node->dataCenter();
     }
+    d_ignoreDataCenter = !clusterHasNodeInLocalDC;
 }
 
 ClusterActiveNodeManager::~ClusterActiveNodeManager()

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
@@ -334,7 +334,7 @@ class ClusterActiveNodeManager {
 
     // ACCESSORS
 
-    /// Return the currently active node, or a null pointer if there are no
+    /// Return the currently active node, or a null pointer if there is no
     /// node currently active.
     ClusterNode* activeNode() const;
 

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
@@ -258,6 +258,13 @@ class ClusterActiveNodeManager {
     // Pointer to the currently active node
     // and its context.
 
+    bool d_ignoreDataCenter;
+    // If true, remove the data center
+    // requirement when selecting active
+    // node. Set to true when the cluster
+    // does not have any nodes in the
+    // current machine's data center.
+
     bool d_useExtendedSelection;
     // If true, drop the same data center
     // requirement when selecting active

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
@@ -258,12 +258,10 @@ class ClusterActiveNodeManager {
     // Pointer to the currently active node
     // and its context.
 
+    /// If true, remove the data center requirement when selecting active
+    /// node.  Set to true when the cluster does not have any nodes in the
+    /// current machine's data center.
     bool d_ignoreDataCenter;
-    // If true, remove the data center
-    // requirement when selecting active
-    // node. Set to true when the cluster
-    // does not have any nodes in the
-    // current machine's data center.
 
     bool d_useExtendedSelection;
     // If true, drop the same data center

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -251,7 +251,7 @@ static void test4_panicInExtendedMode()
     // Populate cluster nodes
     // - 1 node in "east" data center
     // - 1 node in "west" data center
-    mqbnet::Cluster::NodesList nodes;
+    mqbnet::Cluster::NodesList nodes(bmqtst::TestHelperUtil::allocator());
     mqbcfg::ClusterNode clusterNodeConfig(bmqtst::TestHelperUtil::allocator());
 
     clusterNodeConfig.dataCenter() = "east";

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -81,7 +81,7 @@ static void test2_activeNodeWithinDC()
     // Populate cluster nodes
     // - 1 node in "east" data center
     // - 1 node in "west" data center
-    mqbnet::Cluster::NodesList nodes;
+    mqbnet::Cluster::NodesList nodes(bmqtst::TestHelperUtil::allocator());
     mqbcfg::ClusterNode clusterNodeConfig(bmqtst::TestHelperUtil::allocator());
 
     clusterNodeConfig.dataCenter() = "east";

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -173,7 +173,7 @@ static void test3_activeNodeOutsideDC()
     // Populate cluster nodes
     // - 1 node in "east" data center
     // - 1 node in "west" data center
-    mqbnet::Cluster::NodesList nodes;
+    mqbnet::Cluster::NodesList nodes(bmqtst::TestHelperUtil::allocator());
     mqbcfg::ClusterNode clusterNodeConfig(bmqtst::TestHelperUtil::allocator());
 
     clusterNodeConfig.dataCenter() = "east";

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// mqbnet_dummysession.t.cpp                                          -*-C++-*-
+// mqbnet_clusteractivenodemanager.t.cpp                              -*-C++-*-
 #include <mqbnet_clusteractivenodemanager.h>
 
 // MQB

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -1,0 +1,162 @@
+// Copyright 2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbnet_dummysession.t.cpp                                          -*-C++-*-
+#include <mqbnet_clusteractivenodemanager.h>
+
+// MQB
+#include <mqbcfg_messages.h>
+#include <mqbnet_cluster.h>
+#include <mqbnet_mockcluster.h>
+
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+
+// BDE
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bsl_string.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_breathingTest()
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    mqbnet::Cluster::NodesList nodes;
+    bsl::string                description = "dummy";
+    bsl::string                dataCenter  = "east";
+
+    mqbnet::ClusterActiveNodeManager mgr =
+        mqbnet::ClusterActiveNodeManager(nodes, description, dataCenter);
+
+    BMQTST_ASSERT(!mgr.activeNode());
+}
+
+static void test2_activeNodeWithinDC()
+// Validate that an available node in the same data center is promptly
+// selected as the active node. Nodes outside of the data center will not be
+// selected until the selection criteria is explicitly extended.
+{
+    bmqtst::TestHelper::printTestName("ACTIVE NODE IN SAME DC");
+
+    // Set up mock cluster
+    mqbcfg::ClusterDefinition clusterConfig(
+        bmqtst::TestHelperUtil::allocator());
+    bdlbb::PooledBlobBufferFactory bufferFactory(
+        1024,
+        bmqtst::TestHelperUtil::allocator());
+    mqbnet::MockCluster mockCluster(clusterConfig,
+                                    &bufferFactory,
+                                    bmqtst::TestHelperUtil::allocator());
+
+    // Populate cluster nodes
+    // - 1 node in "east" data center
+    // - 1 node in "west" data center
+    mqbnet::Cluster::NodesList nodes;
+    mqbcfg::ClusterNode clusterNodeConfig(bmqtst::TestHelperUtil::allocator());
+
+    clusterNodeConfig.dataCenter() = "east";
+    clusterNodeConfig.name()       = "east-1";
+    mqbnet::MockClusterNode east1(&mockCluster,
+                                  clusterNodeConfig,
+                                  &bufferFactory,
+                                  bmqtst::TestHelperUtil::allocator());
+    nodes.push_back(&east1);
+
+    clusterNodeConfig.dataCenter() = "west";
+    clusterNodeConfig.name()       = "west-1";
+    mqbnet::MockClusterNode west1(&mockCluster,
+                                  clusterNodeConfig,
+                                  &bufferFactory,
+                                  bmqtst::TestHelperUtil::allocator());
+    nodes.push_back(&west1);
+
+    // Create ClusterActiveNodeManager
+    bsl::string                      description = "dummy";
+    bsl::string                      dataCenter  = "east";
+    mqbnet::ClusterActiveNodeManager mgr =
+        mqbnet::ClusterActiveNodeManager(nodes, description, dataCenter);
+    BMQTST_ASSERT(!mgr.activeNode());
+
+    bmqp_ctrlmsg::NegotiationMessage negotiationMessage(
+        bmqtst::TestHelperUtil::allocator());
+    negotiationMessage.makeClientIdentity().hostName() = "dummyIdentity";
+
+    // "west" node up, it should not become active
+    {
+        int rc = mgr.onNodeUp(&west1, negotiationMessage.clientIdentity());
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NO_CHANGE);
+        BMQTST_ASSERT(!mgr.activeNode());
+    }
+
+    // "east" node up, it should become active
+    {
+        int rc = mgr.onNodeUp(&east1, negotiationMessage.clientIdentity());
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NEW_ACTIVE);
+        BMQTST_ASSERT_EQ(mgr.activeNode(), &east1);
+    }
+
+    // "east" node down, no active node
+    {
+        int rc = mgr.onNodeDown(&east1);
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_LOST_ACTIVE);
+        BMQTST_ASSERT(!mgr.activeNode());
+    }
+
+    // Refresh should not change active node
+    {
+        int rc = mgr.refresh();
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NO_CHANGE);
+        BMQTST_ASSERT(!mgr.activeNode());
+    }
+
+    // Relax DC filter logic, "west" should become active
+    {
+        mgr.enableExtendedSelection();
+        int rc = mgr.refresh();
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NEW_ACTIVE);
+        BMQTST_ASSERT_EQ(mgr.activeNode(), &west1);
+    }
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 2: test2_activeNodeWithinDC(); break;
+    case 1: test1_breathingTest(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
+}


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #<number>*

**Describe your changes**
When a broker connects to a cluster and attempts to select an active node, the broker attempts to select a node in the same data center. After 10 seconds, if no active node has been selected, the broker relaxes the data center requirement and picks any available node. If a cluster does not have any nodes in the broker's data center, this leads to a 10 second delay on the first open queue request to a cluster.

This commit changes the active node selection logic for the case where there is no cluster node within the same data center as a broker. In this case, the broker will ignore the data center may use any available node as the active node.

**Testing performed**
Describe the testing you have performed to ensure that the bug has been addressed, or that the new feature works as planned.

**Additional context**
Add any other context about your contribution here.
