### PR TITLE
Perf[MQB]: cache support for MESSAGE_PROPERTIES_EX on PUSH path

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -2045,10 +2045,7 @@ void ClientSession::onPushEvent(const mqbi::DispatcherPushEvent& event)
 
     // Append the message to the builder
     if (pushProperties.isExtended()) {
-        if (!bmqp::ProtocolUtil::hasFeature(
-                bmqp::MessagePropertiesFeatures::k_FIELD_NAME,
-                bmqp::MessagePropertiesFeatures::k_MESSAGE_PROPERTIES_EX,
-                d_clientIdentity_p->features())) {
+        if (!d_supportsMessagePropertiesEX) {
             // Re-encode 'payload'
             // Convert MessageProperties into the old style
             // 1. Copy MPHs (if needed)
@@ -2661,6 +2658,10 @@ ClientSession::ClientSession(
 , d_negotiationMessage(negotiationMessage, allocator)
 , d_clientIdentity_p(extractClientIdentity(d_negotiationMessage))
 , d_isClientGeneratingGUIDs(isClientGeneratingGUIDs(*d_clientIdentity_p))
+, d_supportsMessagePropertiesEX(bmqp::ProtocolUtil::hasFeature(
+      bmqp::MessagePropertiesFeatures::k_FIELD_NAME,
+      bmqp::MessagePropertiesFeatures::k_MESSAGE_PROPERTIES_EX,
+      d_clientIdentity_p->features()))
 , d_description(sessionDescription, allocator)
 , d_channel_sp(channel)
 , d_state(clientStatContext,

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -329,6 +329,12 @@ class ClientSession : public mqbnet::Session,
     /// @bbref{bmqp::MessageGUIDGenerator} and doesn't provide correlation ids.
     const bool d_isClientGeneratingGUIDs;
 
+    /// The flag indicating that the client support extended message
+    /// properties (k_MESSAGE_PROPERTIES_EX).  This flag is evaluated once and
+    /// cached in this variable to speed up the PUSH processing path.
+    /// Note: remove when support for legacy message properties is dropped.
+    const bool d_supportsMessagePropertiesEX;
+
     /// Short identifier for this session.
     bsl::string d_description;
 


### PR DESCRIPTION
This PR gets rid of the repeated `bmqp::ProtocolUtil::hasFeature` calls per every PUSH message.

In this listing, ~2% of all CPU time is lost on these calls:

<img width="1015" alt="Screenshot 2025-02-12 at 19 04 39" src="https://github.com/user-attachments/assets/f2166187-3eae-41d9-bf60-30212b05d8e4" />
