### PR TITLE
fix Getting rid of raw pointer to storage

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -109,10 +109,10 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
 
         // Only create a storage if this is the initial configure; reconfigure
         // should reuse the previously created storage.
-        bslma::ManagedPtr<mqbi::Storage> storageMp;
+        bsl::shared_ptr<mqbi::Storage> storageSp;
         rc = d_state_p->storageManager()->makeStorage(
             errorDescription,
-            &storageMp,
+            &storageSp,
             d_state_p->uri(),
             d_state_p->key(),
             d_state_p->partitionId(),
@@ -124,10 +124,10 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
         }
 
         if (d_state_p->isAtMostOnce()) {
-            storageMp->capacityMeter()->disable();
+            storageSp->capacityMeter()->disable();
         }
 
-        if (!d_state_p->isStorageCompatible(storageMp)) {
+        if (!d_state_p->isStorageCompatible(storageSp)) {
             errorDescription << "Incompatible storage type for LocalQueue "
                              << "[uri: " << d_state_p->uri() << ", key: '"
                              << d_state_p->key()
@@ -136,7 +136,7 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
             return rc_INCOMPATIBLE_STORAGE;  // RETURN
         }
 
-        d_state_p->setStorage(storageMp);
+        d_state_p->setStorage(storageSp);
     }
     else {
         d_state_p->storage()->setConsistency(domainCfg.consistency());

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -79,7 +79,6 @@ namespace mqbblp {
 class QueueState {
   public:
     // TYPES
-    typedef bslma::ManagedPtr<mqbi::Storage> StorageMp;
 
     /// `SubQueuesParameters` is an alias for a map of QueueStreamParameters
     /// (subQueueId) -> queueStreamParameters
@@ -145,7 +144,7 @@ class QueueState {
     bdlmt::FixedThreadPool* d_miscWorkThreadPool_p;
 
     /// Storage used by the queue associated to this state.
-    StorageMp d_storage_mp;
+    bsl::shared_ptr<mqbi::Storage> d_storage_sp;
 
     /// Dispatcher Client Data of the queue associated to this state.
     mqbi::DispatcherClientData d_dispatcherClientData;
@@ -200,7 +199,7 @@ class QueueState {
     QueueState& setId(unsigned int value);
     QueueState& setKey(const mqbu::StorageKey& key);
     QueueState& setPartitionId(int value);
-    QueueState& setStorage(StorageMp& value);
+    QueueState& setStorage(const bsl::shared_ptr<mqbi::Storage>& value);
     QueueState& setStorageManager(mqbi::StorageManager* value);
     QueueState&
     setRoutingConfig(const bmqp_ctrlmsg::RoutingConfiguration& routingConfig);
@@ -303,7 +302,8 @@ class QueueState {
 
     /// Return `true` if the specified `storage` is compatible with the
     /// current configuration, or `false` otherwise.
-    bool isStorageCompatible(const StorageMp& storageMp) const;
+    bool
+    isStorageCompatible(const bsl::shared_ptr<mqbi::Storage>& storageSp) const;
 
     /// Return `true` if the configuration for this queue requires
     /// at-most-once semantics or `false` otherwise.
@@ -373,9 +373,10 @@ inline QueueState& QueueState::setPartitionId(int value)
     return *this;
 }
 
-inline QueueState& QueueState::setStorage(StorageMp& value)
+inline QueueState&
+QueueState::setStorage(const bsl::shared_ptr<mqbi::Storage>& value)
 {
-    d_storage_mp = value;
+    d_storage_sp = value;
     return *this;
 }
 
@@ -566,7 +567,7 @@ inline mqbi::Queue* QueueState::queue() const
 
 inline mqbi::Storage* QueueState::storage() const
 {
-    return d_storage_mp.get();
+    return d_storage_sp.get();
 }
 
 inline mqbi::StorageManager* QueueState::storageManager() const

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -195,12 +195,12 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
         // Only create a storage if this is the initial configure; reconfigure
         // (which happens during conversion to local/remote) should reuse the
         // previously created storage.
-        bslma::ManagedPtr<mqbi::Storage>      storageMp;
+        bsl::shared_ptr<mqbi::Storage>        storageSp;
         bdlma::LocalSequentialAllocator<1024> localAllocator(d_allocator_p);
         bmqu::MemOutStream                    errorDesc(&localAllocator);
         rc = d_state_p->storageManager()->makeStorage(
             errorDesc,
-            &storageMp,
+            &storageSp,
             d_state_p->uri(),
             d_state_p->key(),
             d_state_p->partitionId(),
@@ -223,10 +223,10 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
         }
 
         if (d_state_p->isAtMostOnce()) {
-            storageMp->capacityMeter()->disable();
+            storageSp->capacityMeter()->disable();
         }
 
-        if (!d_state_p->isStorageCompatible(storageMp)) {
+        if (!d_state_p->isStorageCompatible(storageSp)) {
             BMQTSK_ALARMLOG_ALARM("CLUSTER_STATE")
                 << d_state_p->domain()->cluster()->name() << ": Partition ["
                 << d_state_p->partitionId()
@@ -236,7 +236,7 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
             return 10 * rc + rc_QUEUE_CONFIGURE_FAILURE;  // RETURN
         }
 
-        d_state_p->setStorage(storageMp);
+        d_state_p->setStorage(storageSp);
 
         // Create the queueEngine.
         d_queueEngine_mp.load(

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -109,8 +109,8 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     // TTL is not applicable at proxy
 
     // Create the associated storage.
-    bslma::ManagedPtr<mqbi::Storage> storageMp;
-    storageMp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
+    bsl::shared_ptr<mqbi::Storage> storageSp;
+    storageSp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
                        d_state_p->uri(),
                        d_state_p->key(),
                        mqbs::DataStore::k_INVALID_PARTITION_ID,
@@ -125,8 +125,8 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     limits.messages() = bsl::numeric_limits<bsls::Types::Int64>::max();
     limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
 
-    storageMp->setConsistency(domainCfg.consistency());
-    int rc = storageMp->configure(errorDescription,
+    storageSp->setConsistency(domainCfg.consistency());
+    int rc = storageSp->configure(errorDescription,
                                   config,
                                   limits,
                                   domainCfg.messageTtl(),
@@ -135,18 +135,18 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
         return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
     }
 
-    storageMp->capacityMeter()->disable();
+    storageSp->capacityMeter()->disable();
     // In a remote queue, we don't care about monitoring, so disable it for
     // efficiency performance.
 
-    if (!d_state_p->isStorageCompatible(storageMp)) {
+    if (!d_state_p->isStorageCompatible(storageSp)) {
         errorDescription << "Incompatible storage type for ProxyRemoteQueue "
                          << "[uri: " << d_state_p->uri()
                          << ", id: " << d_state_p->id() << "]";
         return rc_INCOMPATIBLE_STORAGE;  // RETURN
     }
 
-    d_state_p->setStorage(storageMp);
+    d_state_p->setStorage(storageSp);
 
     // Create the queueEngine.
     d_queueEngine_mp.load(

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1645,11 +1645,11 @@ void StorageManager::processReplicaDataRequest(
 }
 
 int StorageManager::makeStorage(bsl::ostream& errorDescription,
-                                bslma::ManagedPtr<mqbi::Storage>* out,
-                                const bmqt::Uri&                  uri,
-                                const mqbu::StorageKey&           queueKey,
-                                int                               partitionId,
-                                const bsls::Types::Int64          messageTtl,
+                                bsl::shared_ptr<mqbi::Storage>* out,
+                                const bmqt::Uri&                uri,
+                                const mqbu::StorageKey&         queueKey,
+                                int                             partitionId,
+                                const bsls::Types::Int64        messageTtl,
                                 const int maxDeliveryAttempts,
                                 const mqbconfm::StorageDefinition& storageDef)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -555,7 +555,7 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
         BSLS_KEYWORD_OVERRIDE;
 
     int makeStorage(bsl::ostream&                      errorDescription,
-                    bslma::ManagedPtr<mqbi::Storage>*  out,
+                    bsl::shared_ptr<mqbi::Storage>*    out,
                     const bmqt::Uri&                   uri,
                     const mqbu::StorageKey&            queueKey,
                     int                                partitionId,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4177,11 +4177,11 @@ void StorageManager::processReplicaDataRequest(
 }
 
 int StorageManager::makeStorage(bsl::ostream& errorDescription,
-                                bslma::ManagedPtr<mqbi::Storage>* out,
-                                const bmqt::Uri&                  uri,
-                                const mqbu::StorageKey&           queueKey,
-                                int                               partitionId,
-                                const bsls::Types::Int64          messageTtl,
+                                bsl::shared_ptr<mqbi::Storage>* out,
+                                const bmqt::Uri&                uri,
+                                const mqbu::StorageKey&         queueKey,
+                                int                             partitionId,
+                                const bsls::Types::Int64        messageTtl,
                                 int maxDeliveryAttempts,
                                 const mqbconfm::StorageDefinition& storageDef)
 {

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -918,7 +918,7 @@ class StorageManager BSLS_KEYWORD_FINAL
         BSLS_KEYWORD_OVERRIDE;
 
     int makeStorage(bsl::ostream&                      errorDescription,
-                    bslma::ManagedPtr<mqbi::Storage>*  out,
+                    bsl::shared_ptr<mqbi::Storage>*    out,
                     const bmqt::Uri&                   uri,
                     const mqbu::StorageKey&            queueKey,
                     int                                partitionId,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3203,14 +3203,14 @@ void StorageUtil::setQueueDispatched(
     it->second->setQueue(queue);
 }
 
-int StorageUtil::makeStorage(bsl::ostream& errorDescription,
-                             bslma::ManagedPtr<mqbi::Storage>* out,
-                             StorageSpMap*                     storageMap,
-                             bslmt::Mutex*                     storagesLock,
-                             const bmqt::Uri&                  uri,
-                             const mqbu::StorageKey&           queueKey,
-                             int                               partitionId,
-                             const bsls::Types::Int64          messageTtl,
+int StorageUtil::makeStorage(bsl::ostream&                   errorDescription,
+                             bsl::shared_ptr<mqbi::Storage>* out,
+                             StorageSpMap*                   storageMap,
+                             bslmt::Mutex*                   storagesLock,
+                             const bmqt::Uri&                uri,
+                             const mqbu::StorageKey&         queueKey,
+                             int                             partitionId,
+                             const bsls::Types::Int64        messageTtl,
                              const int maxDeliveryAttempts,
                              const mqbconfm::StorageDefinition& storageDef)
 {
@@ -3267,9 +3267,7 @@ int StorageUtil::makeStorage(bsl::ostream& errorDescription,
         return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
     }
 
-    out->load(storageSp.get(),
-              0,  // cookie
-              bslma::ManagedPtrUtil::noOpDeleter);
+    *out = storageSp;
 
     static_cast<void>(queueKey);
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -724,15 +724,15 @@ struct StorageUtil {
                        const bmqt::Uri&   uri,
                        mqbi::Queue*       queue);
 
-    static int makeStorage(bsl::ostream&                     errorDescription,
-                           bslma::ManagedPtr<mqbi::Storage>* out,
-                           StorageSpMap*                     storageMap,
-                           bslmt::Mutex*                     storagesLock,
-                           const bmqt::Uri&                  uri,
-                           const mqbu::StorageKey&           queueKey,
-                           int                               partitionId,
-                           const bsls::Types::Int64          messageTtl,
-                           const int maxDeliveryAttempts,
+    static int makeStorage(bsl::ostream&                   errorDescription,
+                           bsl::shared_ptr<mqbi::Storage>* out,
+                           StorageSpMap*                   storageMap,
+                           bslmt::Mutex*                   storagesLock,
+                           const bmqt::Uri&                uri,
+                           const mqbu::StorageKey&         queueKey,
+                           int                             partitionId,
+                           const bsls::Types::Int64        messageTtl,
+                           const int                       maxDeliveryAttempts,
                            const mqbconfm::StorageDefinition& storageDef);
 
     /// THREAD: Executed by the queue dispatcher thread associated with

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -325,12 +325,12 @@ class StorageManager {
     processReplicaDataRequest(const bmqp_ctrlmsg::ControlMessage& message,
                               mqbnet::ClusterNode*                source) = 0;
 
-    virtual int makeStorage(bsl::ostream&                     errorDescription,
-                            bslma::ManagedPtr<mqbi::Storage>* out,
-                            const bmqt::Uri&                  uri,
-                            const mqbu::StorageKey&           queueKey,
-                            int                               partitionId,
-                            const bsls::Types::Int64          messageTtl,
+    virtual int makeStorage(bsl::ostream&                   errorDescription,
+                            bsl::shared_ptr<mqbi::Storage>* out,
+                            const bmqt::Uri&                uri,
+                            const mqbu::StorageKey&         queueKey,
+                            int                             partitionId,
+                            const bsls::Types::Int64        messageTtl,
                             const int maxDeliveryAttempts,
                             const mqbconfm::StorageDefinition& storageDef) = 0;
 

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
@@ -172,7 +172,7 @@ void StorageManager::processReplicaDataRequest(
 
 int StorageManager::makeStorage(
     BSLS_ANNOTATION_UNUSED bsl::ostream& errorDescription,
-    BSLS_ANNOTATION_UNUSED bslma::ManagedPtr<mqbi::Storage>* out,
+    BSLS_ANNOTATION_UNUSED bsl::shared_ptr<mqbi::Storage>* out,
     BSLS_ANNOTATION_UNUSED const bmqt::Uri& uri,
     BSLS_ANNOTATION_UNUSED const mqbu::StorageKey& queueKey,
     BSLS_ANNOTATION_UNUSED int                     partitionId,

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
@@ -188,7 +188,7 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
         BSLS_KEYWORD_OVERRIDE;
 
     int makeStorage(bsl::ostream&                      errorDescription,
-                    bslma::ManagedPtr<mqbi::Storage>*  out,
+                    bsl::shared_ptr<mqbi::Storage>*    out,
                     const bmqt::Uri&                   uri,
                     const mqbu::StorageKey&            queueKey,
                     int                                partitionId,


### PR DESCRIPTION
`mqbblp::QueueState::d_storage_mp` was essentially raw (w/ `noDeleter`).  This caused SEGFAULT in `AutoPurger::~AutoPurger`

Replacing with `shared_ptr`