### PR TITLE
Fix[IT]: fix core dumps and failure logs collection

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -178,8 +178,12 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
-      - name: Setup Core Dumps config
+      - name: Setup core_pattern
         run: |
+          # Default Ubuntu core_pattern: '|/usr/lib/systemd/systemd-coredump %P %u %g %s %t 9223372036854775808 %h'
+          # To enable core dumps copying to the failure-logs folder (implemented in src/python/blazingmq/dev/it/cluster.py)
+          # the core_pattern must be an absolute path and must contain %p (i.e. process id)
+
           sudo mkdir /cores
           sudo chmod 777 /cores
           echo "/cores/%e.%p.%s.%t" | sudo tee /proc/sys/kernel/core_pattern
@@ -188,40 +192,41 @@ jobs:
         run: |
           # Allow core dumps
           ulimit -c unlimited
+
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
           ${{ github.workspace }}/src/integration-tests/run-tests "${{ matrix.mode }} and ${{ matrix.cluster }}" \
             --log-level ERROR                   \
             --log-file-level=info               \
             --bmq-tolerate-dirty-shutdown       \
             --bmq-log-dir=failure-logs          \
+            --bmq-keep-logs                      \
             --bmq-log-level=INFO                \
             --domain-consistency="${{ matrix.consistency }}" \
             --junitxml=integration-tests.xml    \
             --tb long                           \
             --reruns=3                          \
             -n 4 -v
+      
+      # logs may contain fileanmes with colon which it's not supported on NTFS filesystem
+      # Thus creating an archive first
+      - name: Compress failure logs
+        if: failure()
+        working-directory: ${{ github.workspace }}/src/integration-tests
+        run: tar -zcvf failure-logs.tar.gz ./failure-logs
 
       - name: Upload failure-logs as artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: failure_logs_${{ env.RUN_UID }}
-          path: ${{ github.workspace }}/src/integration-tests/failure-logs
-          retention-days: 5
-
-      - name: Upload broker core dump as artifacts
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: core_dumps_${{ env.RUN_UID }}
-          path: /cores
+          name: ${{ github.run_id }}_failure_logs_${{ env.RUN_UID }}
+          path: ${{ github.workspace }}/src/integration-tests/failure-logs.tar.gz
           retention-days: 5
 
       - name: Upload broker executable as artifacts to debug the core
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: bmqbrkr.tsk
+          name: ${{ github.run_id }}_bmqbrkr
           overwrite: true # broker binary is the same across all matrix runs
           path: ${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr/bmqbrkr.tsk
           retention-days: 5


### PR DESCRIPTION
**Describe your changes**
- Removed standalone upload of core_dumps, because it's redundant. Core dumps copied to failure-logs folder and uploaded as artifacts together with logs.
- Added archiving step for failure-logs, because log filenames may contain colon symbol which prevents artifacts uploading.
- Extended artefact names of failure-logs and bmqbrkr executable with prefix containing {{github.run_id}} which makes it more convenient to locate and match broker executable and logs after downloading artifacts to the local filesystem.
- Added more comments to build.yaml explaining how core dumps collection is performed

**Testing performed**
- Intentionally made a bug in IT to make them crash to make sure that all artefacts are uploaded and no name collisions happen
https://github.com/bloomberg/blazingmq/actions/runs/14085280500 (2025-03-26):

![image](https://github.com/user-attachments/assets/313ccade-aca7-42be-aff7-2c2c30ca74db)

