### PR TITLE
Docs[mqbblp_clusterqueuehelper.cpp]: fix multi line comment

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2344,18 +2344,18 @@ void ClusterQueueHelper::onGetDomainDispatched(
     //                      Domain::openQueue
     //                              |
     //                              V
-    //                      Cluster::openQueue
-    //                              |
-    //                              V
-    //                      CQH::openQueue
-    //                              |
-    //                              V
-    //                      Queue::getHandle
-    //                              |
-    //                              V
-    //                      CQH::onGetQueueHandle
-    //                              |
-    //                              V
+    //                          Cluster::openQueue
+    //                                  |
+    //                                  V
+    //                              CQH::openQueue
+    //                                      |
+    //                                      V
+    //                                  Queue::getHandle
+    //                                      |
+    //                                      V
+    //                              CQH::onGetQueueHandle
+    //                                  |
+    //                                  V
     //                      Domain::onOpenQueueResponse
     //                        |                  |
     //                        V                  V

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2330,35 +2330,35 @@ void ClusterQueueHelper::onGetDomainDispatched(
         request.choice().openQueue().handleParameters();
 
     //  CQH::processPeerOpenQueueRequest  QueueSessionManager::processOpenQueue
-    //              \                       /
+    //               |                     |
     //               V                     V
     //              DomainFactory::createDomain
-    //              /                      \
-    //             V                        V
-    //  CQH::onGetDomain                  QueueSessionManager::onDomainOpenCb
-    //          |                           /
-    //          V                          /
-    //      CQH::onGetDomainDispatched    /
-    //                      \            /
-    //                       V          V
+    //               |                     |
+    //               V                     V
+    //      CQH::onGetDomain          QueueSessionManager::onDomainOpenCb
+    //               |                     |
+    //               V                     |
+    //      CQH::onGetDomainDispatched     |
+    //                       |             |
+    //                       V             V
     //                      Domain::openQueue
     //                              |
     //                              V
-    //                          Cluster::openQueue
+    //                      Cluster::openQueue
     //                              |
     //                              V
-    //                              CQH::openQueue
-    //                                      \
-    //                                       V
-    //                                  Queue::getHandle
-    //                                      /
-    //                                     V
-    //                              CQH::onGetQueueHandle
-    //                                    /
-    //                                   V
+    //                      CQH::openQueue
+    //                              |
+    //                              V
+    //                      Queue::getHandle
+    //                              |
+    //                              V
+    //                      CQH::onGetQueueHandle
+    //                              |
+    //                              V
     //                      Domain::onOpenQueueResponse
-    //                        /                 \
-    //                       V                   V
+    //                        |                  |
+    //                        V                  V
     //  CQH::onGetQueueHandleDispatched     QueueSessionManager::onQueueOpenCb
     //
 


### PR DESCRIPTION
Ascii-schema generates warnings due to `\` placed in the end of comment lines:

```
[ 85%] Building CXX object src/groups/mqb/CMakeFiles/mqbblp-iface.dir/mqbblp/mqbblp_queueengineutil.cpp.o
/blazingmq/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp:2336:5: warning: multi-line comment [-Wcomment]
 2336 |     //              /                      \
      |     ^
/blazingmq/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp:2351:5: warning: multi-line comment [-Wcomment]
 2351 |     //                                      \
      |     ^
/blazingmq/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp:2360:5: warning: multi-line comment [-Wcomment]
 2360 |     //                        /                 \
      |     ^
```