### PR TITLE
Fix[BMQ]: unsafe schemalearner use

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -60,7 +60,6 @@
 // BMQ
 
 #include <bmqa_queueid.h>
-#include <bmqp_messageproperties.h>
 #include <bmqt_compressionalgorithmtype.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_messageguid.h>
@@ -82,6 +81,10 @@ namespace bmqimp {
 class Event;
 }
 
+namespace bmqp {
+class MessageProperties_Schema;
+}
+
 namespace bmqa {
 
 // FORWARD DECLARATION
@@ -101,6 +104,8 @@ class MessageProperties;
 ///                      `correlationId`), then they should be reset in
 ///                      `bmqa::MessageIterator.nextMessage()`.
 struct MessageImpl {
+    // FORWARD DECLARATION
+
     // PUBLIC DATA
 
     /// Pointer to the Event this message is associated with
@@ -118,7 +123,7 @@ struct MessageImpl {
     /// SubscriptionHandle this message is associated with
     bmqt::SubscriptionHandle d_subscriptionHandle;
 
-    bmqp::MessageProperties::SchemaPtr d_schema_sp;
+    bsl::shared_ptr<const bmqp::MessageProperties_Schema> d_schema_sp;
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
     /// Optional GroupId this message is associated with

--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -60,6 +60,7 @@
 // BMQ
 
 #include <bmqa_queueid.h>
+#include <bmqp_messageproperties.h>
 #include <bmqt_compressionalgorithmtype.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_messageguid.h>
@@ -116,6 +117,8 @@ struct MessageImpl {
 
     /// SubscriptionHandle this message is associated with
     bmqt::SubscriptionHandle d_subscriptionHandle;
+
+    bmqp::MessageProperties::SchemaPtr d_schema_sp;
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
     /// Optional GroupId this message is associated with

--- a/src/groups/bmq/bmqa/bmqa_message.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.t.cpp
@@ -226,7 +226,7 @@ static void test2_validPushMessagePrint()
                           true);
     implPtr->configureAsMessageEvent(bmqpEvent);
 
-    implPtr->addCorrelationId(bmqt::CorrelationId());
+    implPtr->addContext(bmqt::CorrelationId());
 
     bmqa::MessageEvent    pushMsgEvt = event.messageEvent();
     bmqa::MessageIterator mIter      = pushMsgEvt.messageIterator();
@@ -329,7 +329,7 @@ static void test3_messageProperties()
                           true);
 
     implPtr->configureAsMessageEvent(bmqpEvent);
-    implPtr->addCorrelationId(bmqt::CorrelationId());
+    implPtr->addContext(bmqt::CorrelationId());
 
     bmqa::MessageEvent    pushMsgEvt = event.messageEvent();
     bmqa::MessageIterator mIter      = pushMsgEvt.messageIterator();
@@ -493,7 +493,7 @@ static void test4_subscriptionHandle()
         implPtr->configureAsMessageEvent(bmqpEvent);
 
         implPtr->insertQueue(sId, queueSp);
-        implPtr->addCorrelationId(cId, sId);
+        implPtr->addContext(cId, sId);
 
         bmqa::MessageEvent    pushMsgEvt = event.messageEvent();
         bmqa::MessageIterator mIter      = pushMsgEvt.messageIterator();
@@ -547,7 +547,7 @@ static void test4_subscriptionHandle()
         implPtr->configureAsMessageEvent(bmqpEvent);
 
         implPtr->insertQueue(defaultSubscriptionId, queueSp);
-        implPtr->addCorrelationId(emptyCorrelationId, defaultSubscriptionId);
+        implPtr->addContext(emptyCorrelationId, defaultSubscriptionId);
 
         bmqa::MessageEvent    pushMsgEvt = event.messageEvent();
         bmqa::MessageIterator mIter      = pushMsgEvt.messageIterator();
@@ -592,7 +592,7 @@ static void test4_subscriptionHandle()
         implPtr->configureAsMessageEvent(bmqpEvent);
 
         implPtr->insertQueue(queueSp);
-        implPtr->addCorrelationId(cId);
+        implPtr->addContext(cId);
 
         bmqa::MessageEvent    putMsgEvt = event.messageEvent();
         bmqa::MessageIterator mIter     = putMsgEvt.messageIterator();
@@ -629,7 +629,7 @@ static void test4_subscriptionHandle()
         implPtr->configureAsMessageEvent(bmqpEvent);
 
         implPtr->insertQueue(queueSp);
-        implPtr->addCorrelationId(cId);
+        implPtr->addContext(cId);
 
         bmqa::MessageEvent    ackMsgEvt = event.messageEvent();
         bmqa::MessageIterator mIter     = ackMsgEvt.messageIterator();

--- a/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageevent.t.cpp
@@ -190,7 +190,7 @@ static void test2_ackMesageIteratorTest()
     for (bsl::vector<AckData>::const_iterator i = messages.begin();
          i != messages.end();
          ++i) {
-        eventImpl->addCorrelationId(bmqt::CorrelationId(i->d_corrId));
+        eventImpl->addContext(bmqt::CorrelationId(i->d_corrId));
     }
 
     bmqa::MessageEvent              event;
@@ -266,7 +266,7 @@ static void test3_putMessageIteratorTest()
     // 'bmqa::MessageEventBuilder::packMessage' so that the message iterator
     // can access the correlationId for each message.
     for (size_t i = 0; i < k_NUM_MSGS; ++i) {
-        eventImpl->addCorrelationId(bmqt::CorrelationId(i));
+        eventImpl->addContext(bmqt::CorrelationId(i));
     }
 
     bmqa::MessageEvent              event;

--- a/src/groups/bmq/bmqa/bmqa_messageiterator.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageiterator.cpp
@@ -48,6 +48,7 @@ bool MessageIterator::nextMessage()
     msgImpl.d_queueId    = bmqa::QueueId();
     msgImpl.d_correlationId.makeUnset();
     msgImpl.d_subscriptionHandle = bmqt::SubscriptionHandle();
+    msgImpl.d_schema_sp.reset();
 
     int rc = -1;
 
@@ -100,15 +101,20 @@ bool MessageIterator::nextMessage()
         ++d_impl.d_messageIndex;
         BSLS_ASSERT_SAFE(d_impl.d_messageIndex <
                          d_impl.d_event_p->numCorrrelationIds());
-        msgImpl.d_correlationId = d_impl.d_event_p->correlationId(
-            d_impl.d_messageIndex);
+
+        const bmqimp::Event::MessageContext& context =
+            d_impl.d_event_p->context(d_impl.d_messageIndex);
+
+        msgImpl.d_correlationId = context.d_correlationId;
 
         if (d_impl.d_event_p->rawEvent().isPushEvent()) {
-            const unsigned int subscriptionId =
-                d_impl.d_event_p->subscriptionId(d_impl.d_messageIndex);
+            const unsigned int subscriptionId = context.d_subscriptionHandleId;
+
             msgImpl.d_subscriptionHandle = bmqt::SubscriptionHandle(
                 subscriptionId,
                 msgImpl.d_correlationId);
+
+            msgImpl.d_schema_sp = context.d_schema_sp;
         }
 
         return true;  // RETURN

--- a/src/groups/bmq/bmqa/bmqa_messageiterator.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageiterator.cpp
@@ -15,7 +15,7 @@
 
 // bmqa_messageiterator.cpp                                           -*-C++-*-
 #include <bmqa_messageiterator.h>
-
+#include <bmqp_messageproperties.h>
 #include <bmqscm_version.h>
 // BMQ
 #include <bmqa_queueid.h>

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -312,7 +312,7 @@ Event MockSessionUtil::createAckEvent(const bsl::vector<AckParams>& acks,
     implPtr->configureAsMessageEvent(
         bmqp::Event(ackBuilder.blob().get(), alloc, true));
     for (size_t i = 0; i != acks.size(); ++i) {
-        implPtr->addCorrelationId(acks[i].d_correlationId);
+        implPtr->addContext(acks[i].d_correlationId);
     }
 
     return event;
@@ -368,7 +368,7 @@ Event MockSessionUtil::createPushEvent(
                                 logic);
         implPtr->insertQueue(bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID,
                              queueImplPtr);
-        implPtr->addCorrelationId(bmqt::CorrelationId());
+        implPtr->addContext(bmqt::CorrelationId());
     }
 
     bmqp::Event bmqpEvent(pushBuilder.blob().get(), alloc, true);

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -3657,21 +3657,7 @@ void BrokerSession::processPushEvent(const bmqp::Event& event)
                  sIds.begin();
              citer != sIds.end();
              ++citer) {
-            bmqt::CorrelationId         correlationId;
-            unsigned int                subscriptionHandleId;
-            const QueueManager::QueueSp queue =
-                d_queueManager.observePushEvent(&correlationId,
-                                                &subscriptionHandleId,
-                                                *citer);
-
-            BSLS_ASSERT(queue);
-            queueEvent->insertQueue(citer->d_subscriptionId, queue);
-
-            // Use 'subscriptionHandle' instead of the internal
-            // 'citer->d_subscriptionId' so that
-            // 'bmqimp::Event::subscriptionId()' returns 'subscriptionHandle'
-
-            queueEvent->addCorrelationId(correlationId, subscriptionHandleId);
+            d_queueManager.observePushEvent(queueEvent.get(), *citer);
         }
 
         // Update event bytes
@@ -3768,7 +3754,7 @@ void BrokerSession::processAckEvent(const bmqp::Event& event)
         }
 
         // Keep track of user-provided CorrelationId (it may be unset)
-        queueEvent->addCorrelationId(correlationId);
+        queueEvent->addContext(correlationId);
 
         // Insert queue into event
         queueEvent->insertQueue(queue);
@@ -4674,7 +4660,7 @@ bool BrokerSession::cancelPendingMessageImp(
     }
 
     // Keep track of user-provided CorrelationId (it may be unset)
-    (*ackEvent)->addCorrelationId(qac.d_correlationId);
+    (*ackEvent)->addContext(qac.d_correlationId);
 
     // Insert queue into event
     bsl::shared_ptr<Queue> queue = queueSp;

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -6835,7 +6835,7 @@ static void test33_queueNackTest()
     BMQTST_ASSERT_EQ(pQueue->id(), iter->message().queueId());
     BMQTST_ASSERT_EQ(k_ACK_STATUS_UNKNOWN, iter->message().status());
     BMQTST_ASSERT_EQ(1, nackEvent->numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrId, nackEvent->correlationId(0));
+    BMQTST_ASSERT_EQ(corrId, nackEvent->context(0).d_correlationId);
     BMQTST_ASSERT_EQ(0, iter->next());
 
     PVV_SAFE("Step 9. Waiting QUEUE_CLOSE_RESULT event...");
@@ -9252,7 +9252,7 @@ static void test50_putRetransmittingTest()
     BMQTST_ASSERT_EQ(k_ACK_STATUS_SUCCESS, ackIter->message().status());
     BMQTST_ASSERT_EQ(guidFirst, ackIter->message().messageGUID());
     BMQTST_ASSERT_EQ(1, ackEvent->numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrIdFirst, ackEvent->correlationId(0));
+    BMQTST_ASSERT_EQ(corrIdFirst, ackEvent->context(0).d_correlationId);
     BMQTST_ASSERT_EQ(0, ackIter->next());
 
     PVV_SAFE("Step 5. Trigger channel drop and verify no NACK event is sent");
@@ -9324,13 +9324,13 @@ static void test50_putRetransmittingTest()
     BMQTST_ASSERT_EQ(guidSecond, iter->message().messageGUID());
     BMQTST_ASSERT_EQ(k_ACK_STATUS_UNKNOWN, iter->message().status());
     BMQTST_ASSERT_EQ(2, nackEvent->numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrIdSecond, nackEvent->correlationId(0));
+    BMQTST_ASSERT_EQ(corrIdSecond, nackEvent->context(0).d_correlationId);
 
     BMQTST_ASSERT_EQ(1, iter->next());
     BMQTST_ASSERT_EQ(pQueue->id(), iter->message().queueId());
     BMQTST_ASSERT_EQ(guidThird, iter->message().messageGUID());
     BMQTST_ASSERT_EQ(k_ACK_STATUS_UNKNOWN, iter->message().status());
-    BMQTST_ASSERT_EQ(corrIdThird, nackEvent->correlationId(1));
+    BMQTST_ASSERT_EQ(corrIdThird, nackEvent->context(1).d_correlationId);
     BMQTST_ASSERT_EQ(0, iter->next());
 
     PVV_SAFE("Step 11. Send one more PUT message while the channel is down");
@@ -9376,7 +9376,7 @@ static void test50_putRetransmittingTest()
     BMQTST_ASSERT_EQ(guidFourth, iter->message().messageGUID());
     BMQTST_ASSERT_EQ(k_ACK_STATUS_UNKNOWN, iter->message().status());
     BMQTST_ASSERT_EQ(1, nackEvent->numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrIdFourth, nackEvent->correlationId(0));
+    BMQTST_ASSERT_EQ(corrIdFourth, nackEvent->context(0).d_correlationId);
     BMQTST_ASSERT_EQ(0, iter->next());
 
     PVV_SAFE("Step 14. Waiting QUEUE_CLOSE_RESULT event...");
@@ -9610,7 +9610,7 @@ static void test51_putRetransmittingNoAckTest()
     BMQTST_ASSERT_EQ(guid2, iter->message().messageGUID());
     BMQTST_ASSERT_EQ(k_ACK_STATUS_UNKNOWN, iter->message().status());
     BMQTST_ASSERT_EQ(1, nackEvent->numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrId, nackEvent->correlationId(0));
+    BMQTST_ASSERT_EQ(corrId, nackEvent->context(0).d_correlationId);
     BMQTST_ASSERT_EQ(0, iter->next());
 
     PVV_SAFE("Step 13. Waiting QUEUE_CLOSE_RESULT event...");

--- a/src/groups/bmq/bmqimp/bmqimp_event.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.cpp
@@ -57,7 +57,7 @@ Event::Event(bdlbb::BlobBufferFactory* blobBufferFactory,
 , d_putMsgIter(blobBufferFactory, allocator)
 , d_putEventBuilderBuffer()
 , d_isPutEventBuilderConstructed(false)
-, d_correlationIds(allocator)
+, d_contexts(allocator)
 
 {
     // NOTHING
@@ -83,7 +83,7 @@ Event::Event(const Event& other, bslma::Allocator* allocator)
 , d_putMsgIter(other.d_bufferFactory_p, allocator)
 , d_putEventBuilderBuffer()
 , d_isPutEventBuilderConstructed(false)
-, d_correlationIds(other.d_correlationIds, allocator)
+, d_contexts(other.d_contexts, allocator)
 
 {
     // PRECONDITIONS
@@ -156,7 +156,7 @@ Event& Event::operator=(const Event& rhs)
     d_correlationId                   = rhs.d_correlationId;
     d_errorDescription                = rhs.d_errorDescription;
     d_msgEventMode                    = rhs.d_msgEventMode;
-    d_correlationIds                  = rhs.d_correlationIds;
+    d_contexts                        = rhs.d_contexts;
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(d_type ==
                                               EventType::e_SESSION)) {
@@ -224,7 +224,7 @@ void Event::reset()
     d_pushMsgIter.clear();
     d_ackMsgIter.clear();
     d_putMsgIter.clear();
-    d_correlationIds.clear();
+    d_contexts.clear();
 }
 
 void Event::clear()
@@ -356,7 +356,7 @@ Event& Event::upgradeMessageEventModeToWrite()
     d_rawEvent.clear();
     d_queues.clear();
     d_queuesBySubscriptionId.clear();
-    d_correlationIds.clear();
+    d_contexts.clear();
     d_correlationId.makeUnset();
     return *this;
 }
@@ -398,7 +398,7 @@ void Event::addMessageInfo(const bsl::shared_ptr<Queue>& queue,
     // Add correlationId (even if it's empty) to the event's list.  It is
     // used by the message iterator to access correlationId by the message
     // index.
-    addCorrelationId(corrId);
+    addContext(corrId);
 
     // Insert correlationId and queueId and into correlationIds maps of
     // correlationId container.

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -504,13 +504,13 @@ static void test4_messageEvent_setterGetterTest()
                                bmqp::EventType::e_ACK);
     bmqp::Event event(&eventBlob, bmqtst::TestHelperUtil::allocator());
     obj.configureAsMessageEvent(event);
-    obj.addCorrelationId(corrId1);
+    obj.addContext(corrId1);
     BMQTST_ASSERT_EQ(1, obj.numCorrrelationIds());
 
-    obj.addCorrelationId(corrId2);
+    obj.addContext(corrId2);
     BMQTST_ASSERT_EQ(2, obj.numCorrrelationIds());
-    BMQTST_ASSERT_EQ(corrId1, obj.correlationId(0));
-    BMQTST_ASSERT_EQ(corrId2, obj.correlationId(1));
+    BMQTST_ASSERT_EQ(corrId1, obj.context(0).d_correlationId);
+    BMQTST_ASSERT_EQ(corrId2, obj.context(1).d_correlationId);
 
     // setMessageCorrelationIdContainer / messageCorrelationIdContainer
     bmqimp::MessageCorrelationIdContainer container(

--- a/src/groups/bmq/bmqimp/bmqimp_queue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.cpp
@@ -321,8 +321,6 @@ Queue::Queue(bslma::Allocator* allocator)
 , d_isOldStyle(true)
 , d_isSuspendedWithBroker(false)
 , d_schemaGenerator(allocator)
-, d_schemaLearner(allocator)
-, d_schemaLearnerContext(d_schemaLearner.createContext())
 , d_config(allocator)
 , d_registeredInternalSubscriptionIds(allocator)
 {

--- a/src/groups/bmq/bmqimp/bmqimp_queue.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.h
@@ -34,7 +34,6 @@
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_queueid.h>
 #include <bmqp_schemagenerator.h>
-#include <bmqp_schemalearner.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_queueflags.h>
 #include <bmqt_queueoptions.h>
@@ -379,9 +378,7 @@ class Queue {
     bool                                  isOldStyle() const;
     const bmqp_ctrlmsg::StreamParameters& config() const;
 
-    bmqp::SchemaGenerator&        schemaGenerator();
-    bmqp::SchemaLearner&          schemaLearner();
-    bmqp::SchemaLearner::Context& schemaLearnerContext();
+    bmqp::SchemaGenerator& schemaGenerator();
 
     /// Return whether this Queue is valid, i.e., is associated to an
     /// initialized queue.

--- a/src/groups/bmq/bmqimp/bmqimp_queue.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.h
@@ -255,10 +255,6 @@ class Queue {
 
     bmqp::SchemaGenerator d_schemaGenerator;
 
-    bmqp::SchemaLearner d_schemaLearner;
-
-    bmqp::SchemaLearner::Context d_schemaLearnerContext;
-
     bmqp_ctrlmsg::StreamParameters d_config;
 
     bsl::unordered_map<unsigned int, SubscriptionHandle>
@@ -676,16 +672,6 @@ inline bool Queue::isSuspendedWithBroker() const
 inline const bmqp_ctrlmsg::StreamParameters& Queue::config() const
 {
     return d_config;
-}
-
-inline bmqp::SchemaLearner& Queue::schemaLearner()
-{
-    return d_schemaLearner;
-}
-
-inline bmqp::SchemaLearner::Context& Queue::schemaLearnerContext()
-{
-    return d_schemaLearnerContext;
 }
 
 inline bmqp::SchemaGenerator& Queue::schemaGenerator()

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -308,8 +308,6 @@ void QueueManager::observePushEvent(Event*                          queueEvent,
 
     queue->statUpdateOnMessage(info.d_applicationDataSize, false);
 
-    BSLS_ASSERT(queue);
-
     // Use 'subscriptionHandle' instead of the internal
     // 'info.d_subscriptionId' so that
     // 'bmqimp::Event::subscriptionId()' returns 'subscriptionHandle'

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -294,7 +294,7 @@ QueueManager::observePushEvent(bmqt::CorrelationId* correlationId,
                                const bmqp::EventUtilQueueInfo& info)
 {
     // Update stats
-    const QueueSp queue = lookupQueueBySubscriptionIdLocked(
+    const QueueSp queue = lookupQueueBySubscriptionId(
         correlationId,
         subscriptionHandleId,
         info.d_header.queueId(),

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
@@ -71,6 +71,7 @@
 #include <bmqp_pushmessageiterator.h>
 #include <bmqp_putmessageiterator.h>
 #include <bmqp_queueid.h>
+#include <bmqp_schemalearner.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_uri.h>
 

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.h
@@ -216,6 +216,8 @@ class QueueManager {
     // both Queue id and Subscription/
     // SubQueue id,
 
+    bmqp::SchemaLearner d_schemaLearner;
+
     bslma::Allocator* d_allocator_p;
     // Allocator to use
 
@@ -309,9 +311,8 @@ class QueueManager {
                     bool* hasMessageWithMultipleSubQueueIds,
                     const bmqp::PushMessageIterator& iterator);
 
-    const QueueSp observePushEvent(bmqt::CorrelationId* correlationId,
-                                   unsigned int*        subscriptionHandleId,
-                                   const bmqp::EventUtilQueueInfo& info);
+    void observePushEvent(Event*                          queueEvent,
+                          const bmqp::EventUtilQueueInfo& info);
 
     /// Update stats for the queue(s) corresponding to the messages pointed
     /// to by the specified `iterator` and populate the specified
@@ -341,6 +342,8 @@ class QueueManager {
 
     void updateSubscriptions(const bsl::shared_ptr<Queue>&         queue,
                              const bmqp_ctrlmsg::StreamParameters& config);
+
+    bmqp::SchemaLearner& schemaLearner();
 
     // ACCESSORS
     QueueSp lookupQueue(const bmqt::Uri& uri) const;
@@ -447,6 +450,11 @@ inline QueueManager::QueueSp QueueManager::lookupQueueBySubscriptionId(
                                              subscriptionHandleId,
                                              queueId,
                                              internalSubscriptionId);
+}
+
+inline bmqp::SchemaLearner& QueueManager::schemaLearner()
+{
+    return d_schemaLearner;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_eventutil.h
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.h
@@ -60,7 +60,7 @@ class Event;
 /// `bmqp::QueueId(d_queueId, bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID)`.
 /// Otherwise, the key is `d_subscriptionId`
 struct EventUtilQueueInfo {
-    unsigned int d_subscriptionId;
+    const unsigned int d_subscriptionId;
 
     const bmqp::PushHeader d_header;
     const int              d_applicationDataSize;
@@ -81,7 +81,7 @@ struct EventUtilEventInfo {
     typedef bsl::vector<EventUtilQueueInfo> Ids;
 
     // PUBLIC DATA
-    bdlbb::Blob d_blob;
+    const bdlbb::Blob d_blob;
 
     Ids d_ids;
 

--- a/src/groups/bmq/bmqp/bmqp_eventutil.h
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.h
@@ -33,6 +33,7 @@
 #include <bmqp_blobpoolutil.h>
 #include <bmqp_protocol.h>
 #include <bmqp_queueid.h>
+#include <bmqp_schemalearner.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -65,9 +66,12 @@ struct EventUtilQueueInfo {
     const bmqp::PushHeader d_header;
     const int              d_applicationDataSize;
 
+    const bmqp::MessageProperties::SchemaPtr d_schema;
+
     EventUtilQueueInfo(unsigned int            subscriptionId,
                        const bmqp::PushHeader& header,
-                       int                     applicationDataSize);
+                       int                     applicationDataSize,
+                       const bmqp::MessageProperties::SchemaPtr schema);
 };
 // =========================
 // struct EventUtilEventInfo
@@ -146,12 +150,15 @@ struct EventUtil {
 // struct EventUtilQueueInfo
 // --------------------------
 
-inline EventUtilQueueInfo::EventUtilQueueInfo(unsigned int subscriptionId,
-                                              const bmqp::PushHeader& header,
-                                              int appDataSize)
+inline EventUtilQueueInfo::EventUtilQueueInfo(
+    unsigned int                             subscriptionId,
+    const bmqp::PushHeader&                  header,
+    int                                      appDataSize,
+    const bmqp::MessageProperties::SchemaPtr schema)
 : d_subscriptionId(subscriptionId)
 , d_header(header)
 , d_applicationDataSize(appDataSize)
+, d_schema(schema)
 {
     // NOTHING
 }

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -194,6 +194,11 @@ MessageProperties_Schema::MessageProperties_Schema(
     // NOTHING
 }
 
+MessageProperties_Schema::~MessageProperties_Schema()
+{
+    // NOTHING
+}
+
 // PUBLIC ACCESSORS
 bool MessageProperties_Schema::loadIndex(int*               index,
                                          const bsl::string& name) const

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -99,6 +99,8 @@ class MessageProperties_Schema {
                              bslma::Allocator*        basicAllocator);
     MessageProperties_Schema(const MessageProperties_Schema& other);
 
+    ~MessageProperties_Schema();
+
     // PUBLIC ACCESSORS
     bool loadIndex(int* index, const bsl::string& name) const;
 };

--- a/src/groups/bmq/bmqp/bmqp_schemalearner.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemalearner.cpp
@@ -138,16 +138,14 @@ SchemaLearner::Context SchemaLearner::createContext(int foreignId)
     return context->second;
 }
 
-SchemaLearner::SchemaPtr
-SchemaLearner::learn(Context&                     context,
-                     const MessagePropertiesInfo& input,
-                     const bdlbb::Blob&           blob)
+SchemaLearner::SchemaPtr*
+SchemaLearner::observe(Context& context, const MessagePropertiesInfo& input)
 {
     const SchemaIdType inputId = input.schemaId();
 
     if (!isPresentAndValid(inputId)) {
         // Nothing to do
-        return SchemaPtr();  // RETURN
+        return 0;  // RETURN
     }
 
     BSLS_ASSERT_SAFE(context);
@@ -171,19 +169,7 @@ SchemaLearner::learn(Context&                     context,
         // Must destroy previously learned Schema
     }
 
-    const SchemaPtr& result = contextHandle->d_schema_sp;
-
-    if (!result) {
-        // Learn new Schema by reading all MessageProperties.
-        MessageProperties mps(d_allocator_p);
-        int               rc = mps.streamIn(blob, input, result);
-
-        if (rc == 0) {
-            // Learn new schema.
-            contextHandle->d_schema_sp = mps.makeSchema(d_allocator_p);
-        }
-    }
-    return result;
+    return &contextHandle->d_schema_sp;
 }
 
 MessagePropertiesInfo

--- a/src/groups/bmq/bmqp/bmqp_schemalearner.h
+++ b/src/groups/bmq/bmqp/bmqp_schemalearner.h
@@ -215,11 +215,8 @@ class SchemaLearner {
 
     /// If the specified `input` indicates recycling, reset previously learned
     /// schema accumulated in the specified `context` and associated with the
-    /// id in `input`.  Return the previously learned schema if it is valid,
-    /// learn and return new schema otherwise.
-    SchemaPtr learn(Context&                     context,
-                    const MessagePropertiesInfo& input,
-                    const bdlbb::Blob&           blob);
+    /// id in `input`.  Return the address of the corresponding schema holder.
+    SchemaPtr* observe(Context& context, const MessagePropertiesInfo& input);
 
     /// Return `MessagePropertiesLogic` with a unique id associated with the
     /// specified `context` and the id in the specified `input`.  If there

--- a/src/groups/bmq/bmqp/bmqp_schemalearner.h
+++ b/src/groups/bmq/bmqp/bmqp_schemalearner.h
@@ -211,12 +211,15 @@ class SchemaLearner {
     int read(Context&                     context,
              MessageProperties*           mps,
              const MessagePropertiesInfo& messagePropertiesInfo,
-             const bdlbb::Blob&           blob);
+             const bdlbb::Blob&           blob) const;
 
-    /// Reset previously learned schema accumulated with the specified
-    /// `context` and associated with the id in specified `input` if the
-    /// `input` indicates recycling.
-    void observe(Context& context, const MessagePropertiesInfo& input);
+    /// If the specified `input` indicates recycling, reset previously learned
+    /// schema accumulated in the specified `context` and associated with the
+    /// id in `input`.  Return the previously learned schema if it is valid,
+    /// learn and return new schema otherwise.
+    SchemaPtr learn(Context&                     context,
+                    const MessagePropertiesInfo& input,
+                    const bdlbb::Blob&           blob);
 
     /// Return `MessagePropertiesLogic` with a unique id associated with the
     /// specified `context` and the id in the specified `input`.  If there

--- a/src/groups/bmq/bmqp/bmqp_schemalearner.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemalearner.t.cpp
@@ -209,7 +209,7 @@ static void test3_observingTest()
 
     bmqp::MessagePropertiesInfo recycledInput(true, 1, true);
 
-    theLearner.observe(server, recycledInput);
+    theLearner.learn(server, recycledInput, bdlbb::Blob());
 
     BMQTST_ASSERT_EQ(0, theLearner.read(server, &out2, input, blob));
 

--- a/src/groups/bmq/bmqp/bmqp_schemalearner.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_schemalearner.t.cpp
@@ -209,7 +209,7 @@ static void test3_observingTest()
 
     bmqp::MessagePropertiesInfo recycledInput(true, 1, true);
 
-    theLearner.learn(server, recycledInput, bdlbb::Blob());
+    theLearner.observe(server, recycledInput);
 
     BMQTST_ASSERT_EQ(0, theLearner.read(server, &out2, input, blob));
 


### PR DESCRIPTION
Cannot use `bmqp::SchemaLearner` in both FSM and event threads.
Instead, call the leaner in FSM and cache the result (schema) in the generated event.
