### PR TITLE
Fix mqbc::ClusterState: Treat null appIds as equivalent to default appId [178315956]

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.cpp
@@ -21,6 +21,8 @@
 #include <mqbi_domain.h>
 #include <mqbstat_domainstats.h>
 
+// BMQ
+#include <bmqp_protocolutil.h>
 #include <bmqu_printutil.h>
 
 // BDE
@@ -33,8 +35,27 @@ namespace mqbc {
 // class ClusterStateQueueInfo
 // ---------------------------
 
+bool ClusterStateQueueInfo::containsDefaultAppIdOnly(const AppInfos& appInfos)
+{
+    if (appInfos.empty()) {
+        return true;  // RETURN
+    }
+
+    if (appInfos.size() == 1 &&
+        appInfos.count(bmqp::ProtocolUtil::k_DEFAULT_APP_ID) == 1) {
+        return true;  // RETURN
+    }
+
+    return false;
+}
+
 bool ClusterStateQueueInfo::hasTheSameAppIds(const AppInfos& appInfos) const
 {
+    if (containsDefaultAppIdOnly(d_appInfos) &&
+        containsDefaultAppIdOnly(appInfos)) {
+        return true;  // RETURN
+    }
+
     // This ignores the order
 
     if (d_appInfos.size() != appInfos.size()) {

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -236,6 +236,13 @@ class ClusterStateQueueInfo {
     BSLMF_NESTED_TRAIT_DECLARATION(ClusterStateQueueInfo,
                                    bslma::UsesBslmaAllocator)
 
+    // CLASS METHODS
+
+    /// Return true if the specified `appInfos` semantically contains the
+    /// default appId only.  Note that having null appIds is treated as
+    /// equivalent to only having default appId.  Return false otherwise.
+    static bool containsDefaultAppIdOnly(const AppInfos& appInfos);
+
     // CREATORS
 
     /// Create a new `mqbc::ClusterStateQueueInfo` with the specified `uri`,

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -18,12 +18,17 @@
 // MQB
 #include <mqbc_clusterutil.h>
 #include <mqbi_cluster.h>
+#include <mqbi_queueengine.h>
 #include <mqbmock_cluster.h>
+
+// BMQ
+#include <bmqp_protocolutil.h>
 
 // BDE
 #include <bdlb_print.h>
 #include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_string.h>
+#include <bsl_utility.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -213,7 +218,9 @@ static void test1_validateState()
     reference.domainStates().emplace(domainMissingQueue,
                                      missingQueueDomainStateRefSp);
 
-    // 5. Generate a correct queue
+    // 5. Generate two correct queues.  One of them has null appIds in the
+    // original state and default appId in the reference state; they should be
+    // treated as equivalent.
     bsl::string domainCorrectQueue = "domain.correct.queue";
     bsl::string queueCorrectQueue  = "bmq://" + domainCorrectQueue + "/qqq";
     bsl::string keyCorrectQueue    = "correct.queue";
@@ -224,14 +231,40 @@ static void test1_validateState()
                                  correctQueueKey,
                                  5,
                                  mqbc::ClusterState::AppInfos());
+
+    bsl::string queueCorrectQueue2 = "bmq://" + domainCorrectQueue + "/qqq2";
+    bsl::string keyCorrectQueue2   = "correct.queue2";
+    mqbu::StorageKey correctQueueKey2(mqbu::StorageKey::BinaryRepresentation(),
+                                      keyCorrectQueue2.data());
+    mqbc::ClusterState::QueueInfoSp correctQueueInfoSp2NullApp =
+        tester.createQueueInfoSp(queueCorrectQueue2,
+                                 correctQueueKey2,
+                                 6,
+                                 mqbc::ClusterState::AppInfos());
+    mqbc::ClusterState::AppInfos defaultAppInfos;
+    defaultAppInfos.insert(
+        bsl::make_pair(bmqp::ProtocolUtil::k_DEFAULT_APP_ID,
+                       mqbi::QueueEngine::k_DEFAULT_APP_KEY));
+    mqbc::ClusterState::QueueInfoSp correctQueueInfoSp2DefaultApp =
+        tester.createQueueInfoSp(queueCorrectQueue2,
+                                 correctQueueKey2,
+                                 6,
+                                 defaultAppInfos);
+
     mqbc::ClusterState::DomainStateSp correctQueueDomainStateSp =
         tester.createDomainState();
     mqbc::ClusterState::DomainStateSp correctQueueDomainStateRefSp =
         tester.createDomainState();
     correctQueueDomainStateSp->queuesInfo().emplace(queueCorrectQueue,
                                                     correctQueueInfoSp);
+    correctQueueDomainStateSp->queuesInfo().emplace(
+        queueCorrectQueue,
+        correctQueueInfoSp2NullApp);
     correctQueueDomainStateRefSp->queuesInfo().emplace(queueCorrectQueue,
                                                        correctQueueInfoSp);
+    correctQueueDomainStateRefSp->queuesInfo().emplace(
+        queueCorrectQueue,
+        correctQueueInfoSp2DefaultApp);
     original.domainStates().emplace(domainCorrectQueue,
                                     correctQueueDomainStateSp);
     reference.domainStates().emplace(domainCorrectQueue,


### PR DESCRIPTION
Silence false alarms such as Internal Ticket 178315956