### PR TITLE
Fix[MQB]: solaris compatibility

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
+++ b/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
@@ -455,9 +455,10 @@ void StorageInspector::processCommand(
             BALL_LOG_OUTPUT_STREAM << "Details of journal file: \n";
             BALL_LOG_OUTPUT_STREAM << d_journalFd;
             BALL_LOG_OUTPUT_STREAM << "Journal File Header: \n";
-            printJournalFileHeader(BALL_LOG_OUTPUT_STREAM,
-                                   d_journalFileIter.header(),
-                                   d_journalFd);
+            printJournalFileHeader<bmqu::AlignedPrinter>(
+                BALL_LOG_OUTPUT_STREAM,
+                d_journalFileIter.header(),
+                d_journalFd);
             BALL_LOG_OUTPUT_STREAM << "\n";
 
             // Print journal-specific fields

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h
@@ -95,7 +95,7 @@ namespace FileStoreProtocolPrinter {
 
 /// Print the header of the mapped file by the specified `mfd` to the
 /// specified `stream`.
-template <typename PRINTER_TYPE = bmqu::AlignedPrinter>
+template <typename PRINTER_TYPE>
 void printFileHeader(bsl::ostream&                     stream,
                      const mqbs::MappedFileDescriptor& mfd,
                      bslma::Allocator*                 allocator = 0)
@@ -118,7 +118,7 @@ void printFileHeader(bsl::ostream&                     stream,
 
 /// Print the specified `header` while using the specified `journalFd` and the
 /// specified `allocator` to the specified `stream`.
-template <typename PRINTER_TYPE = bmqu::AlignedPrinter>
+template <typename PRINTER_TYPE>
 void printJournalFileHeader(bsl::ostream&                     stream,
                             const mqbs::JournalFileHeader&    header,
                             const mqbs::MappedFileDescriptor& journalFd,
@@ -178,7 +178,7 @@ void printJournalFileHeader(bsl::ostream&                     stream,
 
 /// Print the specified `header` while using the specified `journalFd` and the
 /// specified `allocator` to the specified `stream`.
-template <typename PRINTER_TYPE = bmqu::AlignedPrinter>
+template <typename PRINTER_TYPE>
 void printDataFileHeader(bsl::ostream&               stream,
                          const mqbs::DataFileHeader& header,
                          bslma::Allocator*           allocator = 0)


### PR DESCRIPTION
Solaris build is broken after this PR: https://github.com/bloomberg/blazingmq/pull/529

```
[2025-02-20T16:26:25.685Z] "/blazingmq/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h", line 102: Error: Function templates may not have default template parameters.

[2025-02-20T16:26:25.685Z] "/blazingmq/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h", line 126: Error: Function templates may not have default template parameters.

[2025-02-20T16:26:25.685Z] "/blazingmq/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h", line 185: Error: Function templates may not have default template parameters.
```