### PR TITLE
Fix warnings

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
@@ -288,7 +288,8 @@ inline int PushEventBuilder::eraseCurrentMessage()
         // Flush any buffered changes if necessary, and make this object
         // not refer to any valid blob object.
 
-        d_blob_sp->setLength(d_blob_sp->length() - sizeof(PushHeader) -
+        d_blob_sp->setLength(d_blob_sp->length() -
+                             static_cast<int>(sizeof(PushHeader)) -
                              optionsSize);
 
         d_options.reset();
@@ -352,7 +353,8 @@ inline int PushEventBuilder::eventSize() const
                      (optionsCount == 0 && !d_currPushHeader.isSet()));
 
     if (optionsCount > 0) {
-        return d_blob_sp->length() - sizeof(PushHeader) - d_options.size();
+        return d_blob_sp->length() - static_cast<int>(sizeof(PushHeader)) -
+               d_options.size();
         // RETURN
     }
     return d_blob_sp->length();

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -462,7 +462,7 @@ QueueState::adopt(const bsl::shared_ptr<QueueEngineUtil_AppState>& app)
     unsigned int upstreamSubQueueId = app->upstreamSubQueueId();
 
     if (upstreamSubQueueId == bmqp::QueueId::k_UNASSIGNED_SUBQUEUE_ID) {
-        upstreamSubQueueId = d_subStreams.size();
+        upstreamSubQueueId = static_cast<unsigned int>(d_subStreams.size());
         app->setUpstreamSubQueueId(upstreamSubQueueId);
     }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -1063,7 +1063,7 @@ inline bool ClusterState::isSelfActivePrimary(int partitionId) const
 
 inline int ClusterState::partitionsCount() const
 {
-    return d_partitionsInfo.size();
+    return static_cast<int>(d_partitionsInfo.size());
 }
 
 inline bool ClusterState::isSelfPrimary() const

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -759,7 +759,7 @@ FileBackedStorage::loadVirtualStorageDetails(AppInfos* buffer) const
 
 inline unsigned int FileBackedStorage::numAutoConfirms() const
 {
-    return d_autoConfirms.size();
+    return static_cast<unsigned int>(d_autoConfirms.size());
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -1248,7 +1248,7 @@ inline const DataStoreConfig& FileStore::config() const
 
 inline unsigned int FileStore::clusterSize() const
 {
-    return d_cluster_p->nodes().size();
+    return static_cast<unsigned int>(d_cluster_p->nodes().size());
 }
 
 inline bsls::Types::Uint64 FileStore::numRecords() const

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -790,7 +790,7 @@ inline void InMemoryStorage::loadVirtualStorageDetails(AppInfos* buffer) const
 
 inline unsigned int InMemoryStorage::numAutoConfirms() const
 {
-    return d_autoConfirms.size();
+    return static_cast<unsigned int>(d_autoConfirms.size());
 }
 
 inline mqbu::CapacityMeter* InMemoryStorage::capacityMeter()

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -381,7 +381,7 @@ inline void VirtualStorageCatalog::setQueue(mqbi::Queue* queue)
 // ACCESSORS
 inline int VirtualStorageCatalog::numVirtualStorages() const
 {
-    return d_virtualStorages.size();
+    return static_cast<int>(d_virtualStorages.size());
 }
 
 inline bsls::Types::Int64


### PR DESCRIPTION
Reduces the number of lines in a build log from 2700 to 1500