### PR TITLE
Fix[MQB]: solaris build

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -242,9 +242,9 @@ static void test1_validateState()
                                  6,
                                  mqbc::ClusterState::AppInfos());
     mqbc::ClusterState::AppInfos defaultAppInfos;
-    defaultAppInfos.insert(
-        bsl::make_pair(bmqp::ProtocolUtil::k_DEFAULT_APP_ID,
-                       mqbi::QueueEngine::k_DEFAULT_APP_KEY));
+    defaultAppInfos.insert(bsl::make_pair(
+        bsl::string(bmqp::ProtocolUtil::k_DEFAULT_APP_ID, tester.allocator()),
+        mqbi::QueueEngine::k_DEFAULT_APP_KEY));
     mqbc::ClusterState::QueueInfoSp correctQueueInfoSp2DefaultApp =
         tester.createQueueInfoSp(queueCorrectQueue2,
                                  correctQueueKey2,


### PR DESCRIPTION
The value for `const char ProtocolUtil::k_DEFAULT_APP_ID[]` is defined in cpp file and is not visible when including header `bmqp_protocolutil.h`.

For this reason the solaris compiler struggle to deduce the exact byte size when calling `bsl::make_pair` with `bmqp::ProtocolUtil::k_DEFAULT_APP_ID`
```
[2025-02-20T23:45:25.813Z] "/lib/compilers/include/CC/Cstd/utility", line 101: Error: In this declaration "first" is of an incomplete type "char[]".

[2025-02-20T23:45:25.813Z] "/blazingmq/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp", line 245:     Where: While specializing "std::pair<char[], BloombergLP::mqbu::StorageKey>".

[2025-02-20T23:45:25.813Z] "/blazingmq/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp", line 245:     Where: Specialized in non-template code.

[2025-02-20T23:45:25.813Z] 1 Error(s) detected.
```