### PR TITLE
CI: check C++03 standard build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,6 @@ jobs:
             -BDE_BUILD_TARGET_CPP03=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
-          cat build/blazingmq/CMakeCache.txt
           cmake --build build/blazingmq --parallel 8 --target all all.t
 
   unit_tests_cxx:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,7 +119,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DBDE_BUILD_TARGET_SAFE=ON \
             -DBDE_BUILD_TARGET_64=ON \
-            -BDE_BUILD_TARGET_CPP03=ON \
+            -DBDE_BUILD_TARGET_CPP03=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cmake --build build/blazingmq --parallel 8 --target all all.t

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,7 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
+  build_ubuntu_cxx_98:
     name: Build [ubuntu,C++98]
     runs-on: ubuntu-latest
     needs: get_dependencies

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,53 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
+    name: Build [ubuntu,C++98]
+    runs-on: ubuntu-latest
+    needs: get_dependencies
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache/restore@v4
+        with:
+          path: deps
+          key: ${{ needs.get_dependencies.outputs.cache_key }}
+
+      - name: Set up dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -qy build-essential \
+            gdb \
+            curl \
+            python3.10 \
+            python3-pip \
+            cmake \
+            ninja-build \
+            pkg-config \
+            bison \
+            libfl-dev \
+            libbenchmark-dev \
+            libgmock-dev \
+            libz-dev
+
+      - name: Install cached non packaged dependencies
+        working-directory: deps
+        run: ../docker/build_deps.sh
+
+      - name: Build BlazingMQ
+        env:
+          PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/opt/bb/lib64/pkgconfig
+        run: |
+          cmake -S . -B build/blazingmq -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DBDE_BUILD_TARGET_SAFE=ON \
+            -DBDE_BUILD_TARGET_64=ON \
+            -DBDE_BUILD_TARGET_CPP17=OFF \
+            -DCMAKE_CXX_STANDARD=98 \
+            -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
+            -DCMAKE_INSTALL_LIBDIR=lib64
+          cmake --build build/blazingmq --parallel 8 --target all
+
   unit_tests_cxx:
     name: UT [c++]
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,9 +121,11 @@ jobs:
             -DBDE_BUILD_TARGET_64=ON \
             -DBDE_BUILD_TARGET_CPP17=OFF \
             -DCMAKE_CXX_STANDARD=98 \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+            -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
-          cmake --build build/blazingmq --parallel 8 --target all
+          cmake --build build/blazingmq --parallel 8 --target all all.t
 
   unit_tests_cxx:
     name: UT [c++]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,10 +120,7 @@ jobs:
             -DBDE_BUILD_TARGET_SAFE=ON \
             -DBDE_BUILD_TARGET_64=ON \
             -DBDE_BUILD_TARGET_CPP17=OFF \
-            -DCMAKE_CXX_STANDARD=98 \
-            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
-            -DCMAKE_CXX_EXTENSIONS=OFF \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
+            -DCMAKE_CXX_FLAGS="-std=c++98" \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cat build/blazingmq/CMakeCache.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,8 +77,8 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
-  build_ubuntu_cxx_03:
-    name: Build [ubuntu,C++03]
+  unit_tests_cxx_03:
+    name: UT [c++03]
     runs-on: ubuntu-latest
     needs: get_dependencies
     steps:
@@ -123,6 +123,11 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cmake --build build/blazingmq --parallel 8 --target all all.t
+
+      - name: Run C++ Unit Tests
+        run: |
+          cd ${{ github.workspace }}/build/blazingmq
+          ctest --output-on-failure
 
   unit_tests_cxx:
     name: UT [c++]

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,8 +119,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DBDE_BUILD_TARGET_SAFE=ON \
             -DBDE_BUILD_TARGET_64=ON \
-            -DBDE_BUILD_TARGET_CPP17=OFF \
-            -DCMAKE_CXX_FLAGS="-std=c++98" \
+            -BDE_BUILD_TARGET_CPP03=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cat build/blazingmq/CMakeCache.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,8 +77,8 @@ jobs:
             /opt/bb/include
           key: cache-${{ github.sha }}
 
-  build_ubuntu_cxx_98:
-    name: Build [ubuntu,C++98]
+  build_ubuntu_cxx_03:
+    name: Build [ubuntu,C++03]
     runs-on: ubuntu-latest
     needs: get_dependencies
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install cached non packaged dependencies
         working-directory: deps
-        run: ../docker/build_deps.sh
+        run: ../docker/build_deps.sh --ufid opt_64_cpp03
 
       - name: Build BlazingMQ
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,8 +121,9 @@ jobs:
             -DBDE_BUILD_TARGET_64=ON \
             -DBDE_BUILD_TARGET_CPP17=OFF \
             -DCMAKE_CXX_STANDARD=98 \
-            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
-            -DCMAKE_VERBOSE_MAKEFILE=ON \
+            -DCMAKE_CXX_STANDARD_REQUIRED=On \
+            -DCMAKE_CXX_EXTENSIONS=Off \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
           cmake --build build/blazingmq --parallel 8 --target all all.t

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,11 +121,12 @@ jobs:
             -DBDE_BUILD_TARGET_64=ON \
             -DBDE_BUILD_TARGET_CPP17=OFF \
             -DCMAKE_CXX_STANDARD=98 \
-            -DCMAKE_CXX_STANDARD_REQUIRED=On \
-            -DCMAKE_CXX_EXTENSIONS=Off \
+            -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+            -DCMAKE_CXX_EXTENSIONS=OFF \
             -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
+          cat build/blazingmq/CMakeCache.txt
           cmake --build build/blazingmq --parallel 8 --target all all.t
 
   unit_tests_cxx:

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -71,7 +71,7 @@ configure() {
 
 build_bde() {
     pushd srcs/bde
-    bbs_build configure
+    bbs_build configure -u "${DEPS_CONFIGURE_UFID}"
     bbs_build build -j8
     bbs_build --install=/opt/bb --prefix=/ install
     popd
@@ -85,7 +85,7 @@ build_ntf() {
         --without-usage-examples        \
         --without-applications          \
         --without-warnings-as-errors    \
-        --ufid "${DEPS_CONFIGURE_UFID}"
+        --ufid opt_64_cpp17
     make -j8
     make install
     popd

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -5,7 +5,7 @@
 # If the optional argument '--only-download' is provided, the script will only download
 # dependencies (build and install steps are skipped).
 
-set -euxo pipefail
+set -exo pipefail
 
 DEPS_CONFIGURE_UFID="opt_64_cpp17"
 DEPS_SKIP_BUILD=0
@@ -66,7 +66,7 @@ fetch_deps() {
 configure() {
     PATH="$PATH:$(realpath srcs/bde-tools/bin)"
     export PATH
-    eval "$(bbs_build_env -u ${DEPS_CONFIGURE_UFID})"
+    eval "$(bbs_build_env -u \"${DEPS_CONFIGURE_UFID})\""
 }
 
 build_bde() {
@@ -85,7 +85,7 @@ build_ntf() {
         --without-usage-examples     \
         --without-applications       \
         --without-warnings-as-errors \
-        --ufid ${DEPS_CONFIGURE_UFID}
+        --ufid "${DEPS_CONFIGURE_UFID}"
     make -j8
     make install
     popd
@@ -98,6 +98,6 @@ build() {
 
 fetch_deps
 configure
-if [ "${DO_BUILD}" = true ]; then
+if [ "${DEPS_SKIP_BUILD}" = 0 ]; then
     build
 fi

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -66,7 +66,7 @@ fetch_deps() {
 configure() {
     PATH="$PATH:$(realpath srcs/bde-tools/bin)"
     export PATH
-    eval "$(bbs_build_env -u ${DEPS_CONFIGURE_UFID})"
+    eval "$(bbs_build_env -u "${DEPS_CONFIGURE_UFID}")"
 }
 
 build_bde() {

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -85,7 +85,7 @@ build_ntf() {
         --without-usage-examples        \
         --without-applications          \
         --without-warnings-as-errors    \
-        --ufid opt_64_cpp17
+        --ufid "${DEPS_CONFIGURE_UFID}"
     make -j8
     make install
     popd

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -66,7 +66,7 @@ fetch_deps() {
 configure() {
     PATH="$PATH:$(realpath srcs/bde-tools/bin)"
     export PATH
-    eval "$(bbs_build_env -u \"${DEPS_CONFIGURE_UFID})\""
+    eval "$(bbs_build_env -u ${DEPS_CONFIGURE_UFID})"
 }
 
 build_bde() {
@@ -79,12 +79,12 @@ build_bde() {
 
 build_ntf() {
     pushd srcs/ntf-core
-    ./configure                      \
-        --keep                       \
-        --prefix /opt/bb             \
-        --without-usage-examples     \
-        --without-applications       \
-        --without-warnings-as-errors \
+    ./configure                         \
+        --keep                          \
+        --prefix /opt/bb                \
+        --without-usage-examples        \
+        --without-applications          \
+        --without-warnings-as-errors    \
         --ufid "${DEPS_CONFIGURE_UFID}"
     make -j8
     make install

--- a/src/groups/bmq/bmqc/bmqc_array.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_array.t.cpp
@@ -32,14 +32,14 @@
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 // BENCHMARK
 #include <benchmark/benchmark.h>
 #include <chrono>
 #include <cmath>
 #include <iostream>
 #include <vector>
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -877,7 +877,7 @@ static void test10_pushBackSelfRef()
     }
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 
 using namespace BloombergLP;
 
@@ -929,7 +929,7 @@ static void VectorAssign_GoogleBenchmark(benchmark::State& state)
     }
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -950,7 +950,7 @@ int main(int argc, char* argv[])
     case 3: test3_noMemoryAllocation(); break;
     case 2: test2_outOfBoundValidation(); break;
     case 1: test1_breathingTest(); break;
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     case -1:
         benchmark::Initialize(&argc, argv);
         BENCHMARK(VectorAssign_GoogleBenchmark)->Range(8, 4096);
@@ -962,7 +962,7 @@ int main(int argc, char* argv[])
         BENCHMARK(VectorFindLarge_GoogleBenchmark)->Range(256, 8192);
         benchmark::RunSpecifiedBenchmarks();
         break;
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;

--- a/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccfixedqueue.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccfixedqueue.t.cpp
@@ -39,9 +39,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -554,7 +554,7 @@ static void testN1_MonitoredQueue_performance()
     PRINT("s_antiOptimization = " << s_antiOptimization);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void
 testN1_MonitoredQueue_performance_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -814,7 +814,7 @@ static void testN1_bdlccFixedQueueThreaded_performance_GoogleBenchmark(
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 //=============================================================================
 //                                MAIN PROGRAM
@@ -829,7 +829,7 @@ int main(int argc, char* argv[])
     case 2: test2_MonitoredQueue_reset(); break;
     case 1: test1_MonitoredQueue_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
         BENCHMARK(testN1_MonitoredQueue_performance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_MonitoredQueueThreaded_performance_GoogleBenchmark)

--- a/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccsingleconsumerqueue.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccsingleconsumerqueue.t.cpp
@@ -40,9 +40,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -538,7 +538,7 @@ static void testN1_MonitoredSingleConsumerQueue_performance()
 }
 
 // Begin Benchmark Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_MonitoredSingleConsumerQueue_performance_GoogleBenchmark(
     benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -801,7 +801,7 @@ testN1_bdlccSingleConsumerQueueThreaded_performance_GoogleBenchmark(
     }
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 //=============================================================================
 //                                MAIN PROGRAM
@@ -816,7 +816,7 @@ int main(int argc, char* argv[])
     case 2: test2_MonitoredSingleConsumerQueue_exceed_reset(); break;
     case 1: test1_MonitoredSingleConsumerQueue_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
         BENCHMARK(
             testN1_MonitoredSingleConsumerQueue_performance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);

--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.t.cpp
@@ -44,9 +44,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -376,7 +376,7 @@ static void testN1_performance()
     printProcessedItems(k_NUM_ITERATIONS, endTime - startTime);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_performance_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // PERFORMANCE TEST
@@ -509,7 +509,8 @@ static void testN1_fixedPerformance_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 //=============================================================================
 //                                MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -522,7 +523,7 @@ int main(int argc, char* argv[])
     case 0:
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
         BENCHMARK(testN1_fixedPerformance_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_performance_GoogleBenchmark)

--- a/src/groups/bmq/bmqc/bmqc_orderedhashmap.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmap.t.cpp
@@ -32,9 +32,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -1106,8 +1106,8 @@ BSLA_MAYBE_UNUSED static void testN3_profile()
     }
 }
 
-// Begin benchmarking library tests (Linux only)
-#ifdef BSLS_PLATFORM_OS_LINUX
+// Begin benchmarking library tests
+#ifdef BMQTST_BENCHMARK_ENABLED
 
 static void
 testN1_insertPerformanceUnordered_GoogleBenchmark(benchmark::State& state)
@@ -1223,7 +1223,8 @@ static void testN3_profile_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -1283,7 +1284,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -20,14 +20,15 @@
 #include <bmqeval_simpleevaluatorparser.hpp>
 #include <bmqeval_simpleevaluatorscanner.h>
 
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
 // BENCHMARKING LIBRARY
 #ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
 #endif  // BMQTST_BENCHMARK_ENABLED
 
-// TEST DRIVER
-#include <bmqtst_testhelper.h>
-
+// BDE
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_sstream.h>
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -21,9 +21,9 @@
 #include <bmqeval_simpleevaluatorscanner.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -76,7 +76,7 @@ class MockPropertiesReader : public PropertiesReader {
     }
 };
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_SimpleEvaluator_GoogleBenchmark(benchmark::State& state)
 {
     bmqtst::TestHelper::printTestName("GOOGLE BENCHMARK: SimpleEvaluator");
@@ -569,7 +569,7 @@ int main(int argc, char* argv[])
     } break;
     }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqex/bmqex_executor.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executor.t.cpp
@@ -112,7 +112,7 @@ class StatExecutor {
 
     /// Perform `++statistics()->d_postCallCount` followed by `f()`.
     template <class FUNCTION>
-    void post(bslmf::MovableRef<FUNCTION> f) const
+    void post(FUNCTION f) const
     {
         ++d_statistics_p->d_postCallCount;
         bslmf::MovableRefUtil::access(f)();
@@ -120,7 +120,7 @@ class StatExecutor {
 
     /// Perform `++statistics()->d_dispatchCallCount` followed by `f()`.
     template <class FUNCTION>
-    void dispatch(bslmf::MovableRef<FUNCTION> f) const
+    void dispatch(FUNCTION f) const
     {
         ++d_statistics_p->d_dispatchCallCount;
         bslmf::MovableRefUtil::access(f)();

--- a/src/groups/bmq/bmqex/bmqex_executor.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executor.t.cpp
@@ -112,7 +112,7 @@ class StatExecutor {
 
     /// Perform `++statistics()->d_postCallCount` followed by `f()`.
     template <class FUNCTION>
-    void post(FUNCTION f) const
+    void post(bslmf::MovableRef<FUNCTION> f) const
     {
         ++d_statistics_p->d_postCallCount;
         f();
@@ -120,7 +120,7 @@ class StatExecutor {
 
     /// Perform `++statistics()->d_dispatchCallCount` followed by `f()`.
     template <class FUNCTION>
-    void dispatch(FUNCTION f) const
+    void dispatch(bslmf::MovableRef<FUNCTION> f) const
     {
         ++d_statistics_p->d_dispatchCallCount;
         f();

--- a/src/groups/bmq/bmqex/bmqex_executor.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executor.t.cpp
@@ -115,7 +115,7 @@ class StatExecutor {
     void post(bslmf::MovableRef<FUNCTION> f) const
     {
         ++d_statistics_p->d_postCallCount;
-        f();
+        bslmf::MovableRefUtil::access(f)();
     }
 
     /// Perform `++statistics()->d_dispatchCallCount` followed by `f()`.
@@ -123,7 +123,7 @@ class StatExecutor {
     void dispatch(bslmf::MovableRef<FUNCTION> f) const
     {
         ++d_statistics_p->d_dispatchCallCount;
-        f();
+        bslmf::MovableRefUtil::access(f)();
     }
 
   public:

--- a/src/groups/bmq/bmqex/bmqex_executortraits.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executortraits.t.cpp
@@ -69,7 +69,7 @@ struct PostExecutor {
     template <class FUNCTION>
     void post(FUNCTION f) const
     {
-        f();
+        bslmf::MovableRefUtil::access(f)();
         ++d_postCallCount;
     }
 };
@@ -101,14 +101,14 @@ struct PostDispatchExecutor {
     template <class FUNCTION>
     void post(FUNCTION f) const
     {
-        f();
+        bslmf::MovableRefUtil::access(f)();
         ++d_postCallCount;
     }
 
     template <class FUNCTION>
     void dispatch(FUNCTION f) const
     {
-        f();
+        bslmf::MovableRefUtil::access(f)();
         ++d_dispatchCallCount;
     }
 };

--- a/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
@@ -37,9 +37,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -660,7 +660,7 @@ static void testN1_performance_allocation()
               << '\n';
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void
 testN1_bslmaperformance_allocation_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -776,7 +776,8 @@ testN1_defaultperformance_allocation_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -795,7 +796,7 @@ int main(int argc, char** argv)
     case 2: test2_allocate(); break;
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
         BENCHMARK(testN1_defaultperformance_allocation_GoogleBenchmark)
             ->Unit(benchmark::kMillisecond);
         BENCHMARK(testN1_bslmaperformance_allocation_GoogleBenchmark)

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -36,9 +36,9 @@
 #include <bsls_timeutil.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -1013,7 +1013,7 @@ static void testN3_performanceCompressionRatio()
 }
 
 // Begin Benchmarking Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_performanceCompressionDecompressionDefault_GoogleBenchmark(
     benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -1092,7 +1092,8 @@ static void testN2_calculateThroughput_GoogleBenchmark(benchmark::State& state)
     }
     // </time>
 }
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -1125,7 +1126,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqp/bmqp_crc32c.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_crc32c.t.cpp
@@ -45,9 +45,9 @@
 #include <bsls_timeutil.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -127,7 +127,7 @@ static int populateBufferLengthsSorted(bsl::vector<int>* bufferLengths)
     return bufferLengths->back();
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 /// Populate the specified `bufferLengths` with various lengths in
 /// increasing sorted order. Apply these arguments to Google Benchmark
 /// internals Note that upper bound is 64 Ki
@@ -194,7 +194,7 @@ static void populateBufferLengthsSorted_GoogleBenchmark_Large(
         b->Args({i});
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 /// Print the specified `headers` to the specified `out` in the following
 /// format:
@@ -2209,7 +2209,7 @@ static void testN6_bdldPerformanceDefault()
     bmqtst::TestHelperUtil::allocator()->deallocate(buffer);
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 
 static void
 testN1_performanceDefaultUserInput_GoogleBenchmark(benchmark::State& state)
@@ -2577,7 +2577,7 @@ testN6_bdldPerformanceDefault_GoogleBenchmark(benchmark::State& state)
     bmqtst::TestHelperUtil::allocator()->deallocate(buffer);
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -2651,7 +2651,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
@@ -46,9 +46,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -1854,7 +1854,7 @@ static void testN10_hashCollisionsComparison()
 
 // Begin Benchmarking Tests
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_decode_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // DECODE
@@ -2261,7 +2261,7 @@ static void testN8_orderedMapWithCustomHashBenchmark_GoogleBenchmark(
         }
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -2338,7 +2338,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/bmq/bmqsys/bmqsys_time.t.cpp
+++ b/src/groups/bmq/bmqsys/bmqsys_time.t.cpp
@@ -30,9 +30,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -317,7 +317,7 @@ static void testN1_performance()
 }
 
 // Begin benchmarking tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_defaultPerformance_GoogleBenchmark(benchmark::State& state)
 {
     // Default function call
@@ -378,7 +378,8 @@ static void testN1_bindPerformance_GoogleBenchmark(benchmark::State& state)
         }
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -393,7 +394,7 @@ int main(int argc, char* argv[])
     case 2: test2_defaultInitializeShutdown(); break;
     case 1: test1_breathingTest(); break;
     case -1:
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
         BENCHMARK(testN1_defaultPerformance_GoogleBenchmark)
             ->RangeMultiplier(10)
             ->Range(1000, 100000000)

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -731,7 +731,7 @@
 /* Define benchmarking macros */
 /// We want to be able to build on Linux with older C++03 standard.
 /// In this case we have to disable Benchmark code that uses C++11 features.
-#ifdef BSLS_PLATFORM_OS_LINUX && (__cplusplus >= 201103L)
+#if defined(BSLS_PLATFORM_OS_LINUX) && (__cplusplus >= 201103L)
 #define BMQTST_BENCHMARK_ENABLED
 #endif
 

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -728,19 +728,25 @@
         Test##NAME ::run);                                                    \
     void Test##NAME ::body()
 
-/*Define benchmarking macros*/
+/* Define benchmarking macros */
 /// We want to be able to build on Linux with older C++03 standard.
 /// In this case we have to disable Benchmark code that uses C++11 features.
 #ifdef BSLS_PLATFORM_OS_LINUX && (__cplusplus >= 201103L)
 #define BMQTST_BENCHMARK_ENABLED
+#endif
+
+#ifdef BMQTST_BENCHMARK_ENABLED
+
 #define BMQTST_BENCHMARK_WITH_ARGS(BM_NAME, ARGS)                             \
     BENCHMARK(BM_NAME##_GoogleBenchmark)->ARGS;
 #define BMQTST_BENCHMARK(BM_NAME) BENCHMARK(BM_NAME##_GoogleBenchmark);
-#else  // !BSLS_PLATFORM_OS_LINUX
+
+#else  // !BMQTST_BENCHMARK_ENABLED
+
 #define BMQTST_BENCHMARK(BM_NAME) BM_NAME();
 #define BMQTST_BENCHMARK_WITH_ARGS(BM_NAME, ARGS) BM_NAME();
 
-#endif  // BSLS_PLATFORM_OS_LINUX && (__cplusplus >= 201103L)
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 namespace BloombergLP {
 namespace bmqtst {

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -729,8 +729,7 @@
     void Test##NAME ::body()
 
 /* Define benchmarking macros */
-/// We want to be able to build on Linux with older C++03 standard.
-/// In this case we have to disable Benchmark code that uses C++11 features.
+/// Some Benchmark code uses C++11 features.
 #if defined(BSLS_PLATFORM_OS_LINUX) && (__cplusplus >= 201103L)
 #define BMQTST_BENCHMARK_ENABLED
 #endif

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -729,7 +729,10 @@
     void Test##NAME ::body()
 
 /*Define benchmarking macros*/
-#ifdef BSLS_PLATFORM_OS_LINUX
+/// We want to be able to build on Linux with older C++03 standard.
+/// In this case we have to disable Benchmark code that uses C++11 features.
+#ifdef BSLS_PLATFORM_OS_LINUX && (__cplusplus >= 201103L)
+#define BMQTST_BENCHMARK_ENABLED
 #define BMQTST_BENCHMARK_WITH_ARGS(BM_NAME, ARGS)                             \
     BENCHMARK(BM_NAME##_GoogleBenchmark)->ARGS;
 #define BMQTST_BENCHMARK(BM_NAME) BENCHMARK(BM_NAME##_GoogleBenchmark);
@@ -737,7 +740,7 @@
 #define BMQTST_BENCHMARK(BM_NAME) BM_NAME();
 #define BMQTST_BENCHMARK_WITH_ARGS(BM_NAME, ARGS) BM_NAME();
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BSLS_PLATFORM_OS_LINUX && (__cplusplus >= 201103L)
 
 namespace BloombergLP {
 namespace bmqtst {

--- a/src/groups/bmq/bmqu/bmqu_blob.cpp
+++ b/src/groups/bmq/bmqu/bmqu_blob.cpp
@@ -585,7 +585,7 @@ char* BlobUtil::getAlignedSection(char*               storage,
                                   bool                copyFromBlob)
 {
     BlobPosition end;
-    auto          ret = findOffset(&end, blob, start, length);
+    int          ret = findOffset(&end, blob, start, length);
     if (ret) {
         return 0;  // RETURN
     }

--- a/src/groups/bmq/bmqu/bmqu_blob.cpp
+++ b/src/groups/bmq/bmqu/bmqu_blob.cpp
@@ -585,7 +585,7 @@ char* BlobUtil::getAlignedSection(char*               storage,
                                   bool                copyFromBlob)
 {
     BlobPosition end;
-    int          ret = findOffset(&end, blob, start, length);
+    auto          ret = findOffset(&end, blob, start, length);
     if (ret) {
         return 0;  // RETURN
     }

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1540,11 +1540,11 @@ TCPSessionFactory::PortManager::addChannelContext(bmqst::StatContext* parent,
         bmqst::StatContextConfiguration portConfig(
             static_cast<bsls::Types::Int64>(port),
             &localAllocator);
-        bsl::shared_ptr<bmqst::StatContext> portStatContext =
-            bslmf::MovableRefUtil::move(parent->addSubcontext(
-                portConfig.storeExpiredSubcontextValues(true)));
-        channelStatContext      = portStatContext->addSubcontext(statConfig);
-        PortContext portContext = {portStatContext, 1};
+        bslma::ManagedPtr<bmqst::StatContext> portStatContext_mp = parent->addSubcontext(
+                portConfig.storeExpiredSubcontextValues(true));
+        bsl::shared_ptr<bmqst::StatContext> portStatContext_sp = portStatContext_mp;
+        channelStatContext      = portStatContext_sp->addSubcontext(statConfig);
+        PortContext portContext = {portStatContext_sp, 1};
         d_portMap.emplace(port, portContext);
     }
 

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1541,8 +1541,8 @@ TCPSessionFactory::PortManager::addChannelContext(bmqst::StatContext* parent,
             static_cast<bsls::Types::Int64>(port),
             &localAllocator);
         bsl::shared_ptr<bmqst::StatContext> portStatContext =
-            parent->addSubcontext(
-                portConfig.storeExpiredSubcontextValues(true));
+            bslmf::MovableRefUtil::move(parent->addSubcontext(
+                portConfig.storeExpiredSubcontextValues(true)));
         channelStatContext      = portStatContext->addSubcontext(statConfig);
         PortContext portContext = {portStatContext, 1};
         d_portMap.emplace(port, portContext);

--- a/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
@@ -27,9 +27,9 @@
 #include <bsls_types.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -443,7 +443,7 @@ static void testN4_orderedMapWithCustomHashBenchmark()
          << " insertions per second.\n";
 }
 
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void
 testN1_defaultHashBenchmark_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -560,7 +560,8 @@ static void testN4_orderedMapWithCustomHashBenchmark_GoogleBenchmark(
         }
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -603,7 +604,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
@@ -45,9 +45,9 @@
 #include <bmqtst_testhelper.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -935,7 +935,7 @@ BSLA_MAYBE_UNUSED static void testN8_orderedMapWithCustomHashBenchmark()
 }
 
 // Begin Benchmarking Library
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void testN1_decode_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
 // DECODE
@@ -1311,7 +1311,7 @@ static void testN8_orderedMapWithCustomHashBenchmark_GoogleBenchmark(
         }
     }
 }
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // ============================================================================
 //                                 MAIN PROGRAM
@@ -1386,7 +1386,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();

--- a/src/groups/mqb/mqbu/mqbu_storagekey.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_storagekey.t.cpp
@@ -36,9 +36,9 @@
 #include <bsls_types.h>
 
 // BENCHMARKING LIBRARY
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 #include <benchmark/benchmark.h>
-#endif
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -728,7 +728,7 @@ void testN6_orderedMapWithCustomHashBenchmark()
 }
 
 // Begin Google Benchmark Tests
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
 static void
 testN1_defaultHashBenchmark_GoogleBenchmark(benchmark::State& state)
 // ------------------------------------------------------------------------
@@ -954,7 +954,7 @@ static void testN6_orderedMapWithCustomHashBenchmark_GoogleBenchmark(
     // </time>
 }
 
-#endif  // BSLS_PLATFORM_OS_LINUX
+#endif  // BMQTST_BENCHMARK_ENABLED
 
 }  // close unnamed namespace
 
@@ -1011,7 +1011,7 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BSLS_PLATFORM_OS_LINUX
+#ifdef BMQTST_BENCHMARK_ENABLED
     if (_testCase < 0) {
         benchmark::Initialize(&argc, argv);
         benchmark::RunSpecifiedBenchmarks();


### PR DESCRIPTION
The new c++03 build workflow can catch accidental usage of features not supported by solaris compiler, for example:
```
/home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqu/bmqu_blob.cpp:588:19: error: ‘ret’ does not name a type
  588 |     auto          ret = findOffset(&end, blob, start, length);
```