### PR TITLE
CI: Publish container images to GHCR.io

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,38 +4,54 @@ on:
   push:
     # Publish `v*` tags as releases.
     tags:
-    - v*
+      - v*
+    # Allow us to make manual images from `main`, tagged as `main`.
+    workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  publish:
+  build-and-publish-image:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        if: github.event_name != 'pull_request'
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      - name: Docker meta
+
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          images: bloomberg/blazingmq
-      - name: Build and push
-        id: docker_build
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64, linux/arm64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: simple


### PR DESCRIPTION
We had tested publishing BlazingMQ images to DockerHub, but we believe the GitHub Container Registry (GHCR.io) to be a better platform for our needs.  This patch updates the `publish` workflow to publish our Docker image publicly to GHCR.io every time we tag a release, and on a manual dispatch.  The image is built both for x64 and arm64 architectures, and is automatically tagged with the version number from the Git tag, `latest` if it’s the most recent release, or as `main` if the workflow was manually dispatched from the `main` branch.

Closes: #628