### PR TITLE
Fix: Publish last stage, not “simple” stage to GHCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -54,4 +54,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          target: simple


### PR DESCRIPTION
The Docker publishing workflow had never been exercized, and there was a bug in the existing workflow.  This was exposed when testing the changes in commit c4d280, which fail with:

    buildx failed with: ERROR: failed to solve: target stage "simple" could not be found

As far as I can tell, there has never been a stage “simple” in our Dockerfile, so this was always broken.

This patch removes the target stage from our GHCR publishing workflow. It is not easy to test this without commiting the change, but this should give the same behavior as running

    docker build ./docker/Dockerfile

which yields the image we want to publish, using the final, unnamed stage.