### PR TITLE
Perf[MQB]: do not re-read appData if not necessary

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2156,12 +2156,25 @@ static void test11_initiateShutdown()
         {
         }
 
+        // MANIPULATORS
+        /// Clear any cached data associated with this iterator, if any.
+        /// The cache might be initialized within `appData`, `options` or
+        /// `attributes` routines.
+        /// TODO: refactor iterators to remove cached data.
+        void clearCache() BSLS_KEYWORD_OVERRIDE
+        {
+            d_appData.reset();
+            d_options.reset();
+            d_messageAttributes.reset();
+        }
+
         bool advance() BSLS_KEYWORD_OVERRIDE
         {
             d_guid = bmqp::MessageGUIDGenerator::testGUID();
             return true;
         }
 
+        // ACCESSORS
         void reset(const bmqt::MessageGUID& where = bmqt::MessageGUID())
             BSLS_KEYWORD_OVERRIDE
         {

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -459,6 +459,7 @@ void LocalQueue::postMessage(const bmqp::PutHeader&              putHeader,
             mqbi::StorageMessageAttributes attributes(
                 timestamp,
                 refCount,
+                static_cast<unsigned int>(appData->length()),
                 translation,
                 putHeader.compressionAlgorithmType(),
                 !d_haveStrongConsistency,

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -64,10 +64,8 @@ PushStream::PushStream(
 // ----------------------------
 
 // PRIVATE MANIPULATORS
-void PushStreamIterator::clear()
+void PushStreamIterator::clearCache()
 {
-    // Clear previous state, if any.  This is required so that new state can be
-    // loaded in 'appData', 'options' or 'attributes' routines.
     d_appData_sp.reset();
     d_options_sp.reset();
     d_attributes.reset();
@@ -157,7 +155,7 @@ bool PushStreamIterator::advance()
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!atEnd());
 
-    clear();
+    clearCache();
 
     if (d_iterator->second.numElements() == 0) {
         d_iterator = d_owner_p->d_stream.erase(d_iterator);
@@ -173,7 +171,7 @@ bool PushStreamIterator::advance()
 
 void PushStreamIterator::reset(const bmqt::MessageGUID& where)
 {
-    clear();
+    clearCache();
 
     if (where.isUnset()) {
         // Reset iterator to beginning
@@ -298,7 +296,7 @@ bool VirtualPushStreamIterator::advance()
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!atEnd());
 
-    clear();
+    clearCache();
 
     PushStream::Element* del = d_currentElement;
 

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.h
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.h
@@ -275,12 +275,6 @@ class PushStreamIterator : public mqbi::StorageIterator {
     PushStreamIterator& operator=(const PushStreamIterator&);  // = delete
 
   protected:
-    // PRIVATE MANIPULATORS
-
-    /// Clear previous state, if any.  This is required so that new state
-    /// can be loaded in `appData`, `options` or `attributes` routines.
-    void clear();
-
     // PRIVATE ACCESSORS
 
     /// Load the internal state of this iterator instance with the
@@ -324,6 +318,12 @@ class PushStreamIterator : public mqbi::StorageIterator {
     virtual PushStream::Element* element(unsigned int appOrdinal) const;
 
     // MANIPULATORS
+    /// Clear any cached data associated with this iterator, if any.
+    /// The cache might be initialized within `appData`, `options` or
+    /// `attributes` routines.
+    /// TODO: refactor iterators to remove cached data.
+    void clearCache() BSLS_KEYWORD_OVERRIDE;
+
     bool advance() BSLS_KEYWORD_OVERRIDE;
 
     /// If the specified `atEnd` is `true`, reset the iterator to point to the

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -946,13 +946,16 @@ void QueueEngineTester::post(const bslstl::StringRef& messages,
         BSLS_ASSERT_SAFE(d_messageCount < k_MAX_MESSAGES);
 
         mqbu::MessageGUIDUtil::generateGUID(&msgGUID);
-        msgAttributes.setRefCount(d_queueEngine_mp->messageReferenceCount());
-        msgAttributes.setArrivalTimestamp(d_messageCount);
 
         appData.createInplace(d_allocator_p, &d_bufferFactory, d_allocator_p);
         bdlbb::BlobUtil::append(appData.get(),
                                 msgs[i].data(),
                                 msgs[i].length());
+
+        msgAttributes.setRefCount(d_queueEngine_mp->messageReferenceCount());
+        msgAttributes.setArrivalTimestamp(d_messageCount);
+        msgAttributes.setAppDataLen(
+            static_cast<unsigned int>(appData->length()));
 
         // Consider this non-Proxy.  Imitate replication or Primary PUT
         // ('d_mockCluster_mp->_setIsClusterMember(true)')

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -909,6 +909,11 @@ QueueEngineUtil_AppState::deliverMessages(bsls::TimeInterval*          delay,
     }
 
     size_t numMessages = processDeliveryLists(delay, reader);
+    // `reader` might keep a shared pointer to a memory mapped file area, and
+    // this prevents file set from closing possibly for a very long time.
+    // Make sure to invalidate any cached data within this iterator after use.
+    // TODO: refactor iterators to remove cached data.
+    reader->clearCache();
 
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(d_redeliveryList.size())) {
         // We only attempt to deliver new messages if we successfully
@@ -967,6 +972,11 @@ QueueEngineUtil_AppState::deliverMessages(bsls::TimeInterval*          delay,
 
         start->advance();
     }
+    // `start` might keep a shared pointer to a memory mapped file area, and
+    // this prevents file set from closing possibly for a very long time.
+    // Make sure to invalidate any cached data within this iterator after use.
+    // TODO: refactor iterators to remove cached data.
+    start->clearCache();
     return numMessages;
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -789,24 +789,18 @@ void QueueEngineUtil_AppsDeliveryContext::deliverMessage()
     BSLS_ASSERT_SAFE(d_currentMessage);
 
     if (!d_consumers.empty()) {
-        const mqbi::StorageMessageAttributes& attributes =
-            d_currentMessage->attributes();
         for (Consumers::const_iterator it = d_consumers.begin();
              it != d_consumers.end();
              ++it) {
             BSLS_ASSERT_SAFE(!it->second.empty());
 
             if (QueueEngineUtil::isBroadcastMode(d_queue_p)) {
-                it->first->deliverMessageNoTrack(d_currentMessage->appData(),
-                                                 d_currentMessage->guid(),
-                                                 attributes,
+                it->first->deliverMessageNoTrack(*d_currentMessage,
                                                  "",  // msgGroupId,
                                                  it->second);
             }
             else {
-                it->first->deliverMessage(d_currentMessage->appData(),
-                                          d_currentMessage->guid(),
-                                          attributes,
+                it->first->deliverMessage(*d_currentMessage,
                                           "",  // msgGroupId,
                                           it->second,
                                           false);
@@ -1056,9 +1050,7 @@ Routers::Result QueueEngineUtil_AppState::tryDeliverOneMessage(
         1,
         bmqp::SubQueueInfo(visitor.d_downstreamSubscriptionId,
                            message->appMessageView(ordinal()).d_rdaInfo));
-    visitor.d_handle->deliverMessage(message->appData(),
-                                     message->guid(),
-                                     message->attributes(),
+    visitor.d_handle->deliverMessage(*message,
                                      "",  // msgGroupId
                                      subQueueInfos,
                                      isOutOfOrder);
@@ -1088,9 +1080,7 @@ bool QueueEngineUtil_AppState::visitBroadcast(
     BSLS_ASSERT_SAFE(handle);
     // TBD: groupId: send 'options' as well...
     handle->deliverMessageNoTrack(
-        message->appData(),
-        message->guid(),
-        message->attributes(),
+        *message,
         "",  // msgGroupId
         bmqp::Protocol::SubQueueInfosArray(
             1,

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -794,7 +794,6 @@ void QueueHandle::deliverMessageNoTrack(
         d_queue_sp->dispatcher()->inDispatcherThread(d_queue_sp.get()));
     BSLS_ASSERT_SAFE(
         bmqt::QueueFlagsUtil::isReader(handleParameters().flags()));
-
     deliverMessageImpl(iter.appData(),
                        iter.guid(),
                        iter.attributes(),

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.h
@@ -237,7 +237,6 @@ class QueueHandle : public mqbi::QueueHandle {
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void
     deliverMessageImpl(const bsl::shared_ptr<bdlbb::Blob>&       message,
-                       const int                                 msgSize,
                        const bmqt::MessageGUID&                  msgGUID,
                        const mqbi::StorageMessageAttributes&     attributes,
                        const bmqp::Protocol::MsgGroupId&         msgGroupId,
@@ -353,39 +352,31 @@ class QueueHandle : public mqbi::QueueHandle {
     mqbi::QueueHandle*
     setIsClientClusterMember(bool value) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgSize`, `msgGUID`, `attributes`, `isOutOfOrder`, and
-    /// `msgGroupId` for the specified `subQueueInfos` streams of the queue.
-    /// The behavior is undefined unless the queueHandle can send a message at
-    /// this time for all of the `subQueueInfos` streams (see
-    /// 'canDeliver(unsigned int subQueueId)' for more information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  The behavior is undefined unless the queueHandle can send
+    /// a message at this time for each of the corresponding subStreams (see
+    /// `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void
-    deliverMessage(const bsl::shared_ptr<bdlbb::Blob>&       message,
-                   const bmqt::MessageGUID&                  msgGUID,
-                   const mqbi::StorageMessageAttributes&     attributes,
+    deliverMessage(const mqbi::StorageIterator&              iter,
                    const bmqp::Protocol::MsgGroupId&         msgGroupId,
                    const bmqp::Protocol::SubQueueInfosArray& subscriptions,
                    bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subQueueInfos` streams of the queue.  This method is identical with
-    /// `deliverMessage()` but it doesn't update any flow-control mechanisms
-    /// implemented by this handler.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time for each of the
-    /// `subQueueInfos` (see `canDeliver(unsigned int subQueueId)` for more
-    /// information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  This method is identical with `deliverMessage()` but it
+    /// doesn't update any flow-control mechanisms implemented by this handler.
+    /// The behavior is undefined unless the queueHandle can send a message at
+    /// this time (see `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void deliverMessageNoTrack(
-        const bsl::shared_ptr<bdlbb::Blob>&       message,
-        const bmqt::MessageGUID&                  msgGUID,
-        const mqbi::StorageMessageAttributes&     attributes,
-        const bmqp::Protocol::MsgGroupId&         msgGroupId,
-        const bmqp::Protocol::SubQueueInfosArray& subQueueInfos)
-        BSLS_KEYWORD_OVERRIDE;
+    void deliverMessageNoTrack(const mqbi::StorageIterator&      iter,
+                               const bmqp::Protocol::MsgGroupId& msgGroupId,
+                               const bmqp::Protocol::SubQueueInfosArray&
+                                   subQueueInfos) BSLS_KEYWORD_OVERRIDE;
 
     /// Post the message with the specified PUT `header`, `appData` and
     /// `options` to the queue.

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -356,11 +356,6 @@ void RemoteQueue::pushMessage(
     bool                                 isOutOfOrder)
 {
     // executed by the *QUEUE DISPATCHER* thread
-
-    mqbi::StorageMessageAttributes attributes(0ULL,  // Timestamp; unused
-                                              1,     // RefCount
-                                              messagePropertiesInfo,
-                                              compressionAlgorithmType);
     mqbi::StorageResult::Enum      result  = mqbi::StorageResult::e_SUCCESS;
     mqbi::Storage*                 storage = d_state_p->storage();
     int                            msgSize = 0;
@@ -374,6 +369,13 @@ void RemoteQueue::pushMessage(
     else {
         if (d_state_p->isAtMostOnce()) {
             BSLS_ASSERT_SAFE(appData);
+            msgSize = appData->length();
+            mqbi::StorageMessageAttributes attributes(
+                0ULL,  // Timestamp; unused
+                1,     // RefCount
+                static_cast<unsigned int>(msgSize),
+                messagePropertiesInfo,
+                compressionAlgorithmType);
 
             result = storage->put(&attributes, msgGUID, appData, options);
 
@@ -442,6 +444,12 @@ void RemoteQueue::pushMessage(
     BSLS_ASSERT_SAFE(d_state_p->hasMultipleSubStreams() ||
                      subQueueInfos.size() == 1);
 
+    mqbi::StorageMessageAttributes attributes(
+        0ULL,  // Timestamp; unused
+        1,     // RefCount
+        static_cast<unsigned int>(msgSize),
+        messagePropertiesInfo,
+        compressionAlgorithmType);
     d_queueEngine_mp->push(&attributes,
                            msgGUID,
                            appData,

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -424,7 +424,6 @@ void RemoteQueue::pushMessage(
     }
 
     bmqp::Protocol::SubQueueInfosArray subQueueInfos;
-    StorageKeys                        storageKeys;
 
     // Retrieve subQueueInfos from 'options'
     // Need to look up subQueueIds by subscriptionIds.

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -812,12 +812,7 @@ struct TestHelper {
         if (0 == recNum % 2) {
             mpsInfo = bmqp::MessagePropertiesInfo::makeInvalidSchema();
         }
-        rec.d_msgAttributes = mqbi::StorageMessageAttributes(
-            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
-            recNum % mqbs::FileStoreProtocol::k_MAX_MSG_REF_COUNT_HARD,
-            mpsInfo,
-            bmqt::CompressionAlgorithmType::e_NONE,
-            bsl::numeric_limits<unsigned int>::max() / recNum);
+
         // crc value
         mqbu::MessageGUIDUtil::generateGUID(&rec.d_guid);
         rec.d_appData_sp.createInplace(bmqtst::TestHelperUtil::allocator(),
@@ -829,6 +824,17 @@ struct TestHelper {
         bdlbb::BlobUtil::append(rec.d_appData_sp.get(),
                                 payloadStr.c_str(),
                                 payloadStr.length());
+
+        const unsigned int appDataLen = static_cast<unsigned int>(
+            rec.d_appData_sp->length());
+
+        rec.d_msgAttributes = mqbi::StorageMessageAttributes(
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
+            recNum % mqbs::FileStoreProtocol::k_MAX_MSG_REF_COUNT_HARD,
+            appDataLen,
+            mpsInfo,
+            bmqt::CompressionAlgorithmType::e_NONE,
+            bsl::numeric_limits<unsigned int>::max() / recNum);
 
         const int rc = fs->writeMessageRecord(&rec.d_msgAttributes,
                                               &handle,

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -556,35 +556,29 @@ class QueueHandle {
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void onAckMessage(const bmqp::AckMessage& ackMessage) = 0;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subscriptions` of the queue.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time for each of the
-    /// corresponding subStreams(see `canDeliver(unsigned int subQueueId)`
-    /// for more information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  The behavior is undefined unless the queueHandle can send
+    /// a message at this time for each of the corresponding subStreams (see
+    /// `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void
-    deliverMessage(const bsl::shared_ptr<bdlbb::Blob>&       message,
-                   const bmqt::MessageGUID&                  msgGUID,
-                   const StorageMessageAttributes&           attributes,
+    deliverMessage(const mqbi::StorageIterator&              iter,
                    const bmqp::Protocol::MsgGroupId&         msgGroupId,
                    const bmqp::Protocol::SubQueueInfosArray& subscriptions,
                    bool                                      isOutOfOrder) = 0;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subscriptions` of the queue.  This method is identical with
-    /// `deliverMessage()` but it doesn't update any flow-control mechanisms
-    /// implemented by this handler.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time (see
-    /// `canDeliver(unsigned int subQueueId)` for more information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  This method is identical with `deliverMessage()` but it
+    /// doesn't update any flow-control mechanisms implemented by this handler.
+    /// The behavior is undefined unless the queueHandle can send a message at
+    /// this time (see `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     virtual void deliverMessageNoTrack(
-        const bsl::shared_ptr<bdlbb::Blob>&       message,
-        const bmqt::MessageGUID&                  msgGUID,
-        const StorageMessageAttributes&           attributes,
+        const mqbi::StorageIterator&              iter,
         const bmqp::Protocol::MsgGroupId&         msgGroupId,
         const bmqp::Protocol::SubQueueInfosArray& subscriptions) = 0;
 

--- a/src/groups/mqb/mqbi/mqbi_storage.cpp
+++ b/src/groups/mqb/mqbi/mqbi_storage.cpp
@@ -140,6 +140,7 @@ StorageMessageAttributes::print(bsl::ostream&                   stream,
     printer.printAttribute("arrivalTimestamp", value.arrivalTimestamp());
     printer.printAttribute("arrivalTimepoint", value.arrivalTimepoint());
     printer.printAttribute("refCount", value.refCount());
+    printer.printAttribute("appDataLen", value.appDataLen());
     printer.printAttribute("hasMessageProperties",
                            value.messagePropertiesInfo().isPresent());
     printer.printAttribute("crc32c", value.crc32c());

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -168,6 +168,9 @@ class StorageMessageAttributes {
 
     unsigned int d_refCount;
 
+    /// Unpadded
+    unsigned int d_appDataLen;
+
     bmqp::MessagePropertiesInfo d_messagePropertiesInfo;
 
     bool d_hasReceipt;
@@ -207,6 +210,7 @@ class StorageMessageAttributes {
 
     StorageMessageAttributes(
         bsls::Types::Uint64                  arrivalTimestamp,
+        unsigned int                         appDataLen,
         unsigned int                         refCount,
         const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
         bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
@@ -219,6 +223,7 @@ class StorageMessageAttributes {
     StorageMessageAttributes& setArrivalTimestamp(bsls::Types::Uint64 value);
     StorageMessageAttributes& setArrivalTimepoint(bsls::Types::Int64 value);
     StorageMessageAttributes& setRefCount(unsigned int value);
+    StorageMessageAttributes& setAppDataLen(unsigned int value);
     StorageMessageAttributes& setCrc32c(unsigned int value);
     StorageMessageAttributes&
     setCompressionAlgorithmType(bmqt::CompressionAlgorithmType::Enum value);
@@ -235,6 +240,7 @@ class StorageMessageAttributes {
     bsls::Types::Uint64                arrivalTimestamp() const;
     bsls::Types::Int64                 arrivalTimepoint() const;
     unsigned int                       refCount() const;
+    unsigned int                       appDataLen() const;
     const bmqp::MessagePropertiesInfo& messagePropertiesInfo() const;
     bool                               hasReceipt() const;
     mqbi::QueueHandle*                 queueHandle() const;
@@ -769,6 +775,7 @@ inline StorageMessageAttributes::StorageMessageAttributes()
 : d_arrivalTimestamp(0)
 , d_arrivalTimepoint(0)
 , d_refCount(0)
+, d_appDataLen(0)
 , d_messagePropertiesInfo()
 , d_hasReceipt(true)
 , d_queueHandle(0)
@@ -780,6 +787,7 @@ inline StorageMessageAttributes::StorageMessageAttributes()
 inline StorageMessageAttributes::StorageMessageAttributes(
     bsls::Types::Uint64                  arrivalTimestamp,
     unsigned int                         refCount,
+    unsigned int                         appDataLen,
     const bmqp::MessagePropertiesInfo&   messagePropertiesInfo,
     bmqt::CompressionAlgorithmType::Enum compressionAlgorithmType,
     bool                                 hasReceipt,
@@ -789,6 +797,7 @@ inline StorageMessageAttributes::StorageMessageAttributes(
 : d_arrivalTimestamp(arrivalTimestamp)
 , d_arrivalTimepoint(arrivalTimepoint)
 , d_refCount(refCount)
+, d_appDataLen(appDataLen)
 , d_messagePropertiesInfo(messagePropertiesInfo)
 , d_hasReceipt(hasReceipt)
 , d_queueHandle(queueHandle)
@@ -817,6 +826,13 @@ inline StorageMessageAttributes&
 StorageMessageAttributes::setRefCount(unsigned int value)
 {
     d_refCount = value;
+    return *this;
+}
+
+inline StorageMessageAttributes&
+StorageMessageAttributes::setAppDataLen(unsigned int value)
+{
+    d_appDataLen = value;
     return *this;
 }
 
@@ -855,6 +871,7 @@ inline void StorageMessageAttributes::reset()
     d_arrivalTimestamp         = 0;
     d_arrivalTimepoint         = 0;
     d_refCount                 = 0;
+    d_appDataLen               = 0;
     d_messagePropertiesInfo    = bmqp::MessagePropertiesInfo();
     d_queueHandle              = 0;
     d_hasReceipt               = true;
@@ -876,6 +893,11 @@ inline bsls::Types::Int64 StorageMessageAttributes::arrivalTimepoint() const
 inline unsigned int StorageMessageAttributes::refCount() const
 {
     return d_refCount;
+}
+
+inline unsigned int StorageMessageAttributes::appDataLen() const
+{
+    return d_appDataLen;
 }
 
 inline const bmqp::MessagePropertiesInfo&
@@ -918,6 +940,7 @@ inline bool operator==(const StorageMessageAttributes& lhs,
     return lhs.arrivalTimestamp() == rhs.arrivalTimestamp() &&
            lhs.arrivalTimepoint() == rhs.arrivalTimepoint() &&
            lhs.refCount() == rhs.refCount() &&
+           lhs.appDataLen() == rhs.appDataLen() &&
            lhs.messagePropertiesInfo() == rhs.messagePropertiesInfo() &&
            lhs.crc32c() == rhs.crc32c() &&
            lhs.compressionAlgorithmType() == rhs.compressionAlgorithmType();

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -341,6 +341,12 @@ class StorageIterator {
 
     // MANIPULATORS
 
+    /// Clear any cached data associated with this iterator, if any.
+    /// The cache might be initialized within `appData`, `options` or
+    /// `attributes` routines.
+    /// TODO: refactor iterators to remove cached data.
+    virtual void clearCache() = 0;
+
     /// Advance the iterator to the next item. The behavior is undefined
     /// unless `atEnd` returns `false`.  Return `true` if the iterator then
     /// points to a valid item, or `false` if it now is at the end of the

--- a/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
@@ -277,9 +277,7 @@ void QueueHandle::onAckMessage(
 }
 
 void QueueHandle::deliverMessage(
-    const bsl::shared_ptr<bdlbb::Blob>& message,
-    const bmqt::MessageGUID&            msgGUID,
-    BSLS_ANNOTATION_UNUSED const mqbi::StorageMessageAttributes& attributes,
+    const mqbi::StorageIterator& message,
     BSLS_ANNOTATION_UNUSED const bmqp::Protocol::MsgGroupId& msgGroupId,
     const bmqp::Protocol::SubQueueInfosArray&                subscriptions,
     BSLS_ANNOTATION_UNUSED bool                              isOutOfOrder)
@@ -303,26 +301,20 @@ void QueueHandle::deliverMessage(
         GUIDMap& guids = mapIter->second.d_unconfirmedMessages;
 
         bsl::pair<GUIDMap::iterator, bool> insertRC = guids.insert(
-            bsl::make_pair(msgGUID, bsl::make_pair(message, sId)));
+            bsl::make_pair(message.guid(),
+                           bsl::make_pair(message.appData(), sId)));
         BSLS_ASSERT_OPT(insertRC.second);
         (void)insertRC;  // Compiler happiness
     }
 }
 
 void QueueHandle::deliverMessageNoTrack(
-    const bsl::shared_ptr<bdlbb::Blob>&       message,
-    const bmqt::MessageGUID&                  msgGUID,
-    const mqbi::StorageMessageAttributes&     attributes,
+    const mqbi::StorageIterator&              message,
     const bmqp::Protocol::MsgGroupId&         msgGroupId,
     const bmqp::Protocol::SubQueueInfosArray& subscriptions)
 {
     // Delegate, from a simplified mock perspective.
-    deliverMessage(message,
-                   msgGUID,
-                   attributes,
-                   msgGroupId,
-                   subscriptions,
-                   false);
+    deliverMessage(message, msgGroupId, subscriptions, false);
 }
 
 void QueueHandle::configure(

--- a/src/groups/mqb/mqbmock/mqbmock_queuehandle.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queuehandle.h
@@ -312,39 +312,31 @@ class QueueHandle : public mqbi::QueueHandle {
     void
     onAckMessage(const bmqp::AckMessage& ackMessage) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subscriptions` of the queue.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time for each of the
-    /// corresponding subStreams(see `canDeliver(unsigned int subQueueId)`
-    /// for more information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  The behavior is undefined unless the queueHandle can send
+    /// a message at this time for each of the corresponding subStreams (see
+    /// `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void
-    deliverMessage(const bsl::shared_ptr<bdlbb::Blob>&       message,
-                   const bmqt::MessageGUID&                  msgGUID,
-                   const mqbi::StorageMessageAttributes&     attributes,
+    deliverMessage(const mqbi::StorageIterator&              message,
                    const bmqp::Protocol::MsgGroupId&         msgGroupId,
                    const bmqp::Protocol::SubQueueInfosArray& subscriptions,
                    bool isOutOfOrder) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the `Queue` to deliver the specified `message` with the
-    /// specified `msgGUID`, `attributes` and `msgGroupId` for the specified
-    /// `subscriptions` the queue.  This method is identical with
-    /// `deliverMessage()` but it doesn't update any flow-control mechanisms
-    /// implemented by this handler.  The behavior is undefined unless the
-    /// queueHandle can send a message at this time for each of the
-    /// `subQueueInfos` (see `canDeliver(unsigned int subQueueId)` for more
-    /// information).
+    /// Called by the `Queue` to deliver a message under the specified `iter`
+    /// with the specified `msgGroupId` for the specified `subscriptions` of
+    /// the queue.  This method is identical with `deliverMessage()` but it
+    /// doesn't update any flow-control mechanisms implemented by this handler.
+    /// The behavior is undefined unless the queueHandle can send a message at
+    /// this time (see `canDeliver(unsigned int subQueueId)` for more details).
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void deliverMessageNoTrack(
-        const bsl::shared_ptr<bdlbb::Blob>&       message,
-        const bmqt::MessageGUID&                  msgGUID,
-        const mqbi::StorageMessageAttributes&     attributes,
-        const bmqp::Protocol::MsgGroupId&         msgGroupId,
-        const bmqp::Protocol::SubQueueInfosArray& subscriptions)
-        BSLS_KEYWORD_OVERRIDE;
+    void deliverMessageNoTrack(const mqbi::StorageIterator&      message,
+                               const bmqp::Protocol::MsgGroupId& msgGroupId,
+                               const bmqp::Protocol::SubQueueInfosArray&
+                                   subscriptions) BSLS_KEYWORD_OVERRIDE;
 
     /// Used by the client to configure a given queue handle with the
     /// specified `streamParameters`.  Invoke the specified `configuredCb`

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -294,6 +294,10 @@ FileBackedStorage::put(mqbi::StorageMessageAttributes*     attributes,
                        const bsl::shared_ptr<bdlbb::Blob>& options,
                        mqbi::DataStreamMessage**           out)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(appData);
+    BSLS_ASSERT_SAFE(appData->length() == attributes->appDataLen());
+
     const int msgSize = attributes->appDataLen();
 
     // Store the specified message in the 'physical' as well as *all*

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -294,7 +294,7 @@ FileBackedStorage::put(mqbi::StorageMessageAttributes*     attributes,
                        const bsl::shared_ptr<bdlbb::Blob>& options,
                        mqbi::DataStreamMessage**           out)
 {
-    const int msgSize = appData->length();
+    const int msgSize = attributes->appDataLen();
 
     // Store the specified message in the 'physical' as well as *all*
     // virtual storages.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -603,12 +603,6 @@ struct Tester {
 
             const int data = i + dataOffset;
 
-            mqbi::StorageMessageAttributes attributes(
-                static_cast<bsls::Types::Uint64>(data),
-                refCount,
-                bmqp::MessagePropertiesInfo::makeNoSchema(),
-                bmqt::CompressionAlgorithmType::e_NONE);
-
             const bsl::shared_ptr<bdlbb::Blob> appDataPtr(
                 new (*bmqtst::TestHelperUtil::allocator())
                     bdlbb::Blob(&d_bufferFactory,
@@ -618,6 +612,13 @@ struct Tester {
             bdlbb::BlobUtil::append(&(*appDataPtr),
                                     reinterpret_cast<const char*>(&data),
                                     static_cast<int>(sizeof(int)));
+
+            mqbi::StorageMessageAttributes attributes(
+                static_cast<bsls::Types::Uint64>(data),
+                refCount,
+                static_cast<unsigned int>(appDataPtr->length()),
+                bmqp::MessagePropertiesInfo::makeNoSchema(),
+                bmqt::CompressionAlgorithmType::e_NONE);
 
             mqbi::StorageResult::Enum rc = d_replicatedStorage_mp->put(
                 &attributes,

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7552,6 +7552,7 @@ void FileStore::loadMessageAttributesRaw(
 
     *buffer = mqbi::StorageMessageAttributes(rec->header().timestamp(),
                                              rec->refCount(),
+                                             record.d_appDataUnpaddedLen,
                                              record.d_messagePropertiesInfo,
                                              rec->compressionAlgorithmType(),
                                              record.d_hasReceipt,

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -398,13 +398,6 @@ struct Tester {
                     (0 == i % 2) ? bmqp::MessagePropertiesInfo::makeNoSchema()
                                  : bmqp::MessagePropertiesInfo();
 
-                rec.d_msgAttributes = mqbi::StorageMessageAttributes(
-                    bdlt::EpochUtil::convertToTimeT64(
-                        bdlt::CurrentTime::utc()),
-                    i % mqbs::FileStoreProtocol::k_MAX_MSG_REF_COUNT_HARD,
-                    messagePropertiesInfo,
-                    bmqt::CompressionAlgorithmType::e_NONE,
-                    bsl::numeric_limits<unsigned int>::max() / i);
                 // crc value
                 mqbu::MessageGUIDUtil::generateGUID(&rec.d_guid);
                 rec.d_appData_sp.createInplace(
@@ -417,6 +410,18 @@ struct Tester {
                 bdlbb::BlobUtil::append(rec.d_appData_sp.get(),
                                         payloadStr.c_str(),
                                         payloadStr.length());
+
+                const unsigned int appDataLen = static_cast<unsigned int>(
+                    rec.d_appData_sp->length());
+
+                rec.d_msgAttributes = mqbi::StorageMessageAttributes(
+                    bdlt::EpochUtil::convertToTimeT64(
+                        bdlt::CurrentTime::utc()),
+                    i % mqbs::FileStoreProtocol::k_MAX_MSG_REF_COUNT_HARD,
+                    appDataLen,
+                    messagePropertiesInfo,
+                    bmqt::CompressionAlgorithmType::e_NONE,
+                    bsl::numeric_limits<unsigned int>::max() / i);
 
                 rc = fs->writeMessageRecord(&rec.d_msgAttributes,
                                             &handle,

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -173,7 +173,11 @@ InMemoryStorage::put(mqbi::StorageMessageAttributes*     attributes,
                      const bsl::shared_ptr<bdlbb::Blob>& options,
                      mqbi::DataStreamMessage**           out)
 {
-    const int msgSize = appData->length();
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(appData);
+    BSLS_ASSERT_SAFE(appData->length() == attributes->appDataLen());
+
+    const int    msgSize  = attributes->appDataLen();
     unsigned int refCount = attributes->refCount();
     // Proxies are unaware of the number of apps unlike Replicas.
     // The latter can check for duplicates.

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -289,12 +289,6 @@ struct Tester {
 
             const int data = i + dataOffset;
 
-            mqbi::StorageMessageAttributes attributes(
-                static_cast<bsls::Types::Uint64>(data),
-                refCount,
-                bmqp::MessagePropertiesInfo::makeNoSchema(),
-                bmqt::CompressionAlgorithmType::e_NONE);
-
             const bsl::shared_ptr<bdlbb::Blob> appDataPtr(
                 new (*bmqtst::TestHelperUtil::allocator())
                     bdlbb::Blob(&d_bufferFactory,
@@ -304,6 +298,13 @@ struct Tester {
             bdlbb::BlobUtil::append(&(*appDataPtr),
                                     reinterpret_cast<const char*>(&data),
                                     static_cast<int>(sizeof(int)));
+
+            mqbi::StorageMessageAttributes attributes(
+                static_cast<bsls::Types::Uint64>(data),
+                refCount,
+                static_cast<unsigned int>(appDataPtr->length()),
+                bmqp::MessagePropertiesInfo::makeNoSchema(),
+                bmqt::CompressionAlgorithmType::e_NONE);
 
             mqbi::StorageResult::Enum rc = d_replicatedStorage_mp->put(
                 &attributes,

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
@@ -189,6 +189,7 @@ struct Tester {
             appDataPtr->setLength(i * 10);
 
             mqbi::StorageMessageAttributes attributes;
+            attributes.setAppDataLen(appDataPtr->length());
             d_storage_mp->put(&attributes, guid, appDataPtr, appDataPtr);
         }
 

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
@@ -185,10 +185,8 @@ unsigned int VirtualStorage::ordinal() const
 // ----------------------------
 
 // PRIVATE MANIPULATORS
-void StorageIterator::clear()
+void StorageIterator::clearCache()
 {
-    // Clear previous state, if any.  This is required so that new state can be
-    // loaded in 'appData', 'options' or 'attributes' routines.
     d_appData_sp.reset();
     d_options_sp.reset();
     d_attributes.reset();
@@ -239,14 +237,14 @@ bool StorageIterator::advance()
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!atEnd());
 
-    clear();
+    clearCache();
     ++d_iterator;
     return !atEnd();
 }
 
 void StorageIterator::reset(const bmqt::MessageGUID& where)
 {
-    clear();
+    clearCache();
 
     d_iterator = d_owner_p->begin(where);
 }

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.h
@@ -223,12 +223,6 @@ class StorageIterator : public mqbi::StorageIterator {
     StorageIterator& operator=(const StorageIterator&);  // = delete
 
   private:
-    // PRIVATE MANIPULATORS
-
-    /// Clear previous state, if any.  This is required so that new state
-    /// can be loaded in `appData`, `options` or `attributes` routines.
-    void clear();
-
     // PRIVATE ACCESSORS
 
     /// Load the internal state of this iterator instance with the
@@ -253,6 +247,13 @@ class StorageIterator : public mqbi::StorageIterator {
     ~StorageIterator() BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
+
+    /// Clear any cached data associated with this iterator, if any.
+    /// The cache might be initialized within `appData`, `options` or
+    /// `attributes` routines.
+    /// TODO: refactor iterators to remove cached data.
+    void clearCache() BSLS_KEYWORD_OVERRIDE;
+
     bool advance() BSLS_KEYWORD_OVERRIDE;
 
     /// If the specified 'where' is unset, reset the iterator to point to the


### PR DESCRIPTION
# Problem

In `void QueueEngineUtil_AppsDeliveryContext::deliverMessage()` we load `appData()` from the message iterator when we PUSH messages:

```
if (QueueEngineUtil::isBroadcastMode(d_queue_p)) {
    it->first->deliverMessageNoTrack(d_currentMessage->appData(),
                                     d_currentMessage->guid(),
                                     attributes,
                                     // ...
}
else {
    it->first->deliverMessage(d_currentMessage->appData(),
                              d_currentMessage->guid(),
                              attributes,
                              // ...
}
```

To load `appData` we need to access partition data file, read the full blob from the storage and possibly keep the file set opened until we reset the message iterator. However, this `appData` read here is not necessary if we send PUSH to another cluster node, because: a) the message was already replicated (at least it should be in a write/read buffers earlier than the PUSH that we want to send), b) for cluster node PUSH, it is used here only to get the `appData` size.

`perf` listing showing useless appData read on primary:
![Screenshot 2025-02-26 at 16 19 46](https://github.com/user-attachments/assets/7cc87c25-1212-42b1-bb46-c48f2ad39b2f)


# PR

- Store `appData` size in `mqbi::StorageMessageAttributes`. Now we get `appData` size not from the `appData` Blob, but from message attributes in `void FileStore::loadMessageAttributesRaw`.
- Load `appData` only when we PUSH to a non-cluster node that doesn't have this message replicated.
- Simplify `mqbi::QueueHandle` interface.
- Add `mqbi::StorageIterator::clearCache` public interface. Rename `clear()` -> `clearCache()` in iterator implementations. The name `clear()` was misleading because it doesn't clear everything in the iterator, just the cached data (if any).
- Clear any cached memory mapped file areas after storage iterator usage.
- Put comments about possible storage iterator cache refactor.
- Update UTs.