### PR TITLE
Fix[IT]: Make test_csl_cleanup() a class instance method

### DIFF
--- a/src/integration-tests/test_rollover_csl.py
+++ b/src/integration-tests/test_rollover_csl.py
@@ -36,7 +36,7 @@ timeout = 120
 
 class TestRolloverCSL:
     @tweak.cluster.partition_config.max_cslfile_size(2000)
-    def test_csl_cleanup(cluster: Cluster):
+    def test_csl_cleanup(self, cluster: Cluster):
         """
         Test that rolling over CSL cleans up the old file.
         """


### PR DESCRIPTION
After PR #634 integration test `test_csl_cleanup()` is not run by Pytest, because it is not an instance method of `TestRolloverCSL` class.