### PR TITLE
Fix: Remove expired elements from pushstream

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -138,6 +138,19 @@ void PushStreamIterator::removeCurrentElement()
     }
 }
 
+void PushStreamIterator::removeAllElements()
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!atEnd());
+
+    d_currentElement = d_iterator->second.front();
+    d_currentOrdinal = 0;
+
+    while (d_currentElement) {
+        removeCurrentElement();
+    }
+}
+
 // MANIPULATORS
 bool PushStreamIterator::advance()
 {
@@ -254,11 +267,12 @@ VirtualPushStreamIterator::VirtualPushStreamIterator(
 {
     d_itApp = owner->d_apps.find(upstreamSubQueueId);
 
-    BSLS_ASSERT_SAFE(d_itApp != owner->d_apps.end());
+    if (d_itApp != owner->d_apps.end()) {
+        d_currentElement = d_itApp->second.d_elements.front();
 
-    d_currentElement = d_itApp->second.d_elements.front();
-
-    BSLS_ASSERT_SAFE(d_currentElement->app().d_app == d_itApp->second.d_app);
+        BSLS_ASSERT_SAFE(d_currentElement->app().d_app ==
+                         d_itApp->second.d_app);
+    }
 }
 
 VirtualPushStreamIterator::~VirtualPushStreamIterator()

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.h
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.h
@@ -142,6 +142,7 @@ struct PushStream {
                                  Elements,
                                  bslh::Hash<bmqt::MessageGUIDHashAlgo> >
                                                   Stream;
+
     typedef Stream::iterator                      iterator;
     typedef bsl::unordered_map<unsigned int, App> Apps;
 
@@ -306,6 +307,11 @@ class PushStreamIterator : public mqbi::StorageIterator {
     /// pair) from the current PUSH GUID.
     /// The behavior is undefined unless `atEnd` returns `false`.
     void removeCurrentElement();
+
+    /// Remove all elements (`mqbi::AppMessage`, `upstreamSubQueueId` pairs)
+    /// from the current PUSH GUID.
+    /// The behavior is undefined unless `atEnd` returns `false`.
+    void removeAllElements();
 
     /// Return the number of elements (`mqbi::AppMessage`, `upstreamSubQueueId`
     /// pairs) for the current PUSH GUID.

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -738,7 +738,7 @@ bool QueueEngineUtil_AppsDeliveryContext::processApp(
 
         // Early return.
         // If all Apps return 'e_NO_CAPACITY_ALL', stop the iteration
-        // (d_numApps == 0).
+        // (d_numApps == d_numStops).
 
         ++d_numStops;
 
@@ -956,7 +956,8 @@ QueueEngineUtil_AppState::deliverMessages(bsls::TimeInterval*          delay,
                          result == Routers::e_NO_CAPACITY ||
                          result == Routers::e_NO_SUBSCRIPTION)) {
                 BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-                d_putAsideList.add(start->guid());
+
+                putAside(start->guid());
                 // Do not block other Subscriptions. Continue.
             }
             else if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1503,7 +1503,20 @@ void RelayQueueEngine::beforeMessageRemoved(const bmqt::MessageGUID& msgGUID)
         d_queueState_p->queue()));
 
     if (!d_storageIter_mp->atEnd() && (d_storageIter_mp->guid() == msgGUID)) {
+        d_storageIter_mp->removeAllElements();
+
         d_storageIter_mp->advance();
+    }
+    else {
+        PushStreamIterator del(storage(),
+                               &d_pushStream,
+                               d_pushStream.d_stream.find(msgGUID));
+
+        if (!del.atEnd()) {
+            del.removeAllElements();
+
+            del.advance();
+        }
     }
 }
 


### PR DESCRIPTION
If `QueueEngineUtil_AppState::d_resumePoint` gets removed, an attempt to deliver it results in failure reading the data from the storage:
```
FATAL mqbblp_pushstream.cpp:86 Assertion failed: mqbi::StorageResult::e_SUCCESS == rc
```