### PR TITLE
fix Send StopRequest to Downstreams before Upstreams

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -338,6 +338,8 @@ bool operator==(const SubQueueInfo& lhs, const SubQueueInfo& rhs);
 struct Protocol {
     // TYPES
 
+    enum eStopRequestVersion { e_V1 = 1, e_V2 = 2 };
+
     /// A constant used to declare the length of static part of the array of
     /// subQueueIds (or AppKeys).
     static const size_t k_SUBID_ARRAY_STATIC_LEN = 16;

--- a/src/groups/mqb/mqba/mqba_application.h
+++ b/src/groups/mqb/mqba/mqba_application.h
@@ -62,6 +62,7 @@ class ClusterCatalog;
 }
 namespace mqbnet {
 class TransportManager;
+class Session;
 }
 namespace mqbplug {
 class PluginManager;
@@ -108,6 +109,7 @@ class Application {
         bdlcc::ObjectPoolFunctors::DefaultCreator,
         bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
         BlobSpPool;
+    typedef bsl::vector<bsl::shared_ptr<mqbnet::Session> > Sessions;
 
     // Data members
 
@@ -173,6 +175,10 @@ class Application {
     /// send v2 shutdown requests to all nodes, shutdown clients and proxies,
     /// and return `true`.
     bool initiateShutdown();
+
+    void sendStopRequests(bslmt::Latch*   latch,
+                          const Sessions& brokers,
+                          int             version);
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -716,10 +716,6 @@ void ClientSession::tearDownImpl(bslmt::Semaphore*            semaphore,
 
     const bool hasLostTheClient = (!isBrokerShutdown && !isProxy());
 
-    //    if (d_operationState == e_SHUTTING_DOWN_V2) {
-    //        // Leave over queues and handles
-    //    }
-    //    else {
     // Set up the 'd_operationState' to indicate that the channel is dying and
     // we should not use it anymore trying to send any messages and should also
     // stop enqueuing 'callbacks' to the client dispatcher thread ...
@@ -729,7 +725,7 @@ void ClientSession::tearDownImpl(bslmt::Semaphore*            semaphore,
                                                 hasLostTheClient);
     BALL_LOG_INFO << description() << ": Dropped " << numHandlesDropped
                   << " queue handles.";
-    //    }
+
     // Set up the 'd_operationState' to indicate that the channel is dying and
     // we should not use it anymore trying to send any messages and should also
     // stop enqueuing 'callbacks' to the client dispatcher thread ...
@@ -3158,8 +3154,6 @@ void ClientSession::processClusterMessage(
         const bmqp_ctrlmsg::StopRequest& request =
             message.choice().clusterMessage().choice().stopRequest();
 
-        BSLS_ASSERT_SAFE(request.version() == 2);
-
         // Deconfigure all queues.  Do NOT wait for unconfirmed
 
         BALL_LOG_INFO << description() << ": processing StopRequest.";
@@ -3195,7 +3189,7 @@ void ClientSession::processClusterMessage(
     }
     else {
         BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR " << description()
-                       << ": unknown Cluster in StopResponse: " << message;
+                       << ": unknown Cluster message: " << message;
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -871,7 +871,8 @@ void ClusterOrchestrator::processStopRequest(
                   << ", new status: " << bmqp_ctrlmsg::NodeStatus::E_STOPPING;
 
     // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
-    if (stopRequest.version() == 1 && stopRequest.clusterName() != name) {
+    if (stopRequest.version() == bmqp::Protocol::eStopRequestVersion::e_V1 &&
+        stopRequest.clusterName() != name) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
                        << ": invalid cluster name in the StopRequest from "

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -172,7 +172,8 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
 
     if (supportShutdownV2) {
         d_queueHelper.requestToStopPushing();
-        // 'checkUnconfirmedV2' serves as synchronization
+        // 'checkUnconfirmedV2' serves as synchronization.
+        // It makes sure stopPushing() gets executed before the return.
         bsls::TimeInterval whenToStop(
             bsls::SystemTime::now(bsls::SystemClockType::e_MONOTONIC));
         whenToStop.addMilliseconds(d_clusterData.clusterConfig()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -172,7 +172,7 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback,
 
     if (supportShutdownV2) {
         d_queueHelper.requestToStopPushing();
-
+        // 'checkUnconfirmedV2' serves as synchronization
         bsls::TimeInterval whenToStop(
             bsls::SystemTime::now(bsls::SystemClockType::e_MONOTONIC));
         whenToStop.addMilliseconds(d_clusterData.clusterConfig()

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -952,6 +952,17 @@ bsls::Types::Int64 Queue::countUnconfirmed(unsigned int subId)
 
 void Queue::stopPushing()
 {
+    // executed by the *QUEUE* dispatcher thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
+
+    if (isAtMostOnce()) {
+        // Attempt to deliver all data in the storage.  Otherwise, broadcast
+        // can get dropped.
+
+        flush();
+    }
     queueEngine()->resetState(true);  // isShuttingDown
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -246,10 +246,11 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
         d_queueState_p->queue()));
     BSLS_ASSERT_SAFE(context);
 
-    // Attempt to deliver all data in the storage.  Otherwise, broadcast
-    // can get dropped if the incoming configure response removes consumers.
-
-    deliverMessages();
+    if (d_queueState_p->isAtMostOnce()) {
+        // Attempt to deliver all data in the storage.  Otherwise, broadcast
+        // data can get dropped if the configure response removes consumers.
+        deliverMessages();
+    }
 
     // RelayQueueEngine now assumes that configureQueue request cannot fail.
     // Even if request fails due to some reason (timeout, upstream crashing or

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -246,11 +246,8 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
         d_queueState_p->queue()));
     BSLS_ASSERT_SAFE(context);
 
-    if (d_queueState_p->isAtMostOnce()) {
-        // Attempt to deliver all data in the storage.  Otherwise, broadcast
-        // data can get dropped if the configure response removes consumers.
-        deliverMessages();
-    }
+    // Force re-delivery
+    deliverMessages();
 
     // RelayQueueEngine now assumes that configureQueue request cannot fail.
     // Even if request fails due to some reason (timeout, upstream crashing or

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -923,6 +923,12 @@ void RootQueueEngine::configureHandle(
 
     const AppStateSp& affectedApp = iter->second;
 
+    if (d_queueState_p->isAtMostOnce()) {
+        // Attempt to deliver all data in the storage.  Otherwise, broadcast
+        // data can get dropped if the configure response removes consumers.
+        deliverMessages(affectedApp.get());
+    }
+
     // prepare the App for rebuilding consumers
     affectedApp->undoRouting();
 


### PR DESCRIPTION
Following [https://github.com/bloomberg/blazingmq/pull/399](https://github.com/bloomberg/blazingmq/pull/399), need to make sure Proxies receive StopRequest first, otherwise broadcast PUTs can hit Upstream after it deconfigures consumers.
