### PR TITLE
fix Continuous ordinals in Proxy

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1922,8 +1922,7 @@ void RelayQueueEngine::storePush(
     const bmqt::MessageGUID&                  msgGUID,
     const bsl::shared_ptr<bdlbb::Blob>&       appData,
     const bmqp::Protocol::SubQueueInfosArray& subscriptions,
-
-    bool isOutOfOrder)
+    bool                                      isOutOfOrder)
 {
     if (d_queueState_p->domain()->cluster()->isRemote()) {
         // Save the message along with the subIds in the storage.  Note that

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -109,6 +109,7 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     // TTL is not applicable at proxy
 
     // Create the associated storage.
+    // 'mqbs::DataStore::k_INVALID_PARTITION_ID' indicates the case of Proxy.
     bsl::shared_ptr<mqbi::Storage> storageSp;
     storageSp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
                        d_state_p->uri(),
@@ -158,6 +159,11 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     if (rc != 0) {
         return 10 * rc + rc_QUEUE_ENGINE_CFG_FAILURE;  // RETURN
     }
+
+    // Make the storage be aware of the queue to notify Apps about ordinal
+    // change upon 'VirtualStorageCatalog::addVirtualStorage' /
+    // 'VirtualStorageCatalog::removeVirtualStorage'.
+    storageSp->setQueue(d_state_p->queue());
 
     d_state_p->stats()
         ->onEvent<mqbstat::QueueStatsDomain::EventType::e_CHANGE_ROLE>(

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -85,7 +85,7 @@ InMemoryStorage::InMemoryStorage(const bmqt::Uri&        uri,
     d_virtualStorageCatalog.setDefaultRda(config.maxDeliveryAttempts());
 
     if (isProxy()) {
-        d_virtualStorageCatalog.setDiscontinuousOrdinals();
+        d_virtualStorageCatalog.confgiureAsProxy();
     }
 }
 
@@ -267,7 +267,8 @@ InMemoryStorage::put(mqbi::StorageMessageAttributes*     attributes,
                        attributes->arrivalTimepoint());
     }
 
-    // This overrides  mqbi::DataStreamMessage::d_numApps with 'refCount'
+    // This can override (increase) 'mqbi::DataStreamMessage::d_numApps' with
+    // 'd_virtualStorageCatalog.numVirtualStorages()'.
     // Proxy can detect duplicates by inspecting returned 'DataStreamMessage'.
     d_virtualStorageCatalog.put(msgGUID,
                                 msgSize,

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -85,7 +85,7 @@ InMemoryStorage::InMemoryStorage(const bmqt::Uri&        uri,
     d_virtualStorageCatalog.setDefaultRda(config.maxDeliveryAttempts());
 
     if (isProxy()) {
-        d_virtualStorageCatalog.confgiureAsProxy();
+        d_virtualStorageCatalog.configureAsProxy();
     }
 }
 

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -210,9 +210,6 @@ struct Tester {
                 d_mockDomain.capacityMeter(),
                 d_allocator_p),
             d_allocator_p);
-
-        d_replicatedStorage_mp->setQueue(&d_mockQueue);
-        BSLS_ASSERT_OPT(d_replicatedStorage_mp->queue() == &d_mockQueue);
     }
 
     ~Tester()
@@ -411,8 +408,8 @@ BMQTST_TEST(breathingTest)
     BMQTST_ASSERT_EQ(storage.numBytes(k_NULL_KEY), k_INT64_ZERO);
     BMQTST_ASSERT_EQ(storage.isEmpty(), true);
     BMQTST_ASSERT_EQ(storage.partitionId(), k_PROXY_PARTITION_ID);
-    BMQTST_ASSERT_NE(storage.queue(), static_cast<mqbi::Queue*>(0));
-    // Queue has been set via call to 'setQueue'
+    BMQTST_ASSERT_EQ(storage.queue(), static_cast<mqbi::Queue*>(0));
+    // 'mqbs::DataStore::k_INVALID_PARTITION_ID' does not expose queue
 
     BMQTST_ASSERT_PASS(storage.flushStorage());
     // Does nothing, at the time of this writing

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -287,7 +287,7 @@ class VirtualStorageCatalog {
 
     /// Configure this object as Proxy to skip statistics and checking age of
     /// Apps vs age of messages.
-    void confgiureAsProxy();
+    void configureAsProxy();
 
     void setQueue(mqbi::Queue* queue);
 
@@ -366,7 +366,7 @@ inline void VirtualStorageCatalog::setDefaultRda(int maxDeliveryAttempts)
     }
 }
 
-inline void VirtualStorageCatalog::confgiureAsProxy()
+inline void VirtualStorageCatalog::configureAsProxy()
 {
     d_isProxy = true;
 }

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -114,9 +114,6 @@ class VirtualStorageCatalog {
     /// Map of appKey to corresponding virtual storage
     VirtualStorages d_virtualStorages;
 
-    /// Available ordinal values for virtual storages.
-    AvailableOrdinals d_availableOrdinals;
-
     /// All current App storages ordered by their ordinals.
     bsl::vector<VirtualStorageSp> d_ordinals;
 
@@ -288,8 +285,9 @@ class VirtualStorageCatalog {
     /// Set the default RDA according to the specified 'maxDeliveryAttempts'.
     void setDefaultRda(int maxDeliveryAttempts);
 
-    /// Proxies do not support Ordinals Continuity.
-    void setDiscontinuousOrdinals();
+    /// Configure this object as Proxy to skip statistics and checking age of
+    /// Apps vs age of messages.
+    void confgiureAsProxy();
 
     void setQueue(mqbi::Queue* queue);
 
@@ -368,9 +366,9 @@ inline void VirtualStorageCatalog::setDefaultRda(int maxDeliveryAttempts)
     }
 }
 
-inline void VirtualStorageCatalog::setDiscontinuousOrdinals()
+inline void VirtualStorageCatalog::confgiureAsProxy()
 {
-    d_isProxy = false;
+    d_isProxy = true;
 }
 
 inline void VirtualStorageCatalog::setQueue(mqbi::Queue* queue)
@@ -411,7 +409,7 @@ inline const mqbi::AppMessage& VirtualStorageCatalog::defaultAppMessage() const
 
 inline mqbi::Queue* VirtualStorageCatalog::queue() const
 {
-    return d_queue_p;
+    return d_isProxy ? 0 : d_queue_p;
 }
 
 }  // close package namespace


### PR DESCRIPTION
Make ordinals continuous in Proxy as well to fix the bug with App removal resulting in out of bound ordinal upon PUSH in `RemoteQueue`