### PR TITLE
Fix[IT]: reduce storage file sizes to allow run in GH CI

### DIFF
--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -331,6 +331,23 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
                 for cat in broker_category_levels
             ]
 
+            # We want to be able to spawn a multi-node cluster in the GitHub Actions CI.
+            # We create a local directory with a storage for each node in a cluster,
+            # and we only have 14GB of storage on a GitHub Runner, that is why we need
+            # to reduce storage file sizes for integration tests.
+            configurator.proto.cluster.partition_config.max_data_file_size = (
+                67108864  # 64MiB
+            )
+            configurator.proto.cluster.partition_config.max_journal_file_size = (
+                16777216  # 16MiB
+            )
+            configurator.proto.cluster.partition_config.max_cslfile_size = (
+                16777216  # 16MiB
+            )
+            configurator.proto.cluster.partition_config.max_qlist_file_size = (
+                2097152  # 2MiB
+            )
+
             def apply_tweaks(stage: int):
                 for request_location in "cls", "function", "instance":
                     if request_context := getattr(request, request_location, None):
@@ -365,7 +382,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
             ) as cluster:
                 failures = (
                     0 + request.session.testsfailed
-                )  # it doesn’t work without the ’0 +’, why?
+                )  # it doesn't work without the `0 +`, why?
 
                 try:
                     with internal_use(cluster):


### PR DESCRIPTION
## Before

1472 MiB per cluster node
5888 MiB per 4-node cluster

![Screenshot 2025-03-10 at 15 39 50](https://github.com/user-attachments/assets/bcc2c5e6-9e78-41ec-87fc-fe61781de3c8)

## After

344 MiB per cluster node
1376 MiB per 4-node cluster

![Screenshot 2025-03-10 at 15 30 02](https://github.com/user-attachments/assets/52d280db-821d-443d-a09b-ed3d82d9f233)

