### PR TITLE
Fix[IT]: rework domain consistency coverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -161,7 +161,7 @@ jobs:
       matrix:
         mode: ["legacy_mode", "fsm_mode"]
         cluster: ["single", "multi"]
-        consistency: ["eventual", "strong"]
+        consistency: ["eventual_consistency", "strong_consistency"]
       fail-fast: false
     runs-on: ubuntu-latest
     needs: build_ubuntu
@@ -189,13 +189,13 @@ jobs:
           # Allow core dumps
           ulimit -c unlimited
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
-          ${{ github.workspace }}/src/integration-tests/run-tests "${{ matrix.mode }} and ${{ matrix.cluster }}" \
+          ${{ github.workspace }}/src/integration-tests/run-tests \
+            "${{ matrix.mode }} and ${{ matrix.cluster }} and ${{ matrix.consistency }}" \
             --log-level ERROR                   \
             --log-file-level=info               \
             --bmq-tolerate-dirty-shutdown       \
             --bmq-log-dir=failure-logs          \
             --bmq-log-level=INFO                \
-            --domain-consistency="${{ matrix.consistency }}" \
             --junitxml=integration-tests.xml    \
             --tb long                           \
             --reruns=3                          \

--- a/src/integration-tests/conftest.py
+++ b/src/integration-tests/conftest.py
@@ -15,14 +15,12 @@
 
 import contextlib
 import logging
+
 import pytest
 
 import blazingmq.dev.it.logging
+import blazingmq.dev.it.testconstants as tc
 import blazingmq.util.logging as bul
-from blazingmq.dev.it.testconstants import (
-    eventual_consistency_param,
-    strong_consistency_param,
-)
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
 
 
@@ -118,15 +116,6 @@ def pytest_addoption(parser):
         help=help_,
     )
 
-    help_ = "run with domain consistency: <eventual>, strong or both"
-    parser.addoption(
-        "--domain-consistency",
-        action="store",
-        default="eventual",
-        help=help_,
-        choices=("eventual", "strong", "both"),
-    )
-
 
 def pytest_configure(config):
     logging.setLoggerClass(blazingmq.dev.it.logging.BMQLogger)
@@ -166,15 +155,29 @@ def pytest_collection_modifyitems(config, items):
         )
 
 
-def pytest_generate_tests(metafunc):
-    # If the test function has a "domain_urls" argument, parametrize it
-    # using "--domain-consistency" cmd line option value.
-    if "domain_urls" in metafunc.fixturenames:
-        val = metafunc.config.getoption("domain_consistency")
-        if val == "eventual":
-            params = [eventual_consistency_param()]
-        elif val == "strong":
-            params = [strong_consistency_param()]
-        else:  # both
-            params = [eventual_consistency_param(), strong_consistency_param()]
-        metafunc.parametrize("domain_urls", params)
+@pytest.fixture
+def ec_domain_urls():
+    return tc.EC_DOMAIN_URLS
+
+
+@pytest.fixture
+def sc_domain_urls():
+    return tc.SC_DOMAIN_URLS
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(
+            tc.SC_DOMAIN_URLS,
+            id="strong_consistency",
+            marks=[pytest.mark.strong_consistency],
+        ),
+        pytest.param(
+            tc.EC_DOMAIN_URLS,
+            id="eventual_consistency",
+            marks=[pytest.mark.eventual_consistency],
+        ),
+    ]
+)
+def domain_urls(request):
+    return request.param

--- a/src/integration-tests/pytest.ini
+++ b/src/integration-tests/pytest.ini
@@ -16,3 +16,5 @@ markers =
     legacy_mode
     fsm_mode
     flakey
+    eventual_consistency
+    strong_consistency

--- a/src/python/blazingmq/dev/it/README.md
+++ b/src/python/blazingmq/dev/it/README.md
@@ -216,14 +216,15 @@ class TestDemo:                                                              #4
 14. Another test method.  This one runs only once, using a local cluster
     (obviously it fails).
 
-**NOTE**: If it is needed to test method for different domain consistencies
-   (`eventual`, `strong` or both), optional argument `domain_urls` should 
-   be passed. It should be used instead of direct using `DOMAIN_*` and `URI_*`
-   constants (except DOMAIN_BROADCAST/URI_BROADCAST):
+**NOTE**: To test with different domain consistencies, add one of the URL
+   fixtures to the parameters of the test method (`ec_domain_urls` for
+   eventual, `sc_domain_urls` for strong, or `domain_urls` for both). It should
+   be used instead of using `DOMAIN_*` and `URI_*` constants directly (except
+   DOMAIN_BROADCAST/URI_BROADCAST). For example, to run a test twice, for both
+   consistency modes:
 
 ```python
-    def test_post_message_priority(self, cluster, 
-                                   domain_urls: tc.DomainUrls):
+    def test_post_message_priority(self, cluster, domain_urls: tc.DomainUrls):
         du = domain_urls
         self.producer.open(
             du.uri_priority, flags=['write', 'ack'], succeed=True)

--- a/src/python/blazingmq/dev/it/testconstants.py
+++ b/src/python/blazingmq/dev/it/testconstants.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from typing import NamedTuple
 
 # NOTE: don't use DOMAIN_* and URI_* constants (except DOMAIN_BROADCAST/URI_BROADCAST)
@@ -55,31 +54,21 @@ class DomainUrls(NamedTuple):
     uri_fanout_baz: str
 
 
-def eventual_consistency_param():
-    return pytest.param(
-        DomainUrls(
-            domain_priority=DOMAIN_PRIORITY,
-            domain_fanout=DOMAIN_FANOUT,
-            uri_priority=URI_PRIORITY,
-            uri_fanout=URI_FANOUT,
-            uri_fanout_foo=URI_FANOUT_FOO,
-            uri_fanout_bar=URI_FANOUT_BAR,
-            uri_fanout_baz=URI_FANOUT_BAZ,
-        ),
-        id="eventual_consistency",
-    )
-
-
-def strong_consistency_param():
-    return pytest.param(
-        DomainUrls(
-            domain_priority=DOMAIN_PRIORITY_SC,
-            domain_fanout=DOMAIN_FANOUT_SC,
-            uri_priority=URI_PRIORITY_SC,
-            uri_fanout=URI_FANOUT_SC,
-            uri_fanout_foo=URI_FANOUT_SC_FOO,
-            uri_fanout_bar=URI_FANOUT_SC_BAR,
-            uri_fanout_baz=URI_FANOUT_SC_BAZ,
-        ),
-        id="strong_consistency",
-    )
+EC_DOMAIN_URLS = DomainUrls(
+    domain_priority=DOMAIN_PRIORITY,
+    domain_fanout=DOMAIN_FANOUT,
+    uri_priority=URI_PRIORITY,
+    uri_fanout=URI_FANOUT,
+    uri_fanout_foo=URI_FANOUT_FOO,
+    uri_fanout_bar=URI_FANOUT_BAR,
+    uri_fanout_baz=URI_FANOUT_BAZ,
+)
+SC_DOMAIN_URLS = DomainUrls(
+    domain_priority=DOMAIN_PRIORITY_SC,
+    domain_fanout=DOMAIN_FANOUT_SC,
+    uri_priority=URI_PRIORITY_SC,
+    uri_fanout=URI_FANOUT_SC,
+    uri_fanout_foo=URI_FANOUT_SC_FOO,
+    uri_fanout_bar=URI_FANOUT_SC_BAR,
+    uri_fanout_baz=URI_FANOUT_SC_BAZ,
+)


### PR DESCRIPTION
* Add fixtures for running a test with strong (only; `sc_domain_urls`) and eventual (only; `ec_domain_urls`) consistency.
* Make `domain_urls` a parametric fixture with these parameters.
* Remove command-line for selecting consistency; this is now done using two new markers (`strong_consistency` and `eventual_consistency`)

@dorjesinpo for awareness.
