### PR TITLE
Feat [blazingmq.dev.configurator]: remove_domain, pretty_print->indent

### DIFF
--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -227,6 +227,19 @@ class AbstractCluster:
 
         return domain
 
+    def remove_domain(self, name: str) -> None:
+        """
+        Remove a domain from the Cluster's map and all the domain's maps.
+
+        The domain must exist in `Cluster.domains`. It can be missing from the
+        broker's domain maps.
+        """
+
+        del self.domains[name]
+
+        for node in self.nodes.values():
+            node.domains.pop(name, None)
+
 
 class Cluster(AbstractCluster):
     def domain(self, parameters: mqbconf.Domain) -> "Domain":

--- a/src/python/blazingmq/dev/configurator/configurator.py
+++ b/src/python/blazingmq/dev/configurator/configurator.py
@@ -294,7 +294,7 @@ class Configurator:
                 if v is not None
             }
 
-        config = SerializerConfig(pretty_print=True)
+        config = SerializerConfig(indent=" " * 4)
         config.ignore_default_attributes = True
         serializer = JsonSerializer(
             context=XmlContext(), config=config, dict_factory=json_filter


### PR DESCRIPTION
* add a `Cluster.remove_domain`
* replace deprecated xsdata `pretty_print` config option with `indent`