### PR TITLE
Feat[bmqstoragetool] add --record-type 'all' option

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
@@ -75,6 +75,7 @@ bool isValidQueueKeyHexRepresentation(const char* queueKeyBuf)
 // class CommandLineArguments
 // ==========================
 
+const char* CommandLineArguments::k_ALL_TYPE         = "all";
 const char* CommandLineArguments::k_MESSAGE_TYPE     = "message";
 const char* CommandLineArguments::k_QUEUEOP_TYPE     = "queue-op";
 const char* CommandLineArguments::k_JOURNALOP_TYPE   = "journal-op";
@@ -307,8 +308,8 @@ bool CommandLineArguments::validate(bsl::string*      error,
 bool CommandLineArguments::isValidRecordType(const bsl::string* recordType,
                                              bsl::ostream&      stream)
 {
-    if (*recordType != k_MESSAGE_TYPE && *recordType != k_QUEUEOP_TYPE &&
-        *recordType != k_JOURNALOP_TYPE) {
+    if (*recordType != k_ALL_TYPE && *recordType != k_MESSAGE_TYPE &&
+        *recordType != k_QUEUEOP_TYPE && *recordType != k_JOURNALOP_TYPE) {
         stream << "--record-type invalid: " << *recordType << bsl::endl;
 
         return false;  // RETURN
@@ -404,7 +405,12 @@ Parameters::Parameters(const CommandLineArguments& arguments,
              arguments.d_recordType.begin();
          cit != arguments.d_recordType.end();
          ++cit) {
-        if (*cit == CommandLineArguments::k_MESSAGE_TYPE) {
+        if (*cit == CommandLineArguments::k_ALL_TYPE) {
+            d_processRecordTypes.d_message   = true;
+            d_processRecordTypes.d_queueOp   = true;
+            d_processRecordTypes.d_journalOp = true;
+        }
+        else if (*cit == CommandLineArguments::k_MESSAGE_TYPE) {
             d_processRecordTypes.d_message = true;
         }
         else if (*cit == CommandLineArguments::k_QUEUEOP_TYPE) {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
@@ -57,6 +57,7 @@ struct CommandLineArguments {
     // PUBLIC DATA
 
     /// Record types constants
+    static const char* k_ALL_TYPE;
     static const char* k_MESSAGE_TYPE;
     static const char* k_QUEUEOP_TYPE;
     static const char* k_JOURNALOP_TYPE;


### PR DESCRIPTION
**Describe your changes**
This mode prints all types of records (message, queue-op, journal-op).

**Testing performed**
A unit test already exists to test this behavior: https://github.com/bloomberg/blazingmq/blob/f3ba41816d16540ea09999bbb549eb36f38cc6ed/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp#L2049-L2055

The behavior just wasn't exposed as a valid option to the cli.