### PR TITLE
Fix bmqp::Protocol: Enum class for eStopRequestVersion

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -338,7 +338,9 @@ bool operator==(const SubQueueInfo& lhs, const SubQueueInfo& rhs);
 struct Protocol {
     // TYPES
 
-    enum eStopRequestVersion { e_V1 = 1, e_V2 = 2 };
+    struct eStopRequestVersion {
+        enum Enum { e_V1 = 1, e_V2 = 2 };
+    };
 
     /// A constant used to declare the length of static part of the array of
     /// subQueueIds (or AppKeys).


### PR DESCRIPTION
To fix the build error: 
```
"/tmp/bmqbrkr-0.93.13/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp", line 5255: Error: eStopRequestVersion is not a namespace or class name.
```