### PR TITLE
Build: Turn off `-Wdocumentation-unknown-command` on clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang" )
           "-Wno-conversion"
           "-Wno-undef"                  # BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
           "-Wno-float-equal"            # operator== in generated classes
+          "-Wno-documentation-unknown-command"
+                                        # Don't warn about @bbref{}
   )
 
 


### PR DESCRIPTION
With the transition from BDE style documentation to Doxygen documentation, clang now warns about unknown documentation commands. However, it is not smart enough to understand custom Doxygen commands, including our `bbref` command, which adds a `BloombergLP::` namespace prefix to its argument.  This patch turns off the clang warning about unknown documentation commands, on the assumption that Doxygen will catch them for us anyway.

Before applying this patch, clang yields 186 warnings.  After applying this patch, this is reduced to 123 warnings.  As we convert more documentation to Doxygen format, we expect the first number would rise further if this patch is not applied.