### PR TITLE
Fix[MQB]: Refuse Configure request when stopping

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -871,6 +871,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     void contextHolder(const bsl::shared_ptr<StopContext>& contextSp,
                        const VoidFunctor&                  action);
 
+    /// Send an error response to the specified `destination`.  The specified
+    /// `request` contains original request.  The specified `category`, `code
+    /// ` and `message` are the details of the response.
     void sendErrorResponse(mqbnet::ClusterNode*                destination,
                            const bmqp_ctrlmsg::ControlMessage& request,
                            bmqp_ctrlmsg::StatusCategory::Value category,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -871,6 +871,12 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     void contextHolder(const bsl::shared_ptr<StopContext>& contextSp,
                        const VoidFunctor&                  action);
 
+    void sendErrorResponse(mqbnet::ClusterNode*                destination,
+                           const bmqp_ctrlmsg::ControlMessage& request,
+                           bmqp_ctrlmsg::StatusCategory::Value category,
+                           int                                 code,
+                           const char*                         message);
+
     // PRIVATE ACCESSORS
 
     /// Return true if for the specified `partitionId`, there is currently a


### PR DESCRIPTION
Processing Configure request when stopping can cause SEGFAULT because of destructed handle 