### PR TITLE
Fix: Using genCount for lastPush

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1292,7 +1292,9 @@ void RootQueueEngine::afterNewMessage(
              ++iter) {
             AppStateSp& app = iter->second;
 
-            if (d_appsDeliveryContext.processApp(*app, app->ordinal())) {
+            if (d_appsDeliveryContext.processApp(*app,
+                                                 app->ordinal(),
+                                                 false)) {
                 // Consider this message as sent out
 
                 d_consumptionMonitor.onMessageSent(iter->first);

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -423,9 +423,7 @@ void QueueStatsDomain::onEvent(EventType::Enum    type,
     BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
 
     if (d_subContextsLookup.empty()) {
-        BALL_LOGTHROTTLE_WARN(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
-            << "[THROTTLED] No built sub contexts for domain: "
-            << d_statContext_mp->name() << ", appId: " << appId;
+        // Not an error if the domain is not configured for Apps stats.
         return;  // RETURN
     }
 


### PR DESCRIPTION
Using generation counter as the means to reset `PushStream::App::setLastPush` after each PUSH.
