### PR TITLE
Fix: Regenerate cpp11 simulated files

### DIFF
--- a/src/groups/bmq/bmqex/bmqex_bindutil.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil.h
@@ -151,12 +151,16 @@
 #include <bsls_compilerfeatures.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Tue Oct 15 18:12:34 2024
+// Generated on Wed Apr  2 14:55:13 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
-#define COMPILING_BMQEX_BINDUTIL_H
-#include <bmqex_bindutil_cpp03.h>
-#undef COMPILING_BMQEX_BINDUTIL_H
+
+# define COMPILING_BMQEX_BINDUTIL_H
+# include <bmqex_bindutil_cpp03.h>
+# undef COMPILING_BMQEX_BINDUTIL_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2019-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:47:32 2022
+// Generated on Wed Apr  2 15:03:57 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.cpp
 
 #define INCLUDED_BMQEX_BINDUTIL_CPP03  // Disable inclusion
@@ -29,19 +29,3 @@
 // No C++03 Expansion
 
 #endif  // defined(COMPILING_BMQEX_BINDUTIL_CPP)
-
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Thu Oct 17 16:05:31 2024
+// Generated on Wed Apr  2 14:55:13 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
 
 #ifdef COMPILING_BMQEX_BINDUTIL_H
@@ -1147,6 +1147,3 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 #endif  // ! defined(COMPILING_BMQEX_BINDUTIL_H)
 
 #endif  // ! defined(INCLUDED_BMQEX_BINDUTIL_CPP03)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: 5f2b7427931a119efbbe9a485a7c750fd96f10272c1f3732ffa7af0b1827d1de

--- a/src/groups/bmq/bmqex/bmqex_future.h
+++ b/src/groups/bmq/bmqex/bmqex_future.h
@@ -148,12 +148,16 @@
 #include <bsls_timeinterval.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Jul 17 12:44:45 2024
+// Generated on Wed Apr  2 14:55:18 2025
 // Command line: sim_cpp11_features.pl bmqex_future.h
-#define COMPILING_BMQEX_FUTURE_H
-#include <bmqex_future_cpp03.h>
-#undef COMPILING_BMQEX_FUTURE_H
+
+# define COMPILING_BMQEX_FUTURE_H
+# include <bmqex_future_cpp03.h>
+# undef COMPILING_BMQEX_FUTURE_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Bloomberg Finance L.P.
+// Copyright 2018-2023 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Jul 14 05:51:54 2022
+// Generated on Wed Apr  2 15:03:51 2025
 // Command line: sim_cpp11_features.pl bmqex_future.cpp
 
 #define INCLUDED_BMQEX_FUTURE_CPP03  // Disable inclusion
@@ -29,19 +29,3 @@
 // No C++03 Expansion
 
 #endif  // defined(COMPILING_BMQEX_FUTURE_CPP)
-
-// ----------------------------------------------------------------------------
-// Copyright 2022-2023 Bloomberg Finance L.P.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-// ----------------------------- END-OF-FILE ----------------------------------

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Jul 17 12:44:45 2024
+// Generated on Wed Apr  2 14:55:18 2025
 // Command line: sim_cpp11_features.pl bmqex_future.h
 
 #ifdef COMPILING_BMQEX_FUTURE_H

--- a/src/groups/bmq/bmqex/bmqex_promise.h
+++ b/src/groups/bmq/bmqex/bmqex_promise.h
@@ -89,12 +89,16 @@
 #include <bsls_systemclocktype.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Tue Oct 15 18:12:34 2024
+// Generated on Wed Apr  2 14:55:22 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.h
-#define COMPILING_BMQEX_PROMISE_H
-#include <bmqex_promise_cpp03.h>
-#undef COMPILING_BMQEX_PROMISE_H
+
+# define COMPILING_BMQEX_PROMISE_H
+# include <bmqex_promise_cpp03.h>
+# undef COMPILING_BMQEX_PROMISE_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Oct 17 16:05:31 2024
+// Generated on Wed Apr  2 15:03:38 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.cpp
 
 #define INCLUDED_BMQEX_PROMISE_CPP03  // Disable inclusion
@@ -29,6 +29,3 @@
 // No C++03 Expansion
 
 #endif  // defined(COMPILING_BMQEX_PROMISE_CPP)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: 8dbfd92723c9bbcf70d3bf432a3cfb80c635ac188627e1aa7d3afa37287fe6ee

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Thu Oct 17 16:05:31 2024
+// Generated on Wed Apr  2 14:55:22 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.h
 
 #ifdef COMPILING_BMQEX_PROMISE_H
@@ -1009,6 +1009,3 @@ inline void bmqex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 #endif  // ! defined(COMPILING_BMQEX_PROMISE_H)
 
 #endif  // ! defined(INCLUDED_BMQEX_PROMISE_CPP03)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: 034094ceed9ec6bf34ec4437870a945b9af3dca32ab1d636c2d94e31681e2f94

--- a/src/groups/bmq/bmqu/bmqu_managedcallback.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback.h
@@ -94,12 +94,16 @@
 #include <bsls_compilerfeatures.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Thu Mar 27 15:28:14 2025
+// Generated on Wed Apr  2 14:54:56 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
-#define COMPILING_BMQU_MANAGEDCALLBACK_H
-#include <bmqu_managedcallback_cpp03.h>
-#undef COMPILING_BMQU_MANAGEDCALLBACK_H
+
+# define COMPILING_BMQU_MANAGEDCALLBACK_H
+# include <bmqu_managedcallback_cpp03.h>
+# undef COMPILING_BMQU_MANAGEDCALLBACK_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Feb 20 11:37:00 2025
+// Generated on Wed Apr  2 15:04:54 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.cpp
 
 #define INCLUDED_BMQU_MANAGEDCALLBACK_CPP03  // Disable inclusion

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Thu Mar 27 15:34:42 2025
+// Generated on Wed Apr  2 14:54:56 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
 
 #ifdef COMPILING_BMQU_MANAGEDCALLBACK_H
@@ -317,11 +317,12 @@ inline char* ManagedCallback::place()
     static_assert(
         bslmf::IsAccessibleBaseOf<CallbackFunctor, CALLBACK_TYPE>::value);
 #else
-    BSLS_ASSERT_SAFE(
-        bslmf::IsAccessibleBaseOf<CallbackFunctor, CALLBACK_TYPE>::value);
+    typedef bslmf::IsAccessibleBaseOf<CallbackFunctor, CALLBACK_TYPE> IsBase;
+    BSLS_ASSERT_SAFE(IsBase::value);
 #endif
 
-    d_callbackBuffer.resize(sizeof(CALLBACK_TYPE));
+    d_callbackBuffer.resize(
+        bsls::AlignmentUtil::roundUpToMaximalAlignment(sizeof(CALLBACK_TYPE)));
     d_empty = false;
     return d_callbackBuffer.data();
 }

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
@@ -44,12 +44,16 @@
 #include <bsls_performancehint.h>
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Tue Oct 15 17:38:31 2024
+// Generated on Wed Apr  2 14:55:02 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
-#define COMPILING_BMQU_OBJECTPLACEHOLDER_H
-#include <bmqu_objectplaceholder_cpp03.h>
-#undef COMPILING_BMQU_OBJECTPLACEHOLDER_H
+
+# define COMPILING_BMQU_OBJECTPLACEHOLDER_H
+# include <bmqu_objectplaceholder_cpp03.h>
+# undef COMPILING_BMQU_OBJECTPLACEHOLDER_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Oct 17 16:05:19 2024
+// Generated on Wed Apr  2 15:05:31 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.cpp
 
 #define INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03  // Disable inclusion
@@ -29,6 +29,3 @@
 // No C++03 Expansion
 
 #endif  // defined(COMPILING_BMQU_OBJECTPLACEHOLDER_CPP)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: 4bb706357ef3e32b44b49a314a75e3d2087e62772510513d6eb5a4da1a61d1e9

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Thu Oct 17 16:05:19 2024
+// Generated on Wed Apr  2 14:55:02 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
 
 #ifdef COMPILING_BMQU_OBJECTPLACEHOLDER_H
@@ -939,6 +939,3 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 #endif  // ! defined(COMPILING_BMQU_OBJECTPLACEHOLDER_H)
 
 #endif  // ! defined(INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: efa0e98699d54a0d81108c550e5b40870cd35b454e40f32fa57800ba233d5a88

--- a/src/groups/bmq/bmqu/bmqu_operationchain.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain.h
@@ -191,12 +191,16 @@
 #endif
 
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
+// clang-format off
 // Include version that can be compiled with C++03
-// Generated on Tue Oct 15 17:39:53 2024
+// Generated on Wed Apr  2 14:49:45 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
-#define COMPILING_BMQU_OPERATIONCHAIN_H
-#include <bmqu_operationchain_cpp03.h>
-#undef COMPILING_BMQU_OPERATIONCHAIN_H
+
+# define COMPILING_BMQU_OPERATIONCHAIN_H
+# include <bmqu_operationchain_cpp03.h>
+# undef COMPILING_BMQU_OPERATIONCHAIN_H
+
+// clang-format on
 #else
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Thu Oct 17 15:40:13 2024
+// Generated on Wed Apr  2 15:05:37 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.cpp
 
 #define INCLUDED_BMQU_OPERATIONCHAIN_CPP03  // Disable inclusion
@@ -29,6 +29,3 @@
 // No C++03 Expansion
 
 #endif  // defined(COMPILING_BMQU_OPERATIONCHAIN_CPP)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: e12029cd114eba008f63ef66ad814e4c905d2347c6d6940222d8b6e67cbf7a00

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Thu Oct 17 16:05:19 2024
+// Generated on Wed Apr  2 14:49:45 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
 
 #ifdef COMPILING_BMQU_OPERATIONCHAIN_H
@@ -1288,6 +1288,3 @@ inline void bmqu::swap(OperationChainLink& lhs,
 #endif  // ! defined(COMPILING_BMQU_OPERATIONCHAIN_H)
 
 #endif  // ! defined(INCLUDED_BMQU_OPERATIONCHAIN_CPP03)
-
-// SCRIPT-SHA: 60926cad35f1091c31a7d8cc9d33acc38edd25e4891f3e1d41fe7c40fd6e02f5
-// SOURCE-SHA: 7610aa7a0ecb116c786702dfc71b197eda2f52aa0f3efa66433723466764a626


### PR DESCRIPTION
This is primarily to help [bmqu_managedcallback_cpp03.h](https://github.com/bloomberg/blazingmq/compare/main...hallfox:regen-cpp03?expand=1#diff-e0118a6c0230f9021cb98e946a88390e9b745f11ba0002f325ea7c819233eb95) which has an issue with the use of the `BSLS_ASSERT_SAFE` macro with the templated type, which was fixed in #481 but not regenerated.
