### PR TITLE
Fix: Add a CMake alias using the blazingmq namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ if(DOXYGEN_FOUND)
 endif()
 
 add_library(bmqbrkr_plugins INTERFACE)
+add_library(blazingmq::bmqbrkr_plugins ALIAS bmqbrkr_plugins)
 
 # -----------------------------------------------------------------------------
 #                                   PROJECTS
@@ -323,3 +324,4 @@ configure_package_config_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BmqbrkrPluginsConfig.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/BmqbrkrPlugins
         COMPONENT bmqbrkr_plugins)
+


### PR DESCRIPTION
This is helpful for dependent targets in the same project to use a consistent name whether they're importing it or in the same project.
