### PR TITLE
fix: inlining closeQueue on shutdown

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -817,6 +817,10 @@ class Cluster : public mqbi::Cluster,
     const mqbcfg::ClusterProxyDefinition*
     clusterProxyConfig() const BSLS_KEYWORD_OVERRIDE;
 
+    /// Return `true` if this node is shutting down using new shutdown logic.
+    /// This can only be true when all cluster nodes support StopRequest V2.
+    bool isShutdownLogicOn() const BSLS_KEYWORD_OVERRIDE;
+
     // MANIPULATORS
     //   (virtual: mqbi::Cluster)
 
@@ -949,6 +953,11 @@ inline const bsl::string& Cluster::description() const
 inline mqbi::StorageManager* Cluster::storageManager() const
 {
     return d_storageManager_mp.get();
+}
+
+inline bool Cluster::isShutdownLogicOn() const
+{
+    return d_clusterOrchestrator.queueHelper().isShutdownLogicOn();
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -545,6 +545,10 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
                                  bool*                 isSelfPrimary,
                                  int partitionId) const BSLS_KEYWORD_OVERRIDE;
 
+    /// Return `true` if this node is shutting down using new shutdown logic.
+    /// This can only be true when all cluster nodes support StopRequest V2.
+    bool isShutdownLogicOn() const BSLS_KEYWORD_OVERRIDE;
+
     // MANIPULATORS
     //   (virtual: mqbi::DispatcherClient)
 
@@ -828,6 +832,11 @@ inline const bsl::string& ClusterProxy::description() const
 inline const mqbnet::Cluster& ClusterProxy::netCluster() const
 {
     return *(d_clusterData.membership().netCluster());
+}
+
+inline bool ClusterProxy::isShutdownLogicOn() const
+{
+    return d_queueHelper.isShutdownLogicOn();
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2618,7 +2618,7 @@ void ClusterQueueHelper::configureQueueDispatched(
     BSLS_ASSERT_SAFE(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
 
-    if (d_supportShutdownV2) {
+    if (d_isShutdownLogicOn) {
         BMQ_LOGTHROTTLE_INFO()
             << d_cluster_p->description()
             << ": Shutting down and skipping configure queue [: " << uri
@@ -4404,7 +4404,7 @@ ClusterQueueHelper::ClusterQueueHelper(
 , d_numPendingReopenQueueRequests(0)
 , d_primaryNotLeaderAlarmRaised(false)
 , d_stopContexts(allocator)
-, d_supportShutdownV2(false)
+, d_isShutdownLogicOn(false)
 {
     BSLS_ASSERT(
         d_clusterData_p->clusterConfig()
@@ -4698,28 +4698,6 @@ void ClusterQueueHelper::configureQueue(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->dispatcher()->inDispatcherThread(queue));
-
-    // Application first calls 'Cluster::initiateShutdown' (which may set
-    // 'd_supportShutdownV2'), followed by 'TransportManager::closeClients'
-    // which may result in 'QueueHandle::drop' leading to this call.
-    if (d_supportShutdownV2) {
-        // Assuming thread-safe 'description()'
-        BMQ_LOGTHROTTLE_INFO()
-            << d_cluster_p->description()
-            << ": Shutting down and skipping close queue [: "
-            << handleParameters.uri()
-            << "], queueId: " << handleParameters.qId()
-            << ", handle parameters: " << handleParameters;
-
-        if (callback) {
-            bmqp_ctrlmsg::Status status;
-            status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
-            status.message()  = "Shutting down.";
-            callback(status);
-        }
-
-        return;  // RETURN
-    }
 
     // TBD: Populate the 'bmqp_ctrlmsg::SubQueueIdInfo' of the handleParameters
     //      with subStream-specific (appId, upstreamSubQueueId) if applicable.
@@ -5111,7 +5089,7 @@ void ClusterQueueHelper::requestToStopPushing()
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
 
     // Assume Shutdown V2
-    d_supportShutdownV2 = true;
+    d_isShutdownLogicOn = true;
 
     // Prevent future queue operations from sending PUSHes.
     for (QueueContextMapIter it = d_queues.begin(); it != d_queues.end();

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -462,9 +462,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
 
     StopContexts d_stopContexts;
 
-    /// When `true`, this node is shutting down using shutdown v2 logic.
+    /// When `true`, this node is shutting down using new shutdown logic.
     /// This can only be true when all cluster nodes support StopRequest V2.
-    bsls::AtomicBool d_supportShutdownV2;
+    bsls::AtomicBool d_isShutdownLogicOn;
 
   private:
     // PRIVATE MANIPULATORS
@@ -1119,6 +1119,10 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// Dump the internal state of this object to the specified
     /// `clusterQueueHelper` object.
     void loadState(mqbcmd::ClusterQueueHelper* clusterQueueHelper) const;
+
+    /// Return `true` if this node is shutting down using new shutdown logic.
+    /// This can only be true when all cluster nodes support StopRequest V2.
+    bool isShutdownLogicOn() const;
 };
 
 // ============================================================================
@@ -1325,6 +1329,11 @@ inline bool ClusterQueueHelper::isFailoverInProgress() const
 inline int ClusterQueueHelper::numPendingReopenQueueRequests() const
 {
     return d_numPendingReopenQueueRequests;
+}
+
+inline bool ClusterQueueHelper::isShutdownLogicOn() const
+{
+    return d_isShutdownLogicOn;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1314,18 +1314,43 @@ void RelayQueueEngine::releaseHandleImpl(
 
     proctor->addRef();
 
-    // Send a close queue request upstream.
-    d_queueState_p->domain()->cluster()->configureQueue(
-        d_queueState_p->queue(),
-        effectiveHandleParam,
-        upstreamSubQueueId,
-        bdlf::BindUtil::bind(
-            bmqu::WeakMemFnUtil::weakMemFn(&RelayQueueEngine::onHandleReleased,
-                                           d_self.acquireWeak()),
-            bdlf::PlaceHolders::_1,  // Status
-            handle,
+    mqbi::Cluster* cluster = d_queueState_p->domain()->cluster();
+
+    BSLS_ASSERT_SAFE(cluster);
+
+    if (cluster->isShutdownLogicOn()) {
+        // Application first calls 'Cluster::initiateShutdown' (which may set
+        // 'd_supportShutdownV2'), followed by 'TransportManager::closeClients'
+        // which may result in 'QueueHandle::drop' leading to this call.
+
+        BMQ_LOGTHROTTLE_INFO()
+            << "Shutting down and skipping close queue [: "
+            << d_queueState_p->uri() << "], queueId: " << d_queueState_p->id()
+            << ", handle parameters: " << effectiveHandleParam;
+
+        bmqp_ctrlmsg::Status status;
+        status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+        status.message()  = "Shutting down.";
+
+        onHandleReleasedDispatched(status,
+                                   handle,
+                                   effectiveHandleParam,
+                                   proctor);
+    }
+    else {
+        // Send a close queue request upstream.
+        d_queueState_p->domain()->cluster()->configureQueue(
+            d_queueState_p->queue(),
             effectiveHandleParam,
-            proctor));
+            upstreamSubQueueId,
+            bdlf::BindUtil::bind(bmqu::WeakMemFnUtil::weakMemFn(
+                                     &RelayQueueEngine::onHandleReleased,
+                                     d_self.acquireWeak()),
+                                 bdlf::PlaceHolders::_1,  // Status
+                                 handle,
+                                 effectiveHandleParam,
+                                 proctor));
+    }
 }
 
 void RelayQueueEngine::onHandleUsable(mqbi::QueueHandle* handle,

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -462,6 +462,10 @@ class Cluster : public DispatcherClient {
                                          mqbnet::ClusterNode** node,
                                          bool*                 isSelfPrimary,
                                          int partitionId) const = 0;
+
+    /// Return `true` if this node is shutting down using new shutdown logic.
+    /// This can only be true when all cluster nodes support StopRequest V2.
+    virtual bool isShutdownLogicOn() const = 0;
 };
 
 struct ClusterResources {

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -456,6 +456,10 @@ class Cluster : public mqbi::Cluster {
                                  bool*                 isSelfPrimary,
                                  int partitionId) const BSLS_KEYWORD_OVERRIDE;
 
+    /// Return `true` if this node is shutting down using new shutdown logic.
+    /// This can only be true when all cluster nodes support StopRequest V2.
+    bool isShutdownLogicOn() const BSLS_KEYWORD_OVERRIDE;
+
     // ACCESSORS
     //   (virtual: mqbi::DispatcherClient)
 
@@ -678,6 +682,11 @@ inline bsls::TimeInterval Cluster::getTime() const
 inline bsls::Types::Int64 Cluster::getTimeInt64() const
 {
     return d_timeSource.now().seconds();
+}
+
+inline bool Cluster::isShutdownLogicOn() const
+{
+    return false;
 }
 
 }  // close package namespace


### PR DESCRIPTION
[https://github.com/bloomberg/blazingmq/pull/675](https://github.com/bloomberg/blazingmq/pull/675) did not make closeQueue completely inline (called `RelayQueueEngine::onHandleReleased`)