### PR TITLE
Test: Remove `all.td` target

### DIFF
--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -5,39 +5,10 @@
 
 include_guard()
 
-# :: _bmq_target_generate_td_manifest :::::::::::::::::::::::::::::::::::::::::::::::
-# This function generates a test driver manifest for compatibility with the rat.rb
-# testing tool.
-#
-# TEST DRIVER MANIFEST:
-# A '<grpName>_td.manifest' file is generated at the root of the build
-# directory, containing one line per test driver, in the following format:
-# <grppkg_cmpName>: /full/path/to/component.t.tsk
-# This manifest can be used by test driver executor tools, such as rat.rb.
-#
-function(_bmq_target_generate_td_manifest target)
-  cmake_parse_arguments(""
-    ""
-    ""
-    "TEST_DRIVERS"
-    ${ARGN})
-
-  # Generate the test driver manifest for that group library
-  message(DEBUG "Manifesting ${_TEST_DRIVERS}")
-  string(REGEX REPLACE ";" "\n" td_manifest "${_TEST_DRIVERS}")
-  file(GENERATE
-    OUTPUT "${CMAKE_BINARY_DIR}/${target}_td.manifest"
-    CONTENT "${td_manifest}\n")
-endfunction()
-
 # :: bmq_add_test :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 # This function searches for the test drivers of a UOR-style TARGET within the
 # `tests` directory of each package. For each component, it generates a target
-# named ${UOR_component}.t and ${UOR_component}.td for each component found,
-# and an all.td target which depends on all the tests together.
-#
-# The *.td targets should not be depended upon directly mostly exist for
-# historical compatibility.
+# named ${UOR_component}.t for each component found.
 function(bmq_add_test target)
   cmake_parse_arguments(PARSE_ARGV 1
     ""
@@ -82,30 +53,14 @@ function(bmq_add_test target)
     endforeach()
 
     set(import_test_deps ON)
-    set(td_manifest)
 
     foreach(pkg ${${uor_name}_PACKAGES})
       if(${pkg}_TEST_TARGETS)
         if(NOT TARGET ${target}.t)
           add_custom_target(${target}.t)
-
-          if(_COMPAT)
-            add_custom_target(${target}.td)
-          endif()
         endif()
 
         add_dependencies(${target}.t ${${pkg}_TEST_TARGETS})
-
-        if(_COMPAT)
-          add_dependencies(${target}.td ${target}.t)
-
-          foreach(test_target ${${pkg}_TEST_TARGETS})
-            string(REPLACE ".t" "" component ${test_target})
-            set_target_properties(${test_target} PROPERTIES OUTPUT_NAME "${test_target}.tsk")
-            list(APPEND td_manifest
-              "${component}: $<TARGET_FILE:${test_target}>")
-          endforeach()
-        endif()
 
         if(import_test_deps)
           # Import UOR test dependencies only once and only if we have at least
@@ -115,11 +70,6 @@ function(bmq_add_test target)
         endif()
       endif()
     endforeach()
-
-    # Generate the test driver manifest file for compatibility with rat.rb
-    if(_COMPAT)
-      _bmq_target_generate_td_manifest(${target} TEST_DRIVERS ${td_manifest})
-    endif()
   else()
     # Configure standalone library ( no packages ) and tests from BDE metadata
     bbs_configure_target_tests(${target}
@@ -131,30 +81,13 @@ function(bmq_add_test target)
     if(${target}_TEST_TARGETS)
       bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
     endif()
-
-    # Generate the test driver manifest file for compatibility with rat.rb
-    if(_COMPAT)
-      _bmq_target_generate_td_manifest(${target} TEST_DRIVERS ${td_manifest})
-    endif()
-
-  endif()
-
-  if(_COMPAT AND NOT TARGET all.td)
-    add_custom_target(all.td)
-    add_dependencies(all.td all.t)
   endif()
 endfunction()
 
 # :: bmq_add_application_test :::::::::::::::::::::::::::::::::::::::::::::::::
-# This function searches for the test drivers of an 'application' TARGET. 
-# It expects existence of intermediate library '${uor_name}_lib' which is 
-# created by 'bbs_setup_target_uor()'.
-# It generates a target named ${UOR_component}.t and ${UOR_component}.td for
-# each component found, and an all.td target which depends on all the tests
-# together.
-#
-# The *.td targets should not be depended upon directly mostly exist for
-# historical compatibility.
+# This function searches for the test drivers of an 'application' TARGET.  It
+# expects existence of intermediate library '${uor_name}_lib' which is created
+# by 'bbs_setup_target_uor()'.  It generates a target named ${UOR_component}.t.
 function(bmq_add_application_test target)
   cmake_parse_arguments(PARSE_ARGV 1
     ""
@@ -194,41 +127,13 @@ function(bmq_add_application_test target)
       add_custom_target(${target}.t)
     endif()
     add_dependencies(${target}.t ${lib_target}.t)
-
-    if(_COMPAT)
-      if (NOT TARGET ${target}.td)
-        add_custom_target(${target}.td)
-      endif()
-      add_dependencies(${target}.td ${lib_target}.t)
-    endif()
   endif()
 
   if (${lib_target}_TEST_TARGETS)
     bbs_import_target_dependencies(${lib_target} ${${uor_name}_TEST_PCDEPS})
   endif()
 
-  set(td_manifest)
-
   if(${lib_target}_TEST_TARGETS)
-    if(_COMPAT)
-      foreach(test_target ${${lib_target}_TEST_TARGETS})
-        string(REPLACE ".t" "" component ${test_target})
-        set_target_properties(${test_target} PROPERTIES OUTPUT_NAME "${test_target}.tsk")
-        list(APPEND td_manifest
-          "${component}: $<TARGET_FILE:${test_target}>")
-      endforeach()
-    endif()
-
     bbs_import_target_dependencies(${lib_target} ${${uor_name}_TEST_PCDEPS})
-  endif()
-
-  # Generate the test driver manifest file for compatibility with rat.rb
-  if(_COMPAT)
-    _bmq_target_generate_td_manifest(${lib_target} TEST_DRIVERS ${td_manifest})
-  endif()
-
-  if(_COMPAT AND NOT TARGET all.td)
-    add_custom_target(all.td)
-    add_dependencies(all.td all.t)
   endif()
 endfunction()


### PR DESCRIPTION
This target was already legacy code when it was released.  This patch removes it.
