### PR TITLE
Fix: Disable linux/arm builds on Docker publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,9 +32,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 


### PR DESCRIPTION
This patch disables publishing arm images of the broker on Linux.  This is not a configuration we’ve supported in the past, and although it may be worthwhile to test, currently this blocks publishing.