### PR TITLE
CI: Can preset leader via env var BLAZINGMQ_LEADER_NAME for integration tests

### DIFF
--- a/src/python/blazingmq/dev/it/cluster.py
+++ b/src/python/blazingmq/dev/it/cluster.py
@@ -752,7 +752,7 @@ class Cluster(contextlib.AbstractContextManager):
         return None
 
     def _start_broker(
-        self, broker: cfg.Broker, nodes: List[Broker], cluster_name: Union[str, None]
+        self, broker: cfg.Broker, brokers: List[Broker], cluster_name: Union[str, None]
     ):
         if broker.name in self._processes:
             raise RuntimeError(
@@ -770,7 +770,7 @@ class Cluster(contextlib.AbstractContextManager):
         process.start()
 
         self._processes[broker.name] = process
-        nodes.append(process)
+        brokers.append(process)
 
         process.wait_until_started()
 

--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -397,6 +397,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
 
                         if get_cluster_param(request, "_start_cluster", True):
                             with internal_use(cluster):
+                                leader_name = os.environ.get("BLAZINGMQ_LEADER_NAME")
                                 cluster.start(
                                     wait_leader=get_cluster_param(
                                         request, "_wait_leader", True
@@ -404,6 +405,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
                                     wait_ready=get_cluster_param(
                                         request, "_wait_ready", False
                                     ),
+                                    leader_name=leader_name,
                                 )
 
                         if request.instance is not None and hasattr(


### PR DESCRIPTION
**Describe your changes**
Added a new env var BLAZINGMQ_LEADER_NAME which is respected in Integration tests runner. It allows to preset leader node in the cluster fixture.

The preset of leader is done via altering quorum for nodes. If the evn var BLAZINGMQ_LEADER_NAME is specified, for the selected leader quorum is set to 1, for all other nodes -- 100. This approach allows the specified node to win in leader election.

**Testing performed**
- Created a new test which simply starts the cluster
- Tested setting BLAZINGMQ_LEADER_NAME to all 4 nodes (i.e. ['east1', 'east2', 'west1', 'west2']) and making sure that the specified node is selected as leader.

