### PR TITLE
Fix[CI]: Only upload logs of failed tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -199,27 +199,19 @@ jobs:
             --log-file-level=info               \
             --bmq-tolerate-dirty-shutdown       \
             --bmq-log-dir=failure-logs          \
-            --bmq-keep-logs                      \
             --bmq-log-level=INFO                \
             --domain-consistency="${{ matrix.consistency }}" \
             --junitxml=integration-tests.xml    \
             --tb long                           \
             --reruns=3                          \
-            -n 4 -v
-      
-      # logs may contain fileanmes with colon which it's not supported on NTFS filesystem
-      # Thus creating an archive first
-      - name: Compress failure logs
-        if: failure()
-        working-directory: ${{ github.workspace }}/src/integration-tests
-        run: tar -zcvf failure-logs.tar.gz ./failure-logs
+            -n logical -v
 
       - name: Upload failure-logs as artifacts
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ github.run_id }}_failure_logs_${{ env.RUN_UID }}
-          path: ${{ github.workspace }}/src/integration-tests/failure-logs.tar.gz
+          path: ${{ github.workspace }}/src/integration-tests/failure-logs
           retention-days: 5
 
       - name: Upload broker executable as artifacts to debug the core

--- a/.github/workflows/pylint.yaml
+++ b/.github/workflows/pylint.yaml
@@ -22,6 +22,7 @@ jobs:
           python-version: '3.12.4'
       - name: Install dependencies
         run: |
+          pip3 install -r ${{ github.workspace }}/src/python/requirements.txt
           pip3 install pylint lint-diffs
           ln -s ${{ github.workspace }}/src/python/pylintrc ${{ github.workspace }}/.pylintrc
           echo [pylint] > ${{ github.workspace }}/.lint-diffs

--- a/src/integration-tests/conftest.py
+++ b/src/integration-tests/conftest.py
@@ -24,6 +24,19 @@ from blazingmq.dev.it.testconstants import (
     strong_consistency_param,
 )
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
+from blazingmq.dev.it.testhooks import PHASE_REPORT_KEY
+
+
+@pytest.hookimpl(hookwrapper=True, tryfirst=True)
+def pytest_runtest_makereport(item):
+    # store test results for each phase of a call, which can
+    # be "setup", "call", "teardown"
+    outcome = yield
+    rep = outcome.get_result()
+
+    item.stash.setdefault(PHASE_REPORT_KEY, {})[rep.when] = rep
+
+    return rep
 
 
 def pytest_addoption(parser):

--- a/src/integration-tests/conftest.py
+++ b/src/integration-tests/conftest.py
@@ -29,8 +29,11 @@ from blazingmq.dev.it.testhooks import PHASE_REPORT_KEY
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_runtest_makereport(item):
-    # store test results for each phase of a call, which can
-    # be "setup", "call", "teardown"
+    """
+    Store test results for each phase of a call, which can
+    be "setup", "call", "teardown"
+    """
+
     outcome = yield
     rep = outcome.get_result()
 

--- a/src/python/blazingmq/dev/it/testhooks.py
+++ b/src/python/blazingmq/dev/it/testhooks.py
@@ -1,0 +1,38 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains implentation related to checked test result
+# Filled via pytest hooks in 'conftest.py'
+# Used in 'fixtures.py'
+
+from typing import Dict
+from pytest import StashKey, CollectReport
+
+PHASE_REPORT_KEY = StashKey[Dict[str, CollectReport]]()
+
+
+def is_test_reported_failed(request):
+    # Use the test results reported by the pytest_runtest_makereport hook
+    # To decide if test failed
+
+    report = request.node.stash[PHASE_REPORT_KEY]
+    if report["setup"].failed:
+        return True
+    if report["setup"].skipped:
+        return True
+    if ("call" not in report) or report["call"].failed:
+        return True
+
+    return False

--- a/src/python/blazingmq/dev/it/testhooks.py
+++ b/src/python/blazingmq/dev/it/testhooks.py
@@ -24,8 +24,10 @@ PHASE_REPORT_KEY = StashKey[Dict[str, CollectReport]]()
 
 
 def is_test_reported_failed(request):
-    # Use the test results reported by the pytest_runtest_makereport hook
-    # To decide if test failed
+    """
+    Use the test results reported by the pytest_runtest_makereport hook
+    To decide if test failed
+    """
 
     report = request.node.stash[PHASE_REPORT_KEY]
     if report["setup"].failed:


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #697*

**Describe your changes**

1. Fix detecting if IT test failed in parallel mode (i.e. -n 4). In parallel mode using "request.session.testsfailed" maybe not reliable to detect if the current test has failed. Some times "request.session.testsfailed" is being updated after fixture teardown.
Change "-n 4" to "-n logical" to allow auto-detection of the number of available threads on the system.
2. Remove"::" when logfile is created to avoid file name issues in NTFS file system. 
Thus simplify artifacts upload - no more needed archiving step.

**Testing**
- Tested thoroughly locally
- Here is CI run with single failed test and therefore single logfile in the failed-logs.zip artifact: https://github.com/bloomberg/blazingmq/actions/runs/14405609854/job/40401841272?pr=698