### PR TITLE
Doc[MQB]: fix doxygen comments for clusterstats enums

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
@@ -78,7 +78,9 @@ class BrokerStats {
     static BrokerStats s_instance;
 
     // DATA
-    bmqst::StatContext* d_statContext_p;  // StatContext
+
+    /// StatContext
+    bmqst::StatContext* d_statContext_p;
 
     // PRIVATE TYPES
 

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -64,8 +64,8 @@ class ClusterStats {
     struct PartitionEventType {
         // TYPES
         enum Enum {
+            /// Time in nanoseconds it took for the rollover operation.
             e_PARTITION_ROLLOVER
-            // Time in nanoseconds it took for the rollover operation.
         };
     };
 
@@ -80,31 +80,28 @@ class ClusterStats {
             e_ROLE,
             e_LEADER_STATUS,
             e_PARTITION_CFG_DATA_BYTES,
-            e_PARTITION_CFG_JOURNAL_BYTES
+            e_PARTITION_CFG_JOURNAL_BYTES,
+
             // PartitionStats: those metrics make sense only from the
-            // 'partition
-            //                 level' stat context
-            ,
-            e_PARTITION_PRIMARY_STATUS
-            // Value from the 'PrimaryStatus::Enum' defining the primary
-            // status of this node for the partition.  Note that we report the
-            // highest observed value, so that if the node was primary at any
-            // time, even briefly, during the report interval, then it will be
-            // considered as primary for the whole interval.
-            ,
-            e_PARTITION_ROLLOVER_TIME
-            // Time in nanoseconds it took for the rollover of the partition.
-            // Note that in case when more than one rollover operations
-            // happened during the report interval, then the maximum time is
-            // returned.
-            ,
-            e_PARTITION_DATA_CONTENT
-            // Maximum observed outstanding bytes in the data file of the
-            // partition.
-            ,
+            //                 'partition level' stat context
+
+            /// Value from the 'PrimaryStatus::Enum' defining the primary
+            /// status of this node for the partition.  Note that we report the
+            /// highest observed value, so that if the node was primary at any
+            /// time, even briefly, during the report interval, then it will be
+            /// considered as primary for the whole interval.
+            e_PARTITION_PRIMARY_STATUS,
+            /// Time in nanoseconds it took for the rollover of the partition.
+            /// Note that in case when more than one rollover operations
+            /// happened during the report interval, then the maximum time is
+            /// returned.
+            e_PARTITION_ROLLOVER_TIME,
+            /// Maximum observed outstanding bytes in the data file of the
+            /// partition.
+            e_PARTITION_DATA_CONTENT,
+            /// Maximum observed outstanding bytes in the journal file of the
+            /// partition.
             e_PARTITION_JOURNAL_CONTENT
-            // Maximum observed outstanding bytes in the journal file of the
-            // partition.
         };
     };
 
@@ -159,15 +156,16 @@ class ClusterStats {
 
   private:
     // DATA
-    bslma::ManagedPtr<bmqst::StatContext> d_statContext_mp;
-    // StatContext for the cluster
 
+    /// StatContext for the cluster
+    bslma::ManagedPtr<bmqst::StatContext> d_statContext_mp;
+
+    /// StatContext for each partition in
+    /// the cluster, indexed by the
+    /// partition id.  Those statContext
+    /// are created as children of the
+    /// above 'd_StatContext_mp'.
     bsl::vector<bsl::shared_ptr<bmqst::StatContext> > d_partitionsStatContexts;
-    // StatContext for each partition in
-    // the cluster, indexed by the
-    // partition id.  Those statContext
-    // are created as children of the
-    // above 'd_StatContext_mp'.
 
   private:
     // NOT IMPLEMENTED
@@ -306,23 +304,17 @@ class ClusterNodeStats {
     struct ClusterNodeStatsIndex {
         enum Enum {
             /// Value:      Number of ack messages delivered to the client
-            e_STAT_ACK
-
-            ,
-            e_STAT_CONFIRM
+            e_STAT_ACK,
             // Value:      Number of confirm messages delivered to the client
-
-            ,
-            e_STAT_PUSH
+            e_STAT_CONFIRM,
             // Value:      Accumulated bytes of all messages ever pushed to
             //             the client
             // Increments: Number of messages ever pushed to the client
-
-            ,
-            e_STAT_PUT
+            e_STAT_PUSH,
             // Value:      Accumulated bytes of all messages ever received from
             //             the client
             // Increments: Number of messages ever received from the client
+            e_STAT_PUT
         };
     };
 

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -294,8 +294,9 @@ class ClusterNodeStats {
 
   private:
     // DATA
+
+    /// StatContext
     bslma::ManagedPtr<bmqst::StatContext> d_statContext_mp;
-    // StatContext
 
     // PRIVATE TYPES
 
@@ -305,15 +306,15 @@ class ClusterNodeStats {
         enum Enum {
             /// Value:      Number of ack messages delivered to the client
             e_STAT_ACK,
-            // Value:      Number of confirm messages delivered to the client
+            /// Value:      Number of confirm messages delivered to the client
             e_STAT_CONFIRM,
-            // Value:      Accumulated bytes of all messages ever pushed to
-            //             the client
-            // Increments: Number of messages ever pushed to the client
+            /// Value:      Accumulated bytes of all messages ever pushed to
+            ///             the client
+            /// Increments: Number of messages ever pushed to the client
             e_STAT_PUSH,
-            // Value:      Accumulated bytes of all messages ever received from
-            //             the client
-            // Increments: Number of messages ever received from the client
+            /// Value:      Accumulated bytes of all messages ever received
+            ///             from the client
+            /// Increments: Number of messages ever received from the client
             e_STAT_PUT
         };
     };

--- a/src/groups/mqb/mqbstat/mqbstat_domainstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_domainstats.h
@@ -71,8 +71,9 @@ class DomainStats {
 
   private:
     // DATA
+
+    /// StatContext
     bslma::ManagedPtr<bmqst::StatContext> d_statContext_mp;
-    // StatContext
 
     // PRIVATE TYPES
 

--- a/src/groups/mqb/mqbstat/mqbstat_printer.h
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.h
@@ -67,14 +67,14 @@ class Printer {
     /// Context including table and tip for printing and statcontext for
     /// stats.
     struct Context {
+        /// Stat Context pointer
         bmqst::StatContext* d_statContext_p;
-        // Stat Context pointer
 
+        /// Table
         bmqst::Table d_table;
-        // Table
 
+        /// tip
         bmqst::BasicTableInfoProvider d_tip;
-        // tip
     };
 
     typedef bsl::shared_ptr<Context>                   ContextSp;
@@ -86,28 +86,28 @@ class Printer {
     // DATA
     const mqbcfg::StatsConfig& d_config;  // Config to use.
 
+    /// FileObserver for the stats log dump.
     ball::FileObserver2 d_statsLogFile;
-    // FileObserver for the stats log dump.
 
+    /// Sequence number for stat log
+    /// records, used to synchronize the
+    /// stat log and the normal log.
     int d_lastStatId;
-    // Sequence number for stat log
-    // records, used to synchronize the
-    // stat log and the normal log.
 
+    /// Counter to know when to periodically
+    /// print the stats to file.
     int d_actionCounter;
-    // Counter to know when to periodically
-    // print the stats to file.
 
+    /// HiRes timer value of the last time
+    /// the Counting Allocators snapshot
+    /// happened on the context.
     bsls::Types::Int64 d_lastAllocatorSnapshot;
-    // HiRes timer value of the last time
-    // the Counting Allocators snapshot
-    // happened on the context.
 
+    /// Contexts map
     ContextsMap d_contexts;
-    // Contexts map
 
+    /// Mechanism to clean up old stat logs.
     bmqtsk::LogCleaner d_statLogCleaner;
-    // Mechanism to clean up old stat logs.
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqbstat/mqbstat_printer.h
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.h
@@ -84,7 +84,9 @@ class Printer {
 
   private:
     // DATA
-    const mqbcfg::StatsConfig& d_config;  // Config to use.
+
+    /// Config to use.
+    const mqbcfg::StatsConfig& d_config;
 
     /// FileObserver for the stats log dump.
     ball::FileObserver2 d_statsLogFile;

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -328,8 +328,9 @@ class QueueStatsClient {
 
   private:
     // DATA
+
+    /// StatContext
     bslma::ManagedPtr<bmqst::StatContext> d_statContext_mp;
-    // StatContext
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -136,11 +136,12 @@ class StatController {
     /// Struct containing a statcontext and bool specifying if the
     /// statcontext is managed.
     struct StatContextDetails {
-        StatContextSp d_statContext_sp;  // Stat Context
+        /// Stat Context
+        StatContextSp d_statContext_sp;
 
-        bool d_managed;  // Bool to specify a managed
-                         // statcontext. A managed statcontext
-                         // is never snapshotted.
+        /// Bool to specify a managed statcontext. A managed statcontext is
+        /// never snapshotted.
+        bool d_managed;
 
         StatContextDetails();
 
@@ -155,6 +156,7 @@ class StatController {
         StatContextDetailsMap;
 
     // DATA
+
     /// Allocator store to spawn new allocators
     /// for sub-components.
     bmqma::CountingAllocatorStore d_allocators;


### PR DESCRIPTION
**Describe your changes**
While reviewing https://github.com/bloomberg/blazingmq/pull/678 and looking at a similar approach for partitions, I noticed some docs needed fixing in this package.
