### PR TITLE
Feat: Add `integration-tests` target to CMake

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
             -DBDE_BUILD_TARGET_CPP17=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
-          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool
+          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool all.it
 
       - name: Clean-up build directories before caching
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Run C++ Unit Tests
         run: |
           cd ${{ github.workspace }}/build/blazingmq
-          ctest --output-on-failure
+          ctest --output-on-failure -L \^unit\$
 
   unit_tests_python:
     name: UT [python]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ add_subdirectory( "src/groups" )
 add_subdirectory( "src/applications" )
 add_subdirectory( "src/tutorials" )
 add_subdirectory( "src/plugins" )
+add_subdirectory( "src/integration-tests" )
 
 
 # -----------------------------------------------------------------------------

--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -49,7 +49,7 @@ function(bmq_add_test target)
         ${${pkg}_TEST_DEPENDS}
         ${${uor_name}_PCDEPS}
         ${${uor_name}_TEST_PCDEPS}
-        LABELS "all" ${target} ${pkg})
+        LABELS "unit;all" ${target} ${pkg})
     endforeach()
 
     set(import_test_deps ON)
@@ -76,7 +76,7 @@ function(bmq_add_test target)
       SOURCES ${${uor_name}_TEST_SOURCES}
       TEST_DEPS ${${uor_name}_PCDEPS}
       ${${uor_name}_TEST_PCDEPS}
-      LABELS "all" ${target})
+      LABELS "unit;all" ${target})
 
     if(${target}_TEST_TARGETS)
       bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
@@ -120,7 +120,7 @@ function(bmq_add_application_test target)
     SOURCES    ${${uor_name}_TEST_SOURCES}
     TEST_DEPS  ${${uor_name}_PCDEPS}
                ${${uor_name}_TEST_PCDEPS}
-    LABELS     "all" ${target})
+    LABELS     "unit;all" ${target})
 
   if (TARGET ${lib_target}.t)
     if (NOT TARGET ${target}.t)

--- a/src/integration-tests/CMakeLists.txt
+++ b/src/integration-tests/CMakeLists.txt
@@ -1,0 +1,84 @@
+# integration tests
+# -----------------
+
+# Find Python 3 installed on the system.
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_FOUND)
+  message(STATUS "Setting up Python virtual environment")
+  list(APPEND CMAKE_MESSAGE_INDENT "  ")
+
+  # Create a virtual environment using the system Python.
+  set(ENV{VIRTUAL_ENV} "${CMAKE_CURRENT_BINARY_DIR}/venv")
+  execute_process(
+    COMMAND
+      "${Python3_EXECUTABLE}"
+      -m venv
+      "${CMAKE_CURRENT_BINARY_DIR}/venv"
+  )
+
+  # Forget about the system Python version; look for Python 3 installed within
+  # the virtual environment now.
+  set(Python3_FIND_VIRTUALENV FIRST)
+  unset(Python3_EXECUTABLE)
+  find_package(Python3 COMPONENTS Interpreter)
+
+  # Upgrade virtual environment pip and install required dependencies.
+  message(STATUS "Upgrade virtual environment pip")
+  execute_process(
+    COMMAND
+      "${Python3_EXECUTABLE}"
+      -m pip
+      install
+      --quiet
+      --upgrade
+      pip
+  )
+  message(STATUS "Install dependencies into virtual environment")
+  execute_process(
+    COMMAND
+      "${Python3_EXECUTABLE}"
+        -m pip
+        install
+        --quiet
+        -r "${CMAKE_CURRENT_SOURCE_DIR}/../python/requirements.txt"
+  )
+
+  # Use pytest-cmake from pypi to integrate pytest integration tests as CTest
+  # targets.
+  message(STATUS "Install pytest-cmake into virtual environment")
+  execute_process(
+    COMMAND
+      "${Python3_EXECUTABLE}"
+      -m pip
+      install
+      --quiet
+      pytest-cmake
+  )
+  list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_BINARY_DIR}/venv/share/Pytest/cmake")
+  set(Pytest_ROOT "${CMAKE_CURRENT_BINARY_DIR}/venv/bin")
+  find_package(Pytest)
+
+  # If everything went well, we can use `pytest_discover_tests` to construct
+  # CTest targets for each integration test.
+  if(Pytest_FOUND)
+    message(STATUS "Adding integration tests to CTest")
+
+    file(GLOB_RECURSE integration_test_files "*.py")
+    pytest_discover_tests(
+      all.it
+      ENVIRONMENT
+        "BLAZINGMQ_BUILD_DIR=${CMAKE_BINARY_DIR}"
+      PYTHON_PATH_PREPEND
+        "${CMAKE_SOURCE_DIR}/src/python/"
+      STRIP_PARAM_BRACKETS
+      TRIM_FROM_NAME
+        "^test_"
+      DEPENDS
+        bmqbrkr bmqtool ${integration_test_files}
+      PROPERTIES
+        LABELS "integration;all"
+    )
+  endif()
+
+  list(POP_BACK CMAKE_MESSAGE_INDENT)
+endif()


### PR DESCRIPTION
This PR adds our Python pytest-based integration tests as first-class CTest test cases, so users do not need to manually set up an environment and run the `run-tests` script from any particular directory.  With our integration tests being CTest test cases, it is now possible to run a single integration test from an IDE that understands CTest test cases, such as VSCode with the [vscode-cmake-tools][vscode-cmake-tools] extension, or Emacs with [projectile][emacs-projectile] or [projection][emacs-projection].  After applying this patch, users should be able to simply configure the project and build the `integration-tests` target to build the broker and run all its integration tests.

In order to do this, this PR first sets up a Python 3 virtual environment in the CMake build directory that contains all the development requirements to use our integration test framework.  Then, this patch uses that virtual environment to add the integration tests as CTest targets, with the label `integration`. This allows users to run only the integration tests, without running the unit tests as well.

This PR introduces two optional dependencies during the CMake configuration.  If Python 3 is found, a virtual environment is created, and all requirements in `requirements.txt` are installed into that virtual environment.  Second, an additional dependency on the Python package `cmake-pytest` is added; if Python 3 is found and this package can be installed, then we are able to add the `integration-tests` target.

[vscode-cmake-tools]: https://github.com/microsoft/vscode-cmake-tools
[emacs-projectile]: https://github.com/bbatsov/projectile
[emacs-projection]: https://github.com/mohkale/projection
