### PR TITLE
fixing CS shutdown V2

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -911,44 +911,38 @@ void ClientSession::initiateShutdownDispatched(
     BALL_LOG_INFO << description()
                   << ": initiateShutdownDispatched. Timeout: " << timeout;
 
+    bdlb::ScopeExitAny scopeExit(callback);
+
     if (d_operationState == e_DEAD) {
         // The client is disconnected.  No need to wait for tearDown.
-        callback();
         return;  // RETURN
     }
 
     if (d_operationState == e_SHUTTING_DOWN) {
         // More than one cluster calls 'initiateShutdown'?
-        callback();
-        return;  // RETURN
-    }
-
-    if (d_operationState == e_SHUTTING_DOWN_V2) {
-        // More than one cluster calls 'initiateShutdown'?
-        callback();
         return;  // RETURN
     }
 
     flush();  // Flush any pending messages
 
-    // 'tearDown' should invoke the 'callback'
-    d_shutdownCallback = callback;
-
-    if (d_operationState == e_DISCONNECTING) {
-        // Not teared down yet. No need to wait for unconfirmed messages.
-        // Wait for tearDown.
-
-        closeChannel();
-        return;  // RETURN
-    }
-
     if (supportShutdownV2) {
-        d_operationState = e_SHUTTING_DOWN_V2;
+        d_operationState = e_DISCONNECTING;
         d_queueSessionManager.shutDown();
-
-        callback();
     }
     else {
+        // 'tearDown' should invoke the 'callback'
+        d_shutdownCallback = callback;
+
+        scopeExit.release();
+
+        if (d_operationState == e_DISCONNECTING) {
+            // Not torn down yet. No need to wait for unconfirmed messages.
+            // Wait for tearDown.
+
+            closeChannel();
+            return;  // RETURN
+        }
+
         // After de-configuring (below), wait for unconfirmed messages.
         // Once the wait for unconfirmed is over, close the channel
 
@@ -3221,15 +3215,13 @@ void ClientSession::processStopRequest(ShutdownContextSp& contextSp)
         // Even if the waiting is in progress, still reply with StopResponse
         return;  // RETURN
     }
-    if (d_operationState == e_SHUTTING_DOWN_V2) {
-        // The broker is already shutting down or processing a StopRequest
-        // The de-configuring is done.
-        // Even if the waiting is in progress, still reply with StopResponse
-        return;  // RETURN
-    }
 
     if (d_operationState == e_DISCONNECTING) {
-        // The client is disconnecting.  No-op
+        // The broker is already shutting down or processing a StopRequest or
+        // disconnecting.
+        // The de-configuring is done.
+        // Even if the waiting is in progress, still reply with StopResponse
+
         return;  // RETURN
     }
     for (QueueStateMapCIter cit = d_queueSessionManager.queues().begin();

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -263,8 +263,6 @@ class ClientSession : public mqbnet::Session,
         // V2.
         e_SHUTTING_DOWN,
         /// Shutting down due to `initiateShutdown` request.
-        e_SHUTTING_DOWN_V2,
-        /// Disconnecting due to the client disconnect request.
         e_DISCONNECTING,
         /// The session is disconnected and no longer valid.
         e_DISCONNECTED,
@@ -363,6 +361,7 @@ class ClientSession : public mqbnet::Session,
 
     /// If present, call when `tearDownAllQueuesDone`.  This is the callback
     /// given in `initiateShutdown`.
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest V2.
     ShutdownCb d_shutdownCallback;
 
     /// HiRes timer value of the begin session/queue operation.
@@ -458,6 +457,8 @@ class ClientSession : public mqbnet::Session,
 
     void invalidateDispatched();
 
+    // TODO(shutdown-v2): TEMPORARY, remove when all switch to StopRequest
+    // V2.
     void deconfigureAndWait(ShutdownContextSp& context);
 
     void checkUnconfirmed(const ShutdownContextSp& shutdownCtx,


### PR DESCRIPTION
Bugfix: `ClientSession` calls method on destructed `Latch` in ShutdownV2