### PR TITLE
Fix: Iterator typing in fixtures script

### DIFF
--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -37,8 +37,7 @@ import shutil
 import tempfile
 from enum import IntEnum
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
-from collections.abc import Generator, Iterator
+from typing import Callable, Iterator, List, Optional, Tuple
 import psutil
 
 import pytest


### PR DESCRIPTION
This attempts to fix `TypeError: 'ABCMeta' object is not subscriptable` errors on internal SunOS IT runs.

It looks like this change was introduced (maybe unintentionally?) here: https://github.com/bloomberg/blazingmq/commit/e4bf5f6bc28d6199ddb10a27c300387e7d1c3be3#diff-f647edb068b980bb999e08d1cdb2532932f977fc8658e70094f29e73d0691c25R201

`Generator` is no longer used, it can be removed.
