### PR TITLE
Fix: update BALL enums globally

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -175,7 +175,7 @@ void Application::setUpLog()
     // Set default verbosity to the specified one
     ball::LoggerManager::singleton().setDefaultThresholdLevels(
         ball::Severity::e_OFF,   // recording level
-        logLevel,              // passthrough level
+        logLevel,                // passthrough level
         ball::Severity::e_OFF,   // trigger level
         ball::Severity::e_OFF);  // triggerAll level
 

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -134,26 +134,26 @@ void Application::setUpLog()
                                        ball::LoggerManagerConfiguration(),
                                        d_allocator_p);
 
-    ball::Severity::Level logLevel = ball::Severity::INFO;
+    ball::Severity::Level logLevel = ball::Severity::e_INFO;
     switch (d_parameters.verbosity()) {
     case ParametersVerbosity::e_SILENT: {
-        logLevel = ball::Severity::OFF;
+        logLevel = ball::Severity::e_OFF;
     } break;
     case ParametersVerbosity::e_TRACE: {
-        logLevel = ball::Severity::TRACE;
+        logLevel = ball::Severity::e_TRACE;
     } break;
     case ParametersVerbosity::e_DEBUG: {
-        logLevel = ball::Severity::DEBUG;
+        logLevel = ball::Severity::e_DEBUG;
     } break;
     case ParametersVerbosity::e_INFO: {
-        logLevel = ball::Severity::INFO;
+        logLevel = ball::Severity::e_INFO;
     } break;
     case ParametersVerbosity::e_WARNING: {
-        logLevel = ball::Severity::WARN;
+        logLevel = ball::Severity::e_WARN;
     } break;
     case ParametersVerbosity::e_ERROR:
     case ParametersVerbosity::e_FATAL: {
-        logLevel = ball::Severity::ERROR;
+        logLevel = ball::Severity::e_ERROR;
     } break;
     }
 
@@ -162,7 +162,7 @@ void Application::setUpLog()
             ? CommandLineParameters::DEFAULT_INITIALIZER_LOG_FORMAT
             : d_parameters.logFormat();
 
-    d_consoleObserver.setSeverityThreshold(ball::Severity::TRACE);
+    d_consoleObserver.setSeverityThreshold(ball::Severity::e_TRACE);
     // We use the ballLoggerManager global threshold to determine what gets
     // logged, so the console observer should print any logs it receives.
 
@@ -174,10 +174,10 @@ void Application::setUpLog()
 
     // Set default verbosity to the specified one
     ball::LoggerManager::singleton().setDefaultThresholdLevels(
-        ball::Severity::OFF,   // recording level
+        ball::Severity::e_OFF,   // recording level
         logLevel,              // passthrough level
-        ball::Severity::OFF,   // trigger level
-        ball::Severity::OFF);  // triggerAll level
+        ball::Severity::e_OFF,   // trigger level
+        ball::Severity::e_OFF);  // triggerAll level
 
     d_multiplexObserver.registerObserver(&d_consoleObserver);
 }
@@ -893,7 +893,7 @@ int Application::syschk(const m_bmqtool::Parameters& parameters)
     // Setup logging
     ball::StreamObserver             observer(&bsl::cout);
     ball::LoggerManagerConfiguration configuration;
-    configuration.setDefaultThresholdLevelsIfValid(ball::Severity::WARN);
+    configuration.setDefaultThresholdLevelsIfValid(ball::Severity::e_WARN);
 
     ball::LoggerManagerScopedGuard guard(&observer, configuration);
 

--- a/src/applications/bmqtool/m_bmqtool_filelogger.cpp
+++ b/src/applications/bmqtool/m_bmqtool_filelogger.cpp
@@ -56,7 +56,7 @@ class LogRecord {
   public:
     LogRecord(ball::FileObserver2& out,
               const char*          category,
-              int                  severity = ball::Severity::INFO)
+              int                  severity = ball::Severity::e_INFO)
     : d_record()
     , d_out(out)
     , d_os(init(d_record, category, severity))

--- a/src/applications/bmqtool/m_bmqtool_interactive.cpp
+++ b/src/applications/bmqtool/m_bmqtool_interactive.cpp
@@ -178,8 +178,8 @@ void Interactive::processCommand(const StartCommand& command)
         rc = d_session_p->start(bsls::TimeInterval(5.0));
     }
 
-    ball::Severity::Level severity = (rc == 0 ? ball::Severity::INFO
-                                              : ball::Severity::ERROR);
+    ball::Severity::Level severity = (rc == 0 ? ball::Severity::e_INFO
+                                              : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity)
         << "<-- session.start(5.0) => " << bmqt::GenericResult::Enum(rc)
         << " (" << rc << ")";
@@ -297,8 +297,8 @@ void Interactive::processCommand(const OpenQueueCommand& command)
 
     const ball::Severity::Level severity = ((status.result() ==
                                              bmqt::OpenQueueResult::e_SUCCESS)
-                                                ? ball::Severity::INFO
-                                                : ball::Severity::ERROR);
+                                                ? ball::Severity::e_INFO
+                                                : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.openQueueSync() => "
                               << status.result() << " (" << status << ")";
 
@@ -378,8 +378,8 @@ void Interactive::processCommand(const ConfigureQueueCommand& command)
 
     const ball::Severity::Level severity =
         (status.result() == bmqt::ConfigureQueueResult::e_SUCCESS
-             ? ball::Severity::INFO
-             : ball::Severity::ERROR);
+             ? ball::Severity::e_INFO
+             : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.configureQueueSync() => "
                               << status.result() << " (" << status << ")";
 }
@@ -416,8 +416,8 @@ void Interactive::processCommand(const CloseQueueCommand& command)
 
     const ball::Severity::Level severity =
         (status.result() == bmqt::CloseQueueResult::e_SUCCESS
-             ? ball::Severity::INFO
-             : ball::Severity::ERROR);
+             ? ball::Severity::e_INFO
+             : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.closeQueueSync() => "
                               << status.result() << " (" << status << ")";
 
@@ -508,8 +508,8 @@ void Interactive::processCommand(const PostCommand& command, bool hasMPs)
     // Post
     rc = d_session_p->post(eventBuilder.messageEvent());
 
-    ball::Severity::Level severity = (rc == 0 ? ball::Severity::INFO
-                                              : ball::Severity::ERROR);
+    ball::Severity::Level severity = (rc == 0 ? ball::Severity::e_INFO
+                                              : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity)
         << "<-- session.post() => " << bmqt::GenericResult::Enum(rc) << " ("
         << rc << ")";
@@ -632,8 +632,8 @@ void Interactive::processCommand(const ConfirmCommand& command)
         // this is interactive mode ...)
         rc = d_session_p->confirmMessage(itMsg->second);
 
-        ball::Severity::Level severity = (rc == 0 ? ball::Severity::INFO
-                                                  : ball::Severity::ERROR);
+        ball::Severity::Level severity = (rc == 0 ? ball::Severity::e_INFO
+                                                  : ball::Severity::e_ERROR);
         BALL_LOG_STREAM(severity)
             << "<-- session.confirmMessage() => "
             << bmqt::GenericResult::Enum(rc) << " (" << rc << ")";
@@ -829,8 +829,8 @@ void Interactive::processCommand(const LoadPostCommand& command)
     // Post
     const int rc = d_session_p->post(eventBuilder.messageEvent());
 
-    ball::Severity::Level severity = (rc == 0 ? ball::Severity::INFO
-                                              : ball::Severity::ERROR);
+    ball::Severity::Level severity = (rc == 0 ? ball::Severity::e_INFO
+                                              : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity)
         << "<-- session.post() => " << bmqt::GenericResult::Enum(rc) << " ("
         << rc << ")";
@@ -1093,8 +1093,8 @@ void Interactive::onOpenQueueStatus(const bmqa::OpenQueueStatus& status)
 
     const ball::Severity::Level severity = ((status.result() ==
                                              bmqt::OpenQueueResult::e_SUCCESS)
-                                                ? ball::Severity::INFO
-                                                : ball::Severity::ERROR);
+                                                ? ball::Severity::e_INFO
+                                                : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.openQueueAsync() => "
                               << status.result() << " (" << status << ")";
 
@@ -1117,8 +1117,8 @@ void Interactive::onConfigureQueueStatus(
 
     const ball::Severity::Level severity =
         ((status.result() == bmqt::ConfigureQueueResult::e_SUCCESS)
-             ? ball::Severity::INFO
-             : ball::Severity::ERROR);
+             ? ball::Severity::e_INFO
+             : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.configureQueueAsync() => "
                               << status.result() << " (" << status << ")";
 }
@@ -1131,8 +1131,8 @@ void Interactive::onCloseQueueStatus(const bmqa::CloseQueueStatus& status)
 
     const ball::Severity::Level severity = ((status.result() ==
                                              bmqt::CloseQueueResult::e_SUCCESS)
-                                                ? ball::Severity::INFO
-                                                : ball::Severity::ERROR);
+                                                ? ball::Severity::e_INFO
+                                                : ball::Severity::e_ERROR);
     BALL_LOG_STREAM(severity) << "<-- session.closeQueueAsync() => "
                               << status.result() << " (" << status << ")";
 

--- a/src/groups/bmq/bmqa/bmqa_abstractsession.h
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.h
@@ -411,7 +411,7 @@ class AbstractSession {
     ///-----------------
 
     /// Configure this session instance to dump messages to the installed
-    /// logger at `ball::Severity::INFO` level according to the specified
+    /// logger at `ball::Severity::e_INFO` level according to the specified
     /// `command` that should adhere to the following pattern:
     /// ```
     ///  IN|OUT ON|OFF|100|10s

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -1135,7 +1135,7 @@ class Session : public AbstractSession {
     ///-----------------
 
     /// Configure this session instance to dump messages to the installed
-    /// logger at `ball::Severity::INFO` level according to the specified
+    /// logger at `ball::Severity::e_INFO` level according to the specified
     /// `command` that should adhere to the following pattern:
     /// ```
     ///  IN|OUT|PUSH|ACK|PUT|CONFIRM ON|OFF|100|10s

--- a/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
@@ -249,7 +249,7 @@ static void test3_deallocate()
 
     // 3. Deallocate previously deallocated memory and verify failure, as
     //    well as ensure that an error is logged.
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_SAFE_FAIL(obj.deallocate(buf));
     BMQTST_ASSERT_EQ(logObserver.records().size(), 1U);

--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -644,7 +644,7 @@ static void test7_testLongUri()
 
     bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::WARN,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_WARN,
                                        bmqtst::TestHelperUtil::allocator());
 
     bsl::string domainStr("bmq://my.domain/",
@@ -661,7 +661,7 @@ static void test7_testLongUri()
     BMQTST_ASSERT_EQ(observer.records().size(), 1U);
 
     BMQTST_ASSERT_EQ(observer.records()[0].fixedFields().severity(),
-                     ball::Severity::ERROR);
+                     ball::Severity::e_ERROR);
 
     BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
         observer.records()[0],

--- a/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.cpp
@@ -69,7 +69,7 @@ void AlarmLog::publish(const ball::Record&          record,
                        BSLS_ANNOTATION_UNUSED const ball::Context& context)
 {
     if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(
-            (record.fixedFields().severity() > ball::Severity::ERROR) ||
+            (record.fixedFields().severity() > ball::Severity::e_ERROR) ||
             (record.customFields().length() == 0))) {
         // We are only interested in ERROR severity, and only the ones which
         // have a userField (the alarm type) set.

--- a/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.cpp
@@ -149,12 +149,12 @@ ConsoleObserver::getColorCodeForRecord(const ball::Record& record) const
     BSLMT_MUTEXASSERT_IS_LOCKED_SAFE(&d_mutex);  // mutex was LOCKED
 
     // Errors and Warnings have a special color, regardless of the category
-    if (record.fixedFields().severity() == ball::Severity::WARN) {
+    if (record.fixedFields().severity() == ball::Severity::e_WARN) {
         ColorMap::const_iterator it = d_colorMap.find(k_COLOR_WARN);
         BSLS_ASSERT_SAFE(it != d_colorMap.end());
         return it->second.c_str();  // RETURN
     }
-    if (record.fixedFields().severity() == ball::Severity::ERROR) {
+    if (record.fixedFields().severity() == ball::Severity::e_ERROR) {
         ColorMap::const_iterator it = d_colorMap.find(k_COLOR_ERROR);
         BSLS_ASSERT_SAFE(it != d_colorMap.end());
         return it->second.c_str();  // RETURN
@@ -181,7 +181,7 @@ ConsoleObserver::getColorCodeForRecord(const ball::Record& record) const
 ConsoleObserver::ConsoleObserver(bslma::Allocator* allocator)
 : d_allocator_p(allocator)
 , d_formatter(allocator)
-, d_severityThreshold(ball::Severity::INFO)
+, d_severityThreshold(ball::Severity::e_INFO)
 , d_colorMap(allocator)
 , d_categoryColorVec(allocator)
 {

--- a/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
@@ -65,7 +65,7 @@
 //..
 //  bmqtsk::ConsoleObserver consoleObserver(allocator);
 //
-//  consoleObserver.setSeverityThreshold(ball::Severity::INFO)
+//  consoleObserver.setSeverityThreshold(ball::Severity::e_INFO)
 //                 .setLogFromat("%d (%t) %s %F:%l %m\n");
 //..
 //
@@ -221,7 +221,7 @@ class ConsoleObserver : public ball::ObserverAdapter {
 
     /// Set the severity threshold to the specified `value`: any log which
     /// severity is greater than or equal to `value` will be printed to
-    /// stdout.  Use `ball::Severity::OFF` to completely disable this
+    /// stdout.  Use `ball::Severity::e_OFF` to completely disable this
     /// observer.  Return a reference to this object offering modification
     /// access.
     ConsoleObserver& setSeverityThreshold(ball::Severity::Level value);
@@ -254,7 +254,7 @@ class ConsoleObserver : public ball::ObserverAdapter {
 
     /// Return whether this observer is enabled or not.  Note that this is
     /// just a convenience shortcut for comparing the `severityThreshold`
-    /// with a value of `ball::Severity::OFF`.
+    /// with a value of `ball::Severity::e_OFF`.
     bool isEnabled() const;
 };
 
@@ -288,7 +288,7 @@ inline ball::Severity::Level ConsoleObserver::severityThreshold() const
 
 inline bool ConsoleObserver::isEnabled() const
 {
-    return d_severityThreshold != ball::Severity::OFF;
+    return d_severityThreshold != ball::Severity::e_OFF;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.cpp
@@ -140,17 +140,17 @@ LogControllerConfig::LogControllerConfig(bslma::Allocator* allocator)
 , d_rotationSeconds(60 * 60 * 24)     // 1 day
 , d_logfileFormat("%d (%t) %s %F:%l %m\n\n", allocator)
 , d_consoleFormat("%d (%t) %s %F:%l %m\n", allocator)
-, d_loggingVerbosity(ball::Severity::INFO)
+, d_loggingVerbosity(ball::Severity::e_INFO)
 , d_bslsLogSeverityThreshold(bsls::LogSeverity::e_ERROR)
-, d_consoleSeverityThreshold(ball::Severity::OFF)
+, d_consoleSeverityThreshold(ball::Severity::e_OFF)
 , d_syslogEnabled(false)
 , d_syslogFormat("%d (%t) %s %F:%l %m\n\n", allocator)
 , d_syslogAppName("")
-, d_syslogVerbosity(ball::Severity::ERROR)
+, d_syslogVerbosity(ball::Severity::e_ERROR)
 , d_categories(allocator)
 , d_recordBufferSizeBytes(32 * 1024)  // 32 KB
-, d_recordingVerbosity(ball::Severity::OFF)
-, d_triggerVerbosity(ball::Severity::OFF)
+, d_recordingVerbosity(ball::Severity::e_OFF)
+, d_triggerVerbosity(ball::Severity::e_OFF)
 {
     // NOTHING
 }
@@ -437,7 +437,7 @@ LogController::LogController(bdlmt::EventScheduler* scheduler,
 , d_isInitialized(false)
 , d_config(allocator)
 , d_multiplexObserver(allocator)
-, d_fileObserver(ball::Severity::OFF,  // disable stdout (we use Console)
+, d_fileObserver(ball::Severity::e_OFF,  // disable stdout (we use Console)
                  false,                // use UTC time
                  8192,                 // maxQueueLogEntries
                  allocator)
@@ -685,13 +685,13 @@ void LogController::setVerbosityLevel(ball::Severity::Level passVerbosity,
         recordVerbosity,       // recording level
         passVerbosity,         // passthrough level
         triggerVerbosity,      // trigger level
-        ball::Severity::OFF);  // triggerAll level
+        ball::Severity::e_OFF);  // triggerAll level
     ball::Administration::setThresholdLevels(
         "*",
         recordVerbosity,       // recording level
         passVerbosity,         // passthrough level
         triggerVerbosity,      // trigger level
-        ball::Severity::OFF);  // triggerAll level
+        ball::Severity::e_OFF);  // triggerAll level
 }
 
 void LogController::setCategoryVerbosity(const bsl::string&    category,
@@ -704,17 +704,17 @@ void LogController::setCategoryVerbosity(const bsl::string&    category,
 
     ball::Administration::addCategory(
         categoryNoStar.c_str(),
-        ball::Severity::OFF,   // recording level
+        ball::Severity::e_OFF,   // recording level
         verbosity,             // passthrough level
-        ball::Severity::OFF,   // trigger level
-        ball::Severity::OFF);  // triggerAll level
+        ball::Severity::e_OFF,   // trigger level
+        ball::Severity::e_OFF);  // triggerAll level
 
     ball::Administration::setThresholdLevels(
         category.c_str(),
-        ball::Severity::OFF,   // recording level
+        ball::Severity::e_OFF,   // recording level
         verbosity,             // passthrough level
-        ball::Severity::OFF,   // trigger level
-        ball::Severity::OFF);  // triggerAll level
+        ball::Severity::e_OFF,   // trigger level
+        ball::Severity::e_OFF);  // triggerAll level
 }
 
 int LogController::processCommand(const bsl::string& cmd, bsl::ostream& os)

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.cpp
@@ -438,8 +438,8 @@ LogController::LogController(bdlmt::EventScheduler* scheduler,
 , d_config(allocator)
 , d_multiplexObserver(allocator)
 , d_fileObserver(ball::Severity::e_OFF,  // disable stdout (we use Console)
-                 false,                // use UTC time
-                 8192,                 // maxQueueLogEntries
+                 false,                  // use UTC time
+                 8192,                   // maxQueueLogEntries
                  allocator)
 , d_alarmLog(allocator)
 , d_consoleObserver(allocator)
@@ -682,15 +682,15 @@ void LogController::setVerbosityLevel(ball::Severity::Level passVerbosity,
                                       ball::Severity::Level triggerVerbosity)
 {
     ball::Administration::setDefaultThresholdLevels(
-        recordVerbosity,       // recording level
-        passVerbosity,         // passthrough level
-        triggerVerbosity,      // trigger level
+        recordVerbosity,         // recording level
+        passVerbosity,           // passthrough level
+        triggerVerbosity,        // trigger level
         ball::Severity::e_OFF);  // triggerAll level
     ball::Administration::setThresholdLevels(
         "*",
-        recordVerbosity,       // recording level
-        passVerbosity,         // passthrough level
-        triggerVerbosity,      // trigger level
+        recordVerbosity,         // recording level
+        passVerbosity,           // passthrough level
+        triggerVerbosity,        // trigger level
         ball::Severity::e_OFF);  // triggerAll level
 }
 
@@ -705,14 +705,14 @@ void LogController::setCategoryVerbosity(const bsl::string&    category,
     ball::Administration::addCategory(
         categoryNoStar.c_str(),
         ball::Severity::e_OFF,   // recording level
-        verbosity,             // passthrough level
+        verbosity,               // passthrough level
         ball::Severity::e_OFF,   // trigger level
         ball::Severity::e_OFF);  // triggerAll level
 
     ball::Administration::setThresholdLevels(
         category.c_str(),
         ball::Severity::e_OFF,   // recording level
-        verbosity,             // passthrough level
+        verbosity,               // passthrough level
         ball::Severity::e_OFF,   // trigger level
         ball::Severity::e_OFF);  // triggerAll level
 }

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.h
@@ -169,7 +169,7 @@ class LogControllerConfig {
         /// Create a new object having the optionally specified `verbosity`
         /// and `color` properties.
         explicit CategoryProperties(
-            ball::Severity::Level verbosity = ball::Severity::OFF,
+            ball::Severity::Level verbosity = ball::Severity::e_OFF,
             const bsl::string&    color     = "");
     };
 
@@ -474,8 +474,8 @@ class LogController {
     /// publication of that record and any records in the logger's buffer.
     void setVerbosityLevel(
         ball::Severity::Level passVerbosity,
-        ball::Severity::Level recordVerbosity  = ball::Severity::OFF,
-        ball::Severity::Level triggerVerbosity = ball::Severity::OFF);
+        ball::Severity::Level recordVerbosity  = ball::Severity::e_OFF,
+        ball::Severity::Level triggerVerbosity = ball::Severity::e_OFF);
 
     /// Change the verbosity of the specified `category` to the specified
     /// `verbosity`.  `category` can be an expression, with a terminating
@@ -538,8 +538,8 @@ int LogControllerConfig::fromObj(bsl::ostream& errorDescription,
         return -1;  // RETURN
     }
 
-    d_recordingVerbosity = ball::Severity::OFF;
-    d_triggerVerbosity   = ball::Severity::OFF;
+    d_recordingVerbosity = ball::Severity::e_OFF;
+    d_triggerVerbosity   = ball::Severity::e_OFF;
 
     ball::Severity::Level bslsSeverityAsBal = ball::Severity::e_ERROR;
     // TODO: enforcing 'obj' to have 'bslsLogSeverityThreshold' accessor is a

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.t.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.t.cpp
@@ -84,7 +84,8 @@ static void test1_logControllerConfigFromObj()
     BMQTST_ASSERT_EQ(config.loggingVerbosity(), ball::Severity::e_DEBUG);
     BMQTST_ASSERT_EQ(config.bslsLogSeverityThreshold(),
                      bsls::LogSeverity::e_ERROR);
-    BMQTST_ASSERT_EQ(config.consoleSeverityThreshold(), ball::Severity::e_INFO);
+    BMQTST_ASSERT_EQ(config.consoleSeverityThreshold(),
+                     ball::Severity::e_INFO);
 
     BMQTST_ASSERT_EQ(config.syslogEnabled(), true);
     BMQTST_ASSERT_EQ(config.syslogFormat(), "test %d (%t) %s %F:%l %m\n\n");

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.t.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcontroller.t.cpp
@@ -81,19 +81,19 @@ static void test1_logControllerConfigFromObj()
     BMQTST_ASSERT_EQ(config.rotationBytes(), 2048);
     BMQTST_ASSERT_EQ(config.logfileFormat(), "%d (%t) %s %F:%l %m\n\n");
     BMQTST_ASSERT_EQ(config.consoleFormat(), "%d (%t) %s %F:%l %m\n\n");
-    BMQTST_ASSERT_EQ(config.loggingVerbosity(), ball::Severity::DEBUG);
+    BMQTST_ASSERT_EQ(config.loggingVerbosity(), ball::Severity::e_DEBUG);
     BMQTST_ASSERT_EQ(config.bslsLogSeverityThreshold(),
                      bsls::LogSeverity::e_ERROR);
-    BMQTST_ASSERT_EQ(config.consoleSeverityThreshold(), ball::Severity::INFO);
+    BMQTST_ASSERT_EQ(config.consoleSeverityThreshold(), ball::Severity::e_INFO);
 
     BMQTST_ASSERT_EQ(config.syslogEnabled(), true);
     BMQTST_ASSERT_EQ(config.syslogFormat(), "test %d (%t) %s %F:%l %m\n\n");
     BMQTST_ASSERT_EQ(config.syslogAppName(), "testapp");
-    BMQTST_ASSERT_EQ(config.syslogVerbosity(), ball::Severity::INFO);
+    BMQTST_ASSERT_EQ(config.syslogVerbosity(), ball::Severity::e_INFO);
 
     BMQTST_ASSERT_EQ(config.recordBufferSizeBytes(), 32768);
-    BMQTST_ASSERT_EQ(config.recordingVerbosity(), ball::Severity::OFF);
-    BMQTST_ASSERT_EQ(config.triggerVerbosity(), ball::Severity::OFF);
+    BMQTST_ASSERT_EQ(config.recordingVerbosity(), ball::Severity::e_OFF);
+    BMQTST_ASSERT_EQ(config.triggerVerbosity(), ball::Severity::e_OFF);
 }
 
 // ============================================================================

--- a/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.cpp
@@ -38,7 +38,7 @@ namespace bmqtsk {
 SyslogObserver::SyslogObserver(bslma::Allocator* allocator)
 : d_allocator_p(allocator)
 , d_formatter(allocator)
-, d_severityThreshold(ball::Severity::INFO)
+, d_severityThreshold(ball::Severity::e_INFO)
 {
     d_formatter.disablePublishInLocalTime();  // Always use UTC time
 }

--- a/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
@@ -41,7 +41,7 @@
 //..
 //  bmqtsk::SyslogObserver syslogObserver(allocator);
 //
-//  syslogObserver.setSeverityThreshold(ball::Severity::INFO)
+//  syslogObserver.setSeverityThreshold(ball::Severity::e_INFO)
 //                .setLogFromat("%d (%t) %s %F:%l %m\n");
 //  syslogObserver.enableLogging();
 //..
@@ -150,7 +150,7 @@ class SyslogObserver : public ball::ObserverAdapter {
 
     /// Set the severity threshold to the specified `value`: any log which
     /// severity is greater than or equal to `value` will be printed to
-    /// stdout.  Use `ball::Severity::OFF` to completely disable this
+    /// stdout.  Use `ball::Severity::e_OFF` to completely disable this
     /// observer.  Return a reference to this object offering modification
     /// access.
     SyslogObserver& setSeverityThreshold(ball::Severity::Level value);
@@ -181,7 +181,7 @@ class SyslogObserver : public ball::ObserverAdapter {
 
     /// Return whether this observer is enabled or not.  Note that this is
     /// just a convenience shortcut for comparing the `severityThreshold`
-    /// with a value of `ball::Severity::OFF`.
+    /// with a value of `ball::Severity::e_OFF`.
     bool isEnabled() const;
 };
 
@@ -215,7 +215,7 @@ inline ball::Severity::Level SyslogObserver::severityThreshold() const
 
 inline bool SyslogObserver::isEnabled() const
 {
-    return d_severityThreshold != ball::Severity::OFF;
+    return d_severityThreshold != ball::Severity::e_OFF;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.cpp
@@ -120,7 +120,7 @@ ball::Severity::Level ScopedLogObserver::severityThreshold() const
 
 bool ScopedLogObserver::isEnabled() const
 {
-    return severityThreshold() != ball::Severity::OFF;
+    return severityThreshold() != ball::Severity::e_OFF;
 }
 
 const bsl::vector<ball::Record>& ScopedLogObserver::records() const

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
@@ -45,10 +45,10 @@
 // observer object for testing purposes.
 //
 // First, create a 'bmqtst::ScopedLogObserver' object having a desired severity
-// threshold for capturing log records (in this case, 'ball::Severity::ERROR').
+// threshold for capturing log records (in this case, 'ball::Severity::e_ERROR').
 //..
 //  BALL_LOG_SET_CATEGORY("TEST");
-//  bmqtst::ScopedLogObserver observer(ball::Severity::ERROR,
+//  bmqtst::ScopedLogObserver observer(ball::Severity::e_ERROR,
 //  bmqtst::TestHelperUtil::allocator());
 //..
 // Next, publish a log using the BALL logging infrastructure.  Note that the
@@ -132,7 +132,7 @@ class ScopedLogObserver : public ball::ObserverAdapter {
 
     /// Set the severity threshold to the specified `value`: any log which
     /// severity is greater than or equal to `value` will be recorded.  Use
-    /// `ball::Severity::OFF` to completely disable this observer.  Return a
+    /// `ball::Severity::e_OFF` to completely disable this observer.  Return a
     /// reference to this object.
     ScopedLogObserver& setSeverityThreshold(ball::Severity::Level value);
 
@@ -161,7 +161,7 @@ class ScopedLogObserver : public ball::ObserverAdapter {
 
     /// Return whether this observer is enabled or not.  Note that this is
     /// just a convenience shortcut for comparing the `severityThreshold`
-    /// with a value of `ball::Severity::OFF`.
+    /// with a value of `ball::Severity::e_OFF`.
     bool isEnabled() const;
 
     /// Return a reference not offering modifiable access to the list of

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
@@ -45,7 +45,8 @@
 // observer object for testing purposes.
 //
 // First, create a 'bmqtst::ScopedLogObserver' object having a desired severity
-// threshold for capturing log records (in this case, 'ball::Severity::e_ERROR').
+// threshold for capturing log records (in this case,
+// 'ball::Severity::e_ERROR').
 //..
 //  BALL_LOG_SET_CATEGORY("TEST");
 //  bmqtst::ScopedLogObserver observer(ball::Severity::e_ERROR,

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.t.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.t.cpp
@@ -52,16 +52,16 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::OFF,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_OFF,
                                        bmqtst::TestHelperUtil::allocator());
 
-    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::OFF);
+    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::e_OFF);
     BMQTST_ASSERT(!observer.isEnabled());
     BMQTST_ASSERT(observer.records().empty());
 
-    observer.setSeverityThreshold(ball::Severity::WARN);
+    observer.setSeverityThreshold(ball::Severity::e_WARN);
 
-    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::WARN);
+    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::e_WARN);
     BMQTST_ASSERT(observer.isEnabled());
     BMQTST_ASSERT(observer.records().empty());
 }
@@ -91,25 +91,25 @@ static void test2_publish()
     ball::Context context1(bmqtst::TestHelperUtil::allocator());
     ball::Context context2(bmqtst::TestHelperUtil::allocator());
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_ERROR,
                                        bmqtst::TestHelperUtil::allocator());
 
-    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::ERROR);
+    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::e_ERROR);
     BMQTST_ASSERT(observer.isEnabled());
     BMQTST_ASSERT(observer.records().empty());
 
-    record1.fixedFields().setSeverity(ball::Severity::ERROR);
+    record1.fixedFields().setSeverity(ball::Severity::e_ERROR);
     observer.publish(record1, context1);
 
-    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::ERROR);
+    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::e_ERROR);
     BMQTST_ASSERT(observer.isEnabled());
     BMQTST_ASSERT(observer.records().size() == 1);
     BMQTST_ASSERT(observer.records()[0] == record1);
 
-    record2.fixedFields().setSeverity(ball::Severity::WARN);
+    record2.fixedFields().setSeverity(ball::Severity::e_WARN);
     observer.publish(record2, context2);
 
-    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::ERROR);
+    BMQTST_ASSERT_EQ(observer.severityThreshold(), ball::Severity::e_ERROR);
     BMQTST_ASSERT(observer.isEnabled());
     BMQTST_ASSERT(observer.records().size() == 1);
     BMQTST_ASSERT(observer.records()[0] == record1);
@@ -192,7 +192,7 @@ static void test4_usageExample()
 
     BALL_LOG_SET_CATEGORY("TEST");
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_ERROR,
                                        bmqtst::TestHelperUtil::allocator());
 
     BALL_LOG_ERROR << "MySampleError";

--- a/src/groups/bmq/bmqu/bmqu_throttledaction.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_throttledaction.t.cpp
@@ -148,7 +148,7 @@ static void test2_throttleNoReset()
     const int k_INTERVAL_MS            = 2000;
     const int k_MAX_COUNT_PER_INTERVAL = 3;
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     // No more than 3 logs in a 5s timeframe
@@ -272,7 +272,7 @@ static void test3_throttleWithDefaultReset()
     const int k_INTERVAL_MS            = 2000;
     const int k_MAX_COUNT_PER_INTERVAL = 3;
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     // No more than 3 logs in a 5s timeframe
@@ -401,7 +401,7 @@ static void test4_throttleWithCustomReset()
     const int k_INTERVAL_MS            = 2000;
     const int k_MAX_COUNT_PER_INTERVAL = 3;
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     // No more than 3 logs in a 5s timeframe

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -1996,7 +1996,7 @@ void ClientSession::onPushEvent(const mqbi::DispatcherPushEvent& event)
 
     bdlbb::Blob* blob = event.blob().get();
 
-    if (BALL_LOG_IS_ENABLED(ball::Severity::TRACE)) {
+    if (BALL_LOG_IS_ENABLED(ball::Severity::e_TRACE)) {
         ClientSessionState::QueueStateMap::const_iterator it =
             d_queueSessionManager.queues().find(event.queueId());
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -810,12 +810,12 @@ ClusterProxy::sendRequest(const RequestManagerType::RequestSp& request,
 
     if (!activeNode) {
         // Not connected to any node, can't deliver the request.
-        ball::Severity::Level severity = ball::Severity::ERROR;
+        ball::Severity::Level severity = ball::Severity::e_ERROR;
         if (d_activeNodeLookupEventHandle) {
             // If the cluster is being established, since it's lazily created,
             // it is expected that the first request will fail to send, just
             // silence the error.
-            severity = ball::Severity::INFO;
+            severity = ball::Severity::e_INFO;
         }
         BALL_LOG_STREAM(severity)
             << "#CLUSTER_SEND_FAILURE " << description()

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1488,14 +1488,14 @@ void ClusterQueueHelper::onReopenQueueResponse(
     // TODO: remove this not thread-safe use of 'getUpstreamParameters'.
     if (!queueptr->getUpstreamParameters(&streamParamsCopy,
                                          upstreamSubQueueId)) {
-        ball::Severity::Level logSeverity = ball::Severity::WARN;
+        ball::Severity::Level logSeverity = ball::Severity::e_WARN;
 
         if (bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID == upstreamSubQueueId) {
             // There is an optimization in RelayQueueEngine::configureHandle
             // not to send producer parameters upstream if they are the same as
             // default constructed.  In this case the UpstreamParameters cache
             // does not have parameters for the k_DEFAULT_SUBQUEUE_ID.
-            logSeverity = ball::Severity::INFO;
+            logSeverity = ball::Severity::e_INFO;
 
             // Consider this queue successfully reopen
             notifyQueue(queueContext.get(),

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
@@ -287,7 +287,7 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
     NotificationEvaluator notifications(bmqtst::TestHelperUtil::allocator());
 
@@ -350,7 +350,7 @@ static void test2_checkAlarmsWithResetTest()
 {
     bmqtst::TestHelper::printTestName("CHECK ALARMS WITH RESET");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
     NotificationEvaluator notifications(bmqtst::TestHelperUtil::allocator());
 
@@ -571,7 +571,7 @@ static void test3_alwaysInvalidStateTest()
 {
     bmqtst::TestHelper::printTestName("ALWAYS INVALID STATE");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
     NotificationEvaluator notifications(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -188,7 +188,7 @@ BMQTST_TEST_F(Test, doNotMonitor)
 {
     putMessage();
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_INFO,
                                        bmqtst::TestHelperUtil::allocator());
 
     d_monitor.registerSubStream(d_id);
@@ -214,7 +214,7 @@ BMQTST_TEST_F(Test, emptyQueue)
 // Plan: Start monitoring, make time pass, state should remain ALIVE.
 // ------------------------------------------------------------------------
 {
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
     size_t                    expectedLogRecords = 0U;
 
@@ -247,7 +247,7 @@ BMQTST_TEST_F(Test, putAliveIdleSendAlive)
 // pass, check that state remains 'alive'.
 // ------------------------------------------------------------------------
 {
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
     size_t                    expectedLogRecords = 0U;
 
@@ -360,7 +360,7 @@ BMQTST_TEST_F(Test, changeMaxIdleTime)
     BMQTST_ASSERT_EQ(d_monitor.state(d_id),
                      QueueConsumptionMonitor::State::e_IDLE);
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     d_monitor.setMaxIdleTime(k_MAX_IDLE_TIME * 2);
@@ -402,7 +402,7 @@ BMQTST_TEST_F(Test, reset)
     BMQTST_ASSERT_EQ(d_monitor.state(d_id),
                      QueueConsumptionMonitor::State::e_ALIVE);
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     d_monitor.reset();
@@ -422,7 +422,7 @@ BMQTST_TEST_F(Test, putAliveIdleSendAliveTwoSubstreams)
 // pass, check that state remains 'alive'.
 // ------------------------------------------------------------------------
 {
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     const bsls::Types::Int64 k_MAX_IDLE_TIME = 10;
@@ -533,7 +533,7 @@ BMQTST_TEST_F(Test, usage)
 {
 #define monitor d_monitor
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::INFO,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_INFO,
                                           bmqtst::TestHelperUtil::allocator());
 
     monitor.setMaxIdleTime(20);
@@ -590,10 +590,10 @@ int main(int argc, char* argv[])
     bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     ball::LoggerManager::singleton().setDefaultThresholdLevels(
-        ball::Severity::OFF,
-        ball::Severity::INFO,
-        ball::Severity::OFF,
-        ball::Severity::OFF);
+        ball::Severity::e_OFF,
+        ball::Severity::e_INFO,
+        ball::Severity::e_OFF,
+        ball::Severity::e_OFF);
     {
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -1219,8 +1219,8 @@ void RemoteQueue::onAckMessageDispatched(const mqbi::DispatcherAckEvent& event)
 
         ball::Severity::Level severity = (ackResult ==
                                                   bmqt::AckResult::e_SUCCESS
-                                              ? ball::Severity::DEBUG
-                                              : ball::Severity::INFO);
+                                              ? ball::Severity::e_DEBUG
+                                              : ball::Severity::e_INFO);
 
         if (d_throttledFailedAckMessages.requestPermission()) {
             BALL_LOG_STREAM(severity)

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -2073,7 +2073,7 @@ static void test15_priorityReleaseActiveConsumerWithoutNullReconfigure()
     bmqtst::TestHelper::printTestName("RELEASE ACTIVE CONSUMER WITHOUT NULL"
                                       " RECONFIGURE");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
@@ -2173,7 +2173,7 @@ static void test16_priorityReleaseDormantConsumerWithoutNullReconfigure()
     bmqtst::TestHelper::printTestName("RELEASE DORMANT CONSUMER WITHOUT NULL"
                                       " RECONFIGURE");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -44,7 +44,7 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
 
     mqbnet::Cluster::NodesList nodes;
@@ -65,7 +65,7 @@ static void test2_activeNodeWithinDC()
 {
     bmqtst::TestHelper::printTestName("ACTIVE NODE IN SAME DC");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
 
     // Set up mock cluster
@@ -157,7 +157,7 @@ static void test3_activeNodeOutsideDC()
 {
     bmqtst::TestHelper::printTestName("ACTIVE NDOE OUTSIDE DC");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
 
     // Set up mock cluster
@@ -235,7 +235,7 @@ static void test4_panicInExtendedMode()
 {
     bmqtst::TestHelper::printTestName("ACTIVE NDOE OUTSIDE DC");
 
-    bmqtst::ScopedLogObserver logObserver(ball::Severity::ERROR,
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
                                           bmqtst::TestHelperUtil::allocator());
 
     // Set up mock cluster

--- a/src/groups/mqb/mqbstat/mqbstat_printer.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.cpp
@@ -286,7 +286,7 @@ void Printer::logStats()
     attributes.setFileName(__FILE__);
     attributes.setLineNumber(__LINE__);
     attributes.setCategory(k_LOG_CATEGORY);
-    attributes.setSeverity(ball::Severity::INFO);
+    attributes.setSeverity(ball::Severity::e_INFO);
 
     // Dump stats into bmqbrkr.stats.log
     attributes.clearMessage();

--- a/src/groups/mqb/mqbu/mqbu_capacitymeter.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_capacitymeter.t.cpp
@@ -115,7 +115,7 @@ static void test2_logStateChange()
         PV("STATE - NORMAL");
 
         bmqtst::ScopedLogObserver observer(
-            ball::Severity::WARN,
+            ball::Severity::e_WARN,
             bmqtst::TestHelperUtil::allocator());
         mqbu::CapacityMeter capacityMeter("dummy",
                                           bmqtst::TestHelperUtil::allocator());
@@ -134,7 +134,7 @@ static void test2_logStateChange()
         PV("STATE - HIGH WATERMARK");
 
         bmqtst::ScopedLogObserver observer(
-            ball::Severity::WARN,
+            ball::Severity::e_WARN,
             bmqtst::TestHelperUtil::allocator());
         mqbu::CapacityMeter capacityMeter("dummy",
                                           bmqtst::TestHelperUtil::allocator());
@@ -159,7 +159,7 @@ static void test2_logStateChange()
 
         const ball::Record& record = observer.records()[0];
         BMQTST_ASSERT_EQ(record.fixedFields().severity(),
-                         ball::Severity::ERROR);
+                         ball::Severity::e_ERROR);
 
         BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
             record,
@@ -177,7 +177,7 @@ static void test2_logStateChange()
         PV("STATE - FULL");
 
         bmqtst::ScopedLogObserver observer(
-            ball::Severity::WARN,
+            ball::Severity::e_WARN,
             bmqtst::TestHelperUtil::allocator());
         mqbu::CapacityMeter capacityMeter("dummy",
                                           bmqtst::TestHelperUtil::allocator());
@@ -190,7 +190,7 @@ static void test2_logStateChange()
         BMQTST_ASSERT_EQ(observer.records().size(), 1U);
 
         BMQTST_ASSERT_EQ(observer.records()[0].fixedFields().severity(),
-                         ball::Severity::ERROR);
+                         ball::Severity::e_ERROR);
         BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
             observer.records()[0],
             "ALARM \\[CAPACITY_STATE_FULL\\]",
@@ -208,7 +208,7 @@ static void test2_logStateChange()
         PV("STATE - HIGH WATERMARK TO FULL");
 
         bmqtst::ScopedLogObserver observer(
-            ball::Severity::WARN,
+            ball::Severity::e_WARN,
             bmqtst::TestHelperUtil::allocator());
         mqbu::CapacityMeter capacityMeter("dummy",
                                           bmqtst::TestHelperUtil::allocator());
@@ -231,7 +231,7 @@ static void test2_logStateChange()
             "dummy.*Messages.*HIGH_WATERMARK",
             bmqtst::TestHelperUtil::allocator()));
         BMQTST_ASSERT_EQ(observer.records()[0].fixedFields().severity(),
-                         ball::Severity::ERROR);
+                         ball::Severity::e_ERROR);
 
         PVV("Commit resources -> Full");
         capacityMeter.commitUnreserved(k_MSGS_LIMIT -
@@ -284,7 +284,7 @@ static void test3_enhancedLog()
     const bsls::Types::Int64 k_BYTES_HIGH_WATERMARK_VALUE = k_BYTES_LIMIT *
                                                             k_BYTES_THRESHOLD;
 
-    bmqtst::ScopedLogObserver observer(ball::Severity::WARN,
+    bmqtst::ScopedLogObserver observer(ball::Severity::e_WARN,
                                        bmqtst::TestHelperUtil::allocator());
     mqbu::CapacityMeter       capacityMeter(
         "dummy",
@@ -311,7 +311,7 @@ static void test3_enhancedLog()
     BMQTST_ASSERT_EQ(observer.records().size(), 1U);
 
     const ball::Record& record = observer.records()[0];
-    BMQTST_ASSERT_EQ(record.fixedFields().severity(), ball::Severity::ERROR);
+    BMQTST_ASSERT_EQ(record.fixedFields().severity(), ball::Severity::e_ERROR);
 
     BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
         record,

--- a/src/tutorials/advanced/consumer.cpp
+++ b/src/tutorials/advanced/consumer.cpp
@@ -702,7 +702,7 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     // Set up logging with output to the console and verbosity set to
     // INFO-level.  This way we will get logs from the BlazingMQ SDK.
     const bsl::string           logFormat = "%d (%t) %c %s [%F:%l] %m\n";
-    const ball::Severity::Level level     = ball::Severity::INFO;
+    const ball::Severity::Level level     = ball::Severity::e_INFO;
 
     ball::FileObserver observer;
     observer.disableFileLogging();
@@ -710,10 +710,10 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     observer.setStdoutThreshold(level);
 
     ball::LoggerManagerConfiguration config;
-    config.setDefaultThresholdLevelsIfValid(ball::Severity::OFF,
+    config.setDefaultThresholdLevelsIfValid(ball::Severity::e_OFF,
                                             level,
-                                            ball::Severity::OFF,
-                                            ball::Severity::OFF);
+                                            ball::Severity::e_OFF,
+                                            ball::Severity::e_OFF);
 
     ball::LoggerManagerScopedGuard manager(&observer, config);
     BALL_LOG_SET_CATEGORY("CONSUMER.MAIN");

--- a/src/tutorials/advanced/producer.cpp
+++ b/src/tutorials/advanced/producer.cpp
@@ -842,7 +842,7 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     // Set up logging with output to the console and verbosity set to
     // INFO-level.  This way we will get logs from the BlazingMQ SDK.
     const bsl::string           logFormat = "%d (%t) %c %s [%F:%l] %m\n";
-    const ball::Severity::Level level     = ball::Severity::INFO;
+    const ball::Severity::Level level     = ball::Severity::e_INFO;
 
     ball::FileObserver observer;
     observer.disableFileLogging();
@@ -850,10 +850,10 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     observer.setStdoutThreshold(level);
 
     ball::LoggerManagerConfiguration config;
-    config.setDefaultThresholdLevelsIfValid(ball::Severity::OFF,
+    config.setDefaultThresholdLevelsIfValid(ball::Severity::e_OFF,
                                             level,
-                                            ball::Severity::OFF,
-                                            ball::Severity::OFF);
+                                            ball::Severity::e_OFF,
+                                            ball::Severity::e_OFF);
 
     ball::LoggerManagerScopedGuard manager(&observer, config);
 

--- a/src/tutorials/subscriptions/consumer.cpp
+++ b/src/tutorials/subscriptions/consumer.cpp
@@ -792,7 +792,7 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     // Set up logging with output to the console and verbosity set to
     // INFO-level.  This way we will get logs from the BlazingMQ SDK.
     const bsl::string           logFormat = "%d (%t) %c %s [%F:%l] %m\n";
-    const ball::Severity::Level level     = ball::Severity::INFO;
+    const ball::Severity::Level level     = ball::Severity::e_INFO;
 
     ball::FileObserver observer;
     observer.disableFileLogging();
@@ -800,10 +800,10 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     observer.setStdoutThreshold(level);
 
     ball::LoggerManagerConfiguration config;
-    config.setDefaultThresholdLevelsIfValid(ball::Severity::OFF,
+    config.setDefaultThresholdLevelsIfValid(ball::Severity::e_OFF,
                                             level,
-                                            ball::Severity::OFF,
-                                            ball::Severity::OFF);
+                                            ball::Severity::e_OFF,
+                                            ball::Severity::e_OFF);
 
     ball::LoggerManagerScopedGuard manager(&observer, config);
     BALL_LOG_SET_CATEGORY("CONSUMER.MAIN");

--- a/src/tutorials/subscriptions/producer.cpp
+++ b/src/tutorials/subscriptions/producer.cpp
@@ -856,7 +856,7 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     // Set up logging with output to the console and verbosity set to
     // INFO-level.  This way we will get logs from the BlazingMQ SDK.
     const bsl::string           logFormat = "%d (%t) %c %s [%F:%l] %m\n";
-    const ball::Severity::Level level     = ball::Severity::INFO;
+    const ball::Severity::Level level     = ball::Severity::e_INFO;
 
     ball::FileObserver observer;
     observer.disableFileLogging();
@@ -864,10 +864,10 @@ int main(BSLS_ANNOTATION_UNUSED int         argc,
     observer.setStdoutThreshold(level);
 
     ball::LoggerManagerConfiguration config;
-    config.setDefaultThresholdLevelsIfValid(ball::Severity::OFF,
+    config.setDefaultThresholdLevelsIfValid(ball::Severity::e_OFF,
                                             level,
-                                            ball::Severity::OFF,
-                                            ball::Severity::OFF);
+                                            ball::Severity::e_OFF,
+                                            ball::Severity::e_OFF);
 
     ball::LoggerManagerScopedGuard manager(&observer, config);
 


### PR DESCRIPTION
The changes in commit bb9886c1aef0994f692836814ccb1e19b6be42b5 are meant to fix deprecation warnings from later versions of BDE than our CI builds with.  However, this commit does not apply the change globally, so we still get these warnings; furthermore it causes test failures when building against BDE versions as well.

This patch applies the change globally across the entire project.