### PR TITLE
fix: enable early exit in RelayQE

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -619,9 +619,18 @@ Routers::Result Routers::AppContext::selectConsumer(
         }
     }
     if (group) {
-        return d_router.iterateSubscriptions(visitor, *group)
-                   ? e_SUCCESS
-                   : e_NO_CAPACITY;  // RETURN
+        if (!group->d_canDeliver) {
+            // Another option is to 'iterateGroups'
+            return e_NO_CAPACITY_ALL;  // RETURN
+        }
+        if (d_router.iterateSubscriptions(visitor, *group)) {
+            return e_SUCCESS;
+        }
+        else {
+            group->d_canDeliver = false;
+
+            return e_NO_CAPACITY;  // RETURN
+        }
     }
     else {
         return d_router.iterateGroups(visitor);  // RETURN

--- a/src/integration-tests/test_maxunconfirmed.py
+++ b/src/integration-tests/test_maxunconfirmed.py
@@ -22,6 +22,8 @@ from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
 )
 from blazingmq.dev.it.process.client import Client
 
+from blazingmq.dev.it.util import wait_until
+
 pytestmark = order(4)
 
 
@@ -95,3 +97,103 @@ class TestMaxunconfirmed:
         # Consumer gets just 1
         self.consumer.wait_push_event()
         assert len(self.consumer.list(uri_priority, block=True)) == 1
+
+
+def test_stuck_downstream(multi_node: Cluster, domain_urls: tc.DomainUrls):
+    """
+    Consider 10 consumers with 10 as maxUnconfirmed threshold; combined 100.
+    The delivery to individual consumer starts when number of unconfirmed
+    messages is less or equal to 8 (80% of 10);
+    The delivery to Proxy starts when the number is less or equal to 80 (80% of
+    100).
+    Consider uneven data consumption by consumers. 8 consumers have 9 pending
+    messages each, another one has 8 and the last one has 0.  The total is 80
+    and that is enough for the Primary to send 20 messages.  Upon receipt, the
+    first 8 consumers are already full, the other two get 2 and 10 messages
+    respectively. And Proxy is left with 8 undelivered messages.
+    Those messages should NOT go into the linear put-aside list.
+    """
+    uri = domain_urls.uri_priority
+
+    proxy = next(multi_node.proxy_cycle())
+    producer = proxy.create_client("producer")
+
+    producer.open(uri, flags=["write,ack"], succeed=True)
+
+    # open 10 consumers
+    consumers = {}
+    for i in range(0, 10):
+        consumer = proxy.create_client(f"consumer_{i}")
+
+        consumer.open(uri, flags=["read"], succeed=True, max_unconfirmed_messages=10)
+
+        consumers[i] = consumer
+
+    # post 100 messages
+    for i in range(0, 100):
+        assert (
+            producer.post(
+                uri, payload=["set#1"], wait_ack=True, block=True, succeed=True
+            )
+            == Client.e_SUCCESS
+        )
+
+    # all 10 consumers are full
+    # pylint: disable=cell-var-from-loop
+    for i in range(0, 10):
+        assert wait_until(lambda: len(consumers[i].list(uri, block=True)) == 10, 3)
+
+    # confirm 20 messages (8*1 + 2 + 10), leaving 80 messages
+    for i in range(0, 8):
+        consumers[i].confirm(uri, "+1", succeed=True)
+
+    consumers[8].confirm(uri, "+2", succeed=True)
+    consumers[9].confirm(uri, "+10", succeed=True)
+
+    leader = multi_node.last_known_leader
+
+    # 80 messages are unconfirmed
+    leader.list_messages(domain_urls.domain_priority, tc.TEST_QUEUE, 0, 100)
+    assert leader.outputs_substr("Printing 80 message(s)", 5)
+
+    # post 20 messages which go straight to the proxy
+    # pylint: disable=cell-var-from-loop
+    for i in range(0, 20):
+        assert (
+            producer.post(
+                uri, payload=["set#2"], wait_ack=True, block=True, succeed=True
+            )
+            == Client.e_SUCCESS
+        )
+
+    # but proxy cannot deliver 8 messages (to the first 8 consumers)
+    early_exit_message = r"appId = \'(\w+)\' does not have any subscription capacity; early exits delivery"
+    assert proxy.capture(early_exit_message, timeout=5)
+
+    # the distrubution is this: 8 * 9 + 10 + 10 (92)
+    assert wait_until(lambda: len(consumers[8].list(uri, block=True)) == 10, 3)
+    assert wait_until(lambda: len(consumers[9].list(uri, block=True)) == 10, 3)
+
+    # pylint: disable=cell-var-from-loop
+    for i in range(0, 8):
+        assert wait_until(lambda: len(consumers[i].list(uri, block=True)) == 9, 3)
+
+    # confirm all
+    for i in range(0, 10):
+        consumers[i].confirm(uri, "*", succeed=True)
+
+    # one more round of confirms for messages deleivered after the first round
+    for i in range(0, 10):
+        consumers[i].confirm(uri, "*", succeed=True)
+
+    # The bmqtool does not actually wait and check that confirm command was
+    # completed: 'success' is returned just when the command is enqueued
+    # for send in bmqtool.
+    # We need a strong guarantee that confirm was executed on the primary
+    # node of the cluster. For that reason we open the same queue for write
+    # and close it right away.
+
+    producer.close(uri, succeed=True)
+
+    leader.list_messages(domain_urls.domain_priority, tc.TEST_QUEUE, 0, 100)
+    assert leader.outputs_substr("Printing 0 message(s)", 5)


### PR DESCRIPTION
    Consider 10 consumers with 10 as maxUnconfirmed threshold; combined 100.  
    The delivery to individual consumer starts when number of unconfirmed 
    messages is less or equal to 8 (80% of 10); 
    The delivery to Proxy starts when the number is less or equal to 80 (80% of
    100).
    Consider uneven data consumption by consumers. 8 consumers have 9 pending 
    messages each, another one has 8 and the last one has 0.  The total is 80
    and that is enough for the Primary to send 20 messages.  Upon receipt, the
    first 8 consumers are already full, the other two get 2 and 10 messages
    respectively. And Proxy is left with 8 undelivered messages.  
    Those messages should NOT go into the linear put-aside list.  

