### PR TITLE
Fix: Remove incorrect casts

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -294,9 +294,8 @@ static int getConfig(bsl::ostream&      errorDescription,
                          << "generated config file (first 1024 characters):\n"
                          << taskEnv->d_configJson.substr(
                                 0,
-                                bsl::min(1024,
-                                         static_cast<int>(
-                                             taskEnv->d_configJson.length())));
+                                bsl::min(bsl::string::size_type(1024),
+                                         taskEnv->d_configJson.length()));
         return rc_DECODE_FAILED;  // RETURN
     }
 


### PR DESCRIPTION
This patch removes a narrowing static cast from `bsl::string::size_type`
to `int` which could cause an invalid configuration of sufficient length
to print an arbitrarily long error message.

When an invalid configuration is detected in the current behavior, we
statically cast its length from
`bsl::string::size_type` (a.k.a. `bsl::size_t`) to `int`.  If the JSON
configuration is too large, the results of this are implementation
defined; on many common implementations, though, this may result in a
negative `int`, depending on the exact length of the configuration.  We
then use `bsl::min` to limit it to a maximum of 1024, with the type of
the integral literal `1024` deduced to `int`.  If the casted `int` is
negative, it is propagated through.  Finally, we pass the
resulting `int` to a function that expects a `bsl::string::size_type`
again, causing another implementation-defined conversion.  Here again,
if the `int` is negative, we may get a very large value.  The
combination of a narrowing cast and the conversions between `unsigned`
and `signed` integers cause this pernitious behavior.

Instead of a cast and extra type conversions, this patch makes the
integral literal have the type `bsl::string::size_type`.  The value 1024
is representable with this type, so this is safe.  As a result, there
are no casts or other conversions, and the entire operation is done in
the input and result type `bsl::string::size_type`, avoiding this bug.
