### PR TITLE
CI: do not cache UT binaries in GH Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -330,7 +330,7 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64 \
             -DINSTALL_TARGETS="prometheus;bmqbrkr;bmqtool"
-          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool
+          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool bmqbrkr_plugins
 
       - name: Create prometheus dir
         run:  mkdir -p prometheus_dir

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -330,7 +330,7 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64 \
             -DINSTALL_TARGETS="prometheus;bmqbrkr;bmqtool"
-          cmake --build build/blazingmq --parallel 8 --target prometheus bmqbrkr bmqtool
+          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool
 
       - name: Create prometheus dir
         run:  mkdir -p prometheus_dir

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
             -DBDE_BUILD_TARGET_CPP17=ON \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64
-          cmake --build build/blazingmq --parallel 8 --target all
+          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool
 
       - name: Clean-up build directories before caching
         run: |
@@ -330,7 +330,7 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64 \
             -DINSTALL_TARGETS="prometheus;bmqbrkr;bmqtool"
-          cmake --build build/blazingmq --parallel 8 --target all
+          cmake --build build/blazingmq --parallel 8 --target prometheus bmqbrkr bmqtool
 
       - name: Create prometheus dir
         run:  mkdir -p prometheus_dir

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -330,7 +330,7 @@ jobs:
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/deps/srcs/bde-tools/BdeBuildSystem \
             -DCMAKE_INSTALL_LIBDIR=lib64 \
             -DINSTALL_TARGETS="prometheus;bmqbrkr;bmqtool"
-          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool bmqbrkr_plugins
+          cmake --build build/blazingmq --parallel 8 --target bmqbrkr bmqtool bmqprometheus
 
       - name: Create prometheus dir
         run:  mkdir -p prometheus_dir


### PR DESCRIPTION
Follow up after this PR https://github.com/bloomberg/blazingmq/pull/707
Adding `all.t` to `all` makes us build UTs in workflow steps where we didn't intend to build UTs. We also cache these built UTs and it takes a lot of cache.
This PR removes usage of `all` target in workflows and changes it to specific targets.