### PR TITLE
Fix: remove trailing NOTICE footers from src files

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.t.cpp
@@ -541,6 +541,3 @@ int main(int argc, char* argv[])
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ----------------------------------------------------------------------------
-// NOTICE:

--- a/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.t.cpp
@@ -814,6 +814,3 @@ int main(int argc, char** argv)
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ---------------------------------------------------------------------------
-// NOTICE:

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -1133,6 +1133,3 @@ int main(int argc, char* argv[])
 #endif
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ----------------------------------------------------------------------------
-// NOTICE:

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.t.cpp
@@ -2347,6 +2347,3 @@ int main(int argc, char* argv[])
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ----------------------------------------------------------------------------
-// NOTICE:

--- a/src/groups/bmq/bmqsys/bmqsys_time.t.cpp
+++ b/src/groups/bmq/bmqsys/bmqsys_time.t.cpp
@@ -424,6 +424,3 @@ int main(int argc, char* argv[])
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ----------------------------------------------------------------------------
-// NOTICE:

--- a/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.t.cpp
@@ -612,6 +612,3 @@ int main(int argc, char* argv[])
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }
-
-// ----------------------------------------------------------------------------
-// NOTICE:


### PR DESCRIPTION
**Describe your changes**
These look like legacy copyright footers or something, they can be removed.