### PR TITLE
CI: do not brew install existing packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -265,11 +265,9 @@ jobs:
         run: |
           brew install \
             bison \
-            curl \
             flex \
             google-benchmark \
             googletest \
-            ninja \
             python@3.10 \
             zlib
 


### PR DESCRIPTION
```
Build [macosx_arm64]
curl 8.13.0 is already installed and up-to-date. To reinstall 8.13.0, run: brew reinstall curl
Build [macosx_arm64]
ninja 1.12.1 is already installed and up-to-date. To reinstall 1.12.1, run: brew reinstall ninja
```