### PR TITLE
Fix[MQB]: fix queue assignment capacity late update in CSL mode

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -440,7 +440,7 @@ class ClusterState {
     typedef UriToQueueInfoMap::iterator                UriToQueueInfoMapIter;
     typedef UriToQueueInfoMap::const_iterator          UriToQueueInfoMapCIter;
 
-    struct DomainState {
+    struct DomainState BSLS_KEYWORD_FINAL {
       private:
         // DATA
         int               d_numAssignedQueues;
@@ -455,7 +455,7 @@ class ClusterState {
 
         /// Create a new DomainState using the specified `allocator` for
         /// memory allocations.
-        DomainState(bslma::Allocator* allocator);
+        explicit DomainState(bslma::Allocator* allocator);
 
         // MANIPULATORS
 

--- a/src/integration-tests/test_maxqueues.py
+++ b/src/integration-tests/test_maxqueues.py
@@ -148,8 +148,8 @@ class TestMaxQueues:
     @start_cluster(False)
     def test_max_queue_restore(self, multi_node: Cluster, domain_urls: tc.DomainUrls):
         du = domain_urls
-        [q1, q2, q3, q4, q5, q6, q7, q8, q9] = [
-            f"bmq://{du.domain_priority}/q{i}" for i in range(9)
+        [q1, q2, q3, q4, q5, q6, q7] = [
+            f"bmq://{du.domain_priority}/q{i}" for i in range(7)
         ]
 
         cluster = multi_node


### PR DESCRIPTION
# PR Changes

- `ClusterUtil::assignQueue`: reordered preconditions checks. First, we check if the domain is built and good. After this, we check if we have a queue state built.
- Made more clear early returns if queue state exists already, and queue is in the process of assigning, assigned or being unassigned.
- Do not use `num_assigned` counter to decide if we can assign a new queue. Instead, look at the current number of allocated queue infos.


# IT Failure

We first observed a failure in integration test, we allow to assign 6 queues when we have a limit of 5 queues for this domain:

```
=========================== short test summary info ============================
FAILED test_maxqueues.py::TestMaxQueues::test_max_queue_restore[multi_node_fsm-eventual_consistency] - assert [-6, 0, 0, 0, 0, 0, ...] == [-6, -6, 0, 0, 0, 0, ...]
```

# Bug description

1. Assignment starts in `ClusterUtil::processQueueAssignmentRequest` when we have a **CLUSTER** dispatcher event. It is executed on the sole cluster thread on the current primary (if it's not a primary, the assignment request is refused with an error code).

2. There, we call `ClusterUtil::assignQueue`:

```
    assignQueue(clusterState,
                clusterData,
                ledger,
                cluster,
                uri,
                allocator,
                &status);

    clusterData->messageTransmitter().sendMessage(response, requester);
    // end
}
```

3. Within `ClusterUtil::assignQueue` we check if we have capacity to assign +1 queue to this domain:

```
    const int registeredQueues = domIt->second->numAssignedQueues();
    const int maxQueues        = domIt->second->domain()->config().maxQueues();
    if (maxQueues != 0) {
        const int requestedQueues = registeredQueues + 1;
        if (requestedQueues > maxQueues) {
            local::panic(domIt->second->domain());
        }
    // ...
```

4. Note that `ClusterState::DomainState::numAssignedQueues()` uses an internal variable `d_numAssignedQueues` that is updated only with `ClusterState::DomainState::adjustQueueCount(int by)`.

5. After verifying that we have enough capacity to open a new queue (on the previous step 4), we set the state for this queue to `k_ASSIGNING`.

And now we have difference between non-CSL and CSL:

- For non-CSL mode, we update `d_numAssignedQueues` right away in `clusterState->assignQueue`. We don't have problems in this case. If we have another assign queue request right after this one, we will have a correct counter `domIt->second->numAssignedQueues()`. 

- For CSL mode we only call `ledger->apply(queueAdvisory)` and return OK for the assignment request. After this, we finish processing this **CLUSTER** dispatcher event without updating `d_numAssignedQueues` counter. The counter for this queue will be updated in another **CLUSTER** dispatcher event when we commit queue assignment advisory. **BUG**: after the initial **CLUSTER** queue assignment event and the event that updates the counter we can have intermediate queue assignment events that will check `d_numAssignedQueues` counter, and this counter was not updated yet! It allows to assign more queues than the configured maximum for this domain.

Example timeline (**CLUSTER** thread):
```
[Configure domain max queues == 5]                ->

[Assign Queue "foo" Request]                      ->
[d_numAssignedQueues == 4 is less than maximum 5] ->
[Set state "foo": k_ASSIGNING]                    ->

[Assign Queue "bar" Request]                      ->
[d_numAssignedQueues == 4 is less than maximum 5] ->
[Set state "bar": k_ASSIGNING]                    ->

[Commit queue assignment advisory for "foo"]      ->
[Set state "foo": k_ASSIGNED]                     ->
["foo": d_numAssignedQueues++]                    ->

[Commit queue assignment advisory for "bar"]      ->
[Set state "bar": k_ASSIGNED]                     ->
["bar": d_numAssignedQueues++]                    ->

[d_numAssignedQueues == 6 now, we allowed to assign more queues than configured maximum 5]
```

# Solution

We have a container associated with a domain that holds allocated queue infos: `domIt->second->queuesInfo()`.
In fact this container holds queues that are in `k_ASSIGNED` and `k_ASSIGNING` states, so we can use this container's size as a measure to limit the number of assigning queues.