### PR TITLE
Fix[bmqeval]: Fix or silence warnings in bmqeval

### DIFF
--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -94,10 +94,12 @@ find_package(BISON 3 REQUIRED)
 
 BISON_TARGET(SimpleEvaluatorParser
              bmqeval/bmqeval_simpleevaluatorparser.y
-             ${CMAKE_CURRENT_BINARY_DIR}/bmqeval_simpleevaluatorparser.cpp)
+             ${CMAKE_CURRENT_BINARY_DIR}/bmqeval_simpleevaluatorparser.cpp
+             COMPILE_FLAGS -Wall)
 FLEX_TARGET(SimpleEvaluatorScanner
             bmqeval/bmqeval_simpleevaluatorscanner.l
-            ${CMAKE_CURRENT_BINARY_DIR}/bmqeval_simpleevaluatorscanner.cpp)
+            ${CMAKE_CURRENT_BINARY_DIR}/bmqeval_simpleevaluatorscanner.cpp
+            COMPILE_FLAGS --warn)
 ADD_FLEX_BISON_DEPENDENCY(SimpleEvaluatorScanner SimpleEvaluatorParser)
 
 target_sources(bmqeval-iface

--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -104,6 +104,13 @@ target_sources(bmqeval-iface
                PRIVATE
                ${BISON_SimpleEvaluatorParser_OUTPUTS}
                ${FLEX_SimpleEvaluatorScanner_OUTPUTS})
+target_compile_options(bmqeval-iface PRIVATE
+    $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:
+        -Wno-unused-macros
+        -Wno-old-style-cast
+        -Wno-switch-default
+        -Wno-unused-but-set-variable
+        -Wno-unreachable-code-break>)
 
 target_include_directories(bmqeval-iface SYSTEM PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${FLEX_INCLUDE_DIRS})
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -43,39 +43,43 @@ class MockPropertiesReader : public PropertiesReader {
     bsl::unordered_map<bsl::string, bdld::Datum> d_map;
 
     // CREATORS
-    MockPropertiesReader(bslma::Allocator* allocator)
-    : d_map(allocator)
-    {
-        d_map["b_true"]  = bdld::Datum::createBoolean(true);
-        d_map["b_false"] = bdld::Datum::createBoolean(false);
-        d_map["i_0"]     = bdld::Datum::createInteger(0);
-        d_map["i_1"]     = bdld::Datum::createInteger(1);
-        d_map["i_2"]     = bdld::Datum::createInteger(2);
-        d_map["i_3"]     = bdld::Datum::createInteger(3);
-        d_map["i_42"]    = bdld::Datum::createInteger(42);
-        d_map["i64_42"]  = bdld::Datum::createInteger64(42, allocator);
-        d_map["s_foo"]   = bdld::Datum::createStringRef("foo", allocator);
-        d_map["exists"]  = bdld::Datum::createInteger(42);
-    }
-    // Destroy this object.
+    MockPropertiesReader(bslma::Allocator* allocator);
 
     // MANIPULATORS
 
     /// Return a `bdld::Datum` object with value for the specified `name`.
     /// The `bslma::Allocator*` argument is unused.
     bdld::Datum get(const bsl::string& name,
-                    bslma::Allocator*) BSLS_KEYWORD_OVERRIDE
-    {
-        bsl::unordered_map<bsl::string, bdld::Datum>::const_iterator iter =
-            d_map.find(name);
-
-        if (iter == d_map.end()) {
-            return bdld::Datum::createError(-1);  // RETURN
-        }
-
-        return iter->second;
-    }
+                    bslma::Allocator*) BSLS_KEYWORD_OVERRIDE;
 };
+
+MockPropertiesReader::MockPropertiesReader(bslma::Allocator* allocator)
+: d_map(allocator)
+{
+    d_map["b_true"]  = bdld::Datum::createBoolean(true);
+    d_map["b_false"] = bdld::Datum::createBoolean(false);
+    d_map["i_0"]     = bdld::Datum::createInteger(0);
+    d_map["i_1"]     = bdld::Datum::createInteger(1);
+    d_map["i_2"]     = bdld::Datum::createInteger(2);
+    d_map["i_3"]     = bdld::Datum::createInteger(3);
+    d_map["i_42"]    = bdld::Datum::createInteger(42);
+    d_map["i64_42"]  = bdld::Datum::createInteger64(42, allocator);
+    d_map["s_foo"]   = bdld::Datum::createStringRef("foo", allocator);
+    d_map["exists"]  = bdld::Datum::createInteger(42);
+}
+
+bdld::Datum MockPropertiesReader::get(const bsl::string& name,
+                                      bslma::Allocator*)
+{
+    bsl::unordered_map<bsl::string, bdld::Datum>::const_iterator iter =
+        d_map.find(name);
+
+    if (iter == d_map.end()) {
+        return bdld::Datum::createError(-1);  // RETURN
+    }
+
+    return iter->second;
+}
 
 #ifdef BSLS_PLATFORM_OS_LINUX
 static void testN1_SimpleEvaluator_GoogleBenchmark(benchmark::State& state)
@@ -219,7 +223,7 @@ static void test1_compilationErrors()
         {
             CompilationContext compilationContext(
                 bmqtst::TestHelperUtil::allocator());
-            SimpleEvaluator    evaluator;
+            SimpleEvaluator evaluator;
 
             evaluator.compile(parameters->expression, compilationContext);
             PV(compilationContext.lastErrorMessage());
@@ -545,7 +549,7 @@ static void test3_evaluation()
 
         CompilationContext compilationContext(
             bmqtst::TestHelperUtil::allocator());
-        SimpleEvaluator    evaluator;
+        SimpleEvaluator evaluator;
 
         BMQTST_ASSERT(!evaluator.isValid());
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -474,13 +474,26 @@ static void test3_evaluation()
 
         // logical operators
         {"!b_true", false},
+        {"!!b_true", true},
+        {"!~b_true", true},
+        {"~!b_true", true},
+        {"~~b_true", true},
         {"~b_true", false},
         {"b_true && i64_42 == 42", true},
         {"b_true || i64_42 != 42", true},
         // precedence
         {"!(i64_42 == 42)", false},
+        {"!!(i64_42 == 42)", true},
         {"b_false && b_false || b_true", true},
         {"b_false && (b_false || b_true)", false},
+        {"!b_false && b_false", false},
+        {"!b_false && b_true", true},
+        {"!(b_false && b_false)", true},
+        {"!(b_false && b_true)", true},
+        {"!b_false || b_false", true},
+        {"!b_false || b_true", true},
+        {"!(b_false || b_false)", true},
+        {"!(b_false || b_true)", false},
 
         // type mismatch yields 'runtimeErrorResult' (see above)
         {"s_foo == 42", runtimeErrorResult},

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
@@ -13,6 +13,10 @@
 %define api.namespace { BloombergLP::bmqeval }
 %code requires
 {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wsuggest-destructor-override"
+    #pragma clang diagnostic ignored "-Wswitch-enum"
+
     #include <bsl_functional.h>
     #include <string>
     #include <bmqeval_simpleevaluator.h>
@@ -177,3 +181,5 @@ expression
 void SimpleEvaluatorParser::error(const std::string& message) {
     ctx.d_os << message << " at offset " << scanner.lastTokenLocation();
 }
+
+#pragma clang diagnostic pop

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
@@ -75,6 +75,7 @@
 %token PLUS "+" MINUS "-";
 %token TIMES "*" DIVIDES "/" MODULUS "%";
 %token EQ "=" NE "<>" LT "<" LE "<=" GE ">=" GT ">";
+%token NOT "!";
 %token <bsl::string> EXISTS "exists";
 
 %left OR;
@@ -83,7 +84,7 @@
 %left LT LE GE GT;
 %left PLUS MINUS;
 %left TIMES DIVIDES MODULUS;
-%right NOT "!";
+%precedence NOT;
 
 %type<bsl::string> variable;
 %type<SimpleEvaluator::ExpressionPtr> expression;
@@ -168,7 +169,7 @@ expression
         { $$ = ctx.makeNumBinaryExpression<bsl::divides>($1, $3); }
     | expression MODULUS expression
         { $$ = ctx.makeNumBinaryExpression<bsl::modulus>($1, $3); }
-    | MINUS %prec NOT expression
+    | MINUS expression %prec NOT
         { $$ = ctx.makeUnaryExpression<SimpleEvaluator::UnaryMinus>($2); }
     | LPAR expression RPAR
         { $$ = $2; }

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
@@ -50,10 +50,6 @@
 
 }
 
-%{
-    bsl::ostream* d_os;
-%}
-
 %lex-param { SimpleEvaluatorScanner& scanner }
 %parse-param { SimpleEvaluatorScanner& scanner }
 %parse-param { CompilationContext& ctx }

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.h
@@ -68,11 +68,6 @@
 #define YY_DECL                                                               \
     SimpleEvaluatorParser::symbol_type SimpleEvaluatorScanner::get_next_token()
 
-#define register
-// We compile in C++17, and 'register' is not allowed as a storage class
-// anymore, so disable the keyword. If this is too controversial, we can write
-// the scanner by hand.
-
 #include <bmqeval_simpleevaluatorparser.hpp>  // this is needed for symbol_type
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorscanner.h
@@ -62,7 +62,7 @@
 #endif
 
 // Scanner method signature is defined by this macro. Original yylex() returns
-// int.  Sinice Bison 3 uses symbol_type, we must change returned type. We also
+// int.  Since Bison 3 uses symbol_type, we must change returned type. We also
 // rename it to something sane, since you cannot overload return type.
 #undef YY_DECL
 #define YY_DECL                                                               \


### PR DESCRIPTION
This PR contains a series of patches to fix or silence warnings in the bmqeval package.  Warnings for generated code cannot be fixed, so we silence them instead.