### PR TITLE
fix: FBS::releaseRef w/o deletion on replica

### DIFF
--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -513,7 +513,6 @@ class Storage {
     /// `asPrimary` is `true`, delete the message data and record the event in
     /// the storage.
     /// Return one of the return codes from:
-    /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : `msgGUID` was not found
     /// * e_INVALID_OPERATION   : the value is invalid (already zero)
     /// * e_ZERO_REFERENCES     : message refCount has become zero

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -509,8 +509,9 @@ class Storage {
                                         bool onReject = false) = 0;
 
     /// Decrement the reference count of the message identified by the
-    /// `msgGUID`.  If the resulting value is zero, delete the message data and
-    /// record the event in the storage.
+    /// `msgGUID`.  If the resulting value is zero and the specified
+    /// `asPrimary` is `true`, delete the message data and record the event in
+    /// the storage.
     /// Return one of the return codes from:
     /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : `msgGUID` was not found
@@ -521,8 +522,8 @@ class Storage {
     /// On CONFIRM, the caller of `confirm` is responsible to follow with
     /// `remove` call.  `releaseRef` is an alternative way to remove message in
     /// one call.
-    virtual StorageResult::Enum
-    releaseRef(const bmqt::MessageGUID& msgGUID) = 0;
+    virtual StorageResult::Enum releaseRef(const bmqt::MessageGUID& msgGUID,
+                                           bool asPrimary = true) = 0;
 
     /// Remove from the storage the message having the specified `msgGUID`
     /// and store it's size, in bytes, in the optionally specified `msgSize`.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -62,7 +62,8 @@ const int k_GC_MESSAGES_BATCH_SIZE = 1000;  // how many to process in one run
 // -----------------------
 
 // PRIVATE MANIPULATORS
-void FileBackedStorage::purgeCommon(const mqbu::StorageKey& appKey)
+void FileBackedStorage::purgeCommon(const mqbu::StorageKey& appKey,
+                                    bool                    asPrimary)
 {
     // This method is common to both primary and replica nodes, when a queue or
     // a specified virtual storage is purged.  QueueEngine should not be
@@ -95,7 +96,7 @@ void FileBackedStorage::purgeCommon(const mqbu::StorageKey& appKey)
                 d_handles.historySize());
     }
     else {
-        d_virtualStorageCatalog.removeAll(appKey);
+        d_virtualStorageCatalog.removeAll(appKey, asPrimary);
     }
 }
 
@@ -453,7 +454,7 @@ FileBackedStorage::confirm(const bmqt::MessageGUID& msgGUID,
 }
 
 mqbi::StorageResult::Enum
-FileBackedStorage::releaseRef(const bmqt::MessageGUID& guid)
+FileBackedStorage::releaseRef(const bmqt::MessageGUID& guid, bool asPrimary)
 {
     RecordHandleMapIter it = d_handles.find(guid);
     if (it == d_handles.end()) {
@@ -470,53 +471,55 @@ FileBackedStorage::releaseRef(const bmqt::MessageGUID& guid)
     BSLS_ASSERT_SAFE(!handles.empty());
 
     if (0 == --it->second.d_refCount) {
-        // This appKey was the last outstanding client for this message.
-        // Message can now be deleted.
+        if (asPrimary) {
+            // This appKey was the last outstanding client for this message.
+            // Message can now be deleted.
 
-        int msgLen = static_cast<int>(d_store_p->getMessageLenRaw(handles[0]));
+            unsigned int msgLen = d_store_p->getMessageLenRaw(handles[0]);
 
-        int rc = d_store_p->writeDeletionRecord(
-            guid,
-            d_queueKey,
-            DeletionRecordFlag::e_NONE,
-            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()));
+            int rc = d_store_p->writeDeletionRecord(
+                guid,
+                d_queueKey,
+                DeletionRecordFlag::e_NONE,
+                bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()));
 
-        if (0 != rc) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << "Partition [" << partitionId() << "] failed to write "
-                << "DELETION record for GUID: " << guid << ", for queue '"
-                << d_queueUri << "', queueKey '" << d_queueKey
-                << "' while attempting to purge the message, rc: " << rc
-                << BMQTSK_ALARMLOG_END;
-        }
+            if (0 != rc) {
+                BMQTSK_ALARMLOG_ALARM("FILE_IO")
+                    << "Partition [" << partitionId() << "] failed to write "
+                    << "DELETION record for GUID: " << guid << ", for queue '"
+                    << d_queueUri << "', queueKey '" << d_queueKey
+                    << "' while attempting to purge the message, rc: " << rc
+                    << BMQTSK_ALARMLOG_END;
+            }
 
-        // If a queue is associated, inform it about the message being
-        // deleted, and update queue stats.
-        // The same 'e_DEL_MESSAGE' is about 3 cases: TTL, no SC quorum,
-        // and a purge.
-        if (queue()) {
-            queue()->queueEngine()->beforeMessageRemoved(guid);
-        }
-        d_queueStats_sp
-            ->onEvent<mqbstat::QueueStatsDomain::EventType::e_DEL_MESSAGE>(
-                msgLen);
+            // If a queue is associated, inform it about the message being
+            // deleted, and update queue stats.
+            // The same 'e_DEL_MESSAGE' is about 3 cases: TTL, no SC quorum,
+            // and a purge.
+            if (queue()) {
+                queue()->queueEngine()->beforeMessageRemoved(guid);
+            }
+            d_queueStats_sp
+                ->onEvent<mqbstat::QueueStatsDomain::EventType::e_DEL_MESSAGE>(
+                    msgLen);
 
-        // There is not really a need to remove the guid from all virtual
-        // storages, because we can be here only if guid doesn't exist in
-        // any virtual storage apart from 'vs' (because updated outstanding
-        // refCount is zero).  So we just delete records associated with
-        // the guid from the underlying (this) storage.
+            // There is not really a need to remove the guid from all virtual
+            // storages, because we can be here only if guid doesn't exist in
+            // any virtual storage apart from 'vs' (because updated outstanding
+            // refCount is zero).  So we just delete records associated with
+            // the guid from the underlying (this) storage.
 
-        for (unsigned int i = 0; i < handles.size(); ++i) {
-            d_store_p->removeRecordRaw(handles[i]);
-        }
+            for (unsigned int i = 0; i < handles.size(); ++i) {
+                d_store_p->removeRecordRaw(handles[i]);
+            }
 
-        d_capacityMeter.remove(1, msgLen);
-        d_handles.erase(it);
+            d_capacityMeter.remove(1, msgLen);
+            d_handles.erase(it);
 
-        d_queueStats_sp
-            ->onEvent<mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
+            d_queueStats_sp->onEvent<
+                mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
                 d_handles.historySize());
+        }
 
         return mqbi::StorageResult::e_ZERO_REFERENCES;
     }
@@ -610,7 +613,7 @@ FileBackedStorage::removeAll(const mqbu::StorageKey& appKey)
                                   DataStoreRecordHandle());
 
         if (mqbi::StorageResult::e_SUCCESS == rc) {
-            purgeCommon(mqbu::StorageKey::k_NULL_KEY);
+            purgeCommon(mqbu::StorageKey::k_NULL_KEY, true);
 
             d_isEmpty.storeRelaxed(1);
 
@@ -651,6 +654,7 @@ bool FileBackedStorage::removeVirtualStorage(const mqbu::StorageKey& appKey,
 
     mqbi::StorageResult::Enum rc =
         d_virtualStorageCatalog.removeVirtualStorage(appKey,
+                                                     asPrimary,
                                                      onPurge,
                                                      onRemove);
 
@@ -1080,7 +1084,7 @@ void FileBackedStorage::addQueueOpRecordHandle(
 
 void FileBackedStorage::purge(const mqbu::StorageKey& appKey)
 {
-    purgeCommon(appKey);
+    purgeCommon(appKey, false);
 
     if (queue()) {
         bsl::string appId;

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -464,7 +464,6 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// `asPrimary` is `true`, delete the message data and record the event in
     /// the storage.
     /// Return one of the return codes from:
-    /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : 'msgGUID' was not found
     /// * e_INVALID_OPERATION   : the value is invalid (already zero)
     /// * e_ZERO_REFERENCES     : message refCount has become zero

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -221,7 +221,7 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
 
   private:
     // PRIVATE MANIPULATORS
-    void purgeCommon(const mqbu::StorageKey& appKey);
+    void purgeCommon(const mqbu::StorageKey& appKey, bool asPrimary);
 
     /// Clear the state created by 'selectForAutoConfirming'.
     void clearSelection();
@@ -460,8 +460,9 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
             bool                     onReject = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Decrement the reference count of the message identified by the
-    /// 'msgGUID'.  If the resulting value is zero, delete the message data and
-    /// record the event in the storage.
+    /// `msgGUID`.  If the resulting value is zero and the specified
+    /// `asPrimary` is `true`, delete the message data and record the event in
+    /// the storage.
     /// Return one of the return codes from:
     /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : 'msgGUID' was not found
@@ -473,7 +474,8 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// 'remove' call.  'releaseRef' is an alternative way to remove message in
     /// one call.
     mqbi::StorageResult::Enum
-    releaseRef(const bmqt::MessageGUID& msgGUID) BSLS_KEYWORD_OVERRIDE;
+    releaseRef(const bmqt::MessageGUID& msgGUID,
+               bool asPrimary = true) BSLS_KEYWORD_OVERRIDE;
 
     /// Remove from the storage the message having the specified 'msgGUID'
     /// and store it's size, in bytes, in the optionally specified 'msgSize'.

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -440,6 +440,10 @@ InMemoryStorage::removeAll(const mqbu::StorageKey& appKey)
     // Clear out the virtual storage associated with the specified 'appKey'.
     // Note that this cannot be done while iterating over the it in the above
     // 'while' loop for obvious reasons.
+
+    // `InMemoryStorage::removeAll` is called in primary by
+    // `StorageUtil::purgeQueueDispatched`, in broadcast mode, and in proxy.
+    // All of which are supposed to remove items.
     d_virtualStorageCatalog.removeAll(appKey, true);
 
     if (d_items.empty()) {

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -336,8 +336,9 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
             bool                     onReject = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Decrement the reference count of the message identified by the
-    /// 'msgGUID'.  If the resulting value is zero, delete the message data and
-    /// record the event in the storage.
+    /// `msgGUID`.  If the resulting value is zero and the specified
+    /// `asPrimary` is `true`, delete the message data and record the event in
+    /// the storage.
     /// Return one of the return codes from:
     /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : 'msgGUID' was not found
@@ -349,7 +350,8 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// 'remove' call.  'releaseRef' is an alternative way to remove message in
     /// one call.
     mqbi::StorageResult::Enum
-    releaseRef(const bmqt::MessageGUID& msgGUID) BSLS_KEYWORD_OVERRIDE;
+    releaseRef(const bmqt::MessageGUID& msgGUID,
+               bool asPrimary = true) BSLS_KEYWORD_OVERRIDE;
 
     /// Remove from the storage the message having the specified 'msgGUID'
     /// and store it's size, in bytes, in the optionally specified 'msgSize'.
@@ -679,12 +681,13 @@ inline int InMemoryStorage::addVirtualStorage(bsl::ostream& errorDescription,
 }
 
 inline bool
-InMemoryStorage::removeVirtualStorage(const mqbu::StorageKey& appKey, bool)
+InMemoryStorage::removeVirtualStorage(const mqbu::StorageKey& appKey,
+                                      bool                    asPrimary)
 {
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
     mqbi::StorageResult::Enum rc =
-        d_virtualStorageCatalog.removeVirtualStorage(appKey);
+        d_virtualStorageCatalog.removeVirtualStorage(appKey, asPrimary);
 
     return mqbi::StorageResult::e_SUCCESS == rc;
 }

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -340,7 +340,6 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// `asPrimary` is `true`, delete the message data and record the event in
     /// the storage.
     /// Return one of the return codes from:
-    /// * e_SUCCESS          : success
     /// * e_GUID_NOT_FOUND      : 'msgGUID' was not found
     /// * e_INVALID_OPERATION   : the value is invalid (already zero)
     /// * e_ZERO_REFERENCES     : message refCount has become zero

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -413,6 +413,12 @@ VirtualStorageCatalog::purge(const mqbu::StorageKey& appKey,
             }
         }
 
+        // The caller is `FileBackedStorage::removeAll` where we do want to
+        // `FileBackedStorage::writeAppPurgeRecord`.
+        // The caller of which is `StorageUtil::purgeQueueDispatched`.
+        // Note that `InMemoryStorage` does not call
+        // `VirtualStorageCatalog::purge`.
+
         purgeImpl(vs, itData, numVirtualStorages(), true);
     }
     // else, there is nothing to purge; either no messages or all are too old

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -340,7 +340,8 @@ void VirtualStorageCatalog::removeAll()
     d_totalBytes  = 0;
 }
 
-void VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
+void VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey,
+                                      bool                    asPrimary)
 {
     BSLS_ASSERT_SAFE(!appKey.isNull());
 
@@ -351,7 +352,7 @@ void VirtualStorageCatalog::removeAll(const mqbu::StorageKey& appKey)
     DataStreamIterator itData;
     bsls::Types::Int64 total = d_dataStream.size();
     if (seek(&itData, vs) < total) {
-        purgeImpl(vs, itData, numVirtualStorages());
+        purgeImpl(vs, itData, numVirtualStorages(), asPrimary);
     }
     // else, there is nothing to purge; either no messages or all are too old
 }
@@ -412,7 +413,7 @@ VirtualStorageCatalog::purge(const mqbu::StorageKey& appKey,
             }
         }
 
-        purgeImpl(vs, itData, numVirtualStorages());
+        purgeImpl(vs, itData, numVirtualStorages(), true);
     }
     // else, there is nothing to purge; either no messages or all are too old
 
@@ -422,7 +423,8 @@ VirtualStorageCatalog::purge(const mqbu::StorageKey& appKey,
 mqbi::StorageResult::Enum
 VirtualStorageCatalog::purgeImpl(VirtualStorage*     vs,
                                  DataStreamIterator& itData,
-                                 unsigned int        replacingOrdinal)
+                                 unsigned int        replacingOrdinal,
+                                 bool                asPrimary)
 {
     BSLS_ASSERT_SAFE(!d_ordinals.empty());
 
@@ -437,7 +439,7 @@ VirtualStorageCatalog::purgeImpl(VirtualStorage*     vs,
 
         if (vs->remove(dataStreamMessage, replacingOrdinal)) {
             // The 'data' was not already removed or confirmed.
-            result = d_storage_p->releaseRef(msgGUID);
+            result = d_storage_p->releaseRef(msgGUID, asPrimary);
         }
 
         if (result == mqbi::StorageResult::e_ZERO_REFERENCES) {
@@ -546,6 +548,7 @@ int VirtualStorageCatalog::addVirtualStorage(bsl::ostream& errorDescription,
 
 mqbi::StorageResult::Enum
 VirtualStorageCatalog::removeVirtualStorage(const mqbu::StorageKey& appKey,
+                                            bool                    asPrimary,
                                             const PurgeCallback&    onPurge,
                                             const RemoveCallback&   onRemove)
 {
@@ -602,7 +605,7 @@ VirtualStorageCatalog::removeVirtualStorage(const mqbu::StorageKey& appKey,
         }
     }
 
-    purgeImpl(removing, itData, replacingOrdinal);
+    purgeImpl(removing, itData, replacingOrdinal, asPrimary);
 
     if (d_queue_p) {
         BSLS_ASSERT_SAFE(d_queue_p->queueEngine());

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.h
@@ -160,7 +160,8 @@ class VirtualStorageCatalog {
 
     mqbi::StorageResult::Enum purgeImpl(VirtualStorage*     vs,
                                         DataStreamIterator& itData,
-                                        unsigned int        replacingOrdinal);
+                                        unsigned int        replacingOrdinal,
+                                        bool                asPrimary);
 
   public:
     // TRAITS
@@ -241,8 +242,9 @@ class VirtualStorageCatalog {
                                       const mqbu::StorageKey&  appKey);
 
     /// Update all states of the App corresponding to the 'appKey' as purged.
-    /// This does not affect the underlying `DataStore`.
-    void removeAll(const mqbu::StorageKey& appKey);
+    /// If the  specified `asPrimary` is `true`, delete the messages data and
+    /// record the event in the storage.
+    void removeAll(const mqbu::StorageKey& appKey, bool asPrimary);
 
     /// Erase the entire DataStream;
     /// This does not affect the underlying `DataStore`.
@@ -282,6 +284,7 @@ class VirtualStorageCatalog {
     /// return `e_SUCCESS`.
     mqbi::StorageResult::Enum
     removeVirtualStorage(const mqbu::StorageKey& appKey,
+                         bool                    asPrimary,
                          const PurgeCallback&    onPurge  = PurgeCallback(),
                          const RemoveCallback&   onRemove = RemoveCallback());
 


### PR DESCRIPTION
When purging App, replica must decrement refCount but should not attempt to write deletion record.
Calls leading to `releaseRef` now have `asPrimary` as an argument.
An alternative would be to use `FileStore::d_isPrimary` but it is interesting to trace all calls explicitly as primary or not.