### PR TITLE
CI: print local variables and args in cores

### DIFF
--- a/.github/workflows/ext/print_cores.py
+++ b/.github/workflows/ext/print_cores.py
@@ -67,13 +67,23 @@ def main() -> None:
         print(f"No cores found in directory: {args.cores_dir}")
 
     for core_path in fpaths:
-        cmd = f"gdb -q -batch -ex bt {args.bin_path} {core_path}"
-        print(f"#CORE: {core_path}")
-        print(f"#COMMAND: {cmd}")
+        cmd = [
+            "gdb",
+            "-q",
+            "-batch",
+            "-ex",
+            "bt full",
+            args.bin_path,
+            core_path,
+        ]
 
-        subprocess.run(cmd.split(), check=True)
+        print(f"::group::{core_path}", flush=True)
+        print(f"#CORE: {core_path}", flush=True)
+        print("#COMMAND: " + " ".join(cmd), flush=True)
 
-        print("")
+        subprocess.run(cmd, check=True)
+
+        print("::endgroup::", flush=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Group gdb outputs from different core dumps:

<img width="1482" alt="Screenshot 2025-05-15 at 16 29 12" src="https://github.com/user-attachments/assets/c95740d5-7b4b-4a60-8fcb-1ba2ffd52773" />

2. Print local variables and function args if possible (limitation: no pointed structs deduction)
 
<img width="1400" alt="Screenshot 2025-05-15 at 18 03 18" src="https://github.com/user-attachments/assets/ec7ee8f6-b557-4bc6-87aa-53291d1885b6" />
