### PR TITLE
Feat[ClusterCatalog]: load proxy configs on demand

### DIFF
--- a/src/integration-tests/conftest.py
+++ b/src/integration-tests/conftest.py
@@ -19,10 +19,19 @@ import logging
 import pytest
 
 import blazingmq.dev.it.logging
+
+# This must be done early, before we import any module that could call
+# logging.getLogger.
+logging.setLoggerClass(blazingmq.dev.it.logging.BMQLogger)
+
+
 import blazingmq.dev.it.testconstants as tc
 import blazingmq.util.logging as bul
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
 from blazingmq.dev.it.testhooks import PHASE_REPORT_KEY
+
+# pylint: disable=unused-import, wrong-import-position
+from blazingmq.dev.it.fixtures import cluster, multi_node, single_node
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
@@ -134,8 +143,6 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    logging.setLoggerClass(blazingmq.dev.it.logging.BMQLogger)
-
     level_spec = config.getoption(PYTEST_LOG_SPEC_VAR) or config.getini(
         PYTEST_LOG_SPEC_VAR
     )

--- a/src/integration-tests/test_admin_command_routing.py
+++ b/src/integration-tests/test_admin_command_routing.py
@@ -25,7 +25,6 @@ of commands; only that they get routed to the proper nodes.
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
     Cluster,
-    multi_node,
 )
 from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.client import Client

--- a/src/integration-tests/test_admin_res_log.py
+++ b/src/integration-tests/test_admin_res_log.py
@@ -21,7 +21,6 @@ response is logged.
 
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
-    multi_node,
     Cluster,
 )
 from blazingmq.dev.it.process.admin import AdminClient

--- a/src/integration-tests/test_app_subscriptions.py
+++ b/src/integration-tests/test_app_subscriptions.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import blazingmq.dev.it.testconstants as tc
-import pytest
 
 from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
     Cluster,
@@ -27,8 +26,6 @@ from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
     virtual_cluster_config,
 )
 from blazingmq.dev.it.process.client import Client
-from blazingmq.dev.it.util import wait_until
-from blazingmq.dev.configurator.configurator import Configurator
 
 
 class TestAppSubscriptions:

--- a/src/integration-tests/test_breathing.py
+++ b/src/integration-tests/test_breathing.py
@@ -21,7 +21,6 @@ types of queues.
 from collections import namedtuple
 
 import blazingmq.dev.it.testconstants as tc
-import pytest
 from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
     Cluster,
     cartesian_product_cluster,

--- a/src/integration-tests/test_create_new_domain.py
+++ b/src/integration-tests/test_create_new_domain.py
@@ -1,0 +1,83 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+This test verifies that a proxy will be able to open a domain whose config was
+deployed after the broker started, even if the domain is backed by a cluster
+whose config was also deployed after the broker started.
+"""
+
+from blazingmq.dev.configurator.localsite import LocalSite
+import blazingmq.dev.it.testconstants as tc
+from blazingmq.dev.it.fixtures import start_cluster
+from blazingmq.dev.reserveport import reserve_port
+
+
+def test_deploy_new_domain_existing_cluster(multi_node):
+    proxies = multi_node.proxy_cycle()
+    proxy = next(proxies)
+
+    new_domain_name = "my.new.domain"
+    queue = f"bmq://{new_domain_name}/q"
+
+    producer = proxy.create_client("producer")
+    producer.open(queue, flags=["write,ack"], succeed=False)
+
+    new_domain = multi_node.config.priority_domain(new_domain_name)
+    proxy.config.proxy(new_domain)
+    multi_node.deploy_domains()
+
+    producer = proxy.create_client("producer")
+    producer.open(queue, flags=["write,ack"], succeed=True)
+
+
+@start_cluster(False, False)
+def test_deploy_new_domain_new_cluster(multi_node):
+    configurator = multi_node.configurator
+    proxy_name = "westp2"
+
+    with reserve_port() as tcp_address:
+        # Add a proxy. It doesn't know about the domains or the cluster yet.
+        proxy_config = configurator.broker(
+            name=proxy_name,
+            tcp_host="localhost",
+            tcp_port=tcp_address.port,
+            data_center="north",
+        )
+        configurator.deploy(proxy_config, LocalSite(multi_node.work_dir / proxy_name))
+
+        try:
+            multi_node.start()
+
+            proxy = multi_node.proxies(datacenter="north")[0]
+            producer = proxy.create_client("producer")
+
+            # This fails because the proxy doesn't know about the domain.
+            producer.open(tc.URI_PRIORITY, flags=["write,ack"], succeed=False)
+
+            # Add the domain to the proxy. This also adds the cluster.
+            proxy_config.proxy(
+                configurator.clusters[multi_node.name].domains[tc.DOMAIN_PRIORITY]
+            )
+            configurator.deploy(
+                proxy_config, LocalSite(multi_node.work_dir / proxy_name)
+            )
+
+            # Now openQueue works.
+            producer.open(tc.URI_PRIORITY, flags=["write,ack"], succeed=True)
+
+        finally:
+            multi_node.stop()

--- a/src/integration-tests/test_domain_remove.py
+++ b/src/integration-tests/test_domain_remove.py
@@ -20,15 +20,9 @@ This suite of test cases verifies the admin command
 """
 
 import blazingmq.dev.it.testconstants as tc
-from blazingmq.dev.it.fixtures import (
-    multi_node,
-    single_node,
-    cluster,
-    Cluster,
-)
+from blazingmq.dev.it.fixtures import Cluster
 from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.client import Client
-import time
 
 
 def write_messages(proxy, uri, n_msgs=5, do_confirm=True):

--- a/src/integration-tests/test_rollover_csl.py
+++ b/src/integration-tests/test_rollover_csl.py
@@ -27,7 +27,6 @@ from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
 )
 from blazingmq.dev.it.util import wait_until
 import glob
-import time
 
 pytestmark = order(4)
 

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -24,19 +24,15 @@ scripts for running a cluster.
 
 import copy
 import functools
-import itertools
-import logging
 from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Set, Union
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from blazingmq.dev.configurator import Configurator
 
-from blazingmq.dev.configurator.site import Site
-from blazingmq.dev.paths import required_paths as paths
 from blazingmq.schemas import mqbcfg, mqbconf
 
 __all__ = [

--- a/src/python/blazingmq/dev/configurator/configurator.py
+++ b/src/python/blazingmq/dev/configurator/configurator.py
@@ -27,9 +27,8 @@ import functools
 import itertools
 import logging
 from dataclasses import dataclass, field
-from decimal import Decimal
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Tuple
 
 from xsdata.formats.dataclass.context import XmlContext
 from xsdata.formats.dataclass.serializers import JsonSerializer

--- a/src/python/blazingmq/dev/configurator/configurator.py
+++ b/src/python/blazingmq/dev/configurator/configurator.py
@@ -23,6 +23,7 @@ scripts for running a cluster.
 # pyright: reportOptionalMemberAccess=false
 
 import copy
+import dataclasses
 import functools
 import itertools
 import logging
@@ -316,7 +317,29 @@ class Configurator:
             site.mkdir(str(stats_dir))
 
     def deploy_domains(self, broker: Broker, site: Site) -> None:
-        self._create_json_file(broker.clusters, site, "etc/clusters.json")
+        # Separate proxy clusters from clusters involved in reversed proxy
+        # connections. The latter must go in the main clusters.json file.
+        # The others can go in their own files, one per cluster.
+        reversed_clusters = {
+            cluster.name for cluster in broker.clusters.reversed_cluster_connections
+        }
+        proxy_clusters = []
+        lazy_proxy_clusters = []
+
+        for cluster in broker.clusters.proxy_clusters:
+            if cluster.name in reversed_clusters:
+                proxy_clusters.append(cluster)
+            else:
+                lazy_proxy_clusters.append(cluster)
+
+        self._create_json_file(
+            dataclasses.replace(broker.clusters, proxy_clusters=proxy_clusters),
+            site,
+            "etc/clusters.json",
+        )
+
+        for proxy in lazy_proxy_clusters:
+            self._create_json_file(proxy, site, f"etc/proxyclusters/{proxy.name}.json")
 
         for cluster in broker.clusters.my_clusters:
             for storage_dir in (

--- a/src/python/blazingmq/dev/configurator/localsite.py
+++ b/src/python/blazingmq/dev/configurator/localsite.py
@@ -15,7 +15,7 @@
 
 from pathlib import Path
 from shutil import rmtree
-from typing import Dict, Tuple, Union
+from typing import Union
 
 from blazingmq.dev.configurator.site import Site
 

--- a/src/python/blazingmq/dev/configurator/site.py
+++ b/src/python/blazingmq/dev/configurator/site.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 
 import abc
-from pathlib import Path
-from typing import Union
 
 
 class Site(abc.ABC):

--- a/src/python/blazingmq/dev/fuzztest/__init__.py
+++ b/src/python/blazingmq/dev/fuzztest/__init__.py
@@ -22,7 +22,6 @@ o 'fuzz': launch fuzzing session with the given 'host':'port' of a BlazingMQ
           provided, fuzz only the request with the given name.
 """
 
-import logging
 from enum import IntEnum
 from typing import List, Optional
 

--- a/src/python/blazingmq/dev/it/cluster.py
+++ b/src/python/blazingmq/dev/it/cluster.py
@@ -229,7 +229,7 @@ class Cluster(contextlib.AbstractContextManager):
                     process.stop()
                 except Exception as error:
                     self._logger.error(
-                        f"Exception raised while stopping process: {error}"
+                        "Exception raised while stopping process: %s", error
                     )
                 if process.name in self._processes:
                     del self._processes[process.name]
@@ -341,7 +341,6 @@ class Cluster(contextlib.AbstractContextManager):
 
     def destroy(self):
         """Free the resources owned by this cluster."""
-        pass
         # self._esx.close()
 
     # TODO: fold following three in start_broker

--- a/src/python/blazingmq/dev/it/cluster.py
+++ b/src/python/blazingmq/dev/it/cluster.py
@@ -43,12 +43,18 @@ QUORUM_TO_ENSURE_LEADER = 1
 QUORUM_TO_ENSURE_NOT_LEADER = 100
 
 
-def _match_broker(broker, **kw):
-    datacenter = kw.get("datacenter", None)
-    near = kw.get("near", None)
-    exclude = kw.get("exclude", None)
+def _match_broker(
+    broker,
+    *,
+    datacenter: str = None,
+    near: Broker = None,
+    exclude: Union[Broker, List[Broker]] = None,
+    alive=False,
+    invert=False,
+):
     if datacenter is not None and near is not None:
         raise RuntimeError("`near` and `datacenter` options cannot be both specified")
+
     result = True
 
     if exclude is not None and (broker is exclude or broker in exclude):
@@ -57,10 +63,13 @@ def _match_broker(broker, **kw):
         result = result and broker.datacenter == datacenter
     elif near is not None:
         result = result and broker.datacenter == near.datacenter
-    if kw.get("alive", None):
+
+    if alive:
         result = result and broker.is_alive()
-    if kw.get("invert", False):
+
+    if invert:
         result = not result
+
     return result
 
 
@@ -416,7 +425,15 @@ class Cluster(contextlib.AbstractContextManager):
 
         return self._processes[name]
 
-    def nodes(self, **kw) -> List[Broker]:
+    def nodes(
+        self,
+        *,
+        datacenter: str = None,
+        near: Broker = None,
+        exclude: Union[Broker, List[Broker]] = None,
+        alive=False,
+        invert=False,
+    ) -> List[Broker]:
         """Return the nodes matching the conditions specified by 'kw'.
 
         Conditions
@@ -432,9 +449,28 @@ class Cluster(contextlib.AbstractContextManager):
         the nodes that do *not* match the condition(s).
         """
 
-        return [broker for broker in self._nodes if _match_broker(broker, **kw)]
+        return [
+            broker
+            for broker in self._nodes
+            if _match_broker(
+                broker,
+                datacenter=datacenter,
+                near=near,
+                exclude=exclude,
+                alive=alive,
+                invert=invert,
+            )
+        ]
 
-    def virtual_nodes(self, **kw):
+    def virtual_nodes(
+        self,
+        *,
+        datacenter: str = None,
+        near: Broker = None,
+        exclude: Union[Broker, List[Broker]] = None,
+        alive=False,
+        invert=False,
+    ):
         """Return the virtual nodes matching the conditions specified by 'kw'.
 
         Conditions can be any combination of: - datacenter:<name> return the
@@ -445,9 +481,28 @@ class Cluster(contextlib.AbstractContextManager):
         is true, return the nodes that do *not* match the condition(s).
         """
 
-        return [broker for broker in self._virtual_nodes if _match_broker(broker, **kw)]
+        return [
+            broker
+            for broker in self._virtual_nodes
+            if _match_broker(
+                broker,
+                datacenter=datacenter,
+                near=near,
+                exclude=exclude,
+                alive=alive,
+                invert=invert,
+            )
+        ]
 
-    def proxies(self, **kw) -> List[Broker]:
+    def proxies(
+        self,
+        *,
+        datacenter: str = None,
+        near: Broker = None,
+        exclude: Union[Broker, List[Broker]] = None,
+        alive=False,
+        invert=False,
+    ) -> List[Broker]:
         """Return the proxies matching the conditions specified by 'kw'.
 
         Conditions can be any combination of: - datacenter:<name> return the
@@ -458,7 +513,18 @@ class Cluster(contextlib.AbstractContextManager):
         is true, return the nodes that do *not* match the condition(s).
         """
 
-        return [broker for broker in self._proxies if _match_broker(broker, **kw)]
+        return [
+            broker
+            for broker in self._proxies
+            if _match_broker(
+                broker,
+                datacenter=datacenter,
+                near=near,
+                exclude=exclude,
+                alive=alive,
+                invert=invert,
+            )
+        ]
 
     def proxy_cycle(self):
         """

--- a/src/python/blazingmq/dev/it/process/bmqproc.py
+++ b/src/python/blazingmq/dev/it/process/bmqproc.py
@@ -15,7 +15,6 @@
 
 from blazingmq.dev.it.process.proc import Process
 
-import blazingmq.dev.it.logging
 
 import logging
 import re

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -22,8 +22,6 @@ PURPOSE: Provide a BMQ client.
 Provide a subclass of 'ito.proc.Process' that wraps 'bmqtool.tsk'.
 """
 
-from contextlib import ExitStack
-
 from collections import namedtuple
 import json
 import re
@@ -50,8 +48,6 @@ blocktimeout = 15
 
 class ITError(Exception):
     """Base class for exceptions specific to integration tests."""
-
-    pass
 
 
 def _build_command(
@@ -138,7 +134,7 @@ class Client(BMQProcess):
         Send a command to the client and return immediately.  This function
         returns nothing.
         """
-        self._logger.info(f"send: command = {command}")
+        self._logger.info("send: command = %s", command)
         self.write_stdin(command + "\n").flush_stdin()
 
     def start_session(self, block=None, succeed=None, no_except=None, **kw):
@@ -372,7 +368,7 @@ class Client(BMQProcess):
 
                 msgs.append(Message(m[1], m[2], m[3], m[4]))
 
-            self._logger.info(f"list -> {len(msgs)} message(s)")
+            self._logger.info("list -> %s message(s)", len(msgs))
 
             return msgs
 
@@ -451,7 +447,7 @@ class Client(BMQProcess):
         with internal_use(self):
             if self.outputs_regex("EVENT received:.*STATE_RESTORED", timeout=timeout):
                 return True
-        self._logger.info(f"TIMEOUT: timed out after {timeout}s while {action}")
+        self._logger.info("TIMEOUT: timed out after %ss while %s", timeout, action)
         return False
 
     def wait_connection_lost(self, timeout=blocktimeout):
@@ -460,7 +456,7 @@ class Client(BMQProcess):
         with internal_use(self):
             if self.outputs_regex("EVENT received:.*CONNECTION_LOST", timeout=timeout):
                 return True
-        self._logger.info(f"TIMEOUT: timed out after {timeout}s while {action}")
+        self._logger.info("TIMEOUT: timed out after %ss while %s", timeout, action)
         return False
 
     def open_priority_queues(self, count, start=0, uri_priority=URI_PRIORITY, **kw):
@@ -602,7 +598,7 @@ class Client(BMQProcess):
             error_code = self._parse_command_result(
                 command, result, succeed, no_except, timeout
             )
-            self._logger.info(f"{command} -> {error_code}")
+            self._logger.info("%s -> %s", command, error_code)
 
         return CommandResult(error_code, extra_matches)
 

--- a/src/python/blazingmq/dev/paths.py
+++ b/src/python/blazingmq/dev/paths.py
@@ -44,7 +44,6 @@ have the following Path attributes:
 
 from dataclasses import dataclass
 import os
-import platform
 from pathlib import Path
 from typing import Optional
 

--- a/src/python/blazingmq/dev/pytest.py
+++ b/src/python/blazingmq/dev/pytest.py
@@ -19,7 +19,7 @@ Provide various pytest utilities.
 
 import functools
 import os
-from typing import Callable, List
+from typing import Callable
 
 import pytest
 


### PR DESCRIPTION
**Description**

A proxy picks "new" domain configurations installed even after it has started.  However, it reads cluster proxy definitions from `cluster.json`, only once,  at startup. This causes an error when a "new" domain is backed by a cluster unknown at startup. This PR handles proxy cluster configs in the same way as domain configs. The entirety of `clusters.json` is read during startup, as before. However, if, during an `openQueue`, a domain refers to a cluster not yet available in `ClusterCatalog`, the broker looks for a file named after the cluster, with a `.json` extension,  in the `proxyclusters` subdirectory of the config directory. If found, and it can be parsed as a `ClusterProxyDefinition`, it added to the `ClusterCatalog`.

Cluster names may contain directory separators. They don't receive any special treatment. Thus, if the proxy does not yet have a configuration for, say, cluster `foo/bar`, it will look for a `<config_dir>/proxyclusters/foo/bar.json`.

Note that `ClusterProxyDefinition`s for reversed proxy connections must still be present in `clusters.json` from the get-go.

**Testing performed**
Added new integration tests (`src/integration-tests/test_create_new_domain.py`).
