### PR TITLE
Fix[bmq]: Regenerate C++11 simulation components

### DIFF
--- a/src/groups/bmq/bmqex/bmqex_bindutil.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil.h
@@ -153,7 +153,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:55:13 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
 
 # define COMPILING_BMQEX_BINDUTIL_H
@@ -170,7 +170,7 @@ namespace bmqex {
 // struct BindUtil_DummyNullaryFunction
 // ====================================
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
 /// Provides a dummy nullary function object which result type is the same
 /// as the result type of the specified `FUNCTION` when invoked with
@@ -257,7 +257,7 @@ class BindUtil_BindWrapper {
     typename ExecutionUtil::ExecuteResult<POLICY, FUNCTION>::Type
     operator()() const;
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
 
     /// Call `ExecutionUtil::execute(p, bsl::move(f2))` and return the
     /// result of that operation, where `p` is the contained execution
@@ -375,7 +375,7 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()() const
     return ExecutionUtil::execute(d_policy, d_function.object());
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=8
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=8
 template <class POLICY, class FUNCTION>
 template <class ARG1, class... ARGS>
 inline typename ExecutionUtil::ExecuteResult<
@@ -422,6 +422,6 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:03:57 2025
+// Generated on Thu May 22 13:07:13 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.cpp
 
 #define INCLUDED_BMQEX_BINDUTIL_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_BINDUTIL_CPP)
+#endif // defined(COMPILING_BMQEX_BINDUTIL_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:55:13 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_bindutil.h
 
 #ifdef COMPILING_BMQEX_BINDUTIL_H
@@ -60,57 +60,49 @@ namespace bmqex {
 
 template <class FUNCTION
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
-          ,
-          class ARGS_0 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_0 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
-          ,
-          class ARGS_1 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_1 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-          ,
-          class ARGS_2 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_2 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-          ,
-          class ARGS_3 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_3 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-          ,
-          class ARGS_4 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_4 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-          ,
-          class ARGS_5 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_5 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-          ,
-          class ARGS_6 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_6 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-          ,
-          class ARGS_7 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_7 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class ARGS_8 = BSLS_COMPILERFEATURES_NILT
+        , class ARGS_8 = BSLS_COMPILERFEATURES_NILT
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-          ,
-          class = BSLS_COMPILERFEATURES_NILT>
+        , class = BSLS_COMPILERFEATURES_NILT>
 struct BindUtil_DummyNullaryFunction;
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 0
 template <class FUNCTION>
 struct BindUtil_DummyNullaryFunction<FUNCTION> {
+
     typedef typename bsl::invoke_result<FUNCTION>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -119,193 +111,205 @@ struct BindUtil_DummyNullaryFunction<FUNCTION> {
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 template <class FUNCTION, class ARGS_1>
 struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1> {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS_1>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
-template <class FUNCTION, class ARGS_1, class ARGS_2>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
-template <class FUNCTION, class ARGS_1, class ARGS_2, class ARGS_3>
-struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1, ARGS_2, ARGS_3> {
-    typedef typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3>::type
-        ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4> {
-    typedef
-        typename bsl::invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4>::
-            type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5> {
-    typedef typename bsl::
-        invoke_result<FUNCTION, ARGS_1, ARGS_2, ARGS_3, ARGS_4, ARGS_5>::type
-            ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8>::type ResultType;
+
 
     ResultType operator()() const;
 };
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 8
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_A >= 9
-template <class FUNCTION,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-struct BindUtil_DummyNullaryFunction<FUNCTION,
-                                     ARGS_1,
-                                     ARGS_2,
-                                     ARGS_3,
-                                     ARGS_4,
-                                     ARGS_5,
-                                     ARGS_6,
-                                     ARGS_7,
-                                     ARGS_8,
-                                     ARGS_9> {
-    typedef typename bsl::invoke_result<FUNCTION,
-                                        ARGS_1,
-                                        ARGS_2,
-                                        ARGS_3,
-                                        ARGS_4,
-                                        ARGS_5,
-                                        ARGS_6,
-                                        ARGS_7,
-                                        ARGS_8,
-                                        ARGS_9>::type ResultType;
+template <class FUNCTION, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
+struct BindUtil_DummyNullaryFunction<FUNCTION, ARGS_1,
+                                               ARGS_2,
+                                               ARGS_3,
+                                               ARGS_4,
+                                               ARGS_5,
+                                               ARGS_6,
+                                               ARGS_7,
+                                               ARGS_8,
+                                               ARGS_9> {
+
+    typedef typename bsl::invoke_result<FUNCTION, ARGS_1,
+                                                  ARGS_2,
+                                                  ARGS_3,
+                                                  ARGS_4,
+                                                  ARGS_5,
+                                                  ARGS_6,
+                                                  ARGS_7,
+                                                  ARGS_8,
+                                                  ARGS_9>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -317,7 +321,9 @@ struct BindUtil_DummyNullaryFunction<FUNCTION,
 
 template <class FUNCTION, class... ARGS>
 struct BindUtil_DummyNullaryFunction {
+
     typedef typename bsl::invoke_result<FUNCTION, ARGS...>::type ResultType;
+
 
     ResultType operator()() const;
 };
@@ -407,8 +413,9 @@ class BindUtil_BindWrapper {
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-    operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type
+        operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const;
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 0
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
@@ -424,7 +431,8 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 1
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
-    template <class ARG1, class ARGS_1, class ARGS_2>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -438,7 +446,9 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 2
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
-    template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -454,11 +464,10 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 3
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -476,12 +485,11 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 4
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -501,13 +509,12 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 5
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -529,14 +536,13 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 6
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -560,15 +566,14 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 7
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
-    template <class ARG1,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class ARG1, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
@@ -594,8 +599,8 @@ class BindUtil_BindWrapper {
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_B >= 8
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class ARG1, class... ARGS>
     typename ExecutionUtil::ExecuteResult<
@@ -722,18 +727,19 @@ inline typename ExecutionUtil::ExecuteResult<
     BindUtil_DummyNullaryFunction<FUNCTION,
                                   typename bsl::decay<ARG1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
         BindUtil_DummyNullaryFunction<FUNCTION,
-                                      typename bsl::decay<ARG1>::type> >::Type
-        ResultType;
+                                      typename bsl::decay<ARG1>::type> >::
+        Type ResultType;
 
-    return ExecutionUtil::execute(
-        d_policy,
-        bdlf::BindUtil::bindR<ResultType>(d_function.object(),
-                                          bslmf::Util::forward<ARG1>(arg1)));
+    return ExecutionUtil::execute(d_policy,
+                                  bdlf::BindUtil::bindR<ResultType>(
+                                      d_function.object(),
+                                      bslmf::Util::forward<ARG1>(arg1)));
 }
 #endif  // BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 0
 
@@ -746,8 +752,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS_1>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -766,7 +773,8 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 2
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -774,9 +782,10 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_1>::type,
                                   typename bsl::decay<ARGS_2>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -797,7 +806,9 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 3
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -806,10 +817,11 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_2>::type,
                                   typename bsl::decay<ARGS_3>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -832,7 +844,10 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 4
 template <class POLICY, class FUNCTION>
-template <class ARG1, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -842,11 +857,12 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_3>::type,
                                   typename bsl::decay<ARGS_4>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -871,12 +887,11 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 5
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -887,12 +902,13 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_4>::type,
                                   typename bsl::decay<ARGS_5>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -919,13 +935,12 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 6
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -937,13 +952,14 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_5>::type,
                                   typename bsl::decay<ARGS_6>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -972,14 +988,13 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 7
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -992,14 +1007,15 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_6>::type,
                                   typename bsl::decay<ARGS_7>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1030,15 +1046,14 @@ BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
 
 #if BMQEX_BINDUTIL_VARIADIC_LIMIT_C >= 8
 template <class POLICY, class FUNCTION>
-template <class ARG1,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
+template <class ARG1, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
 inline typename ExecutionUtil::ExecuteResult<
     POLICY,
     BindUtil_DummyNullaryFunction<FUNCTION,
@@ -1052,15 +1067,16 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARGS_7>::type,
                                   typename bsl::decay<ARGS_8>::type> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1102,8 +1118,9 @@ inline typename ExecutionUtil::ExecuteResult<
                                   typename bsl::decay<ARG1>::type,
                                   typename bsl::decay<ARGS>::type...> >::Type
 BindUtil_BindWrapper<POLICY, FUNCTION>::operator()(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const
+                                  BSLS_COMPILERFEATURES_FORWARD_REF(ARG1) arg1,
+                                BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args
+                                ) const
 {
     typedef typename ExecutionUtil::ExecuteResult<
         POLICY,
@@ -1142,8 +1159,9 @@ BindUtil::bindExecute(BSLS_COMPILERFEATURES_FORWARD_REF(POLICY) policy,
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_BINDUTIL_H)
-#error Not valid except when included from bmqex_bindutil.h
-#endif  // ! defined(COMPILING_BMQEX_BINDUTIL_H)
+#else // if ! defined(DEFINED_BMQEX_BINDUTIL_H)
+# error Not valid except when included from bmqex_bindutil.h
+#endif // ! defined(COMPILING_BMQEX_BINDUTIL_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_BINDUTIL_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_BINDUTIL_CPP03)
+

--- a/src/groups/bmq/bmqex/bmqex_future.h
+++ b/src/groups/bmq/bmqex/bmqex_future.h
@@ -150,7 +150,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:55:18 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_future.h
 
 # define COMPILING_BMQEX_FUTURE_H
@@ -955,7 +955,7 @@ class FutureSharedState {
     /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Atomically initialize the stored value as if by direct-non-list-
     /// initializing an object of type `R` with 'bsl::forward<ARGS>(
@@ -1665,7 +1665,7 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
     emplaceValue(bslmf::MovableRefUtil::move(value));
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(ARGS&&... args)
@@ -1902,6 +1902,6 @@ inline void bmqex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:03:51 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_future.cpp
 
 #define INCLUDED_BMQEX_FUTURE_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_FUTURE_CPP)
+#endif // defined(COMPILING_BMQEX_FUTURE_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:55:18 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_future.h
 
 #ifdef COMPILING_BMQEX_FUTURE_H
@@ -856,20 +856,26 @@ class FutureSharedState {
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -962,8 +968,8 @@ class FutureSharedState {
 #endif  // BMQEX_FUTURE_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
@@ -1672,7 +1678,8 @@ inline void FutureSharedState<R>::setValue(bslmf::MovableRef<R> value)
 #endif
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 0
 template <class R>
-inline void FutureSharedState<R>::emplaceValue()
+inline void FutureSharedState<R>::emplaceValue(
+                               )
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1696,9 +1703,8 @@ inline void FutureSharedState<R>::emplaceValue()
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 1
 template <class R>
 template <class ARGS_1>
-inline void
-FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                       args_1)
+inline void FutureSharedState<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1722,10 +1728,11 @@ FutureSharedState<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 2
 template <class R>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1750,11 +1757,13 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 3
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1780,12 +1789,15 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 4
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1812,13 +1824,17 @@ inline void FutureSharedState<R>::emplaceValue(
 
 #if BMQEX_FUTURE_VARIADIC_LIMIT_B >= 5
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1853,12 +1869,12 @@ template <class ARGS_1,
           class ARGS_5,
           class ARGS_6>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1895,13 +1911,13 @@ template <class ARGS_1,
           class ARGS_6,
           class ARGS_7>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1940,14 +1956,14 @@ template <class ARGS_1,
           class ARGS_7,
           class ARGS_8>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -1988,15 +2004,15 @@ template <class ARGS_1,
           class ARGS_8,
           class ARGS_9>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2032,7 +2048,7 @@ inline void FutureSharedState<R>::emplaceValue(
 template <class R>
 template <class... ARGS>
 inline void FutureSharedState<R>::emplaceValue(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     typedef bsls::ObjectBuffer<ValueType> Buffer;
 
@@ -2266,8 +2282,9 @@ inline void bmqex::swap(FutureResult<R>& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_FUTURE_H)
-#error Not valid except when included from bmqex_future.h
-#endif  // ! defined(COMPILING_BMQEX_FUTURE_H)
+#else // if ! defined(DEFINED_BMQEX_FUTURE_H)
+# error Not valid except when included from bmqex_future.h
+#endif // ! defined(COMPILING_BMQEX_FUTURE_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_FUTURE_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_FUTURE_CPP03)
+

--- a/src/groups/bmq/bmqex/bmqex_promise.h
+++ b/src/groups/bmq/bmqex/bmqex_promise.h
@@ -91,7 +91,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:55:22 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.h
 
 # define COMPILING_BMQEX_PROMISE_H
@@ -202,7 +202,7 @@ class Promise {
     /// the C++ standard.
     void setValue(bslmf::MovableRef<R> value);
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Atomically store a value into the shared state as if by direct-non-
     /// list-initializing an object of type `R` with 'bsl::forward<ARGS>(
@@ -513,7 +513,7 @@ inline void Promise<R>::setValue(bslmf::MovableRef<R> value)
     d_sharedState->setValue(bslmf::MovableRefUtil::move(value));
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class R>
 template <class... ARGS>
 inline void Promise<R>::emplaceValue(ARGS&&... args)
@@ -723,6 +723,6 @@ inline void bmqex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:03:38 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.cpp
 
 #define INCLUDED_BMQEX_PROMISE_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQEX_PROMISE_CPP)
+#endif // defined(COMPILING_BMQEX_PROMISE_CPP)
+

--- a/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_promise_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:55:22 2025
+// Generated on Thu May 22 13:07:14 2025
 // Command line: sim_cpp11_features.pl bmqex_promise.h
 
 #ifdef COMPILING_BMQEX_PROMISE_H
@@ -162,20 +162,26 @@ class Promise {
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 1
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 2
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 3
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                       BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -268,8 +274,8 @@ class Promise {
 #endif  // BMQEX_PROMISE_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
@@ -577,7 +583,8 @@ inline void Promise<R>::setValue(bslmf::MovableRef<R> value)
 #endif
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 0
 template <class R>
-inline void Promise<R>::emplaceValue()
+inline void Promise<R>::emplaceValue(
+                               )
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -588,8 +595,8 @@ inline void Promise<R>::emplaceValue()
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 1
 template <class R>
 template <class ARGS_1>
-inline void Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                         args_1)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -599,10 +606,11 @@ inline void Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 2
 template <class R>
-template <class ARGS_1, class ARGS_2>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+template <class ARGS_1,
+          class ARGS_2>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -613,11 +621,13 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 3
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -629,12 +639,15 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 4
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -647,13 +660,17 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 
 #if BMQEX_PROMISE_VARIADIC_LIMIT_B >= 5
 template <class R>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -673,13 +690,13 @@ template <class ARGS_1,
           class ARGS_4,
           class ARGS_5,
           class ARGS_6>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -701,14 +718,14 @@ template <class ARGS_1,
           class ARGS_5,
           class ARGS_6,
           class ARGS_7>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -732,15 +749,15 @@ template <class ARGS_1,
           class ARGS_6,
           class ARGS_7,
           class ARGS_8>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -766,16 +783,16 @@ template <class ARGS_1,
           class ARGS_7,
           class ARGS_8,
           class ARGS_9>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-                         BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+inline void Promise<R>::emplaceValue(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -796,8 +813,8 @@ Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
 // forwarding in some compilers.
 template <class R>
 template <class... ARGS>
-inline void
-Promise<R>::emplaceValue(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void Promise<R>::emplaceValue(
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     BSLS_ASSERT(d_sharedState);
 
@@ -1004,8 +1021,9 @@ inline void bmqex::swap(Promise<R>& lhs, Promise<R>& rhs) BSLS_KEYWORD_NOEXCEPT
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQEX_PROMISE_H)
-#error Not valid except when included from bmqex_promise.h
-#endif  // ! defined(COMPILING_BMQEX_PROMISE_H)
+#else // if ! defined(DEFINED_BMQEX_PROMISE_H)
+# error Not valid except when included from bmqex_promise.h
+#endif // ! defined(COMPILING_BMQEX_PROMISE_H)
 
-#endif  // ! defined(INCLUDED_BMQEX_PROMISE_CPP03)
+#endif // ! defined(INCLUDED_BMQEX_PROMISE_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_managedcallback.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback.h
@@ -96,7 +96,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:54:56 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
 
 # define COMPILING_BMQU_MANAGEDCALLBACK_H
@@ -157,7 +157,7 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
     /// call a destructor for it and set this object empty.
     void reset();
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
     /// Construct a callback object of the specified CALLBACK_TYPE in this
     /// objects' reusable buffer, with the specified `args` passed to its
     /// constructor.  The buffer must be empty before construction, it is
@@ -271,7 +271,7 @@ inline void ManagedCallback::operator()() const
     (*reinterpret_cast<const CallbackFunctor*>(d_callbackBuffer.data()))();
 }
 
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class CALLBACK_TYPE, class... ARGS>
 inline void ManagedCallback::createInplace(ARGS&&... args)
 {
@@ -284,6 +284,6 @@ inline void ManagedCallback::createInplace(ARGS&&... args)
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:04:54 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.cpp
 
 #define INCLUDED_BMQU_MANAGEDCALLBACK_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_MANAGEDCALLBACK_CPP)
+#endif // defined(COMPILING_BMQU_MANAGEDCALLBACK_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:54:56 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_managedcallback.h
 
 #ifdef COMPILING_BMQU_MANAGEDCALLBACK_H
@@ -99,8 +99,7 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A
-#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A                                 \
-    BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
+#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
 #endif
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 0
     template <class CALLBACK_TYPE>
@@ -113,24 +112,26 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 2
-    template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 3
-    template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 4
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -138,12 +139,11 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 4
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 5
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -152,13 +152,12 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 5
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 6
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -168,14 +167,13 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 6
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 7
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -186,15 +184,14 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 7
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 8
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7,
+                                   class ARGS_8>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -206,16 +203,15 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 8
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 9
-    template <class CALLBACK_TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8,
-              class ARGS_9>
+    template <class CALLBACK_TYPE, class ARGS_1,
+                                   class ARGS_2,
+                                   class ARGS_3,
+                                   class ARGS_4,
+                                   class ARGS_5,
+                                   class ARGS_6,
+                                   class ARGS_7,
+                                   class ARGS_8,
+                                   class ARGS_9>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                        BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -228,8 +224,8 @@ class ManagedCallback BSLS_KEYWORD_FINAL {
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
     template <class CALLBACK_TYPE, class... ARGS>
     void createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
@@ -347,216 +343,258 @@ inline void ManagedCallback::operator()() const
 #define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B
-#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B                                 \
-    BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
+#define BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT
 #endif
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 0
 template <class CALLBACK_TYPE>
-inline void ManagedCallback::createInplace()
+inline void ManagedCallback::createInplace(
+                               )
 {
-    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE();
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                           );
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 0
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 1
 template <class CALLBACK_TYPE, class ARGS_1>
-inline void
-ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                   args_1)
+inline void ManagedCallback::createInplace(
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 1
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 2
-template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 2
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 3
-template <class CALLBACK_TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 3
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 4
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 4
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 5
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 5
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 6
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 6
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 7
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 7
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 8
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7,
+                               class ARGS_8>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 8
 
 #if BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 9
-template <class CALLBACK_TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
+template <class CALLBACK_TYPE, class ARGS_1,
+                               class ARGS_2,
+                               class ARGS_3,
+                               class ARGS_4,
+                               class ARGS_5,
+                               class ARGS_6,
+                               class ARGS_7,
+                               class ARGS_8,
+                               class ARGS_9>
 inline void ManagedCallback::createInplace(
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8),
-                      BSLS_COMPILERFEATURES_FORWARD(ARGS_9, args_9));
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_9,
+                                          args_9));
 }
 #endif  // BMQU_MANAGEDCALLBACK_VARIADIC_LIMIT_B >= 9
 
@@ -564,11 +602,12 @@ inline void ManagedCallback::createInplace(
 // The generated code below is a workaround for the absence of perfect
 // forwarding in some compilers.
 template <class CALLBACK_TYPE, class... ARGS>
-inline void
-ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void ManagedCallback::createInplace(
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
-    new (place<CALLBACK_TYPE>())
-        CALLBACK_TYPE(BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    new (place<CALLBACK_TYPE>()) CALLBACK_TYPE(
+                                           BSLS_COMPILERFEATURES_FORWARD(ARGS,
+                                           args)...);
 }
 // }}} END GENERATED CODE
 #endif
@@ -576,8 +615,9 @@ ManagedCallback::createInplace(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_MANAGEDCALLBACK_H)
-#error Not valid except when included from bmqu_managedcallback.h
-#endif  // ! defined(COMPILING_BMQU_MANAGEDCALLBACK_H)
+#else // if ! defined(DEFINED_BMQU_MANAGEDCALLBACK_H)
+# error Not valid except when included from bmqu_managedcallback.h
+#endif // ! defined(COMPILING_BMQU_MANAGEDCALLBACK_H)
 
-#endif  // ! defined(INCLUDED_BMQU_MANAGEDCALLBACK_CPP03)
+#endif // ! defined(INCLUDED_BMQU_MANAGEDCALLBACK_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
@@ -46,7 +46,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:55:02 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
 
 # define COMPILING_BMQU_OBJECTPLACEHOLDER_H
@@ -193,7 +193,7 @@ class ObjectPlaceHolder {
 
   public:
     // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Initialize this placeholder with an object of the specified `TYPE`
     /// constructed from the specified `args` arguments.  Specify an
@@ -389,7 +389,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 }
 
 // MANIPULATORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
@@ -472,6 +472,6 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:05:31 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.cpp
 
 #define INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_OBJECTPLACEHOLDER_CPP)
+#endif // defined(COMPILING_BMQU_OBJECTPLACEHOLDER_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:55:02 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
 
 #ifdef COMPILING_BMQU_OBJECTPLACEHOLDER_H
@@ -185,8 +185,7 @@ class ObjectPlaceHolder {
 #define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A
-#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A                               \
-    BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 0
@@ -197,139 +196,136 @@ class ObjectPlaceHolder {
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
     template <class TYPE, class ARGS_1>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
-    template <class TYPE, class ARGS_1, class ARGS_2>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
-    template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 4
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 5
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 6
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 7
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 8
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
-    template <class TYPE,
-              class ARGS_1,
-              class ARGS_2,
-              class ARGS_3,
-              class ARGS_4,
-              class ARGS_5,
-              class ARGS_6,
-              class ARGS_7,
-              class ARGS_8,
-              class ARGS_9>
+    template <class TYPE, class ARGS_1,
+                          class ARGS_2,
+                          class ARGS_3,
+                          class ARGS_4,
+                          class ARGS_5,
+                          class ARGS_6,
+                          class ARGS_7,
+                          class ARGS_8,
+                          class ARGS_9>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                             BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9);
 #endif  // BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class TYPE, class... ARGS>
     void createObject(bslma::Allocator* allocator,
-                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args);
 // }}} END GENERATED CODE
 #endif
 
@@ -523,8 +519,7 @@ inline ObjectPlaceHolder<SIZE>::~ObjectPlaceHolder()
 #define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT 9
 #endif
 #ifndef BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B
-#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B                               \
-    BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
+#define BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT
 #endif
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 0
@@ -538,7 +533,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(object, allocator);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator);
 
     objectGuard.release();
 }
@@ -547,10 +543,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator)
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 1
 template <size_t SIZE>
 template <class TYPE, class ARGS_1>
-inline void
-ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
-                                      BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1)
-                                          args_1)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -558,10 +552,10 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1));
 
     objectGuard.release();
 }
@@ -569,11 +563,11 @@ ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 2
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -581,11 +575,12 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2));
 
     objectGuard.release();
 }
@@ -593,12 +588,13 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 3
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -606,12 +602,14 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3));
 
     objectGuard.release();
 }
@@ -619,13 +617,15 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 4
 template <size_t SIZE>
-template <class TYPE, class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -633,13 +633,16 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4));
 
     objectGuard.release();
 }
@@ -647,19 +650,17 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 5
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -667,14 +668,18 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5));
 
     objectGuard.release();
 }
@@ -682,21 +687,19 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 6
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -704,15 +707,20 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6));
 
     objectGuard.release();
 }
@@ -720,23 +728,21 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 7
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -744,16 +750,22 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7));
 
     objectGuard.release();
 }
@@ -761,25 +773,23 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 8
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -787,17 +797,24 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8));
 
     objectGuard.release();
 }
@@ -805,27 +822,25 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 #if BMQU_OBJECTPLACEHOLDER_VARIADIC_LIMIT_B >= 9
 template <size_t SIZE>
-template <class TYPE,
-          class ARGS_1,
-          class ARGS_2,
-          class ARGS_3,
-          class ARGS_4,
-          class ARGS_5,
-          class ARGS_6,
-          class ARGS_7,
-          class ARGS_8,
-          class ARGS_9>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
+template <class TYPE, class ARGS_1,
+                      class ARGS_2,
+                      class ARGS_3,
+                      class ARGS_4,
+                      class ARGS_5,
+                      class ARGS_6,
+                      class ARGS_7,
+                      class ARGS_8,
+                      class ARGS_9>
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8,
+                              BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -833,18 +848,26 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_1, args_1),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_2, args_2),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_3, args_3),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_4, args_4),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_5, args_5),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_6, args_6),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_7, args_7),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_8, args_8),
-        BSLS_COMPILERFEATURES_FORWARD(ARGS_9, args_9));
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_1,
+                                          args_1),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_2,
+                                          args_2),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_3,
+                                          args_3),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_4,
+                                          args_4),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_5,
+                                          args_5),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_6,
+                                          args_6),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_7,
+                                          args_7),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_8,
+                                          args_8),
+                                          BSLS_COMPILERFEATURES_FORWARD(ARGS_9,
+                                          args_9));
 
     objectGuard.release();
 }
@@ -856,9 +879,8 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
 
 template <size_t SIZE>
 template <class TYPE, class... ARGS>
-inline void ObjectPlaceHolder<SIZE>::createObject(
-    bslma::Allocator* allocator,
-    BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
+inline void ObjectPlaceHolder<SIZE>::createObject(bslma::Allocator* allocator,
+                               BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args)
 {
     BSLS_ASSERT_SAFE(allocator);
     BSLS_ASSERT_SAFE(d_state == e_EMPTY);
@@ -866,10 +888,10 @@ inline void ObjectPlaceHolder<SIZE>::createObject(
     TYPE*       object = allocateObject<TYPE>(allocator);
     ObjectGuard objectGuard(this);
 
-    bslma::ConstructionUtil::construct<TYPE>(
-        object,
-        allocator,
-        BSLS_COMPILERFEATURES_FORWARD(ARGS, args)...);
+    bslma::ConstructionUtil::construct<TYPE>(object,
+                                             allocator,
+                                           BSLS_COMPILERFEATURES_FORWARD(ARGS,
+                                           args)...);
 
     objectGuard.release();
 }
@@ -934,8 +956,9 @@ ObjectPlaceHolder<SIZE>::objectAddress() const BSLS_KEYWORD_NOEXCEPT
 }  // close package namespace
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_OBJECTPLACEHOLDER_H)
-#error Not valid except when included from bmqu_objectplaceholder.h
-#endif  // ! defined(COMPILING_BMQU_OBJECTPLACEHOLDER_H)
+#else // if ! defined(DEFINED_BMQU_OBJECTPLACEHOLDER_H)
+# error Not valid except when included from bmqu_objectplaceholder.h
+#endif // ! defined(COMPILING_BMQU_OBJECTPLACEHOLDER_H)
 
-#endif  // ! defined(INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03)
+#endif // ! defined(INCLUDED_BMQU_OBJECTPLACEHOLDER_CPP03)
+

--- a/src/groups/bmq/bmqu/bmqu_operationchain.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain.h
@@ -193,7 +193,7 @@
 #if BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES
 // clang-format off
 // Include version that can be compiled with C++03
-// Generated on Wed Apr  2 14:49:45 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
 
 # define COMPILING_BMQU_OPERATIONCHAIN_H
@@ -305,7 +305,7 @@ class OperationChain_CompletionCallbackWrapper {
 
   public:
     // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 
     /// Invoke the associated completion callback with the specified `args`
     /// arguments and notify the associated operation chain. Propagate any
@@ -810,7 +810,7 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 }
 
 // ACCESSORS
-#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES  // $var-args=9
+#if !BSLS_COMPILERFEATURES_SIMULATE_CPP11_FEATURES // $var-args=9
 template <class CO_CALLBACK>
 template <class... ARGS>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
@@ -1025,6 +1025,6 @@ inline void bmqu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#endif  // End C++11 code
+#endif // End C++11 code
 
 #endif

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
@@ -17,7 +17,7 @@
 
 // Automatically generated file.  **DO NOT EDIT**
 
-// Generated on Wed Apr  2 15:05:37 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.cpp
 
 #define INCLUDED_BMQU_OPERATIONCHAIN_CPP03  // Disable inclusion
@@ -28,4 +28,5 @@
 
 // No C++03 Expansion
 
-#endif  // defined(COMPILING_BMQU_OPERATIONCHAIN_CPP)
+#endif // defined(COMPILING_BMQU_OPERATIONCHAIN_CPP)
+

--- a/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
@@ -36,7 +36,7 @@
 // regions of C++11 code, then this header contains no code and is not
 // '#include'd in the original header.
 //
-// Generated on Wed Apr  2 14:49:45 2025
+// Generated on Thu May 22 13:07:08 2025
 // Command line: sim_cpp11_features.pl bmqu_operationchain.h
 
 #ifdef COMPILING_BMQU_OPERATIONCHAIN_H
@@ -163,20 +163,26 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 1
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
-    template <class ARGS_1, class ARGS_2>
+    template <class ARGS_1,
+              class ARGS_2>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const;
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 2
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
-    template <class ARGS_1, class ARGS_2, class ARGS_3>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const;
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 3
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 4
-    template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+    template <class ARGS_1,
+              class ARGS_2,
+              class ARGS_3,
+              class ARGS_4>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
                     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3,
@@ -269,8 +275,8 @@ class OperationChain_CompletionCallbackWrapper {
 #endif  // BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_A >= 9
 
 #else
-    // The generated code below is a workaround for the absence of perfect
-    // forwarding in some compilers.
+// The generated code below is a workaround for the absence of perfect
+// forwarding in some compilers.
 
     template <class... ARGS>
     void operator()(BSLS_COMPILERFEATURES_FORWARD_REF(ARGS)... args) const;
@@ -784,11 +790,12 @@ inline OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::
 #endif
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 0
 template <class CO_CALLBACK>
-inline void
-OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()() const
+inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
+    ) const
 {
     try {
-        bslmf::Util::moveIfSupported((*d_coCallback_p))();
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            );
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -820,15 +827,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 2
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2>
+template <class ARGS_1,
+          class ARGS_2>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -841,17 +849,19 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 3
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_3) args_3) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -864,7 +874,10 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 4
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -872,11 +885,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_4) args_4) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -889,7 +902,11 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
 
 #if BMQU_OPERATIONCHAIN_VARIADIC_LIMIT_B >= 5
 template <class CO_CALLBACK>
-template <class ARGS_1, class ARGS_2, class ARGS_3, class ARGS_4, class ARGS_5>
+template <class ARGS_1,
+          class ARGS_2,
+          class ARGS_3,
+          class ARGS_4,
+          class ARGS_5>
 inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_1) args_1,
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_2) args_2,
@@ -898,12 +915,12 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_5) args_5) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -931,13 +948,13 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_6) args_6) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -967,14 +984,14 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_7) args_7) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1006,15 +1023,15 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_8) args_8) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1048,16 +1065,16 @@ inline void OperationChain_CompletionCallbackWrapper<CO_CALLBACK>::operator()(
     BSLS_COMPILERFEATURES_FORWARD_REF(ARGS_9) args_9) const
 {
     try {
-        bslmf::Util::moveIfSupported(
-            (*d_coCallback_p))(bslmf::Util::forward<ARGS_1>(args_1),
-                               bslmf::Util::forward<ARGS_2>(args_2),
-                               bslmf::Util::forward<ARGS_3>(args_3),
-                               bslmf::Util::forward<ARGS_4>(args_4),
-                               bslmf::Util::forward<ARGS_5>(args_5),
-                               bslmf::Util::forward<ARGS_6>(args_6),
-                               bslmf::Util::forward<ARGS_7>(args_7),
-                               bslmf::Util::forward<ARGS_8>(args_8),
-                               bslmf::Util::forward<ARGS_9>(args_9));
+        bslmf::Util::moveIfSupported((*d_coCallback_p))(
+            bslmf::Util::forward<ARGS_1>(args_1),
+            bslmf::Util::forward<ARGS_2>(args_2),
+            bslmf::Util::forward<ARGS_3>(args_3),
+            bslmf::Util::forward<ARGS_4>(args_4),
+            bslmf::Util::forward<ARGS_5>(args_5),
+            bslmf::Util::forward<ARGS_6>(args_6),
+            bslmf::Util::forward<ARGS_7>(args_7),
+            bslmf::Util::forward<ARGS_8>(args_8),
+            bslmf::Util::forward<ARGS_9>(args_9));
     }
     catch (...) {
         d_chain_p->onOperationCompleted(d_jobHandle);
@@ -1283,8 +1300,9 @@ inline void bmqu::swap(OperationChainLink& lhs,
 
 }  // close enterprise namespace
 
-#else  // if ! defined(DEFINED_BMQU_OPERATIONCHAIN_H)
-#error Not valid except when included from bmqu_operationchain.h
-#endif  // ! defined(COMPILING_BMQU_OPERATIONCHAIN_H)
+#else // if ! defined(DEFINED_BMQU_OPERATIONCHAIN_H)
+# error Not valid except when included from bmqu_operationchain.h
+#endif // ! defined(COMPILING_BMQU_OPERATIONCHAIN_H)
 
-#endif  // ! defined(INCLUDED_BMQU_OPERATIONCHAIN_CPP03)
+#endif // ! defined(INCLUDED_BMQU_OPERATIONCHAIN_CPP03)
+


### PR DESCRIPTION
This PR regenerates the components that simulate C++11 features in C++03, using BDE’s [`sim_cpp11_features.pl`][sim-cpp11-features] script. These changes seem to be entirely formatting; with the new version of this script, there should be no need to placate clang-format anymore when updating these files.

[sim-cpp11-features]: https://github.com/bloomberg/bde-tools/blob/main/BdeBuildSystem/scripts/sim_cpp11_features.pl
