### PR TITLE
Docs[bmq]: Fix Markdown formatting in deprecation warnings

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_abstractsession.h
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.h
@@ -240,7 +240,7 @@ class AbstractSession {
                    const bmqt::QueueOptions& options = bmqt::QueueOptions(),
                    const bsls::TimeInterval& timeout = bsls::TimeInterval());
 
-    /// DEPRECATED: Use the 'configureQueueSync(QueueId *queueId...)
+    /// DEPRECATED: Use the `configureQueueSync(QueueId *queueId...)`
     ///             instead.  This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.
@@ -293,7 +293,7 @@ class AbstractSession {
     //         EventHandler thread(s) (or if a SessionEventHandler was not
     //         specified, from the thread invoking 'nextEvent').
 
-    /// DEPRECATED: Use the 'closeQueueSync(QueueId *queueId...) instead.
+    /// DEPRECATED: Use the `closeQueueSync(QueueId *queueId...)` instead.
     ///             This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -1382,7 +1382,7 @@ class MockSession : public AbstractSession {
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE;
 
-    /// DEPRECATED: Use the 'configureQueueSync(QueueId *queueId...)
+    /// DEPRECATED: Use the `configureQueueSync(QueueId *queueId...)`
     ///             instead.  This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -799,7 +799,7 @@ class Session : public AbstractSession {
     /// operation is cheap, and `MessageEventBuilder` can be obtained on
     /// demand and kept on the stack.
     ///
-    /// DEPRECATED: Use the 'loadMessageEventBuilder instead.  This
+    /// DEPRECATED: Use the `loadMessageEventBuilder` instead.  This
     ///             method will be marked as `BSLS_ANNOTATION_DEPRECATED` in
     ///             future release of libbmq.
     virtual MessageEventBuilder createMessageEventBuilder();
@@ -934,7 +934,7 @@ class Session : public AbstractSession {
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE;
 
-    /// DEPRECATED: Use the 'configureQueueSync(QueueId *queueId...)
+    /// DEPRECATED: Use the `configureQueueSync(QueueId *queueId...)`
     ///             instead.  This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.
@@ -998,7 +998,7 @@ class Session : public AbstractSession {
                              const bsls::TimeInterval&     timeout =
                                  bsls::TimeInterval()) BSLS_KEYWORD_OVERRIDE;
 
-    /// DEPRECATED: Use the 'closeQueueSync(QueueId *queueId...) instead.
+    /// DEPRECATED: Use the `closeQueueSync(QueueId *queueId...)` instead.
     ///             This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.
@@ -1027,7 +1027,7 @@ class Session : public AbstractSession {
                    const bsls::TimeInterval& timeout = bsls::TimeInterval())
         BSLS_KEYWORD_OVERRIDE;
 
-    /// DEPRECATED: Use the 'closeQueue(QueueId *queueId...) instead.  This
+    /// DEPRECATED: Use the `closeQueue(QueueId *queueId...)` instead.  This
     ///             method will be marked as `BSLS_ANNOTATION_DEPRECATED` in
     ///             future release of libbmq.
     virtual int

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -290,8 +290,8 @@ class SessionOptions {
     setTraceOptions(const bsl::shared_ptr<bmqpi::DTContext>& dtContext,
                     const bsl::shared_ptr<bmqpi::DTTracer>&  dtTracer);
 
-    /// DEPRECATED: Use 'configureEventQueue(int lowWatermark,
-    ///                                      int highWatermark)'
+    /// DEPRECATED: Use `configureEventQueue(int lowWatermark,
+    ///                                      int highWatermark)`
     ///             instead.  This method will be marked as
     ///             `BSLS_ANNOTATION_DEPRECATED` in future release of
     ///             libbmq.


### PR DESCRIPTION
This patch fixes some old BDE formatting that was not properly converted to Doxygen Markdown.
