### PR TITLE
CI: Run build action on integration branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - 'integration/**'
   pull_request:
     branches:
       - main
+      - 'integration/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Currently, the GitHub Action `build.yaml` is set to run on pushes and PRs that target the `main` branch.  This severely restricts our ability to make changes against longer-lived integration branches that may not be released immediately.  This patch relaxes that restriction, so we can run CI builds on pushes and PRs that target branches beginning with the prefix `integration/`.