### PR TITLE
Fix: Clang warnings related to unused or potentially unused variables

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_compositesequencenumber.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_compositesequencenumber.cpp
@@ -74,12 +74,12 @@ CompositeSequenceNumber::fromString(bool*              success,
             uLong     = bsl::stoul(firstPart, &posFirst);
             seqNumber = bsl::stoul(secondPart, &posSecond);
         }
-        catch (const bsl::invalid_argument& e) {
+        catch (const bsl::invalid_argument&) {
             errorDescription
                 << "Invalid input: non-numeric values encountered.";
             break;  // BREAK
         }
-        catch (const bsl::out_of_range& e) {
+        catch (const bsl::out_of_range&) {
             errorDescription << "Invalid input: number out of range.";
             break;  // BREAK
         }

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.h
@@ -47,6 +47,9 @@
 #include <mqbc_clusterstateledgerprotocol.h>
 #include <mqbsi_ledger.h>
 
+// BDE
+#include <bsla_annotations.h>
+
 namespace BloombergLP {
 namespace m_bmqstoragetool {
 
@@ -95,7 +98,7 @@ class CslSearchShortResult : public CslSearchResult {
     /// Record counters
     CslRecordCount d_recordCount;
     /// Allocator used inside the class.
-    bslma::Allocator* d_allocator_p;
+    BSLA_UNUSED bslma::Allocator* d_allocator_p;
 
   public:
     // CREATORS
@@ -141,7 +144,7 @@ class CslSearchDetailResult : public CslSearchResult {
     /// Record counters
     CslRecordCount d_recordCount;
     /// Allocator used inside the class.
-    bslma::Allocator* d_allocator_p;
+    BSLA_UNUSED bslma::Allocator* d_allocator_p;
 
   public:
     // CREATORS
@@ -306,7 +309,7 @@ class CslSummaryResult : public CslSearchResult {
     /// Limit number of queues to display
     unsigned int d_cslSummaryQueuesLimit;
     /// Pointer to allocator that is used inside the class.
-    bslma::Allocator* d_allocator_p;
+    BSLA_UNUSED bslma::Allocator* d_allocator_p;
 
   public:
     // CREATORS

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -32,6 +32,7 @@
 // BDE
 #include <bdls_filesystemutil.h>
 #include <bdls_pathutil.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace m_bmqstoragetool {
@@ -206,9 +207,8 @@ FileManagerImpl::CslFileHandler::CslFileHandler(const bsl::string& path,
 FileManagerImpl::CslFileHandler::~CslFileHandler()
 {
     if (d_ledger_p) {
-        const int rc = d_ledger_p->close();
+        BSLA_MAYBE_UNUSED const int rc = d_ledger_p->close();
         BSLS_ASSERT(rc == 0);
-        (void)rc;  // Compiler happiness
     }
 }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -547,8 +547,8 @@ bool SearchDetailResult::processDeletionRecord(
 
 bool SearchDetailResult::processQueueOpRecord(
     const mqbs::QueueOpRecord& record,
-    BSLA_UNUSED bsls::Types::Uint64 recordIndex,
-    BSLA_UNUSED bsls::Types::Uint64 recordOffset)
+    bsls::Types::Uint64        recordIndex,
+    bsls::Types::Uint64        recordOffset)
 {
     bsl::optional<bmqp_ctrlmsg::QueueInfo> queueInfo =
         d_queueMap.findInfoByKey(record.queueKey());
@@ -576,8 +576,8 @@ bool SearchDetailResult::processQueueOpRecord(
 
 bool SearchDetailResult::processJournalOpRecord(
     const mqbs::JournalOpRecord& record,
-    BSLA_UNUSED bsls::Types::Uint64 recordIndex,
-    BSLA_UNUSED bsls::Types::Uint64 recordOffset)
+    bsls::Types::Uint64          recordIndex,
+    bsls::Types::Uint64          recordOffset)
 {
     RecordDetails<mqbs::JournalOpRecord> details(record,
                                                  recordIndex,

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -56,6 +56,7 @@
 #include <bdlt_timeunitratio.h>
 #include <bsl_numeric.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslmt_semaphore.h>
@@ -752,14 +753,13 @@ void Application::onMessageEvent(const bmqa::MessageEvent& event)
                     const bmqa::Message& message)>
                     f(&bmqa::ConfirmEventBuilder::addMessageConfirmation);
 
-                bmqt::EventBuilderResult::Enum rc =
+                BSLA_MAYBE_UNUSED bmqt::EventBuilderResult::Enum rc =
                     bmqp::ProtocolUtil::buildEvent(
                         BuildConfirmFunctor(confirmBuilder, message),
                         BuildConfirmOverflowFunctor(*d_session_mp.get(),
                                                     confirmBuilder));
 
                 BSLS_ASSERT_SAFE(rc == 0);
-                (void)rc;  // compiler happiness
 
                 // Write to log file
                 d_fileLogger.writeConfirmMessage(message);
@@ -987,9 +987,8 @@ int Application::start()
     d_scheduler.start();
 
     if (!d_parameters.logFilePath().empty()) {
-        bool rc = d_fileLogger.open();
+        BSLA_MAYBE_UNUSED bool rc = d_fileLogger.open();
         BSLS_ASSERT_SAFE(rc);
-        (void)rc;  // Compiler happiness
     }
 
     int rc = initialize();

--- a/src/applications/bmqtool/m_bmqtool_inpututil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.cpp
@@ -27,6 +27,7 @@
 #include <bsl_fstream.h>
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
@@ -173,11 +174,10 @@ void InputUtil::verifyProperties(
         if (in.hasProperty("pairs_", &type)) {
             BSLS_ASSERT_SAFE(type == bmqt::PropertyType::e_INT32);
 
-            int numPairs = in.getPropertyAsInt32("pairs_");
+            BSLA_MAYBE_UNUSED int numPairs = in.getPropertyAsInt32("pairs_");
 
             BSLS_ASSERT_SAFE(in.numProperties() == (numPairs * 2 + 1));
 
-            (void)numPairs;
             bmqa::MessagePropertiesIterator it(&in);
 
             bsl::unordered_set<bsl::string> pairs;
@@ -192,10 +192,9 @@ void InputUtil::verifyProperties(
                 }
 
                 name += "_value";
-                bool hasValue = in.hasProperty(name, &type);
+                BSLA_MAYBE_UNUSED bool hasValue = in.hasProperty(name, &type);
 
                 BSLS_ASSERT_SAFE(hasValue);
-                (void)hasValue;
                 BSLS_ASSERT_SAFE(it.type() == type);
 
                 pairs.insert(name);

--- a/src/applications/bmqtool/m_bmqtool_messages.cpp
+++ b/src/applications/bmqtool/m_bmqtool_messages.cpp
@@ -23,17 +23,17 @@
 #include <bdlb_string.h>
 
 #include <bdlb_nullablevalue.h>
-#include <bsl_string.h>
-#include <bsl_vector.h>
-#include <bslim_printer.h>
-#include <bsls_assert.h>
-#include <bsls_types.h>
-
 #include <bsl_cstring.h>
 #include <bsl_iomanip.h>
 #include <bsl_limits.h>
 #include <bsl_ostream.h>
+#include <bsl_string.h>
 #include <bsl_utility.h>
+#include <bsl_vector.h>
+#include <bsla_annotations.h>
+#include <bslim_printer.h>
+#include <bsls_assert.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
@@ -410,10 +410,9 @@ const char CloseStorageCommand::CLASS_NAME[] = "CloseStorageCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-CloseStorageCommand::lookupAttributeInfo(const char* name, int nameLength)
+CloseStorageCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
+                                         BSLA_UNUSED int         nameLength)
 {
-    (void)name;
-    (void)nameLength;
     return 0;
 }
 
@@ -1479,10 +1478,9 @@ const char ListQueuesCommand::CLASS_NAME[] = "ListQueuesCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-ListQueuesCommand::lookupAttributeInfo(const char* name, int nameLength)
+ListQueuesCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
+                                       BSLA_UNUSED int         nameLength)
 {
-    (void)name;
-    (void)nameLength;
     return 0;
 }
 
@@ -1706,10 +1704,9 @@ const char MetadataCommand::CLASS_NAME[] = "MetadataCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-MetadataCommand::lookupAttributeInfo(const char* name, int nameLength)
+MetadataCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
+                                     BSLA_UNUSED int         nameLength)
 {
-    (void)name;
-    (void)nameLength;
     return 0;
 }
 

--- a/src/applications/bmqtool/m_bmqtool_messages.h
+++ b/src/applications/bmqtool/m_bmqtool_messages.h
@@ -19,36 +19,23 @@
 
 //@PURPOSE: Provide value-semantic attribute classes
 
-#include <bslalg_typetraits.h>
-
 #include <bdlat_attributeinfo.h>
-
 #include <bdlat_enumeratorinfo.h>
-
 #include <bdlat_selectioninfo.h>
-
 #include <bdlat_typetraits.h>
-
-#include <bslh_hash.h>
-#include <bsls_objectbuffer.h>
-
-#include <bslma_default.h>
-
-#include <bsls_assert.h>
-
 #include <bdlb_nullablevalue.h>
-
-#include <bsl_string.h>
-
-#include <bsl_vector.h>
-
-#include <bsls_types.h>
-
 #include <bsl_iosfwd.h>
 #include <bsl_limits.h>
-
 #include <bsl_ostream.h>
 #include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bsla_annotations.h>
+#include <bslalg_typetraits.h>
+#include <bslh_hash.h>
+#include <bslma_default.h>
+#include <bsls_assert.h>
+#include <bsls_objectbuffer.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 
@@ -7345,17 +7332,17 @@ inline bool CloseQueueCommand::async() const
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int CloseStorageCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
+int CloseStorageCommand::manipulateAttributes(
+    BSLA_UNUSED t_MANIPULATOR& manipulator)
 {
-    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int CloseStorageCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                             int            id)
+int CloseStorageCommand::manipulateAttribute(
+    BSLA_UNUSED t_MANIPULATOR& manipulator,
+    int                        id)
 {
-    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -7381,16 +7368,16 @@ int CloseStorageCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int CloseStorageCommand::accessAttributes(t_ACCESSOR& accessor) const
+int CloseStorageCommand::accessAttributes(
+    BSLA_UNUSED t_ACCESSOR& accessor) const
 {
-    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int CloseStorageCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
+int CloseStorageCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
+                                         int                     id) const
 {
-    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8075,16 +8062,17 @@ inline const bdlb::NullableValue<bsl::string>& ListCommand::uri() const
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int ListQueuesCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
+int ListQueuesCommand::manipulateAttributes(
+    BSLA_UNUSED t_MANIPULATOR& manipulator)
 {
-    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int ListQueuesCommand::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+int ListQueuesCommand::manipulateAttribute(
+    BSLA_UNUSED t_MANIPULATOR& manipulator,
+    int                        id)
 {
-    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8110,16 +8098,15 @@ int ListQueuesCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int ListQueuesCommand::accessAttributes(t_ACCESSOR& accessor) const
+int ListQueuesCommand::accessAttributes(BSLA_UNUSED t_ACCESSOR& accessor) const
 {
-    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int ListQueuesCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
+int ListQueuesCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
+                                       int                     id) const
 {
-    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8298,16 +8285,17 @@ MessagePropertyType::print(bsl::ostream&              stream,
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int MetadataCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
+int MetadataCommand::manipulateAttributes(
+    BSLA_UNUSED t_MANIPULATOR& manipulator)
 {
-    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int MetadataCommand::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+int MetadataCommand::manipulateAttribute(
+    BSLA_UNUSED t_MANIPULATOR& manipulator,
+    int                        id)
 {
-    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8333,16 +8321,15 @@ int MetadataCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int MetadataCommand::accessAttributes(t_ACCESSOR& accessor) const
+int MetadataCommand::accessAttributes(BSLA_UNUSED t_ACCESSOR& accessor) const
 {
-    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int MetadataCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
+int MetadataCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
+                                     int                     id) const
 {
-    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {

--- a/src/groups/bmq/bmqa/bmqa_message.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.cpp
@@ -37,6 +37,7 @@
 #include <bsl_iostream.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslim_printer.h>
 #include <bslma_default.h>
 #include <bslmf_assert.h>
@@ -393,11 +394,11 @@ int Message::ackStatus() const
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(isInitialized());
 
-    const bmqp::Event& rawEvent = d_impl.d_event_p->rawEvent();
+    BSLA_MAYBE_UNUSED const bmqp::Event& rawEvent =
+        d_impl.d_event_p->rawEvent();
 
     BSLS_ASSERT_SAFE(rawEvent.isAckEvent() &&
                      "Event is not an AckMessage event");
-    (void)rawEvent;  // Compiler happiness
 
     return bmqp::ProtocolUtil::ackResultFromCode(
         d_impl.d_event_p->ackMessageIterator()->message().status());

--- a/src/groups/bmq/bmqa/bmqa_messageevent.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageevent.cpp
@@ -23,6 +23,7 @@
 
 // BDE
 #include <bsl_ostream.h>
+#include <bsla_annotations.h>
 #include <bslmf_assert.h>
 #include <bslmf_ispolymorphic.h>
 #include <bsls_assert.h>
@@ -53,11 +54,10 @@ MessageIterator MessageEvent::messageIterator() const
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_impl_sp);
 
-    const bmqp::Event& rawEvent = d_impl_sp->rawEvent();
+    BSLA_MAYBE_UNUSED const bmqp::Event& rawEvent = d_impl_sp->rawEvent();
 
     BSLS_ASSERT(rawEvent.isAckEvent() || rawEvent.isPushEvent() ||
                 rawEvent.isPutEvent());
-    (void)rawEvent;  // compiler happiness
 
     d_impl_sp->resetIterators();
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -1758,14 +1758,12 @@ void MockSession::openQueueAsync(BSLA_UNUSED QueueId*                 queueId,
     BMQA_ASSERT_AND_POP_FRONT();
 }
 
-int MockSession::configureQueue(QueueId*                  queueId,
-                                const bmqt::QueueOptions& options,
-                                const bsls::TimeInterval& timeout)
+int MockSession::configureQueue(BSLA_MAYBE_UNUSED QueueId* queueId,
+                                const bmqt::QueueOptions&  options,
+                                const bsls::TimeInterval&  timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT(queueId);
-
-    (void)queueId;  // Compiler happiness in 'opt' build
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -1792,14 +1790,12 @@ int MockSession::configureQueue(QueueId*                  queueId,
 }
 
 ConfigureQueueStatus
-MockSession::configureQueueSync(QueueId*                  queueId,
-                                const bmqt::QueueOptions& options,
-                                const bsls::TimeInterval& timeout)
+MockSession::configureQueueSync(BSLA_MAYBE_UNUSED QueueId* queueId,
+                                const bmqt::QueueOptions&  options,
+                                const bsls::TimeInterval&  timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT(queueId && "'queueId' not provided");
-
-    (void)queueId;  // Compiler happiness in 'opt' build
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -1837,14 +1833,12 @@ MockSession::configureQueueSync(QueueId*                  queueId,
     return _result;
 }
 
-int MockSession::configureQueueAsync(QueueId*                  queueId,
-                                     const bmqt::QueueOptions& options,
-                                     const bsls::TimeInterval& timeout)
+int MockSession::configureQueueAsync(BSLA_MAYBE_UNUSED QueueId* queueId,
+                                     const bmqt::QueueOptions&  options,
+                                     const bsls::TimeInterval&  timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT(queueId);
-
-    (void)queueId;  // Compiler happiness in 'opt' build
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -1873,15 +1867,13 @@ int MockSession::configureQueueAsync(QueueId*                  queueId,
 }
 
 void MockSession::configureQueueAsync(
-    QueueId*                                  queueId,
+    BSLA_MAYBE_UNUSED QueueId*                queueId,
     const bmqt::QueueOptions&                 options,
     BSLA_UNUSED const ConfigureQueueCallback& callback,
     const bsls::TimeInterval&                 timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueId && "'queueId' not provided");
-
-    (void)queueId;  // Compiler happiness in 'opt' build
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -2016,14 +2008,12 @@ int MockSession::closeQueueAsync(QueueId*                  queueId,
 }
 
 void MockSession::closeQueueAsync(
-    QueueId*                              queueId,
+    BSLA_MAYBE_UNUSED QueueId*            queueId,
     BSLA_UNUSED const CloseQueueCallback& callback,
     const bsls::TimeInterval&             timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueId && "'queueId' not provided");
-
-    (void)queueId;  // Compiler happiness in 'opt' build
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -49,6 +49,7 @@
 #include <bdlt_timeunitratio.h>
 #include <bsl_cstdio.h>
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>
 #include <bslma_default.h>
 #include <bslma_managedptr.h>
 #include <bslmf_assert.h>
@@ -596,10 +597,10 @@ SessionUtil::validateAndSetConfigureQueueParameters(
 }
 
 bmqt::CloseQueueResult::Enum SessionUtil::validateAndSetCloseQueueParameters(
-    bmqu::MemOutStream*       errorDescription,
-    const QueueId*            queueId,
-    const SessionImpl*        sessionImpl,
-    const bsls::TimeInterval& timeout)
+    bmqu::MemOutStream*                  errorDescription,
+    const QueueId*                       queueId,
+    BSLA_MAYBE_UNUSED const SessionImpl* sessionImpl,
+    const bsls::TimeInterval&            timeout)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(sessionImpl && "Must provide 'sessionImpl'");
@@ -613,8 +614,6 @@ bmqt::CloseQueueResult::Enum SessionUtil::validateAndSetCloseQueueParameters(
         (*errorDescription) << "Not connected";
         return bmqt::CloseQueueResult::e_NOT_CONNECTED;  // RETURN
     }
-
-    (void)sessionImpl;  // Compiler happiness in OPT build
 
     // Make sure the provided QueueId is valid
     if (!queueId->isValid()) {

--- a/src/groups/bmq/bmqc/bmqc_monitoredqueue.h
+++ b/src/groups/bmq/bmqc/bmqc_monitoredqueue.h
@@ -72,6 +72,7 @@
 #include <bsl_limits.h>
 #include <bsl_sstream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_allocatorargt.h>
@@ -485,7 +486,7 @@ MonitoredQueue<QUEUE, QUEUE_TRAITS>::setWatermarks(
     bsls::Types::Int64 highWatermark,
     bsls::Types::Int64 highWatermark2)
 {
-    const bsls::Types::Int64 intMax =
+    BSLA_MAYBE_UNUSED const bsls::Types::Int64 intMax =
         bsl::numeric_limits<bsls::Types::Int64>::max();
     BSLS_ASSERT(lowWatermark >= 0);
     BSLS_ASSERT(lowWatermark < highWatermark);
@@ -496,8 +497,6 @@ MonitoredQueue<QUEUE, QUEUE_TRAITS>::setWatermarks(
     d_lowWatermark   = lowWatermark;
     d_highWatermark  = highWatermark;
     d_highWatermark2 = highWatermark2;
-
-    (void)intMax;  // prod-build compiler happiness
 
     return *this;
 }

--- a/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccfixedqueue.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccfixedqueue.t.cpp
@@ -28,6 +28,7 @@
 #include <bsl_iostream.h>
 #include <bsl_limits.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslmt_semaphore.h>
 #include <bslmt_threadattributes.h>
 #include <bslmt_threadutil.h>
@@ -204,10 +205,10 @@ static void test1_MonitoredQueue_breathingTest()
         //
         // Verify timed popFront is undefined
         // // int                      item    = -1;
-        // const bsls::TimeInterval timeout = bsls::TimeInterval(
+        // BSLA_MAYBE_UNUSED const bsls::TimeInterval timeout =
+        // bsls::TimeInterval(
         //     0, 5 * bdlt::TimeUnitRatio::k_NANOSECONDS_PER_MILLISECOND);
         // BMQTST_ASSERT_SAFE_FAIL(queue.timedPopFront(&item, timeout));
-        // (void)timeout;  // prod-build compiler happiness
 
         // popfront two items
         item = -1;

--- a/src/groups/bmq/bmqex/bmqex_bdlmtfixedthreadpoolexecutor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtfixedthreadpoolexecutor.cpp
@@ -19,6 +19,7 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlmt_fixedthreadpool.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace bmqex {
@@ -33,9 +34,7 @@ void BdlmtFixedThreadPoolExecutor::post(const bsl::function<void()>& f) const
     // PRECONDITIONS
     BSLS_ASSERT(f);
 
-    int rc = d_context_p->enqueueJob(f);
-
-    (void)rc;
+    BSLA_MAYBE_UNUSED int rc = d_context_p->enqueueJob(f);
     BSLS_ASSERT(rc == 0);
 }
 

--- a/src/groups/bmq/bmqex/bmqex_bdlmtmultiprioritythreadpoolexecutor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtmultiprioritythreadpoolexecutor.cpp
@@ -19,6 +19,7 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlmt_multiprioritythreadpool.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace bmqex {
@@ -34,9 +35,7 @@ void BdlmtMultipriorityThreadPoolExecutor::post(
     // PRECONDITIONS
     BSLS_ASSERT(f);
 
-    int rc = d_context_p->enqueueJob(f, d_priority);
-
-    (void)rc;
+    BSLA_MAYBE_UNUSED int rc = d_context_p->enqueueJob(f, d_priority);
     BSLS_ASSERT(rc == 0);
 }
 

--- a/src/groups/bmq/bmqex/bmqex_bdlmtmultiqueuethreadpoolexecutor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtmultiqueuethreadpoolexecutor.cpp
@@ -19,6 +19,7 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlmt_multiqueuethreadpool.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace bmqex {
@@ -33,9 +34,7 @@ void BdlmtMultiQueueThreadPoolExecutor::post(
     // PRECONDITIONS
     BSLS_ASSERT(f);
 
-    int rc = d_context_p->enqueueJob(d_queueId, f);
-
-    (void)rc;
+    BSLA_MAYBE_UNUSED int rc = d_context_p->enqueueJob(d_queueId, f);
     BSLS_ASSERT(rc == 0);
 }
 

--- a/src/groups/bmq/bmqex/bmqex_bdlmtthreadpoolexecutor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtthreadpoolexecutor.cpp
@@ -19,6 +19,7 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlmt_threadpool.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace bmqex {
@@ -33,9 +34,7 @@ void BdlmtThreadPoolExecutor::post(const bsl::function<void()>& f) const
     // PRECONDITIONS
     BSLS_ASSERT(f);
 
-    int rc = d_context_p->enqueueJob(f);
-
-    (void)rc;
+    BSLA_MAYBE_UNUSED int rc = d_context_p->enqueueJob(f);
     BSLS_ASSERT(rc == 0);
 }
 

--- a/src/groups/bmq/bmqex/bmqex_strand.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_strand.t.cpp
@@ -262,14 +262,17 @@ class ThrowingExecutor {
     }
 
     template <class FUNCTION>
-    BSLA_NORETURN void dispatch(FUNCTION) const
+    BSLA_MAYBE_UNUSED BSLA_NORETURN void dispatch(FUNCTION) const
     {
         throw ExceptionType();
     }
 
   public:
     // ACCESSORS
-    bool operator==(const ThrowingExecutor&) const { return true; }
+    BSLA_MAYBE_UNUSED bool operator==(const ThrowingExecutor&) const
+    {
+        return true;
+    }
 };
 
 // ==========================
@@ -408,12 +411,6 @@ static void test1_strand_creators()
 // ------------------------------------------------------------------------
 {
     typedef bmqex::Strand<IdentifiableExecutor> Strand;
-
-    // compiler hapiness
-    {
-        (void)&ThrowingExecutor::dispatch<int>;
-        (void)&ThrowingExecutor::operator==;
-    }
 
     // 1. default constructor
     {

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -3177,9 +3177,8 @@ void BrokerSession::fsmThreadLoop()
     while (true) {
         bsl::shared_ptr<Event> event;
 
-        const int rc = d_fsmEventQueue.popFront(&event);
+        BSLA_MAYBE_UNUSED const int rc = d_fsmEventQueue.popFront(&event);
         BSLS_ASSERT_SAFE(rc == 0);
-        (void)rc;
         if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!event)) {  // PoisonPill
             BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
             // Drain left over events (there should be none)
@@ -6247,13 +6246,13 @@ void BrokerSession::onConfigureQueueResponse(
     if (context->isError()) {
         // Ignore cancelled request that has already timed out
         if (context->isLateResponse()) {
-            const bmqt::GenericResult::Enum res = context->result();
+            BSLA_MAYBE_UNUSED const bmqt::GenericResult::Enum res =
+                context->result();
 
             BSLS_ASSERT_SAFE(res == bmqt::GenericResult::e_CANCELED ||
                              res == bmqt::GenericResult::e_NOT_CONNECTED ||
                              res == bmqt::GenericResult::e_NOT_SUPPORTED);
 
-            (void)res;
             BALL_LOG_INFO << id() << "Ignore cancelled request: "
                           << context->request();
             return;  // RETURN
@@ -7128,10 +7127,10 @@ void BrokerSession::removePendingControlMessage(
     // Remove the request from the retransmission buffer
     bmqt::MessageGUID guid;
     guid.fromHex(context->userData().theString().data());
-    const int rc = d_messageCorrelationIdContainer.remove(guid);
+    BSLA_MAYBE_UNUSED const int rc = d_messageCorrelationIdContainer.remove(
+        guid);
 
     BSLS_ASSERT_SAFE(0 == rc);
-    (void)rc;
 
     // Reset request id
     context->adoptUserData(bdld::Datum::createNull());

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.cpp
@@ -37,6 +37,7 @@
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslmt_threadutil.h>
 #include <bsls_assert.h>
@@ -547,10 +548,9 @@ bsl::shared_ptr<Event> EventQueue::popFront()
     }
 
     // Look in the queue
-    QueueItem item;
-    const int rc = d_queue.popFront(&item);
+    QueueItem                   item;
+    BSLA_MAYBE_UNUSED const int rc = d_queue.popFront(&item);
     BSLS_ASSERT_SAFE(rc == 0);
-    (void)rc;
     event = item.d_event_sp;
     afterEventPopped(item);
     return event;

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.cpp
@@ -40,6 +40,7 @@
 #include <bsl_cstdlib.h>  // for bsl::atoi
 #include <bsl_sstream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
@@ -446,11 +447,10 @@ void MessageDumper::dumpPutEvent(bsl::ostream&             out,
     bmqt::CorrelationId correlationId;
     int                 msgNum = 0;
     while (iter.next() == 1) {
-        int rc = d_messageCorrelationIdContainer_p->find(
+        BSLA_MAYBE_UNUSED int rc = d_messageCorrelationIdContainer_p->find(
             &correlationId,
             iter.header().messageGUID());
         BSLS_ASSERT_SAFE((rc == 0) && "correlationId not found");
-        (void)rc;  // Compiler happiness
 
         out << "PUT Message #" << ++msgNum << ": "
             << "[correlationId: " << correlationId << ", queue: "

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -25,6 +25,7 @@
 // BDE
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 #include <bslmf_assert.h>
 #include <bslmt_mutexassert.h>
 #include <bsls_assert.h>
@@ -175,18 +176,16 @@ void QueueManager::insertQueue(const QueueSp& queue)
 
     BSLS_ASSERT_SAFE(queueInfo.d_subQueueIdsMap.find(queue->uri().id()) ==
                      queueInfo.d_subQueueIdsMap.end());
-    bsl::pair<SubQueueIdsMap::iterator, bool> insertRet =
+    BSLA_MAYBE_UNUSED bsl::pair<SubQueueIdsMap::iterator, bool> insertRet =
         queueInfo.d_subQueueIdsMap.insert(
             bsl::make_pair(queue->uri().id(), subId));
     BSLS_ASSERT_SAFE(insertRet.second);
-    (void)insertRet;  // Compiler happiness
 
     // Insert into queues map
     const bmqp::QueueId queueId(queue->id(), subId);
-    bsl::pair<QueuesMap::iterator, QueuesMap::InsertResult> addRet =
-        d_queues.insert(queueId, queue->correlationId(), queue);
+    BSLA_MAYBE_UNUSED   bsl::pair<QueuesMap::iterator, QueuesMap::InsertResult>
+        addRet = d_queues.insert(queueId, queue->correlationId(), queue);
     BSLS_ASSERT_SAFE(addRet.second == QueuesMap::e_INSERTED);
-    (void)addRet.second;  // Compiler happiness
 }
 
 QueueManager::QueueSp QueueManager::removeQueue(const Queue* queue)
@@ -221,10 +220,9 @@ QueueManager::QueueSp QueueManager::removeQueue(const Queue* queue)
     if (subQueueIdsMap.empty()) {
         // No more appIds for this canonical URI, so we can remove it from the
         // URIs map
-        UrisMap::size_type numErasedUris = d_uris.erase(
+        BSLA_MAYBE_UNUSED UrisMap::size_type numErasedUris = d_uris.erase(
             bsl::string(queue->uri().canonical(), d_allocator_p));
         BSLS_ASSERT_SAFE(numErasedUris == 1);
-        (void)numErasedUris;  // Compiler happiness
     }
 
     return queueSp;

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
@@ -145,6 +145,7 @@ class Tester {
 
   public:
     // TRAITS
+    BSLA_MAYBE_UNUSED
     BSLMF_NESTED_TRAIT_DECLARATION(Tester, bslma::UsesBslmaAllocator)
 
     // CREATORS

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.t.cpp
@@ -77,8 +77,8 @@ void doFail()
     BMQTST_ASSERT(false && "Must not be invoked");
 }
 
-void executeOnClosedChannelFunc(bmqio::NtcChannel* channel,
-                                const Status&      status)
+void executeOnClosedChannelFunc(bmqio::NtcChannel*        channel,
+                                BSLA_UNUSED const Status& status)
 {
     // PRECONDITIONS
     BMQTST_ASSERT(channel);
@@ -251,9 +251,9 @@ void Tester::onAcceptConnection(
     d_semaphore.post();
 }
 
-void Tester::onChannelResult(ChannelFactoryEvent::Enum       event,
-                             const Status&                   status,
-                             const bsl::shared_ptr<Channel>& channel)
+void Tester::onChannelResult(BSLA_UNUSED ChannelFactoryEvent::Enum event,
+                             BSLA_UNUSED const Status&             status,
+                             const bsl::shared_ptr<Channel>&       channel)
 {
     d_connectChannels.push_back(channel);
 }

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
@@ -487,10 +487,9 @@ void Tester::resultCb(const bsl::string&              handleName,
 }
 
 void Tester::preCreationCb(
-    const bsl::shared_ptr<NtcChannel>&               channel,
-    const bsl::shared_ptr<ChannelFactory::OpHandle>& handle)
+    const bsl::shared_ptr<NtcChannel>& channel,
+    BSLA_UNUSED const bsl::shared_ptr<ChannelFactory::OpHandle>& handle)
 {
-    (void)handle;
     d_preCreateCbCalls.push_back(channel);
 }
 

--- a/src/groups/bmq/bmqp/bmqp_eventutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.cpp
@@ -31,6 +31,7 @@
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslmf_assert.h>
 #include <bsls_assert.h>
@@ -336,9 +337,9 @@ Flattener::EventBuilderResult Flattener::importOptions()
             LSA                        lsa(d_allocator_p);
             bmqp::Protocol::MsgGroupId msgGroupId(&lsa);
 
-            int rc = d_optionsView.loadMsgGroupIdOption(&msgGroupId);
+            BSLA_MAYBE_UNUSED int rc = d_optionsView.loadMsgGroupIdOption(
+                &msgGroupId);
             BSLS_ASSERT_SAFE(rc == 0);
-            (void)rc;  // Compiler happiness
             result = d_builder.addMsgGroupIdOption(msgGroupId);
         } break;
         case OptionType::e_SUB_QUEUE_INFOS: {

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -35,6 +35,7 @@
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_algorithm.h>
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>
 #include <bslim_printer.h>
 #include <bslma_default.h>
 #include <bslmf_assert.h>
@@ -224,11 +225,10 @@ const MessageProperties::PropertyVariant&
 MessageProperties::getPropertyValue(const Property& property) const
 {
     if (property.d_value.isUnset()) {
-        bool result = streamInPropertyValue(property);
+        BSLA_MAYBE_UNUSED bool result = streamInPropertyValue(property);
         BSLS_ASSERT_SAFE(result);
         // We assert 'true' result because the length and offset have already
         // been checked.
-        (void)result;
     }
     return property.d_value;
 }
@@ -874,9 +874,8 @@ MessageProperties::streamOut(bdlbb::BlobBufferFactory*          bufferFactory,
          ++cit) {
         const Property& p = cit->second;
         if (p.d_value.isUnset() && p.d_isValid) {
-            bool result = streamInPropertyValue(p);
+            BSLA_MAYBE_UNUSED bool result = streamInPropertyValue(p);
             BSLS_ASSERT(result);
-            (void)result;
         }
     }
 

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -751,11 +751,10 @@ inline const TYPE& MessageProperties::getPropertyOr(const bsl::string& name,
     }
     const Property& p = cit->second;
     if (p.d_value.isUnset()) {
-        bool result = streamInPropertyValue(p);
+        BSLA_MAYBE_UNUSED bool result = streamInPropertyValue(p);
         BSLS_ASSERT(result);
         // We assert 'true' result because the length and offset have already
         // been checked.
-        (void)result;
     }
     BSLS_ASSERT(p.d_value.is<TYPE>() && "Property data type mismatch");
 

--- a/src/groups/bmq/bmqp/bmqp_optionutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionutil.cpp
@@ -25,6 +25,7 @@
 // BDE
 #include <bdlbb_blobutil.h>
 #include <bsl_cstring.h>  // for bsl::memset
+#include <bsla_annotations.h>
 #include <bslmf_assert.h>
 #include <bsls_performancehint.h>
 
@@ -243,8 +244,8 @@ bool OptionUtil::loadOptionsPosition(int*                      optionsSize,
     return true;
 }
 
-bmqt::EventBuilderResult::Enum
-OptionUtil::isValidMsgGroupId(const Protocol::MsgGroupId& msgGroupId)
+bmqt::EventBuilderResult::Enum OptionUtil::isValidMsgGroupId(
+    BSLA_MAYBE_UNUSED const Protocol::MsgGroupId& msgGroupId)
 {
 #ifdef BMQ_ENABLE_MSG_GROUPID
     const int length = msgGroupId.length();
@@ -259,7 +260,6 @@ OptionUtil::isValidMsgGroupId(const Protocol::MsgGroupId& msgGroupId)
     }
     return bmqt::EventBuilderResult::e_SUCCESS;
 #else
-    (void)msgGroupId;
     return bmqt::EventBuilderResult::e_UNKNOWN;
 #endif
 }

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -155,7 +155,7 @@
 
 #include <bsl_limits.h>
 #include <bsl_string.h>  // for bslstl::StringRef
-
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 #include <bsls_types.h>
 
@@ -805,7 +805,7 @@ struct EventHeader {
     unsigned char d_typeSpecific;
     // Options and flags specific to this event's type
 
-    unsigned char d_reserved;
+    BSLA_MAYBE_UNUSED unsigned char d_reserved;
     // Reserved.
 
   public:
@@ -1179,7 +1179,7 @@ struct MessagePropertiesHeader {
 
     bdlb::BigEndianUint16 d_msgPropsAreaWordsLower;
 
-    char d_reserved;
+    BSLA_MAYBE_UNUSED char d_reserved;
 
     unsigned char d_numProperties;
 
@@ -1476,7 +1476,7 @@ struct PutHeader {
 
     SchemaWireId d_schemaId;
 
-    unsigned char d_reserved[2];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[2];
     // Reserved.
 
   public:
@@ -1779,7 +1779,7 @@ struct AckHeader {
     unsigned char d_flags;
     // Bitmask of flags.
 
-    unsigned char d_reserved[2];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[2];
     // Reserved.
 
   public:
@@ -2072,7 +2072,7 @@ struct PushHeader {
 
     SchemaWireId d_schemaId;
 
-    unsigned char d_reserved[2];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[2];
     // Reserved.
   public:
     // PUBLIC CLASS DATA
@@ -2344,7 +2344,7 @@ struct ConfirmHeader {
     // Total size (words) of this header and number of words of
     // each ConfirmMessage in the payload that follows.
 
-    unsigned char d_reserved[3];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[3];
     // Reserved
 
   public:
@@ -2514,7 +2514,7 @@ struct RejectHeader {
     // Total size (words) of this header and number of words of
     // each RejectMessage in the payload that follows.
 
-    unsigned char d_reserved[3];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[3];
     // Reserved
 
   public:
@@ -3211,7 +3211,7 @@ struct RecoveryHeader {
     // the message (including this header
     // and message payload)
 
-    char d_reserved;
+    BSLA_MAYBE_UNUSED char d_reserved;
 
     unsigned char d_headerWordsAndFileChunkType;
 
@@ -3731,8 +3731,6 @@ inline EventHeader::EventHeader()
     setType(EventType::e_UNDEFINED);
     setHeaderWords(sizeof(EventHeader) / Protocol::k_WORD_SIZE);
     setLength(sizeof(EventHeader));
-
-    (void)d_reserved;  // warning: private field 'd_reserved' is not used
 }
 
 inline EventHeader::EventHeader(EventType::Enum type)
@@ -3961,7 +3959,6 @@ inline MessagePropertiesHeader::MessagePropertiesHeader()
         static_cast<int>(roundedSize / Protocol::k_WORD_SIZE));
 
     setMessagePropertyHeaderSize(sizeof(MessagePropertyHeader));
-    static_cast<void>(d_reserved);
 }
 
 // MANIPULATORS
@@ -4173,8 +4170,6 @@ inline PutHeader::PutHeader()
     const int headerSizeWords = sizeof(PutHeader) / Protocol::k_WORD_SIZE;
     setHeaderWords(headerSizeWords);
     setMessageWords(headerSizeWords);
-
-    (void)d_reserved;
 }
 
 // MANIPULATORS
@@ -4351,8 +4346,6 @@ inline AckHeader::AckHeader()
     bsl::memset(this, 0, sizeof(AckHeader));
     setHeaderWords(sizeof(AckHeader) / Protocol::k_WORD_SIZE);
     setPerMessageWords(sizeof(AckMessage) / Protocol::k_WORD_SIZE);
-    (void)
-        d_reserved;  // silent warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -4498,8 +4491,6 @@ inline PushHeader::PushHeader()
     const int headerWords = sizeof(PushHeader) / Protocol::k_WORD_SIZE;
     setHeaderWords(headerWords);
     setMessageWords(headerWords);
-
-    (void)d_reserved;
 }
 
 // MANIPULATORS
@@ -4658,7 +4649,6 @@ inline ConfirmHeader::ConfirmHeader()
     bsl::memset(this, 0, sizeof(ConfirmHeader));
     setHeaderWords(sizeof(ConfirmHeader) / Protocol::k_WORD_SIZE);
     setPerMessageWords(sizeof(ConfirmMessage) / Protocol::k_WORD_SIZE);
-    (void)d_reserved;  // warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -4753,7 +4743,6 @@ inline RejectHeader::RejectHeader()
     bsl::memset(this, 0, sizeof(RejectHeader));
     setHeaderWords(sizeof(RejectHeader) / Protocol::k_WORD_SIZE);
     setPerMessageWords(sizeof(RejectMessage) / Protocol::k_WORD_SIZE);
-    (void)d_reserved;  // warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -5034,7 +5023,6 @@ inline RecoveryHeader::RecoveryHeader()
     const int headerWords = sizeof(RecoveryHeader) / Protocol::k_WORD_SIZE;
     setMessageWords(headerWords);
     setHeaderWords(headerWords);
-    static_cast<void>(d_reserved);
 }
 
 // MANIPULATORS

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -67,6 +67,7 @@
 #include <bsl_streambuf.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
@@ -1090,10 +1091,10 @@ ProtocolUtil::QueueInfo<VALUE>::insert(const bsl::string& appId,
     iterator itStream(result.first);
 
     for (size_t i = 0; i < subscriptions.size(); ++i) {
-        bsl::pair<typename SubscriptionsMap::iterator, bool> insertRC =
-            d_subscriptions.insert(bsl::make_pair(subscriptions[i], itStream));
+        BSLA_MAYBE_UNUSED bsl::pair<typename SubscriptionsMap::iterator, bool>
+                          insertRC = d_subscriptions.insert(
+                bsl::make_pair(subscriptions[i], itStream));
         BSLS_ASSERT_SAFE(insertRC.second);
-        (void)insertRC;
     }
     return itStream;
 }
@@ -1295,10 +1296,10 @@ inline void ProtocolUtil::QueueInfo<VALUE>::addSubscriptions(
     for (Subscriptions::const_iterator it = subscriptions.begin();
          it != subscriptions.end();
          ++it) {
-        bsl::pair<typename SubscriptionsMap::iterator, bool> insertRC =
-            d_subscriptions.insert(bsl::make_pair(it->sId(), itStream));
+        BSLA_MAYBE_UNUSED bsl::pair<typename SubscriptionsMap::iterator, bool>
+                          insertRC = d_subscriptions.insert(
+                bsl::make_pair(it->sId(), itStream));
         BSLS_ASSERT_SAFE(insertRC.second);
-        (void)insertRC;
     }
 }
 

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
@@ -26,6 +26,7 @@
 #include <bsl_algorithm.h>
 #include <bsl_cstring.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslmf_assert.h>
 #include <bsls_performancehint.h>
@@ -199,10 +200,9 @@ bmqt::EventBuilderResult::Enum PushEventBuilder::addSubQueueIdsOption(
     const Protocol::SubQueueIdsArrayOld& subQueueIds)
 {
     // PRECONDITIONS
-    const int optionsSize = d_options.size();
+    BSLA_MAYBE_UNUSED const int optionsSize = d_options.size();
     BSLS_ASSERT_SAFE((optionsSize > 0 && d_currPushHeader.isSet()) ||
                      (optionsSize == 0 && !d_currPushHeader.isSet()));
-    (void)optionsSize;  // compiler happiness
 
     typedef bmqt::EventBuilderResult Result;
     typedef OptionUtil::OptionMeta   OptionMeta;
@@ -254,10 +254,9 @@ bmqt::EventBuilderResult::Enum PushEventBuilder::addSubQueueInfosOption(
     bool                                packRdaCounter)
 {
     // PRECONDITIONS
-    const int optionsSize = d_options.size();
+    BSLA_MAYBE_UNUSED const int optionsSize = d_options.size();
     BSLS_ASSERT_SAFE((optionsSize > 0 && d_currPushHeader.isSet()) ||
                      (optionsSize == 0 && !d_currPushHeader.isSet()));
-    (void)optionsSize;  // compiler happiness
 
     typedef bmqt::EventBuilderResult Result;
     typedef OptionUtil::OptionMeta   OptionMeta;
@@ -366,10 +365,9 @@ PushEventBuilder::addMsgGroupIdOption(const Protocol::MsgGroupId& msgGroupId)
     // is meant to ensure that both error scenarios are captured by this
     // method.
 
-    const int optionsSize = d_options.size();
+    BSLA_MAYBE_UNUSED const int optionsSize = d_options.size();
     BSLS_ASSERT_SAFE((optionsSize > 0 && d_currPushHeader.isSet()) ||
                      (optionsSize == 0 && !d_currPushHeader.isSet()));
-    (void)optionsSize;  // compiler happiness
 
     typedef bmqt::EventBuilderResult Result;
     typedef OptionUtil::OptionMeta   OptionMeta;

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
@@ -30,6 +30,7 @@
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_iostream.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_default.h>
 #include <bsls_performancehint.h>
 
@@ -68,9 +69,8 @@ void PushMessageIterator::initCachedOptionsView() const
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(d_optionsView.isNull())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         // Load options iterator
-        int rc = loadOptionsView(&d_optionsView.makeValue());
+        BSLA_MAYBE_UNUSED int rc = loadOptionsView(&d_optionsView.makeValue());
         BSLS_ASSERT_SAFE(rc == 0);
-        (void)rc;  // compiler happiness
     }
 
     BSLS_ASSERT_SAFE(!d_optionsView.isNull());
@@ -434,14 +434,13 @@ void PushMessageIterator::extractQueueInfo(int*          queueId,
     // Load SubQueueInfos
     Protocol::SubQueueInfosArray subQueueInfos;
 
-    int rc = optionsView.loadSubQueueInfosOption(&subQueueInfos);
+    BSLA_MAYBE_UNUSED int rc = optionsView.loadSubQueueInfosOption(
+        &subQueueInfos);
     BSLS_ASSERT_SAFE(rc == 0);
     BSLS_ASSERT_SAFE(subQueueInfos.size() == 1);
 
     *subscriptionId = subQueueInfos[0].id();
     *rdaInfo        = RdaInfo(subQueueInfos[0].rdaInfo());
-
-    (void)rc;  // Compiler happiness
 }
 
 void PushMessageIterator::extractMsgGroupId(
@@ -471,10 +470,8 @@ void PushMessageIterator::extractMsgGroupId(
     }
 
     // Load Group Id
-    int rc = optionsView.loadMsgGroupIdOption(msgGroupId);
+    BSLA_MAYBE_UNUSED int rc = optionsView.loadMsgGroupIdOption(msgGroupId);
     BSLS_ASSERT_SAFE(rc == 0);
-
-    (void)rc;  // Compiler happiness
 }
 
 // MANIPULATORS

--- a/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
@@ -31,6 +31,7 @@
 // BDE
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>
 #include <bsls_performancehint.h>
 
 namespace BloombergLP {
@@ -89,9 +90,8 @@ void PutMessageIterator::initCachedOptionsView() const
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(d_optionsView.isNull())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         // Load options iterator
-        int rc = loadOptionsView(&d_optionsView.makeValue());
+        BSLA_MAYBE_UNUSED int rc = loadOptionsView(&d_optionsView.makeValue());
         BSLS_ASSERT_SAFE(rc == 0);
-        (void)rc;  // compiler happiness
     }
 
     // POSTCONDITIONS

--- a/src/groups/bmq/bmqp/bmqp_queueutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_queueutil.cpp
@@ -27,6 +27,7 @@
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_limits.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslma_default.h>
 #include <bslmf_assert.h>
 #include <bsls_assert.h>
@@ -218,9 +219,8 @@ bmqp_ctrlmsg::QueueHandleParameters QueueUtil::createHandleParameters(
 
         bmqt::UriBuilder uriBuilder(uri);
         uriBuilder.setId(subStreamInfo.appId());
-        int rc = uriBuilder.uri(&uri, 0);
+        BSLA_MAYBE_UNUSED int rc = uriBuilder.uri(&uri, 0);
         BSLS_ASSERT_SAFE(rc == 0);
-        (void)rc;
 
         result.uri() = uri.asString();
     }

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -353,6 +353,7 @@
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
@@ -1394,10 +1395,9 @@ bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
                                  requestId)));
 
     // Insert the request in the map
-    bsl::pair<RequestMapIter, bool> insertRC = d_requests.insert(
-        bsl::make_pair(requestId, request));
+    BSLA_MAYBE_UNUSED bsl::pair<RequestMapIter, bool> insertRC =
+        d_requests.insert(bsl::make_pair(requestId, request));
     BSLS_ASSERT_SAFE(insertRC.second);
-    (void)insertRC;  // Compiler happiness
 
     return bmqt::GenericResult::e_SUCCESS;
 }
@@ -1484,11 +1484,10 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
                 || groupId == it->second->groupId()) {
                 // Do not notify about timed out requests.
                 if (!it->second->d_haveTimeout) {
-                    bsl::pair<RequestMapIter, bool> insertRC =
-                        requestsCopy.insert(
+                    BSLA_MAYBE_UNUSED bsl::pair<RequestMapIter, bool>
+                                      insertRC = requestsCopy.insert(
                             bsl::make_pair(it->first, it->second));
                     BSLS_ASSERT_SAFE(insertRC.second);
-                    (void)insertRC;  // Compiler happiness
                 }
                 d_requests.erase(it++);
             }

--- a/src/groups/bmq/bmqscm/bmqscm_version.t.cpp
+++ b/src/groups/bmq/bmqscm/bmqscm_version.t.cpp
@@ -19,6 +19,7 @@
 // BDE
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslim_testutil.h>
 
 // CONVENIENCE
@@ -41,16 +42,11 @@ static void aSsErT(bool b, const char* s, int i)
 
 int main(int argc, char** argv)
 {
-    int  test                = argc > 1 ? atoi(argv[1]) : 0;
-    bool verbose             = argc > 2;
-    bool veryVerbose         = argc > 3;
-    bool veryVeryVerbose     = argc > 4;
-    bool veryVeryVeryVerbose = argc > 5;
-    // Prevent potential compiler unused warning
-    (void)verbose;
-    (void)veryVerbose;
-    (void)veryVeryVerbose;
-    (void)veryVeryVeryVerbose;
+    int              test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool             verbose             = argc > 2;
+    BSLA_UNUSED bool veryVerbose         = argc > 3;
+    BSLA_UNUSED bool veryVeryVerbose     = argc > 4;
+    BSLA_UNUSED bool veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
     switch (test) {

--- a/src/groups/bmq/bmqscm/bmqscm_versiontag.t.cpp
+++ b/src/groups/bmq/bmqscm/bmqscm_versiontag.t.cpp
@@ -18,6 +18,7 @@
 
 // BDE
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>
 #include <bslim_testutil.h>
 
 // CONVENIENCE
@@ -40,16 +41,11 @@ static void aSsErT(bool b, const char* s, int i)
 
 int main(int argc, char** argv)
 {
-    int  test                = argc > 1 ? atoi(argv[1]) : 0;
-    bool verbose             = argc > 2;
-    bool veryVerbose         = argc > 3;
-    bool veryVeryVerbose     = argc > 4;
-    bool veryVeryVeryVerbose = argc > 5;
-    // Prevent potential compiler unused warning
-    (void)verbose;
-    (void)veryVerbose;
-    (void)veryVeryVerbose;
-    (void)veryVeryVeryVerbose;
+    int              test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool             verbose             = argc > 2;
+    BSLA_UNUSED bool veryVerbose         = argc > 3;
+    BSLA_UNUSED bool veryVeryVerbose     = argc > 4;
+    BSLA_UNUSED bool veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
     switch (test) {

--- a/src/groups/bmq/bmqst/bmqst_basictableinfoprovider.h
+++ b/src/groups/bmq/bmqst/bmqst_basictableinfoprovider.h
@@ -33,6 +33,7 @@
 #include <bdlb_nullablevalue.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bslmf_nil.h>
@@ -327,9 +328,8 @@ class BasicTableInfoProvider : public bmqst::TableInfoProvider {
 // ACCESSORS
 template <typename TYPE>
 int BasicTableInfoProvider_ValueSizeVisitor::operator()(
-    const TYPE& value) const
+    BSLA_UNUSED const TYPE& value) const
 {
-    (void)value;  // compiler warning unused parameter 'value'
     return 1;
 }
 

--- a/src/groups/bmq/bmqst/bmqst_statcontext.t.cpp
+++ b/src/groups/bmq/bmqst/bmqst_statcontext.t.cpp
@@ -1088,11 +1088,6 @@ int main(int argc, char** argv)
     veryVerbose         = argc > 3;
     veryVeryVerbose     = argc > 4;
     veryVeryVeryVerbose = argc > 5;
-    // Prevent potential compiler unused warning
-    (void)verbose;
-    (void)veryVerbose;
-    (void)veryVeryVerbose;
-    (void)veryVeryVeryVerbose;
 
     // Initialize BALL
     INIT_BALL_LOGGING_VERBOSITY(verbose, veryVerbose);

--- a/src/groups/bmq/bmqu/bmqu_atomicstate.h
+++ b/src/groups/bmq/bmqu/bmqu_atomicstate.h
@@ -33,6 +33,7 @@
 //
 
 // BDE
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 #include <bsls_atomic.h>
 
@@ -121,10 +122,8 @@ inline bool AtomicState::tryLock()
 
 inline void AtomicState::unlock()
 {
-    const int result = d_value.subtract(e_LOCK);
-
+    BSLA_MAYBE_UNUSED const int result = d_value.subtract(e_LOCK);
     BSLS_ASSERT_SAFE(result >= e_INIT);
-    (void)result;
 }
 
 inline void AtomicState::reset()

--- a/src/groups/bmq/bmqu/bmqu_blobobjectproxy.h
+++ b/src/groups/bmq/bmqu/bmqu_blobobjectproxy.h
@@ -244,6 +244,7 @@
 // BDE
 #include <bdlbb_blob.h>
 #include <bsl_cstring.h>
+#include <bsla_annotations.h>
 #include <bsls_objectbuffer.h>
 #include <bsls_performancehint.h>
 #include <bsls_types.h>
@@ -805,8 +806,8 @@ template <class TYPE>
 inline void
 BlobObjectProxy<TYPE>::loadEndPosition(bmqu::BlobPosition* pos) const
 {
-    int ret = bmqu::BlobUtil::findOffset(pos, *d_blob_p, d_position, d_length);
-    (void)ret;
+    BSLA_MAYBE_UNUSED int ret =
+        bmqu::BlobUtil::findOffset(pos, *d_blob_p, d_position, d_length);
     // This should never fail since 'isSet()' will only be true if there are
     // 'd_length' bytes in the blob.
     BSLS_ASSERT(ret == 0);

--- a/src/groups/bmq/bmqu/bmqu_managedcallback.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback.t.cpp
@@ -232,6 +232,7 @@ class ManagedCallbackBuffer BSLS_KEYWORD_FINAL {
 
     // ACCESSORS
 
+    BSLA_MAYBE_UNUSED
     inline bool empty() const { return d_empty; }
 
     inline void operator()() const

--- a/src/groups/bmq/bmqu/bmqu_managedcallback.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_managedcallback.t.cpp
@@ -181,6 +181,7 @@ class ManagedCallbackBuffer BSLS_KEYWORD_FINAL {
 
   public:
     // TRAITS
+    BSLA_MAYBE_UNUSED
     BSLMF_NESTED_TRAIT_DECLARATION(ManagedCallbackBuffer,
                                    bslma::UsesBslmaAllocator)
 

--- a/src/groups/bmq/bmqu/bmqu_operationchain.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_operationchain.t.cpp
@@ -333,7 +333,8 @@ static void test1_usageExample()
     chain.join();
 }
 
-static void test2_chain_creators(bdlmt::ThreadPool* threadPool)
+static void
+test2_chain_creators(BSLA_MAYBE_UNUSED bdlmt::ThreadPool* threadPool)
 // ------------------------------------------------------------------------
 // CHAIN CREATORS
 //
@@ -665,7 +666,8 @@ static void test5_chain_append1(bdlmt::ThreadPool* threadPool)
     }
 }
 
-static void test6_chain_append2(bdlmt::ThreadPool* threadPool)
+static void
+test6_chain_append2(BSLA_MAYBE_UNUSED bdlmt::ThreadPool* threadPool)
 // ------------------------------------------------------------------------
 // CHAIN APPEND 2
 //
@@ -766,7 +768,8 @@ static void test6_chain_append2(bdlmt::ThreadPool* threadPool)
     }
 }
 
-static void test7_chain_appendInplace(bdlmt::ThreadPool* threadPool)
+static void
+test7_chain_appendInplace(BSLA_MAYBE_UNUSED bdlmt::ThreadPool* threadPool)
 // ------------------------------------------------------------------------
 // CHAIN APPEND INPLACE
 //
@@ -1129,7 +1132,8 @@ static void test10_chain_serialization(bdlmt::ThreadPool* threadPool)
     }
 }
 
-static void test11_chain_exceptionHandling(bdlmt::ThreadPool* threadPool)
+static void
+test11_chain_exceptionHandling(BSLA_MAYBE_UNUSED bdlmt::ThreadPool* threadPool)
 // ------------------------------------------------------------------------
 // CHAIN EXCEPTION HANDLING
 //

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -226,12 +226,10 @@ void AdminSession::finalizeAdminCommand(
 
 void AdminSession::onProcessedAdminCommand(
     const bmqp_ctrlmsg::ControlMessage& adminCommandCtrlMsg,
-    int                                 rc,
+    BSLA_UNUSED int                     rc,
     const bsl::string&                  commandExecResults)
 {
     // executed by the *ANY* thread
-    (void)rc;
-
     dispatcher()->execute(
         bdlf::BindUtil::bind(&AdminSession::finalizeAdminCommand,
                              this,
@@ -384,12 +382,10 @@ void AdminSession::tearDownImpl(bslmt::Semaphore* semaphore)
     semaphore->post();
 }
 
-void AdminSession::tearDown(const bsl::shared_ptr<void>& session,
-                            bool                         isBrokerShutdown)
+void AdminSession::tearDown(BSLA_UNUSED const bsl::shared_ptr<void>& session,
+                            BSLA_UNUSED bool isBrokerShutdown)
 {
     // executed by the *IO* thread
-    (void)session;
-    (void)isBrokerShutdown;
 
     // Cancel the reads on the channel
     d_channel_sp->cancelRead();
@@ -414,13 +410,12 @@ void AdminSession::tearDown(const bsl::shared_ptr<void>& session,
     // 'session' go out of scope.
 }
 
-void AdminSession::initiateShutdown(const ShutdownCb&         callback,
-                                    const bsls::TimeInterval& timeout,
-                                    bool supportShutdownV2)
+void AdminSession::initiateShutdown(
+    const ShutdownCb& callback,
+    BSLA_UNUSED const bsls::TimeInterval& timeout,
+    BSLA_UNUSED bool                      supportShutdownV2)
 {
     // executed by the *ANY* thread
-    (void)timeout;
-    (void)supportShutdownV2;
 
     dispatcher()->execute(
         bdlf::BindUtil::bind(&AdminSession::initiateShutdownDispatched,

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -123,12 +123,10 @@ struct TestAdminRetranslator {
     TestAdminRetranslator() {}
 
     int enqueueCommand(
-        const bslstl::StringRef&                        source,
+        BSLA_UNUSED const bslstl::StringRef&            source,
         const bsl::string&                              cmd,
         const mqbnet::Session::AdminCommandProcessedCb& onProcessedCb)
     {
-        (void)source;
-
         int rc = 0;
         onProcessedCb(rc, cmd);
         return rc;
@@ -244,7 +242,7 @@ static void test1_watermark()
     // Prepare sample admin command control message event
     bdlma::LocalSequentialAllocator<2048> localAllocator(
         bmqtst::TestHelperUtil::allocator());
-    bmqp_ctrlmsg::ControlMessage          admin(&localAllocator);
+    bmqp_ctrlmsg::ControlMessage admin(&localAllocator);
 
     admin.rId() = rId;
     admin.choice().makeAdminCommand();

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -1280,7 +1280,8 @@ void ClientSession::processDisconnect(
     // executed by the *CLIENT* dispatcher thread
 
     // Want to keep `opLogger` until the end of this scope to log the current
-    // operation execution time.
+    // operation execution time, but we don't use it directly, so it's marked
+    // as `BSLA_UNUSED`.
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
@@ -1369,7 +1370,8 @@ void ClientSession::openQueueCb(
     // executed by the *CLIENT* dispatcher thread
 
     // Want to keep `opLogger` until the end of this scope to log the current
-    // operation execution time.
+    // operation execution time, but we don't use it directly, so it's marked
+    // as `BSLA_UNUSED`.
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));
@@ -1449,7 +1451,8 @@ void ClientSession::closeQueueCb(
     // executed by the *CLIENT* dispatcher thread
 
     // Want to keep `opLogger` until the end of this scope to log the current
-    // operation execution time.
+    // operation execution time, but we don't use it directly, so it's marked
+    // as `BSLA_UNUSED`.
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(this));

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -1274,8 +1274,8 @@ void ClientSession::processDisconnectAllQueuesDone(
 }
 
 void ClientSession::processDisconnect(
-    const bmqp_ctrlmsg::ControlMessage&             controlMessage,
-    const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
+    const bmqp_ctrlmsg::ControlMessage& controlMessage,
+    BSLA_UNUSED const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
 {
     // executed by the *CLIENT* dispatcher thread
 
@@ -1361,10 +1361,10 @@ void ClientSession::processOpenQueue(
 
 void ClientSession::openQueueCb(
     const bmqp_ctrlmsg::Status& status,
-    BSLA_UNUSED mqbi::QueueHandle*                  handle,
-    const bmqp_ctrlmsg::OpenQueueResponse&          openQueueResponse,
-    const bmqp_ctrlmsg::ControlMessage&             handleParamsCtrlMsg,
-    const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
+    BSLA_UNUSED mqbi::QueueHandle*         handle,
+    const bmqp_ctrlmsg::OpenQueueResponse& openQueueResponse,
+    const bmqp_ctrlmsg::ControlMessage&    handleParamsCtrlMsg,
+    BSLA_UNUSED const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
 {
     // executed by the *CLIENT* dispatcher thread
 
@@ -1442,9 +1442,9 @@ void ClientSession::processCloseQueue(
 }
 
 void ClientSession::closeQueueCb(
-    const bsl::shared_ptr<mqbi::QueueHandle>&       handle,
-    const bmqp_ctrlmsg::ControlMessage&             handleParamsCtrlMsg,
-    const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
+    const bsl::shared_ptr<mqbi::QueueHandle>& handle,
+    const bmqp_ctrlmsg::ControlMessage&       handleParamsCtrlMsg,
+    BSLA_UNUSED const bsl::shared_ptr<bmqsys::OperationLogger>& opLogger)
 {
     // executed by the *CLIENT* dispatcher thread
 
@@ -3195,9 +3195,10 @@ void ClientSession::processClusterMessage(
     }
 }
 
-void ClientSession::onDeconfiguredHandle(const ShutdownContextSp& contextSp)
+void ClientSession::onDeconfiguredHandle(
+    BSLA_UNUSED const ShutdownContextSp& contextSp)
 {
-    (void)contextSp;
+    // empty
 }
 
 void ClientSession::processStopRequest(ShutdownContextSp& contextSp)

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2125,7 +2125,7 @@ static void test11_initiateShutdown()
         100000000);  // 100 ms
     bslmt::TimedSemaphore      semaphore;
     bmqp::Protocol::MsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    const unsigned int             subscriptionId =
+    const unsigned int         subscriptionId =
         bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID;
     const unsigned int subQueueId = bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID;
 
@@ -2147,7 +2147,7 @@ static void test11_initiateShutdown()
         mqbi::StorageMessageAttributes d_messageAttributes;
 
         // CREATORS
-        MockStorageIterator(bslma::Allocator* allocator = 0)
+        MockStorageIterator(BSLA_UNUSED bslma::Allocator* allocator = 0)
         : d_guid(bmqp::MessageGUIDGenerator::testGUID())
         , d_appMessage(bmqp::RdaInfo())
         , d_appData()
@@ -2186,14 +2186,14 @@ static void test11_initiateShutdown()
             return d_guid;
         }
 
-        const mqbi::AppMessage&
-        appMessageView(unsigned int appOrdinal) const BSLS_KEYWORD_OVERRIDE
+        const mqbi::AppMessage& appMessageView(
+            BSLA_UNUSED unsigned int appOrdinal) const BSLS_KEYWORD_OVERRIDE
         {
             return d_appMessage;
         }
 
-        mqbi::AppMessage&
-        appMessageState(unsigned int appOrdinal) BSLS_KEYWORD_OVERRIDE
+        mqbi::AppMessage& appMessageState(BSLA_UNUSED unsigned int appOrdinal)
+            BSLS_KEYWORD_OVERRIDE
         {
             return d_appMessage;
         }
@@ -2376,11 +2376,11 @@ static void test11_initiateShutdown()
 
     PV("Confirm multiple messsages while shutting down");
     {
-        const int       NUM_MESSAGES = 5;
+        const int                      NUM_MESSAGES = 5;
         TestBench                      tb(client(e_FirstHop),
                      isAtMostOnce,
                      bmqtst::TestHelperUtil::allocator());
-        bsls::AtomicInt callbackCounter(0);
+        bsls::AtomicInt                callbackCounter(0);
         bsl::vector<bmqt::MessageGUID> guids(
             bmqtst::TestHelperUtil::allocator());
         guids.reserve(NUM_MESSAGES);

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -151,8 +151,8 @@ Dispatcher_ClientExecutor::processorHandle() const BSLS_CPP11_NOEXCEPT
 
 // CREATORS
 Dispatcher_ClientExecutor::Dispatcher_ClientExecutor(
-    const Dispatcher*             dispacher,
-    const mqbi::DispatcherClient* client) BSLS_CPP11_NOEXCEPT
+    BSLA_MAYBE_UNUSED const Dispatcher* dispacher,
+    const mqbi::DispatcherClient*       client) BSLS_CPP11_NOEXCEPT
 : d_client_p(client)
 {
     // PRECONDITIONS

--- a/src/groups/mqb/mqba/mqba_domainmanager.cpp
+++ b/src/groups/mqb/mqba/mqba_domainmanager.cpp
@@ -70,8 +70,8 @@ const int k_MAX_WAIT_SECONDS_AT_DOMAIN_REMOVE = 5;
 /// external source and called after all the interesting
 /// processing is done.
 void onDomain(const bmqp_ctrlmsg::Status& status,
-              mqbi::Domain*               domain,
-              bslmt::Latch*               latch)
+              BSLA_MAYBE_UNUSED mqbi::Domain* domain,
+              bslmt::Latch*                   latch)
 {
     // executed by *ANY* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -129,15 +129,15 @@ void ClusterOrchestrator::onElectorStateChange(
     }
 }
 
-void ClusterOrchestrator::electorTransitionToDormant(int leaderNodeId,
-                                                     bsls::Types::Uint64 term)
+void ClusterOrchestrator::electorTransitionToDormant(
+    BSLA_MAYBE_UNUSED int leaderNodeId,
+    bsls::Types::Uint64   term)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT(mqbnet::Elector::k_INVALID_NODE_ID == leaderNodeId);
-    (void)leaderNodeId;  // Compiler happiness
 
     if (mqbnet::ElectorState::e_DORMANT ==
         d_clusterData_p->electorInfo().electorState()) {
@@ -236,8 +236,8 @@ void ClusterOrchestrator::electorTransitionToFollower(int leaderNodeId,
 }
 
 void ClusterOrchestrator::electorTransitionToCandidate(
-    int                 leaderNodeId,
-    bsls::Types::Uint64 term)
+    BSLA_MAYBE_UNUSED int leaderNodeId,
+    bsls::Types::Uint64   term)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -246,7 +246,6 @@ void ClusterOrchestrator::electorTransitionToCandidate(
     BSLS_ASSERT(mqbnet::ElectorState::e_CANDIDATE !=
                 d_clusterData_p->electorInfo().electorState());
     BSLS_ASSERT(mqbnet::Elector::k_INVALID_NODE_ID == leaderNodeId);
-    (void)leaderNodeId;  // Compiler happiness
 
     d_clusterData_p->electorInfo().setElectorInfo(
         mqbnet::ElectorState::e_CANDIDATE,
@@ -255,8 +254,9 @@ void ClusterOrchestrator::electorTransitionToCandidate(
         mqbc::ElectorInfoLeaderStatus::e_UNDEFINED);
 }
 
-void ClusterOrchestrator::electorTransitionToLeader(int leaderNodeId,
-                                                    bsls::Types::Uint64 term)
+void ClusterOrchestrator::electorTransitionToLeader(
+    BSLA_MAYBE_UNUSED int leaderNodeId,
+    bsls::Types::Uint64   term)
 {
     // executed by the *DISPATCHER* thread
 
@@ -267,7 +267,6 @@ void ClusterOrchestrator::electorTransitionToLeader(int leaderNodeId,
         leaderNodeId);
     BSLS_ASSERT_SAFE(mqbnet::ElectorState::e_CANDIDATE ==
                      d_clusterData_p->electorInfo().electorState());
-    (void)leaderNodeId;  // Compiler happiness
 
     // The 'leaderMessageSequence' of this node should NOT be updated with new
     // term and sequenceNum of zero, because it will be used during leader

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -144,7 +144,8 @@ void afterAppIdUnregisteredDispatched(
     queue->queueEngine()->afterAppIdUnregistered(appInfos);
 }
 
-void handleHolderDummy(const bsl::shared_ptr<mqbi::QueueHandle>& handle)
+void handleHolderDummy(
+    BSLA_MAYBE_UNUSED const bsl::shared_ptr<mqbi::QueueHandle>& handle)
 {
     // executed by ONE of the *QUEUE* dispatcher threads
 
@@ -1914,9 +1915,9 @@ bool ClusterQueueHelper::createQueue(
             context->d_handleParameters),
         d_allocator_p);
 
-    bdlma::LocalSequentialAllocator<1024>      la(d_allocator_p);
-    bmqu::MemOutStream                         errorDescription(&la);
-    bmqp_ctrlmsg::Status                       status;
+    bdlma::LocalSequentialAllocator<1024> la(d_allocator_p);
+    bmqu::MemOutStream                    errorDescription(&la);
+    bmqp_ctrlmsg::Status                  status;
 
     bsl::shared_ptr<mqbi::Queue> queue = createQueueFactory(errorDescription,
                                                             *context,
@@ -4285,10 +4286,11 @@ void ClusterQueueHelper::onQueueUnassigned(
                   << ": Unassigned queue: " << *info;
 }
 
-void ClusterQueueHelper::onQueueUpdated(const bmqt::Uri&   uri,
-                                        const bsl::string& domain,
-                                        const AppInfos&    addedAppIds,
-                                        const AppInfos&    removedAppIds)
+void ClusterQueueHelper::onQueueUpdated(
+    const bmqt::Uri&        uri,
+    BSLA_MAYBE_UNUSED const bsl::string& domain,
+    const AppInfos&                      addedAppIds,
+    const AppInfos&                      removedAppIds)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -4675,7 +4677,7 @@ void ClusterQueueHelper::openQueue(
         QueueContextSp queueContext;
         queueContext.createInplace(d_allocator_p, uriKey, d_allocator_p);
 
-        d_queues[uriKey]         = queueContext;
+        d_queues[uriKey] = queueContext;
         context->setQueueContext(queueContext.get());
 
         // Register the context to the pending list.
@@ -5137,13 +5139,12 @@ void ClusterQueueHelper::requestToStopPushing()
 }
 
 void ClusterQueueHelper::contextHolder(
-    const bsl::shared_ptr<StopContext>& contextSp,
-    const VoidFunctor&                  action)
+    BSLA_UNUSED const bsl::shared_ptr<StopContext>& contextSp,
+    const VoidFunctor&                              action)
 {
     if (action) {
         action();
     }
-    (void)contextSp;
 }
 
 void ClusterQueueHelper::sendErrorResponse(
@@ -6402,7 +6403,7 @@ void ClusterQueueHelper::loadState(
     int qIdx = 0;
     for (QueueContextMapConstIter it = d_queues.begin(); it != d_queues.end();
          ++it, ++qIdx) {
-        const QueueLiveState&                info = it->second->d_liveQInfo;
+        const QueueLiveState&                  info = it->second->d_liveQInfo;
         const bsl::vector<OpenQueueContextSp>& contexts =
             it->second->d_liveQInfo.d_pending;
         const int pid = it->second->partitionId();

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -951,8 +951,8 @@ void ClusterStateManager::processPartitionPrimaryAdvisoryRaw(
 // PRIVATE MANIPULATORS
 //   (virtual: mqbc::ElectorInfoObserver)
 void ClusterStateManager::onClusterLeader(
-    mqbnet::ClusterNode*                node,
-    mqbc::ElectorInfoLeaderStatus::Enum status)
+    mqbnet::ClusterNode* node,
+    BSLA_MAYBE_UNUSED mqbc::ElectorInfoLeaderStatus::Enum status)
 {
     // executed by the cluster *DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_messagegroupidmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_messagegroupidmanager.cpp
@@ -88,6 +88,7 @@
 #include <bsl_iostream.h>
 #include <bsl_map.h>
 #include <bsl_sstream.h>
+#include <bsla_annotations.h>
 #include <bslim_printer.h>
 
 namespace BloombergLP {
@@ -369,9 +370,9 @@ void MessageGroupIdManager::Index::removeHandle(const Handle& handle)
         BSLS_ASSERT_SAFE(iterator != d_msgGroupIdInfo.end());
 
         // Remove from data structure b).
-        const int erased = d_leastUsedMsgGroupIdFirst.erase(iterator);
+        BSLA_MAYBE_UNUSED const int erased = d_leastUsedMsgGroupIdFirst.erase(
+            iterator);
         BSLS_ASSERT_SAFE(erased == 1);
-        (void)erased;
 
         // Remove from data structure a).
         d_msgGroupIdInfo.erase(iterator);
@@ -414,9 +415,9 @@ MessageGroupIdManager::Index::insert(const MsgGroupId& msgGroupId,
     d_leastLoadedHandleFirst.erase(it);
 
     // Insert to data structure c).
-    const bsl::pair<MsgGroupIdSet::iterator, bool> rs = it->second.insert(mit);
+    BSLA_MAYBE_UNUSED const bsl::pair<MsgGroupIdSet::iterator, bool> rs =
+        it->second.insert(mit);
     BSLS_ASSERT_SAFE(rs.second);
-    (void)rs;
 
     // Update data structure d) (2/2).
     d_leastLoadedHandleFirst.insert(it);
@@ -430,9 +431,9 @@ void MessageGroupIdManager::Index::updateTime(
 {
     // This does a remove and re-add to the data structure b) and a
     // modification in data structure a).  All the others should be unaffected.
-    const int erased = d_leastUsedMsgGroupIdFirst.erase(target);
+    BSLA_MAYBE_UNUSED const int erased = d_leastUsedMsgGroupIdFirst.erase(
+        target);
     BSLS_ASSERT_SAFE(erased == 1);
-    (void)erased;
 
     target->second.second = lastSeen;
 
@@ -482,18 +483,17 @@ void MessageGroupIdManager::Index::erase(
     // Modify the appropriate 'MsgGroupIdSet' from the data structure c).  Note
     // that this doesn't remove any handle from 'd_handleToGroups' thus all
     // 'HandleToGroups::iterator's (including 'it') remain unaffected/valid.
-    MsgGroupIdSet& msgGroupIdSet = it->second;
-    const int      count         = msgGroupIdSet.erase(iterator);
+    MsgGroupIdSet&              msgGroupIdSet = it->second;
+    BSLA_MAYBE_UNUSED const int count         = msgGroupIdSet.erase(iterator);
     BSLS_ASSERT_SAFE(count == 1);
-    (void)count;
 
     // Update data structure d) (2/2).
     d_leastLoadedHandleFirst.insert(it);
 
     // Remove from data structure b).
-    const int erased = d_leastUsedMsgGroupIdFirst.erase(iterator);
+    BSLA_MAYBE_UNUSED const int erased = d_leastUsedMsgGroupIdFirst.erase(
+        iterator);
     BSLS_ASSERT_SAFE(erased == 1);
-    (void)erased;
 
     // Remove from data structure a).
     d_msgGroupIdInfo.erase(iterator);

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -19,6 +19,9 @@
 
 #include <mqbscm_version.h>
 
+// BDE
+#include <bsla_annotations.h>
+
 namespace BloombergLP {
 namespace mqbblp {
 
@@ -321,14 +324,13 @@ bool VirtualPushStreamIterator::atEnd() const
 }
 
 PushStream::Element*
-VirtualPushStreamIterator::element(unsigned int appOrdinal) const
+VirtualPushStreamIterator::element(BSLA_UNUSED unsigned int appOrdinal) const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!atEnd());
 
-    // Ignore ordinal  when the app is fixed;
+    // Ignore ordinal when the app is fixed;
     // 'd_currentElement' does not depend on 'appOrdinal'
-    (void)appOrdinal;
 
     return d_currentElement;
 }

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -54,6 +54,7 @@
 #include <bsl_fstream.h>
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 #include <bsls_performancehint.h>
 #include <bsls_timeinterval.h>
@@ -208,10 +209,11 @@ int QueueEngineUtil::validateUri(
     mqbi::QueueHandle*                         handle,
     const mqbi::QueueHandleRequesterContext&   clientContext)
 {
-    bmqt::Uri   uri;
-    bsl::string error;
-    int rc = bmqt::UriParser::parse(&uri, &error, handleParameters.uri());
-    (void)rc;  // compiler happiness
+    bmqt::Uri       uri;
+    bsl::string     error;
+    BSLA_UNUSED int rc = bmqt::UriParser::parse(&uri,
+                                                &error,
+                                                handleParameters.uri());
     if (handle->queue()->uri().canonical() != uri.canonical()) {
         BALL_LOG_ERROR_BLOCK
         {

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandlecatalog.cpp
@@ -36,6 +36,7 @@
 #include <bdlf_placeholder.h>
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
 
@@ -182,14 +183,14 @@ mqbi::QueueHandle* QueueHandleCatalog::createHandle(
         d_allocator_p);
 
     // Insert handle into map
-    bsl::pair<HandleMap::iterator, HandleMap::InsertResult> insertResult =
-        d_handles.insert(handle,
-                         bsl::make_pair(clientContext->requesterId(),
-                                        handleParameters.qId()),
-                         queueHandleSp);
+    BSLA_MAYBE_UNUSED bsl::pair<HandleMap::iterator, HandleMap::InsertResult>
+                      insertResult = d_handles.insert(
+            handle,
+            bsl::make_pair(clientContext->requesterId(),
+                           handleParameters.qId()),
+            queueHandleSp);
 
     BSLS_ASSERT_SAFE(insertResult.second == HandleMap::e_INSERTED);
-    (void)insertResult;  // Compiler happiness
 
     return handle;
 }

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -3388,7 +3388,6 @@ void RecoveryManager::processRecoveryEvent(
         }
 
         BSLS_ASSERT_SAFE(isData || isJournal || isQlist);
-        (void)isJournal;  // Compiler happiness
 
         if (header.fileChunkType() != recoveryCtx.expectedChunkFileType()) {
             BMQTSK_ALARMLOG_ALARM("RECOVERY")

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -741,12 +741,11 @@ void RelayQueueEngine::configureApp(
 
     // Update effective upstream parameters if specified 'handle' is a reader
     bmqp_ctrlmsg::StreamParameters streamParamsToSend;
-    bool hasStreamParamsToSend = d_queueState_p->getUpstreamParameters(
-        &streamParamsToSend,
-        upstreamSubQueueId);
+    BSLA_MAYBE_UNUSED bool         hasStreamParamsToSend =
+        d_queueState_p->getUpstreamParameters(&streamParamsToSend,
+                                              upstreamSubQueueId);
 
     BSLS_ASSERT_SAFE(hasStreamParamsToSend);
-    (void)hasStreamParamsToSend;
 
     if (hadParameters && previousParameters == streamParamsToSend) {
         // Last advertised stream parameters for this queue are same as the
@@ -1709,9 +1708,10 @@ void RelayQueueEngine::registerStorage(const bsl::string&      appId,
     iter->second->authorize(appKey, appOrdinal);
 }
 
-void RelayQueueEngine::unregisterStorage(const bsl::string&      appId,
-                                         const mqbu::StorageKey& appKey,
-                                         unsigned int            appOrdinal)
+void RelayQueueEngine::unregisterStorage(
+    const bsl::string&      appId,
+    BSLA_MAYBE_UNUSED const mqbu::StorageKey& appKey,
+    BSLA_UNUSED unsigned int                  appOrdinal)
 {
     // executed by the *QUEUE DISPATCHER* thread
 
@@ -1731,8 +1731,6 @@ void RelayQueueEngine::unregisterStorage(const bsl::string&      appId,
 
         iter->second->unauthorize();
     }
-
-    (void)appOrdinal;
 }
 
 bool RelayQueueEngine::subscriptionId2upstreamSubQueueId(

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -751,15 +751,12 @@ void RemoteQueue::onHandleReleased(
                     // previously added virtual storage
                     const bsl::string& appId =
                         handleParameters.subIdInfo().value().appId();
-                    mqbu::StorageKey appKey;
-                    const bool       hasVirtualStorage =
+                    mqbu::StorageKey             appKey;
+                    BSLA_MAYBE_UNUSED const bool hasVirtualStorage =
                         d_state_p->storage()->hasVirtualStorage(appId,
                                                                 &appKey);
                     BSLS_ASSERT_SAFE(hasVirtualStorage);
                     d_state_p->storage()->removeVirtualStorage(appKey, false);
-
-                    (void)
-                        hasVirtualStorage;  // Compiler happiness in opt build
                 }
             }
             else if (!bmqt::QueueFlagsUtil::isReader(

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -701,11 +701,11 @@ mqbi::QueueHandle* RootQueueEngine::getHandle(
     if (queueHandle) {
         // Already aware of this queueId from this client.
 
-        bmqt::Uri   uri;
-        bsl::string error;
-        int rc = bmqt::UriParser::parse(&uri, &error, handleParameters.uri());
+        bmqt::Uri             uri;
+        bsl::string           error;
+        BSLA_MAYBE_UNUSED int rc =
+            bmqt::UriParser::parse(&uri, &error, handleParameters.uri());
         BSLS_ASSERT_SAFE(rc == 0);
-        (void)rc;  // compiler happiness
         BSLS_ASSERT_SAFE(queueHandle->queue()->uri().asString() ==
                          queueHandle->queue()->uri().canonical());
         // Queue's 'uri' should always be the canonical uri
@@ -1324,13 +1324,12 @@ void RootQueueEngine::afterNewMessage(
 
     if (QueueEngineUtil::isBroadcastMode(d_queueState_p->queue())) {
         // Clear storage status
-        mqbi::StorageResult::Enum rc =
+        BSLA_MAYBE_UNUSED mqbi::StorageResult::Enum rc =
             d_queueState_p->queue()->storage()->removeAll(
                 mqbu::StorageKey::k_NULL_KEY);
         // Intended to be used with 'InMemoryStorage'.  Since 'appKey' isn't
         //  used while calling 'removeAll()', it should always succeed.
         BSLS_ASSERT_SAFE(mqbi::StorageResult::e_SUCCESS == rc);
-        (void)rc;  // Compiler happiness
 
         d_storageIter_mp->reset();
     }
@@ -1404,9 +1403,10 @@ int RootQueueEngine::onConfirmMessage(mqbi::QueueHandle*       handle,
     return rc_ERROR;
 }
 
-int RootQueueEngine::onRejectMessage(mqbi::QueueHandle*       handle,
-                                     const bmqt::MessageGUID& msgGUID,
-                                     unsigned int             subQueueId)
+int RootQueueEngine::onRejectMessage(
+    BSLA_MAYBE_UNUSED mqbi::QueueHandle* handle,
+    const bmqt::MessageGUID&             msgGUID,
+    unsigned int                         subQueueId)
 {
     // executed by the *QUEUE DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -40,6 +40,7 @@
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslmf_assert.h>
@@ -727,7 +728,8 @@ static void test2_broadcastConfirmAssertFails()
     mqbblp::QueueEngineTesterGuard<mqbblp::RootQueueEngine> guard(&tester);
 
     // 1) 1 consumer
-    mqbmock::QueueHandle* C1 = tester.getHandle("C1 readCount=1");
+    BSLA_MAYBE_UNUSED mqbmock::QueueHandle* C1 = tester.getHandle(
+        "C1 readCount=1");
     tester.configureHandle("C1 consumerPriority=-1 consumerPriorityCount=1");
 
     // 2) Post 1 message to the queue, and invoke the engine to broadcast it
@@ -740,7 +742,6 @@ static void test2_broadcastConfirmAssertFails()
     BMQTST_ASSERT_SAFE_FAIL(tester.confirm(
         "C1",
         mqbblp::QueueEngineTestUtil::getMessages(C1->_messages(), "0")));
-    (void)C1;  // Compiler happiness
 }
 
 static void test3_broadcastCannotDeliver()

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -247,9 +247,8 @@ class Routers {
             void release()
             {
                 if (isValid()) {
-                    size_t n = d_owner.erase(d_key);
+                    BSLA_MAYBE_UNUSED size_t n = d_owner.erase(d_key);
                     BSLS_ASSERT_SAFE(n == 1);
-                    (void)n;
                 }
             }
             VALUE&     value() { return d_value.object(); }
@@ -406,8 +405,8 @@ class Routers {
     struct SubscriptionId {
         /// The Expression.
         const Expressions::SharedItem d_itExpression;
-        const unsigned int d_upstreamSubQueueId;
-        PriorityGroup*     d_priorityGroup;
+        const unsigned int            d_upstreamSubQueueId;
+        PriorityGroup*                d_priorityGroup;
 
         SubscriptionId(const Expressions::SharedItem& itExpression,
                        const unsigned int             upstreamSubQueueId);

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -585,11 +585,11 @@ void StorageManager::processStorageEventDispatched(
     mqbs::FileStore* fs = d_fileStores[static_cast<size_t>(partitionId)].get();
     BSLS_ASSERT_SAFE(fs);
 
-    const PartitionInfo& pinfo = d_partitionInfoVec[partitionId];
+    BSLA_MAYBE_UNUSED const PartitionInfo& pinfo =
+        d_partitionInfoVec[partitionId];
     BSLS_ASSERT_SAFE(pinfo.primary() == source);
     BSLS_ASSERT_SAFE(pinfo.primaryStatus() ==
                      bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE);
-    (void)pinfo;  // silence compiler warning
 
     if (d_recoveryManager_mp->isRecoveryInProgress(partitionId)) {
         d_recoveryManager_mp->processStorageEvent(partitionId, blob, source);

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
@@ -34,6 +34,7 @@
 
 // BDE
 #include <bsl_ostream.h>
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
@@ -94,7 +95,7 @@ struct ClusterStateFileHeader {
     char d_fileKey[mqbu::StorageKey::e_KEY_LENGTH_BINARY];
 
     /// Reserved.
-    unsigned char d_reserved[2];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[2];
 
   public:
     // CONSTANTS
@@ -288,7 +289,7 @@ struct ClusterStateRecordHeader {
     unsigned char d_headerWordsAndRecordType;
 
     /// Reserved.
-    unsigned char d_reserved[3];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[3];
 
     /// Total size (in words) of the leader advisory representing the cluster
     /// state updates.
@@ -399,9 +400,6 @@ inline ClusterStateFileHeader::ClusterStateFileHeader()
     setHeaderWords(sizeof(ClusterStateFileHeader) /
                    bmqp::Protocol::k_WORD_SIZE);
     setFileKey(mqbu::StorageKey::k_NULL_KEY);
-
-    // Suppress "unused variable" warning
-    (void)d_reserved;
 }
 
 // MANIPULATORS
@@ -470,9 +468,6 @@ inline ClusterStateRecordHeader::ClusterStateRecordHeader()
     bsl::memset(this, 0, sizeof(ClusterStateRecordHeader));
     setHeaderWords(sizeof(ClusterStateRecordHeader) /
                    bmqp::Protocol::k_WORD_SIZE);
-
-    // Suppress "unused variable" warning
-    (void)d_reserved;
 }
 
 // MANIPULATORS

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1451,8 +1451,9 @@ void ClusterStateManager::setPrimaryStatus(
     d_state_p->setPartitionPrimaryStatus(partitionId, status);
 }
 
-void ClusterStateManager::markOrphan(const bsl::vector<int>& partitions,
-                                     mqbnet::ClusterNode*    primary)
+void ClusterStateManager::markOrphan(
+    const bsl::vector<int>& partitions,
+    BSLA_MAYBE_UNUSED mqbnet::ClusterNode* primary)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1804,10 +1805,9 @@ void ClusterStateManager::processShutdownEvent()
     applyFSMEvent(ClusterFSM::Event::e_STOP_NODE, ClusterFSMEventMetadata());
 }
 
-void ClusterStateManager::onNodeUnavailable(mqbnet::ClusterNode* node)
+void ClusterStateManager::onNodeUnavailable(
+    BSLA_UNUSED mqbnet::ClusterNode* node)
 {
-    (void)node;
-
     BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
 }
 
@@ -1823,8 +1823,9 @@ void ClusterStateManager::onNodeStopped()
 
 // MANIPULATORS
 //   (virtual: mqbc::ElectorInfoObserver)
-void ClusterStateManager::onClusterLeader(mqbnet::ClusterNode*          node,
-                                          ElectorInfoLeaderStatus::Enum status)
+void ClusterStateManager::onClusterLeader(
+    BSLA_MAYBE_UNUSED mqbnet::ClusterNode* node,
+    BSLA_MAYBE_UNUSED ElectorInfoLeaderStatus::Enum status)
 {
     // executed by the cluster *DISPATCHER* thread
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -28,6 +28,7 @@
 #include <bdlb_print.h>
 #include <bsl_string.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -67,11 +68,11 @@ struct Tester {
         return domainState;
     }
 
-    mqbc::ClusterState::QueueInfoSp
-    createQueueInfoSp(const bsl::string&                  uriString,
-                      const mqbu::StorageKey&             key,
-                      int                                 partitionId,
-                      const mqbc::ClusterState::AppInfos& appIdInfos)
+    mqbc::ClusterState::QueueInfoSp createQueueInfoSp(
+        const bsl::string&      uriString,
+        const mqbu::StorageKey& key,
+        int                     partitionId,
+        BSLA_UNUSED const mqbc::ClusterState::AppInfos& appIdInfos)
     {
         bmqp_ctrlmsg::QueueInfo advisory(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbc/mqbc_recoveryutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoveryutil.cpp
@@ -30,6 +30,7 @@
 
 // BDE
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
@@ -203,19 +204,15 @@ int RecoveryUtil::loadOffsets(
 }
 
 void RecoveryUtil::validateArgs(
-    const bmqp_ctrlmsg::PartitionSequenceNumber& beginSeqNum,
-    const bmqp_ctrlmsg::PartitionSequenceNumber& endSeqNum,
-    mqbnet::ClusterNode*                         destination)
+    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::PartitionSequenceNumber& beginSeqNum,
+    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::PartitionSequenceNumber& endSeqNum,
+    BSLA_MAYBE_UNUSED mqbnet::ClusterNode* destination)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(beginSeqNum < endSeqNum);
     BSLS_ASSERT_SAFE(0 < endSeqNum.primaryLeaseId());
     BSLS_ASSERT_SAFE(0 < endSeqNum.sequenceNumber());  // TBD: Is this ok?
     BSLS_ASSERT_SAFE(destination);
-
-    (void)beginSeqNum;  // Compiler happiness
-    (void)endSeqNum;    // Compiler happiness
-    (void)destination;  // Compiler happiness
 }
 
 int RecoveryUtil::bootstrapCurrentSeqNum(

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -475,10 +475,11 @@ int StorageUtil::addVirtualStoragesInternal(
     return rc_SUCCESS;
 }
 
-int StorageUtil::removeVirtualStorageInternal(mqbs::ReplicatedStorage* storage,
-                                              const mqbu::StorageKey&  appKey,
-                                              int  partitionId,
-                                              bool asPrimary)
+int StorageUtil::removeVirtualStorageInternal(
+    mqbs::ReplicatedStorage* storage,
+    const mqbu::StorageKey&  appKey,
+    BSLA_MAYBE_UNUSED int    partitionId,
+    bool                     asPrimary)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -1035,14 +1036,14 @@ unsigned int StorageUtil::extractPartitionId<true>(const bmqp::Event& event)
 }
 
 bool StorageUtil::validateStorageEvent(
-    const bmqp::Event&                 event,
-    int                                partitionId,
-    const mqbnet::ClusterNode*         source,
-    const mqbnet::ClusterNode*         primary,
-    bmqp_ctrlmsg::PrimaryStatus::Value status,
-    const bsl::string&                 clusterDescription,
-    bool                               skipAlarm,
-    bool                               isFSMWorkflow)
+    BSLA_MAYBE_UNUSED const bmqp::Event& event,
+    int                                  partitionId,
+    const mqbnet::ClusterNode*           source,
+    const mqbnet::ClusterNode*           primary,
+    bmqp_ctrlmsg::PrimaryStatus::Value   status,
+    const bsl::string&                   clusterDescription,
+    bool                                 skipAlarm,
+    bool                                 isFSMWorkflow)
 {
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId' or
     // by the *CLUSTER DISPATCHER* thread
@@ -2274,18 +2275,19 @@ StorageUtil::generateAppKey(bsl::unordered_set<mqbu::StorageKey>* appKeys,
     return appKey;
 }
 
-void StorageUtil::registerQueue(const mqbi::Cluster*           cluster,
-                                mqbi::Dispatcher*              dispatcher,
-                                StorageSpMap*                  storageMap,
-                                bslmt::Mutex*                  storagesLock,
-                                mqbs::FileStore*               fs,
-                                bmqma::CountingAllocatorStore* allocators,
-                                const bmqt::Uri&               uri,
-                                const mqbu::StorageKey&        queueKey,
-                                const bsl::string& clusterDescription,
-                                int                partitionId,
-                                const AppInfos&    appIdKeyPairs,
-                                mqbi::Domain*      domain)
+void StorageUtil::registerQueue(
+    const mqbi::Cluster* cluster,
+    mqbi::Dispatcher*    dispatcher,
+    StorageSpMap*        storageMap,
+    bslmt::Mutex*        storagesLock,
+    mqbs::FileStore*     fs,
+    BSLA_MAYBE_UNUSED bmqma::CountingAllocatorStore* allocators,
+    const bmqt::Uri&                                 uri,
+    const mqbu::StorageKey&                          queueKey,
+    const bsl::string&                               clusterDescription,
+    int                                              partitionId,
+    const AppInfos&                                  appIdKeyPairs,
+    mqbi::Domain*                                    domain)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
@@ -2689,15 +2691,16 @@ void StorageUtil::unregisterQueueDispatched(mqbs::FileStore*     fs,
     fs->flushStorage();
 }
 
-int StorageUtil::updateQueuePrimary(StorageSpMap*           storageMap,
-                                    bslmt::Mutex*           storagesLock,
-                                    mqbs::FileStore*        fs,
-                                    const bsl::string&      clusterDescription,
-                                    const bmqt::Uri&        uri,
-                                    const mqbu::StorageKey& queueKey,
-                                    int                     partitionId,
-                                    const AppInfos&         addedIdKeyPairs,
-                                    const AppInfos&         removedIdKeyPairs)
+int StorageUtil::updateQueuePrimary(
+    StorageSpMap*           storageMap,
+    bslmt::Mutex*           storagesLock,
+    mqbs::FileStore*        fs,
+    const bsl::string&      clusterDescription,
+    const bmqt::Uri&        uri,
+    BSLA_MAYBE_UNUSED const mqbu::StorageKey& queueKey,
+    int                                       partitionId,
+    const AppInfos&                           addedIdKeyPairs,
+    const AppInfos&                           removedIdKeyPairs)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -2741,18 +2744,18 @@ int StorageUtil::updateQueuePrimary(StorageSpMap*           storageMap,
 }
 
 void StorageUtil::registerQueueReplicaDispatched(
-    int*                           status,
-    StorageSpMap*                  storageMap,
-    bslmt::Mutex*                  storagesLock,
-    mqbs::FileStore*               fs,
-    mqbi::DomainFactory*           domainFactory,
-    bmqma::CountingAllocatorStore* allocators,
-    const bsl::string&             clusterDescription,
-    int                            partitionId,
-    const bmqt::Uri&               uri,
-    const mqbu::StorageKey&        queueKey,
-    mqbi::Domain*                  domain,
-    bool                           allowDuplicate)
+    int*                 status,
+    StorageSpMap*        storageMap,
+    bslmt::Mutex*        storagesLock,
+    mqbs::FileStore*     fs,
+    mqbi::DomainFactory* domainFactory,
+    BSLA_MAYBE_UNUSED bmqma::CountingAllocatorStore* allocators,
+    const bsl::string&                               clusterDescription,
+    int                                              partitionId,
+    const bmqt::Uri&                                 uri,
+    const mqbu::StorageKey&                          queueKey,
+    mqbi::Domain*                                    domain,
+    bool                                             allowDuplicate)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -3173,7 +3176,7 @@ int StorageUtil::makeStorage(bsl::ostream&                   errorDescription,
                              bslmt::Mutex*                   storagesLock,
                              const bmqt::Uri&                uri,
                              const mqbu::StorageKey&         queueKey,
-                             int                             partitionId,
+                             BSLA_MAYBE_UNUSED int           partitionId,
                              const bsls::Types::Int64        messageTtl,
                              const int maxDeliveryAttempts,
                              const mqbconfm::StorageDefinition& storageDef)

--- a/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queuehandle.cpp
@@ -36,6 +36,7 @@
 #include <bsl_numeric.h>
 #include <bsl_string.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 
 namespace BloombergLP {
 namespace mqbmock {
@@ -298,11 +299,11 @@ void QueueHandle::deliverMessage(
 
         GUIDMap& guids = mapIter->second.d_unconfirmedMessages;
 
-        bsl::pair<GUIDMap::iterator, bool> insertRC = guids.insert(
-            bsl::make_pair(message.guid(),
-                           bsl::make_pair(message.appData(), sId)));
+        BSLA_MAYBE_UNUSED bsl::pair<GUIDMap::iterator, bool> insertRC =
+            guids.insert(
+                bsl::make_pair(message.guid(),
+                               bsl::make_pair(message.appData(), sId)));
         BSLS_ASSERT_OPT(insertRC.second);
-        (void)insertRC;  // Compiler happiness
     }
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
@@ -322,10 +322,9 @@ void ClusterActiveNodeManager::loadNodesInfo(mqbcmd::NodeStatuses* out) const
         mqbcmd::ClusterNodeInfo& node = nodes.back();
         node.description()            = it->first->nodeDescription();
         node.isAvailable().makeValue(it->first->isAvailable());
-        int rc = mqbcmd::NodeStatus::fromInt(&node.status(),
-                                             it->second.d_status);
+        BSLA_MAYBE_UNUSED int rc =
+            mqbcmd::NodeStatus::fromInt(&node.status(), it->second.d_status);
         BSLS_ASSERT_SAFE(!rc && "Unsupported node status");
-        (void)rc;
     }
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -47,6 +47,7 @@
 #include <bsl_functional.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_assert.h>
@@ -467,11 +468,11 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
             numRequests = --(context->d_numOutstandingRequests);
 
             bmqp_ctrlmsg::Status& failure = it->second.choice().makeStatus();
-            const int             rc = bmqp_ctrlmsg::StatusCategory::fromInt(
-                &failure.category(),
-                static_cast<int>(sendRc));
+            BSLA_MAYBE_UNUSED const int rc =
+                bmqp_ctrlmsg::StatusCategory::fromInt(
+                    &failure.category(),
+                    static_cast<int>(sendRc));
             BSLS_ASSERT_SAFE(rc == 0);
-            (void)rc;  // compiler happiness
             failure.code() = static_cast<int>(sendRc);
 
             bmqu::MemOutStream errorMsg;

--- a/src/groups/mqb/mqbplug/mqbplug_pluginmanager.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_pluginmanager.cpp
@@ -33,6 +33,7 @@
 #include <bsl_algorithm.h>
 #include <bsl_functional.h>
 #include <bsl_unordered_map.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bslma_managedptr.h>
@@ -54,13 +55,10 @@ const char k_PLUGIN_ENTRY_POINT[] = "instantiatePluginLibrary";
 typedef void (*PluginEntryFnPtr)(bslma::ManagedPtr<mqbplug::PluginLibrary>*,
                                  bslma::Allocator*);
 
-void dlcloseDeleter(void* dlopenHandle, void* unused)
+void dlcloseDeleter(void* dlopenHandle, BSLA_UNUSED void*)
 {
-    (void)unused;
-
-    int rc = dlclose(dlopenHandle);
+    BSLA_MAYBE_UNUSED int rc = dlclose(dlopenHandle);
     BSLS_ASSERT_SAFE(rc == 0);
-    (void)rc;  // Assert is unevaluated in production builds.
 }
 
 bool findPluginPredicate(const bsl::string&         target,

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -48,6 +48,7 @@
 #include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bsls_assert.h>
@@ -174,7 +175,7 @@ class MockDataStore : public mqbs::DataStore {
 
   private:
     // DATA
-    bslma::Allocator* d_allocator_p;
+    BSLA_UNUSED bslma::Allocator* d_allocator_p;
 
     mqbs::DataStoreConfig      d_config;
     mqbi::DispatcherClientData d_dispatcherClientData;

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3399,7 +3399,8 @@ void FileStore::gc(FileSet* fileSet)
                                  fileSet));
 }
 
-void FileStore::gcDispatched(int partitionId, FileSet* fileSet)
+void FileStore::gcDispatched(BSLA_MAYBE_UNUSED int partitionId,
+                             FileSet*              fileSet)
 {
     // executed by the *DISPATCHER* thread
 
@@ -3407,7 +3408,6 @@ void FileStore::gcDispatched(int partitionId, FileSet* fileSet)
     BSLS_ASSERT_SAFE(partitionId == d_config.partitionId());
     BSLS_ASSERT_SAFE(fileSet);
     BSLS_ASSERT_SAFE(0 < d_fileSets.size());
-    (void)partitionId;  // Compiler happiness
 
     if (fileSet == d_fileSets[0].get()) {
         // This occurs when FileStore::close() has happened.

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -132,10 +132,10 @@
 #include <bsl_cstddef.h>
 #include <bsl_cstring.h>  // for bsl::memset & bsl::memcpy
 #include <bsl_ostream.h>
-#include <bsls_types.h>
-
+#include <bsla_annotations.h>
 #include <bslmf_assert.h>
 #include <bsls_assert.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 namespace mqbs {
@@ -374,11 +374,11 @@ struct FileHeader {
 
     char d_bitnessAndFileType;
 
-    char d_reserved1[10];
+    BSLA_MAYBE_UNUSED char d_reserved1[10];
 
     bdlb::BigEndianInt32 d_partitionId;
 
-    char d_reserved2[8];
+    BSLA_MAYBE_UNUSED char d_reserved2[8];
 
   public:
     // CREATORS
@@ -453,11 +453,11 @@ struct DataFileHeader {
     // DATA
     unsigned char d_headerWords;
 
-    char d_reserved1;
+    BSLA_MAYBE_UNUSED char d_reserved1;
 
     char d_fileKey[FileStoreProtocol::k_KEY_LENGTH];
 
-    char d_reserved2;
+    BSLA_MAYBE_UNUSED char d_reserved2;
 
   public:
     // CREATORS
@@ -517,7 +517,7 @@ struct JournalFileHeader {
 
     unsigned char d_recordWords;
 
-    char d_reserved[k_NUM_RESERVED_BYTES];
+    BSLA_MAYBE_UNUSED char d_reserved[k_NUM_RESERVED_BYTES];
 
     bdlb::BigEndianUint32 d_firstSyncPointOffsetUpperBits;
 
@@ -579,7 +579,7 @@ struct QlistFileHeader {
     // DATA
     unsigned char d_headerWords;
 
-    char d_reserved[k_NUM_RESERVED_BYTES];
+    BSLA_MAYBE_UNUSED char d_reserved[k_NUM_RESERVED_BYTES];
 
   public:
     // CREATORS
@@ -763,7 +763,7 @@ struct DataHeader {
 
     bmqp::SchemaWireId d_schemaId;
 
-    unsigned char d_reserved[2];
+    BSLA_MAYBE_UNUSED unsigned char d_reserved[2];
     // Reserved.
   public:
     // CREATORS
@@ -1391,7 +1391,7 @@ struct ConfirmRecord {
     // DATA
     RecordHeader d_header;
 
-    char d_reserved1[2];
+    BSLA_MAYBE_UNUSED char d_reserved1[2];
 
     char d_queueKey[FileStoreProtocol::k_KEY_LENGTH];
 
@@ -1399,7 +1399,7 @@ struct ConfirmRecord {
 
     unsigned char d_guid[bmqt::MessageGUID::e_SIZE_BINARY];
 
-    char d_reserved2[8];
+    BSLA_MAYBE_UNUSED char d_reserved2[8];
 
     bdlb::BigEndianUint32 d_magic;
 
@@ -1569,13 +1569,13 @@ struct DeletionRecord {
     // DATA
     RecordHeader d_header;
 
-    char d_reserved1[3];
+    BSLA_MAYBE_UNUSED char d_reserved1[3];
 
     char d_queueKey[FileStoreProtocol::k_KEY_LENGTH];
 
     unsigned char d_guid[bmqt::MessageGUID::e_SIZE_BINARY];
 
-    char d_reserved2[12];
+    BSLA_MAYBE_UNUSED char d_reserved2[12];
 
     bdlb::BigEndianUint32 d_magic;
 
@@ -1754,7 +1754,7 @@ struct QueueOpRecord {
     // DATA
     RecordHeader d_header;
 
-    char d_reserved1[2];
+    BSLA_MAYBE_UNUSED char d_reserved1[2];
 
     char d_queueKey[FileStoreProtocol::k_KEY_LENGTH];
 
@@ -1770,7 +1770,7 @@ struct QueueOpRecord {
 
     bdlb::BigEndianUint32 d_startPrimaryLeaseId;
 
-    char d_reserved2[4];
+    BSLA_MAYBE_UNUSED char d_reserved2[4];
 
     bdlb::BigEndianUint32 d_magic;
 
@@ -2015,7 +2015,7 @@ struct JournalOpRecord {
     // DATA
     RecordHeader d_header;
 
-    char d_reserved1[3];
+    BSLA_MAYBE_UNUSED char d_reserved1[3];
 
     unsigned char d_syncPointType;
 
@@ -2033,7 +2033,7 @@ struct JournalOpRecord {
 
     bdlb::BigEndianUint32 d_qlistFileOffsetWords;
 
-    char d_reserved2[4];
+    BSLA_MAYBE_UNUSED char d_reserved2[4];
 
     bdlb::BigEndianUint32 d_magic;
 
@@ -2138,9 +2138,6 @@ inline FileHeader::FileHeader()
     setBitness(static_cast<Bitness::Enum>(sizeof(size_t) / 4));
     setMagic1(FileHeader::k_MAGIC1);
     setMagic2(FileHeader::k_MAGIC2);
-
-    (void)d_reserved1[0];  // warning: private field 'd_reserved1' is not used
-    (void)d_reserved2[0];  // warning: private field 'd_reserved2' is not used
 }
 
 // MANIPULATORS
@@ -2256,10 +2253,6 @@ inline DataFileHeader::DataFileHeader()
     bsl::memset(reinterpret_cast<char*>(this), 0, sizeof(DataFileHeader));
     setHeaderWords(sizeof(DataFileHeader) / bmqp::Protocol::k_WORD_SIZE);
     setFileKey(mqbu::StorageKey::k_NULL_KEY);
-
-    // Suppress "unused variable" warning
-    (void)d_reserved1;
-    (void)d_reserved2;
 }
 
 // MANIPULATORS
@@ -2299,7 +2292,6 @@ inline JournalFileHeader::JournalFileHeader()
     setRecordWords(FileStoreProtocol::k_JOURNAL_RECORD_SIZE /
                    bmqp::Protocol::k_WORD_SIZE);
     setFirstSyncPointOffsetWords(0);
-    (void)d_reserved;  // suppress 'unused variable' compiler diagnostic
 }
 
 // MANIPULATORS
@@ -2352,7 +2344,6 @@ inline QlistFileHeader::QlistFileHeader()
 {
     bsl::memset(reinterpret_cast<char*>(this), 0, sizeof(QlistFileHeader));
     setHeaderWords(sizeof(QlistFileHeader) / bmqp::Protocol::k_WORD_SIZE);
-    (void)d_reserved[0];  // warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -2400,8 +2391,6 @@ inline DataHeader::DataHeader()
     const size_t size = sizeof(DataHeader) / bmqp::Protocol::k_WORD_SIZE;
     setHeaderWords(size);
     setMessageWords(size);
-
-    (void)d_reserved;
 }
 
 // MANIPULATORS
@@ -2811,9 +2800,6 @@ inline ConfirmRecord::ConfirmRecord()
     d_header.setType(RecordType::e_CONFIRM);
     setQueueKey(mqbu::StorageKey::k_NULL_KEY);
     setAppKey(mqbu::StorageKey::k_NULL_KEY);
-
-    (void)d_reserved1[0];  // warning: private field 'd_reserved' is not used
-    (void)d_reserved2[0];  // warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -2894,9 +2880,6 @@ inline DeletionRecord::DeletionRecord()
     bsl::memset(reinterpret_cast<char*>(this), 0, sizeof(DeletionRecord));
     d_header.setType(RecordType::e_DELETION);
     setQueueKey(mqbu::StorageKey::k_NULL_KEY);
-
-    (void)d_reserved1[0];  // warning: private field 'd_reserved1' is not used
-    (void)d_reserved2[0];  // warning: private field 'd_reserved2' is not used
 }
 
 // MANIPULATORS
@@ -2968,9 +2951,6 @@ inline QueueOpRecord::QueueOpRecord()
     d_header.setType(RecordType::e_QUEUE_OP);
     setQueueKey(mqbu::StorageKey::k_NULL_KEY);
     setAppKey(mqbu::StorageKey::k_NULL_KEY);
-
-    (void)d_reserved1[0];  // warning: private field 'd_reserved' is not used
-    (void)d_reserved2[0];  // warning: private field 'd_reserved' is not used
 }
 
 // MANIPULATORS
@@ -3087,9 +3067,6 @@ inline JournalOpRecord::JournalOpRecord()
 {
     bsl::memset(reinterpret_cast<char*>(this), 0, sizeof(JournalOpRecord));
     d_header.setType(RecordType::e_JOURNAL_OP);
-
-    (void)d_reserved1[0];  // warning: private field 'd_reserved1' is not used
-    (void)d_reserved2[0];  // warning: private field 'd_reserved2' is not used
 }
 
 inline JournalOpRecord::JournalOpRecord(JournalOpType::Enum type,

--- a/src/groups/mqb/mqbs/mqbs_filesystemutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filesystemutil.cpp
@@ -152,6 +152,7 @@
 #include <bdls_filesystemutil.h>
 #include <bdls_pathutil.h>
 #include <bsl_ostream.h>
+#include <bsla_annotations.h>
 #include <bsls_assert.h>
 #include <bsls_platform.h>
 
@@ -663,7 +664,8 @@ int FileSystemUtil::flush(void*               mapping,
     return rc_SUCCESS;
 }
 
-void FileSystemUtil::disableDump(void* mapping, bsls::Types::Uint64 size)
+void FileSystemUtil::disableDump(BSLA_MAYBE_UNUSED void* mapping,
+                                 BSLA_MAYBE_UNUSED bsls::Types::Uint64 size)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(mapping);
@@ -677,9 +679,6 @@ void FileSystemUtil::disableDump(void* mapping, bsls::Types::Uint64 size)
 #if defined(BSLS_PLATFORM_OS_LINUX) && defined(MADV_DONTDUMP)
     madvise(mapping, size, MADV_DONTDUMP);
 #endif
-
-    (void)mapping;
-    (void)size;  // Compiler happiness
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -545,10 +545,8 @@ void InMemoryStorage::selectForAutoConfirming(const bmqt::MessageGUID& msgGUID)
 
 mqbi::StorageResult::Enum
 InMemoryStorage::autoConfirm(const mqbu::StorageKey& appKey,
-                             bsls::Types::Uint64     timestamp)
+                             BSLA_UNUSED bsls::Types::Uint64 timestamp)
 {
-    (void)timestamp;
-
     d_autoConfirms.emplace_back(appKey);
 
     return mqbi::StorageResult::e_SUCCESS;

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
@@ -37,6 +37,7 @@
 #include <bdlt_datetime.h>
 #include <bdlt_datetimetz.h>
 #include <bsl_algorithm.h>
+#include <bsla_annotations.h>
 #include <bslmt_lockguard.h>
 #include <bslmt_mutex.h>
 #include <bsls_assert.h>
@@ -95,9 +96,9 @@ int StoragePrintUtil::listMessages(mqbcmd::QueueContents* queueContents,
         appKey = mqbu::StorageKey::k_NULL_KEY;
     }
     else {
-        bool hasTheStorage = storage->hasVirtualStorage(appId, &appKey);
+        BSLA_MAYBE_UNUSED bool hasTheStorage =
+            storage->hasVirtualStorage(appId, &appKey);
         BSLS_ASSERT_SAFE(hasTheStorage);
-        (void)hasTheStorage;
     }
 
     const bsls::Types::Int64 numMessages        = storage->numMessages(appKey);

--- a/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstorage.cpp
@@ -21,6 +21,7 @@
 // BDE
 #include <bsl_cstring.h>
 #include <bsl_utility.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
 
@@ -296,10 +297,9 @@ const mqbi::StorageMessageAttributes& StorageIterator::attributes() const
     if (d_attributes.refCount() == 0) {
         // No loaded Attributes for the current message yet.
 
-        mqbi::StorageResult::Enum rc = d_storage_p->get(&d_attributes,
-                                                        d_iterator->first);
+        BSLA_MAYBE_UNUSED mqbi::StorageResult::Enum rc =
+            d_storage_p->get(&d_attributes, d_iterator->first);
         BSLS_ASSERT_SAFE(mqbi::StorageResult::e_SUCCESS == rc);
-        (void)rc;
     }
     // else return reference to the previously loaded attributes.
 

--- a/src/groups/mqb/mqbscm/mqbscm_version.t.cpp
+++ b/src/groups/mqb/mqbscm/mqbscm_version.t.cpp
@@ -19,6 +19,7 @@
 // BDE
 #include <bsl_iostream.h>
 #include <bsl_string.h>
+#include <bsla_annotations.h>
 #include <bslim_testutil.h>
 
 // CONVENIENCE
@@ -41,16 +42,11 @@ static void aSsErT(bool b, const char* s, int i)
 
 int main(int argc, char** argv)
 {
-    int  test                = argc > 1 ? atoi(argv[1]) : 0;
-    bool verbose             = argc > 2;
-    bool veryVerbose         = argc > 3;
-    bool veryVeryVerbose     = argc > 4;
-    bool veryVeryVeryVerbose = argc > 5;
-    // Prevent potential compiler unused warning
-    (void)verbose;
-    (void)veryVerbose;
-    (void)veryVeryVerbose;
-    (void)veryVeryVeryVerbose;
+    int              test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool             verbose             = argc > 2;
+    BSLA_UNUSED bool veryVerbose         = argc > 3;
+    BSLA_UNUSED bool veryVeryVerbose     = argc > 4;
+    BSLA_UNUSED bool veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
     switch (test) {

--- a/src/groups/mqb/mqbscm/mqbscm_versiontag.t.cpp
+++ b/src/groups/mqb/mqbscm/mqbscm_versiontag.t.cpp
@@ -18,6 +18,7 @@
 
 // BDE
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>
 #include <bslim_testutil.h>
 
 // CONVENIENCE
@@ -40,16 +41,11 @@ static void aSsErT(bool b, const char* s, int i)
 
 int main(int argc, char** argv)
 {
-    int  test                = argc > 1 ? atoi(argv[1]) : 0;
-    bool verbose             = argc > 2;
-    bool veryVerbose         = argc > 3;
-    bool veryVeryVerbose     = argc > 4;
-    bool veryVeryVeryVerbose = argc > 5;
-    // Prevent potential compiler unused warning
-    (void)verbose;
-    (void)veryVerbose;
-    (void)veryVeryVerbose;
-    (void)veryVeryVeryVerbose;
+    int              test                = argc > 1 ? atoi(argv[1]) : 0;
+    bool             verbose             = argc > 2;
+    BSLA_UNUSED bool veryVerbose         = argc > 3;
+    BSLA_UNUSED bool veryVeryVerbose     = argc > 4;
+    BSLA_UNUSED bool veryVeryVeryVerbose = argc > 5;
 
     cout << "TEST " << __FILE__ << " CASE " << test << endl;
     switch (test) {


### PR DESCRIPTION
This PR fixes warnings that Clang emits due to unused entities, or entities that may be unused, depending on whether assertions are enabled or not.

Please see commit messages for more details.