### PR TITLE
Fix: Clang warnings related to switch statements

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.cpp
@@ -87,6 +87,7 @@ void CslFileProcessor::process()
             checkRecord = d_parameters->d_processCslRecordTypes.d_ack;
             break;  // BREAK
         }
+        case mqbc::ClusterStateRecordType::e_UNDEFINED:
         default: BSLS_ASSERT(false && "Unknown record type");
         }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
@@ -189,10 +189,10 @@ createClusterMessage(bmqp_ctrlmsg::ClusterMessage*              message,
 
         return mqbc::ClusterStateRecordType::e_ACK;
     }
+    default:
+        BSLS_ASSERT(false && "Unreachable by design.");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT_OPT(false && "Unreachable by design.");
-    return mqbc::ClusterStateRecordType::e_UNDEFINED;
 }
 
 int extractLogIdCallback(mqbu::StorageKey*                      logId,

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.cpp
@@ -50,6 +50,7 @@ void updateRecordCount(CslRecordCount*                    recordCount_p,
     case mqbc::ClusterStateRecordType::e_ACK:
         recordCount_p->d_ackCount++;
         break;
+    case mqbc::ClusterStateRecordType::e_UNDEFINED:
     default: BSLS_ASSERT(false && "Unknown record type");
     }
 }

--- a/src/applications/bmqtool/CMakeLists.txt
+++ b/src/applications/bmqtool/CMakeLists.txt
@@ -16,6 +16,14 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang")
     PROPERTY COMPILE_FLAGS "-Wno-format-nonliteral")
 endif()
 
+# Turn off warnings in generated code.
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+    set_property(SOURCE "m_bmqtool_messages.cpp"
+                 APPEND
+                 PROPERTY COMPILE_OPTIONS "-Wno-everything"
+    )
+endif()
+
 target_bmq_default_compiler_flags(bmqtool)
 
 set_target_properties(bmqtool

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -162,6 +162,9 @@ void Application::setUpLog()
     case ParametersVerbosity::e_FATAL: {
         logLevel = ball::Severity::e_ERROR;
     } break;
+    default: {
+        BSLS_ASSERT(false && "Invalid verbosity specified");
+    }
     }
 
     const bsl::string logFormat =

--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -63,6 +63,15 @@ target_sources(bmqbrkr_plugins PUBLIC FILE_SET HEADERS
   BASE_DIRS "${bmq_INCLUDE_DIRS}"
 )
 
+# Turn off warnings in generated code.
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+    set_property(SOURCE "bmqp/bmqp_ctrlmsg_messages.cpp"
+                        "bmqstm/bmqstm_messages.cpp"
+                 APPEND
+                 PROPERTY COMPILE_OPTIONS "-Wno-everything"
+    )
+endif()
+
 if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
   # Search homebrewed keg-only versions of Bison and Flex on macOS.
   execute_process(

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -733,9 +733,10 @@ const char* MockSession::toAscii(const Method method)
         return "int confirmMessage(const MessageConfirmationCookie& cookie)";
     case e_CONFIRM_MESSAGES:
         return "int confirmMessages(ConfirmEventBuilder *builder)";
+    default: return "UNKNOWN";
     }
 
-    return "UNKNOWN";
+    BSLA_UNREACHABLE;
 }
 
 void MockSession::initializeStats()

--- a/src/groups/bmq/bmqex/bmqex_future.h
+++ b/src/groups/bmq/bmqex/bmqex_future.h
@@ -1644,6 +1644,10 @@ inline FutureSharedState<R>::~FutureSharedState()
         reinterpret_cast<Buffer*>(&d_result)->object().~ExceptionObjType();
         break;  // BREAK
     }
+    default: {
+        // Unreachable code, but makes the compiler happy.
+        BSLS_ASSERT(false);
+    }
     }
 }
 
@@ -1817,11 +1821,12 @@ inline R& FutureSharedState<R>::get()
         typedef bsls::ObjectBuffer<ExceptionObjType> Buffer;
         reinterpret_cast<Buffer*>(&d_result)->object().emit();  // THROW
     }
+    default: {
+        // Unreachable code, but makes the compiler happy.
+        BSLS_ASSERT(false);
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    // Unreachable code, but makes the compiler happy.
-    BSLS_ASSERT(false);
-    return *reinterpret_cast<R*>(0x42);
+    }
 }
 
 template <class R>

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.h
@@ -1644,6 +1644,11 @@ inline FutureSharedState<R>::~FutureSharedState()
         reinterpret_cast<Buffer*>(&d_result)->object().~ExceptionObjType();
         break;  // BREAK
     }
+    default: {
+        // Unreachable code, but makes the compiler happy.
+        BSLS_ASSERT(false);
+        BSLS_ASSERT_INVOKE_NORETURN("");
+    }
     }
 }
 
@@ -2185,11 +2190,12 @@ inline R& FutureSharedState<R>::get()
         typedef bsls::ObjectBuffer<ExceptionObjType> Buffer;
         reinterpret_cast<Buffer*>(&d_result)->object().emit();  // THROW
     }
+    default: {
+        // Unreachable code, but makes the compiler happy.
+        BSLS_ASSERT(false);
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    // Unreachable code, but makes the compiler happy.
-    BSLS_ASSERT(false);
-    return *reinterpret_cast<R*>(0x42);
+    }
 }
 
 template <class R>

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.h
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.h
@@ -37,6 +37,7 @@
 #include <ball_log.h>
 #include <bdlbb_blob.h>
 #include <bsl_iostream.h>
+#include <bsla_annotations.h>  // BSLA_UNREACHABLE
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -280,6 +281,7 @@ inline bool MessageDumper::DumpContext::isEnabled() const
         d_isEnabled = (d_actionValue >= bmqsys::Time::highResolutionTimer());
         // Expiration time is in the future
     } break;  // BREAK
+    default: BSLA_UNREACHABLE;
     }
 
     return d_isEnabled;

--- a/src/groups/bmq/bmqst/bmqst_statcontext.h
+++ b/src/groups/bmq/bmqst/bmqst_statcontext.h
@@ -497,6 +497,7 @@
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>  // BSLA_UNREACHABLE
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_allocatorargt.h>
@@ -1189,6 +1190,7 @@ inline const StatValue& StatContext::value(ValueType valueType,
         break;
     case e_DIRECT_VALUE: valueVec = d_directValues_p.ptr(); break;
     case e_EXPIRED_VALUE: valueVec = d_expiredValues_p.ptr(); break;
+    default: BSLA_UNREACHABLE;
     }
 
     return (*valueVec)[valueIndex];

--- a/src/groups/bmq/bmqst/bmqst_statvalue.cpp
+++ b/src/groups/bmq/bmqst/bmqst_statvalue.cpp
@@ -200,6 +200,9 @@ void StatValue::setFromUpdate(const bmqstm::StatValueUpdate& update)
             case Fields::E_VALUE: {
                 d_currentStats.d_value = *f;
             } break;
+            default: {
+                BSLS_ASSERT(false && "Unknown stat value field");
+            }
             }
             ++f;
         }
@@ -419,6 +422,9 @@ void StatValueUtil::loadUpdateImp(bmqstm::StatValueUpdate* update,
                     mask = bdlb::BitUtil::withBitSet(mask, i);
                 }
             } break;
+            default: {
+                BSLS_ASSERT(false && "Unknown stat value field");
+            }
             }
         }
     }

--- a/src/groups/bmq/bmqstm/bmqstm_values.cpp
+++ b/src/groups/bmq/bmqstm/bmqstm_values.cpp
@@ -413,10 +413,11 @@ const char* StatContextConfigurationFlags::toString(
     case E_STORE_EXPIRED_VALUES: {
         return "E_STORE_EXPIRED_VALUES";
     }
+    default: {
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT(!"invalid enumerator");
-    return 0;
+    }
 }
 
 // ----------------------------
@@ -480,10 +481,11 @@ StatContextUpdateFlags::toString(StatContextUpdateFlags::Value value)
     case E_CONTEXT_DELETED: {
         return "E_CONTEXT_DELETED";
     }
+    default: {
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT(!"invalid enumerator");
-    return 0;
+    }
 }
 
 // ---------------------
@@ -586,10 +588,11 @@ const char* StatValueFields::toString(StatValueFields::Value value)
     case E_DECREMENTS: {
         return "E_DECREMENTS";
     }
+    default: {
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT(!"invalid enumerator");
-    return 0;
+    }
 }
 
 // -------------------
@@ -648,10 +651,11 @@ const char* StatValueType::toString(StatValueType::Value value)
     case E_DISCRETE: {
         return "E_DISCRETE";
     }
+    default: {
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT(!"invalid enumerator");
-    return 0;
+    }
 }
 
 // ---------------------

--- a/src/groups/mqb/CMakeLists.txt
+++ b/src/groups/mqb/CMakeLists.txt
@@ -23,6 +23,16 @@ set_property(SOURCE "mqba/mqba_application.cpp"
 set(MQB_PRIVATE_PACKAGES mqba mqbblp mqbc mqbcmd mqbconfm mqbi mqbmock mqbnet mqbs mqbsi mqbsl mqbu)
 target_bmq_style_uor( mqb PRIVATE_PACKAGES ${MQB_PRIVATE_PACKAGES})
 
+# Turn off warnings in generated code.
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
+    set_property(SOURCE "mqbcfg/mqbcfg_messages.cpp"
+                        "mqbcmd/mqbcmd_messages.cpp"
+                        "mqbconfm/mqbconfm_messages.cpp"
+                 APPEND
+                 PROPERTY COMPILE_OPTIONS "-Wno-everything"
+    )
+endif()
+
 # Extras package containing the plugin headers
 bbs_read_metadata(GROUP mqb SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 target_sources(bmqbrkr_plugins PUBLIC FILE_SET HEADERS

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -448,6 +448,7 @@ void Dispatcher::queueEventCb(mqbi::DispatcherClientType::Enum type,
             }
         }
     } break;
+    default: BSLA_UNREACHABLE;
     }
 }
 

--- a/src/groups/mqb/mqba/mqba_dispatcher.h
+++ b/src/groups/mqb/mqba/mqba_dispatcher.h
@@ -64,6 +64,7 @@
 #include <bsl_memory.h>
 #include <bsl_ostream.h>
 #include <bsl_vector.h>
+#include <bsla_annotations.h>  // BSLA_UNREACHABLE
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
@@ -631,6 +632,7 @@ Dispatcher::numProcessors(mqbi::DispatcherClientType::Enum type) const
         BSLS_ASSERT_OPT(false && "Invalid type");
         return -1;  // RETURN
     }  // break;
+    default: BSLA_UNREACHABLE;
     }
 
     return 0;

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -129,6 +129,19 @@ void ClusterOrchestrator::onElectorStateChange(
     case mqbnet::ElectorState::e_LEADER: {
         electorTransitionToLeader(leaderNodeId, term);
     } break;  // BREAK
+
+    default: {
+        BALL_LOG_WARN << d_clusterData_p->identity().description()
+                      << ": Unknown new elector state: " << state
+                      << ", new code: " << code
+                      << ", new leaderNodeId: " << leaderNodeId
+                      << ", new term: " << term << ", old state: "
+                      << d_clusterData_p->electorInfo().electorState()
+                      << ", old leaderNodeId: "
+                      << d_clusterData_p->electorInfo().leaderNodeId()
+                      << ", old term: "
+                      << d_clusterData_p->electorInfo().electorTerm();
+    }
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -3443,6 +3443,16 @@ void RecoveryManager::processRecoveryEvent(
 
         case bmqp::RecoveryFileChunkType::e_UNDEFINED:
             BSLS_ASSERT_SAFE(false && "Unreachable by design.");
+            break;  // BREAK
+
+        default:
+            BMQTSK_ALARMLOG_ALARM("RECOVERY")
+                << d_clusterData_p->identity().description()
+                << ": For Partition [" << partitionId
+                << "], received unknown file chunk type: "
+                << header.fileChunkType()
+                << ", from: " << source->nodeDescription() << "."
+                << BMQTSK_ALARMLOG_END;
         }
 
         BSLS_ASSERT_SAFE(isData || isJournal || isQlist);

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -1566,7 +1566,12 @@ int RecoveryManager::sendFile(RequestContext*                   context,
         break;  // BREAK
 
     case bmqp::RecoveryFileChunkType::e_UNDEFINED:
-        BSLS_ASSERT_SAFE(false);
+        BSLS_ASSERT_SAFE(false && "Unreachable by design.");
+        break;  // BREAK
+
+    default:
+        BSLS_ASSERT_SAFE(false && "Unreachable by design.");
+        BSLA_UNREACHABLE;
         break;  // BREAK
     }
 

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -1095,6 +1095,10 @@ void RemoteQueue::confirmMessage(const bmqt::MessageGUID& msgGUID,
     case SubStreamContext::e_OPENED: {
         sendConfirmMessage(msgGUID, upstreamSubQueueId, source);
     } break;
+    default: {
+        BSLS_ASSERT(false && "Unknown SubStreamContext state.");
+        BSLA_UNREACHABLE;
+    }
     }
 }
 
@@ -1152,6 +1156,10 @@ int RemoteQueue::rejectMessage(const bmqt::MessageGUID& msgGUID,
                                 // partitionId is needed only by replica
         dispatcher->dispatchEvent(dispEvent, cluster);
     } break;
+    default: {
+        BSLS_ASSERT(false && "Unknown SubStreamContext state.");
+        BSLA_UNREACHABLE;
+    }
     }
     return result;
 }

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
@@ -185,6 +185,8 @@ struct Tester {
 
             message->choice().makeLeaderAdvisoryCommit(commit);
         } break;
+        default:
+            BSLS_ASSERT(false && "Advisory type is not a cluster message");
         }
     }
 

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.t.cpp
@@ -42,6 +42,7 @@
 #include <bsl_string.h>
 #include <bsl_utility.h>  // bsl::pair, bsl::make_pair
 #include <bsl_vector.h>
+#include <bsla_annotations.h>  // BSLA_UNREACHABLE
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bsls_assert.h>
@@ -175,6 +176,7 @@ createClusterMessage(bmqp_ctrlmsg::ClusterMessage*              message,
 
         return mqbc::ClusterStateRecordType::e_COMMIT;
     }
+    default: BSLA_UNREACHABLE;
     }
 
     BSLS_ASSERT_OPT(false && "Unreachable by design.");

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1045,12 +1045,6 @@ void StorageManager::processReplicaDataResponseDispatched(
                   << responder->nodeDescription();
 
     switch (dataType) {
-    case bmqp_ctrlmsg::ReplicaDataType::E_UNKNOWN: {
-        BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: ReplicaDataResponse has an unknown data type, "
-                       << "ignoring.";
-    } break;
     case bmqp_ctrlmsg::ReplicaDataType::E_PULL: {
         dispatchEventToPartition(fs,
                                  PartitionFSM::Event::e_REPLICA_DATA_RSPN_PULL,
@@ -1065,6 +1059,13 @@ void StorageManager::processReplicaDataResponseDispatched(
         dispatchEventToPartition(fs,
                                  PartitionFSM::Event::e_REPLICA_DATA_RSPN_DROP,
                                  eventDataVec);
+    } break;
+    case bmqp_ctrlmsg::ReplicaDataType::E_UNKNOWN:
+    default: {
+        BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                       << " Partition [" << partitionId
+                       << "]: ReplicaDataResponse has an unknown data type, "
+                       << "ignoring.";
     } break;
     }
 }

--- a/src/groups/mqb/mqbcmd/mqbcmd_util.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_util.cpp
@@ -230,6 +230,9 @@ void Util::printCommandResponses(const mqbcmd::RouteResponseList& responseList,
     case mqbcmd::EncodingFormat::JSON_PRETTY: {
         mqbcmd::JsonPrinter::printResponses(os, responseList, true);
     } break;  // BREAK
+    default: {
+        BSLS_ASSERT(false && "Unsupported encoding");
+    } break;  // BREAK
     }
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -856,6 +856,10 @@ void Channel::threadFn()
                     mode = e_BLOCK;
                 }
             } break;
+            default: {
+                BSLS_ASSERT(false && "Unreachable by design");
+                BSLA_UNREACHABLE;
+            }
             }
         }
         else if (item->d_type == bmqp::EventType::e_UNDEFINED) {

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -727,6 +727,11 @@ void TCPSessionFactory::channelStateCallback(
                             context->d_resultState_p,
                             bmqio::Channel::ReadCallback());
     } break;
+    default: {
+        BSLS_ASSERT(false &&
+                    "Unexpected ChannelFactorEvent; unreachable by design.");
+        BSLA_UNREACHABLE;
+    }
     }
 }
 

--- a/src/groups/mqb/mqbplug/mqbplug_plugintype.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_plugintype.cpp
@@ -49,6 +49,7 @@ const char* PluginType::toAscii(PluginType::Enum value)
 
     switch (value) {
         CASE(STATS_CONSUMER)
+        CASE(AUTHENTICATOR)
     default: return "(* UNKNOWN *)";
     }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7566,7 +7566,8 @@ bsl::ostream& FileStoreIterator::print(bsl::ostream& stream,
         printer.printAttribute("queueOpRecord", record);
     } break;
     case mqbs::RecordType::e_JOURNAL_OP:
-    case mqbs::RecordType::e_UNDEFINED: {
+    case mqbs::RecordType::e_UNDEFINED:
+    default: {
         // we should never be here
         BSLS_ASSERT_SAFE(false && "Invalid file store record");
     }

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
@@ -451,20 +451,7 @@ void printOption(bsl::ostream&     stream,
                  BSLA_UNUSED const bmqp::OptionsView*     ov,
                  const bmqp::OptionsView::const_iterator& cit)
 {
-    switch (*cit) {
-    case bmqp::OptionType::e_SUB_QUEUE_IDS_OLD: {
-        stream << "      " << *cit;
-    } break;  // BREAK
-    case bmqp::OptionType::e_MSG_GROUP_ID: {
-        stream << "      " << *cit;
-    } break;  // BREAK
-    case bmqp::OptionType::e_SUB_QUEUE_INFOS: {
-        stream << "      " << *cit;
-    } break;  // BREAK
-    case bmqp::OptionType::e_UNDEFINED: {
-        stream << "      " << *cit;
-    } break;  // BREAK
-    }
+    stream << "      " << *cit;
 }
 
 void printOptions(bsl::ostream& stream, const char* options, unsigned int len)

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -159,11 +159,10 @@ const char* QueueStatsDomain::Stat::toString(Stat::Enum value)
         MQBSTAT_CASE(e_NO_SC_MSGS_DELTA, "queue_nack_noquorum_msgs")
         MQBSTAT_CASE(e_NO_SC_MSGS_ABS, "queue_nack_noquorum_msgs_abs")
         MQBSTAT_CASE(e_HISTORY_ABS, "queue_history_abs")
+    default:
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
     }
-
-    BSLS_ASSERT(!"invalid enumerator");
-    return 0;
-
 #undef MQBSTAT_CASE
 }
 


### PR DESCRIPTION
This PR fixes warnings that Clang emits due to missing `default` cases in switch statements.

Please see commit messages for more details.