### PR TITLE
InitialConnectionContext leak

### DIFF
--- a/src/groups/mqb/mqba/mqba_initialconnectionhandler.cpp
+++ b/src/groups/mqb/mqba/mqba_initialconnectionhandler.cpp
@@ -293,7 +293,7 @@ void InitialConnectionHandler::complete(
     const bsl::string&                      error,
     const bsl::shared_ptr<mqbnet::Session>& session)
 {
-    context->initialConnectionCompleteCb()(rc, error, session);
+    context->complete(rc, error, session);
 }
 
 InitialConnectionHandler::InitialConnectionHandler(

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -52,8 +52,7 @@ InitialConnectionContext& InitialConnectionContext::setChannel(
     return *this;
 }
 
-InitialConnectionContext&
-InitialConnectionContext::setInitialConnectionCompleteCb(
+InitialConnectionContext& InitialConnectionContext::setCompleteCb(
     const InitialConnectionCompleteCb& value)
 {
     d_initialConnectionCompleteCb = value;
@@ -88,10 +87,14 @@ InitialConnectionContext::channel() const
     return d_channelSp;
 }
 
-const InitialConnectionContext::InitialConnectionCompleteCb&
-InitialConnectionContext::initialConnectionCompleteCb() const
+void InitialConnectionContext::complete(
+    const int                               rc,
+    const bsl::string&                      error,
+    const bsl::shared_ptr<mqbnet::Session>& session) const
 {
-    return d_initialConnectionCompleteCb;
+    BSLS_ASSERT_SAFE(d_initialConnectionCompleteCb);
+
+    d_initialConnectionCompleteCb(rc, error, session, channel(), this);
 }
 
 const bsl::shared_ptr<NegotiationContext>&

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -59,9 +59,12 @@ struct NegotiationContext;
 /// `InitialConnectionCompleteCb` method.
 class InitialConnectionContext {
   public:
-    typedef bsl::function<void(int                status,
-                               const bsl::string& errorDescription,
-                               const bsl::shared_ptr<Session>& session)>
+    typedef bsl::function<void(
+        int                                    status,
+        const bsl::string&                     errorDescription,
+        const bsl::shared_ptr<Session>&        session,
+        const bsl::shared_ptr<bmqio::Channel>& channel,
+        const InitialConnectionContext*        initialConnectionContext)>
         InitialConnectionCompleteCb;
 
   private:
@@ -131,19 +134,22 @@ class InitialConnectionContext {
     InitialConnectionContext&
     setChannel(const bsl::shared_ptr<bmqio::Channel>& value);
     InitialConnectionContext&
-    setInitialConnectionCompleteCb(const InitialConnectionCompleteCb& value);
+    setCompleteCb(const InitialConnectionCompleteCb& value);
     InitialConnectionContext&
     setNegotiationContext(const bsl::shared_ptr<NegotiationContext>& value);
 
     // ACCESSORS
 
     /// Return the value of the corresponding field.
-    bool                                   isIncoming() const;
-    void*                                  userData() const;
-    void*                                  resultState() const;
-    const bsl::shared_ptr<bmqio::Channel>& channel() const;
-    const InitialConnectionCompleteCb&     initialConnectionCompleteCb() const;
+    bool                                       isIncoming() const;
+    void*                                      userData() const;
+    void*                                      resultState() const;
+    const bsl::shared_ptr<bmqio::Channel>&     channel() const;
     const bsl::shared_ptr<NegotiationContext>& negotiationContext() const;
+
+    void complete(const int                               rc,
+                  const bsl::string&                      error,
+                  const bsl::shared_ptr<mqbnet::Session>& session) const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -437,12 +437,12 @@ class TCPSessionFactory {
     /// case, the specified `callback` must be invoked to notify the channel
     /// factory of the status.
     void negotiationComplete(
-        int                                              statusCode,
-        const bsl::string&                               errorDescription,
-        const bsl::shared_ptr<Session>&                  session,
-        const bsl::shared_ptr<bmqio::Channel>&           channel,
-        const bsl::shared_ptr<OperationContext>&         context,
-        const bsl::shared_ptr<InitialConnectionContext>& negotiatorContext);
+        int                                      statusCode,
+        const bsl::string&                       errorDescription,
+        const bsl::shared_ptr<Session>&          session,
+        const bsl::shared_ptr<bmqio::Channel>&   channel,
+        const InitialConnectionContext*          initialConnectionContext,
+        const bsl::shared_ptr<OperationContext>& operationContext);
 
     /// Custom deleter of the session's shared_ptr for the specified
     /// `session` (of type `Session`) associated with the specified `sprep`


### PR DESCRIPTION
removing circular counted reference InitialConnectionContext <-> InitialConnectionCompleteCb