### PR TITLE
[WIP]Feat[BMQC]: batched object pool

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_batchedpool.cpp
+++ b/src/groups/bmq/bmqc/bmqc_batchedpool.cpp
@@ -1,0 +1,30 @@
+// Copyright 2014-2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqc_batchedpool.h                                                 -*-C++-*-
+
+//@PURPOSE:
+
+#include <bmqc_batchedpool.h>
+
+// BDE
+#include <bsl_functional.h>  // for 'bsl::hash'
+
+namespace BloombergLP {
+namespace bmqc {
+
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqc/bmqc_batchedpool.h
+++ b/src/groups/bmq/bmqc/bmqc_batchedpool.h
@@ -1,0 +1,216 @@
+// Copyright 2014-2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqc_batchedpool.h                                                 -*-C++-*-
+#ifndef INCLUDED_BMQC_BATCHEDPOOL
+#define INCLUDED_BMQC_BATCHEDPOOL
+
+//@PURPOSE:
+
+// BDE
+#include <bdlcc_objectpool.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bdlf_bind.h>
+
+namespace BloombergLP {
+namespace bmqc {
+
+// FORWARD DECLARATIONS
+template <class TYPE>
+struct PoolBatch;
+
+template <class TYPE>
+class BatchedObjectPool;
+
+
+template <class TYPE>
+struct BatchNode {
+  public:
+    PoolBatch<TYPE>* d_batch_p;
+
+    /// The user defined object owned by this node
+    bsls::ObjectBuffer<TYPE> d_object;
+
+    void release() {
+        d_batch_p->onNodeRelease();
+    }
+
+    void reset() {
+        d_object.object().reset();
+    }
+
+    explicit BatchNode(PoolBatch<TYPE>*  batch_p,
+                       bslma::Allocator* allocator = 0)
+    : d_batch_p(batch_p)
+    , d_object()
+    {
+        bslalg::ScalarPrimitives::defaultConstruct(
+            reinterpret_cast<TYPE*>(d_object.buffer()),
+            allocator);
+    }
+
+    ~BatchNode() {
+        d_object.object().~TYPE();
+    }
+
+    // NOT IMPLEMENTED
+    /// Copy constructor and assignment operator are not implemented.
+    BatchNode(const BatchNode&) BSLS_KEYWORD_DELETED;
+    BatchNode& operator=(const BatchNode&) BSLS_KEYWORD_DELETED;    
+};
+
+template <class TYPE>
+struct PoolBatch {
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(PoolBatch,
+                                   bslma::UsesBslmaAllocator)
+
+    bsls::AtomicInt            d_refCount;
+
+    BatchedObjectPool<TYPE>*   d_owner_p;
+
+    bsl::vector<bsl::shared_ptr<BatchNode<TYPE> > > d_nodes;
+
+    void onNodeRelease() {
+        const int refCount = d_refCount.subtractRelaxed(1);
+        if (0 == refCount) {
+            d_owner_p->d_pool.releaseObject(this);
+        }
+    }
+
+    explicit PoolBatch(size_t batchSize,
+                       BatchedObjectPool<TYPE>* owner_p,
+                       bslma::Allocator *allocator = 0)
+    : d_refCount(batchSize)
+    , d_owner_p(owner_p)
+    , d_nodes(allocator)
+    {
+        d_nodes.resize(batchSize);
+        for (size_t i = 0; i < batchSize; i++) {
+            d_nodes[i] = bsl::allocate_shared<BatchNode<TYPE> >(allocator, this);
+        }
+    }
+
+    void reset() {
+        for (size_t i = 0; i < d_nodes.size(); i++) {
+            d_nodes[i]->reset();
+        }
+        d_refCount = d_nodes.size();
+    }
+};
+
+template <class TYPE>
+// template collection for release/get/size etc
+class LocalBatcher {
+  private:
+    BatchedObjectPool<TYPE> *d_owner_p;
+
+    PoolBatch<TYPE>* d_batch_p;
+
+    size_t     d_batchPos;
+    
+  public:
+    explicit LocalBatcher(BatchedObjectPool<TYPE> *owner_p)
+    : d_owner_p(owner_p)
+    , d_batch_p(0)
+    , d_batchPos(0)
+    {
+        BSLS_ASSERT_SAFE(d_owner_p);
+        
+        d_batch_p = d_owner_p->d_pool.getObject();
+        d_batchPos = 0;
+    }
+
+    ~LocalBatcher() {
+        while (d_batchPos < d_batch_p->d_nodes.size()) {
+            d_batch_p->d_nodes[d_batchPos++]->release();
+        }
+    }
+
+    BatchNode<TYPE>* getObject()
+    {
+        if (d_batch_p->d_nodes.size() <= d_batchPos) {
+            d_batch_p = d_owner_p->d_pool.getObject();
+            d_batchPos = 0;
+        }
+        return d_batch_p->d_nodes[d_batchPos++].get();
+    }
+};
+
+template <class TYPE>
+class BatchedObjectPool {
+  private:
+  public: //rm
+    // PRIVATE TYPES
+    /// `CreatorFn` is an alias for a functor creating an object of `TYPE`
+    /// in the specified `arena` using the specified `allocator`.
+    typedef bsl::function<void(void* arena, bslma::Allocator* allocator)>
+        CreatorFn;
+
+    typedef PoolBatch<TYPE> BatchedPoolObject;
+
+    typedef bdlcc::
+        ObjectPool<BatchedPoolObject, CreatorFn, bdlcc::ObjectPoolFunctors::Reset<BatchedPoolObject> >
+            BasePool;
+
+    // PRIVATE DATA
+    bslma::Allocator *d_allocator_p;
+
+    BasePool d_pool;
+
+    // PRIVATE CLASS METHODS
+    static void batchCreatorFn(size_t batchSize,
+                          BatchedObjectPool<TYPE> *owner_p,
+                          void* arena,
+                          bslma::Allocator* allocator) {
+        // PRECONDITIONS
+        BSLS_ASSERT_SAFE(owner_p);
+        BSLS_ASSERT_SAFE(arena);
+        BSLS_ASSERT_SAFE(allocator);
+
+        bslalg::ScalarPrimitives::construct(reinterpret_cast<PoolBatch<TYPE>*>(arena),
+                                            batchSize,
+                                            owner_p,
+                                            allocator);
+    }
+
+  public:
+
+    explicit BatchedObjectPool(size_t batchSize,
+                               bslma::Allocator* allocator = 0)
+    : d_allocator_p(bslma::Default::allocator(allocator))
+    , d_pool(bdlf::BindUtil::bindS(d_allocator_p,
+                              &BatchedObjectPool<TYPE>::batchCreatorFn,
+                              batchSize,
+                              this,
+                              bdlf::PlaceHolders::_1,   // arena
+                              bdlf::PlaceHolders::_2),  // allocator
+             -1,
+             d_allocator_p) {
+
+    }
+
+    bsl::shared_ptr<LocalBatcher<TYPE> > getBatcher() {
+        return bsl::allocate_shared<LocalBatcher<TYPE> >(d_allocator_p, this);
+    }
+
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqc/bmqc_batchedpool.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_batchedpool.t.cpp
@@ -1,0 +1,455 @@
+// Copyright 2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqc_batchedpool.t.cpp                                             -*-C++-*-
+#include <bmqc_batchedpool.h>
+
+#include <bmqc_monitoredqueue_bdlccfixedqueue.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_printutil.h>
+
+// BDE
+#include <bdlcc_fixedqueue.h>
+#include <bdlcc_objectpool.h>
+#include <bdlf_bind.h>
+#include <bdlf_placeholder.h>
+#include <bdlmt_threadpool.h>
+#include <bdlt_timeunitratio.h>
+#include <bsl_iostream.h>
+#include <bsl_limits.h>
+#include <bsl_map.h>
+#include <bsl_vector.h>
+#include <bsla_annotations.h>
+#include <bslma_allocator.h>
+#include <bslma_managedptr.h>
+#include <bslmt_barrier.h>
+#include <bslmt_latch.h>
+#include <bslmt_threadattributes.h>
+#include <bslmt_threadutil.h>
+#include <bsls_assert.h>
+#include <bsls_timeinterval.h>
+#include <bsls_timeutil.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// BENCHMARKING LIBRARY
+#ifdef BMQTST_BENCHMARK_ENABLED
+#include <benchmark/benchmark.h>
+#endif
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+namespace {
+
+/// The number of iterations per each thread in all benchmarks
+static const size_t k_NUM_ITERATIONS = 1000000;
+
+static bsls::AtomicInt64 g_NUM_CONSTRUCT = 0;
+static bsls::AtomicInt64 g_NUM_DESTRUCT = 0;
+
+struct TestItem {
+  private:
+    // PRIVATE DATA
+    int d_value;
+
+  public:
+    // CREATORS
+    TestItem()
+    : d_value(0)
+    {
+        g_NUM_CONSTRUCT.addRelaxed(1);
+    }
+
+    ~TestItem() {
+        g_NUM_DESTRUCT.addRelaxed(1);
+    }
+
+    // MANIPULATORS
+    void reset() {
+        d_value = 0;
+    }
+
+    int& value() { return d_value; }
+};
+
+void creatorFn(void* arena, bslma::Allocator* allocator) {
+        // PRECONDITIONS
+        BSLS_ASSERT_SAFE(arena);
+        BSLS_ASSERT_SAFE(allocator);
+
+        bslalg::ScalarPrimitives::construct(reinterpret_cast<TestItem*>(arena),
+                                            allocator);
+}
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_breathingTest()
+// ------------------------------------------------------------------------
+// BREATHING TEST
+//
+// Concerns:
+//   Exercise basic functionality before beginning testing in earnest.
+//   Probe that functionality to discover basic errors.
+//
+// Testing:
+//   Basic functionality.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    balst::StackTraceTestAllocator allocator(bmqtst::TestHelperUtil::allocator());
+
+    {
+        bmqc::BatchedObjectPool<TestItem> itemPool(128, &allocator);
+
+        bsl::shared_ptr<bmqc::LocalBatcher<TestItem> > batcher = itemPool.getBatcher();
+
+        bsl::vector<bmqc::BatchNode<TestItem>* > objects;
+        objects.reserve(k_NUM_ITERATIONS);
+
+        for (size_t i = 0; i < k_NUM_ITERATIONS; i++) {
+            objects.push_back(batcher->getObject());
+        }
+
+        for (size_t i = 0; i < k_NUM_ITERATIONS; i++) {
+            objects[i]->release();
+        }
+        objects.clear();
+    }
+    // All TestItem objects must be destructed
+
+    BMQTST_ASSERT_EQ(g_NUM_CONSTRUCT, g_NUM_DESTRUCT);
+    PRINT(g_NUM_CONSTRUCT);    PRINT(g_NUM_DESTRUCT);
+}
+
+template <size_t k_NUM_THREADS, size_t k_BATCH_SIZE>
+static void testN1_batchedPool_benchmark(benchmark::State& state)
+// ------------------------------------------------------------------------
+// PERFORMANCE TEST
+//
+// Concerns:
+//  a) Check the overhead of the MQTP with multiple producer threads
+//
+// Plan:
+//  1) Create a MQTP with a single queue and enqueue events as quickly as
+//     possible on it from multiple producer threads.  See how many we can
+//     process in a few seconds.
+//
+// Testing:
+//  Performance
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    bmqtst::TestHelper::printTestName("MQTP MULTI PRODUCER PERFORMANCE TEST");
+
+    struct Local {
+        static void benchFn(bmqc::BatchedObjectPool<TestItem>* pool_p,
+                            bslmt::Latch*   initLatch_p,
+                            bslmt::Barrier* startBarrier_p,
+                            bslmt::Latch*   finishLatch_p)
+        {
+            // PRECONDITIONS
+            BSLS_ASSERT_OPT(pool_p);
+            BSLS_ASSERT_OPT(initLatch_p);
+            BSLS_ASSERT_OPT(startBarrier_p);
+            BSLS_ASSERT_OPT(finishLatch_p);
+
+            bsl::shared_ptr<bmqc::LocalBatcher<TestItem> > batcher = pool_p->getBatcher();
+
+            initLatch_p->arrive();
+            startBarrier_p->wait();
+
+            for (size_t i = 0; i < k_NUM_ITERATIONS; ++i) {
+                bmqc::BatchNode<TestItem>* item = batcher->getObject();
+                item->d_object.object().value() = i;
+                item->release();
+            }
+
+            finishLatch_p->arrive();
+        }
+    };
+
+    bmqc::BatchedObjectPool<TestItem> itemPool(k_BATCH_SIZE, bmqtst::TestHelperUtil::allocator());
+
+    bdlmt::ThreadPool workThreadPool(
+        bslmt::ThreadAttributes(),        // default
+        k_NUM_THREADS,                    // minThreads
+        k_NUM_THREADS,                    // maxThreads
+        bsl::numeric_limits<int>::max(),  // maxIdleTime
+        bmqtst::TestHelperUtil::allocator());
+    BSLS_ASSERT_OPT(workThreadPool.start() == 0);
+
+    bslmt::Latch   initThreadLatch(k_NUM_THREADS);
+    bslmt::Barrier startBenchmarkBarrier(k_NUM_THREADS + 1);
+    bslmt::Latch finishBenchmarkLatch(k_NUM_THREADS);
+
+    for (size_t i = 0; i < k_NUM_THREADS; i++) {
+        workThreadPool.enqueueJob(
+            bdlf::BindUtil::bindS(bmqtst::TestHelperUtil::allocator(),
+                                  &Local::benchFn,
+                                  &itemPool,
+                                  &initThreadLatch,
+                                  &startBenchmarkBarrier,
+                                  &finishBenchmarkLatch));
+    }
+
+    initThreadLatch.wait();
+
+    size_t iter = 0;
+    for (auto _ : state) {
+        // Benchmark time start
+
+        // We don't support running multi-iteration benchmarks because we
+        // prepare and start complex tasks in separate threads.
+        // Once these tasks are finished, we cannot simply re-run them without
+        // reinitialization, and it goes against benchmark library design. 
+        // Make sure we run this only once.
+        BSLS_ASSERT_OPT(0 == iter++ && "Must be run only once");
+
+        startBenchmarkBarrier.wait();
+        finishBenchmarkLatch.wait();
+
+        // Benchmark time end
+    }
+
+    workThreadPool.stop();
+}
+
+template <size_t k_NUM_THREADS>
+static void testN1_legacyPool_benchmark(benchmark::State& state)
+// ------------------------------------------------------------------------
+// PERFORMANCE TEST
+//
+// Concerns:
+//  a) Check the overhead of the MQTP with multiple producer threads
+//
+// Plan:
+//  1) Create a MQTP with a single queue and enqueue events as quickly as
+//     possible on it from multiple producer threads.  See how many we can
+//     process in a few seconds.
+//
+// Testing:
+//  Performance
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    bmqtst::TestHelper::printTestName("MQTP MULTI PRODUCER PERFORMANCE TEST");
+
+    typedef bsl::function<void(void* arena, bslma::Allocator* allocator)>
+        CreatorFn;
+
+    typedef bdlcc::ObjectPool<TestItem, CreatorFn, bdlcc::ObjectPoolFunctors::Reset<TestItem> > TestItemPool;
+
+    struct Local {
+        static void benchFn(TestItemPool*   pool_p,
+                            bslmt::Latch*   initLatch_p,
+                            bslmt::Barrier* startBarrier_p,
+                            bslmt::Latch*   finishLatch_p)
+        {
+            // PRECONDITIONS
+            BSLS_ASSERT_OPT(pool_p);
+            BSLS_ASSERT_OPT(initLatch_p);
+            BSLS_ASSERT_OPT(startBarrier_p);
+            BSLS_ASSERT_OPT(finishLatch_p);
+
+            initLatch_p->arrive();
+            startBarrier_p->wait();
+
+            for (size_t i = 0; i < k_NUM_ITERATIONS; ++i) {
+                TestItem* item = pool_p->getObject();
+                item->value() = i;
+                pool_p->releaseObject(item);
+            }
+
+            finishLatch_p->arrive();
+        }
+    };
+
+    TestItemPool itemPool(&creatorFn, 128, bmqtst::TestHelperUtil::allocator());
+
+    bdlmt::ThreadPool workThreadPool(
+        bslmt::ThreadAttributes(),        // default
+        k_NUM_THREADS,                    // minThreads
+        k_NUM_THREADS,                    // maxThreads
+        bsl::numeric_limits<int>::max(),  // maxIdleTime
+        bmqtst::TestHelperUtil::allocator());
+    BSLS_ASSERT_OPT(workThreadPool.start() == 0);
+
+    bslmt::Latch   initThreadLatch(k_NUM_THREADS);
+    bslmt::Barrier startBenchmarkBarrier(k_NUM_THREADS + 1);
+    bslmt::Latch finishBenchmarkLatch(k_NUM_THREADS);
+
+    for (size_t i = 0; i < k_NUM_THREADS; i++) {
+        workThreadPool.enqueueJob(
+            bdlf::BindUtil::bindS(bmqtst::TestHelperUtil::allocator(),
+                                  &Local::benchFn,
+                                  &itemPool,
+                                  &initThreadLatch,
+                                  &startBenchmarkBarrier,
+                                  &finishBenchmarkLatch));
+    }
+
+    initThreadLatch.wait();
+
+    size_t iter = 0;
+    for (auto _ : state) {
+        // Benchmark time start
+
+        // We don't support running multi-iteration benchmarks because we
+        // prepare and start complex tasks in separate threads.
+        // Once these tasks are finished, we cannot simply re-run them without
+        // reinitialization, and it goes against benchmark library design. 
+        // Make sure we run this only once.
+        BSLS_ASSERT_OPT(0 == iter++ && "Must be run only once");
+
+        startBenchmarkBarrier.wait();
+        finishBenchmarkLatch.wait();
+
+        // Benchmark time end
+    }
+
+    workThreadPool.stop();
+}
+
+/// Function alias to simplify benchmark table output.
+template <size_t k_NUM_THREADS>
+static void testN1_batchedPool_batch_1_benchmark(benchmark::State& state) {
+    testN1_batchedPool_benchmark<k_NUM_THREADS, 1>(state);
+}
+
+/// Function alias to simplify benchmark table output.
+template <size_t k_NUM_THREADS>
+static void testN1_batchedPool_batch_32_benchmark(benchmark::State& state) {
+    testN1_batchedPool_benchmark<k_NUM_THREADS, 32>(state);
+}
+
+/// Function alias to simplify benchmark table output.
+template <size_t k_NUM_THREADS>
+static void testN1_batchedPool_batch_128_benchmark(benchmark::State& state) {
+    testN1_batchedPool_benchmark<k_NUM_THREADS, 128>(state);
+}
+
+//=============================================================================
+//                                MAIN PROGRAM
+//-----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 1: test1_breathingTest(); break;
+    case -1:
+#ifdef BMQTST_BENCHMARK_ENABLED
+        /// Basic `bdlcc::ObjectPool` usage benchmarks.
+        /// Test objects are acquired and released one by one.
+        BENCHMARK(testN1_legacyPool_benchmark<1>)
+            ->Name("bdlcc::ObjectPool threads=1             ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_legacyPool_benchmark<4>)
+            ->Name("bdlcc::ObjectPool threads=4             ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_legacyPool_benchmark<10>)
+            ->Name("bdlcc::ObjectPool threads=10            ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        
+        /// Using `bmqc::BatchedPool` with batch size 1.
+        /// Expecting similar or worse performance than the basic
+        /// `bdlcc::ObjectPool`, because batches contain only one test object
+        /// and we still pay the full price for batch management.
+        BENCHMARK(testN1_batchedPool_batch_1_benchmark<1>)
+            ->Name("bmqc::BatchedPool threads=1   batch=1   ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_1_benchmark<4>)
+            ->Name("bmqc::BatchedPool threads=4   batch=1   ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_1_benchmark<10>)
+            ->Name("bmqc::BatchedPool threads=10  batch=1   ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+
+        /// Using `bmqc::BatchedPool` with batch size 32.
+        BENCHMARK(testN1_batchedPool_batch_32_benchmark<1>)
+            ->Name("bmqc::BatchedPool threads=1   batch=32  ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_32_benchmark<4>)
+            ->Name("bmqc::BatchedPool threads=4   batch=32  ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_32_benchmark<10>)
+            ->Name("bmqc::BatchedPool threads=10  batch=32  ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+
+        /// Using `bmqc::BatchedPool` with batch size 128.
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<1>)
+            ->Name("bmqc::BatchedPool threads=1   batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<4>)
+            ->Name("bmqc::BatchedPool threads=4   batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<10>)
+            ->Name("bmqc::BatchedPool threads=10  batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+
+        /// Using `bmqc::BatchedPool` with batch size 128.
+        /// Spawning so many threads that desktop CPU cannot process at the
+        /// same time.
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<64>)
+            ->Name("bmqc::BatchedPool threads=64  batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<128>)
+            ->Name("bmqc::BatchedPool threads=128 batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        BENCHMARK(testN1_batchedPool_batch_128_benchmark<256>)
+            ->Name("bmqc::BatchedPool threads=256 batch=128 ")
+            ->Iterations(1)
+            ->Unit(benchmark::kMillisecond);
+        benchmark::Initialize(&argc, argv);
+        benchmark::RunSpecifiedBenchmarks();
+#endif
+        break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqc/package/bmqc.mem
+++ b/src/groups/bmq/bmqc/package/bmqc.mem
@@ -1,4 +1,5 @@
 bmqc_array
+bmqc_batchedpool
 bmqc_monitoredqueue
 bmqc_monitoredqueue_bdlccfixedqueue
 bmqc_monitoredqueue_bdlccsingleconsumerqueue


### PR DESCRIPTION
# Problem

Multi-thread access to object pools might become slow due to thread safety mechanisms used in the pool implementation.

# Batching

One of the way of dealing with this problem is to acquire/release more objects from the pool at a time (use batches of objects). This PR introduces `bmqc::BatchedObjectPool` class that operates `bdlcc::ObjectPool` under the hood but gets objects in batches. These batches are hidden from the library users who can operate smaller objects as before. As a result, batching allows to reduce thread contention significantly while also benefiting from the thread safety mechanisms existing in `bdlcc::ObjectPool`.

# Benchmarks

**amd64**

```
Run on (48 X 3000.24 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x24)
  L1 Instruction 32 KiB (x24)
  L2 Unified 256 KiB (x24)
  L3 Unified 30720 KiB (x2)
Load Average: 11.57, 6.59, 3.37
------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------
bdlcc::ObjectPool threads=1             /iterations:1       49.9 ms        0.010 ms            1
bdlcc::ObjectPool threads=4             /iterations:1       2100 ms        0.014 ms            1
bdlcc::ObjectPool threads=10            /iterations:1       5376 ms        0.018 ms            1
bmqc::BatchedPool threads=1   batch=1   /iterations:1       62.4 ms        0.008 ms            1
bmqc::BatchedPool threads=4   batch=1   /iterations:1       2052 ms        0.015 ms            1
bmqc::BatchedPool threads=10  batch=1   /iterations:1       7899 ms        0.016 ms            1
bmqc::BatchedPool threads=1   batch=32  /iterations:1       11.3 ms        0.007 ms            1
bmqc::BatchedPool threads=4   batch=32  /iterations:1       75.6 ms        0.007 ms            1
bmqc::BatchedPool threads=10  batch=32  /iterations:1        256 ms        0.017 ms            1
bmqc::BatchedPool threads=1   batch=128 /iterations:1       10.2 ms        0.007 ms            1
bmqc::BatchedPool threads=4   batch=128 /iterations:1       26.1 ms        0.007 ms            1
bmqc::BatchedPool threads=10  batch=128 /iterations:1       65.8 ms        0.009 ms            1
bmqc::BatchedPool threads=64  batch=128 /iterations:1       1039 ms        0.016 ms            1
bmqc::BatchedPool threads=128 batch=128 /iterations:1       1837 ms        0.026 ms            1
bmqc::BatchedPool threads=256 batch=128 /iterations:1       3655 ms        0.040 ms            1
```

**Mac M2 Darwin**

```
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 16.91, 13.45, 7.10
------------------------------------------------------------------------------------------------
Benchmark                                                      Time             CPU   Iterations
------------------------------------------------------------------------------------------------
bdlcc::ObjectPool threads=1             /iterations:1       31.8 ms        0.009 ms            1
bdlcc::ObjectPool threads=4             /iterations:1        922 ms        0.009 ms            1
bdlcc::ObjectPool threads=10            /iterations:1       4913 ms        0.027 ms            1
bmqc::BatchedPool threads=1   batch=1   /iterations:1       61.2 ms        0.007 ms            1
bmqc::BatchedPool threads=4   batch=1   /iterations:1        661 ms        0.010 ms            1
bmqc::BatchedPool threads=10  batch=1   /iterations:1       3734 ms        0.031 ms            1
bmqc::BatchedPool threads=1   batch=32  /iterations:1       21.3 ms        0.007 ms            1
bmqc::BatchedPool threads=4   batch=32  /iterations:1       29.1 ms        0.007 ms            1
bmqc::BatchedPool threads=10  batch=32  /iterations:1        161 ms        0.012 ms            1
bmqc::BatchedPool threads=1   batch=128 /iterations:1       19.1 ms        0.005 ms            1
bmqc::BatchedPool threads=4   batch=128 /iterations:1       21.1 ms        0.007 ms            1
bmqc::BatchedPool threads=10  batch=128 /iterations:1       54.1 ms        0.016 ms            1
bmqc::BatchedPool threads=64  batch=128 /iterations:1        256 ms        0.099 ms            1
bmqc::BatchedPool threads=128 batch=128 /iterations:1        471 ms        0.101 ms            1
bmqc::BatchedPool threads=256 batch=128 /iterations:1        931 ms        0.360 ms            1
```

Conclusions
1. `bmqc::BatchedPool threads=1   batch=1` works 2x times slower than the original object pool as expected, because we have the introduced batch overhead, but don't benefit from the batch size (here the batch size is 1 so it is equal to the original object pool).

2. `bmqc::BatchedPool threads=1   batch=32` works 1.5x times faster than the original object pool. We have the batch overhead but also we don't suffer that much from thread safety mechanisms used in the original object pool.

3. `bmqc::BatchedPool threads=4   batch=32` works 30x times faster than the corresponding benchmark of the original object pool. The same with `batch=128`.

4. `bmqc::BatchedPool threads=10  batch=128` works 90x times faster than the corresponding benchmark of the original object pool.

5. Note that CPU cannot really process 64, 128 or 256 threads at the same time in the last benchmarks, so the actual work time increases linearly to the number of threads. It also means that even in these conditions the batched pool doesn't suffer that much from the thread contention problem as the original object pool.