### PR TITLE
CI: print IT run time

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -208,6 +208,7 @@ jobs:
             --junitxml=integration-tests.xml    \
             --tb long                           \
             --reruns=3                          \
+            --durations=0                       \
             -n logical -v
 
       - name: Print core information

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ CMakeUserPresets.json
 .project
 .cproject
 
+# VSCode IDE
+.vscode
+
 # Mac DS_Store files
 **/.DS_Store
 .lcldev/


### PR DESCRIPTION
Adds these lines to CI output log:
```
============================== slowest durations ===============================
137.50s call     test_subscriptions.py::test_incorrect_expressions[single_node_fsm-strong_consistency]
120.70s call     test_rollover_csl.py::TestRolloverCSL::test_rollover_queue_assignments[single_node_fsm-strong_consistency]
77.94s call     test_subscriptions.py::test_numeric_limits[single_node_fsm-strong_consistency]
30.15s call     test_alarms.py::test_capacity_alarm_subscription_mismatch[single_node_fsm-strong_consistency]
22.06s call     test_appids.py::test_old_data_new_app[single_node_fsm-strong_consistency]
20.50s call     test_subscriptions.py::test_empty_expression[single_node_fsm-strong_consistency]
19.65s call     test_fanout_priorities.py::test_fanout_priorities[single_node_fsm-strong_consistency]
15.70s call     test_appids.py::test_add_remove_add_app[single_node_fsm-strong_consistency]
10.36s call     test_subscriptions.py::test_no_capacity_all_optimization[single_node_fsm-strong_consistency]
9.19s call     test_alarms.py::test_no_alarms_for_a_slow_queue[single_node_fsm-strong_consistency]
7.68s call     test_appids.py::test_open_alarm_authorize_post[single_node_fsm-strong_consistency]
7.29s call     test_breathing.py::test_verify_priority[single_node_fsm-strong_consistency]
6.31s call     test_subscriptions.py::test_no_capacity_all_fanout[single_node_fsm-strong_consistency]
5.31s call     test_appids.py::test_dynamic_twice_alarm_once[single_node_fsm-strong_consistency]
5.16s call     test_connection_loss.py::test_broker_client[single_node_fsm-strong_consistency]
```