### PR TITLE
Fix[IT]: use correct keyword timeout argument

### DIFF
--- a/src/integration-tests/test_subscriptions.py
+++ b/src/integration-tests/test_subscriptions.py
@@ -1136,7 +1136,7 @@ def test_incorrect_expressions(cluster: Cluster, domain_urls: tc.DomainUrls):
 
     for i, expression in enumerate(expressions):
         try:
-            consumer.configure([expression], timeout=5)
+            consumer.configure([expression], timeout=1)
             assert False  # must not get here, expect exception
         except ITError:
             # expected
@@ -1242,7 +1242,7 @@ def test_numeric_limits(cluster: Cluster, domain_urls: tc.DomainUrls):
         consumer.configure(["x < 0"])
 
         try:
-            consumer.configure([f"x != {value}"], timeout=5)
+            consumer.configure([f"x != {value}"], timeout=1)
             assert value in supported_ints
         except ITError:
             # exception is expected for values from 'unsupported_ints'

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -246,7 +246,7 @@ class Client(BMQProcess):
             f"<--.*configureQueue.*uri = {re.escape(uri)}.*" r"\((-?\d+)\)",
             succeed,
             no_except,
-            timeout,
+            timeout=timeout,
         )
         return res.error_code
 
@@ -290,7 +290,7 @@ class Client(BMQProcess):
             r"<--.*post.*\((-?\d+)\)",
             succeed,
             no_except,
-            extra_patterns,
+            extra_patterns=extra_patterns,
         )
         error_code = res.error_code
         if wait_ack:
@@ -541,6 +541,7 @@ class Client(BMQProcess):
         pattern: str,
         succeed: Optional[bool],
         no_except: Optional[bool],
+        *,
         extra_patterns: Optional[List[str]] = None,
         timeout: Optional[int] = None,
     ) -> CommandResult:


### PR DESCRIPTION
There was a bug with `timeout` arg position that caused subscriptions ITs run longer than needed:
```
        res = self._command_helper(
            command,
            block,
            f"<--.*configureQueue.*uri = {re.escape(uri)}.*" r"\((-?\d+)\)",
            succeed,
            no_except,
            timeout,  # <- extra_patterns
        )
```

As a result, default 15s timeout was used.