### PR TITLE
Refactor[MQBMOCK]: do not require buffer factory arg

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -677,7 +677,7 @@ class TestBench {
                    1024,  // blob pool growth strategy
                    allocator)
     , d_channel(new bmqio::TestChannel(allocator))
-    , d_cluster(&d_bufferFactory, allocator)
+    , d_cluster(allocator)
     , d_mockDispatcher(allocator)
     , d_domain(&d_mockDispatcher, &d_cluster, atMostOnce, allocator)
     , d_mockDomainFactory(d_domain, allocator)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
@@ -39,7 +39,6 @@
 #include <ball_log.h>
 #include <ball_severity.h>
 #include <bdlb_nullablevalue.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlf_bind.h>
 #include <bdlf_placeholder.h>
 #include <bsl_iostream.h>
@@ -124,8 +123,6 @@ struct TestHelper {
 
   public:
     // PUBLIC DATA
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
-
     bslma::ManagedPtr<mqbmock::Cluster> d_cluster_mp;
 
     bsl::vector<mqbnet::MockClusterNode*> d_nodes;
@@ -134,8 +131,7 @@ struct TestHelper {
 
     // CREATORS
     TestHelper()
-    : d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
-    , d_cluster_mp(0)
+    : d_cluster_mp(0)
     , d_nodes(bmqtst::TestHelperUtil::allocator())
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     {
@@ -180,8 +176,7 @@ struct TestHelper {
 
         d_cluster_mp.load(
             new (*bmqtst::TestHelperUtil::allocator())
-                mqbmock::Cluster(&d_bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+                mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
                                  false,  // isCSLMode

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -42,7 +42,6 @@
 #include <ball_record.h>
 #include <ball_severity.h>
 #include <bdlb_string.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlt_timeunitratio.h>
 #include <bsl_memory.h>
 #include <bsl_set.h>
@@ -67,7 +66,6 @@ struct Test : bmqtst::Test {
     // PUBLIC DATA
     bsl::string                    d_id;
     mqbmock::Dispatcher            d_dispatcher;
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
     mqbmock::Cluster               d_cluster;
     mqbmock::Domain                d_domain;
     mqbmock::Queue                 d_queue;
@@ -88,8 +86,7 @@ struct Test : bmqtst::Test {
 Test::Test()
 : d_id()
 , d_dispatcher(bmqtst::TestHelperUtil::allocator())
-, d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
-, d_cluster(&d_bufferFactory, bmqtst::TestHelperUtil::allocator())
+, d_cluster(bmqtst::TestHelperUtil::allocator())
 , d_domain(&d_cluster, bmqtst::TestHelperUtil::allocator())
 , d_queue(&d_domain, bmqtst::TestHelperUtil::allocator())
 , d_queueState(&d_queue,

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -370,7 +370,6 @@ QueueEngineTester::QueueEngineTester(const mqbconfm::Domain& domainConfig,
                                      bool                    startScheduler,
                                      bslma::Allocator*       allocator)
 : d_invalidGuid()
-, d_bufferFactory(1024, allocator)
 , d_handles(allocator)
 , d_subIds(allocator)
 , d_clientContexts(allocator)
@@ -433,9 +432,8 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig,
     d_mockDispatcherClient_mp->_setDescription("test.tsk:1");
 
     // Cluster
-    d_mockCluster_mp.load(
-        new (*d_allocator_p) mqbmock::Cluster(&d_bufferFactory, d_allocator_p),
-        d_allocator_p);
+    d_mockCluster_mp.load(new (*d_allocator_p) mqbmock::Cluster(d_allocator_p),
+                          d_allocator_p);
     d_mockCluster_mp->_setIsClusterMember(true);
 
     BSLS_ASSERT_OPT(d_mockCluster_mp->isClusterMember());
@@ -947,7 +945,9 @@ void QueueEngineTester::post(const bslstl::StringRef& messages,
 
         mqbu::MessageGUIDUtil::generateGUID(&msgGUID);
 
-        appData.createInplace(d_allocator_p, &d_bufferFactory, d_allocator_p);
+        appData.createInplace(d_allocator_p,
+                              d_mockCluster_mp->bufferFactory(),
+                              d_allocator_p);
         bdlbb::BlobUtil::append(appData.get(),
                                 msgs[i].data(),
                                 msgs[i].length());

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
@@ -134,7 +134,6 @@
 
 // BDE
 #include <ball_log.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlmt_eventscheduler.h>
 #include <bsl_unordered_map.h>
 #include <bslma_allocator.h>
@@ -194,9 +193,6 @@ class QueueEngineTester {
     /// Constant representing a null Message GUID.  This value should be used
     /// for the GUID of a message whose GUID is not important or unknown.
     const bmqt::MessageGUID d_invalidGuid;
-
-    /// Buffer factory to use for messages.
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
 
     /// Mock dispatcher.
     bslma::ManagedPtr<mqbmock::Dispatcher> d_mockDispatcher_mp;

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
@@ -36,7 +36,6 @@
 #include <bmqu_atomicstate.h>
 
 // BDE
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlmt_eventscheduler.h>
 #include <bsl_memory.h>
 #include <bsl_queue.h>
@@ -129,7 +128,6 @@ class TestBench {
     };
 
   public:
-    bdlbb::PooledBlobBufferFactory      d_bufferFactory;
     mqbmock::Dispatcher                 d_dispatcher;
     mqbmock::Cluster                    d_cluster;
     mqbmock::Domain                     d_domain;
@@ -162,9 +160,8 @@ class TestBench {
 };
 
 TestBench::TestBench(bslma::Allocator* allocator_p)
-: d_bufferFactory(256, allocator_p)
-, d_dispatcher(allocator_p)
-, d_cluster(&d_bufferFactory, allocator_p)
+: d_dispatcher(allocator_p)
+, d_cluster(allocator_p)
 , d_domain(&d_cluster, allocator_p)
 , d_event(allocator_p)
 , d_event_sp(d_dispatcher._withEvent(&d_cluster, &d_event))
@@ -374,7 +371,8 @@ void TestQueueHandle::postOneMessage(mqbblp::RemoteQueue* queue_p)
 {
     bsl::shared_ptr<bdlbb::Blob> data_sp;
 
-    data_sp.createInplace(d_bench.d_allocator_p, &d_bench.d_bufferFactory);
+    data_sp.createInplace(d_bench.d_allocator_p,
+                          d_bench.d_cluster.bufferFactory());
     d_data.push(data_sp);
 
     // save data and options for future checks
@@ -387,7 +385,8 @@ void TestQueueHandle::postOneMessage(mqbblp::RemoteQueue* queue_p)
 
     bsl::shared_ptr<bdlbb::Blob> options_sp;
 
-    options_sp.createInplace(d_bench.d_allocator_p, &d_bench.d_bufferFactory);
+    options_sp.createInplace(d_bench.d_allocator_p,
+                             d_bench.d_cluster.bufferFactory());
 
     d_options.push(options_sp);
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -40,7 +40,6 @@
 #include <bmqu_tempdirectory.h>
 
 // BDE
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlf_bind.h>
 #include <bsl_memory.h>
 #include <bslma_managedptr.h>
@@ -87,7 +86,6 @@ struct Tester {
   public:
     // PUBLIC DATA
     bool                                         d_isLeader;
-    bdlbb::PooledBlobBufferFactory               d_bufferFactory;
     bmqu::TempDirectory                          d_tempDir;
     bslma::ManagedPtr<mqbmock::Cluster>          d_cluster_mp;
     mqbmock::ClusterStateLedger*                 d_clusterStateLedger_p;
@@ -98,7 +96,6 @@ struct Tester {
     // CREATORS
     Tester(bool isLeader)
     : d_isLeader(isLeader)
-    , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     , d_cluster_mp(0)
     , d_clusterStateLedger_p(0)
@@ -139,8 +136,7 @@ struct Tester {
 
         d_cluster_mp.load(
             new (*bmqtst::TestHelperUtil::allocator())
-                mqbmock::Cluster(&d_bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+                mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,  // isClusterMember
                                  d_isLeader,
                                  true,   // isCSLMode

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -26,7 +26,6 @@
 
 // BDE
 #include <bdlb_print.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_string.h>
 #include <bsl_utility.h>
 
@@ -45,17 +44,16 @@ using namespace bsl;
 struct Tester {
   private:
     // DATA
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
-    mqbmock::Cluster               d_cluster;
-    bslma::Allocator*              d_allocator_p;
+    bslma::Allocator* d_allocator_p;
+    mqbmock::Cluster  d_cluster;
 
   public:
     // CREATORS
     Tester(bslma::Allocator* allocator = bmqtst::TestHelperUtil::allocator())
-    : d_bufferFactory(256, allocator)
-    , d_cluster(&d_bufferFactory, allocator)
-    , d_allocator_p(allocator)
+    : d_allocator_p(bslma::Default::allocator(allocator))
+    , d_cluster(d_allocator_p)
     {
+        // NOTHING
     }
 
     mqbi::Cluster* cluster() { return &d_cluster; }

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -40,7 +40,6 @@
 #include <balber_berencoder.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdls_filesystemutil.h>
 #include <bdlsb_memoutstreambuf.h>
 #include <bsl_algorithm.h>
@@ -186,7 +185,6 @@ struct Tester {
   public:
     // PUBLIC DATA
     bool                                              d_isLeader;
-    bdlbb::PooledBlobBufferFactory                    d_bufferFactory;
     bmqu::TempDirectory                               d_tempDir;
     bsl::string                                       d_location;
     bslma::ManagedPtr<mqbmock::Cluster>               d_cluster_mp;
@@ -198,7 +196,6 @@ struct Tester {
     // CREATORS
     Tester(bool isLeader = true, const bslstl::StringRef& location = "")
     : d_isLeader(isLeader)
-    , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     , d_location(
           !location.empty()
@@ -242,8 +239,7 @@ struct Tester {
 
         d_cluster_mp.load(
             new (*bmqtst::TestHelperUtil::allocator())
-                mqbmock::Cluster(&d_bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+                mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,  // isClusterMember
                                  isLeader,
                                  true,   // isCSLMode
@@ -340,7 +336,7 @@ struct Tester {
         BSLS_ASSERT_OPT(event);
 
         // Create ledger record
-        bdlbb::Blob record(d_cluster_mp->_bufferFactory(),
+        bdlbb::Blob record(d_cluster_mp->bufferFactory(),
                            bmqtst::TestHelperUtil::allocator());
         BSLS_ASSERT_OPT(
             mqbc::ClusterStateLedgerUtil::appendRecord(&record,
@@ -375,7 +371,7 @@ struct Tester {
         bmqp_ctrlmsg::ClusterMessage message;
         message.choice().makeLeaderAdvisoryAck(ack);
 
-        bdlbb::Blob ackEvent(d_cluster_mp->_bufferFactory(),
+        bdlbb::Blob ackEvent(d_cluster_mp->bufferFactory(),
                              bmqtst::TestHelperUtil::allocator());
         constructEventBlob(&ackEvent,
                            message,
@@ -496,7 +492,7 @@ struct Tester {
             }
         }
 
-        bdlbb::Blob record(d_cluster_mp->_bufferFactory(),
+        bdlbb::Blob record(d_cluster_mp->bufferFactory(),
                            bmqtst::TestHelperUtil::allocator());
         bdlbb::BlobUtil::append(&record, *blob, sizeof(bmqp::EventHeader));
 
@@ -892,7 +888,7 @@ static void test7_apply_ClusterStateRecord()
     bmqp_ctrlmsg::ClusterMessage updateMessage;
     updateMessage.choice().makePartitionPrimaryAdvisory(pmAdvisory);
 
-    bdlbb::Blob updateEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob updateEvent(tester.d_cluster_mp->bufferFactory(),
                             bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&updateEvent,
                               updateMessage,
@@ -940,7 +936,7 @@ static void test7_apply_ClusterStateRecord()
     bmqp_ctrlmsg::ClusterMessage snapshotMessage;
     snapshotMessage.choice().makeLeaderAdvisory(leaderAdvisory);
 
-    bdlbb::Blob snapshotEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob snapshotEvent(tester.d_cluster_mp->bufferFactory(),
                               bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&snapshotEvent,
                               snapshotMessage,
@@ -1004,7 +1000,7 @@ static void test8_apply_ClusterStateRecordCommit()
     bmqp_ctrlmsg::ClusterMessage advisoryMessage;
     advisoryMessage.choice().makePartitionPrimaryAdvisory(advisory);
 
-    bdlbb::Blob advisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob advisoryEvent(tester.d_cluster_mp->bufferFactory(),
                               bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&advisoryEvent,
                               advisoryMessage,
@@ -1028,7 +1024,7 @@ static void test8_apply_ClusterStateRecordCommit()
     bmqp_ctrlmsg::ClusterMessage commitMessage;
     commitMessage.choice().makeLeaderAdvisoryCommit(commit);
 
-    bdlbb::Blob commitEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob commitEvent(tester.d_cluster_mp->bufferFactory(),
                             bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&commitEvent,
                               commitMessage,
@@ -1067,7 +1063,7 @@ static void test8_apply_ClusterStateRecordCommit()
     bmqp_ctrlmsg::ClusterMessage invalidCommitMessage;
     invalidCommitMessage.choice().makeLeaderAdvisoryCommit(invalidCommit);
 
-    bdlbb::Blob invalidCommitEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob invalidCommitEvent(tester.d_cluster_mp->bufferFactory(),
                                    bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&invalidCommitEvent,
                               invalidCommitMessage,
@@ -1347,7 +1343,7 @@ static void test10_persistanceFollower()
         ->electorInfo()
         .nextLeaderMessageSequence(&pmAdvisory.sequenceNumber());
 
-    bdlbb::Blob pmAdvisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob pmAdvisoryEvent(tester.d_cluster_mp->bufferFactory(),
                                 bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&pmAdvisoryEvent,
                               pmAdvisoryMsg,
@@ -1376,7 +1372,7 @@ static void test10_persistanceFollower()
 
     qAssignAdvisory.queues().push_back(qinfo);
 
-    bdlbb::Blob qAssignAdvisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob qAssignAdvisoryEvent(tester.d_cluster_mp->bufferFactory(),
                                      bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&qAssignAdvisoryEvent,
                               qAssignAdvisoryMsg,
@@ -1398,7 +1394,7 @@ static void test10_persistanceFollower()
 
     qUnassignedAdvisory.queues().push_back(qinfo);
 
-    bdlbb::Blob qUnassignedAdvisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob qUnassignedAdvisoryEvent(tester.d_cluster_mp->bufferFactory(),
                                          bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&qUnassignedAdvisoryEvent,
                               qUnassignedAdvisoryMsg,
@@ -1443,7 +1439,7 @@ static void test10_persistanceFollower()
 
     qUpdateAdvisory.queueUpdates().push_back(qupdate);
 
-    bdlbb::Blob qUpdateAdvisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob qUpdateAdvisoryEvent(tester.d_cluster_mp->bufferFactory(),
                                      bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&qUpdateAdvisoryEvent,
                               qUpdateAdvisoryMsg,
@@ -1477,7 +1473,7 @@ static void test10_persistanceFollower()
         ->electorInfo()
         .nextLeaderMessageSequence(&leaderAdvisory.sequenceNumber());
 
-    bdlbb::Blob leaderAdvisoryEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob leaderAdvisoryEvent(tester.d_cluster_mp->bufferFactory(),
                                     bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&leaderAdvisoryEvent,
                               leaderAdvisoryMsg,
@@ -1498,7 +1494,7 @@ static void test10_persistanceFollower()
         .nextLeaderMessageSequence(&commit.sequenceNumber());
     commit.sequenceNumberCommitted() = leaderAdvisory.sequenceNumber();
 
-    bdlbb::Blob commitEvent(tester.d_cluster_mp->_bufferFactory(),
+    bdlbb::Blob commitEvent(tester.d_cluster_mp->bufferFactory(),
                             bmqtst::TestHelperUtil::allocator());
     tester.constructEventBlob(&commitEvent,
                               commitMsg,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -50,7 +50,6 @@
 // BDE
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlf_bind.h>
 #include <bdlmt_fixedthreadpool.h>
 #include <bdlt_currenttime.h>
@@ -125,8 +124,6 @@ struct TestHelper {
 
   public:
     // PUBLIC DATA
-    bdlbb::PooledBlobBufferFactory d_bufferFactory;
-
     bslma::ManagedPtr<mqbmock::Cluster> d_cluster_mp;
 
     bmqu::TempDirectory d_tempDir;
@@ -135,8 +132,7 @@ struct TestHelper {
 
     // CREATORS
     TestHelper()
-    : d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
-    , d_cluster_mp(0)
+    : d_cluster_mp(0)
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     , d_tempArchiveDir(bmqtst::TestHelperUtil::allocator())
     {
@@ -174,8 +170,7 @@ struct TestHelper {
 
         d_cluster_mp.load(
             new (*bmqtst::TestHelperUtil::allocator())
-                mqbmock::Cluster(&d_bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+                mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
                                  true,   // isCSLMode
@@ -819,7 +814,7 @@ struct TestHelper {
         // crc value
         mqbu::MessageGUIDUtil::generateGUID(&rec.d_guid);
         rec.d_appData_sp.createInplace(bmqtst::TestHelperUtil::allocator(),
-                                       &d_bufferFactory,
+                                       d_cluster_mp->bufferFactory(),
                                        bmqtst::TestHelperUtil::allocator());
         bsl::string payloadStr(recNum * 10,
                                'x',

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -139,7 +139,7 @@ void Cluster::_initializeNetcluster()
     // Create 'mqbnet::MockCluster'
     d_netCluster_mp.load(new (*d_allocator_p)
                              mqbnet::MockCluster(d_clusterDefinition,
-                                                 d_bufferFactory_p,
+                                                 &d_bufferFactory,
                                                  d_allocator_p),
                          d_allocator_p);
 
@@ -201,21 +201,20 @@ void Cluster::_initializeNodeSessions()
 }
 
 // CREATORS
-Cluster::Cluster(bdlbb::BlobBufferFactory* bufferFactory,
-                 bslma::Allocator*         allocator,
-                 bool                      isClusterMember,
-                 bool                      isLeader,
-                 bool                      isCSLMode,
-                 bool                      isFSMWorkflow,
-                 bool                      doesFSMwriteQLIST,
-                 const ClusterNodeDefs&    clusterNodeDefs,
-                 const bslstl::StringRef&  name,
-                 const bslstl::StringRef&  location,
-                 const bslstl::StringRef&  archive)
+Cluster::Cluster(bslma::Allocator*        allocator,
+                 bool                     isClusterMember,
+                 bool                     isLeader,
+                 bool                     isCSLMode,
+                 bool                     isFSMWorkflow,
+                 bool                     doesFSMwriteQLIST,
+                 const ClusterNodeDefs&   clusterNodeDefs,
+                 const bslstl::StringRef& name,
+                 const bslstl::StringRef& location,
+                 const bslstl::StringRef& archive)
 : d_allocator_p(allocator)
-, d_bufferFactory_p(bufferFactory)
+, d_bufferFactory(1024, allocator)
 , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
-                                    d_bufferFactory_p,
+                                    &d_bufferFactory,
                                     bdlf::PlaceHolders::_1,   // arena
                                     bdlf::PlaceHolders::_2),  // allocator
                k_BLOB_POOL_GROWTH_STRATEGY,
@@ -228,7 +227,7 @@ Cluster::Cluster(bdlbb::BlobBufferFactory* bufferFactory,
 , d_channels(allocator)
 , d_initialConnectionHandler_mp()
 , d_transportManager(&d_scheduler,
-                     bufferFactory,
+                     &d_bufferFactory,
                      d_initialConnectionHandler_mp,
                      0,  // mqbstat::StatController*
                      allocator)
@@ -244,7 +243,7 @@ Cluster::Cluster(bdlbb::BlobBufferFactory* bufferFactory,
 , d_isLeader(isLeader)
 , d_isRestoringState(false)
 , d_processor()
-, d_resources(&d_scheduler, bufferFactory, &d_blobSpPool)
+, d_resources(&d_scheduler, &d_bufferFactory, &d_blobSpPool)
 {
     // PRECONDITIONS
     if (isClusterMember) {

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -57,6 +57,7 @@
 
 // BDE
 #include <bdlbb_blob.h>
+#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlcc_objectpool.h>
 #include <bdlcc_sharedobjectpool.h>
 #include <bdlmt_eventscheduler.h>
@@ -156,7 +157,7 @@ class Cluster : public mqbi::Cluster {
     bslma::Allocator* d_allocator_p;
     // Allocator to use
 
-    bdlbb::BlobBufferFactory* d_bufferFactory_p;
+    bdlbb::PooledBlobBufferFactory d_bufferFactory;
     // Buffer factory to use
 
     BlobSpPool d_blobSpPool;
@@ -257,17 +258,16 @@ class Cluster : public mqbi::Cluster {
     /// the optionally specified `isLeader` is true, self will become the
     /// leader of the cluster.  Note that if `isClusterMember` is false,
     /// `isLeader` cannot be true.
-    Cluster(bdlbb::BlobBufferFactory* bufferFactory,
-            bslma::Allocator*         allocator,
-            bool                      isClusterMember   = false,
-            bool                      isLeader          = false,
-            bool                      isCSLMode         = false,
-            bool                      isFSMWorkflow     = false,
-            bool                      doesFSMwriteQLIST = false,
-            const ClusterNodeDefs&    clusterNodeDefs   = ClusterNodeDefs(),
-            const bslstl::StringRef&  name              = "testCluster",
-            const bslstl::StringRef&  location          = "",
-            const bslstl::StringRef&  archive           = "");
+    Cluster(bslma::Allocator*        allocator,
+            bool                     isClusterMember   = false,
+            bool                     isLeader          = false,
+            bool                     isCSLMode         = false,
+            bool                     isFSMWorkflow     = false,
+            bool                     doesFSMwriteQLIST = false,
+            const ClusterNodeDefs&   clusterNodeDefs   = ClusterNodeDefs(),
+            const bslstl::StringRef& name              = "testCluster",
+            const bslstl::StringRef& location          = "",
+            const bslstl::StringRef& archive           = "");
 
     /// Destructor
     ~Cluster() BSLS_KEYWORD_OVERRIDE;
@@ -426,7 +426,7 @@ class Cluster : public mqbi::Cluster {
     Cluster& _setIsRestoringState(bool value);
 
     /// Get a modifiable reference to this object's buffer factory.
-    bdlbb::BlobBufferFactory* _bufferFactory();
+    bdlbb::BlobBufferFactory* bufferFactory();
 
     /// Get a modifiable reference to this object's blob shared pointer pool.
     BlobSpPool* _blobSpPool();
@@ -583,11 +583,6 @@ inline void Cluster::_setEventProcessor(const EventProcessor& processor)
     d_processor = processor;
 }
 
-inline bdlbb::BlobBufferFactory* Cluster::_bufferFactory()
-{
-    return d_bufferFactory_p;
-}
-
 inline Cluster::BlobSpPool* Cluster::_blobSpPool()
 {
     return &d_blobSpPool;
@@ -611,6 +606,11 @@ inline mqbc::ClusterData* Cluster::_clusterData()
 inline mqbc::ClusterState& Cluster::_state()
 {
     return d_state;
+}
+
+inline bdlbb::BlobBufferFactory* Cluster::bufferFactory()
+{
+    return &d_bufferFactory;
 }
 
 inline void Cluster::advanceTime(int seconds)

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -119,33 +119,29 @@ struct Caller {
 
 class TestContext {
   private:
-    bdlbb::PooledBlobBufferFactory d_blobBufferFactory;
-    // Buffer factory provided to the various builders
+    /// Allocator to use
+    bslma::Allocator* d_allocator_p;
+
+    /// Temp directory needed for Cluster object
+    bmqu::TempDirectory d_tempDir;
+
+    /// Cluster object used for generating mock nodes
+    bslma::ManagedPtr<mqbmock::Cluster> d_cluster_mp;
+
+    /// Cluster nodes used to send them request by MultiRequestManager
+    Nodes d_nodes;
 
     /// Blob shared pointer pool used in event builders.
     bmqp::BlobPoolUtil::BlobSpPoolSp d_blobSpPool_sp;
 
+    /// RequestManager object under testing
     ReqManagerTypeSp d_requestManager;
-    // RequestManager object under testing
 
+    /// MultiRequestManager object under testing
     MultiReqManagerTypeSp d_multiRequestManager;
-    // MultiRequestManager object under testing
 
+    /// Context object used to collect responses from the nodes
     ReqContextSp d_requestContextSp;
-    // MultiRequestManagerRequestContext object used to collect responses from
-    // the nodes
-
-    bslma::ManagedPtr<mqbmock::Cluster> d_cluster_mp;
-    // Cluster object used for generating mock nodes
-
-    Nodes d_nodes;
-    // Cluster nodes used to send them request by MultiRequestManager
-
-    bmqu::TempDirectory d_tempDir;
-    // Temp directory needed for Cluster object
-
-    bslma::Allocator* d_allocator_p;
-    // Allocator to use
 
   public:
     // TRAITS
@@ -169,9 +165,6 @@ class TestContext {
     /// Return shared pointer to the MultiRequestManagerRequestContext
     /// object.
     ReqContextSp& context();
-
-    /// Return reference to the buffer factory
-    bdlbb::PooledBlobBufferFactory& factory();
 
     /// Return shared pointer to the RequestManager object
     ReqManagerTypeSp manager();
@@ -235,48 +228,34 @@ class TestContext {
 };
 
 TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
-: d_blobBufferFactory(1024, allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_tempDir(d_allocator_p)
+, d_cluster_mp(new(*d_allocator_p) mqbmock::Cluster(
+                   d_allocator_p,
+                   true,   // isClusterMember
+                   false,  // isLeader
+                   false,  // isCSLMode
+                   false,  // isFSMWorkflow
+                   false,  // doesFSMwriteQLIST
+                   generateNodeDefs(nodesCount, d_allocator_p),
+                   "testCluster",
+                   d_tempDir.path()),
+               d_allocator_p)
+, d_nodes(clusterNodes(d_cluster_mp.get(), d_allocator_p), d_allocator_p)
 , d_blobSpPool_sp(
-      bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
-                                         bmqtst::TestHelperUtil::allocator()))
-, d_requestManager(0)
-, d_multiRequestManager(0)
-, d_requestContextSp(0)
-, d_cluster_mp(0)
-, d_nodes(allocator)
-, d_tempDir(allocator)
-, d_allocator_p(allocator)
+      bmqp::BlobPoolUtil::createBlobPool(d_cluster_mp->bufferFactory(),
+                                         d_allocator_p))
+, d_requestManager(
+      bsl::make_shared<ReqManagerType>(bmqp::EventType::e_CONTROL,
+                                       d_blobSpPool_sp.get(),
+                                       &d_cluster_mp->_scheduler(),
+                                       false,  // lateResponseMode
+                                       d_allocator_p))
+, d_multiRequestManager(
+      bsl::make_shared<MultiReqManagerType>(d_requestManager.get(),
+                                            d_allocator_p))
+, d_requestContextSp(d_multiRequestManager->createRequestContext())
 {
-    mqbmock::Cluster::ClusterNodeDefs defs = generateNodeDefs(nodesCount,
-                                                              d_allocator_p);
-
-    d_cluster_mp.load(new (*d_allocator_p)
-                          mqbmock::Cluster(&d_blobBufferFactory,
-                                           d_allocator_p,
-                                           true,   // isClusterMember
-                                           false,  // isLeader
-                                           false,  // isCSLMode
-                                           false,  // isFSMWorkflow
-                                           false,  // doesFSMwriteQLIST
-                                           defs,
-                                           "testCluster",
-                                           d_tempDir.path()),
-                      d_allocator_p);
-
-    d_nodes = clusterNodes(d_cluster_mp.get(), d_allocator_p);
-
-    d_requestManager = bsl::make_shared<ReqManagerType>(
-        bmqp::EventType::e_CONTROL,
-        d_blobSpPool_sp.get(),
-        &d_cluster_mp->_scheduler(),
-        false,  // lateResponseMode
-        d_allocator_p);
-
-    d_multiRequestManager = bsl::make_shared<MultiReqManagerType>(
-        d_requestManager.get(),
-        d_allocator_p);
-
-    d_requestContextSp = d_multiRequestManager->createRequestContext();
     d_requestContextSp->setDestinationNodes(d_nodes);
 
     bmqsys::Time::shutdown();
@@ -312,11 +291,6 @@ bslma::Allocator* TestContext::allocator() const
 ReqContextSp& TestContext::context()
 {
     return d_requestContextSp;
-}
-
-bdlbb::PooledBlobBufferFactory& TestContext::factory()
-{
-    return d_blobBufferFactory;
 }
 
 ReqManagerTypeSp TestContext::manager()
@@ -477,12 +451,8 @@ static void test1_contextTest()
         mqbmock::Cluster::ClusterNodeDefs defs = TestContext::generateNodeDefs(
             5,
             bmqtst::TestHelperUtil::allocator());
-        bdlbb::PooledBlobBufferFactory blobBufferFactory(
-            1024,
-            bmqtst::TestHelperUtil::allocator());
         bmqu::TempDirectory tempDir(bmqtst::TestHelperUtil::allocator());
-        mqbmock::Cluster    cluster(&blobBufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+        mqbmock::Cluster    cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
                                  false,  // isCSLMode

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -44,7 +44,6 @@
 #include <ball_severity.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_algorithm.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -193,10 +192,10 @@ class MockDataStore : public mqbs::DataStore {
 
   public:
     MockDataStore(bslma::Allocator* allocator, int partitionId)
-    : d_allocator_p(allocator)
-    , d_attributes(allocator)
-    , d_appData(allocator)
-    , d_options(allocator)
+    : d_allocator_p(bslma::Default::allocator(allocator))
+    , d_attributes(d_allocator_p)
+    , d_appData(d_allocator_p)
+    , d_options(d_allocator_p)
     {
         d_message_counter  = 0ULL;
         d_confirm_counter  = 0ULL;
@@ -478,7 +477,6 @@ struct Tester {
 
   private:
     // DATA
-    bdlbb::PooledBlobBufferFactory             d_bufferFactory;
     mqbmock::Cluster                           d_mockCluster;
     mqbmock::Domain                            d_mockDomain;
     mqbmock::Queue                             d_mockQueue;
@@ -495,8 +493,7 @@ struct Tester {
            const bslstl::StringRef& uri         = k_URI_STR,
            const mqbu::StorageKey&  queueKey    = k_QUEUE_KEY,
            bsls::Types::Int64       ttlSeconds  = k_INT64_MAX)
-    : d_bufferFactory(1024, allocator)
-    , d_mockCluster(&d_bufferFactory, allocator)
+    : d_mockCluster(allocator)
     , d_mockDomain(&d_mockCluster, allocator)
     , d_mockQueue(&d_mockDomain, allocator)
     , d_mockQueueEngine(allocator)
@@ -604,7 +601,7 @@ struct Tester {
 
             const bsl::shared_ptr<bdlbb::Blob> appDataPtr(
                 new (*bmqtst::TestHelperUtil::allocator())
-                    bdlbb::Blob(&d_bufferFactory,
+                    bdlbb::Blob(d_mockCluster.bufferFactory(),
                                 bmqtst::TestHelperUtil::allocator()),
                 bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -44,7 +44,6 @@
 #include <ball_severity.h>
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_algorithm.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -169,7 +168,6 @@ struct Tester {
 
   private:
     // DATA
-    bdlbb::PooledBlobBufferFactory             d_bufferFactory;
     mqbmock::Cluster                           d_mockCluster;
     mqbmock::Domain                            d_mockDomain;
     mqbmock::Queue                             d_mockQueue;
@@ -185,8 +183,7 @@ struct Tester {
            const bslstl::StringRef& uri         = k_URI_STR,
            const mqbu::StorageKey&  queueKey    = k_QUEUE_KEY,
            bsls::Types::Int64       ttlSeconds  = k_INT64_MAX)
-    : d_bufferFactory(1024, allocator)
-    , d_mockCluster(&d_bufferFactory, allocator)
+    : d_mockCluster(allocator)
     , d_mockDomain(&d_mockCluster, allocator)
     , d_mockQueue(&d_mockDomain, allocator)
     , d_mockQueueEngine(allocator)
@@ -288,7 +285,7 @@ struct Tester {
 
             const bsl::shared_ptr<bdlbb::Blob> appDataPtr(
                 new (*bmqtst::TestHelperUtil::allocator())
-                    bdlbb::Blob(&d_bufferFactory,
+                    bdlbb::Blob(d_mockCluster.bufferFactory(),
                                 bmqtst::TestHelperUtil::allocator()),
                 bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
@@ -32,7 +32,6 @@
 #include <bmqu_memoutstream.h>
 
 // BDE
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bsl_memory.h>
 
 // TEST DRIVER
@@ -62,11 +61,7 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelper::printTestName("Breathing Test");
 
-    bdlbb::PooledBlobBufferFactory bufferFactory(
-        1024,
-        bmqtst::TestHelperUtil::allocator());
-    mqbmock::Cluster mockCluster(&bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator());
+    mqbmock::Cluster mockCluster(bmqtst::TestHelperUtil::allocator());
     mqbmock::Domain  mockDomain(&mockCluster,
                                bmqtst::TestHelperUtil::allocator());
 
@@ -277,11 +272,7 @@ static void test3_queueStatsDomain()
     bmqtst::TestHelper::printTestName("QueueStatsDomain");
 
     // Create statcontext
-    bdlbb::PooledBlobBufferFactory bufferFactory(
-        1024,
-        bmqtst::TestHelperUtil::allocator());
-    mqbmock::Cluster mockCluster(&bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator());
+    mqbmock::Cluster mockCluster(bmqtst::TestHelperUtil::allocator());
     mqbmock::Domain  mockDomain(&mockCluster,
                                bmqtst::TestHelperUtil::allocator());
 
@@ -449,14 +440,10 @@ static void test4_queueStatsDomainContent()
                          mqbstat::QueueStatsDomain::Stat::PARAM));
 
     // Create the necessary objects to test
-    bdlbb::PooledBlobBufferFactory bufferFactory(
-        1024,
-        bmqtst::TestHelperUtil::allocator());
-    mqbmock::Cluster               mockCluster(&bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator());
-    mqbmock::Domain                mockDomain(&mockCluster,
+    mqbmock::Cluster    mockCluster(bmqtst::TestHelperUtil::allocator());
+    mqbmock::Domain     mockDomain(&mockCluster,
                                bmqtst::TestHelperUtil::allocator());
-    bmqst::StatContext*            sc = mockDomain.queueStatContext();
+    bmqst::StatContext* sc = mockDomain.queueStatContext();
 
     mqbstat::QueueStatsDomain obj(bmqtst::TestHelperUtil::allocator());
     obj.initialize(bmqt::Uri(bmqtst::TestHelperUtil::allocator()),
@@ -587,11 +574,7 @@ static void test5_appIdMetrics()
                                              3,
                                          bmqtst::TestHelperUtil::allocator());
 
-    bdlbb::PooledBlobBufferFactory bufferFactory(
-        1024,
-        bmqtst::TestHelperUtil::allocator());
-    mqbmock::Cluster mockCluster(&bufferFactory,
-                                 bmqtst::TestHelperUtil::allocator(),
+    mqbmock::Cluster mockCluster(bmqtst::TestHelperUtil::allocator(),
                                  isClusterMember,
                                  isLeader,
                                  isCSL,


### PR DESCRIPTION
Do not require `BlobBufferFactory` arg when constructing `mqbmock::Cluster`, use its own instance stored in a field instead and expose it in manipulator.