### PR TITLE
UT[BMQ]: log default allocations

### DIFF
--- a/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
@@ -182,33 +182,7 @@ void CountingAllocator::configureStatContextTableInfoProvider(
         .zeroString("");
 }
 
-void CountingAllocator::onAllocationChange(bsls::Types::Int64 deltaValue)
-{
-    const bsls::Types::Uint64 totalAllocated = d_allocated.addRelaxed(
-        deltaValue);
-
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(totalAllocated >
-                                              d_allocationLimit)) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        const bsls::Types::Uint64 uint64Max =
-            bsl::numeric_limits<bsls::Types::Uint64>::max();
-        if (d_allocationLimit.swap(uint64Max) != uint64Max) {
-            // Use an atomic swap to only invoke the callback the first time
-            // limit is crossed.  Swap 'allocationLimit' with 'Uint64::max',
-            // which will disable all further maximum allocation checks.
-
-            BSLS_ASSERT_SAFE(d_allocationLimitCb);
-            // If d_allocationLimit was set, 'd_allocationLimitCb' must be
-            // a valid callback
-            d_allocationLimitCb();
-        }
-    }
-
-    // Propagate allocation change to parent, if any
-    if (d_parentCounting_p) {
-        d_parentCounting_p->onAllocationChange(deltaValue);
-    }
-}
+// CREATORS
 
 CountingAllocator::CountingAllocator(const bslstl::StringRef& name,
                                      bslma::Allocator*        allocator)
@@ -269,6 +243,34 @@ CountingAllocator::~CountingAllocator()
 }
 
 // MANIPULATORS
+
+void CountingAllocator::onAllocationChange(bsls::Types::Int64 deltaValue)
+{
+    const bsls::Types::Uint64 totalAllocated = d_allocated.addRelaxed(
+        deltaValue);
+
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(totalAllocated >
+                                              d_allocationLimit)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        const bsls::Types::Uint64 uint64Max =
+            bsl::numeric_limits<bsls::Types::Uint64>::max();
+        if (d_allocationLimit.swap(uint64Max) != uint64Max) {
+            // Use an atomic swap to only invoke the callback the first time
+            // limit is crossed.  Swap 'allocationLimit' with 'Uint64::max',
+            // which will disable all further maximum allocation checks.
+
+            BSLS_ASSERT_SAFE(d_allocationLimitCb);
+            // If d_allocationLimit was set, 'd_allocationLimitCb' must be
+            // a valid callback
+            d_allocationLimitCb();
+        }
+    }
+
+    // Propagate allocation change to parent, if any
+    if (d_parentCounting_p) {
+        d_parentCounting_p->onAllocationChange(deltaValue);
+    }
+}
 
 void CountingAllocator::setAllocationLimit(
     bsls::Types::Uint64            limit,

--- a/src/groups/bmq/bmqtst/bmqtst_loggingallocator.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_loggingallocator.cpp
@@ -1,0 +1,102 @@
+// Copyright 2014-2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqtst_loggingallocator.cpp                                        -*-C++-*-
+#include <bmqtst_loggingallocator.h>
+
+#include <bmqscm_version.h>
+
+#include <bmqu_memoutstream.h>
+
+// BDE
+#include <balst_stacktraceprintutil.h>  // balst::StackTracePrintUtil
+#include <bsl_iostream.h>               // bsl::cerr
+
+namespace BloombergLP {
+namespace bmqtst {
+
+namespace {
+
+static bool isStackInExceptions(const bslstl::StringRef& str)
+{
+    struct StackExceptionRule {
+        const char* d_stackStr;
+    } k_RULES[] = {
+        {"bdlmt::EventSchedulerTestTimeSource::EventSchedulerTestTimeSource"},
+        {"bdls::FilesystemUtil::makeUnsafeTemporaryFilename"},
+        {"bdls::FilesystemUtil::remove"},
+        {"MessageGUIDUtil::initialize"}};
+
+    const size_t k_NUM_RULES = sizeof(k_RULES) / sizeof(*k_RULES);
+    for (size_t idx = 0; idx < k_NUM_RULES; ++idx) {
+        const StackExceptionRule& rule = k_RULES[idx];
+        if (str.find(rule.d_stackStr) != bsl::string::npos)
+            return true;
+    }
+    return false;
+}
+
+}
+
+// ----------------------
+// class LoggingAllocator
+// ----------------------
+
+// CREATORS
+
+LoggingAllocator::LoggingAllocator(bool failFast, bslma::Allocator* allocator)
+: d_allocator_p(allocator)
+, d_failFast(failFast)
+, d_failed(false)
+{
+    // NOTHING
+}
+
+LoggingAllocator::~LoggingAllocator()
+{
+    // NOTHING
+}
+
+// MANIPULATORS
+
+void* LoggingAllocator::allocate(size_type size)
+{
+    bmqu::MemOutStream os(d_allocator_p);
+    balst::StackTracePrintUtil::printStackTrace(os);
+
+    if (!isStackInExceptions(os.str())) {
+        bsl::cerr << os.str() << bsl::endl;
+        bsl::flush(bsl::cerr);
+
+        d_failed.storeRelaxed(true);
+        if (d_failFast) {
+            BSLS_ASSERT_OPT(false && "The allocation was recorded");
+        }
+    }
+    return d_allocator_p->allocate(size);
+}
+
+void LoggingAllocator::deallocate(void* address)
+{
+    d_allocator_p->deallocate(address);
+}
+
+void LoggingAllocator::checkNoAllocations()
+{
+    BSLS_ASSERT_OPT(!d_failed.load() && "The allocations were recorded");
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqtst/bmqtst_loggingallocator.h
+++ b/src/groups/bmq/bmqtst/bmqtst_loggingallocator.h
@@ -1,0 +1,117 @@
+// Copyright 2014-2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqtst_loggingallocator.h                                          -*-C++-*-
+#ifndef INCLUDED_BMQTST_LOGGINGALLOCATOR
+#define INCLUDED_BMQTST_LOGGINGALLOCATOR
+
+//@PURPOSE: Provide a 'bslma::Allocator' caching allocation stack traces.
+//
+//@CLASSES:
+//  bmqtst::LoggingAllocator : allocator adaptor.
+//
+//@DESCRIPTION: This component defines a mechanism, 'bmqtst::LoggingAllocator'
+// which implements the 'bslma::Allocator' protocol and which logs stack traces
+// on any allocation.
+
+// BDE
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bsls_atomic.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+
+namespace bmqtst {
+
+// ======================
+// class LoggingAllocator
+// ======================
+
+/// An allocator caching allocation stack traces.
+class LoggingAllocator BSLS_KEYWORD_FINAL : public bslma::Allocator {
+  public:
+    // PUBLIC TYPES
+
+    /// Alias for a signed integral type capable of representing the number
+    /// of bytes in this platform's virtual address space.
+    typedef bsls::Types::size_type size_type;
+
+  private:
+    // DATA
+    /// @brief Base allocator to use.
+    bslma::Allocator* d_allocator_p;
+
+    /// @brief The flag indicaing that the allocator must fail instantly if any
+    ///        undesired allocation happens.
+    bool d_failFast;
+
+    /// @brief The flag indicating that this allocator has failed.
+    bsls::AtomicBool d_failed;
+
+  private:
+    // NOT IMPLEMENTED
+    LoggingAllocator(const LoggingAllocator&) BSLS_KEYWORD_DELETED;
+    LoggingAllocator& operator=(const LoggingAllocator&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // CREATORS
+
+    /// @brief Construct a logging allocator.
+    /// @param failFast The flag indicating whether this allocator must raise
+    ///                 an exception instantly on any undesired allocation.
+    /// @param allocator The base allocator to use, or use the default
+    ///                  allocator if this arg is null.
+    explicit LoggingAllocator(bool              failFast  = false,
+                              bslma::Allocator* allocator = 0);
+
+    /// Destroy this object.
+    ~LoggingAllocator() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+
+    //  (virtual bslma::Allocator)
+
+    /// @brief Return a newly allocated block of memory.  If this allocator
+    ///        cannot return the requested number of bytes, then it will
+    ///        throw a `bsl::bad_alloc` exception in an exception-enabled
+    ///        build, or else will abort the program in a non-exception build.
+    ///        The behavior is undefined unless `0 <= size`.  Note that the
+    ///        alignment of the address returned conforms to the platform
+    ///        requirement for any object of the specified `size`.
+    /// @param size The minimum size of the newly allocated block (in bytes).
+    ///             If `size` is 0, a null pointer is returned with no other
+    ///             effect.
+    /// @return The memory address of the allocated block or a null pointer.
+    void* allocate(size_type size) BSLS_KEYWORD_OVERRIDE;
+
+    /// @brief Return the memory block at the specified `address` back to this
+    ///        allocator.   The behavior is undefined unless `address` was
+    ///        allocated using this allocator object and has not already been
+    ///        deallocated.
+    /// @param address The address of the memory block to deallocate.  If this
+    ///        argument is a null pointer, the function doesn't have an effect.
+    void deallocate(void* address) BSLS_KEYWORD_OVERRIDE;
+
+    /// @brief Check whether the undesired allocations were recorded and raise
+    ///        an exception if any.
+    void checkNoAllocations();
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -278,6 +278,9 @@
 //  }
 //..
 
+// BMQ
+#include <bmqtst_loggingallocator.h>
+
 // BDE
 #include <ball_attributecontext.h>
 #include <ball_fileobserver.h>
@@ -629,7 +632,10 @@
     bslma::TestAllocator _defAlloc(                                           \
         "default",                                                            \
         (bmqtst::TestHelperUtil::verbosityLevel() >= 4));                     \
-    bslma::DefaultAllocatorGuard _defAllocGuard(&_defAlloc);                  \
+    bmqtst::LoggingAllocator _loggingAlloc(                                   \
+        (F) & bmqtst::TestHelper::e_INSTANT_DEF_ALLOC_FAIL,                   \
+        &_defAlloc);                                                          \
+    bslma::DefaultAllocatorGuard _defAllocGuard(&_loggingAlloc);              \
                                                                               \
     /* Test driver allocator */                                               \
     bslma::TestAllocator _testAlloc(                                          \
@@ -655,13 +661,14 @@
     BMQTST_ASSERT_EQ(_testAlloc.numBlocksInUse(), 0);                         \
                                                                               \
     /* Verify no default allocator usage */                                   \
-    if (F & bmqtst::TestHelper::e_CHECK_DEF_ALLOC &&                          \
+    if ((F) & bmqtst::TestHelper::e_CHECK_DEF_ALLOC &&                        \
         !bmqtst::TestHelperUtil::ignoreCheckDefAlloc()) {                     \
+        _loggingAlloc.checkNoAllocations();                                   \
         BMQTST_ASSERT_EQ(_defAlloc.numBlocksTotal(), 0);                      \
     }                                                                         \
                                                                               \
     /* Verify no global allocator usage */                                    \
-    if (F & bmqtst::TestHelper::e_CHECK_GBL_ALLOC &&                          \
+    if ((F) & bmqtst::TestHelper::e_CHECK_GBL_ALLOC &&                        \
         !bmqtst::TestHelperUtil::ignoreCheckGblAlloc()) {                     \
         BMQTST_ASSERT_EQ(_gblAlloc.numBlocksTotal(), 0);                      \
     }                                                                         \
@@ -891,10 +898,14 @@ struct TestHelper {
     enum e_FLAGS {
         e_DEFAULT = 0,
 
-        // PROLOG FLAGS
+        /// ==== PROLOG FLAGS ====
+        /// Use `balst::StackTraceTestAllocator` to search for memory leaks.
         e_USE_STACKTRACE_ALLOCATOR = 1 << 0,
+        /// Raise an exception instantly if any unneeded default allocation
+        /// happens.
+        e_INSTANT_DEF_ALLOC_FAIL = 1 << 1,
 
-        // EPILOG FLAGS
+        /// ==== EPILOG FLAGS ====
         e_CHECK_DEF_ALLOC     = 1 << 0,
         e_CHECK_GBL_ALLOC     = 1 << 1,
         e_CHECK_DEF_GBL_ALLOC = e_CHECK_DEF_ALLOC | e_CHECK_GBL_ALLOC

--- a/src/groups/bmq/bmqtst/package/bmqtst.mem
+++ b/src/groups/bmq/bmqtst/package/bmqtst.mem
@@ -1,4 +1,5 @@
 bmqtst_blobtestutil
+bmqtst_loggingallocator
 bmqtst_scopedlogobserver
 bmqtst_table
 bmqtst_testhelper


### PR DESCRIPTION
```
[21:29:46] CASE 497: FAILURE (rc -6)
TEST /Users/emalygin/work/blazingmq/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp CASE 497
(0): BloombergLP::bmqtst::LoggingAllocator::allocate(unsigned long)+0x58 at 0x10500b210 in mqbs_inmemorystorage.t
(1): void bsl::shared_ptr<BloombergLP::ntsb::Resolver>::createInplace<BloombergLP::bslma::Allocator*&>(BloombergLP::bslma::Allocator*, BloombergLP::bslma::Allocator*&)+0x4c at 0x105419f98 in mqbs_inmemorystorage.t
(2): BloombergLP::ntsf::System::createResolver(BloombergLP::bslma::Allocator*)+0x5c at 0x105419f14 in mqbs_inmemorystorage.t
(3): BloombergLP::bmqio::ResolveUtil::getHostname(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>*)+0x70 at 0x104ee2568 in mqbs_inmemorystorage.t
(4): BloombergLP::mqbu::MessageGUIDUtil::initialize()+0x9c at 0x104e7e6ec in mqbs_inmemorystorage.t
(5): main+0x444 at 0x104c1ec7c in mqbs_inmemorystorage.t
(6): start+0x17bc at 0x1926cab98 in /usr/lib/dyld

Error /Users/emalygin/work/blazingmq/src/groups/bmq/bmqtst/bmqtst_loggingallocator.cpp(81): false && "The allocation was recorded"    (failed)
libc++abi: terminating due to uncaught exception of type BloombergLP::bsls::AssertTestException

[21:29:46] CASE 498: FAILURE (rc -6)
TEST /Users/emalygin/work/blazingmq/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp CASE 498
(0): BloombergLP::bmqtst::LoggingAllocator::allocate(unsigned long)+0x58 at 0x102e57210 in mqbs_inmemorystorage.t
(1): void bsl::shared_ptr<BloombergLP::ntsb::Resolver>::createInplace<BloombergLP::bslma::Allocator*&>(BloombergLP::bslma::Allocator*, BloombergLP::bslma::Allocator*&)+0x4c at 0x103265f98 in mqbs_inmemorystorage.t
(2): BloombergLP::ntsf::System::createResolver(BloombergLP::bslma::Allocator*)+0x5c at 0x103265f14 in mqbs_inmemorystorage.t
(3): BloombergLP::bmqio::ResolveUtil::getHostname(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>*)+0x70 at 0x102d2e568 in mqbs_inmemorystorage.t
(4): BloombergLP::mqbu::MessageGUIDUtil::initialize()+0x9c at 0x102cca6ec in mqbs_inmemorystorage.t
(5): main+0x444 at 0x102a6ac7c in mqbs_inmemorystorage.t
(6): start+0x17bc at 0x1926cab98 in /usr/lib/dyld

Error /Users/emalygin/work/blazingmq/src/groups/bmq/bmqtst/bmqtst_loggingallocator.cpp(81): false && "The allocation was recorded"    (failed)
libc++abi: terminating due to uncaught exception of type BloombergLP::bsls::AssertTestException

[21:29:46] CASE 499: FAILURE (rc -6)
TEST /Users/emalygin/work/blazingmq/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp CASE 499
(0): BloombergLP::bmqtst::LoggingAllocator::allocate(unsigned long)+0x58 at 0x10267b210 in mqbs_inmemorystorage.t
(1): void bsl::shared_ptr<BloombergLP::ntsb::Resolver>::createInplace<BloombergLP::bslma::Allocator*&>(BloombergLP::bslma::Allocator*, BloombergLP::bslma::Allocator*&)+0x4c at 0x102a89f98 in mqbs_inmemorystorage.t
(2): BloombergLP::ntsf::System::createResolver(BloombergLP::bslma::Allocator*)+0x5c at 0x102a89f14 in mqbs_inmemorystorage.t
(3): BloombergLP::bmqio::ResolveUtil::getHostname(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>*)+0x70 at 0x102552568 in mqbs_inmemorystorage.t
(4): BloombergLP::mqbu::MessageGUIDUtil::initialize()+0x9c at 0x1024ee6ec in mqbs_inmemorystorage.t
(5): main+0x444 at 0x10228ec7c in mqbs_inmemorystorage.t
(6): start+0x17bc at 0x1926cab98 in /usr/lib/dyld

Error /Users/emalygin/work/blazingmq/src/groups/bmq/bmqtst/bmqtst_loggingallocator.cpp(81): false && "The allocation was recorded"    (failed)
libc++abi: terminating due to uncaught exception of type BloombergLP::bsls::AssertTestException
```