### PR TITLE
UT[bmqt::Uri]: fix default allocations

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -38,40 +38,6 @@ using namespace BloombergLP;
 using namespace bsl;
 
 // ============================================================================
-//                            TEST HELPERS UTILITY
-// ----------------------------------------------------------------------------
-namespace {
-
-/// Thread function: wait on the specified `barrier` and then generate the
-/// specified `numGUIDs` (in a tight loop) and store them in the specified
-/// `out`.
-static void threadFunction(int                                      threadId,
-                           bsl::vector<bsl::pair<bmqt::Uri, int> >* out,
-                           bslmt::Barrier*                          barrier,
-                           int numIterations)
-{
-    out->reserve(numIterations);
-    barrier->wait();
-
-    for (int i = 0; i < numIterations; ++i) {
-        bmqu::MemOutStream osstrDomain(bmqtst::TestHelperUtil::allocator());
-        bmqu::MemOutStream osstrQueue(bmqtst::TestHelperUtil::allocator());
-        osstrDomain << "my.domain." << threadId << "." << i;
-        osstrQueue << "queue-foo-bar-" << threadId << "-" << i;
-
-        bmqt::Uri        qualifiedUri(bmqtst::TestHelperUtil::allocator());
-        bmqt::UriBuilder builder(bmqtst::TestHelperUtil::allocator());
-        builder.setDomain(osstrDomain.str());
-        builder.setQueue(osstrQueue.str());
-
-        int rc = builder.uri(&qualifiedUri);
-        out->push_back(bsl::make_pair(qualifiedUri, rc));
-    }
-}
-
-}  // close unnamed namespace
-
-// ============================================================================
 //                                    TESTS
 // ----------------------------------------------------------------------------
 
@@ -452,36 +418,60 @@ static void test2_URIBuilder()
 /// from multiple threads.
 static void test3_URIBuilderMultiThreaded()
 {
-    bmqtst::TestHelperUtil::ignoreCheckGblAlloc() = true;
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't ensure no global memory is allocated because
-    // 'bslmt::ThreadUtil::create()' uses the global allocator to allocate
-    // memory.
-
     bmqtst::TestHelper::printTestName("MULTI-THREADED URI BUILDER TEST");
 
     bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     const int          k_NUM_THREADS    = 6;
-    const int          k_NUM_ITERATIONS = 10000;
-    bslmt::ThreadGroup threadGroup(bmqtst::TestHelperUtil::allocator());
+    const size_t       k_NUM_ITERATIONS = 10000;
+
+    struct Local {
+        static void threadFunction(size_t                  threadId,
+                                   bsl::vector<bmqt::Uri>* out,
+                                   bslmt::Barrier*         barrier)
+        {
+            out->reserve(k_NUM_ITERATIONS);
+            barrier->wait();
+
+            for (size_t i = 0; i < k_NUM_ITERATIONS; ++i) {
+                bmqu::MemOutStream osstrDomain(
+                    bmqtst::TestHelperUtil::allocator());
+                bmqu::MemOutStream osstrQueue(
+                    bmqtst::TestHelperUtil::allocator());
+                osstrDomain << "my.domain." << threadId << "." << i;
+                osstrQueue << "queue-foo-bar-" << threadId << "-" << i;
+
+                bmqt::Uri qualifiedUri(bmqtst::TestHelperUtil::allocator());
+                bmqt::UriBuilder builder(bmqtst::TestHelperUtil::allocator());
+                builder.setDomain(osstrDomain.str());
+                builder.setQueue(osstrQueue.str());
+
+                const int rc = builder.uri(&qualifiedUri);
+                BMQTST_ASSERT_EQ_D("Failed to build bmqt::Uri, i="
+                                       << i << ", rc=" << rc,
+                                   rc,
+                                   0);
+                out->emplace_back(bslmf::MovableRefUtil::move(qualifiedUri));
+            }
+        }
+    };
 
     // Barrier to get each thread to start at the same time; `+1` for this
     // (main) thread.
     bslmt::Barrier barrier(k_NUM_THREADS + 1);
 
-    typedef bsl::pair<bmqt::Uri, int> Result;
-
-    bsl::vector<bsl::vector<Result> > threadsData(
+    bsl::vector<bsl::vector<bmqt::Uri> > threadsData(
         bmqtst::TestHelperUtil::allocator());
     threadsData.resize(k_NUM_THREADS);
 
-    for (int i = 0; i < k_NUM_THREADS; ++i) {
-        int rc = threadGroup.addThread(bdlf::BindUtil::bind(&threadFunction,
-                                                            i,
-                                                            &threadsData[i],
-                                                            &barrier,
-                                                            k_NUM_ITERATIONS));
+    bslmt::ThreadGroup threadGroup(bmqtst::TestHelperUtil::allocator());
+    for (size_t i = 0; i < k_NUM_THREADS; ++i) {
+        const int rc = threadGroup.addThread(
+            bdlf::BindUtil::bindS(bmqtst::TestHelperUtil::allocator(),
+                                  &Local::threadFunction,
+                                  i,
+                                  &threadsData[i],
+                                  &barrier));
         BMQTST_ASSERT_EQ_D(i, rc, 0);
     }
 
@@ -490,17 +480,12 @@ static void test3_URIBuilderMultiThreaded()
 
     // Validate for each thread.
 
-    for (int i = 0; i < k_NUM_THREADS; ++i) {
-        const bsl::vector<Result>& threadResults = threadsData[i];
+    for (size_t i = 0; i < k_NUM_THREADS; ++i) {
+        const bsl::vector<bmqt::Uri>& uris = threadsData[i];
 
-        BSLS_ASSERT_OPT(threadResults.size() ==
-                        static_cast<size_t>(k_NUM_ITERATIONS));
+        BMQTST_ASSERT_EQ(uris.size(), k_NUM_ITERATIONS);
 
-        for (int j = 0; j < k_NUM_ITERATIONS; ++j) {
-            BMQTST_ASSERT_EQ_D(i << ", " << j,
-                               threadResults[j].second,
-                               0);  // builder rc
-
+        for (size_t j = 0; j < k_NUM_ITERATIONS; ++j) {
             bmqu::MemOutStream expectedUriStr(
                 bmqtst::TestHelperUtil::allocator());
             expectedUriStr << "bmq://my.domain." << i << "." << j
@@ -508,9 +493,7 @@ static void test3_URIBuilderMultiThreaded()
             bmqt::Uri expectedUri(expectedUriStr.str(),
                                   bmqtst::TestHelperUtil::allocator());
 
-            BMQTST_ASSERT_EQ_D(i << ", " << j,
-                               threadResults[j].first,
-                               expectedUri);
+            BMQTST_ASSERT_EQ_D(i << ", " << j, uris[j], expectedUri);
         }
     }
 


### PR DESCRIPTION
1. Fix allocation that happens when the pair is created:
```
(0): BloombergLP::bmqtst::LoggingAllocator::allocate(unsigned long)+0x48 at 0x1000dece0 in bmqt_uri.t
(1): BloombergLP::bslma::Allocator::do_allocate(unsigned long, unsigned long)+0x1c at 0x1000a0564 in bmqt_uri.t
(2): bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>::privateAppend(char const*, unsigned long, char const*)+0x7c at 0x1000a8c1c in bmqt_uri.t
(3): bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>::operator=(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>> const&)+0x40 at 0x1000aa570 in bmqt_uri.t
(4): BloombergLP::bmqt::Uri::copyImpl(BloombergLP::bmqt::Uri const&)+0x2c at 0x10004d330 in bmqt_uri.t
(5): BloombergLP::bmqt::Uri::Uri(BloombergLP::bmqt::Uri const&, BloombergLP::bslma::Allocator*)+0xac at 0x10004d2cc in bmqt_uri.t
(6): BloombergLP::bmqt::Uri::Uri(BloombergLP::bmqt::Uri const&, BloombergLP::bslma::Allocator*)+0x2c at 0x10004d5e8 in bmqt_uri.t
(7): std::__1::pair<BloombergLP::bmqt::Uri, int>::pair[abi:ne190102]<BloombergLP::bmqt::Uri&, int&, 0>(BloombergLP::bmqt::Uri&, int&)+0x2c at 0x100044fa8 in bmqt_uri.t
(8): std::__1::pair<BloombergLP::bmqt::Uri, int>::pair[abi:ne190102]<BloombergLP::bmqt::Uri&, int&, 0>(BloombergLP::bmqt::Uri&, int&)+0x2c at 0x100044f6c in bmqt_uri.t
(9): std::__1::pair<std::__1::__unwrap_ref_decay<BloombergLP::bmqt::Uri&>::type, std::__1::__unwrap_ref_decay<int&>::type> std::__1::make_pair[abi:ne190102]<BloombergLP::bmqt::Uri&, int&>(BloombergLP::bmqt::Uri&, int&)+0x34 at 0x100043b28 in bmqt_uri.t
(10): (anonymous namespace)::threadFunction(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int)+0x258 at 0x10003d0e0 in bmqt_uri.t
(11): void BloombergLP::bdlf::Bind_Invoker<void, 4>::invoke<void (* const)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int> const, BloombergLP::bdlf::Bind_ArgTuple0>(void (* const*)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int> const*, BloombergLP::bdlf::Bind_ArgTuple0&) const+0xd8 at 0x100040e9c in bmqt_uri.t
(12): void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (*)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int>>::invokeImpl<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&, BloombergLP::bslmf::Tag<0u>) const+0x40 at 0x100040db8 in bmqt_uri.t
(13): void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (*)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int>>::invoke<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&) const+0x30 at 0x100040d58 in bmqt_uri.t
(14): BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (*)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int>>::operator()() const+0x30 at 0x100040ba8 in bmqt_uri.t
(15): BloombergLP::bslmt::EntryPointFunctorAdapter<BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (*)(int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int), BloombergLP::bdlf::Bind_BoundTuple4<int, bsl::vector<bsl::pair<BloombergLP::bmqt::Uri, int>, bsl::allocator<bsl::pair<BloombergLP::bmqt::Uri, int>>>*, BloombergLP::bslmt::Barrier*, int>>>::invokerFunction(void*)+0xb0 at 0x100040a04 in bmqt_uri.t
(16): bslmt_EntryPointFunctorAdapter_invoker+0x10 at 0x1000a2714 in bmqt_uri.t
(17): _pthread_start+0x88 at 0x192a6ac0c in /usr/lib/system/libsystem_pthread.dylib
(18): thread_start+0x8 at 0x192a65b80 in /usr/lib/system/libsystem_pthread.dylib
```

2. Fix allocation with thread function (use `bindS`)
3. Simplify code