### PR TITLE
Misc bmqa::Messages: Do not include bmqp

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_message.cpp
+++ b/src/groups/bmq/bmqa/bmqa_message.cpp
@@ -24,6 +24,7 @@
 #include <bmqimp_queue.h>
 #include <bmqp_event.h>
 #include <bmqp_eventutil.h>
+#include <bmqp_messageproperties.h>
 #include <bmqp_protocolutil.h>
 #include <bmqp_queueid.h>
 #include <bmqt_resultcode.h>

--- a/src/groups/bmq/bmqa/bmqa_message.h
+++ b/src/groups/bmq/bmqa/bmqa_message.h
@@ -60,7 +60,6 @@
 // BMQ
 
 #include <bmqa_queueid.h>
-#include <bmqp_messageproperties.h>
 #include <bmqt_compressionalgorithmtype.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_messageguid.h>
@@ -80,6 +79,9 @@ namespace BloombergLP {
 // FORWARD DECLARATION
 namespace bmqimp {
 class Event;
+}
+namespace bmqp {
+class MessageProperties_Schema;
 }
 
 namespace bmqa {
@@ -118,7 +120,8 @@ struct MessageImpl {
     /// SubscriptionHandle this message is associated with
     bmqt::SubscriptionHandle d_subscriptionHandle;
 
-    bmqp::MessageProperties::SchemaPtr d_schema_sp;
+    /// Schema pointer
+    bsl::shared_ptr<const bmqp::MessageProperties_Schema> d_schema_sp;
 
 #ifdef BMQ_ENABLE_MSG_GROUPID
     /// Optional GroupId this message is associated with


### PR DESCRIPTION
It broke libbmq release because libbmq allows bmqa headers but not bmqp headers.