### PR TITLE
Deprecate: commit QueueUnAssignmentAdvisory

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
@@ -71,9 +71,8 @@ struct AdvisoryType {
         e_PARTITION_PRIMARY  = 1,
         e_QUEUE_ASSIGNMENT   = 2,
         e_QUEUE_UNASSIGNMENT = 3,
-        e_QUEUE_UNASSIGNED   = 4,
-        e_COMMIT             = 5,
-        e_ACK                = 6
+        e_COMMIT             = 4,
+        e_ACK                = 5
     };
 };
 
@@ -164,26 +163,6 @@ createClusterMessage(bmqp_ctrlmsg::ClusterMessage*              message,
         advisory.queues().push_back(qinfo);
 
         message->choice().makeQueueUnAssignmentAdvisory(advisory);
-
-        return mqbc::ClusterStateRecordType::e_UPDATE;
-    }
-    case AdvisoryType::e_QUEUE_UNASSIGNED: {
-        bmqp_ctrlmsg::QueueInfo qinfo;
-        qinfo.partitionId() = 1U;
-        qinfo.uri()         = queueUri;
-
-        const mqbu::StorageKey key(mqbu::StorageKey::HexRepresentation(),
-                                   queueKey.c_str());
-        key.loadBinary(&qinfo.key());
-
-        bmqp_ctrlmsg::QueueUnassignedAdvisory advisory;
-        advisory.sequenceNumber() = sequenceNumber;
-        advisory.primaryNodeId()  = 1;
-        advisory.partitionId()    = 1U;
-        advisory.primaryLeaseId() = 1U;
-        advisory.queues().push_back(qinfo);
-
-        message->choice().makeQueueUnassignedAdvisory(advisory);
 
         return mqbc::ClusterStateRecordType::e_UPDATE;
     }
@@ -455,14 +434,6 @@ static void test1_breathingTest()
                    mqbc::ClusterStateRecordType::e_UPDATE},
                   {L_,
                    3U,
-                   3U,
-                   123567U,
-                   "bmq://bmq.random.y/q2",
-                   "1111111111",
-                   AdvisoryType::e_QUEUE_UNASSIGNED,
-                   mqbc::ClusterStateRecordType::e_UPDATE},
-                  {L_,
-                   3U,
                    4U,
                    123678U,
                    "bmq://bmq.random.y/q2",
@@ -633,7 +604,7 @@ static void test2_searchRecordsByTypeTest()
                    123567U,
                    "bmq://bmq.random.y/q2",
                    "1111111111",
-                   AdvisoryType::e_QUEUE_UNASSIGNED,
+                   AdvisoryType::e_QUEUE_UNASSIGNMENT,
                    mqbc::ClusterStateRecordType::e_UPDATE},
                   {L_,
                    3U,
@@ -793,7 +764,7 @@ static void test3_searchRecordsByQueueKeyTest()
                    123567U,
                    "bmq://bmq.random.y/q1",
                    "1111111111",
-                   AdvisoryType::e_QUEUE_UNASSIGNED,
+                   AdvisoryType::e_QUEUE_UNASSIGNMENT,
                    mqbc::ClusterStateRecordType::e_UPDATE},
                   {L_,
                    3U,
@@ -810,14 +781,6 @@ static void test3_searchRecordsByQueueKeyTest()
                    "bmq://bmq.random.y/q3",
                    "3333333333",
                    AdvisoryType::e_QUEUE_UNASSIGNMENT,
-                   mqbc::ClusterStateRecordType::e_UPDATE},
-                  {L_,
-                   3U,
-                   3U,
-                   123567U,
-                   "bmq://bmq.random.y/q3",
-                   "3333333333",
-                   AdvisoryType::e_QUEUE_UNASSIGNED,
                    mqbc::ClusterStateRecordType::e_UPDATE},
                   {L_,
                    3U,
@@ -1715,14 +1678,6 @@ static void test9_summaryTest()
                    "bmq://bmq.random.y/q2",
                    "1111111111",
                    AdvisoryType::e_QUEUE_UNASSIGNMENT,
-                   mqbc::ClusterStateRecordType::e_UPDATE},
-                  {L_,
-                   3U,
-                   3U,
-                   123567U,
-                   "bmq://bmq.random.y/q2",
-                   "1111111111",
-                   AdvisoryType::e_QUEUE_UNASSIGNED,
                    mqbc::ClusterStateRecordType::e_UPDATE},
                   {L_,
                    3U,

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filters.cpp
@@ -186,14 +186,6 @@ bool Filters::apply(const mqbc::ClusterStateRecordHeader& recordHeader,
             }
             else if (selectionId ==
                      ClusterMessageChoice::
-                         SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY) {
-                const QueueUnassignedAdvisory& queueAdvisory =
-                    record.choice().queueUnassignedAdvisory();
-                queueKeyMatch = isQueueKeyMatch(queueAdvisory.queues(),
-                                                d_queueKeys);
-            }
-            else if (selectionId ==
-                     ClusterMessageChoice::
                          SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY) {
                 const QueueUnAssignmentAdvisory& queueAdvisory =
                     record.choice().queueUnAssignmentAdvisory();

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -562,8 +562,8 @@
         <element name='primaryStatusAdvisory'           type='tns:PrimaryStatusAdvisory'/>
         <element name='clusterSyncRequest'              type='tns:DummyType'/>
         <element name='clusterSyncResponse'             type='tns:DummyType'/>
+        <element name='queueUnassignedAdvisory'         type='tns:DummyType'/>        
         <element name='queueUnAssignmentAdvisory'       type='tns:QueueUnAssignmentAdvisory'/>
-        <element name='queueUnassignedAdvisory'         type='tns:QueueUnassignedAdvisory'/>
         <element name='leaderAdvisoryAck'               type='tns:LeaderAdvisoryAck'/>
         <element name='leaderAdvisoryCommit'            type='tns:LeaderAdvisoryCommit'/>
         <element name='stateNotification'               type='tns:StateNotification'/>
@@ -949,23 +949,6 @@
   </complexType>
 
   <complexType name='QueueUnAssignmentAdvisory'>
-    <annotation>
-      <documentation>
-        This type represents a one way message sent by the primary of a
-        partition to all peers when queues are unmapped from that partition.
-        NOTE: The 'partitionId' member of 'QueueInfo' is unused (superseeded by
-              the 'partitionId' at this level of the data structure).
-      </documentation>
-    </annotation>
-    <sequence>
-      <element name='primaryNodeId'  type='int'/>
-      <element name='primaryLeaseId' type='unsignedInt'/>
-      <element name='partitionId'    type='int'/>
-      <element name='queues'         type='tns:QueueInfo' maxOccurs='unbounded'/>
-    </sequence>
-  </complexType>
-
-  <complexType name='QueueUnassignedAdvisory'>
     <annotation>
       <documentation>
         This type represents a one way message sent by the leader to all peers

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -9295,173 +9295,6 @@ const char QueueUnAssignmentAdvisory::CLASS_NAME[] =
     "QueueUnAssignmentAdvisory";
 
 const bdlat_AttributeInfo QueueUnAssignmentAdvisory::ATTRIBUTE_INFO_ARRAY[] = {
-    {ATTRIBUTE_ID_PRIMARY_NODE_ID,
-     "primaryNodeId",
-     sizeof("primaryNodeId") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
-     "primaryLeaseId",
-     sizeof("primaryLeaseId") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_PARTITION_ID,
-     "partitionId",
-     sizeof("partitionId") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_QUEUES,
-     "queues",
-     sizeof("queues") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT}};
-
-// CLASS METHODS
-
-const bdlat_AttributeInfo*
-QueueUnAssignmentAdvisory::lookupAttributeInfo(const char* name,
-                                               int         nameLength)
-{
-    for (int i = 0; i < 4; ++i) {
-        const bdlat_AttributeInfo& attributeInfo =
-            QueueUnAssignmentAdvisory::ATTRIBUTE_INFO_ARRAY[i];
-
-        if (nameLength == attributeInfo.d_nameLength &&
-            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
-            return &attributeInfo;
-        }
-    }
-
-    return 0;
-}
-
-const bdlat_AttributeInfo*
-QueueUnAssignmentAdvisory::lookupAttributeInfo(int id)
-{
-    switch (id) {
-    case ATTRIBUTE_ID_PRIMARY_NODE_ID:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_NODE_ID];
-    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
-    case ATTRIBUTE_ID_PARTITION_ID:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
-    case ATTRIBUTE_ID_QUEUES:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUES];
-    default: return 0;
-    }
-}
-
-// CREATORS
-
-QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    bslma::Allocator* basicAllocator)
-: d_queues(basicAllocator)
-, d_primaryLeaseId()
-, d_primaryNodeId()
-, d_partitionId()
-{
-}
-
-QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    const QueueUnAssignmentAdvisory& original,
-    bslma::Allocator*                basicAllocator)
-: d_queues(original.d_queues, basicAllocator)
-, d_primaryLeaseId(original.d_primaryLeaseId)
-, d_primaryNodeId(original.d_primaryNodeId)
-, d_partitionId(original.d_partitionId)
-{
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    QueueUnAssignmentAdvisory&& original) noexcept
-: d_queues(bsl::move(original.d_queues)),
-  d_primaryLeaseId(bsl::move(original.d_primaryLeaseId)),
-  d_primaryNodeId(bsl::move(original.d_primaryNodeId)),
-  d_partitionId(bsl::move(original.d_partitionId))
-{
-}
-
-QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    QueueUnAssignmentAdvisory&& original,
-    bslma::Allocator*           basicAllocator)
-: d_queues(bsl::move(original.d_queues), basicAllocator)
-, d_primaryLeaseId(bsl::move(original.d_primaryLeaseId))
-, d_primaryNodeId(bsl::move(original.d_primaryNodeId))
-, d_partitionId(bsl::move(original.d_partitionId))
-{
-}
-#endif
-
-QueueUnAssignmentAdvisory::~QueueUnAssignmentAdvisory()
-{
-}
-
-// MANIPULATORS
-
-QueueUnAssignmentAdvisory&
-QueueUnAssignmentAdvisory::operator=(const QueueUnAssignmentAdvisory& rhs)
-{
-    if (this != &rhs) {
-        d_primaryNodeId  = rhs.d_primaryNodeId;
-        d_primaryLeaseId = rhs.d_primaryLeaseId;
-        d_partitionId    = rhs.d_partitionId;
-        d_queues         = rhs.d_queues;
-    }
-
-    return *this;
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnAssignmentAdvisory&
-QueueUnAssignmentAdvisory::operator=(QueueUnAssignmentAdvisory&& rhs)
-{
-    if (this != &rhs) {
-        d_primaryNodeId  = bsl::move(rhs.d_primaryNodeId);
-        d_primaryLeaseId = bsl::move(rhs.d_primaryLeaseId);
-        d_partitionId    = bsl::move(rhs.d_partitionId);
-        d_queues         = bsl::move(rhs.d_queues);
-    }
-
-    return *this;
-}
-#endif
-
-void QueueUnAssignmentAdvisory::reset()
-{
-    bdlat_ValueTypeFunctions::reset(&d_primaryNodeId);
-    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
-    bdlat_ValueTypeFunctions::reset(&d_partitionId);
-    bdlat_ValueTypeFunctions::reset(&d_queues);
-}
-
-// ACCESSORS
-
-bsl::ostream& QueueUnAssignmentAdvisory::print(bsl::ostream& stream,
-                                               int           level,
-                                               int spacesPerLevel) const
-{
-    bslim::Printer printer(&stream, level, spacesPerLevel);
-    printer.start();
-    printer.printAttribute("primaryNodeId", this->primaryNodeId());
-    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
-    printer.printAttribute("partitionId", this->partitionId());
-    printer.printAttribute("queues", this->queues());
-    printer.end();
-    return stream;
-}
-
-// -----------------------------
-// class QueueUnassignedAdvisory
-// -----------------------------
-
-// CONSTANTS
-
-const char QueueUnassignedAdvisory::CLASS_NAME[] = "QueueUnassignedAdvisory";
-
-const bdlat_AttributeInfo QueueUnassignedAdvisory::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_SEQUENCE_NUMBER,
      "sequenceNumber",
      sizeof("sequenceNumber") - 1,
@@ -9491,11 +9324,12 @@ const bdlat_AttributeInfo QueueUnassignedAdvisory::ATTRIBUTE_INFO_ARRAY[] = {
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-QueueUnassignedAdvisory::lookupAttributeInfo(const char* name, int nameLength)
+QueueUnAssignmentAdvisory::lookupAttributeInfo(const char* name,
+                                               int         nameLength)
 {
     for (int i = 0; i < 5; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
-            QueueUnassignedAdvisory::ATTRIBUTE_INFO_ARRAY[i];
+            QueueUnAssignmentAdvisory::ATTRIBUTE_INFO_ARRAY[i];
 
         if (nameLength == attributeInfo.d_nameLength &&
             0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
@@ -9506,7 +9340,8 @@ QueueUnassignedAdvisory::lookupAttributeInfo(const char* name, int nameLength)
     return 0;
 }
 
-const bdlat_AttributeInfo* QueueUnassignedAdvisory::lookupAttributeInfo(int id)
+const bdlat_AttributeInfo*
+QueueUnAssignmentAdvisory::lookupAttributeInfo(int id)
 {
     switch (id) {
     case ATTRIBUTE_ID_SEQUENCE_NUMBER:
@@ -9525,7 +9360,7 @@ const bdlat_AttributeInfo* QueueUnassignedAdvisory::lookupAttributeInfo(int id)
 
 // CREATORS
 
-QueueUnassignedAdvisory::QueueUnassignedAdvisory(
+QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
     bslma::Allocator* basicAllocator)
 : d_queues(basicAllocator)
 , d_sequenceNumber()
@@ -9535,9 +9370,9 @@ QueueUnassignedAdvisory::QueueUnassignedAdvisory(
 {
 }
 
-QueueUnassignedAdvisory::QueueUnassignedAdvisory(
-    const QueueUnassignedAdvisory& original,
-    bslma::Allocator*              basicAllocator)
+QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
+    const QueueUnAssignmentAdvisory& original,
+    bslma::Allocator*                basicAllocator)
 : d_queues(original.d_queues, basicAllocator)
 , d_sequenceNumber(original.d_sequenceNumber)
 , d_primaryLeaseId(original.d_primaryLeaseId)
@@ -9548,8 +9383,8 @@ QueueUnassignedAdvisory::QueueUnassignedAdvisory(
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnassignedAdvisory::QueueUnassignedAdvisory(
-    QueueUnassignedAdvisory&& original) noexcept
+QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
+    QueueUnAssignmentAdvisory&& original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber)),
   d_primaryLeaseId(bsl::move(original.d_primaryLeaseId)),
@@ -9558,9 +9393,9 @@ QueueUnassignedAdvisory::QueueUnassignedAdvisory(
 {
 }
 
-QueueUnassignedAdvisory::QueueUnassignedAdvisory(
-    QueueUnassignedAdvisory&& original,
-    bslma::Allocator*         basicAllocator)
+QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
+    QueueUnAssignmentAdvisory&& original,
+    bslma::Allocator*           basicAllocator)
 : d_queues(bsl::move(original.d_queues), basicAllocator)
 , d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 , d_primaryLeaseId(bsl::move(original.d_primaryLeaseId))
@@ -9570,14 +9405,14 @@ QueueUnassignedAdvisory::QueueUnassignedAdvisory(
 }
 #endif
 
-QueueUnassignedAdvisory::~QueueUnassignedAdvisory()
+QueueUnAssignmentAdvisory::~QueueUnAssignmentAdvisory()
 {
 }
 
 // MANIPULATORS
 
-QueueUnassignedAdvisory&
-QueueUnassignedAdvisory::operator=(const QueueUnassignedAdvisory& rhs)
+QueueUnAssignmentAdvisory&
+QueueUnAssignmentAdvisory::operator=(const QueueUnAssignmentAdvisory& rhs)
 {
     if (this != &rhs) {
         d_sequenceNumber = rhs.d_sequenceNumber;
@@ -9592,8 +9427,8 @@ QueueUnassignedAdvisory::operator=(const QueueUnassignedAdvisory& rhs)
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnassignedAdvisory&
-QueueUnassignedAdvisory::operator=(QueueUnassignedAdvisory&& rhs)
+QueueUnAssignmentAdvisory&
+QueueUnAssignmentAdvisory::operator=(QueueUnAssignmentAdvisory&& rhs)
 {
     if (this != &rhs) {
         d_sequenceNumber = bsl::move(rhs.d_sequenceNumber);
@@ -9607,7 +9442,7 @@ QueueUnassignedAdvisory::operator=(QueueUnassignedAdvisory&& rhs)
 }
 #endif
 
-void QueueUnassignedAdvisory::reset()
+void QueueUnAssignmentAdvisory::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_sequenceNumber);
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
@@ -9618,9 +9453,9 @@ void QueueUnassignedAdvisory::reset()
 
 // ACCESSORS
 
-bsl::ostream& QueueUnassignedAdvisory::print(bsl::ostream& stream,
-                                             int           level,
-                                             int spacesPerLevel) const
+bsl::ostream& QueueUnAssignmentAdvisory::print(bsl::ostream& stream,
+                                               int           level,
+                                               int spacesPerLevel) const
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
@@ -12458,14 +12293,14 @@ const bdlat_SelectionInfo ClusterMessageChoice::SELECTION_INFO_ARRAY[] = {
      sizeof("clusterSyncResponse") - 1,
      "",
      bdlat_FormattingMode::e_DEFAULT},
-    {SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY,
-     "queueUnAssignmentAdvisory",
-     sizeof("queueUnAssignmentAdvisory") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT},
     {SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY,
      "queueUnassignedAdvisory",
      sizeof("queueUnassignedAdvisory") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT},
+    {SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY,
+     "queueUnAssignmentAdvisory",
+     sizeof("queueUnAssignmentAdvisory") - 1,
      "",
      bdlat_FormattingMode::e_DEFAULT},
     {SELECTION_ID_LEADER_ADVISORY_ACK,
@@ -12582,12 +12417,12 @@ const bdlat_SelectionInfo* ClusterMessageChoice::lookupSelectionInfo(int id)
         return &SELECTION_INFO_ARRAY[SELECTION_INDEX_CLUSTER_SYNC_REQUEST];
     case SELECTION_ID_CLUSTER_SYNC_RESPONSE:
         return &SELECTION_INFO_ARRAY[SELECTION_INDEX_CLUSTER_SYNC_RESPONSE];
-    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
-        return &SELECTION_INFO_ARRAY
-            [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY];
     case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
         return &SELECTION_INFO_ARRAY
             [SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY];
+    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
+        return &SELECTION_INFO_ARRAY
+            [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY];
     case SELECTION_ID_LEADER_ADVISORY_ACK:
         return &SELECTION_INFO_ARRAY[SELECTION_INDEX_LEADER_ADVISORY_ACK];
     case SELECTION_ID_LEADER_ADVISORY_COMMIT:
@@ -12707,14 +12542,13 @@ ClusterMessageChoice::ClusterMessageChoice(
         new (d_clusterSyncResponse.buffer())
             DummyType(original.d_clusterSyncResponse.object());
     } break;
+    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
+        new (d_queueUnassignedAdvisory.buffer())
+            DummyType(original.d_queueUnassignedAdvisory.object());
+    } break;
     case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
         new (d_queueUnAssignmentAdvisory.buffer()) QueueUnAssignmentAdvisory(
             original.d_queueUnAssignmentAdvisory.object(),
-            d_allocator_p);
-    } break;
-    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        new (d_queueUnassignedAdvisory.buffer()) QueueUnassignedAdvisory(
-            original.d_queueUnassignedAdvisory.object(),
             d_allocator_p);
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
@@ -12854,14 +12688,13 @@ ClusterMessageChoice::ClusterMessageChoice(ClusterMessageChoice&& original)
         new (d_clusterSyncResponse.buffer())
             DummyType(bsl::move(original.d_clusterSyncResponse.object()));
     } break;
+    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
+        new (d_queueUnassignedAdvisory.buffer())
+            DummyType(bsl::move(original.d_queueUnassignedAdvisory.object()));
+    } break;
     case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
         new (d_queueUnAssignmentAdvisory.buffer()) QueueUnAssignmentAdvisory(
             bsl::move(original.d_queueUnAssignmentAdvisory.object()),
-            d_allocator_p);
-    } break;
-    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        new (d_queueUnassignedAdvisory.buffer()) QueueUnassignedAdvisory(
-            bsl::move(original.d_queueUnassignedAdvisory.object()),
             d_allocator_p);
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
@@ -13002,14 +12835,13 @@ ClusterMessageChoice::ClusterMessageChoice(ClusterMessageChoice&& original,
         new (d_clusterSyncResponse.buffer())
             DummyType(bsl::move(original.d_clusterSyncResponse.object()));
     } break;
+    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
+        new (d_queueUnassignedAdvisory.buffer())
+            DummyType(bsl::move(original.d_queueUnassignedAdvisory.object()));
+    } break;
     case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
         new (d_queueUnAssignmentAdvisory.buffer()) QueueUnAssignmentAdvisory(
             bsl::move(original.d_queueUnAssignmentAdvisory.object()),
-            d_allocator_p);
-    } break;
-    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        new (d_queueUnassignedAdvisory.buffer()) QueueUnassignedAdvisory(
-            bsl::move(original.d_queueUnassignedAdvisory.object()),
             d_allocator_p);
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
@@ -13130,13 +12962,13 @@ ClusterMessageChoice::operator=(const ClusterMessageChoice& rhs)
         case SELECTION_ID_CLUSTER_SYNC_RESPONSE: {
             makeClusterSyncResponse(rhs.d_clusterSyncResponse.object());
         } break;
-        case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
-            makeQueueUnAssignmentAdvisory(
-                rhs.d_queueUnAssignmentAdvisory.object());
-        } break;
         case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
             makeQueueUnassignedAdvisory(
                 rhs.d_queueUnassignedAdvisory.object());
+        } break;
+        case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+            makeQueueUnAssignmentAdvisory(
+                rhs.d_queueUnAssignmentAdvisory.object());
         } break;
         case SELECTION_ID_LEADER_ADVISORY_ACK: {
             makeLeaderAdvisoryAck(rhs.d_leaderAdvisoryAck.object());
@@ -13257,13 +13089,13 @@ ClusterMessageChoice::operator=(ClusterMessageChoice&& rhs)
             makeClusterSyncResponse(
                 bsl::move(rhs.d_clusterSyncResponse.object()));
         } break;
-        case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
-            makeQueueUnAssignmentAdvisory(
-                bsl::move(rhs.d_queueUnAssignmentAdvisory.object()));
-        } break;
         case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
             makeQueueUnassignedAdvisory(
                 bsl::move(rhs.d_queueUnassignedAdvisory.object()));
+        } break;
+        case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+            makeQueueUnAssignmentAdvisory(
+                bsl::move(rhs.d_queueUnAssignmentAdvisory.object()));
         } break;
         case SELECTION_ID_LEADER_ADVISORY_ACK: {
             makeLeaderAdvisoryAck(bsl::move(rhs.d_leaderAdvisoryAck.object()));
@@ -13370,11 +13202,11 @@ void ClusterMessageChoice::reset()
     case SELECTION_ID_CLUSTER_SYNC_RESPONSE: {
         d_clusterSyncResponse.object().~DummyType();
     } break;
+    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
+        d_queueUnassignedAdvisory.object().~DummyType();
+    } break;
     case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
         d_queueUnAssignmentAdvisory.object().~QueueUnAssignmentAdvisory();
-    } break;
-    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        d_queueUnassignedAdvisory.object().~QueueUnassignedAdvisory();
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
         d_leaderAdvisoryAck.object().~LeaderAdvisoryAck();
@@ -13469,11 +13301,11 @@ int ClusterMessageChoice::makeSelection(int selectionId)
     case SELECTION_ID_CLUSTER_SYNC_RESPONSE: {
         makeClusterSyncResponse();
     } break;
-    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
-        makeQueueUnAssignmentAdvisory();
-    } break;
     case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
         makeQueueUnassignedAdvisory();
+    } break;
+    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        makeQueueUnAssignmentAdvisory();
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
         makeLeaderAdvisoryAck();
@@ -14465,6 +14297,52 @@ DummyType& ClusterMessageChoice::makeClusterSyncResponse(DummyType&& value)
 }
 #endif
 
+DummyType& ClusterMessageChoice::makeQueueUnassignedAdvisory()
+{
+    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
+        bdlat_ValueTypeFunctions::reset(&d_queueUnassignedAdvisory.object());
+    }
+    else {
+        reset();
+        new (d_queueUnassignedAdvisory.buffer()) DummyType();
+        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
+    }
+
+    return d_queueUnassignedAdvisory.object();
+}
+
+DummyType&
+ClusterMessageChoice::makeQueueUnassignedAdvisory(const DummyType& value)
+{
+    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
+        d_queueUnassignedAdvisory.object() = value;
+    }
+    else {
+        reset();
+        new (d_queueUnassignedAdvisory.buffer()) DummyType(value);
+        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
+    }
+
+    return d_queueUnassignedAdvisory.object();
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+DummyType& ClusterMessageChoice::makeQueueUnassignedAdvisory(DummyType&& value)
+{
+    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
+        d_queueUnassignedAdvisory.object() = bsl::move(value);
+    }
+    else {
+        reset();
+        new (d_queueUnassignedAdvisory.buffer()) DummyType(bsl::move(value));
+        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
+    }
+
+    return d_queueUnassignedAdvisory.object();
+}
+#endif
+
 QueueUnAssignmentAdvisory&
 ClusterMessageChoice::makeQueueUnAssignmentAdvisory()
 {
@@ -14513,56 +14391,6 @@ QueueUnAssignmentAdvisory& ClusterMessageChoice::makeQueueUnAssignmentAdvisory(
     }
 
     return d_queueUnAssignmentAdvisory.object();
-}
-#endif
-
-QueueUnassignedAdvisory& ClusterMessageChoice::makeQueueUnassignedAdvisory()
-{
-    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
-        bdlat_ValueTypeFunctions::reset(&d_queueUnassignedAdvisory.object());
-    }
-    else {
-        reset();
-        new (d_queueUnassignedAdvisory.buffer())
-            QueueUnassignedAdvisory(d_allocator_p);
-        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
-    }
-
-    return d_queueUnassignedAdvisory.object();
-}
-
-QueueUnassignedAdvisory& ClusterMessageChoice::makeQueueUnassignedAdvisory(
-    const QueueUnassignedAdvisory& value)
-{
-    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
-        d_queueUnassignedAdvisory.object() = value;
-    }
-    else {
-        reset();
-        new (d_queueUnassignedAdvisory.buffer())
-            QueueUnassignedAdvisory(value, d_allocator_p);
-        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
-    }
-
-    return d_queueUnassignedAdvisory.object();
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnassignedAdvisory& ClusterMessageChoice::makeQueueUnassignedAdvisory(
-    QueueUnassignedAdvisory&& value)
-{
-    if (SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId) {
-        d_queueUnassignedAdvisory.object() = bsl::move(value);
-    }
-    else {
-        reset();
-        new (d_queueUnassignedAdvisory.buffer())
-            QueueUnassignedAdvisory(bsl::move(value), d_allocator_p);
-        d_selectionId = SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY;
-    }
-
-    return d_queueUnassignedAdvisory.object();
 }
 #endif
 
@@ -15081,13 +14909,13 @@ bsl::ostream& ClusterMessageChoice::print(bsl::ostream& stream,
         printer.printAttribute("clusterSyncResponse",
                                d_clusterSyncResponse.object());
     } break;
-    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
-        printer.printAttribute("queueUnAssignmentAdvisory",
-                               d_queueUnAssignmentAdvisory.object());
-    } break;
     case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
         printer.printAttribute("queueUnassignedAdvisory",
                                d_queueUnassignedAdvisory.object());
+    } break;
+    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        printer.printAttribute("queueUnAssignmentAdvisory",
+                               d_queueUnAssignmentAdvisory.object());
     } break;
     case SELECTION_ID_LEADER_ADVISORY_ACK: {
         printer.printAttribute("leaderAdvisoryAck",
@@ -15193,13 +15021,13 @@ const char* ClusterMessageChoice::selectionName() const
     case SELECTION_ID_CLUSTER_SYNC_RESPONSE:
         return SELECTION_INFO_ARRAY[SELECTION_INDEX_CLUSTER_SYNC_RESPONSE]
             .name();
+    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
+        return SELECTION_INFO_ARRAY[SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY]
+            .name();
     case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
         return SELECTION_INFO_ARRAY
             [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY]
                 .name();
-    case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
-        return SELECTION_INFO_ARRAY[SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY]
-            .name();
     case SELECTION_ID_LEADER_ADVISORY_ACK:
         return SELECTION_INFO_ARRAY[SELECTION_INDEX_LEADER_ADVISORY_ACK]
             .name();
@@ -15362,13 +15190,13 @@ ClusterMessage::lookupAttributeInfo(const char* name, int nameLength)
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CHOICE];
     }
 
-    if (bdlb::String::areEqualCaseless("queueUnAssignmentAdvisory",
+    if (bdlb::String::areEqualCaseless("queueUnassignedAdvisory",
                                        name,
                                        nameLength)) {
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CHOICE];
     }
 
-    if (bdlb::String::areEqualCaseless("queueUnassignedAdvisory",
+    if (bdlb::String::areEqualCaseless("queueUnAssignmentAdvisory",
                                        name,
                                        nameLength)) {
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CHOICE];

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -276,9 +276,6 @@ namespace bmqp_ctrlmsg {
 class QueueUnAssignmentAdvisory;
 }
 namespace bmqp_ctrlmsg {
-class QueueUnassignedAdvisory;
-}
-namespace bmqp_ctrlmsg {
 class QueueUpdateAdvisory;
 }
 namespace bmqp_ctrlmsg {
@@ -15904,16 +15901,18 @@ namespace bmqp_ctrlmsg {
 // ===============================
 
 class QueueUnAssignmentAdvisory {
-    // This type represents a one way message sent by the primary of a
-    // partition to all peers when queues are unmapped from that partition.
-    // NOTE: The 'partitionId' member of 'QueueInfo' is unused (superseeded by
-    // the 'partitionId' at this level of the data structure).
+    // This type represents a one way message sent by the leader to all peers
+    // when queues are unmapped from that partition.  Once the logic is updated
+    // such that leader broadcasts queue unassigned advisories, primary node
+    // will no longer broadcastthem, and the other similar type
+    // 'QueueUnAssignmentAdvisory' will be removed.
 
     // INSTANCE DATA
     bsl::vector<QueueInfo> d_queues;
+    LeaderMessageSequence  d_sequenceNumber;
     unsigned int           d_primaryLeaseId;
-    int                    d_primaryNodeId;
     int                    d_partitionId;
+    int                    d_primaryNodeId;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
@@ -15924,19 +15923,21 @@ class QueueUnAssignmentAdvisory {
   public:
     // TYPES
     enum {
-        ATTRIBUTE_ID_PRIMARY_NODE_ID  = 0,
-        ATTRIBUTE_ID_PRIMARY_LEASE_ID = 1,
-        ATTRIBUTE_ID_PARTITION_ID     = 2,
-        ATTRIBUTE_ID_QUEUES           = 3
+        ATTRIBUTE_ID_SEQUENCE_NUMBER  = 0,
+        ATTRIBUTE_ID_PARTITION_ID     = 1,
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID = 2,
+        ATTRIBUTE_ID_PRIMARY_NODE_ID  = 3,
+        ATTRIBUTE_ID_QUEUES           = 4
     };
 
-    enum { NUM_ATTRIBUTES = 4 };
+    enum { NUM_ATTRIBUTES = 5 };
 
     enum {
-        ATTRIBUTE_INDEX_PRIMARY_NODE_ID  = 0,
-        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID = 1,
-        ATTRIBUTE_INDEX_PARTITION_ID     = 2,
-        ATTRIBUTE_INDEX_QUEUES           = 3
+        ATTRIBUTE_INDEX_SEQUENCE_NUMBER  = 0,
+        ATTRIBUTE_INDEX_PARTITION_ID     = 1,
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID = 2,
+        ATTRIBUTE_INDEX_PRIMARY_NODE_ID  = 3,
+        ATTRIBUTE_INDEX_QUEUES           = 4
     };
 
     // CONSTANTS
@@ -15998,265 +15999,6 @@ class QueueUnAssignmentAdvisory {
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
     QueueUnAssignmentAdvisory& operator=(QueueUnAssignmentAdvisory&& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-    // After performing this action, the 'rhs' object will be left in a
-    // valid, but unspecified state.
-#endif
-
-    void reset();
-    // Reset this object to the default value (i.e., its value upon
-    // default construction).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttributes(t_MANIPULATOR& manipulator);
-    // Invoke the specified 'manipulator' sequentially on the address of
-    // each (modifiable) attribute of this object, supplying 'manipulator'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'manipulator' (i.e., the invocation that
-    // terminated the sequence).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'id',
-    // supplying 'manipulator' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'manipulator' if 'id' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator,
-                            const char*    name,
-                            int            nameLength);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'name' of the
-    // specified 'nameLength', supplying 'manipulator' with the
-    // corresponding attribute information structure.  Return the value
-    // returned from the invocation of 'manipulator' if 'name' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    int& primaryNodeId();
-    // Return a reference to the modifiable "PrimaryNodeId" attribute of
-    // this object.
-
-    unsigned int& primaryLeaseId();
-    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
-    // this object.
-
-    int& partitionId();
-    // Return a reference to the modifiable "PartitionId" attribute of this
-    // object.
-
-    bsl::vector<QueueInfo>& queues();
-    // Return a reference to the modifiable "Queues" attribute of this
-    // object.
-
-    // ACCESSORS
-    bsl::ostream&
-    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
-    // Format this object to the specified output 'stream' at the
-    // optionally specified indentation 'level' and return a reference to
-    // the modifiable 'stream'.  If 'level' is specified, optionally
-    // specify 'spacesPerLevel', the number of spaces per indentation level
-    // for this and all of its nested objects.  Each line is indented by
-    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    // negative, suppress indentation of the first line.  If
-    // 'spacesPerLevel' is negative, suppress line breaks and format the
-    // entire output on one line.  If 'stream' is initially invalid, this
-    // operation has no effect.  Note that a trailing newline is provided
-    // in multiline mode only.
-
-    template <typename t_ACCESSOR>
-    int accessAttributes(t_ACCESSOR& accessor) const;
-    // Invoke the specified 'accessor' sequentially on each
-    // (non-modifiable) attribute of this object, supplying 'accessor'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'accessor' (i.e., the invocation that terminated
-    // the sequence).
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor, int id) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'id', supplying 'accessor'
-    // with the corresponding attribute information structure.  Return the
-    // value returned from the invocation of 'accessor' if 'id' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor,
-                        const char* name,
-                        int         nameLength) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'name' of the specified
-    // 'nameLength', supplying 'accessor' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'accessor' if 'name' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    int primaryNodeId() const;
-    // Return the value of the "PrimaryNodeId" attribute of this object.
-
-    unsigned int primaryLeaseId() const;
-    // Return the value of the "PrimaryLeaseId" attribute of this object.
-
-    int partitionId() const;
-    // Return the value of the "PartitionId" attribute of this object.
-
-    const bsl::vector<QueueInfo>& queues() const;
-    // Return a reference offering non-modifiable access to the "Queues"
-    // attribute of this object.
-
-    // HIDDEN FRIENDS
-    friend bool operator==(const QueueUnAssignmentAdvisory& lhs,
-                           const QueueUnAssignmentAdvisory& rhs)
-    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
-    // have the same value, and 'false' otherwise.  Two attribute objects
-    // have the same value if each respective attribute has the same value.
-    {
-        return lhs.isEqualTo(rhs);
-    }
-
-    friend bool operator!=(const QueueUnAssignmentAdvisory& lhs,
-                           const QueueUnAssignmentAdvisory& rhs)
-    // Returns '!(lhs == rhs)'
-    {
-        return !(lhs == rhs);
-    }
-
-    friend bsl::ostream& operator<<(bsl::ostream&                    stream,
-                                    const QueueUnAssignmentAdvisory& rhs)
-    // Format the specified 'rhs' to the specified output 'stream' and
-    // return a reference to the modifiable 'stream'.
-    {
-        return rhs.print(stream, 0, -1);
-    }
-
-    template <typename t_HASH_ALGORITHM>
-    friend void hashAppend(t_HASH_ALGORITHM&                hashAlg,
-                           const QueueUnAssignmentAdvisory& object)
-    // Pass the specified 'object' to the specified 'hashAlg'.  This
-    // function integrates with the 'bslh' modular hashing system and
-    // effectively provides a 'bsl::hash' specialization for
-    // 'QueueUnAssignmentAdvisory'.
-    {
-        object.hashAppendImpl(hashAlg);
-    }
-};
-
-}  // close package namespace
-
-// TRAITS
-
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueUnAssignmentAdvisory)
-
-namespace bmqp_ctrlmsg {
-
-// =============================
-// class QueueUnassignedAdvisory
-// =============================
-
-class QueueUnassignedAdvisory {
-    // This type represents a one way message sent by the leader to all peers
-    // when queues are unmapped from that partition.  Once the logic is updated
-    // such that leader broadcasts queue unassigned advisories, primary node
-    // will no longer broadcastthem, and the other similar type
-    // 'QueueUnAssignmentAdvisory' will be removed.
-
-    // INSTANCE DATA
-    bsl::vector<QueueInfo> d_queues;
-    LeaderMessageSequence  d_sequenceNumber;
-    unsigned int           d_primaryLeaseId;
-    int                    d_partitionId;
-    int                    d_primaryNodeId;
-
-    // PRIVATE ACCESSORS
-    template <typename t_HASH_ALGORITHM>
-    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
-
-    bool isEqualTo(const QueueUnassignedAdvisory& rhs) const;
-
-  public:
-    // TYPES
-    enum {
-        ATTRIBUTE_ID_SEQUENCE_NUMBER  = 0,
-        ATTRIBUTE_ID_PARTITION_ID     = 1,
-        ATTRIBUTE_ID_PRIMARY_LEASE_ID = 2,
-        ATTRIBUTE_ID_PRIMARY_NODE_ID  = 3,
-        ATTRIBUTE_ID_QUEUES           = 4
-    };
-
-    enum { NUM_ATTRIBUTES = 5 };
-
-    enum {
-        ATTRIBUTE_INDEX_SEQUENCE_NUMBER  = 0,
-        ATTRIBUTE_INDEX_PARTITION_ID     = 1,
-        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID = 2,
-        ATTRIBUTE_INDEX_PRIMARY_NODE_ID  = 3,
-        ATTRIBUTE_INDEX_QUEUES           = 4
-    };
-
-    // CONSTANTS
-    static const char CLASS_NAME[];
-
-    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
-
-  public:
-    // CLASS METHODS
-    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
-    // Return attribute information for the attribute indicated by the
-    // specified 'id' if the attribute exists, and 0 otherwise.
-
-    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
-                                                          int nameLength);
-    // Return attribute information for the attribute indicated by the
-    // specified 'name' of the specified 'nameLength' if the attribute
-    // exists, and 0 otherwise.
-
-    // CREATORS
-    explicit QueueUnassignedAdvisory(bslma::Allocator* basicAllocator = 0);
-    // Create an object of type 'QueueUnassignedAdvisory' having the
-    // default value.  Use the optionally specified 'basicAllocator' to
-    // supply memory.  If 'basicAllocator' is 0, the currently installed
-    // default allocator is used.
-
-    QueueUnassignedAdvisory(const QueueUnassignedAdvisory& original,
-                            bslma::Allocator*              basicAllocator = 0);
-    // Create an object of type 'QueueUnassignedAdvisory' having the value
-    // of the specified 'original' object.  Use the optionally specified
-    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
-    // currently installed default allocator is used.
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    QueueUnassignedAdvisory(QueueUnassignedAdvisory&& original) noexcept;
-    // Create an object of type 'QueueUnassignedAdvisory' having the value
-    // of the specified 'original' object.  After performing this action,
-    // the 'original' object will be left in a valid, but unspecified
-    // state.
-
-    QueueUnassignedAdvisory(QueueUnassignedAdvisory&& original,
-                            bslma::Allocator*         basicAllocator);
-    // Create an object of type 'QueueUnassignedAdvisory' having the value
-    // of the specified 'original' object.  After performing this action,
-    // the 'original' object will be left in a valid, but unspecified
-    // state.  Use the optionally specified 'basicAllocator' to supply
-    // memory.  If 'basicAllocator' is 0, the currently installed default
-    // allocator is used.
-#endif
-
-    ~QueueUnassignedAdvisory();
-    // Destroy this object.
-
-    // MANIPULATORS
-    QueueUnassignedAdvisory& operator=(const QueueUnassignedAdvisory& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    QueueUnassignedAdvisory& operator=(QueueUnassignedAdvisory&& rhs);
     // Assign to this object the value of the specified 'rhs' object.
     // After performing this action, the 'rhs' object will be left in a
     // valid, but unspecified state.
@@ -16376,8 +16118,8 @@ class QueueUnassignedAdvisory {
     // attribute of this object.
 
     // HIDDEN FRIENDS
-    friend bool operator==(const QueueUnassignedAdvisory& lhs,
-                           const QueueUnassignedAdvisory& rhs)
+    friend bool operator==(const QueueUnAssignmentAdvisory& lhs,
+                           const QueueUnAssignmentAdvisory& rhs)
     // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
@@ -16385,15 +16127,15 @@ class QueueUnassignedAdvisory {
         return lhs.isEqualTo(rhs);
     }
 
-    friend bool operator!=(const QueueUnassignedAdvisory& lhs,
-                           const QueueUnassignedAdvisory& rhs)
+    friend bool operator!=(const QueueUnAssignmentAdvisory& lhs,
+                           const QueueUnAssignmentAdvisory& rhs)
     // Returns '!(lhs == rhs)'
     {
         return !(lhs == rhs);
     }
 
-    friend bsl::ostream& operator<<(bsl::ostream&                  stream,
-                                    const QueueUnassignedAdvisory& rhs)
+    friend bsl::ostream& operator<<(bsl::ostream&                    stream,
+                                    const QueueUnAssignmentAdvisory& rhs)
     // Format the specified 'rhs' to the specified output 'stream' and
     // return a reference to the modifiable 'stream'.
     {
@@ -16401,12 +16143,12 @@ class QueueUnassignedAdvisory {
     }
 
     template <typename t_HASH_ALGORITHM>
-    friend void hashAppend(t_HASH_ALGORITHM&              hashAlg,
-                           const QueueUnassignedAdvisory& object)
+    friend void hashAppend(t_HASH_ALGORITHM&                hashAlg,
+                           const QueueUnAssignmentAdvisory& object)
     // Pass the specified 'object' to the specified 'hashAlg'.  This
     // function integrates with the 'bslh' modular hashing system and
     // effectively provides a 'bsl::hash' specialization for
-    // 'QueueUnassignedAdvisory'.
+    // 'QueueUnAssignmentAdvisory'.
     {
         object.hashAppendImpl(hashAlg);
     }
@@ -16417,7 +16159,7 @@ class QueueUnassignedAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueUnassignedAdvisory)
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory)
 
 namespace bmqp_ctrlmsg {
 
@@ -19960,14 +19702,14 @@ class ClusterMessageChoice {
         bsls::ObjectBuffer<PrimaryStatusAdvisory> d_primaryStatusAdvisory;
         bsls::ObjectBuffer<DummyType>             d_clusterSyncRequest;
         bsls::ObjectBuffer<DummyType>             d_clusterSyncResponse;
+        bsls::ObjectBuffer<DummyType>             d_queueUnassignedAdvisory;
         bsls::ObjectBuffer<QueueUnAssignmentAdvisory>
-            d_queueUnAssignmentAdvisory;
-        bsls::ObjectBuffer<QueueUnassignedAdvisory> d_queueUnassignedAdvisory;
-        bsls::ObjectBuffer<LeaderAdvisoryAck>       d_leaderAdvisoryAck;
-        bsls::ObjectBuffer<LeaderAdvisoryCommit>    d_leaderAdvisoryCommit;
-        bsls::ObjectBuffer<StateNotification>       d_stateNotification;
-        bsls::ObjectBuffer<StopRequest>             d_stopRequest;
-        bsls::ObjectBuffer<StopResponse>            d_stopResponse;
+                                                 d_queueUnAssignmentAdvisory;
+        bsls::ObjectBuffer<LeaderAdvisoryAck>    d_leaderAdvisoryAck;
+        bsls::ObjectBuffer<LeaderAdvisoryCommit> d_leaderAdvisoryCommit;
+        bsls::ObjectBuffer<StateNotification>    d_stateNotification;
+        bsls::ObjectBuffer<StopRequest>          d_stopRequest;
+        bsls::ObjectBuffer<StopResponse>         d_stopResponse;
         bsls::ObjectBuffer<QueueUnassignmentRequest>
                                                    d_queueUnassignmentRequest;
         bsls::ObjectBuffer<QueueUpdateAdvisory>    d_queueUpdateAdvisory;
@@ -20008,8 +19750,8 @@ class ClusterMessageChoice {
         SELECTION_ID_PRIMARY_STATUS_ADVISORY             = 16,
         SELECTION_ID_CLUSTER_SYNC_REQUEST                = 17,
         SELECTION_ID_CLUSTER_SYNC_RESPONSE               = 18,
-        SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY        = 19,
-        SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY           = 20,
+        SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY           = 19,
+        SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY        = 20,
         SELECTION_ID_LEADER_ADVISORY_ACK                 = 21,
         SELECTION_ID_LEADER_ADVISORY_COMMIT              = 22,
         SELECTION_ID_STATE_NOTIFICATION                  = 23,
@@ -20043,8 +19785,8 @@ class ClusterMessageChoice {
         SELECTION_INDEX_PRIMARY_STATUS_ADVISORY             = 16,
         SELECTION_INDEX_CLUSTER_SYNC_REQUEST                = 17,
         SELECTION_INDEX_CLUSTER_SYNC_RESPONSE               = 18,
-        SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY        = 19,
-        SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY           = 20,
+        SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY           = 19,
+        SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY        = 20,
         SELECTION_INDEX_LEADER_ADVISORY_ACK                 = 21,
         SELECTION_INDEX_LEADER_ADVISORY_COMMIT              = 22,
         SELECTION_INDEX_STATE_NOTIFICATION                  = 23,
@@ -20371,6 +20113,17 @@ class ClusterMessageChoice {
     // 'value' is not specified, the default "ClusterSyncResponse" value is
     // used.
 
+    DummyType& makeQueueUnassignedAdvisory();
+    DummyType& makeQueueUnassignedAdvisory(const DummyType& value);
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    DummyType& makeQueueUnassignedAdvisory(DummyType&& value);
+#endif
+    // Set the value of this object to be a "QueueUnassignedAdvisory"
+    // value.  Optionally specify the 'value' of the
+    // "QueueUnassignedAdvisory".  If 'value' is not specified, the default
+    // "QueueUnassignedAdvisory" value is used.
+
     QueueUnAssignmentAdvisory& makeQueueUnAssignmentAdvisory();
     QueueUnAssignmentAdvisory&
     makeQueueUnAssignmentAdvisory(const QueueUnAssignmentAdvisory& value);
@@ -20383,19 +20136,6 @@ class ClusterMessageChoice {
     // value.  Optionally specify the 'value' of the
     // "QueueUnAssignmentAdvisory".  If 'value' is not specified, the
     // default "QueueUnAssignmentAdvisory" value is used.
-
-    QueueUnassignedAdvisory& makeQueueUnassignedAdvisory();
-    QueueUnassignedAdvisory&
-    makeQueueUnassignedAdvisory(const QueueUnassignedAdvisory& value);
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    QueueUnassignedAdvisory&
-    makeQueueUnassignedAdvisory(QueueUnassignedAdvisory&& value);
-#endif
-    // Set the value of this object to be a "QueueUnassignedAdvisory"
-    // value.  Optionally specify the 'value' of the
-    // "QueueUnassignedAdvisory".  If 'value' is not specified, the default
-    // "QueueUnassignedAdvisory" value is used.
 
     LeaderAdvisoryAck& makeLeaderAdvisoryAck();
     LeaderAdvisoryAck& makeLeaderAdvisoryAck(const LeaderAdvisoryAck& value);
@@ -20625,17 +20365,17 @@ class ClusterMessageChoice {
     // The behavior is undefined unless "ClusterSyncResponse" is the
     // selection of this object.
 
+    DummyType& queueUnassignedAdvisory();
+    // Return a reference to the modifiable "QueueUnassignedAdvisory"
+    // selection of this object if "QueueUnassignedAdvisory" is the current
+    // selection.  The behavior is undefined unless
+    // "QueueUnassignedAdvisory" is the selection of this object.
+
     QueueUnAssignmentAdvisory& queueUnAssignmentAdvisory();
     // Return a reference to the modifiable "QueueUnAssignmentAdvisory"
     // selection of this object if "QueueUnAssignmentAdvisory" is the
     // current selection.  The behavior is undefined unless
     // "QueueUnAssignmentAdvisory" is the selection of this object.
-
-    QueueUnassignedAdvisory& queueUnassignedAdvisory();
-    // Return a reference to the modifiable "QueueUnassignedAdvisory"
-    // selection of this object if "QueueUnassignedAdvisory" is the current
-    // selection.  The behavior is undefined unless
-    // "QueueUnassignedAdvisory" is the selection of this object.
 
     LeaderAdvisoryAck& leaderAdvisoryAck();
     // Return a reference to the modifiable "LeaderAdvisoryAck" selection
@@ -20837,17 +20577,17 @@ class ClusterMessageChoice {
     // selection.  The behavior is undefined unless "ClusterSyncResponse"
     // is the selection of this object.
 
+    const DummyType& queueUnassignedAdvisory() const;
+    // Return a reference to the non-modifiable "QueueUnassignedAdvisory"
+    // selection of this object if "QueueUnassignedAdvisory" is the current
+    // selection.  The behavior is undefined unless
+    // "QueueUnassignedAdvisory" is the selection of this object.
+
     const QueueUnAssignmentAdvisory& queueUnAssignmentAdvisory() const;
     // Return a reference to the non-modifiable "QueueUnAssignmentAdvisory"
     // selection of this object if "QueueUnAssignmentAdvisory" is the
     // current selection.  The behavior is undefined unless
     // "QueueUnAssignmentAdvisory" is the selection of this object.
-
-    const QueueUnassignedAdvisory& queueUnassignedAdvisory() const;
-    // Return a reference to the non-modifiable "QueueUnassignedAdvisory"
-    // selection of this object if "QueueUnassignedAdvisory" is the current
-    // selection.  The behavior is undefined unless
-    // "QueueUnassignedAdvisory" is the selection of this object.
 
     const LeaderAdvisoryAck& leaderAdvisoryAck() const;
     // Return a reference to the non-modifiable "LeaderAdvisoryAck"
@@ -20980,13 +20720,13 @@ class ClusterMessageChoice {
     // Return 'true' if the value of this object is a "ClusterSyncResponse"
     // value, and return 'false' otherwise.
 
-    bool isQueueUnAssignmentAdvisoryValue() const;
-    // Return 'true' if the value of this object is a
-    // "QueueUnAssignmentAdvisory" value, and return 'false' otherwise.
-
     bool isQueueUnassignedAdvisoryValue() const;
     // Return 'true' if the value of this object is a
     // "QueueUnassignedAdvisory" value, and return 'false' otherwise.
+
+    bool isQueueUnAssignmentAdvisoryValue() const;
+    // Return 'true' if the value of this object is a
+    // "QueueUnAssignmentAdvisory" value, and return 'false' otherwise.
 
     bool isLeaderAdvisoryAckValue() const;
     // Return 'true' if the value of this object is a "LeaderAdvisoryAck"
@@ -33063,225 +32803,6 @@ void QueueUnAssignmentAdvisory::hashAppendImpl(
     t_HASH_ALGORITHM& hashAlgorithm) const
 {
     using bslh::hashAppend;
-    hashAppend(hashAlgorithm, this->primaryNodeId());
-    hashAppend(hashAlgorithm, this->primaryLeaseId());
-    hashAppend(hashAlgorithm, this->partitionId());
-    hashAppend(hashAlgorithm, this->queues());
-}
-
-inline bool QueueUnAssignmentAdvisory::isEqualTo(
-    const QueueUnAssignmentAdvisory& rhs) const
-{
-    return this->primaryNodeId() == rhs.primaryNodeId() &&
-           this->primaryLeaseId() == rhs.primaryLeaseId() &&
-           this->partitionId() == rhs.partitionId() &&
-           this->queues() == rhs.queues();
-}
-
-// CLASS METHODS
-// MANIPULATORS
-template <typename t_MANIPULATOR>
-int QueueUnAssignmentAdvisory::manipulateAttributes(t_MANIPULATOR& manipulator)
-{
-    int ret;
-
-    ret = manipulator(&d_primaryNodeId,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_NODE_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_primaryLeaseId,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_partitionId,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_queues, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUES]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
-}
-
-template <typename t_MANIPULATOR>
-int QueueUnAssignmentAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                                   int            id)
-{
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_PRIMARY_NODE_ID: {
-        return manipulator(
-            &d_primaryNodeId,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_NODE_ID]);
-    }
-    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
-        return manipulator(
-            &d_primaryLeaseId,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return manipulator(&d_partitionId,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
-    }
-    case ATTRIBUTE_ID_QUEUES: {
-        return manipulator(&d_queues,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUES]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_MANIPULATOR>
-int QueueUnAssignmentAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                                   const char*    name,
-                                                   int            nameLength)
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return manipulateAttribute(manipulator, attributeInfo->d_id);
-}
-
-inline int& QueueUnAssignmentAdvisory::primaryNodeId()
-{
-    return d_primaryNodeId;
-}
-
-inline unsigned int& QueueUnAssignmentAdvisory::primaryLeaseId()
-{
-    return d_primaryLeaseId;
-}
-
-inline int& QueueUnAssignmentAdvisory::partitionId()
-{
-    return d_partitionId;
-}
-
-inline bsl::vector<QueueInfo>& QueueUnAssignmentAdvisory::queues()
-{
-    return d_queues;
-}
-
-// ACCESSORS
-template <typename t_ACCESSOR>
-int QueueUnAssignmentAdvisory::accessAttributes(t_ACCESSOR& accessor) const
-{
-    int ret;
-
-    ret = accessor(d_primaryNodeId,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_NODE_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_primaryLeaseId,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_partitionId,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_queues, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUES]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
-}
-
-template <typename t_ACCESSOR>
-int QueueUnAssignmentAdvisory::accessAttribute(t_ACCESSOR& accessor,
-                                               int         id) const
-{
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_PRIMARY_NODE_ID: {
-        return accessor(d_primaryNodeId,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_NODE_ID]);
-    }
-    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
-        return accessor(
-            d_primaryLeaseId,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return accessor(d_partitionId,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
-    }
-    case ATTRIBUTE_ID_QUEUES: {
-        return accessor(d_queues,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_QUEUES]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_ACCESSOR>
-int QueueUnAssignmentAdvisory::accessAttribute(t_ACCESSOR& accessor,
-                                               const char* name,
-                                               int         nameLength) const
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return accessAttribute(accessor, attributeInfo->d_id);
-}
-
-inline int QueueUnAssignmentAdvisory::primaryNodeId() const
-{
-    return d_primaryNodeId;
-}
-
-inline unsigned int QueueUnAssignmentAdvisory::primaryLeaseId() const
-{
-    return d_primaryLeaseId;
-}
-
-inline int QueueUnAssignmentAdvisory::partitionId() const
-{
-    return d_partitionId;
-}
-
-inline const bsl::vector<QueueInfo>& QueueUnAssignmentAdvisory::queues() const
-{
-    return d_queues;
-}
-
-// -----------------------------
-// class QueueUnassignedAdvisory
-// -----------------------------
-
-// PRIVATE ACCESSORS
-template <typename t_HASH_ALGORITHM>
-void QueueUnassignedAdvisory::hashAppendImpl(
-    t_HASH_ALGORITHM& hashAlgorithm) const
-{
-    using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->sequenceNumber());
     hashAppend(hashAlgorithm, this->partitionId());
     hashAppend(hashAlgorithm, this->primaryLeaseId());
@@ -33289,8 +32810,8 @@ void QueueUnassignedAdvisory::hashAppendImpl(
     hashAppend(hashAlgorithm, this->queues());
 }
 
-inline bool
-QueueUnassignedAdvisory::isEqualTo(const QueueUnassignedAdvisory& rhs) const
+inline bool QueueUnAssignmentAdvisory::isEqualTo(
+    const QueueUnAssignmentAdvisory& rhs) const
 {
     return this->sequenceNumber() == rhs.sequenceNumber() &&
            this->partitionId() == rhs.partitionId() &&
@@ -33302,7 +32823,7 @@ QueueUnassignedAdvisory::isEqualTo(const QueueUnassignedAdvisory& rhs) const
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int QueueUnassignedAdvisory::manipulateAttributes(t_MANIPULATOR& manipulator)
+int QueueUnAssignmentAdvisory::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
     int ret;
 
@@ -33339,8 +32860,8 @@ int QueueUnassignedAdvisory::manipulateAttributes(t_MANIPULATOR& manipulator)
 }
 
 template <typename t_MANIPULATOR>
-int QueueUnassignedAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                                 int            id)
+int QueueUnAssignmentAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                                   int            id)
 {
     enum { NOT_FOUND = -1 };
 
@@ -33373,9 +32894,9 @@ int QueueUnassignedAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
 }
 
 template <typename t_MANIPULATOR>
-int QueueUnassignedAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                                 const char*    name,
-                                                 int            nameLength)
+int QueueUnAssignmentAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                                   const char*    name,
+                                                   int            nameLength)
 {
     enum { NOT_FOUND = -1 };
 
@@ -33388,34 +32909,34 @@ int QueueUnassignedAdvisory::manipulateAttribute(t_MANIPULATOR& manipulator,
     return manipulateAttribute(manipulator, attributeInfo->d_id);
 }
 
-inline LeaderMessageSequence& QueueUnassignedAdvisory::sequenceNumber()
+inline LeaderMessageSequence& QueueUnAssignmentAdvisory::sequenceNumber()
 {
     return d_sequenceNumber;
 }
 
-inline int& QueueUnassignedAdvisory::partitionId()
+inline int& QueueUnAssignmentAdvisory::partitionId()
 {
     return d_partitionId;
 }
 
-inline unsigned int& QueueUnassignedAdvisory::primaryLeaseId()
+inline unsigned int& QueueUnAssignmentAdvisory::primaryLeaseId()
 {
     return d_primaryLeaseId;
 }
 
-inline int& QueueUnassignedAdvisory::primaryNodeId()
+inline int& QueueUnAssignmentAdvisory::primaryNodeId()
 {
     return d_primaryNodeId;
 }
 
-inline bsl::vector<QueueInfo>& QueueUnassignedAdvisory::queues()
+inline bsl::vector<QueueInfo>& QueueUnAssignmentAdvisory::queues()
 {
     return d_queues;
 }
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int QueueUnassignedAdvisory::accessAttributes(t_ACCESSOR& accessor) const
+int QueueUnAssignmentAdvisory::accessAttributes(t_ACCESSOR& accessor) const
 {
     int ret;
 
@@ -33452,8 +32973,8 @@ int QueueUnassignedAdvisory::accessAttributes(t_ACCESSOR& accessor) const
 }
 
 template <typename t_ACCESSOR>
-int QueueUnassignedAdvisory::accessAttribute(t_ACCESSOR& accessor,
-                                             int         id) const
+int QueueUnAssignmentAdvisory::accessAttribute(t_ACCESSOR& accessor,
+                                               int         id) const
 {
     enum { NOT_FOUND = -1 };
 
@@ -33484,9 +33005,9 @@ int QueueUnassignedAdvisory::accessAttribute(t_ACCESSOR& accessor,
 }
 
 template <typename t_ACCESSOR>
-int QueueUnassignedAdvisory::accessAttribute(t_ACCESSOR& accessor,
-                                             const char* name,
-                                             int         nameLength) const
+int QueueUnAssignmentAdvisory::accessAttribute(t_ACCESSOR& accessor,
+                                               const char* name,
+                                               int         nameLength) const
 {
     enum { NOT_FOUND = -1 };
 
@@ -33500,27 +33021,27 @@ int QueueUnassignedAdvisory::accessAttribute(t_ACCESSOR& accessor,
 }
 
 inline const LeaderMessageSequence&
-QueueUnassignedAdvisory::sequenceNumber() const
+QueueUnAssignmentAdvisory::sequenceNumber() const
 {
     return d_sequenceNumber;
 }
 
-inline int QueueUnassignedAdvisory::partitionId() const
+inline int QueueUnAssignmentAdvisory::partitionId() const
 {
     return d_partitionId;
 }
 
-inline unsigned int QueueUnassignedAdvisory::primaryLeaseId() const
+inline unsigned int QueueUnAssignmentAdvisory::primaryLeaseId() const
 {
     return d_primaryLeaseId;
 }
 
-inline int QueueUnassignedAdvisory::primaryNodeId() const
+inline int QueueUnAssignmentAdvisory::primaryNodeId() const
 {
     return d_primaryNodeId;
 }
 
-inline const bsl::vector<QueueInfo>& QueueUnassignedAdvisory::queues() const
+inline const bsl::vector<QueueInfo>& QueueUnAssignmentAdvisory::queues() const
 {
     return d_queues;
 }
@@ -35737,11 +35258,11 @@ void ClusterMessageChoice::hashAppendImpl(
     case Class::SELECTION_ID_CLUSTER_SYNC_RESPONSE:
         hashAppend(hashAlgorithm, this->clusterSyncResponse());
         break;
-    case Class::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
-        hashAppend(hashAlgorithm, this->queueUnAssignmentAdvisory());
-        break;
     case Class::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
         hashAppend(hashAlgorithm, this->queueUnassignedAdvisory());
+        break;
+    case Class::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
+        hashAppend(hashAlgorithm, this->queueUnAssignmentAdvisory());
         break;
     case Class::SELECTION_ID_LEADER_ADVISORY_ACK:
         hashAppend(hashAlgorithm, this->leaderAdvisoryAck());
@@ -35829,12 +35350,12 @@ ClusterMessageChoice::isEqualTo(const ClusterMessageChoice& rhs) const
             return this->clusterSyncRequest() == rhs.clusterSyncRequest();
         case Class::SELECTION_ID_CLUSTER_SYNC_RESPONSE:
             return this->clusterSyncResponse() == rhs.clusterSyncResponse();
-        case Class::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
-            return this->queueUnAssignmentAdvisory() ==
-                   rhs.queueUnAssignmentAdvisory();
         case Class::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
             return this->queueUnassignedAdvisory() ==
                    rhs.queueUnassignedAdvisory();
+        case Class::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
+            return this->queueUnAssignmentAdvisory() ==
+                   rhs.queueUnAssignmentAdvisory();
         case Class::SELECTION_ID_LEADER_ADVISORY_ACK:
             return this->leaderAdvisoryAck() == rhs.leaderAdvisoryAck();
         case Class::SELECTION_ID_LEADER_ADVISORY_COMMIT:
@@ -35965,14 +35486,14 @@ int ClusterMessageChoice::manipulateSelection(t_MANIPULATOR& manipulator)
         return manipulator(
             &d_clusterSyncResponse.object(),
             SELECTION_INFO_ARRAY[SELECTION_INDEX_CLUSTER_SYNC_RESPONSE]);
-    case ClusterMessageChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
-        return manipulator(&d_queueUnAssignmentAdvisory.object(),
-                           SELECTION_INFO_ARRAY
-                               [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY]);
     case ClusterMessageChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
         return manipulator(
             &d_queueUnassignedAdvisory.object(),
             SELECTION_INFO_ARRAY[SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY]);
+    case ClusterMessageChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
+        return manipulator(&d_queueUnAssignmentAdvisory.object(),
+                           SELECTION_INFO_ARRAY
+                               [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY]);
     case ClusterMessageChoice::SELECTION_ID_LEADER_ADVISORY_ACK:
         return manipulator(
             &d_leaderAdvisoryAck.object(),
@@ -36139,17 +35660,17 @@ inline DummyType& ClusterMessageChoice::clusterSyncResponse()
     return d_clusterSyncResponse.object();
 }
 
+inline DummyType& ClusterMessageChoice::queueUnassignedAdvisory()
+{
+    BSLS_ASSERT(SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId);
+    return d_queueUnassignedAdvisory.object();
+}
+
 inline QueueUnAssignmentAdvisory&
 ClusterMessageChoice::queueUnAssignmentAdvisory()
 {
     BSLS_ASSERT(SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY == d_selectionId);
     return d_queueUnAssignmentAdvisory.object();
-}
-
-inline QueueUnassignedAdvisory& ClusterMessageChoice::queueUnassignedAdvisory()
-{
-    BSLS_ASSERT(SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId);
-    return d_queueUnassignedAdvisory.object();
 }
 
 inline LeaderAdvisoryAck& ClusterMessageChoice::leaderAdvisoryAck()
@@ -36296,14 +35817,14 @@ int ClusterMessageChoice::accessSelection(t_ACCESSOR& accessor) const
         return accessor(
             d_clusterSyncResponse.object(),
             SELECTION_INFO_ARRAY[SELECTION_INDEX_CLUSTER_SYNC_RESPONSE]);
-    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
-        return accessor(d_queueUnAssignmentAdvisory.object(),
-                        SELECTION_INFO_ARRAY
-                            [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY]);
     case SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
         return accessor(
             d_queueUnassignedAdvisory.object(),
             SELECTION_INFO_ARRAY[SELECTION_INDEX_QUEUE_UNASSIGNED_ADVISORY]);
+    case SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
+        return accessor(d_queueUnAssignmentAdvisory.object(),
+                        SELECTION_INFO_ARRAY
+                            [SELECTION_INDEX_QUEUE_UN_ASSIGNMENT_ADVISORY]);
     case SELECTION_ID_LEADER_ADVISORY_ACK:
         return accessor(
             d_leaderAdvisoryAck.object(),
@@ -36476,18 +35997,17 @@ inline const DummyType& ClusterMessageChoice::clusterSyncResponse() const
     return d_clusterSyncResponse.object();
 }
 
+inline const DummyType& ClusterMessageChoice::queueUnassignedAdvisory() const
+{
+    BSLS_ASSERT(SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId);
+    return d_queueUnassignedAdvisory.object();
+}
+
 inline const QueueUnAssignmentAdvisory&
 ClusterMessageChoice::queueUnAssignmentAdvisory() const
 {
     BSLS_ASSERT(SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY == d_selectionId);
     return d_queueUnAssignmentAdvisory.object();
-}
-
-inline const QueueUnassignedAdvisory&
-ClusterMessageChoice::queueUnassignedAdvisory() const
-{
-    BSLS_ASSERT(SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId);
-    return d_queueUnassignedAdvisory.object();
 }
 
 inline const LeaderAdvisoryAck& ClusterMessageChoice::leaderAdvisoryAck() const
@@ -36644,14 +36164,14 @@ inline bool ClusterMessageChoice::isClusterSyncResponseValue() const
     return SELECTION_ID_CLUSTER_SYNC_RESPONSE == d_selectionId;
 }
 
-inline bool ClusterMessageChoice::isQueueUnAssignmentAdvisoryValue() const
-{
-    return SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY == d_selectionId;
-}
-
 inline bool ClusterMessageChoice::isQueueUnassignedAdvisoryValue() const
 {
     return SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY == d_selectionId;
+}
+
+inline bool ClusterMessageChoice::isQueueUnAssignmentAdvisoryValue() const
+{
+    return SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY == d_selectionId;
 }
 
 inline bool ClusterMessageChoice::isLeaderAdvisoryAckValue() const

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -2215,10 +2215,8 @@ void Cluster::onRecoveryStatusDispatched(
     // This must be done before setting self status to AVAILABLE, which will
     // proceed with any pending queue-open requests etc.
 
-    BALL_LOG_INFO << description() << ": Transitioning to AVAILABLE, applying "
-                  << "buffered queue [un]assignment advisories, if any.";
+    BALL_LOG_INFO << description() << ": Transitioning to AVAILABLE.";
 
-    d_clusterOrchestrator.processBufferedQueueAdvisories();
     if (!isFSMWorkflow()) {
         d_clusterOrchestrator.validateClusterStateLedger();
     }
@@ -3103,13 +3101,9 @@ void Cluster::processClusterControlMessage(
             this);
     } break;  // BREAK
     case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
-        dispatcher()->execute(
-            bdlf::BindUtil::bind(
-                &ClusterOrchestrator::processQueueUnAssignmentAdvisory,
-                &d_clusterOrchestrator,
-                message,
-                source),
-            this);
+        // NO-OP
+        // This version unconditionally applies all CSL commits including
+        // unassignment advisories.
     } break;  // BREAK
     case MsgChoice::SELECTION_ID_STATE_NOTIFICATION: {
         dispatcher()->execute(

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -3111,15 +3111,6 @@ void Cluster::processClusterControlMessage(
                 source),
             this);
     } break;  // BREAK
-    case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        dispatcher()->execute(
-            bdlf::BindUtil::bind(
-                &ClusterOrchestrator::processQueueUnassignedAdvisory,
-                &d_clusterOrchestrator,
-                message,
-                source),
-            this);
-    } break;  // BREAK
     case MsgChoice::SELECTION_ID_STATE_NOTIFICATION: {
         dispatcher()->execute(
             bdlf::BindUtil::bind(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -282,17 +282,6 @@ void ClusterOrchestrator::electorTransitionToLeader(int leaderNodeId,
     d_stateManager_mp->initiateLeaderSync(true);
 }
 
-void ClusterOrchestrator::processBufferedQueueAdvisories()
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(
-        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
-
-    d_stateManager_mp->processBufferedQueueAdvisories();
-}
-
 void ClusterOrchestrator::registerQueueInfo(const bmqt::Uri& uri,
                                             int              partitionId,
                                             const mqbu::StorageKey& queueKey,
@@ -1268,19 +1257,6 @@ void ClusterOrchestrator::processQueueAssignmentRequest(
         d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
 
     d_stateManager_mp->processQueueAssignmentRequest(request, requester);
-}
-
-void ClusterOrchestrator::processQueueUnAssignmentAdvisory(
-    const bmqp_ctrlmsg::ControlMessage& msg,
-    mqbnet::ClusterNode*                source)
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(
-        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
-
-    d_stateManager_mp->processQueueUnAssignmentAdvisory(msg, source);
 }
 
 void ClusterOrchestrator::processLeaderSyncDataQuery(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1270,19 +1270,6 @@ void ClusterOrchestrator::processQueueAssignmentRequest(
     d_stateManager_mp->processQueueAssignmentRequest(request, requester);
 }
 
-void ClusterOrchestrator::processQueueUnassignedAdvisory(
-    const bmqp_ctrlmsg::ControlMessage& msg,
-    mqbnet::ClusterNode*                source)
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(
-        d_cluster_p->dispatcher()->inDispatcherThread(d_cluster_p));
-
-    d_stateManager_mp->processQueueUnassignedAdvisory(msg, source);
-}
-
 void ClusterOrchestrator::processQueueUnAssignmentAdvisory(
     const bmqp_ctrlmsg::ControlMessage& msg,
     mqbnet::ClusterNode*                source)

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
@@ -339,11 +339,6 @@ class ClusterOrchestrator {
     void
     processClusterStateEvent(const mqbi::DispatcherClusterStateEvent& event);
 
-    /// Process any queue assignment and un-assignment advisory messages
-    /// which were received while self node was starting.  Behavior is
-    /// undefined unless self node has transitioned to AVAILABLE.
-    void processBufferedQueueAdvisories();
-
     /// Process the queue assignment in the specified `request`, received
     /// from the specified `requester`.
     ///
@@ -352,15 +347,6 @@ class ClusterOrchestrator {
     void
     processQueueAssignmentRequest(const bmqp_ctrlmsg::ControlMessage& request,
                                   mqbnet::ClusterNode* requester);
-
-    /// Process the queue unAssignment advisory in the specified `msg`
-    /// received from the specified `source`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    void
-    processQueueUnAssignmentAdvisory(const bmqp_ctrlmsg::ControlMessage& msg,
-                                     mqbnet::ClusterNode* source);
 
     /// Process the specified storage sync request `message` from the
     /// specified `source`.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.h
@@ -353,15 +353,6 @@ class ClusterOrchestrator {
     processQueueAssignmentRequest(const bmqp_ctrlmsg::ControlMessage& request,
                                   mqbnet::ClusterNode* requester);
 
-    /// Process the queue unAssigned advisory in the specified `msg`
-    /// received from the specified `source`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    void
-    processQueueUnassignedAdvisory(const bmqp_ctrlmsg::ControlMessage& msg,
-                                   mqbnet::ClusterNode*                source);
-
     /// Process the queue unAssignment advisory in the specified `msg`
     /// received from the specified `source`.
     ///

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -6231,12 +6231,12 @@ int ClusterQueueHelper::gcExpiredQueues(bool               immediate,
         // generating sequence numbers).  In the current scheme of things,
         // primary and leader nodes can be different (even if cluster is
         // configured with 'leader-is-primary-for-all-partitions' flag).  If
-        // this occurs, primary cannot broadcast a QueueUnassignedAdvisory
+        // this occurs, primary cannot broadcast a QueueUnAssignmentAdvisory
         // since only leader can do so.  So for now, queue gc logic is
         // suppressed if leader and primary nodes are different.  This logic
         // will be updated such that primary will send a QueueUnassignedRequest
         // to the leader, and then leader will broadcast
-        // QueueUnassignedAdvisory.
+        // QueueUnAssignmentAdvisory.
 
         if (!d_primaryNotLeaderAlarmRaised) {
             BMQTSK_ALARMLOG_ALARM("CLUSTER_STATE")
@@ -6267,34 +6267,35 @@ int ClusterQueueHelper::gcExpiredQueues(bool               immediate,
 
         mqbc::ClusterUtil::setPendingUnassignment(d_clusterState_p, uriCopy);
 
-        // Populate 'queueUnassignedAdvisory'
+        // Populate 'QueueUnAssignmentAdvisory'
         bdlma::LocalSequentialAllocator<1024>  localAlloc(d_allocator_p);
         bmqp_ctrlmsg::ControlMessage           controlMsg(&localAlloc);
-        bmqp_ctrlmsg::QueueUnassignedAdvisory& queueAdvisory =
+        bmqp_ctrlmsg::QueueUnAssignmentAdvisory& queueAdvisory =
             controlMsg.choice()
                 .makeClusterMessage()
                 .choice()
-                .makeQueueUnassignedAdvisory();
+                .makeQueueUnAssignmentAdvisory();
 
-        mqbc::ClusterUtil::populateQueueUnassignedAdvisory(&queueAdvisory,
-                                                           d_clusterData_p,
-                                                           uriCopy,
-                                                           keyCopy,
-                                                           pid,
-                                                           *d_clusterState_p);
+        mqbc::ClusterUtil::populateQueueUnAssignmentAdvisory(
+            &queueAdvisory,
+            d_clusterData_p,
+            uriCopy,
+            keyCopy,
+            pid,
+            *d_clusterState_p);
 
         if (!d_cluster_p->isCSLModeEnabled()) {
-            // Broadcast 'queueUnassignedAdvisory' to all followers
+            // Broadcast 'QueueUnAssignmentAdvisory' to all followers
             //
             // NOTE: We must broadcast this control message before applying to
             // CSL, because if CSL is running in eventual consistency it will
             // immediately apply a commit with a higher seqeuence number than
-            // the QueueUnassignedAdvisory.  If we ever receive the commit
+            // the QueueUnAssignmentAdvisory.  If we ever receive the commit
             // before the QUA, we will alarm due to out-of-sequence advisory.
             d_clusterData_p->messageTransmitter().broadcastMessage(controlMsg);
         }
 
-        // Apply 'queueUnassignedAdvisory' to CSL
+        // Apply 'QueueUnAssignmentAdvisory' to CSL
         d_clusterStateManager_p->unassignQueue(queueAdvisory);
     }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -102,16 +102,6 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// Signature of a `void` callback method.
     typedef bsl::function<void(void)> VoidFunctor;
 
-    /// Signature of a callback invoked upon assignment of a queue by this
-    /// leader.
-    typedef bsl::function<void(const bmqp_ctrlmsg::QueueAssignmentAdvisory&)>
-        OnQueueAssignedCb;
-
-    /// Signature of a callback invoked upon un-assignment of a queue by
-    /// this leader.
-    typedef bsl::function<void(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory&)>
-        OnQueueUnassignedCb;
-
   private:
     // PRIVATE TYPES
     typedef bsl::shared_ptr<const mqbc::ClusterStateQueueInfo>

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -109,7 +109,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
 
     /// Signature of a callback invoked upon un-assignment of a queue by
     /// this leader.
-    typedef bsl::function<void(const bmqp_ctrlmsg::QueueUnassignedAdvisory&)>
+    typedef bsl::function<void(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory&)>
         OnQueueUnassignedCb;
 
   private:

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -153,12 +153,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
 
     bool d_isFirstLeaderAdvisory;
 
-    /// List of queue advisories which were received when self node was
-    /// starting, and will be processed once this node transitions to
-    /// AVAILABLE.  A queue advisory can be either an assignment or an
-    /// un-assignment msg.
-    QueueAdvisories d_bufferedQueueAdvisories;
-
     AfterPartitionPrimaryAssignmentCb d_afterPartitionPrimaryAssignmentCb;
 
   private:
@@ -461,11 +455,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processClusterStateEvent(
         const mqbi::DispatcherClusterStateEvent& event) BSLS_KEYWORD_OVERRIDE;
 
-    /// Process any queue assignment and unassignment advisory messages
-    /// which were received while self node was starting.  Behavior is
-    /// undefined unless self node has transitioned to AVAILABLE.
-    void processBufferedQueueAdvisories() BSLS_KEYWORD_OVERRIDE;
-
     /// Process the queue assignment in the specified `request`, received
     /// from the specified `requester`.  Return the queue assignment result.
     ///
@@ -474,21 +463,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processQueueAssignmentRequest(
         const bmqp_ctrlmsg::ControlMessage& request,
         mqbnet::ClusterNode*                requester) BSLS_KEYWORD_OVERRIDE;
-
-    /// Process the queue unAssignment advisory in the specified `message`
-    /// received from the specified `source`.  If the specified `delayed` is
-    /// true, the advisory has previously been delayed for processing.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    void processQueueUnAssignmentAdvisory(
-        const bmqp_ctrlmsg::ControlMessage& message,
-        mqbnet::ClusterNode*                source,
-        bool delayed = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the shutdown event.
     ///

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -369,7 +369,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void unassignQueue(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    void unassignQueue(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
 
     /// Send the current cluster state to follower nodes.  If the specified
@@ -474,19 +474,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processQueueAssignmentRequest(
         const bmqp_ctrlmsg::ControlMessage& request,
         mqbnet::ClusterNode*                requester) BSLS_KEYWORD_OVERRIDE;
-
-    /// Process the queue unAssigned advisory in the specified `message`
-    /// received from the specified `source`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    void processQueueUnassignedAdvisory(
-        const bmqp_ctrlmsg::ControlMessage& message,
-        mqbnet::ClusterNode*                source) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the queue unAssignment advisory in the specified `message`
     /// received from the specified `source`.  If the specified `delayed` is

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
@@ -282,7 +282,7 @@ class ClusterStateLedger : public ElectorInfoObserver {
     virtual int
     apply(const bmqp_ctrlmsg::QueueAssignmentAdvisory& advisory) = 0;
     virtual int
-    apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)         = 0;
+    apply(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)       = 0;
     virtual int apply(const bmqp_ctrlmsg::QueueUpdateAdvisory& advisory) = 0;
     virtual int apply(const bmqp_ctrlmsg::LeaderAdvisory& advisory)      = 0;
     /// @}
@@ -292,7 +292,7 @@ class ClusterStateLedger : public ElectorInfoObserver {
     /// consistency level has been achieved.  Note that *only* a leader node
     /// may invoke this routine.  Behavior is undefined unless the contained
     /// advisory is one of `PartitionPrimaryAdvisory`,
-    /// `QueueAssignmentAdvisory`, `QueueUnassignedAdvisory`.
+    /// `QueueAssignmentAdvisory`, `isQueueUnAssignmentAdvisoryValue`.
     /// `QueueUpdateAdvisory` or `LeaderAdvisory`.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
@@ -77,7 +77,7 @@ struct ClusterStateLedgerTestImp
         return markDone();
     }
 
-    int apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    int apply(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
@@ -190,7 +190,7 @@ static void test1_clusterStateLedger_protocol()
             apply(bmqp_ctrlmsg::QueueAssignmentAdvisory()));
         BSLS_PROTOCOLTEST_ASSERT(
             testObj,
-            apply(bmqp_ctrlmsg::QueueUnassignedAdvisory()));
+            apply(bmqp_ctrlmsg::QueueUnAssignmentAdvisory()));
         BSLS_PROTOCOLTEST_ASSERT(testObj,
                                  apply(bmqp_ctrlmsg::QueueUpdateAdvisory()));
         BSLS_PROTOCOLTEST_ASSERT(testObj,

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1736,15 +1736,6 @@ void ClusterStateManager::processClusterStateEvent(
     }
 }
 
-void ClusterStateManager::processBufferedQueueAdvisories()
-{
-    // While this method could be invoked by mqbblp::Cluster as part of
-    // pre-CSL workflow, we can do a no-op here because there won't be any
-    // buffered queue advisories anymore under the new CSL logic.
-
-    // NOTHING
-}
-
 void ClusterStateManager::processQueueAssignmentRequest(
     const bmqp_ctrlmsg::ControlMessage& request,
     mqbnet::ClusterNode*                requester)
@@ -1762,15 +1753,6 @@ void ClusterStateManager::processQueueAssignmentRequest(
         request,
         requester,
         d_allocator_p);
-}
-
-void ClusterStateManager::processQueueUnAssignmentAdvisory(
-    BSLS_ANNOTATION_UNUSED const bmqp_ctrlmsg::ControlMessage& message,
-    BSLS_ANNOTATION_UNUSED mqbnet::ClusterNode* source,
-    BSLS_ANNOTATION_UNUSED bool                 delayed)
-{
-    BSLS_ASSERT_SAFE(false &&
-                     "This method should only be invoked in non-CSL mode");
 }
 
 void ClusterStateManager::processShutdownEvent()

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1520,7 +1520,7 @@ void ClusterStateManager::registerQueueInfo(
 }
 
 void ClusterStateManager::unassignQueue(
-    const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
 {
     // executed by the *DISPATCHER* thread
 
@@ -1762,14 +1762,6 @@ void ClusterStateManager::processQueueAssignmentRequest(
         request,
         requester,
         d_allocator_p);
-}
-
-void ClusterStateManager::processQueueUnassignedAdvisory(
-    BSLA_UNUSED const bmqp_ctrlmsg::ControlMessage& message,
-    BSLA_UNUSED mqbnet::ClusterNode* source)
-{
-    BSLS_ASSERT_SAFE(false &&
-                     "This method should only be invoked in non-CSL mode");
 }
 
 void ClusterStateManager::processQueueUnAssignmentAdvisory(

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -549,11 +549,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processClusterStateEvent(
         const mqbi::DispatcherClusterStateEvent& event) BSLS_KEYWORD_OVERRIDE;
 
-    /// Process any queue assignment and unassignment advisory messages
-    /// which were received while self node was starting.  Behavior is
-    /// undefined unless self node has transitioned to AVAILABLE.
-    void processBufferedQueueAdvisories() BSLS_KEYWORD_OVERRIDE;
-
     /// Process the queue assignment in the specified `request`, received
     /// from the specified `requester`.  Return the queue assignment result.
     ///
@@ -562,21 +557,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processQueueAssignmentRequest(
         const bmqp_ctrlmsg::ControlMessage& request,
         mqbnet::ClusterNode*                requester) BSLS_KEYWORD_OVERRIDE;
-
-    /// Process the queue unAssignment advisory in the specified `message`
-    /// received from the specified `source`.  If the specified `delayed` is
-    /// true, the advisory has previously been delayed for processing.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    void processQueueUnAssignmentAdvisory(
-        const bmqp_ctrlmsg::ControlMessage& message,
-        mqbnet::ClusterNode*                source,
-        bool delayed = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the shutdown event.
     ///

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -457,7 +457,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void unassignQueue(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    void unassignQueue(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
 
     /// Send the current cluster state to follower nodes.  If the specified
@@ -562,19 +562,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void processQueueAssignmentRequest(
         const bmqp_ctrlmsg::ControlMessage& request,
         mqbnet::ClusterNode*                requester) BSLS_KEYWORD_OVERRIDE;
-
-    /// Process the queue unAssigned advisory in the specified `message`
-    /// received from the specified `source`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    void processQueueUnassignedAdvisory(
-        const bmqp_ctrlmsg::ControlMessage& message,
-        mqbnet::ClusterNode*                source) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the queue unAssignment advisory in the specified `message`
     /// received from the specified `source`.  If the specified `delayed` is

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -776,13 +776,13 @@ void ClusterUtil::populateQueueAssignmentAdvisory(
                   << ": Populated QueueAssignmentAdvisory: " << *advisory;
 }
 
-void ClusterUtil::populateQueueUnassignedAdvisory(
-    bmqp_ctrlmsg::QueueUnassignedAdvisory* advisory,
-    ClusterData*                           clusterData,
-    const bmqt::Uri&                       uri,
-    const mqbu::StorageKey&                key,
-    int                                    partitionId,
-    const ClusterState&                    clusterState)
+void ClusterUtil::populateQueueUnAssignmentAdvisory(
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory* advisory,
+    ClusterData*                             clusterData,
+    const bmqt::Uri&                         uri,
+    const mqbu::StorageKey&                  key,
+    int                                      partitionId,
+    const ClusterState&                      clusterState)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(advisory);
@@ -811,7 +811,7 @@ void ClusterUtil::populateQueueUnassignedAdvisory(
     key.loadBinary(&queueInfo.key());
 
     BALL_LOG_INFO << clusterData->identity().description()
-                  << ": Populated QueueUnassignedAdvisory: " << *advisory;
+                  << ": Populated QueueUnAssignmentAdvisory: " << *advisory;
 }
 
 ClusterUtil::QueueAssignmentResult::Enum
@@ -1512,9 +1512,9 @@ void ClusterUtil::apply(mqbc::ClusterState*                 clusterState,
             clusterMessage.choice().queueAssignmentAdvisory();
         applyQueueAssignment(clusterState, queueAdvisory.queues());
     } break;  // BREAK
-    case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        const bmqp_ctrlmsg::QueueUnassignedAdvisory& queueAdvisory =
-            clusterMessage.choice().queueUnassignedAdvisory();
+    case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& queueAdvisory =
+            clusterMessage.choice().queueUnAssignmentAdvisory();
 
         applyQueueUnassignment(clusterState, queueAdvisory.queues());
     } break;  // BREAK
@@ -1901,7 +1901,7 @@ int ClusterUtil::load(ClusterState*               state,
         case MsgChoice::SELECTION_ID_PARTITION_PRIMARY_ADVISORY:
         case MsgChoice::SELECTION_ID_LEADER_ADVISORY:
         case MsgChoice::SELECTION_ID_QUEUE_ASSIGNMENT_ADVISORY:
-        case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY:
+        case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY:
         case MsgChoice::SELECTION_ID_QUEUE_UPDATE_ADVISORY: {
             BALL_LOG_INFO << "#CSL_RECOVERY "
                           << clusterData.identity().description()

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -217,13 +217,13 @@ struct ClusterUtil {
     /// queue unassignment of the specified `uri` having the specified `key`
     /// and `partitionId`, using the specified `clusterData` and and
     /// `clusterState`.
-    static void populateQueueUnassignedAdvisory(
-        bmqp_ctrlmsg::QueueUnassignedAdvisory* advisory,
-        ClusterData*                           clusterData,
-        const bmqt::Uri&                       uri,
-        const mqbu::StorageKey&                key,
-        int                                    partitionId,
-        const ClusterState&                    clusterState);
+    static void populateQueueUnAssignmentAdvisory(
+        bmqp_ctrlmsg::QueueUnAssignmentAdvisory* advisory,
+        ClusterData*                             clusterData,
+        const bmqt::Uri&                         uri,
+        const mqbu::StorageKey&                  key,
+        int                                      partitionId,
+        const ClusterState&                      clusterState);
 
     /// Perform the actual assignment of the queue represented by the
     /// specified `uri` for a cluster member queue, that is assign it a

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -982,7 +982,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     }
 
     BSLS_ASSERT_SAFE(message.choice().isQueueAssignmentAdvisoryValue() ||
-                     message.choice().isQueueUnassignedAdvisoryValue() ||
+                     message.choice().isQueueUnAssignmentAdvisoryValue() ||
                      message.choice().isQueueUpdateAdvisoryValue() ||
                      message.choice().isPartitionPrimaryAdvisoryValue() ||
                      message.choice().isLeaderAdvisoryValue() ||
@@ -1357,7 +1357,7 @@ int IncoreClusterStateLedger::apply(
 }
 
 int IncoreClusterStateLedger::apply(
-    const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
@@ -1368,7 +1368,7 @@ int IncoreClusterStateLedger::apply(
     BSLS_ASSERT_SAFE(isSelfLeader());
 
     bmqp_ctrlmsg::ClusterMessage clusterMessage;
-    clusterMessage.choice().makeQueueUnassignedAdvisory(advisory);
+    clusterMessage.choice().makeQueueUnAssignmentAdvisory(advisory);
 
     return applyAdvisoryInternal(clusterMessage,
                                  advisory.sequenceNumber(),
@@ -1437,8 +1437,8 @@ int IncoreClusterStateLedger::apply(
     case MsgChoice::SELECTION_ID_QUEUE_ASSIGNMENT_ADVISORY: {
         return apply(choice.queueAssignmentAdvisory());  // RETURN
     }
-    case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        return apply(choice.queueUnassignedAdvisory());  // RETURN
+    case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        return apply(choice.queueUnAssignmentAdvisory());  // RETURN
     }
     case MsgChoice::SELECTION_ID_QUEUE_UPDATE_ADVISORY: {
         return apply(choice.queueUpdateAdvisory());  // RETURN

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -87,7 +87,7 @@ struct IncoreClusterStateLedger_ClusterMessageInfo {
     ///   - `PartitionPrimaryAdvisory`,
     ///   - `QueueAssignmentAdvisory`,
     ///   - `LeaderAdvisory`,
-    ///   - `QueueUnassignedAdvisory`.
+    ///   - `QueueUnAssignmentAdvisory`.
     bmqp_ctrlmsg::ClusterMessage d_clusterMessage;
 
     /// Number of ACKs received for this `ClusterMessage`.
@@ -343,7 +343,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
         BSLS_KEYWORD_OVERRIDE;
     int apply(const bmqp_ctrlmsg::QueueAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
-    int apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    int apply(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
     int apply(const bmqp_ctrlmsg::QueueUpdateAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
@@ -356,7 +356,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     /// consistency level has been achieved.  Note that *only* a leader node
     /// may invoke this routine.  Behavior is undefined unless the contained
     /// advisory is one of `PartitionPrimaryAdvisory`,
-    /// `QueueAssignmentAdvisory`, `QueueUnassignedAdvisory`.
+    /// `QueueAssignmentAdvisory`, `QueueUnAssignmentAdvisory`.
     /// `QueueUpdateAdvisory` or `LeaderAdvisory`.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -72,7 +72,7 @@ using namespace bsl;
 // - apply (leader + follower):
 //     o PartitionPrimaryAdvisory,
 //       QueueAssignmentAdvisory,
-//       QueueUnassignedAdvisory
+//       QueueUnAssignmentAdvisory
 //       QueueUpdateAdvisory
 //       LeaderAdvisory
 //     o LeaderAdvisoryAck (at leader)
@@ -676,11 +676,11 @@ static void test4_apply_QueueUnassignedAdvisory()
 // QUEUE UNASSIGNED ADVISORY
 //
 // Concerns:
-//   Applying 'QueueUnassignedAdvisory' (only at leader), receive a quorum of
+//   Applying 'QueueUnAssignmentAdvisory' (only at leader), receive a quorum of
 //   acks, then commit the advisory.
 //
 // Testing:
-//   int apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory);
+//   int apply(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory);
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("APPLY - QUEUE UNASSIGNED ADVISORY");
@@ -689,8 +689,8 @@ static void test4_apply_QueueUnassignedAdvisory()
     mqbc::IncoreClusterStateLedger* obj = tester.d_clusterStateLedger_mp.get();
     BSLS_ASSERT_OPT(obj->open() == 0);
 
-    // Apply 'QueueUnassignedAdvisory'
-    bmqp_ctrlmsg::QueueUnassignedAdvisory qadvisory;
+    // Apply 'QueueUnAssignmentAdvisory'
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory qadvisory;
     tester.d_cluster_mp->_clusterData()
         ->electorInfo()
         .nextLeaderMessageSequence(&qadvisory.sequenceNumber());
@@ -707,7 +707,7 @@ static void test4_apply_QueueUnassignedAdvisory()
     expected.choice()
         .makeClusterMessage()
         .choice()
-        .makeQueueUnassignedAdvisory(qadvisory);
+        .makeQueueUnAssignmentAdvisory(qadvisory);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
     BMQTST_ASSERT(tester.hasBroadcastedMessages(1));
     BMQTST_ASSERT_EQ(tester.broadcastedMessage(0), expected);
@@ -1165,8 +1165,8 @@ static void test9_persistanceLeader()
     BSLS_ASSERT_OPT(tester.numCommittedMessages() == 3U);
     BMQTST_ASSERT(tester.hasBroadcastedMessages(6));
 
-    // Apply and commit 'QueueUnassignedAdvisory'
-    bmqp_ctrlmsg::QueueUnassignedAdvisory qUnassignedAdvisory;
+    // Apply and commit 'QueueUnAssignmentAdvisory'
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory qUnassignedAdvisory;
     tester.d_cluster_mp->_clusterData()
         ->electorInfo()
         .nextLeaderMessageSequence(&qUnassignedAdvisory.sequenceNumber());
@@ -1264,7 +1264,7 @@ static void test9_persistanceLeader()
 
     verifyLeaderAdvisoryCommit(*cslIter, qUpdateAdvisory.sequenceNumber());
 
-    // Verify 'QueueUnassignedAdvisory' and its commit
+    // Verify 'QueueUnAssignmentAdvisory' and its commit
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
     BMQTST_ASSERT(cslIter->isValid());
     verifyRecordHeader(*cslIter,
@@ -1273,8 +1273,8 @@ static void test9_persistanceLeader()
 
     rc = cslIter->loadClusterMessage(&msg);
     BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT(msg.choice().isQueueUnassignedAdvisoryValue());
-    BMQTST_ASSERT_EQ(msg.choice().queueUnassignedAdvisory(),
+    BMQTST_ASSERT(msg.choice().isQueueUnAssignmentAdvisoryValue());
+    BMQTST_ASSERT_EQ(msg.choice().queueUnAssignmentAdvisory(),
                      qUnassignedAdvisory);
 
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
@@ -1384,10 +1384,10 @@ static void test10_persistanceFollower()
                                tester.d_cluster_mp->netCluster().lookupNode(
                                    mqbmock::Cluster::k_LEADER_NODE_ID)) == 0);
 
-    // Apply 'QueueUnassignedAdvisory'
+    // Apply 'QueueUnAssignmentAdvisory'
     bmqp_ctrlmsg::ClusterMessage           qUnassignedAdvisoryMsg;
-    bmqp_ctrlmsg::QueueUnassignedAdvisory& qUnassignedAdvisory =
-        qUnassignedAdvisoryMsg.choice().makeQueueUnassignedAdvisory();
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory& qUnassignedAdvisory =
+        qUnassignedAdvisoryMsg.choice().makeQueueUnAssignmentAdvisory();
     tester.d_cluster_mp->_clusterData()
         ->electorInfo()
         .nextLeaderMessageSequence(&qUnassignedAdvisory.sequenceNumber());
@@ -1544,7 +1544,7 @@ static void test10_persistanceFollower()
     BMQTST_ASSERT(msg.choice().isQueueAssignmentAdvisoryValue());
     BMQTST_ASSERT_EQ(msg.choice().queueAssignmentAdvisory(), qAssignAdvisory);
 
-    // Verify 'QueueUnassignedAdvisory'
+    // Verify 'QueueUnAssignmentAdvisory'
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
     BMQTST_ASSERT(cslIter->isValid());
     verifyRecordHeader(*cslIter,
@@ -1554,8 +1554,8 @@ static void test10_persistanceFollower()
 
     rc = cslIter->loadClusterMessage(&msg);
     BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT(msg.choice().isQueueUnassignedAdvisoryValue());
-    BMQTST_ASSERT_EQ(msg.choice().queueUnassignedAdvisory(),
+    BMQTST_ASSERT(msg.choice().isQueueUnAssignmentAdvisoryValue());
+    BMQTST_ASSERT_EQ(msg.choice().queueUnAssignmentAdvisory(),
                      qUnassignedAdvisory);
 
     // Verify 'QueueUpdateAdvisory'
@@ -1659,10 +1659,10 @@ static void test11_persistanceAcrossRolloverLeader()
     BSLS_ASSERT_OPT(tester.hasBroadcastedMessages(1));
     BSLS_ASSERT_OPT(tester.broadcastedMessage(0) == expectedPmAdvisory);
 
-    // Apply 'QueueUnassignedAdvisory'
+    // Apply 'QueueUnAssignmentAdvisory'
     bmqp_ctrlmsg::ClusterMessage           qUnassignedAdvisoryMsg;
-    bmqp_ctrlmsg::QueueUnassignedAdvisory& qUnassignedAdvisory =
-        qUnassignedAdvisoryMsg.choice().makeQueueUnassignedAdvisory();
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory& qUnassignedAdvisory =
+        qUnassignedAdvisoryMsg.choice().makeQueueUnAssignmentAdvisory();
     tester.d_cluster_mp->_clusterData()
         ->electorInfo()
         .nextLeaderMessageSequence(&qUnassignedAdvisory.sequenceNumber());
@@ -1682,7 +1682,7 @@ static void test11_persistanceAcrossRolloverLeader()
     expectedQUnassignedAdvisory.choice()
         .makeClusterMessage()
         .choice()
-        .makeQueueUnassignedAdvisory(qUnassignedAdvisory);
+        .makeQueueUnAssignmentAdvisory(qUnassignedAdvisory);
     uncommittedAdvisories.push_back(
         AdvisoryInfo(expectedQUnassignedAdvisory,
                      qUnassignedAdvisory.sequenceNumber(),
@@ -1850,8 +1850,8 @@ static void test11_persistanceAcrossRolloverLeader()
                      pmAdvisory2.sequenceNumber(),
                      mqbc::ClusterStateRecordType::e_UPDATE));
 
-    // Apply 'QueueUnassignedAdvisory'
-    bmqp_ctrlmsg::QueueUnassignedAdvisory qUnassignedAdvisory2;
+    // Apply 'QueueUnAssignmentAdvisory'
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory qUnassignedAdvisory2;
     tester.d_cluster_mp->_clusterData()
         ->electorInfo()
         .nextLeaderMessageSequence(&qUnassignedAdvisory2.sequenceNumber());
@@ -1874,7 +1874,7 @@ static void test11_persistanceAcrossRolloverLeader()
     expectedQUnassignedAdvisory2.choice()
         .makeClusterMessage()
         .choice()
-        .makeQueueUnassignedAdvisory(qUnassignedAdvisory2);
+        .makeQueueUnAssignmentAdvisory(qUnassignedAdvisory2);
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), i + 3);
     BMQTST_ASSERT_EQ(tester.committedMessage(i + 2),
                      expectedQUnassignedAdvisory2);

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.t.cpp
@@ -154,14 +154,14 @@ createClusterMessage(bmqp_ctrlmsg::ClusterMessage*              message,
                                    "12345");
         key.loadBinary(&qinfo.key());
 
-        bmqp_ctrlmsg::QueueUnassignedAdvisory advisory;
+        bmqp_ctrlmsg::QueueUnAssignmentAdvisory advisory;
         advisory.sequenceNumber() = sequenceNumber;
         advisory.primaryNodeId()  = 1;
         advisory.partitionId()    = 1U;
         advisory.primaryLeaseId() = 1U;
         advisory.queues().push_back(qinfo);
 
-        message->choice().makeQueueUnassignedAdvisory(advisory);
+        message->choice().makeQueueUnAssignmentAdvisory(advisory);
 
         return mqbc::ClusterStateRecordType::e_UPDATE;
     }

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -208,7 +208,7 @@ class ClusterStateManager {
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
     virtual void
-    unassignQueue(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory) = 0;
+    unassignQueue(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory) = 0;
 
     /// Send the current cluster state to follower nodes.  If the specified
     /// `sendPartitionPrimaryInfo` is true, the specified partition-primary
@@ -311,19 +311,6 @@ class ClusterStateManager {
     virtual void
     processQueueAssignmentRequest(const bmqp_ctrlmsg::ControlMessage& request,
                                   mqbnet::ClusterNode* requester) = 0;
-
-    /// Process the queue unAssigned advisory in the specified `message`
-    /// received from the specified `source`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    virtual void
-    processQueueUnassignedAdvisory(const bmqp_ctrlmsg::ControlMessage& message,
-                                   mqbnet::ClusterNode* source) = 0;
 
     /// Process the queue unAssignment advisory in the specified `message`
     /// received from the specified `source`.  If the specified `delayed` is

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -298,11 +298,6 @@ class ClusterStateManager {
     virtual void processClusterStateEvent(
         const mqbi::DispatcherClusterStateEvent& event) = 0;
 
-    /// Process any queue assignment and unassignment advisory messages
-    /// which were received while self node was starting.  Behavior is
-    /// undefined unless self node has transitioned to AVAILABLE.
-    virtual void processBufferedQueueAdvisories() = 0;
-
     /// Process the queue assignment in the specified `request`, received
     /// from the specified `requester`.  Return the queue assignment result.
     ///
@@ -311,21 +306,6 @@ class ClusterStateManager {
     virtual void
     processQueueAssignmentRequest(const bmqp_ctrlmsg::ControlMessage& request,
                                   mqbnet::ClusterNode* requester) = 0;
-
-    /// Process the queue unAssignment advisory in the specified `message`
-    /// received from the specified `source`.  If the specified `delayed` is
-    /// true, the advisory has previously been delayed for processing.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's
-    ///         dispatcher thread.
-    ///
-    /// TODO_CSL: This is the current workflow which we should be able to
-    /// remove after the new workflow via
-    /// ClusterQueueHelper::onQueueUnassigned() is stable.
-    virtual void processQueueUnAssignmentAdvisory(
-        const bmqp_ctrlmsg::ControlMessage& message,
-        mqbnet::ClusterNode*                source,
-        bool                                delayed = false) = 0;
 
     /// Process the shutdown event.
     ///

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
@@ -131,7 +131,7 @@ int ClusterStateLedger::apply(
 }
 
 int ClusterStateLedger::apply(
-    const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
@@ -142,7 +142,7 @@ int ClusterStateLedger::apply(
     BSLS_ASSERT_SAFE(isSelfLeader());
 
     bmqp_ctrlmsg::ClusterMessage clusterMessage;
-    clusterMessage.choice().makeQueueUnassignedAdvisory(advisory);
+    clusterMessage.choice().makeQueueUnAssignmentAdvisory(advisory);
 
     return applyAdvisoryInternal(clusterMessage);
 }
@@ -205,8 +205,8 @@ int ClusterStateLedger::apply(
     case MsgChoice::SELECTION_ID_QUEUE_ASSIGNMENT_ADVISORY: {
         return apply(choice.queueAssignmentAdvisory());  // RETURN
     }
-    case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        return apply(choice.queueUnassignedAdvisory());  // RETURN
+    case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        return apply(choice.queueUnAssignmentAdvisory());  // RETURN
     }
     case MsgChoice::SELECTION_ID_QUEUE_UPDATE_ADVISORY: {
         return apply(choice.queueUpdateAdvisory());  // RETURN
@@ -276,9 +276,9 @@ void ClusterStateLedger::_commitAdvisories(
                 commit.sequenceNumberCommitted() =
                     choice.queueAssignmentAdvisory().sequenceNumber();
             } break;  // BREAK
-            case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
+            case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
                 commit.sequenceNumberCommitted() =
-                    choice.queueUnassignedAdvisory().sequenceNumber();
+                    choice.queueUnAssignmentAdvisory().sequenceNumber();
             } break;  // BREAK
             case MsgChoice::SELECTION_ID_QUEUE_UPDATE_ADVISORY: {
                 commit.sequenceNumberCommitted() =

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
@@ -152,7 +152,7 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
         BSLS_KEYWORD_OVERRIDE;
     int apply(const bmqp_ctrlmsg::QueueAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
-    int apply(const bmqp_ctrlmsg::QueueUnassignedAdvisory& advisory)
+    int apply(const bmqp_ctrlmsg::QueueUnAssignmentAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
     int apply(const bmqp_ctrlmsg::QueueUpdateAdvisory& advisory)
         BSLS_KEYWORD_OVERRIDE;
@@ -171,7 +171,7 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
     /// consistency level has been achieved.  Note that *only* a leader node
     /// may invoke this routine.  Behavior is undefined unless the contained
     /// advisory is one of `PartitionPrimaryAdvisory`,
-    /// `QueueAssignmentAdvisory`, `QueueUnassignedAdvisory`.
+    /// `QueueAssignmentAdvisory`, `QueueUnAssignmentAdvisory`.
     /// `QueueUpdateAdvisory` or `LeaderAdvisory`.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledgeriterator.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledgeriterator.cpp
@@ -81,8 +81,8 @@ int ClusterStateLedgerIterator::next()
         d_currRecordHeader.setRecordType(
             mqbc::ClusterStateRecordType::e_UPDATE);
     } break;  // BREAK
-    case MsgChoice::SELECTION_ID_QUEUE_UNASSIGNED_ADVISORY: {
-        lsn = &choice.queueUnassignedAdvisory().sequenceNumber();
+    case MsgChoice::SELECTION_ID_QUEUE_UN_ASSIGNMENT_ADVISORY: {
+        lsn = &choice.queueUnAssignmentAdvisory().sequenceNumber();
         d_currRecordHeader.setRecordType(
             mqbc::ClusterStateRecordType::e_UPDATE);
     } break;  // BREAK

--- a/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
+++ b/src/groups/mqb/mqbs/mqbs_virtualstoragecatalog.cpp
@@ -741,11 +741,12 @@ void VirtualStorageCatalog::loadVirtualStorageDetails(AppInfos* buffer) const
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(buffer);
 
-    for (VirtualStoragesConstIter cit = d_virtualStorages.begin();
-         cit != d_virtualStorages.end();
-         ++cit) {
-        BSLS_ASSERT_SAFE(cit->key2() == cit->value()->appKey());
-        buffer->insert(bsl::make_pair(cit->key1(), cit->key2()));
+    // Return ordered by ordinals
+    for (size_t i = 0; i < d_ordinals.size(); ++i) {
+        BSLS_ASSERT_SAFE(d_ordinals[i]);
+        const VirtualStorage& storage = *d_ordinals[i];
+
+        buffer->insert(bsl::make_pair(storage.appId(), storage.appKey()));
     }
 }
 


### PR DESCRIPTION
1) bugfix: return ordered collection of storages in `VirtualStorageCatalog::loadVirtualStorageDetails`
2) retire ancient `QueueUnAssignmentAdvisory`.  But use the name of `QueueUnAssignmentAdvisory` instead of `QueueUnassignedAdvisory` for the name consistency
3) commit `QueueUnAssignmentAdvisory` so no shortcut is needed in non-CSL mode