### PR TITLE
Fix: Require latency monitoring domain to match prefix

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -522,7 +522,7 @@ int ClusterUtil::getNextPartitionId(const ClusterState& clusterState,
     const bsl::string&       latencyMonitorDomain =
         mqbcfg::BrokerConfig::get().latencyMonitorDomain();
 
-    if (domainName.find(latencyMonitorDomain) != bsl::string::npos) {
+    if (domainName.starts_with(latencyMonitorDomain)) {
         // latemon domain
         const int partitionId = clusterState.extractPartitionId(queueName);
         if (partitionId < 0) {

--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -77,7 +77,7 @@
         hostDataCenter.......: datacenter the current host resides in
         isRunningOnDev.......: true if running on dev
         logsObserverMaxSize..: maximum number of log records to keep
-        latencyMonitorDomain.: common part of all latemon domains
+        latencyMonitorDomain.: common prefix of all latemon domains
         dispatcherConfig.....: configuration for the dispatcher
         stats................: configuration for the stats
         networkInterfaces....: configuration for the network interfaces


### PR DESCRIPTION
Latency monitoring domains are an under-documented feature of BlazingMQ that can be used to measure end-to-end message latency through the broker.  To support partition-aware latency measurement, the broker parses queue names on these domains using this regex (src/groups/mqb/mqbc/mqbc_clusterstate.cpp:765):

    ^\S+\.([0-9]+)\.\S+\.\S+$

An example string that matches this is:

    foo.2.bar.baz

If a queue name matches this regex, the integer in the second component (e.g., `2` in `foo.2.bar.baz`) is treated as the target partition, and the queue is assigned to that partition.

Latency monitoring domains are expected to start with a configured prefix (by default `bmq.sys.latemon.latency`, see
src/groups/mqb/mqbcfg/mqbcfg.xsd:102).  However, the existing implementation matches the configured prefix *anywhere* within the domain name.  This patch fixes this behavior: domains are not recognized as latency monitoring domains only if they begin with the configured prefix.