### PR TITLE
IT test_puts_retransmission.py: Disable eventual consistency for one test

### DIFF
--- a/src/integration-tests/test_puts_retransmission.py
+++ b/src/integration-tests/test_puts_retransmission.py
@@ -557,9 +557,9 @@ class TestPutsRetransmission:
         self.inspect_results(allow_duplicates=True)
 
     def test_kill_primary_keep_replica(
-        self, multi_node: Cluster, domain_urls: tc.DomainUrls
+        self, multi_node: Cluster, sc_domain_urls: tc.DomainUrls
     ):
-        self.setup_cluster_fanout(multi_node, domain_urls)
+        self.setup_cluster_fanout(multi_node, sc_domain_urls)
 
         # prevent 'active_node' from becoming new primary
         self.active_node.set_quorum(4)


### PR DESCRIPTION
Disabling this test, because it is supposed to fail in eventual consistency.