### PR TITLE
Fix: Only enable integration tests in CTest when venv can be created

### DIFF
--- a/src/integration-tests/CMakeLists.txt
+++ b/src/integration-tests/CMakeLists.txt
@@ -21,7 +21,15 @@ execute_process(
     "${Python3_EXECUTABLE}"
     -m venv
     "${CMAKE_CURRENT_BINARY_DIR}/venv"
+  RESULT_VARIABLE STATUS
 )
+if(STATUS AND NOT STATUS EQUAL 0)
+  message(WARN
+    "Could not create Python virtual environment; disabling integration tests"
+  )
+  list(POP_BACK CMAKE_MESSAGE_INDENT)
+  return()
+endif()
 
 # Forget about the system Python version; look for Python 3 installed within
 # the virtual environment now.


### PR DESCRIPTION
The CTest - integration test integration incorrectly assumes that if a Python interpreter was installed, we could create a venv.  This PR fixes that incorrect assumption.