### PR TITLE
Feat[bmqt]: Limit queue names to 64 characters

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_uri.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.cpp
@@ -262,12 +262,13 @@ int UriParser::parse(Uri*                     result,
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS        = 0,
-        rc_INVALID_FORMAT = -1,
-        rc_BAD_QUERY      = -2,
-        rc_MISSING_DOMAIN = -3,
-        rc_MISSING_QUEUE  = -4,
-        rc_MISSING_TIER   = -5
+        rc_SUCCESS             = 0,
+        rc_INVALID_FORMAT      = -1,
+        rc_BAD_QUERY           = -2,
+        rc_MISSING_DOMAIN      = -3,
+        rc_MISSING_QUEUE       = -4,
+        rc_MISSING_TIER        = -5,
+        rc_QUEUE_NAME_TOO_LONG = -6
     };
 
     enum {
@@ -382,20 +383,11 @@ int UriParser::parse(Uri*                     result,
     }
 
     if (result->d_path.length() > Uri::k_QUEUENAME_MAX_LENGTH) {
-        // TBD: Convert to a real error once certified all active queues are
-        //      within the limit.  When converting to an error, add test cases
-        //      in the test driver.
-        BSLMT_ONCE_DO
-        {
-            bmqu::MemOutStream os;
-            os << "The queue name part of '" << uriString << "' is exceeding "
-               << "the maximum size limit of " << Uri::k_QUEUENAME_MAX_LENGTH
-               << ".  This is only a warning at the moment, but this limit "
-               << "will soon be enforced and  queue URI will be rejected!";
-            bsl::cerr << "BMQALARM [INVALID_QUEUE_NAME]: " << os.str() << '\n'
-                      << bsl::flush;
-            BALL_LOG_ERROR << os.str();
+        if (errorDescription) {
+            *errorDescription = "queue name exceeds 64 characters";
         }
+        result->reset();
+        return rc_QUEUE_NAME_TOO_LONG;
     }
 
     // Success

--- a/src/groups/bmq/bmqt/bmqt_uri.h
+++ b/src/groups/bmq/bmqt/bmqt_uri.h
@@ -228,7 +228,7 @@ class Uri {
 
     /// Implicit constructor of this object from the specified `uri` string
     /// using the optionally specified `allocator`.  If the `uri` input
-    /// string doesn't not represent a valid URI, this object is left in an
+    /// string does not represent a valid URI, this object is left in an
     /// invalid state (isValid() will return false).
     Uri(const bsl::string& uri,
         bslma::Allocator*  allocator = 0);  // IMPLICIT

--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -658,17 +658,7 @@ static void test7_testLongUri()
 
     bmqt::Uri obj(stream.str(), bmqtst::TestHelperUtil::allocator());
 
-    BMQTST_ASSERT_EQ(observer.records().size(), 1U);
-
-    BMQTST_ASSERT_EQ(observer.records()[0].fixedFields().severity(),
-                     ball::Severity::e_ERROR);
-
-    BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
-        observer.records()[0],
-        pathStr.data(),
-        bmqtst::TestHelperUtil::allocator()));
-
-    BMQTST_ASSERT_EQ(obj.isValid(), true);
+    BMQTST_ASSERT_EQ(obj.isValid(), false);
 
     bmqt::UriParser::shutdown();
 }


### PR DESCRIPTION
This PR formalizes a 64 character limit on queue names.

Previously, queues that exceed this limit would warn. Now, queues that exceed this limit will be treated as invalid from the broker and therefore cannot be opened, used, etc.