### PR TITLE
Fix[bmqtool]: handle warning on CorrelationId destruction

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_inpututil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.cpp
@@ -332,7 +332,7 @@ bool InputUtil::populateSubscriptions(bmqt::QueueOptions* out,
     bool failed = false;
     for (int i = 0; i < autoPubSubModulo; ++i) {
         bmqt::Subscription       to;
-        bmqt::CorrelationId      correlationId(i);
+        bmqt::CorrelationId      correlationId(bmqt::CorrelationId::autoValue());
         bmqt::SubscriptionHandle handle(correlationId);
 
         bsl::string equality(autoPubSubPropertyName, allocator);

--- a/src/applications/bmqtool/m_bmqtool_inpututil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.cpp
@@ -332,7 +332,7 @@ bool InputUtil::populateSubscriptions(bmqt::QueueOptions* out,
     bool failed = false;
     for (int i = 0; i < autoPubSubModulo; ++i) {
         bmqt::Subscription       to;
-        bmqt::CorrelationId      correlationId(bmqt::CorrelationId::autoValue());
+        bmqt::CorrelationId correlationId(bmqt::CorrelationId::autoValue());
         bmqt::SubscriptionHandle handle(correlationId);
 
         bsl::string equality(autoPubSubPropertyName, allocator);


### PR DESCRIPTION
There is a problem with `bdlb::Variant4` implementation that produces a warning. It is probably a false alarm, but we can still avoid this.
```
    inlined from 'BloombergLP::bmqt::CorrelationId::~CorrelationId()' at /blazingmq/src/groups/bmq/bmqt/bmqt_correlationid.h:193:7,
    inlined from 'static bool BloombergLP::m_bmqtool::InputUtil::populateSubscriptions(BloombergLP::bmqt::QueueOptions*, int, const char*, BloombergLP::bslma::Allocator*)' at /blazingmq/src/applications/bmqtool/m_bmqtool_inpututil.cpp:355:5:
/include/bslstl_sharedptr.h:5140:9: warning: '*(bsl::shared_ptr<void>*)((char*)&correlationId + offsetof(BloombergLP::bmqt::CorrelationId, BloombergLP::bmqt::CorrelationId::d_variant.BloombergLP::bdlb::Variant4<long long int, void*, bsl::shared_ptr<void>, long long unsigned int>::<unnamed>.BloombergLP::bdlb::VariantImp<BloombergLP::bslmf::TypeList<long long int, void*, bsl::shared_ptr<void>, long long unsigned int> >::<unnamed>.BloombergLP::bdlb::VariantImp_NoAllocatorBase<BloombergLP::bslmf::TypeList<long long int, void*, bsl::shared_ptr<void>, long long unsigned int> >::d_value)).bsl::shared_ptr<void>::d_rep_p' may be used uninitialized [-Wmaybe-uninitialized]
 5140 |     if (d_rep_p) {
      |         ^~~~~~~
/blazingmq/src/applications/bmqtool/m_bmqtool_inpututil.cpp: In static member function 'static bool BloombergLP::m_bmqtool::InputUtil::populateSubscriptions(BloombergLP::bmqt::QueueOptions*, int, const char*, BloombergLP::bslma::Allocator*)':
/blazingmq/src/applications/bmqtool/m_bmqtool_inpututil.cpp:335:34: note: 'correlationId' declared here
  335 |         bmqt::CorrelationId      correlationId(i);
```