### PR TITLE
Remove[MQB]: isFirstLeaderAdvisory

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -641,8 +641,6 @@ void ClusterStateManager::onClusterLeader(
 
     if (!node) {
         BSLS_ASSERT_SAFE(mqbc::ElectorInfoLeaderStatus::e_UNDEFINED == status);
-
-        d_isFirstLeaderAdvisory = true;
     }
 }
 
@@ -677,8 +675,6 @@ void ClusterStateManager::onPartitionPrimaryAssignment(
                                                     oldPrimary,
                                                     oldLeaseId);
 
-    d_isFirstLeaderAdvisory = false;
-
     d_afterPartitionPrimaryAssignmentCb(partitionId, primary, status);
 }
 
@@ -699,7 +695,6 @@ ClusterStateManager::ClusterStateManager(
 , d_state_p(clusterState)
 , d_clusterStateLedger_mp(clusterStateLedger)
 , d_storageManager_p(0)
-, d_isFirstLeaderAdvisory(true)
 {
     // executed by *ANY* thread
 
@@ -909,9 +904,6 @@ void ClusterStateManager::sendClusterState(
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT_SAFE(mqbnet::ElectorState::e_LEADER ==
                      d_clusterData_p->electorInfo().electorState());
-
-    // Self is leader and has published advisory above, so update it.
-    d_isFirstLeaderAdvisory = false;
 
     mqbc::ClusterUtil::sendClusterState(d_clusterData_p,
                                         d_clusterStateLedger_mp.get(),

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.h
@@ -151,8 +151,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
 
     mqbi::StorageManager* d_storageManager_p;
 
-    bool d_isFirstLeaderAdvisory;
-
     AfterPartitionPrimaryAssignmentCb d_afterPartitionPrimaryAssignmentCb;
 
   private:
@@ -486,9 +484,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void onNodeStopped() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
-    //   (virtual: mqbi::ClusterStateManager)
-    bool isFirstLeaderAdvisory() const BSLS_KEYWORD_OVERRIDE;
-
     /// Return the cluster state managed by this instacne.
     const mqbc::ClusterState* clusterState() const BSLS_KEYWORD_OVERRIDE;
 
@@ -550,12 +545,6 @@ inline void ClusterStateManager::setAfterPartitionPrimaryAssignmentCb(
 }
 
 // ACCESSORS
-//   (virtual: mqbi::ClusterStateManager)
-inline bool ClusterStateManager::isFirstLeaderAdvisory() const
-{
-    return d_isFirstLeaderAdvisory;
-}
-
 inline const mqbc::ClusterState* ClusterStateManager::clusterState() const
 {
     return d_state_p;

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -599,9 +599,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
         BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
-    //   (virtual: mqbi::ClusterStateManager)
-    bool isFirstLeaderAdvisory() const BSLS_KEYWORD_OVERRIDE;
-
     /// Return the cluster state managed by this instacne.
     const mqbc::ClusterState* clusterState() const BSLS_KEYWORD_OVERRIDE;
 
@@ -663,13 +660,6 @@ inline void ClusterStateManager::setAfterPartitionPrimaryAssignmentCb(
 
 // ACCESSORS
 //   (virtual: mqbi::ClusterStateManager)
-inline bool ClusterStateManager::isFirstLeaderAdvisory() const
-{
-    BSLS_ASSERT_SAFE(false && "NOT IMPLEMENTED!");
-
-    return false;
-}
-
 inline const mqbc::ClusterState* ClusterStateManager::clusterState() const
 {
     return d_state_p;

--- a/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_clusterstatemanager.h
@@ -312,8 +312,6 @@ class ClusterStateManager {
     virtual void onNodeStopped() = 0;
 
     // ACCESSORS
-    virtual bool isFirstLeaderAdvisory() const = 0;
-
     /// Return the cluster state managed by this instacne.
     virtual const mqbc::ClusterState* clusterState() const = 0;
 


### PR DESCRIPTION
The use of that flag results in a race between cluster and partition threads