### PR TITLE
Perf[BMQ,MQB]: simplify evaluator

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -343,7 +343,6 @@ MessageProperties::MessageProperties(bslma::Allocator* basicAllocator)
 , d_numProps(0)
 , d_dataOffset(0)
 , d_schema()
-, d_lastError(0)
 , d_originalNumProps(0)
 {
 }
@@ -362,7 +361,6 @@ MessageProperties::MessageProperties(const MessageProperties& other,
 , d_numProps(other.d_numProps)
 , d_dataOffset(other.d_dataOffset)
 , d_schema(other.d_schema)
-, d_lastError(other.d_lastError)
 , d_originalNumProps(other.d_originalNumProps)
 {
     if (other.d_isBlobConstructed) {
@@ -404,7 +402,6 @@ MessageProperties& MessageProperties::operator=(const MessageProperties& rhs)
     d_numProps         = rhs.d_numProps;
     d_dataOffset       = rhs.d_dataOffset;
     d_schema           = rhs.d_schema;
-    d_lastError        = rhs.d_lastError;
     d_originalNumProps = rhs.d_originalNumProps;
 
     return *this;
@@ -421,8 +418,6 @@ void MessageProperties::clear()
     d_numProps     = 0;
     d_dataOffset   = 0;
     d_schema.clear();
-
-    d_lastError = 0;
 
     d_originalNumProps = 0;
 
@@ -739,7 +734,6 @@ int MessageProperties::loadProperties(bool isFirstTime,
                                         start,
                                         i);
         if (rc) {
-            d_lastError = rc;
             return rc;
         }
 
@@ -1029,10 +1023,6 @@ bsl::ostream& MessageProperties::print(bsl::ostream& stream,
     printer.start();
 
     MessagePropertiesIterator msgPropIter(this);
-
-    if (d_lastError) {
-        printer.printAttribute("lastError", d_lastError);
-    }
 
     while (msgPropIter.hasNext()) {
         bdlma::LocalSequentialAllocator<64> nameLsa(0);

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -784,7 +784,6 @@ MessageProperties::findProperty(const bsl::string& name) const
         // Starts with '0'
 
         Property theProperty;
-        Property next;
         int      totalLength = d_dataOffset;
         int      offset      = d_mphOffset + index * d_mphSize;
         int      rc          = 0;
@@ -807,6 +806,7 @@ MessageProperties::findProperty(const bsl::string& name) const
         }
 
         if (index < (d_originalNumProps - 1)) {
+            Property next;
             rc = streamInPropertyHeader(&next,
                                         0,
                                         &theProperty,

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -237,8 +237,6 @@ class MessageProperties {
 
     SchemaPtr d_schema;
 
-    mutable int d_lastError;
-
     int d_originalNumProps;
     // The count as read from the wire
     // _before_ any property can change.
@@ -805,7 +803,6 @@ MessageProperties::findProperty(const bsl::string& name) const
         if (rc) {
             // REVISIT: there are no means to report the error other than
             //          returning 'end()'
-            d_lastError = rc;
             return d_properties.end();  // RETURN
         }
 

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -196,9 +196,10 @@ class MessageProperties {
     // DATA
     bslma::Allocator* d_allocator_p;
 
+    /// Rb-tree containing property name->value pairs.
+    /// Note: when the number of properties is small map works faster than
+    ///       unordered_map. Also, map takes less space.
     mutable PropertyMap d_properties;
-    // Hash table containing property
-    // name->value pairs.
 
     int d_totalSize;
     // Total size of the BlazingMQ wire

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -134,6 +134,9 @@ class MessageProperties {
         PropertyVariant;
 
     struct Property {
+        mutable PropertyVariant d_value;
+        // Property value; gets read on on demand.
+
         int d_offset;
         // Offset in the blob to the value (not the
         // name) or '0' for newly added properties.
@@ -144,9 +147,6 @@ class MessageProperties {
         bmqt::PropertyType::Enum d_type;
         // Type of the value.  Available even if
         // the value is 'unSet'.
-
-        mutable PropertyVariant d_value;
-        // Property value; gets read on on demand.
 
         bool d_isValid;
         // If the property is removed, it stays in
@@ -589,10 +589,10 @@ class MessagePropertiesIterator {
 // class MessageProperties::Property
 // ---------------------------------
 inline MessageProperties::Property::Property()
-: d_offset(0)
+: d_value()
+, d_offset(0)
 , d_length(0)
 , d_type(bmqt::PropertyType::e_UNDEFINED)
-, d_value()
 , d_isValid(true)
 {
     // NOTHING

--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -188,7 +188,13 @@ bool Routers::Expression::evaluate()
     /// |============|=========|========================|
 
     if (d_evaluator.isValid()) {
-        /// Evaluator returns `false` if there are any errors.
+        /// 1. If there are no errors during evaluation, evaluator returns
+        ///    the expression evaluation result (a bool).
+        /// 2. If there are any errors during evaluation, evaluator returns
+        ///    `false`.  Possible error types are:
+        /// - Result type is not a boolean
+        /// - Property used in the expression is not found in the message
+        /// - Unexpected type for expression operand
         return d_evaluator.evaluate(*d_evaluationContext_p);  // RETURN
     }
 

--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -178,22 +178,20 @@ void Routers::MessagePropertiesReader::next(
 
 bool Routers::Expression::evaluate()
 {
-    // Consider anything other than SimpleEvaluator as 'true'.
-    if (!d_evaluator.isCompiled()) {
-        return true;  // RETURN
-    }
+    /// |============|=========|========================|
+    /// | isCompiled | isValid | evaluate() = ?         |
+    /// |============|=========|========================|
+    /// | false      | false   | true                   |
+    /// | false      | true    | IMPOSSIBLE             |
+    /// | true       | false   | true                   |
+    /// | true       | true    | d_evaluator.evaluate() |
+    /// |============|=========|========================|
 
     if (d_evaluator.isValid()) {
-        bool result = d_evaluator.evaluate(*d_evaluationContext_p);
-
-        if (d_evaluationContext_p->hasError()) {
-            return false;  // RETURN
-        }
-
-        return result;  // RETURN
+        /// Evaluator returns `false` if there are any errors.
+        return d_evaluator.evaluate(*d_evaluationContext_p);  // RETURN
     }
 
-    // Consider compiled but not valid expressions as 'true'.
     return true;
 }
 


### PR DESCRIPTION
Changes

1. `bmqeval::EvaluationContext`: get rid of the bool flag `d_stop` and use `d_lastError` to exit evaluation early. This also speeds up the reset of evaluation context. The idea is that if we have an error stored in the field already we must stop early, and we don't need a special bool flag for this.
2. `mqbblp::Routers`: remove unnecessary check `if (!d_evaluator.isCompiled())`. The same behaviour can be achieved by only checking `d_evaluator.isValid()`. Look at the table in the comments that explains return values of `bool Routers::Expression::evaluate()`.
3. `mqbblp::Routers`: remove unnecessary check `if (d_evaluationContext_p->hasError())`. The same can be checked in evaluator itself.
4. Remove `mutable int bmqp::MessageProperties::d_lastError`
5. `bmqp::MessageProperties::Property`: reorder fields and put `bdlb::Variant7` in the beginning to improve field packing and alignment. `sizeof` of this structure reduced from 88 bytes to 80. This struct has to be aligned by 16 byte offset, so the old version used 96 bytes if places continuously in memory, now these structures can be placed in memory without gaps because `80 = 16*5`.
6. `bmqp::MessageProperties::findProperty`: do not construct next property on stack if not needed.