### PR TITLE
Fix[IT]: execute tests that do not have a consistency mark

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -198,7 +198,7 @@ jobs:
           export GOPATH=$HOME/go
           export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
-          ret=${{ github.workspace }}/src/integration-tests/run-tests \
+          ${{ github.workspace }}/src/integration-tests/run-tests \
             "${{ matrix.mode }} and ${{ matrix.cluster }} and ${{ matrix.consistency }}" \
             --log-level ERROR                   \
             --log-file-level=info               \
@@ -209,12 +209,7 @@ jobs:
             --tb long                           \
             --reruns=3                          \
             --durations=0                       \
-            -n logical -v -rs
-          if [ "$ret" = 5 ]; then
-            echo "No tests collected. Exiting with 0."
-            exit 0
-          fi
-          exit "$ret"
+            -n logical -v -rs || [ $? -eq 5 ]
       - name: Print core information
         if: failure()
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -163,7 +163,7 @@ jobs:
       matrix:
         mode: ["legacy_mode", "fsm_mode"]
         cluster: ["single", "multi"]
-        consistency: ["eventual_consistency", "strong_consistency"]
+        consistency: ["eventual_consistency", "strong_consistency", "not (eventual_consistency or strong_consistency)"]
       fail-fast: false
     runs-on: ubuntu-latest
     needs: build_ubuntu
@@ -198,7 +198,7 @@ jobs:
           export GOPATH=$HOME/go
           export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
-          ${{ github.workspace }}/src/integration-tests/run-tests \
+          ret=${{ github.workspace }}/src/integration-tests/run-tests \
             "${{ matrix.mode }} and ${{ matrix.cluster }} and ${{ matrix.consistency }}" \
             --log-level ERROR                   \
             --log-file-level=info               \
@@ -209,8 +209,12 @@ jobs:
             --tb long                           \
             --reruns=3                          \
             --durations=0                       \
-            -n logical -v
-
+            -n logical -v -rs
+          if [ "$ret" = 5 ]; then
+            echo "No tests collected. Exiting with 0."
+            exit 0
+          fi
+          exit "$ret"
       - name: Print core information
         if: failure()
         run: |
@@ -255,7 +259,7 @@ jobs:
             deps
             /opt/bb/include
           key: cache-${{ github.sha }}
-      
+
       - name: Setup core_pattern
         run: |
           sudo mkdir /cores
@@ -267,7 +271,7 @@ jobs:
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
           cd src/python
           python3 -m blazingmq.dev.fuzztest --broker-dir ${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr --request ${{ matrix.request }}
-      
+
       - name: Print core information
         if: failure()
         run: |

--- a/src/integration-tests/test_admin_command_routing.py
+++ b/src/integration-tests/test_admin_command_routing.py
@@ -22,6 +22,8 @@ This test suite does not concern itself with verifying the functional details
 of commands; only that they get routed to the proper nodes.
 """
 
+import pytest
+
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
     Cluster,
@@ -30,7 +32,6 @@ from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.client import Client
 import json
 import multiprocessing.pool
-import pytest
 
 pytest.skip(
     "Skip admin command routing tests until admin command routing is re-enabled",

--- a/src/integration-tests/test_admin_command_routing.py
+++ b/src/integration-tests/test_admin_command_routing.py
@@ -30,9 +30,15 @@ from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.client import Client
 import json
 import multiprocessing.pool
+import pytest
+
+pytest.skip(
+    "Skip admin command routing tests until admin command routing is re-enabled",
+    allow_module_level=True,
+)
 
 
-def test_primary_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> None:
+def test_primary_rerouting(multi_node: Cluster) -> None:
     """
     Test: commands intended only for primary node are automatically routed to
           primary node and response it sent back when executed from non-primary
@@ -48,11 +54,6 @@ def test_primary_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> N
     - CLUSTERS CLUSTER <name> FORCE_GC_QUEUES
     - CLUSTERS CLUSTER <name> STORAGE PARTITION <partitionId> ENABLE/DISABLE
     """
-
-    # TODO Skip admin command routing tests until admin command routing is re-enabled
-    return
-
-    du = domain_urls
 
     admin = AdminClient()
 
@@ -115,7 +116,7 @@ def test_primary_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> N
     admin.stop()
 
 
-def test_cluster_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> None:
+def test_cluster_rerouting(multi_node: Cluster) -> None:
     """
     Test: commands intended for cluster are routed to all nodes in the cluster
           regardless of the node the command is initially sent to
@@ -132,11 +133,6 @@ def test_cluster_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> N
     - CLUSTERS CLUSTER <name> STATE ELECTOR SET_ALL <param> <value>
     - CLUSTERS CLUSTER <name> STATE ELECTOR GET_ALL <param> <value>
     """
-
-    # TODO Skip admin command routing tests until admin command routing is re-enabled
-    return
-
-    du = domain_urls
 
     admin = AdminClient()
 
@@ -190,7 +186,7 @@ def test_cluster_rerouting(multi_node: Cluster, domain_urls: tc.DomainUrls) -> N
     admin.stop()
 
 
-def test_multi_response_encoding(multi_node: Cluster, domain_urls: tc.DomainUrls):
+def test_multi_response_encoding(multi_node: Cluster):
     """
     Test: JSON encoding options work with multiple responses (when routing to
           multiple nodes)
@@ -205,11 +201,6 @@ def test_multi_response_encoding(multi_node: Cluster, domain_urls: tc.DomainUrls
     Stage 3: Test pretty json formatting
 
     """
-
-    # TODO Skip admin command routing tests until admin command routing is re-enabled
-    return
-
-    du = domain_urls
 
     def is_compact(json_str: str) -> bool:
         return "    " not in json_str
@@ -277,8 +268,6 @@ def test_concurrently_routed_commands(multi_node: Cluster, domain_urls: tc.Domai
     Stage 2: Issue command in parallel
     Stage 3: Expect
     """
-    # TODO Skip admin command routing tests until admin command routing is re-enabled
-    return
 
     # Connect a client to each node in the cluster
     clients = []


### PR DESCRIPTION
This fixes how CI runs the integration tests. Currently, a test that does _not_ use one of the `domain_urls` fixtures is not executed, because it does not have a consistency pytest mark. To work around this, some tests (e.g. in `test_admin_command_routing.py`) artificially "use" `domain_urls`, and do nothing with it (because they don't open any queue).

This PR adds a mark expression to `strategy.matrix.consistency` to run the tests that don't have the mark.