### PR TITLE
CI[build.yaml]: apt-get update before installing gdb

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Print core information
         if: failure()
         run: |
-          sudo apt-get install -qy gdb
+          sudo apt-get update && sudo apt-get install -qy gdb
 
           python3 ${{ github.workspace }}/.github/workflows/ext/print_cores.py \
           --cores-dir=${{ github.workspace }}/src/integration-tests/failure-logs \
@@ -271,7 +271,7 @@ jobs:
       - name: Print core information
         if: failure()
         run: |
-          sudo apt-get install -qy gdb
+          sudo apt-get update && sudo apt-get install -qy gdb
 
           python3 ${{ github.workspace }}/.github/workflows/ext/print_cores.py \
           --cores-dir=/cores \


### PR DESCRIPTION
We have this error in GH Actions when trying to install gdb to print cores:
```
Need to get 12.0 MB of archives.
After this operation, 26.1 MB of additional disk space will be used.
Get:1 file:/etc/apt/apt-mirrors.txt Mirrorlist [144 B]
Get:2 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libdebuginfod-common all 0.190-1.1ubuntu0.1 [14.6 kB]
Get:3 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libbabeltrace1 amd64 1.5.11-3build3 [164 kB]
Get:4 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libdebuginfod1t64 amd64 0.190-1.1ubuntu0.1 [17.1 kB]
Get:5 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libipt2 amd64 2.0.6-1build1 [45.7 kB]
Get:6 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsource-highlight-common all 3.1.9-4.3build1 [64.2 kB]
Get:7 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 libsource-highlight4t64 amd64 3.1.9-4.3build1 [258 kB]
Get:8 http://azure.archive.ubuntu.com/ubuntu noble/main amd64 gdb amd64 15.0.50.20[24](https://github.com/bloomberg/blazingmq/actions/runs/16448117967/job/46486423948#step:6:25)0403-0ubuntu1 [4010 kB]
Ign:9 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.4
Ign:9 https://archive.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.4
Ign:9 https://security.ubuntu.com/ubuntu noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.4
Err:9 mirror+file:/etc/apt/apt-mirrors.txt noble-updates/main amd64 libc6-dbg amd64 2.39-0ubuntu8.4
  404  Not Found [IP: 52.[25](https://github.com/bloomberg/blazingmq/actions/runs/16448117967/job/46486423948#step:6:26)2.163.49 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/g/glibc/libc6-dbg_2.39-0ubuntu8.4_amd64.deb  404  Not Found [IP: 52.252.163.49 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Fetched 4573 kB in 2s ([27](https://github.com/bloomberg/blazingmq/actions/runs/16448117967/job/46486423948#step:6:28)24 kB/s)
```