### PR TITLE
Refactor[MQB]: simplify PushStream and QueueEngine

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -161,8 +161,9 @@ Application::Application(bdlmt::EventScheduler* scheduler,
                                     bdlf::PlaceHolders::_2),  // allocator
                k_BLOB_POOL_GROWTH_STRATEGY,
                d_allocators.get("BlobSpPool"))
-, d_pushElementsPool(sizeof(mqbblp::PushStream::Element),
-                     d_allocators.get("PushElementsPool"))
+, d_pushElementsPool_sp(bsl::allocate_shared<bdlma::ConcurrentPool>(
+      d_allocators.get("PushElementsPool"),
+      sizeof(mqbblp::PushStream::Element)))
 , d_allocatorsStatContext_p(allocatorsStatContext)
 , d_pluginManager_mp()
 , d_statController_mp()
@@ -273,7 +274,7 @@ int Application::start(bsl::ostream& errorDescription)
     mqbi::ClusterResources resources(d_scheduler_p,
                                      &d_bufferFactory,
                                      &d_blobSpPool,
-                                     &d_pushElementsPool);
+                                     d_pushElementsPool_sp);
 
     // Start the StatController
     d_statController_mp.load(

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -163,7 +163,10 @@ Application::Application(bdlmt::EventScheduler* scheduler,
                d_allocators.get("BlobSpPool"))
 , d_pushElementsPool_sp(bsl::allocate_shared<bdlma::ConcurrentPool>(
       d_allocators.get("PushElementsPool"),
-      sizeof(mqbblp::PushStream::Element)))
+      sizeof(mqbblp::PushStream::Element),
+      d_allocators.get("PushElementsPool")))
+// ConcurrentPool doesn't have allocator class trait, have to pass
+// allocator twice.
 , d_allocatorsStatContext_p(allocatorsStatContext)
 , d_pluginManager_mp()
 , d_statController_mp()

--- a/src/groups/mqb/mqba/mqba_application.h
+++ b/src/groups/mqb/mqba/mqba_application.h
@@ -136,7 +136,7 @@ class Application {
 
     BlobSpPool d_blobSpPool;
 
-    bdlma::ConcurrentPool d_pushElementsPool;
+    bsl::shared_ptr<bdlma::ConcurrentPool> d_pushElementsPool_sp;
 
     /// Stat context of the counting allocators, if used.
     bmqst::StatContext* d_allocatorsStatContext_p;

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -600,8 +600,7 @@ void LocalQueue::deliverIfNeeded()
 {
     // Now that storage messages have been flushed, notify the engine (and thus
     // any peer or downstream client) to deliver next applicable message.
-    d_queueEngine_mp->afterNewMessage(bmqt::MessageGUID(),
-                                      static_cast<mqbi::QueueHandle*>(0));
+    d_queueEngine_mp->afterNewMessage();
 }
 
 void LocalQueue::confirmMessage(const bmqt::MessageGUID& msgGUID,

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -35,7 +35,14 @@ PushStream::PushStream(
     bslma::Allocator*                             allocator)
 : d_stream(allocator)
 , d_apps(allocator)
-, d_pushElementsPool_sp(pushElementsPool_sp)
+, d_pushElementsPool_sp(
+      pushElementsPool_sp
+          ? pushElementsPool_sp
+          : bsl::allocate_shared<bdlma::ConcurrentPool>(allocator,
+                                                        sizeof(Element),
+                                                        allocator))
+// ConcurrentPool doesn't have allocator traits, have to pass allocator
+// twice
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_pushElementsPool_sp);

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -26,39 +26,18 @@
 namespace BloombergLP {
 namespace mqbblp {
 
-namespace {
-
-void noOpDeleter(bdlma::ConcurrentPool*)
-{
-    // NOTHING
-}
-
-}  // close unnamed namespace
-
 // ----------------
 // class PushStream
 // ----------------
 
 PushStream::PushStream(
-    const bsl::optional<bdlma::ConcurrentPool*>& pushElementsPool,
-    bslma::Allocator*                            allocator)
+    const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool_sp,
+    bslma::Allocator*                             allocator)
 : d_stream(allocator)
 , d_apps(allocator)
-, d_pushElementsPool_sp()
+, d_pushElementsPool_sp(pushElementsPool_sp)
 {
-    allocator = bslma::Default::allocator(allocator);
-
-    if (pushElementsPool.has_value()) {
-        d_pushElementsPool_sp.reset(pushElementsPool.value(),
-                                    noOpDeleter,
-                                    allocator);
-    }
-
-    if (!d_pushElementsPool_sp) {
-        d_pushElementsPool_sp.load(
-            new (*allocator) bdlma::ConcurrentPool(sizeof(Element), allocator),
-            allocator);
-    }
+    // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_pushElementsPool_sp);
     BSLS_ASSERT_SAFE(d_pushElementsPool_sp->blockSize() == sizeof(Element));
 }

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.h
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.h
@@ -193,14 +193,21 @@ struct PushStream {
         Element* nextInApp() const;
     };
 
+    // PUBLIC DATA
     Stream d_stream;
 
     Apps d_apps;
 
     bsl::shared_ptr<bdlma::ConcurrentPool> d_pushElementsPool_sp;
 
-    PushStream(const bsl::optional<bdlma::ConcurrentPool*>& pushElementsPool,
-               bslma::Allocator*                            allocator);
+    // CREATORS
+    /// @brief Construct this object.
+    /// @param pushElementsPool_sp The shared push element pool used to supply
+    ///        objects to this PushStream.  Must be not null.
+    /// @param allocator The allocator to use.
+    explicit PushStream(
+        const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool_sp,
+        bslma::Allocator*                             allocator);
 
     /// Introduce the specified `guid` to the Push Stream if it is not present.
     /// Return an iterator pointing to the `guid`.

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.h
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.h
@@ -75,7 +75,11 @@ namespace mqbblp {
 struct RelayQueueEngine_AppState;
 
 /// The ordered sequence of GUIDs for one-time delivery.
-struct PushStream {
+class PushStream {
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(PushStream, bslma::UsesBslmaAllocator)
+
     // forward declaration
     struct Element;
 
@@ -203,7 +207,8 @@ struct PushStream {
     // CREATORS
     /// @brief Construct this object.
     /// @param pushElementsPool_sp The shared push element pool used to supply
-    ///        objects to this PushStream.  Must be not null.
+    ///        objects to this PushStream.  If the provided pointer is null,
+    ///        create its own object pool.
     /// @param allocator The allocator to use.
     explicit PushStream(
         const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool_sp,

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -44,7 +44,8 @@ static void test1_basic()
     bsl::shared_ptr<bdlma::ConcurrentPool> pushElementsPool(
         bsl::allocate_shared<bdlma::ConcurrentPool>(
             bmqtst::TestHelperUtil::allocator(),
-            sizeof(mqbblp::PushStream::Element)));
+            sizeof(mqbblp::PushStream::Element),
+            bmqtst::TestHelperUtil::allocator()));
 
     mqbblp::PushStream                                 ps(pushElementsPool,
                           bmqtst::TestHelperUtil::allocator());
@@ -74,7 +75,8 @@ static void test2_iterations()
     bsl::shared_ptr<bdlma::ConcurrentPool> pushElementsPool(
         bsl::allocate_shared<bdlma::ConcurrentPool>(
             bmqtst::TestHelperUtil::allocator(),
-            sizeof(mqbblp::PushStream::Element)));
+            sizeof(mqbblp::PushStream::Element),
+            bmqtst::TestHelperUtil::allocator()));
 
     mqbblp::PushStream ps(pushElementsPool,
                           bmqtst::TestHelperUtil::allocator());

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -41,11 +41,12 @@ static void test1_basic()
 {
     bmqtst::TestHelper::printTestName("PushStream basic test");
 
-    bdlma::ConcurrentPool pushElementsPool(
-        sizeof(mqbblp::PushStream::Element),
-        bmqtst::TestHelperUtil::allocator());
+    bsl::shared_ptr<bdlma::ConcurrentPool> pushElementsPool(
+        bsl::allocate_shared<bdlma::ConcurrentPool>(
+            bmqtst::TestHelperUtil::allocator(),
+            sizeof(mqbblp::PushStream::Element)));
 
-    mqbblp::PushStream                                 ps(&pushElementsPool,
+    mqbblp::PushStream                                 ps(pushElementsPool,
                           bmqtst::TestHelperUtil::allocator());
     unsigned int                                       subQueueId = 0;
     bsl::shared_ptr<mqbblp::RelayQueueEngine_AppState> app;  // unused
@@ -70,7 +71,12 @@ static void test2_iterations()
 
     // Imitate {m1, a1}, {m2, a2}, {m1, a2}, {m2, a1}
 
-    mqbblp::PushStream ps(bsl::optional<bdlma::ConcurrentPool*>(),
+    bsl::shared_ptr<bdlma::ConcurrentPool> pushElementsPool(
+        bsl::allocate_shared<bdlma::ConcurrentPool>(
+            bmqtst::TestHelperUtil::allocator(),
+            sizeof(mqbblp::PushStream::Element)));
+
+    mqbblp::PushStream ps(pushElementsPool,
                           bmqtst::TestHelperUtil::allocator());
     unsigned int       subQueueId1 = 1;
     unsigned int       subQueueId2 = 2;

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -351,7 +351,7 @@ void Queue::convertToLocalDispatched()
     // In this case, 'onHandleUsable' event did not trigger any delivery.
     // Now that the queue is local, nudge its delivery to cover for this case.
 
-    d_localQueue_mp->queueEngine()->afterNewMessage(bmqt::MessageGUID(), 0);
+    d_localQueue_mp->queueEngine()->afterNewMessage();
 }
 
 void Queue::updateStats()

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -1012,13 +1012,7 @@ void QueueEngineTester::afterNewMessage(const int numMessages)
         const bmqt::MessageGUID& msgGUID = it->second;
         BSLS_ASSERT_OPT(!msgGUID.isUnset());
 
-        // NOTE: At the time of this writing, only the 'RelayQueueEngine' uses
-        //       the 'bmqt::MessageGUID msgGUID' parameter.
-        //
-        // NOTE: At the time of this writing, none of the Queue Engines use the
-        //       'mqbi::QueueHandle source' parameter, but if that changes then
-        //       we will need to keep track of that.
-        d_queueEngine_mp->afterNewMessage(msgGUID, 0);
+        d_queueEngine_mp->afterNewMessage();
 
         // Advance and delete from 'd_newMessages'
         it = d_newMessages.erase(it);

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -274,7 +274,7 @@ class QueueState {
     bdlbb::BlobBufferFactory*                    blobBufferFactory() const;
     bdlmt::EventScheduler*                       scheduler() const;
     mqbi::ClusterResources::BlobSpPool*          blobSpPool() const;
-    const bsl::optional<bdlma::ConcurrentPool*>& pushElementsPool() const;
+    const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool() const;
     bdlmt::FixedThreadPool*                      miscWorkThreadPool() const;
     const bsl::string&                           description() const;
     const mqbi::DispatcherClientData&            dispatcherClientData() const;
@@ -505,7 +505,7 @@ inline mqbi::ClusterResources::BlobSpPool* QueueState::blobSpPool() const
     return d_resources.blobSpPool();
 }
 
-inline const bsl::optional<bdlma::ConcurrentPool*>&
+inline const bsl::shared_ptr<bdlma::ConcurrentPool>&
 QueueState::pushElementsPool() const
 {
     return d_resources.pushElementsPool();

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -683,8 +683,7 @@ void RelayQueueEngine::processAppRedelivery(unsigned int upstreamSubQueueId,
 
     if (app->isReadyForDelivery()) {
         // can continue delivering
-        const bmqt::MessageGUID dummy;
-        afterNewMessage(dummy, 0);
+        afterNewMessage();
     }
 }
 
@@ -1390,9 +1389,7 @@ void RelayQueueEngine::onHandleUsable(mqbi::QueueHandle* handle,
     }
 }
 
-void RelayQueueEngine::afterNewMessage(
-    BSLA_UNUSED const bmqt::MessageGUID& msgGUID,
-    BSLA_UNUSED mqbi::QueueHandle* source)
+void RelayQueueEngine::afterNewMessage()
 {
     // executed by the *QUEUE DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -450,12 +450,9 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     onHandleUsable(mqbi::QueueHandle* handle,
                    unsigned int upstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the mqbi::Queue when a new message with the specified
-    /// `msgGUID` is available on the queue and ready to be sent to eventual
-    /// interested clients.  If available, the specified `source` points to
-    /// the originator of the message.
-    void afterNewMessage(const bmqt::MessageGUID& msgGUID,
-                         mqbi::QueueHandle* source) BSLS_KEYWORD_OVERRIDE;
+    /// Called by the mqbi::Queue when a new message is available on the queue
+    /// and ready to be sent to eventual interested clients.
+    void afterNewMessage() BSLS_KEYWORD_OVERRIDE;
 
     /// Called by the `mqbi::Queue` when the message identified by the
     /// specified `msgGUID` is confirmed for the specified

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -874,8 +874,7 @@ void RemoteQueue::flush()
         d_state_p->storage()->gcHistory(now);
     }
     if (d_queueEngine_mp) {
-        const bmqt::MessageGUID dummy;
-        d_queueEngine_mp->afterNewMessage(dummy, 0);
+        d_queueEngine_mp->afterNewMessage();
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -147,8 +147,7 @@ void RootQueueEngine::deliverMessages(AppState* app)
         // continue the delivery from the queue position in the stream.
         // Cannot rely on 'LocalQueue' calling 'afterNewMessage' since it turns
         // off 'd_hasNewMessages'.  Just call it explicitly.
-        const bmqt::MessageGUID dummy;
-        afterNewMessage(dummy, 0);
+        afterNewMessage();
     }
 }
 
@@ -1281,9 +1280,7 @@ void RootQueueEngine::onHandleUsable(mqbi::QueueHandle* handle,
     }
 }
 
-void RootQueueEngine::afterNewMessage(
-    BSLA_UNUSED const bmqt::MessageGUID& msgGUID,
-    BSLA_UNUSED mqbi::QueueHandle* source)
+void RootQueueEngine::afterNewMessage()
 {
     // executed by the *QUEUE DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -321,14 +321,11 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     onHandleUsable(mqbi::QueueHandle* handle,
                    unsigned int upstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the mqbi::Queue when a new message with the specified
-    /// `msgGUID` is available on the queue and ready to be sent to eventual
-    /// interested clients.  If available, the specified `source` points to
-    /// the originator of the message.
+    /// Called by the mqbi::Queue when a new message is available on the queue
+    /// and ready to be sent to eventual interested clients.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void afterNewMessage(const bmqt::MessageGUID& msgGUID,
-                         mqbi::QueueHandle* source) BSLS_KEYWORD_OVERRIDE;
+    void afterNewMessage() BSLS_KEYWORD_OVERRIDE;
 
     /// Called by the `mqbi::Queue` when the message identified by the
     /// specified `msgGUID` is confirmed for the specified `subQueueId`

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -4457,8 +4457,7 @@ static void test38_unauthorizedAppIds()
 //  4. Verify that no message remains in queue after C1 confirms messages.
 //
 // Testing:
-//  virtual void afterNewMessage(const bmqt::MessageGUID&  msgGUID,
-//                               mqbi::QueueHandle        *source)
+//  virtual void afterNewMessage()
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -489,7 +489,7 @@ struct ClusterResources {
     BlobSpPool* d_blobSpPool_p;
 
     /// Pool of PushStream elements for Proxy/Replica QueueEngine.
-    bsl::optional<bdlma::ConcurrentPool*> d_pushElementsPool;
+    bsl::shared_ptr<bdlma::ConcurrentPool> d_pushElementsPool_sp;
 
   public:
     // CREATORS
@@ -498,10 +498,11 @@ struct ClusterResources {
                               bdlbb::BlobBufferFactory* bufferFactory,
                               BlobSpPool*               blobSpPool);
 
-    explicit ClusterResources(bdlmt::EventScheduler*    scheduler,
-                              bdlbb::BlobBufferFactory* bufferFactory,
-                              BlobSpPool*               blobSpPool,
-                              bdlma::ConcurrentPool*    pushElementsPool);
+    explicit ClusterResources(
+        bdlmt::EventScheduler*                        scheduler,
+        bdlbb::BlobBufferFactory*                     bufferFactory,
+        BlobSpPool*                                   blobSpPool,
+        const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool_sp);
 
     ClusterResources(const ClusterResources& copy);
 
@@ -516,8 +517,8 @@ struct ClusterResources {
     /// Returns a pointer to the shared blob objects pool
     BlobSpPool* blobSpPool() const;
 
-    /// Returns a pointer to the concurrent pool for Push elements
-    const bsl::optional<bdlma::ConcurrentPool*>& pushElementsPool() const;
+    /// Returns a shared pointer to the concurrent pool for Push elements
+    const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool() const;
 };
 
 // ============================================================================
@@ -546,7 +547,7 @@ inline ClusterResources::ClusterResources(
 : d_scheduler_p(scheduler)
 , d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool)
-, d_pushElementsPool()
+, d_pushElementsPool_sp()
 {
     BSLS_ASSERT_SAFE(d_scheduler_p);
     BSLS_ASSERT_SAFE(d_bufferFactory_p);
@@ -554,26 +555,26 @@ inline ClusterResources::ClusterResources(
 }
 
 inline ClusterResources::ClusterResources(
-    bdlmt::EventScheduler*    scheduler,
-    bdlbb::BlobBufferFactory* bufferFactory,
-    BlobSpPool*               blobSpPool,
-    bdlma::ConcurrentPool*    pushElementsPool)
+    bdlmt::EventScheduler*                        scheduler,
+    bdlbb::BlobBufferFactory*                     bufferFactory,
+    BlobSpPool*                                   blobSpPool,
+    const bsl::shared_ptr<bdlma::ConcurrentPool>& pushElementsPool_sp)
 : d_scheduler_p(scheduler)
 , d_bufferFactory_p(bufferFactory)
 , d_blobSpPool_p(blobSpPool)
-, d_pushElementsPool(pushElementsPool)
+, d_pushElementsPool_sp(pushElementsPool_sp)
 {
     BSLS_ASSERT_SAFE(d_scheduler_p);
     BSLS_ASSERT_SAFE(d_bufferFactory_p);
     BSLS_ASSERT_SAFE(d_blobSpPool_p);
-    BSLS_ASSERT_SAFE(d_pushElementsPool);
+    BSLS_ASSERT_SAFE(d_pushElementsPool_sp);
 }
 
 inline ClusterResources::ClusterResources(const ClusterResources& copy)
 : d_scheduler_p(copy.d_scheduler_p)
 , d_bufferFactory_p(copy.d_bufferFactory_p)
 , d_blobSpPool_p(copy.d_blobSpPool_p)
-, d_pushElementsPool(copy.d_pushElementsPool)
+, d_pushElementsPool_sp(copy.d_pushElementsPool_sp)
 {
     // NOTHING
 }
@@ -597,10 +598,10 @@ inline ClusterResources::BlobSpPool* ClusterResources::blobSpPool() const
 // Pool of shared pointers to blob to
 // use.
 
-inline const bsl::optional<bdlma::ConcurrentPool*>&
+inline const bsl::shared_ptr<bdlma::ConcurrentPool>&
 ClusterResources::pushElementsPool() const
 {
-    return d_pushElementsPool;
+    return d_pushElementsPool_sp;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -136,14 +136,11 @@ class QueueEngine {
     virtual void onHandleUsable(QueueHandle* handle,
                                 unsigned int upstreamSubscriptionId) = 0;
 
-    /// Called by the mqbi::Queue when a new message with the specified
-    /// `msgGUID` is available on the queue and ready to be sent to eventual
-    /// interested clients.  If available, the specified `source` points to
-    /// the originator of the message.
+    /// Called by the mqbi::Queue when a new message is available on the queue
+    /// and ready to be sent to eventual interested clients.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    virtual void afterNewMessage(const bmqt::MessageGUID& msgGUID,
-                                 QueueHandle*             source) = 0;
+    virtual void afterNewMessage() = 0;
 
     /// Called by the `mqbi::Queue` when the message identified by the
     /// specified `msgGUID` is confirmed for the specified

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
@@ -91,8 +91,7 @@ void QueueEngine::onHandleUsable(BSLA_UNUSED mqbi::QueueHandle* handle,
     // NOTHING
 }
 
-void QueueEngine::afterNewMessage(BSLA_UNUSED const bmqt::MessageGUID& msgGUID,
-                                  BSLA_UNUSED mqbi::QueueHandle* source)
+void QueueEngine::afterNewMessage()
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.h
@@ -147,11 +147,9 @@ class QueueEngine : public mqbi::QueueEngine {
     void onHandleUsable(mqbi::QueueHandle* handle,
                         unsigned int upstreamSubQueueId) BSLS_KEYWORD_OVERRIDE;
 
-    /// Called by the mqbi::Queue when a new message with the specified
-    /// `msgGUID` is available on the queue and ready to be sent to eventual
-    /// interested clients.
-    void afterNewMessage(const bmqt::MessageGUID& msgGUID,
-                         mqbi::QueueHandle* source) BSLS_KEYWORD_OVERRIDE;
+    /// Called by the mqbi::Queue when a new message is available on the queue
+    /// and ready to be sent to eventual interested clients.
+    void afterNewMessage() BSLS_KEYWORD_OVERRIDE;
 
     /// Called by the `mqbi::Queue` when the message identified by the
     /// specified `msgGUID` is confirmed for the specified `subQueueId`

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -7242,7 +7242,7 @@ void FileStore::setReplicationFactor(int value)
              affectedQueues.begin();
          qit != affectedQueues.end();
          ++qit) {
-        (*qit)->queueEngine()->afterNewMessage(bmqt::MessageGUID(), 0);
+        (*qit)->queueEngine()->afterNewMessage();
     }
 }
 


### PR DESCRIPTION
1. Pass simple `shared_ptr<ConcurrentPool>` to `PushStream` constructor. This helps to avoid building `shared_ptr` with noDeleter.
2. Remove unused arguments from `QueueEngine::afterNewMessage`. This is a frequent code path on Primary, and this change should improve performance slightly.