### PR TITLE
Fix blp::ClusterOrchestrator: Skip process cluster FSM message if stopping

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -840,6 +840,16 @@ void ClusterOrchestrator::processClusterStateFSMMessage(
                     .choice()
                     .isClusterStateFSMMessageValue());
 
+    if (bmqp_ctrlmsg::NodeStatus::E_STOPPING ==
+        d_clusterData_p->membership().selfNodeStatus()) {
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Not processing cluster state FSM message : "
+                      << message << " from " << source->nodeDescription()
+                      << " since self is stopping";
+
+        return;  // RETURN
+    }
+
     typedef bmqp_ctrlmsg::ClusterStateFSMMessageChoice MsgChoice;  // shortcut
     switch (message.choice()
                 .clusterMessage()


### PR DESCRIPTION
Internal Ticket 180066129, specifically fixing the second crash. See the ticket for a more detailed explanation on why this fixes the crash.

```
22JUL2025_23:20:14.570 (140642363508480) FATAL mqbc_clusterstatemanager.cpp:813 Assertion failed: inputMessage.source()->nodeId() == d_clusterData_p->ele
ctorInfo().leaderNodeId(), stack trace:
(0): bmqAssertHandler(char const*, char const*, int)+0x6d at 0xb16d6d source:bmqbrkr.m.cpp in /bb/bin/bmqbrkr.tsk
(1): BloombergLP::bsls::Assert::invokeHandler(BloombergLP::bsls::AssertViolation const&)+0x17 at 0x159c037 in /bb/bin/bmqbrkr.tsk
(2): BloombergLP::mqbc::ClusterStateManager::do_logErrorLeaderNotHealed(bsl::shared_ptr<bsl::queue<bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::E
num, BloombergLP::mqbc::ClusterFSMEventMetadata>, bsl::deque<bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEven
tMetadata>, bsl::allocator<bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEventMetadata> > > > > const&)+0x442 a
t 0xe8b202 in /bb/bin/bmqbrkr.tsk
```