### PR TITLE
Refactor[MQBU]: Remove unnecessary buffer from `mqbu_storagekey`

### DIFF
--- a/src/groups/mqb/mqbu/mqbu_storagekey.cpp
+++ b/src/groups/mqb/mqbu/mqbu_storagekey.cpp
@@ -29,7 +29,6 @@ BSLMF_ASSERT(StorageKey::e_KEY_LENGTH_BINARY == sizeof(StorageKey));
 // class StorageKey
 // ----------------
 
-const char*      StorageKey::k_NULL_KEY_BUFFER("\0\0\0\0\0");
 const StorageKey StorageKey::k_NULL_KEY;
 
 // ------------------------

--- a/src/groups/mqb/mqbu/mqbu_storagekey.h
+++ b/src/groups/mqb/mqbu/mqbu_storagekey.h
@@ -79,9 +79,6 @@ class StorageKey {
   private:
     // PRIVATE CONSTANTS
 
-    // This binary buffer can be used to construct an empty storage key.
-    static const char* k_NULL_KEY_BUFFER;
-
   private:
     // DATA
     char d_buffer[e_KEY_LENGTH_BINARY];
@@ -279,7 +276,7 @@ class StorageKeyHashAlgo {
 // CREATORS
 inline StorageKey::StorageKey()
 {
-    bsl::memcpy(d_buffer, k_NULL_KEY_BUFFER, StorageKey::e_KEY_LENGTH_BINARY);
+    bsl::memset(d_buffer, '\0', StorageKey::e_KEY_LENGTH_BINARY);
 }
 
 inline StorageKey::StorageKey(const BinaryRepresentation&, const void* data)


### PR DESCRIPTION
This patch removes a statically allocated buffer `k_NULL_KEY_BUFFER`
containing five null bytes from `mqbu_storagekey`.  This buffer is only
used in the default constructor for `StorageKey`, where we copy the five
null bytes into the `StorageKey`'s internal buffer.  In place of this,
we `memset` the internal buffer to `\0`.

Note that elsewhere we rely on `k_NULL_KEY_BUFFER[0] == '\0'` (see
src/groups/mqb/mqbu/mqbu_storagekey.h:312), so we can't freely change
this constant later on.