### PR TITLE
CI: Run sanitizers as part of Tests workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -184,6 +184,11 @@ jobs:
           --cores-dir=/cores \
           --bin-path=${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr/bmqbrkr.tsk
 
+  sanitize_ubuntu:
+    name: Sanitize
+    uses: ./.github/workflows/sanitize.yaml
+    needs: integration_tests_ubuntu
+
   integration_tests_storagetool_ubuntu:
     name: IT [Storage tool]
     runs-on: ubuntu-latest

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -3,10 +3,6 @@ name: Sanitize
 on:
   workflow_call:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   build_and_run_sanitizer:
     name: ${{ matrix.mode }}${{ matrix.fuzz == 'on' && '-fuzz' || '' }}

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -1,9 +1,7 @@
 name: Sanitize
 
 on:
-  workflow_run:
-    workflows: ["Tests"]
-    types: [completed]
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -21,7 +19,6 @@ jobs:
             fuzz: "on"
       fail-fast: false
     runs-on: ubuntu-24.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - name: Purge runner


### PR DESCRIPTION
Change trigger for Sanitizers workflow. Make it run on Integration Tests success as part of Tests workflow which in turn runs on every change to an open PR or submitting a new PR.

This change makes Sanitizer workflow results visible on the PR page.