### PR TITLE
Fix[mqbnet::Channel]: deadlock on setChannel

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -596,8 +596,9 @@ class Channel {
               bmqp::EventType::Enum                     type,
               const bsl::shared_ptr<bmqu::AtomicState>& state = 0);
 
-    /// Write everything unless there is a thread actively writing already.
-    void flush();
+    /// Wake up the internal thread if it's waiting for a new item to write.
+    /// This leads to flushing of the inner message builders.
+    void wakeUp();
 
     /// Notify the channel when a watermark of the specified `type` is being
     /// reached.

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -808,7 +808,7 @@ static void test1_write()
     size_t writeBlobs = 0;
 
     // Flush ACKs which are secondary
-    channel.flush();
+    channel.wakeUp();
 
     BMQTST_ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(3)), true);
 
@@ -923,7 +923,7 @@ static void test2_highWatermark()
     size_t writeBlobs = 0;
 
     // Flush ACKs which are secondary
-    channel.flush();
+    channel.wakeUp();
 
     BMQTST_ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(1)), true);
 
@@ -1040,7 +1040,7 @@ static void test3_highWatermarkInWriteCb()
     testChannel->setLimit(0);
 
     // Flush ACKs which are secondary
-    channel.flush();
+    channel.wakeUp();
     BMQTST_ASSERT_EQ(testChannel->waitForChannel(bsls::TimeInterval(10)),
                      true);
 
@@ -1125,7 +1125,7 @@ static void test4_controlBlob()
     payload_sp->appendDataBuffer(blobBuffer);
 
     // Flush ACKs which are secondary
-    channel.flush();
+    channel.wakeUp();
 
     BMQTST_ASSERT_EQ(channel.writeBlob(payload_sp, bmqp::EventType::e_CONTROL),
                      bmqt::GenericResult::e_SUCCESS);


### PR DESCRIPTION
Note that in both stack traces we look at the same `mqbnet::Channel` (`this == 0x252c390`)

IO thread:

```
#0  futex_wait_cancelable (private=0, expected=4, futex_word=0x252ca90) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  __pthread_cond_wait_common (abstime=0x0, mutex=0x252caa0, cond=0x252ca68) at pthread_cond_wait.c:425
#2  __pthread_cond_wait (cond=0x252ca68, mutex=0x252caa0) at pthread_cond_wait.c:496
#3  0x0000000001099c1b in BloombergLP::bslmt::ConditionImpl<BloombergLP::bslmt::Platform::PosixThreads>::wait (mutex=0x252caa0, this=0x252ca68) at /include/bslmt_conditionimpl_pthread.h:191
#4  BloombergLP::bslmt::Condition::wait (mutex=0x252caa0, this=0x252ca68) at /include/bslmt_condition.h:383
#5  BloombergLP::mqbnet::Channel::setChannel (this=this@entry=0x252c390, value=const bsl::weak_ptr<BloombergLP::bmqio::Channel> [ref:5,weak:2] = {...}) at /src/groups/mqb/mqbnet/mqbnet_channel.cpp:304
#6  0x00000000010aa0f3 in BloombergLP::mqbnet::ClusterNodeImp::setChannel (this=0x252c240, value=const bsl::weak_ptr<BloombergLP::bmqio::Channel> [ref:5,weak:2] = {...}, identity=..., readCb=...) at /src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp:80
#7  0x00000000010ccdd3 in BloombergLP::mqbnet::TransportManager::processSession (this=0x24f1cf0, cluster=0x24ca9f0, state=0x2674138, session=const bsl::shared_ptr<BloombergLP::mqbnet::Session> [ref:2,weak:0] = {...}, readCb=...)
    at /src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp:170
#8  0x00000000010d0e1d in BloombergLP::bdlf::MemFn<bool (BloombergLP::mqbnet::TransportManager::*)(BloombergLP::bmqio::ChannelFactoryEvent::Enum, BloombergLP::bmqio::Status const&, bsl::shared_ptr<BloombergLP::mqbnet::Session> const&, BloombergLP::mqbnet::Cluster*, void*, bsl::function<void(BloombergLP::bmqio::Status const&, int*, BloombergLP::bdlbb::Blob*)> const&, bool)>::operator()<BloombergLP::mqbnet::TransportManager*> (this=<optimized out>, object=<optimized out>, arg7=<optimized out>, arg6=..., arg5=<optimized out>, 
    arg4=<optimized out>, arg3=..., arg2=..., arg1=<optimized out>) at /include/bdlf_memfn.h:645
...
#25 BloombergLP::bmqio::StatChannel::readCbWrapper (this=0x7fa22048dcd8, userCb=..., status=..., numNeeded=<optimized out>, blob=0x7fa2f0001650) at /src/groups/bmq/bmqio/bmqio_statchannel.cpp:68
#26 0x00000000012c8f23 in BloombergLP::bslstl::Function_Variadic<void(BloombergLP::bmqio::Status const&, int*, BloombergLP::bdlbb::Blob*)>::operator() (args#2=0x7fa2f0001650, args#1=0x7fa241ddd8c0, args#0=..., this=0x7fa2f0015600)
    at /include/bslstl_function.h:1545
#27 BloombergLP::bmqio::NtcChannel::processReadQueueLowWatermark (this=0x7fa2f00015c0, streamSocket=..., event=...) at /src/groups/bmq/bmqio/bmqio_ntcchannel.cpp:746
#28 0x00000000017f658e in BloombergLP::ntcs::Dispatch::announceReadQueueLowWatermark (session=const bsl::shared_ptr<BloombergLP::ntci::StreamSocketSession> [ref:7,weak:1] = {...}, socket=const bsl::shared_ptr<BloombergLP::ntci::StreamSocket> [ref:8,weak:1] = {...}, 
    event=..., destination=const bsl::shared_ptr<BloombergLP::ntci::Strand> [ref:0,weak:0] = {...}, source=const bsl::shared_ptr<BloombergLP::ntci::Strand> [ref:0,weak:0] = {...}, executor=const bsl::shared_ptr<BloombergLP::ntci::Executor> [ref:8,weak:1] = {...}, 
    defer=<optimized out>, mutex=<optimized out>) at /ntf-core-2.5.4/groups/ntc/ntcs/ntcs_dispatch.cpp:1516
#29 0x00000000016e91fa in BloombergLP::ntcr::StreamSocket::privateSocketReadableIteration (this=this@entry=0x7fa2f000ad30, self=const bsl::shared_ptr<BloombergLP::ntcr::StreamSocket> [ref:8,weak:1] = {...})
    at /ntf-core-2.5.4/groups/ntc/ntcr/ntcr_streamsocket.cpp:930
#30 0x00000000016ef50c in BloombergLP::ntcr::StreamSocket::processSocketReadable (this=0x7fa2f000ad30, event=...) at /ntf-core-2.5.4/groups/ntc/ntcr/ntcr_streamsocket.cpp:313
#31 0x000000000177bac9 in BloombergLP::ntcs::Dispatch::announceReadable (destination=..., event=..., socket=...) at /tmp/ntf-core-2.5.4/groups/ntc/ntcs/ntcs_dispatch.h:1611
#32 BloombergLP::ntcs::RegistryEntry::announceReadable (event=..., this=<optimized out>) at /ntf-core-2.5.4/groups/ntc/ntcs/ntcs_registry.h:745
#33 BloombergLP::ntco::Epoll::run (this=0x24fc110, waiter=<optimized out>) at /ntf-core-2.5.4/groups/ntc/ntco/ntco_epoll.cpp:2355
#34 0x00000000016fff9b in BloombergLP::ntcr::Interface::run (context=0x7ffe16d02cd0) at /ntf-core-2.5.4/groups/ntc/ntcr/ntcr_interface.cpp:118
```

`mqbnet::Channel::threadFn` thread:

```
#0  futex_wait_cancelable (private=0, expected=38521905, futex_word=0x252c71c) at ../sysdeps/unix/sysv/linux/futex-internal.h:88
#1  __pthread_cond_wait_common (abstime=0x0, mutex=0x252c6c8, cond=0x252c6f0) at pthread_cond_wait.c:425
#2  __pthread_cond_wait (cond=0x252c6f0, mutex=0x252c6c8) at pthread_cond_wait.c:496
#3  0x00000000010a284d in BloombergLP::bslmt::ConditionImpl<BloombergLP::bslmt::Platform::PosixThreads>::wait (mutex=0x252c6c8, this=0x252c6f0) at /include/bslmt_conditionimpl_pthread.h:191
#4  BloombergLP::bslmt::Condition::wait (mutex=0x252c6c8, this=0x252c6f0) at /include/bslmt_condition.h:383
#5  BloombergLP::bdlcc::SingleConsumerQueueImpl<BloombergLP::bslma::ManagedPtr<BloombergLP::mqbnet::Channel::Item>, BloombergLP::bsls::AtomicOperations, BloombergLP::bslmt::Mutex, BloombergLP::bslmt::Condition>::popFront (this=this@entry=0x252c6b8, value=value@entry=0x7fa224bfcc70) at /include/bdlcc_singleconsumerqueueimpl.h:973
#6  0x000000000109fef8 in BloombergLP::bdlcc::SingleConsumerQueue<BloombergLP::bslma::ManagedPtr<BloombergLP::mqbnet::Channel::Item> >::popFront (value=0x7fa224bfcc70, this=0x252c6b8) at /include/bdlcc_singleconsumerqueue.h:372
#7  BloombergLP::bmqc::MonitoredQueueTraits<BloombergLP::bdlcc::SingleConsumerQueue<BloombergLP::bslma::ManagedPtr<BloombergLP::mqbnet::Channel::Item> > >::popFront (buffer=0x7fa224bfcc70, queue=0x252c6b8) at /src/groups/bmq/bmqc/bmqc_monitoredqueue_bdlccsingleconsumerqueue.h:113
#8  BloombergLP::bmqc::MonitoredQueue<BloombergLP::bdlcc::SingleConsumerQueue<BloombergLP::bslma::ManagedPtr<BloombergLP::mqbnet::Channel::Item> >, BloombergLP::bmqc::MonitoredQueueTraits<BloombergLP::bdlcc::SingleConsumerQueue<BloombergLP::bslma::ManagedPtr<BloombergLP::mqbnet::Channel::Item> > > >::popFront (value=0x7fa224bfcc70, this=0x252c640) at /src/groups/bmq/bmqc/bmqc_monitoredqueue.h:641
#9  BloombergLP::mqbnet::Channel::threadFn (this=0x252c390) at /tmp/bmqbrkr-0.93.18/src/groups/mqb/mqbnet/mqbnet_channel.cpp:838
```

`threadFn` is blocked while trying to get an item with `popFront`. There is no activity, and there are no items to get out of this state. At the same time, IO thread is blocked on trying to get a signal from `threadFn` that it never receives.

The solution is to unblock `threadFn` right after we set `e_RESET` state, so it can go to the next iteration of the while-loop and signal correctly.