### PR TITLE
fix[mqbblp]: position VirtualPushStreamIterator

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.cpp
@@ -84,13 +84,13 @@ PushStreamIterator::PushStreamIterator(
     PushStream*                 owner,
     const PushStream::iterator& initialPosition)
 : d_storage_p(storage)
-, d_iterator(initialPosition)
 , d_attributes()
 , d_appData_sp()
 , d_options_sp()
 , d_owner_p(owner)
 , d_currentElement(0)
 , d_currentOrdinal(mqbi::Storage::k_INVALID_ORDINAL)
+, d_iterator(initialPosition)
 {
     BSLS_ASSERT_SAFE(d_storage_p);
     BSLS_ASSERT_SAFE(d_owner_p);
@@ -256,8 +256,12 @@ VirtualPushStreamIterator::VirtualPushStreamIterator(
     d_itApp = owner->d_apps.find(upstreamSubQueueId);
 
     if (d_itApp != owner->d_apps.end()) {
+        // Assume VirtualPushStreamIterator always starts with the first
+        // element in the App
+
         d_currentElement = d_itApp->second.d_elements.front();
 
+        BSLS_ASSERT_SAFE(d_currentElement->iteratorGuid() == initialPosition);
         BSLS_ASSERT_SAFE(d_currentElement->app().d_app ==
                          d_itApp->second.d_app);
     }
@@ -301,6 +305,8 @@ bool VirtualPushStreamIterator::advance()
 
     BSLS_ASSERT_SAFE(d_itApp->second.d_elements.numElements());
     BSLS_ASSERT_SAFE(d_currentElement);
+
+    d_iterator = d_currentElement->iteratorGuid();
 
     return true;
 }

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -901,11 +901,10 @@ QueueEngineUtil_AppState::~QueueEngineUtil_AppState()
     // existing `RelayQueueEngine` routing contexts.
 }
 
-size_t
-QueueEngineUtil_AppState::deliverMessages(bsls::TimeInterval*          delay,
-                                          mqbi::StorageIterator*       reader,
-                                          mqbi::StorageIterator*       start,
-                                          const mqbi::StorageIterator* end)
+size_t QueueEngineUtil_AppState::catchUp(bsls::TimeInterval*          delay,
+                                         mqbi::StorageIterator*       reader,
+                                         mqbi::StorageIterator*       start,
+                                         const mqbi::StorageIterator* end)
 {
     // executed by the *QUEUE DISPATCHER* thread
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -411,10 +411,10 @@ struct QueueEngineUtil_AppState {
     /// to all consumers (broadcast mode), or in a round-robin manner (every
     /// other mode).
     /// Use the specified `reader` to read data for delivery.
-    size_t deliverMessages(bsls::TimeInterval*          delay,
-                           mqbi::StorageIterator*       reader,
-                           mqbi::StorageIterator*       start,
-                           const mqbi::StorageIterator* end);
+    size_t catchUp(bsls::TimeInterval*          delay,
+                   mqbi::StorageIterator*       reader,
+                   mqbi::StorageIterator*       start,
+                   const mqbi::StorageIterator* end);
 
     /// Try to deliver to the next available consumer the specified `message`.
     /// If poisonous message handling requires a delay in the delivery, iterate

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -667,10 +667,10 @@ void RelayQueueEngine::processAppRedelivery(unsigned int upstreamSubQueueId,
     }
 
     bsls::TimeInterval delay;
-    app->deliverMessages(&delay,
-                         d_realStorageIter_mp.get(),
-                         start,
-                         d_storageIter_mp.get());
+    app->catchUp(&delay,
+                 d_realStorageIter_mp.get(),
+                 start,
+                 d_storageIter_mp.get());
 
     if (delay != bsls::TimeInterval()) {
         app->scheduleThrottle(
@@ -1876,7 +1876,7 @@ RelayQueueEngine::push(mqbi::StorageMessageAttributes*     attributes,
         else {
             const PushStream::App& app = itApp->second;
 
-            if (app.last() && app.last()->equal(itGuid)) {
+            if (app.last() && app.last()->iteratorGuid() == itGuid) {
                 BMQ_LOGTHROTTLE_INFO()
                     << "Remote queue: " << d_queueState_p->uri()
                     << " (id: " << d_queueState_p->id() << ", App '"

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -125,10 +125,10 @@ void RootQueueEngine::deliverMessages(AppState* app)
     }
 
     bsls::TimeInterval delay;
-    const size_t       numMessages = app->deliverMessages(&delay,
-                                                    d_realStorageIter_mp.get(),
-                                                    start,
-                                                    d_storageIter_mp.get());
+    const size_t       numMessages = app->catchUp(&delay,
+                                                  d_realStorageIter_mp.get(),
+                                                  start,
+                                                  d_storageIter_mp.get());
 
     if (delay != bsls::TimeInterval()) {
         app->scheduleThrottle(


### PR DESCRIPTION
Fixing bug in `VirtualPushStreamIterator` when `RelayQueueEngine` catches up with `RelayQueueEngine::d_storageIter_mp`, it may crass the latter, resulting in message processing twice.  If all other apps are gone, it will crash because the same iterator gets erased twice.