### PR TITLE
Fix[MQBBLP]: restore queue ptr from domain when reopen pending queue

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -28,6 +28,7 @@
 #include <mqbnet_session.h>
 #include <mqbs_datastore.h>
 #include <mqbs_replicatedstorage.h>
+#include <mqbstat_queuestats.h>
 
 // BMQ
 #include <bmqp_ackmessageiterator.h>

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -36,6 +36,7 @@
 //
 
 // MQB
+#include <mqbblp_queue.h>
 #include <mqbblp_storagemanager.h>
 #include <mqbc_clusterdata.h>
 #include <mqbc_clusternodesession.h>
@@ -2084,9 +2085,7 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
         /// `d_liveQInfo->d_queue_sp` is reset, but the corresponding domain
         /// still contains a shared_ptr to this queue.
         /// We must restore `d_queue_sp` from the domain.
-        queueContext->d_liveQInfo.d_queue_sp = bsl::shared_ptr<mqbblp::Queue>(
-            iQueueSp,
-            static_cast<mqbblp::Queue*>(iQueueSp.get()));
+        queueContext->d_liveQInfo.d_queue_sp = iQueueSp;
         return iQueueSp;  // RETURN
     }
 
@@ -3869,7 +3868,7 @@ ClusterQueueHelper::restoreStateHelper(QueueLiveState&      queueInfo,
                           << "ReopenQueue request: " << REQ << ", rc: " << RC \
                           << ".";
 
-    const mqbblp::Queue* queuePtr = queueInfo.d_queue_sp.get();
+    const mqbi::Queue* queuePtr = queueInfo.d_queue_sp.get();
 
     for (StreamsMap::iterator iter = queueInfo.d_subQueueIds.begin();
          iter != queueInfo.d_subQueueIds.end();
@@ -4422,7 +4421,7 @@ void ClusterQueueHelper::onQueueUpdated(
     BSLS_ASSERT_SAFE(qiter != d_queues.end());
 
     QueueContext&  queueContext = *qiter->second;
-    mqbblp::Queue* queue        = queueContext.d_liveQInfo.d_queue_sp.get();
+    mqbi::Queue*   queue        = queueContext.d_liveQInfo.d_queue_sp.get();
     const int      partitionId  = queueContext.partitionId();
     BSLS_ASSERT_SAFE(partitionId != mqbs::DataStore::k_INVALID_PARTITION_ID);
 
@@ -5848,7 +5847,7 @@ void ClusterQueueHelper::checkUnconfirmed(
         return;  // RETURN
     }
 
-    bsl::shared_ptr<mqbblp::Queue>& queueSp =
+    bsl::shared_ptr<mqbi::Queue>& queueSp =
         queueContextSp->d_liveQInfo.d_queue_sp;
 
     if (!queueSp) {
@@ -5968,7 +5967,7 @@ void ClusterQueueHelper::checkUnconfirmedQueueDispatched(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueContextSp);
-    bsl::shared_ptr<mqbblp::Queue>& queueSp =
+    bsl::shared_ptr<mqbi::Queue>& queueSp =
         queueContextSp->d_liveQInfo.d_queue_sp;
     BSLS_ASSERT_SAFE(queueSp);
     BSLS_ASSERT_SAFE(queueSp->dispatcher()->inDispatcherThread(queueSp.get()));

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2080,6 +2080,13 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
     // Domain is already aware of the queue, reuse it.
     bsl::shared_ptr<mqbi::Queue> iQueueSp;
     if (context.d_domain_p->lookupQueue(&iQueueSp, queueContext->uri()) == 0) {
+        /// In rare situations we call `resetButKeepPending` and
+        /// `d_liveQInfo->d_queue_sp` is reset, but the corresponding domain
+        /// still contains a shared_ptr to this queue.
+        /// We must restore `d_queue_sp` from the domain.
+        queueContext->d_liveQInfo.d_queue_sp = bsl::shared_ptr<mqbblp::Queue>(
+            iQueueSp,
+            static_cast<mqbblp::Queue*>(iQueueSp.get()));
         return iQueueSp;  // RETURN
     }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -30,7 +30,6 @@
 ///       stated, should be executed by the dispatcher thread.
 
 // MQB
-#include <mqbblp_queue.h>
 #include <mqbc_clusterdata.h>
 #include <mqbc_clustermembership.h>
 #include <mqbc_clusterstate.h>
@@ -191,7 +190,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         unsigned int d_nextSubQueueId;
 
         // Queue created (null if no queue created yet)
-        bsl::shared_ptr<mqbblp::Queue> d_queue_sp;
+        bsl::shared_ptr<mqbi::Queue> d_queue_sp;
 
         // Number of queue handles associated with this queue.
         int d_numQueueHandles;

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -178,7 +178,7 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
                       int                       ackWindowSize,
                       RemoteQueue::StateSpPool* statePool);
 
-    void convertToLocal();
+    void convertToLocal() BSLS_KEYWORD_OVERRIDE;
     void convertToRemote();
 
     // ACCESSORS

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -899,6 +899,9 @@ class Queue : public DispatcherClient {
     virtual int processCommand(mqbcmd::QueueResult*        result,
                                const mqbcmd::QueueCommand& command) = 0;
 
+    /// Convert this queue to local.
+    virtual void convertToLocal() = 0;
+
     // ACCESSORS
 
     /// Return the domain this queue belong to.

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -391,6 +391,11 @@ int Queue::processCommand(mqbcmd::QueueResult*        result,
     return -1;
 }
 
+void Queue::convertToLocal()
+{
+    // NOTHING
+}
+
 // MANIPULATORS
 //   (specific to mqbmock::Queue)
 Queue& Queue::_setDispatcher(mqbi::Dispatcher* value)

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -352,6 +352,8 @@ class Queue : public mqbi::Queue {
     processCommand(mqbcmd::QueueResult*        result,
                    const mqbcmd::QueueCommand& command) BSLS_KEYWORD_OVERRIDE;
 
+    void convertToLocal() BSLS_KEYWORD_OVERRIDE;
+
     // MANIPULATORS
     //   (specific to mqbmock::Queue)
     Queue& _setDispatcher(mqbi::Dispatcher* value);


### PR DESCRIPTION
Fixing crash:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f8f5e969e65 in __GI_abort () at abort.c:79
#2  0x0000000000aab955 in BloombergLP::bsls::AssertImpUtil::failByAbort ()
    at /src/groups/bsl/bsls/bsls_assertimputil.cpp:91
#3  0x0000000000b0a3e3 in bmqAssertHandler (
    comment=0x1b59eb8 "queueContextSp->d_liveQInfo.d_queue_sp.get() == queue", 
    file=0x1b59788 
"/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp",
 line=3059)
    at /src/applications/bmqbrkr/bmqbrkr.m.cpp:184
#4  0x0000000001593c27 in BloombergLP::bsls::Assert::invokeHandler (
    violation=...)
    at /groups/bsl/bsls/bsls_assert.cpp:252
#5  0x0000000000cc02e2 in 
BloombergLP::mqbblp::ClusterQueueHelper::onQueueHandleCreatedDispatched 
(this=0x3aef868, queue=0x7f8e982b9980, uri=..., 
    handleCreated=<optimized out>)
    at 
/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp:3059
#6  0x0000000000be397e in BloombergLP::mqba::Dispatcher::queueEventCb (
    this=<optimized out>, 
    type=BloombergLP::mqbi::DispatcherClientType::e_CLUSTER, processorId=0, 
    context=<optimized out>, event=0x7f8e88c000f0)
    at /src/groups/mqb/mqba/mqba_dispatcher.cpp:418
```

Debugger:
`queue` pointer is not null:
```
(gdb) print queue
$1 = (BloombergLP::mqbi::Queue *) 0x7f8e982b9980
```

`d_queue_sp` pointer is empty:
```
(gdb) print queueContextSp
$2 = BloombergLP::mqbblp::ClusterQueueHelper::QueueContextSp [ref:1,weak:0] = {*d_ptr_p = {d_liveQInfo = {d_id = 317,
...
      d_queue_sp = bsl::shared_ptr<BloombergLP::mqbblp::Queue> [ref:0,weak:0] = {d_ptr_p = 0x0}, d_numQueueHandles = 0, d_numHandleCreationsInProgress = 1, d_queueExpirationTimestampMs = 0,
...
```