### PR TITLE
CI: Fix syntax error in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   create-github-prerelease:
     runs-on: ubuntu-latest
-    if: github.event_name == ’push’ && contains(github.ref_name, “rc”)
+    if: github.event_name == 'push' && contains(github.ref_name, "rc")
     permissions:
       contents: write
 
@@ -32,7 +32,7 @@ jobs:
 
   create-github-release:
     runs-on: ubuntu-latest
-    if: github.event_name == ’push’ && !contains(github.ref_name, “rc”)
+    if: github.event_name == 'push' && !contains(github.ref_name, "rc")
     permissions:
       contents: write
 


### PR DESCRIPTION
Stray fancy-quotes got into this workflow, when they should have been ASCII quotes, giving a syntax error.