### PR TITLE
Add thread name attribute to dispatcher processor

### DIFF
--- a/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
+++ b/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
@@ -6,8 +6,8 @@
             "fileName": "localBMQ/logs/logs.%T.%p",
             "fileMaxAgeDays": 10,
             "rotationBytes": 268435456,
-            "logfileFormat": "%d (%t) %s %F:%l %m\n\n",
-            "consoleFormat": "%d (%t) %s %F:%l %m\n",
+            "logfileFormat": "%d (%t) %s %F:%l %a %m\n\n",
+            "consoleFormat": "%d (%t) %s %F:%l %a %m\n",
             "loggingVerbosity": "INFO",
             "consoleSeverityThreshold": "INFO",
             "categories": [
@@ -20,7 +20,7 @@
             "syslog": {
                 "enabled": false,
                 "appName": "BMQ",
-                "logFormat": "%d (%t) %s %F:%l %m\n\n",
+                "logFormat": "%d (%t) %s %F:%l %a %m\n\n",
                 "verbosity": ""
             }
         }

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -391,6 +391,11 @@ void Dispatcher::queueEventCb(mqbi::DispatcherClientType::Enum type,
                               BSLA_UNUSED void*                context,
                               const ProcessorPool::Event*      event)
 {
+    // Set the thread name attribute
+    bsl::string threadName;
+    bslmt::ThreadUtil::getThreadName(&threadName);
+    ball::ScopedAttribute threadNameAttr("thread.name", threadName);
+
     switch (event->type()) {
     case ProcessorPool::Event::BMQC_USER: {
         BALL_LOG_TRACE << "Dispatching Event to queue " << processorId


### PR DESCRIPTION
This is an experimental idea to used scoped attributes to include the thread name of the dispatcher in its logs
