### PR TITLE
UT: remove special handling of BDE < 4.9

### DIFF
--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -286,9 +286,7 @@
 #include <ball_multiplexobserver.h>
 #include <ball_severity.h>
 #include <balst_stacktracetestallocator.h>
-#if BSL_VERSION >= BSL_MAKE_VERSION(4, 9)
 #include <bdlm_metricsregistry.h>
-#endif
 #include <bdlsb_memoutstreambuf.h>
 #include <bsl_cstddef.h>
 #include <bsl_cstdio.h>
@@ -603,15 +601,6 @@
     ball::LoggerManagerScopedGuard _logManagerGuard(&_logMultiplexObserver,   \
                                                     _logConfig);
 
-#if BSL_VERSION >= BSL_MAKE_VERSION(4, 9)
-#define INIT_METRICS_REGISTRY()                                               \
-    /* Access the metrics registry default instance before assign the */      \
-    /* global allocator                                               */      \
-    bdlm::MetricsRegistry::defaultInstance();
-#else
-#define INIT_METRICS_REGISTRY() /* Not required for previous BDE versions */
-#endif
-
 #define INIT_GLOBAL_ALLOCATOR_INTERNAL()                                      \
     /* Global Allocator */                                                    \
     /* NOTE: The global allocator has a static storage duration to outlive */ \
@@ -619,7 +608,9 @@
     static bslma::TestAllocator _gblAlloc(                                    \
         "global",                                                             \
         (bmqtst::TestHelperUtil::verbosityLevel() >= 4));                     \
-    INIT_METRICS_REGISTRY()                                                   \
+    /* Access the metrics registry default instance before assigning the */   \
+    /* global allocator                                                  */   \
+    bdlm::MetricsRegistry::defaultInstance();                                 \
     bslma::Default::setGlobalAllocator(&_gblAlloc);
 
 #ifdef BSLS_PLATFORM_CMP_CLANG

--- a/src/groups/bmq/bmqu/bmqu_sharedresource.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_sharedresource.t.cpp
@@ -222,24 +222,7 @@ static void test1_resource_creators()
     }
 
     // 4. exception safety
-    // Current BDE version 4.8 has a memory leak which is already fixed
-    // (https://github.com/bloomberg/bde/commit/42950dfbcaf2c76cdabc266afacecee67da21a59)
-    // but not released yet. Skip address sanitizer check for BDE version less
-    // than 4.9.
-#if BSL_VERSION < BSL_MAKE_VERSION(4, 9)
-#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
-    static const bool skipTest = __has_feature(address_sanitizer);
-#elif defined(__SANITIZE_ADDRESS__)
-    // GCC-supported macros for checking ASAN.
-    static const bool skipTest = true;
-#else
-    static const bool skipTest = false;  // Default to running the test.
-#endif
-#else
-    static const bool skipTest = false;  // Default to running the test.
-#endif
-
-    if (!skipTest) {
+    {
         typedef bmqu::SharedResourceFactoryDeleter<int, bslma::Allocator>
             Deleter;
 
@@ -525,24 +508,7 @@ static void test4_resource_reset()
     }
 
     // 5. exception safety
-    // Current BDE version 4.8 has a memory leak which is already fixed
-    // (https://github.com/bloomberg/bde/commit/42950dfbcaf2c76cdabc266afacecee67da21a59)
-    // but not released yet. Skip address sanitizer check for BDE version less
-    // than 4.9.
-#if BSL_VERSION < BSL_MAKE_VERSION(4, 9)
-#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
-    static const bool skipTest = __has_feature(address_sanitizer);
-#elif defined(__SANITIZE_ADDRESS__)
-    // GCC-supported macros for checking ASAN.
-    static const bool skipTest = true;
-#else
-    static const bool skipTest = false;  // Default to running the test.
-#endif
-#else
-    static const bool skipTest = false;  // Default to running the test.
-#endif
-
-    if (!skipTest) {
+    {
         typedef bmqu::SharedResourceFactoryDeleter<int, bslma::Allocator>
             Deleter;
 


### PR DESCRIPTION
We have updated the used BDE version a long time ago and now we use `4.23`.
We have a few outdated checks for `BDE >= 4.9` that are true now.