### PR TITLE
Fix[MQB]: Enable/disable heartbeats under lock

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -559,7 +559,7 @@ void TCPSessionFactory::negotiationComplete(
         ++d_nbSessions;
 
         info.createInplace(d_allocator_p,
-                           channel.get(),
+                           channel,
                            monitoredSession,
                            initialConnectionContext_p->negotiationContext()
                                ->d_eventProcessor_p,
@@ -1525,10 +1525,10 @@ bool TCPSessionFactory::isEndpointLoopback(const bslstl::StringRef& uri) const
 
 TCPSessionFactory::ChannelInfo::ChannelInfo(
     const bsl::shared_ptr<bmqio::Channel>& channel_sp,
-    const bsl::shared_ptr<Session>& monitoredSession,
-    SessionEventProcessor*          eventProcessor,
-    int                             maxMissedHeartbeats,
-    int                             initialMissedHeartbeatCounter)
+    const bsl::shared_ptr<Session>&        monitoredSession,
+    SessionEventProcessor*                 eventProcessor,
+    int                                    maxMissedHeartbeats,
+    int                                    initialMissedHeartbeatCounter)
 : d_channel_sp(channel_sp)
 , d_session_sp(monitoredSession)
 , d_eventProcessor_p(eventProcessor)

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -190,7 +190,7 @@ class TCPSessionFactory {
 
         bmqp::HeartbeatMonitor d_monitor;
 
-        /// @param channel The channel
+        /// @param channel_sp The channel
         /// @param session The session associated with this channel.
         /// @param eventProcessor The event processor of Events received on
         /// this channel.
@@ -198,10 +198,10 @@ class TCPSessionFactory {
         /// missed heartbeats on this channel.
         /// @param initialMissedHeartbeatCounter The initial missed heartbeats
         /// for this channel.
-        explicit ChannelInfo(bmqio::Channel*                 channel,
-                             const bsl::shared_ptr<Session>& session,
-                             SessionEventProcessor*          eventProcessor,
-                             int maxMissedHeartbeats,
+        explicit ChannelInfo(const bsl::shared_ptr<bmqio::Channel>& channel_sp,
+                             const bsl::shared_ptr<Session>&        session,
+                             SessionEventProcessor* eventProcessor,
+                             int                    maxMissedHeartbeats,
                              int initialMissedHeartbeatCounter);
     };
 


### PR DESCRIPTION
For the upcoming authentication feature.
`TCPSessionFactory::negotiationComplete` could be called from a thread (Authenticator) different from `TCPSessionFactory::onClose` (IO).
Therefore, an instantaneous disconnect could result in inconsistent heartbeat state.
Enforcing consistency by using the lock
