### PR TITLE
Fix[BMQ]: Move the read queue low watermark for each new reader

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
@@ -1177,6 +1177,9 @@ void NtcChannel::read(Status*                   status,
 
             return;
         }
+        // Move the read queue low watermark so not to miss already received
+        // data.
+        d_streamSocket_sp->setReadQueueLowWatermark(1);
     }
 
     if (timer) {


### PR DESCRIPTION
Switching `NtcChannel` reader in the presence of unconsumed data, should invoke the new reader with existing data.