### PR TITLE
Fix[mqb]: queue/client broker stat enums

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
@@ -87,7 +87,7 @@ class BrokerStats {
     /// Namespace for the constants of stat values that applies to the queues
     /// from the clients
     struct BrokerStatsIndex {
-        enum Enum { e_STAT_QUEUE_COUNT, e_STAT_CLIENT_COUNT };
+        enum Enum { e_STAT_CLIENT_COUNT, e_STAT_QUEUE_COUNT };
     };
 
   private:


### PR DESCRIPTION
**Describe your changes**
The public enums did not match the internal, private enums. As a result, the two stat values were swapped.
