### PR TITLE
Queue::confgiure deadlocks with QueueHandle::deconfigure

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -122,9 +122,10 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
 
   private:
     // PRIVATE MANIPULATORS
-    void configureDispatched(int*          result,
-                             bsl::ostream* errorDescription,
-                             bool          isReconfigure);
+    void configureDispatched(int*              result,
+                             bsl::ostream*     errorDescription,
+                             bool              isReconfigure,
+                             bslmt::Semaphore* sync);
 
     void getHandleDispatched(
         const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>&

--- a/src/groups/mqb/mqbi/mqbi_cluster.cpp
+++ b/src/groups/mqb/mqbi/mqbi_cluster.cpp
@@ -63,6 +63,7 @@ const char* ClusterErrorCode::toAscii(ClusterErrorCode::Enum value)
         CASE(NOT_FOLLOWER)
         CASE(NOT_REPLICA)
         CASE(CSL_FAILURE)
+        CASE(STORAGE_FAILURE)
     default: return "(* UNKNOWN *)";
     }
 


### PR DESCRIPTION
Two threads.  Cluster and Queue.

1) OpenQueue. `Queue::configure` (executed by the cluster *DISPATCHER* thread) calls `dispatcher()->synchronize(this)`.  This enqueues `event1` on the queue dispatcher thread.  

2) It then waits for `event1` to complete.

3) ConfigureQueue. `RelayQueueEngine::configureApp` (executed by the queue *DISPATCHER* thread) calls `Cluster::configureQueue`. This enqueues `event2` on the cluster dispatcher thread.

4) `QueueHandle::~QueueHandle` (executed by the queue *DISPATCHER* thread) waits for `event2` to complete

The following sequence - 1), 3), 4), 2) - results in 1) waiting for `event1` on the queue thread and blocking the cluster thread and 4) waiting for `event2` on the cluster thread and blocking the queue thread.  Deadlock.
