### PR TITLE
IT: Pin version of `pytest-rerunfailures`

### DIFF
--- a/src/python/requirements.txt
+++ b/src/python/requirements.txt
@@ -6,7 +6,7 @@ pytest
 pytest-cov
 pytest-order
 pytest-repeat
-pytest-rerunfailures
+pytest-rerunfailures==15.1
 pytest-xdist
 pyyaml
 termcolor


### PR DESCRIPTION
Version 16 of `pytest-rerunfailures` causes pytest-internal failures on our integration test CI.  This seems to be a compatibility issue with `pytest` or one of the other plugins we use.  However, we know version 15.1 passes.

This patch pins `pytest-rerunfailures` to version 15.1.  We should revisit this in the future, but for the moment this fixes our integration tests.