### PR TITLE
Fix[mqbs_inmemorystorage.cpp]: remove empty WARN log

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -118,12 +118,9 @@ int InMemoryStorage::configure(BSLA_UNUSED bsl::ostream& errorDescription,
 
 void InMemoryStorage::setConsistency(const mqbconfm::Consistency& value)
 {
-    BALL_LOG_WARN_BLOCK
-    {
-        if (value.isStrongValue()) {
-            BALL_LOG_OUTPUT_STREAM << "Trying to configure strong consistency "
-                                   << "for in-memory storage";
-        }
+    if (value.isStrongValue()) {
+        BALL_LOG_WARN << "Trying to configure strong consistency "
+                      << "for in-memory storage";
     }
 }
 


### PR DESCRIPTION
`BALL_LOG_WARN_BLOCK` unconditionally makes a log record even if empty

```
02SEP2025_16:01:17.959 (140361930364672) WARN mqbs_inmemorystorage.cpp:121
```