### PR TITLE
docs: Generate Doxygen tag files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,9 @@ if(DOXYGEN_FOUND)
   set(DOXYGEN_ALPHABETICAL_INDEX     NO)
   set(DOXYGEN_FULL_SIDEBAR           YES)
   set(DOXYGEN_GENERATE_TREEVIEW      YES)
+  set(DOXYGEN_GENERATE_TAGFILE
+    "${CMAKE_CURRENT_BINARY_DIR}/apidocs/tags.xml"
+  )
   doxygen_add_docs(
     apidocs
     src/groups/bmq/bmqa
@@ -291,6 +294,9 @@ if(DOXYGEN_FOUND)
   set(DOXYGEN_GENERATE_TODOLIST      YES)
   set(DOXYGEN_STRIP_FROM_PATH        src/groups)
   set(DOXYGEN_OUTPUT_DIRECTORY       internaldocs)
+  set(DOXYGEN_GENERATE_TAGFILE
+    "${CMAKE_CURRENT_BINARY_DIR}/internaldocs/tags.xml"
+  )
   doxygen_add_docs(
     internaldocs
     src/groups/


### PR DESCRIPTION
Tag files are a feature of Doxygen that enable other projects to generate documentation that links into our published generated documentation.  For example, a project with a BlazingMQ consumer that exposes `bmqa::Message` in the interface can be configured to link to our published documentation for `bmqa::Message`.  It’s good practice to generate these.

This patch turns on the generation of tagfiles in our documentation targets.  By default, they are named `tags.xml` and put in the output directory for each of our documentation targets.