### PR TITLE
Fix[MQB]: fix possible int32 overflow in queue handle parameters

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -180,11 +180,11 @@ static void parseMessages(bsl::vector<bsl::string>* messages,
 /// attributes are populated with default values.  The format of attributes
 /// must be as follows:
 ///
-///   "[readCount=<N>] [writeCount=<M>] [isFinal=(true|false)]"
+///  "[readCount=<N>] [writeCount=<M>] [adminCount=<K>] [isFinal=(true|false)]"
 ///
 /// E.g.:
 ///
-///   "readCount=2 writeCount=1 isFinal=true"
+///  "readCount=2 writeCount=1 adminCount=1 isFinal=true"
 static int
 parseHandleParameters(bmqp_ctrlmsg::QueueHandleParameters* handleParams,
                       bool*                                isFinal,
@@ -232,6 +232,18 @@ parseHandleParameters(bmqp_ctrlmsg::QueueHandleParameters* handleParams,
 
             handleParams->writeCount() = bsl::stoi(tokenizer.token());
             bmqt::QueueFlagsUtil::setWriter(&handleParams->flags());
+
+            ++tokenizer;
+        }
+        else if (bdlb::String::areEqualCaseless("adminCount", attribute)) {
+            BSLS_ASSERT_OPT(handleParams->adminCount() == 0 &&
+                            "Duplicate adminCount in 'attributesStr'");
+
+            ++tokenizer;
+            BSLS_ASSERT_OPT(!tokenizer.isTrailingHard());
+
+            handleParams->adminCount() = bsl::stoi(tokenizer.token());
+            bmqt::QueueFlagsUtil::setAdmin(&handleParams->flags());
 
             ++tokenizer;
         }
@@ -888,6 +900,7 @@ int QueueEngineTester::configureHandle(const bsl::string& clientText)
 
     // 2. Configure the handle
     mqbi::QueueHandle* handle = client(clientKey);
+    BSLS_ASSERT_OPT(handle != NULL);
 
     int rc = bmqp_ctrlmsg::StatusCategory::E_UNKNOWN;
     const mqbi::QueueHandle::HandleConfiguredCallback configuredCb =

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -267,6 +267,22 @@ void QueueState::loadInternals(mqbcmd::QueueState* out) const
     d_handleCatalog.loadInternals(&out->handles());
 }
 
+bool QueueState::canMerge(
+    const bmqp_ctrlmsg::QueueHandleParameters& handleParameters) const
+{
+    // It is enough to check d_handleParameters, it includes counters for any
+    // registered substream.
+#define MQBBLP_NO_OVERFLOW(C)                                                 \
+    (static_cast<bsls::Types::Int64>(d_handleParameters.C()) +                \
+         static_cast<bsls::Types::Int64>(handleParameters.C()) <=             \
+     static_cast<bsls::Types::Int64>(bsl::numeric_limits<int>::max()))
+
+    return MQBBLP_NO_OVERFLOW(readCount) && MQBBLP_NO_OVERFLOW(writeCount) &&
+           MQBBLP_NO_OVERFLOW(adminCount);
+
+#undef MQBBLP_NO_OVERFLOW
+}
+
 bsl::ostream& operator<<(bsl::ostream&                          os,
                          const QueueState::SubQueuesParameters& rhs)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.h
@@ -328,6 +328,14 @@ class QueueState {
     /// Return non-modifiable access reference to the collection of cached
     /// references to subStreams.
     const SubQueues& subQueues() const;
+
+    /// @brief Check whether this queue can be extended with the provided
+    ///        handle parameters.  The behaviour is undefined unless handle
+    ///        parameters are valid (counters are non-negative).
+    /// @param handleParameters Handle parameters to add.
+    /// @return bool True if the queue can be extended, false otherwise.
+    bool canMerge(
+        const bmqp_ctrlmsg::QueueHandleParameters& handleParameters) const;
 };
 
 // ============================================================================

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1048,6 +1048,14 @@ mqbi::QueueHandle* RelayQueueEngine::getHandle(
         return 0;  // RETURN
     }
 
+    if (!d_queueState_p->canMerge(handleParameters)) {
+        CALLBACK(bmqp_ctrlmsg::StatusCategory::E_REFUSED,
+                 -1,
+                 "Reached maximum read/write/admin counters for a queue",
+                 0);
+        return 0;  // RETURN
+    }
+
     mqbi::QueueHandle* queueHandle =
         d_queueState_p->handleCatalog().getHandleByRequester(
             *clientContext,

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
@@ -54,9 +54,15 @@ const mqbi::QueueHandle* k_nullHandle_p = 0;
 /// Return a fanout domain.
 mqbconfm::Domain fanoutConfig()
 {
-    mqbconfm::Domain domainConfig;
+    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
     domainConfig.mode().makeFanout();
+    return domainConfig;
+}
 
+mqbconfm::Domain priorityDomainConfig()
+{
+    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
+    domainConfig.mode().makePriority();
     return domainConfig;
 }
 
@@ -83,16 +89,9 @@ static void test1_breathingTest()
 //   Basic functionality
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -164,16 +163,9 @@ static void test2_aggregateDownstream()
 //   consumers
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("AGGREGATE DOWNSTREAM");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -335,16 +327,9 @@ static void test3_reconfigure()
 //     - 'configureHandle()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks
-    // from 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RECONFIGURE");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -474,16 +459,9 @@ static void test4_cannotDeliver()
 //   more highest priority consumers.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CANNOT CONSUMERS");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -589,16 +567,9 @@ static void test5_localRedelivery()
 //   when other consumers are available and able to receive messages.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY TO OTHER CONSUMERS");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -670,16 +641,9 @@ static void test6_clearDeliveryStateWhenLostReaders()
 //   message lists when it loses the last consumer.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY TO FIRST CONSUMER UP");
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -740,10 +704,6 @@ static void test7_broadcastMode()
 //   RelayQueueEngine is sending to all handlers if mode is broadcast.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BROADCAST MODE");
 
     mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
@@ -832,17 +792,10 @@ static void test8_priority_beforeMessageRemoved_garbageCollection()
 //   - 'beforeMessageRemoved()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - GARBAGE "
                                       "COLLECTION");
 
-    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,  // start scheduler
                                      bmqtst::TestHelperUtil::allocator());
 
@@ -908,16 +861,9 @@ static void test9_releaseHandle_isDeletedFlag()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE - IS-DELETED FLAG");
 
-    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,
                                      bmqtst::TestHelperUtil::allocator());
     mqbblp::QueueEngineTesterGuard<mqbblp::RelayQueueEngine> guard(&tester);
@@ -975,10 +921,6 @@ static void test10_configureFanoutAppIds()
 //                  const mqbi::QueueHandle::HandleConfiguredCallback&);
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName(
         "CONFIGURING DIFFERENT APPIDs FOR UPSTREAM");
 
@@ -1063,10 +1005,6 @@ static void test11_roundRobinAndRedelivery()
 //   'getHandle' and 'configureHandle' for multiple distinct appIds.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("ROUND-ROBIN AND REDELIVERY");
 
     mqbconfm::Domain          config = fanoutConfig();
@@ -1167,16 +1105,9 @@ static void test12_redeliverAfterGc()
 //   them.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY AFTER GC");
 
-    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
-    domainConfig.mode().makePriority();
-
-    mqbblp::QueueEngineTester tester(domainConfig,
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
                                      false,
                                      bmqtst::TestHelperUtil::allocator());
     mqbblp::QueueEngineTesterGuard<mqbblp::RelayQueueEngine> guard(&tester);
@@ -1239,10 +1170,6 @@ static void test13_deconfigureWhenOpen()
 //                  const mqbi::QueueHandle::HandleConfiguredCallback&);
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName(
         "DECONFIGURE IN BETWEEN OPEN AND CONFIGURE");
 
@@ -1296,14 +1223,9 @@ static void test14_throttleRedeliveryPriority()
 //   rda reaches 2.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY PRIORITY");
 
-    mqbconfm::Domain config;
-    config.mode().makePriority();
+    mqbconfm::Domain config      = priorityDomainConfig();
     config.maxDeliveryAttempts() = 5;
 
     mqbblp::TimeControlledQueueEngineTester tester(
@@ -1393,10 +1315,6 @@ static void test15_throttleRedeliveryFanout()
 //   rda reaches 2.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY FANOUT");
 
     mqbconfm::Domain          config = fanoutConfig();
@@ -1538,14 +1456,9 @@ static void test16_throttleRedeliveryCancelledDelay()
 //   mqbblp::QueueEngine cancelThrottle on a delayed message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY CANCELLED DELAY");
 
-    mqbconfm::Domain config;
-    config.mode().makePriority();
+    mqbconfm::Domain config      = priorityDomainConfig();
     config.maxDeliveryAttempts() = 5;
 
     mqbblp::TimeControlledQueueEngineTester tester(
@@ -1633,14 +1546,9 @@ static void test17_throttleRedeliveryNewHandle()
 //   for the current message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY NEW HANDLE");
 
-    mqbconfm::Domain config;
-    config.mode().makePriority();
+    mqbconfm::Domain config      = priorityDomainConfig();
     config.maxDeliveryAttempts() = 5;
 
     mqbblp::TimeControlledQueueEngineTester tester(
@@ -1697,14 +1605,9 @@ static void test18_throttleRedeliveryNoMoreHandles()
 //   should end the delay for the current message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY NO MORE HANDLES");
 
-    mqbconfm::Domain config;
-    config.mode().makePriority();
+    mqbconfm::Domain config      = priorityDomainConfig();
     config.maxDeliveryAttempts() = 5;
 
     mqbblp::TimeControlledQueueEngineTester tester(
@@ -1784,10 +1687,6 @@ static void test19_redeliveryAndResume()
 //   'processAppRedelivery'.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("ROUND-ROBIN AND REDELIVERY");
 
     mqbconfm::Domain          config = fanoutConfig();
@@ -1884,6 +1783,95 @@ static void test19_redeliveryAndResume()
     BMQTST_ASSERT_EQ(C3->_numMessages("a"), 5);
 }
 
+static void test20_handleParametersLimits()
+// ------------------------------------------------------------------------
+// HANDLE PARAMETERS LIMITS
+//
+// Concerns:
+//   Trying to set up unreasonable handle parameters (readCount, writeCount,
+//   adminCount) fails.
+//
+// Plan:
+//   Repeat the same sequence for readCount, writeCount, adminCount
+//   1) Open handles C1/C2 with count == 1kkk (expect SUCCESS)
+//   2) Try open handle C3 with count == 1kkk (expect FAILURE)
+//   3) Open handle C4 with count == 1 (expect SUCCESS)
+//   4) Try to configure valid handles C1/C2/C4 (expect SUCCESS)
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE PARAMETERS LIMITS TEST");
+
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
+                                     false,  // start scheduler
+                                     bmqtst::TestHelperUtil::allocator());
+
+    mqbblp::QueueEngineTesterGuard<mqbblp::RelayQueueEngine> guard(&tester);
+
+    {
+        // 1. readCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_r readCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_r readCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_r readCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_r readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_r consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_r consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_r consumerPriority=1 consumerPriorityCount=1");
+    }
+    {
+        // 2. writeCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_w writeCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_w writeCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_w writeCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_w readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_w consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_w consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_w consumerPriority=1 consumerPriorityCount=1");
+    }
+    {
+        // 3. adminCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_a adminCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_a adminCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_a adminCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_a readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_a consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_a consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_a consumerPriority=1 consumerPriorityCount=1");
+    }
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -1906,6 +1894,7 @@ int main(int argc, char* argv[])
 
         switch (_testCase) {
         case 0:
+        case 20: test20_handleParametersLimits(); break;
         case 19: test19_redeliveryAndResume(); break;
         case 18: test18_throttleRedeliveryNoMoreHandles(); break;
         case 17: test17_throttleRedeliveryNewHandle(); break;
@@ -1935,5 +1924,8 @@ int main(int argc, char* argv[])
         bmqt::UriParser::shutdown();
     }
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    // Default allocator check is disabled for all UTs:
+    // `mqbblp::QueueEngine` and mocks from `mqbi` methods use ball logging
+    // that allocates using default allocator.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -647,6 +647,14 @@ mqbi::QueueHandle* RootQueueEngine::getHandle(
         return 0;  // RETURN
     }
 
+    if (!d_queueState_p->canMerge(handleParameters)) {
+        CALLBACK(bmqp_ctrlmsg::StatusCategory::E_REFUSED,
+                 -1,
+                 "Reached maximum read/write/admin counters for a queue",
+                 0);
+        return 0;  // RETURN
+    }
+
     // Check num producer/consumer limits.  Note that this check is prone to
     // race during failover scenarios, these max producer/consumer config
     // fields should be used with caution (perhaps as a hint or soft-limit

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -612,7 +612,7 @@ static void parseStrings(bsl::vector<bsl::string>* strings, bsl::string str)
 /// The behavior is undefined unless `appIdsStr` is formatted as above.
 mqbconfm::Domain fanoutConfig(const bsl::string& appIdsStr)
 {
-    mqbconfm::Domain domainConfig;
+    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
     domainConfig.mode().makeFanout();
     bsl::vector<bsl::string>& appIDs = domainConfig.mode().fanout().appIDs();
     parseStrings(&appIDs, appIdsStr);
@@ -622,9 +622,8 @@ mqbconfm::Domain fanoutConfig(const bsl::string& appIdsStr)
 
 mqbconfm::Domain priorityDomainConfig()
 {
-    mqbconfm::Domain domainConfig;
+    mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
     domainConfig.mode().makePriority();
-
     return domainConfig;
 }
 
@@ -655,10 +654,6 @@ static void test1_broadcastBreathingTest()
 //   Basic functionality.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -720,10 +715,6 @@ static void test2_broadcastConfirmAssertFails()
 //   Calling confirm assert fails.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CONFIRM ASSERT FAILS TEST");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -775,10 +766,6 @@ static void test3_broadcastCannotDeliver()
 //   more highest priority consumers.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CANNOT CONSUMERS");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -884,10 +871,6 @@ static void test4_broadcastPostAfterResubscribe()
 //   Queue Engine delivery when we have re-subscription
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("POST AFTER RESUBSCRIBE");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -953,10 +936,6 @@ static void test5_broadcastReleaseHandle_isDeletedFlag()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE - IS-DELETED FLAG");
 
     mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
@@ -1022,10 +1001,6 @@ static void test6_broadcastDynamicPriorities()
 //   Queue Engine delivery when consumer priorities can change.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("DYNAMIC PRIORITIES");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -1123,10 +1098,6 @@ static void test7_broadcastPriorityFailover()
 //   unsubscribe or become busy gradually.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("PRIORITY FAILOVER");
 
     mqbblp::QueueEngineTester tester(broadcastConfig(),
@@ -1212,11 +1183,6 @@ static void testN1_broadcastExhaustiveSubscriptions()
 //   That the queue works with any permutation of basic operations.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("EXHAUSTIVE SUBSCRIPTIONS TEST");
 
     Operations operations;
@@ -1255,10 +1221,6 @@ static void testN2_broadcastExhaustiveCanDeliver()
 //   clients being unable to process data (e.g. due to high watermark).
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("EXHAUSTIVE CAN DELIVER TEST");
 
     Operations operations;
@@ -1302,10 +1264,6 @@ static void testN3_broadcastExhaustiveConsumerPriority()
 //   consumers of various priorities are being added.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("EXHAUSTIVE CONSUMER PRIORITY TEST");
 
     Operations operations;
@@ -1354,10 +1312,6 @@ static void test8_priorityBreathingTest()
 //   Basic functionality
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -1424,10 +1378,6 @@ static void test9_priorityCreateAndConfigure()
 //   messageReferenceCount
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CREATE AND CONFIGURE");
 
     class PriorityQueueEngineTester : public mqbblp::QueueEngineTester {
@@ -1505,10 +1455,6 @@ static void test10_priorityAggregateDownstream()
 //   consumers
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("AGGREGATE DOWNSTREAM");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -1673,10 +1619,6 @@ static void test11_priorityReconfigure()
 //     - 'configureHandle()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks
-    // from 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RECONFIGURE");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -1809,10 +1751,6 @@ static void test12_priorityCannotDeliver()
 //   more highest priority consumers.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CANNOT CONSUMERS");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -1923,10 +1861,6 @@ static void test13_priorityRedeliverToFirstConsumerUp()
 //   before the first next consumer comes up.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY TO FIRST CONSUMER UP");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -1989,10 +1923,6 @@ static void test14_priorityRedeliverToOtherConsumers()
 //   when other consumers are available and able to receive messages.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY TO OTHER CONSUMERS");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -2070,10 +2000,6 @@ static void test15_priorityReleaseActiveConsumerWithoutNullReconfigure()
 //   parameters.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE ACTIVE CONSUMER WITHOUT NULL"
                                       " RECONFIGURE");
 
@@ -2170,10 +2096,6 @@ static void test16_priorityReleaseDormantConsumerWithoutNullReconfigure()
 //   stream parameters.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE DORMANT CONSUMER WITHOUT NULL"
                                       " RECONFIGURE");
 
@@ -2272,10 +2194,6 @@ static void test17_priorityBeforeMessageRemoved_garbageCollection()
 //   - 'beforeMessageRemoved()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - GARBAGE "
                                       "COLLECTION");
 
@@ -2340,10 +2258,6 @@ static void test18_priorityAfterQueuePurged_queueStreamResets()
 //      messages.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("AFTER QUEUE PURGED - QUEUE STREAM"
                                       " RESETS");
 
@@ -2449,10 +2363,6 @@ static void test19_priorityReleaseHandle_isDeletedFlag()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE - IS-DELETED FLAG");
 
     mqbconfm::Domain domainConfig(bmqtst::TestHelperUtil::allocator());
@@ -2519,10 +2429,6 @@ static void test20_priorityRedeliverAfterGc()
 //   them.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY AFTER GC");
 
     mqbblp::QueueEngineTester tester(priorityDomainConfig(),
@@ -2593,10 +2499,6 @@ static void test21_breathingTest()
 //   Basic functionality
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -2754,10 +2656,6 @@ static void test22_createAndConfigure()
 //   configure
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CREATE AND CONFIGURE");
 
     class FanoutQueueEngineTester : public mqbblp::QueueEngineTester {
@@ -2819,10 +2717,6 @@ static void test23_loadRoutingConfiguration()
 //   loadRoutingConfiguration
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("ROUTING CONFIGURATION");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a"),
@@ -2884,10 +2778,6 @@ static void test24_getHandleDuplicateAppId()
 //   'getHandle' for an appId that was already opened.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("GET HANDLE - DUPLICATE APP ID");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a"),
@@ -2930,10 +2820,6 @@ static void test25_getHandleSameHandleMultipleAppIds()
 //   'getHandle' for multiple distinct appIds succeeds.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("GET HANDLE - MULTIPLE APP IDS");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -2975,10 +2861,6 @@ static void test26_getHandleUnauthorizedAppId()
 //   getHandle for an unauthorized appId
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("GET HANDLE - UNAUTHORIZED APP ID");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -3025,10 +2907,6 @@ static void test27_configureHandleMultipleAppIds()
 //   'configureHandle' for multiple distinct appIds.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CONFIGURE HANDLE - MULTIPLE APP IDS");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -3128,10 +3006,6 @@ static void test28_releaseHandle()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -3213,10 +3087,6 @@ static void test29_releaseHandleMultipleProducers()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE - MULTIPLE PRODUCERS");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c"),
@@ -3282,10 +3152,6 @@ static void test30_releaseHandle_isDeletedFlag()
 //      const mqbi::QueueHandle::HandleReleasedCallback&  releasedCb)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("RELEASE HANDLE - IS-DELETED FLAG");
 
     mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c,d"),
@@ -3384,10 +3250,6 @@ static void test31_afterNewMessageDeliverToAllActiveConsumers()
 //                               mqbi::QueueHandle        *source)
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName(
         "AFTER NEW MESSAGE - DELIVER TO ALL ACTIVE CONSUMERS");
 
@@ -3530,10 +3392,6 @@ static void test32_afterNewMessageRespectsFlowControl()
 //  virtual void onHandleUsable
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName(
         "AFTER NEW MESSAGE - RESPECT FLOW CONTROL");
 
@@ -3830,10 +3688,6 @@ static void test33_consumerUpAfterMessagePosted()
 //  onConfirmMessage
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName(
         "HANDLE CONSUMER SUBSCRIPTION AFTER POST");
 
@@ -3970,10 +3824,6 @@ static void test34_beforeMessageRemoved_deadConsumers()
 //   with regards to configured consumers that are not alive at the time.
 //   - 'beforeMessageRemoved()'
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - DEAD"
                                       " CONSUMERS");
 
@@ -4055,10 +3905,6 @@ static void test35_beforeMessageRemoved_withActiveConsumers()
 //   - 'beforeMessageRemoved()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - WITH ALIVE"
                                       " CONSUMERS");
 
@@ -4145,10 +3991,6 @@ static void test36_afterQueuePurged_queueStreamResets()
 //   - 'afterQueuePurged()'
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - WITH ALIVE"
                                       " CONSUMERS");
 
@@ -4310,10 +4152,6 @@ static void test37_afterQueuePurged_specificSubStreamResets()
 //     specific subStream of the queue.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("BEFORE MESSAGE REMOVED - WITH ALIVE"
                                       " CONSUMERS");
 
@@ -4460,10 +4298,6 @@ static void test38_unauthorizedAppIds()
 //  virtual void afterNewMessage()
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("UNAUTHORIZED APP IDS - DELIVER ONLY TO "
                                       "CONSUMERS USING AUTHORIZED APPID");
 
@@ -4539,10 +4373,6 @@ static void test39_maxConsumersProducers()
 //   'getHandle' for multiple distinct appIds.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("CONSUMERS/PRODUCERS LIMITS PER APP");
 
     // 1. Set maxConsumers and maxProducers limits to the value (2) less than
@@ -4602,10 +4432,6 @@ static void test40_roundRobinAndRedelivery()
 //   'getHandle' and 'configureHandle' for multiple distinct appIds.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("ROUND-ROBIN AND REDELIVERY");
 
     mqbconfm::Domain config = fanoutConfig("a,b,c");
@@ -4703,10 +4529,6 @@ static void test41_redeliverAfterGc()
 //   them.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("REDELIVERY AFTER GC");
 
     mqbconfm::Domain config = fanoutConfig("a");
@@ -4782,10 +4604,6 @@ static void test42_throttleRedeliveryPriority()
 //   rda reaches 2.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY PRIORITY");
 
     mqbconfm::Domain config      = priorityDomainConfig();
@@ -4876,10 +4694,6 @@ static void test43_throttleRedeliveryFanout()
 //   rda reaches 2.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY FANOUT");
 
     mqbconfm::Domain config      = fanoutConfig("a,b,c");
@@ -5015,10 +4829,6 @@ static void test44_throttleRedeliveryCancelledDelay()
 //   mqbblp::QueueEngine cancelThrottle on a delayed message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY CANCELLED DELAY");
 
     mqbconfm::Domain config      = priorityDomainConfig();
@@ -5127,10 +4937,6 @@ static void test45_throttleRedeliveryNewHandle()
 //   for the current message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY NEW HANDLE");
 
     mqbconfm::Domain config      = priorityDomainConfig();
@@ -5190,10 +4996,6 @@ static void test46_throttleRedeliveryNoMoreHandles()
 //   should end the delay for the current message.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
-    // Can't check the default allocator: 'mqbblp::QueueEngine' and mocks from
-    // 'mqbi' methods print with ball, which allocates.
-
     bmqtst::TestHelper::printTestName("THROTTLED REDELIVERY NO MORE HANDLES");
 
     mqbconfm::Domain config      = priorityDomainConfig();
@@ -5259,6 +5061,95 @@ static void test46_throttleRedeliveryNoMoreHandles()
     BMQTST_ASSERT_EQ(C3->_numMessages(), 2);
 }
 
+static void test47_handleParametersLimits()
+// ------------------------------------------------------------------------
+// HANDLE PARAMETERS LIMITS
+//
+// Concerns:
+//   Trying to set up unreasonable handle parameters (readCount, writeCount,
+//   adminCount) fails.
+//
+// Plan:
+//   Repeat the same sequence for readCount, writeCount, adminCount
+//   1) Open handles C1/C2 with count == 1kkk (expect SUCCESS)
+//   2) Try open handle C3 with count == 1kkk (expect FAILURE)
+//   3) Open handle C4 with count == 1 (expect SUCCESS)
+//   4) Try to configure valid handles C1/C2/C4 (expect SUCCESS)
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE PARAMETERS LIMITS TEST");
+
+    mqbblp::QueueEngineTester tester(priorityDomainConfig(),
+                                     false,  // start scheduler
+                                     bmqtst::TestHelperUtil::allocator());
+
+    mqbblp::QueueEngineTesterGuard<mqbblp::RootQueueEngine> guard(&tester);
+
+    {
+        // 1. readCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_r readCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_r readCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_r readCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_r readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_r consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_r consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_r consumerPriority=1 consumerPriorityCount=1");
+    }
+    {
+        // 2. writeCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_w writeCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_w writeCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_w writeCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_w readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_w consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_w consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_w consumerPriority=1 consumerPriorityCount=1");
+    }
+    {
+        // 3. adminCount
+        mqbmock::QueueHandle* C1 = tester.getHandle(
+            "C1_a adminCount=1000000000");
+        BMQTST_ASSERT(C1 != NULL);
+        mqbmock::QueueHandle* C2 = tester.getHandle(
+            "C2_a adminCount=1000000000");
+        BMQTST_ASSERT(C2 != NULL);
+        mqbmock::QueueHandle* C3 = tester.getHandle(
+            "C3_a adminCount=1000000000");
+        BMQTST_ASSERT(C3 == NULL);
+        mqbmock::QueueHandle* C4 = tester.getHandle("C4_a readCount=1");
+        BMQTST_ASSERT(C4 != NULL);
+
+        tester.configureHandle(
+            "C1_a consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C2_a consumerPriority=1 consumerPriorityCount=1");
+        tester.configureHandle(
+            "C4_a consumerPriority=1 consumerPriorityCount=1");
+    }
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -5281,6 +5172,7 @@ int main(int argc, char* argv[])
 
         switch (_testCase) {
         case 0:
+        case 47: test47_handleParametersLimits(); break;
         case 46: test46_throttleRedeliveryNoMoreHandles(); break;
         case 45: test45_throttleRedeliveryNewHandle(); break;
         case 44: test44_throttleRedeliveryCancelledDelay(); break;
@@ -5346,5 +5238,8 @@ int main(int argc, char* argv[])
     bmqp::ProtocolUtil::shutdown();
     bmqt::UriParser::shutdown();
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    // Default allocator check is disabled for all UTs:
+    // `mqbblp::QueueEngine` and mocks from `mqbi` methods use ball logging
+    // that allocates using default allocator.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }


### PR DESCRIPTION
1. Add check `bool QueueState::canMerge` to prevent possible int32 overflow
2. `mqbblp::RootQueueEngine`, `mqbblp::RelayQueueEngine`: check that handle parameters can be merged without signed integer overflow before merging
3. `mqbblp::QueueEngineTester`: extend to support `adminCount`
4. UTs `mqbblp::RootQueueEngine`, `mqbblp::RelayQueueEngine`: remove repetitive disable default allocator checks and set it in one place. This should remove ~`(47+20) * 4 = 268` lines of code
5. UTs `mqbblp::RootQueueEngine`, `mqbblp::RelayQueueEngine`: add UTs to check reasonable and unreasonable read/write/admin counters setup

The added UTs are failing in the main branch and passing with this PR's fix

```
TEST /blazingmq/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp CASE 20

Error /blazingmq/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp(1114): bmqp::QueueUtil::isValidSubset(queueHandle->handleParameters(), d_queueState_p->handleParameters())    (failed)
libc++abi: terminating due to uncaught exception of type BloombergLP::bsls::AssertTestException
zsh: abort      ./src/groups/mqb/mqbblp_relayqueueengine.t 20

TEST /blazingmq/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp CASE 47

Error /blazingmq/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp(829): bmqp::QueueUtil::isValidSubset(queueHandle->handleParameters(), d_queueState_p->handleParameters())    (failed)
libc++abi: terminating due to uncaught exception of type BloombergLP::bsls::AssertTestException
zsh: abort      ./src/groups/mqb/mqbblp_rootqueueengine.t 47
```