### PR TITLE
Fix Partition FSM: Clear buffered live data upon ReplicaDataRequestPush

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -247,6 +247,8 @@ class PartitionStateTableActions {
 
     virtual void do_processBufferedLiveData(const ARGS& args) = 0;
 
+    virtual void do_clearBufferedLiveData(const ARGS& args) = 0;
+
     virtual void
     do_processBufferedPrimaryStatusAdvisories(const ARGS& args) = 0;
 
@@ -328,6 +330,8 @@ class PartitionStateTableActions {
         const ARGS& args);
 
     void do_setExpectedDataChunkRange_replicaDataRequestPull(const ARGS& args);
+
+    void do_setExpectedDataChunkRange_clearBufferedLiveData(const ARGS& args);
 
     void
     do_resetReceiveDataCtx_closeRecoveryFileSet_storeSelfSeq_attemptOpenStorage_replicaDataRequestPush_replicaDataRequestDrop_startSendDataChunks_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
@@ -565,7 +569,7 @@ class PartitionStateTable
             UNKNOWN);
         PST_CFG(REPLICA_HEALING,
                 REPLICA_DATA_RQST_PUSH,
-                setExpectedDataChunkRange,
+                setExpectedDataChunkRange_clearBufferedLiveData,
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,
                 REPLICA_DATA_RQST_DROP,
@@ -817,6 +821,14 @@ void PartitionStateTableActions<ARGS>::
 {
     do_setExpectedDataChunkRange(args);
     do_replicaDataRequestPull(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<
+    ARGS>::do_setExpectedDataChunkRange_clearBufferedLiveData(const ARGS& args)
+{
+    do_setExpectedDataChunkRange(args);
+    do_clearBufferedLiveData(args);
 }
 
 template <typename ARGS>

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -1646,6 +1646,21 @@ int RecoveryManager::loadBufferedStorageEvents(
     return rc_SUCCESS;
 }
 
+void RecoveryManager::clearBufferedStorageEvent(int partitionId)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with 'partitionId'
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(0 <= partitionId);
+
+    RecoveryContext& recoveryCtx = d_recoveryContextVec[partitionId];
+    recoveryCtx.d_bufferedEvents.clear();
+
+    BALL_LOG_INFO << d_clusterData.identity().description() << " Partition ["
+                  << partitionId
+                  << "]: " << "Cleared all buffered storage events.";
+}
+
 // ACCESSORS
 void RecoveryManager::loadReplicaDataResponsePush(
     bmqp_ctrlmsg::ControlMessage* out,

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -432,6 +432,12 @@ class RecoveryManager {
                               const mqbnet::ClusterNode* source,
                               int                        partitionId);
 
+    /// Cleared all buffered storage event for the specified `partitionId`.
+    ///
+    /// THREAD: Executed in the dispatcher thread associated with the
+    /// specified `partitionId`.
+    void clearBufferedStorageEvent(int partitionId);
+
     // ACCESSORS
 
     /// Return true if the specified `partitionId` is expecting data chunks,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2495,6 +2495,30 @@ void StorageManager::do_processBufferedLiveData(const PartitionFSMArgsSp& args)
     }
 }
 
+void StorageManager::do_clearBufferedLiveData(const PartitionFSMArgsSp& args)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with the paritionId
+    // contained in 'args'
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!args->eventsQueue()->empty());
+
+    // NOTE: As a healing replica, upon e_REPLICA_DATA_RQST_PUSH FSM event, we
+    // *must* clear buffered live data because it is possible that the buffered
+    // data contains duplicate records as the recovery data primary is about to
+    // send us.
+
+    const PartitionFSM::EventWithData& eventWithData =
+        args->eventsQueue()->front();
+    const EventData& eventDataVec = eventWithData.second;
+    BSLS_ASSERT_SAFE(eventDataVec.size() == 1);
+
+    const PartitionFSMEventData& eventData   = eventDataVec[0];
+    const int                    partitionId = eventData.partitionId();
+
+    d_recoveryManager_mp->clearBufferedStorageEvent(partitionId);
+}
+
 void StorageManager::do_processBufferedPrimaryStatusAdvisories(
     const PartitionFSMArgsSp& args)
 {

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -631,6 +631,9 @@ class StorageManager BSLS_KEYWORD_FINAL
     void do_processBufferedLiveData(const PartitionFSMArgsSp& args)
         BSLS_KEYWORD_OVERRIDE;
 
+    void do_clearBufferedLiveData(const PartitionFSMArgsSp& args)
+        BSLS_KEYWORD_OVERRIDE;
+
     void do_processBufferedPrimaryStatusAdvisories(
         const PartitionFSMArgsSp& args) BSLS_KEYWORD_OVERRIDE;
 

--- a/src/integration-tests/test_startup.py
+++ b/src/integration-tests/test_startup.py
@@ -14,13 +14,10 @@
 # limitations under the License.
 
 import blazingmq.dev.it.testconstants as tc
-from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
+from blazingmq.dev.it.fixtures import (
     Cluster,
-    cluster,
     order,
-    multi_node,
     start_cluster,
-    tweak,
 )
 from blazingmq.dev.it.process.client import Client
 
@@ -32,14 +29,14 @@ pytestmark = order(4)
 def test_early_assign(multi_node: Cluster, domain_urls: tc.DomainUrls):
     """
     Early open a queue on a soon-to-be leader.  Legacy leader when it becomes
-    ACTIVE, starts assigning queues _before_ it assignes partiotions.  Then,
+    ACTIVE, starts assigning queues _before_ it assignes partitions.  Then,
     the leader observes `onQueueAssigned` event _before_ it becomes ACTVIE
     primary.  If that event logic erroneously decides that the self is replica,
     the soon-to-be primary does not write QueueCreationRecord.  The primary
     still writes any posted message record though.  That leads to either assert
     in rollover or recovery failure on restart with "Encountered a MESSAGE
     record for queueKey [...], offset: ..., index: ..., for which a
-    QueueOp.CREATION record was not seen...
+    QueueOp.CREATION record was not seen..."
     """
 
     cluster = multi_node

--- a/src/integration-tests/test_startup.py
+++ b/src/integration-tests/test_startup.py
@@ -14,11 +14,7 @@
 # limitations under the License.
 
 import blazingmq.dev.it.testconstants as tc
-from blazingmq.dev.it.fixtures import (
-    Cluster,
-    order,
-    start_cluster,
-)
+from blazingmq.dev.it.fixtures import Cluster, order, start_cluster
 from blazingmq.dev.it.process.client import Client
 
 pytestmark = order(4)
@@ -68,3 +64,44 @@ def test_early_assign(multi_node: Cluster, domain_urls: tc.DomainUrls):
         == Client.e_SUCCESS
     )
     cluster.restart_nodes(wait_leader=True, wait_ready=True)
+
+
+@start_cluster(start=False)
+def test_replica_late_join(multi_node: Cluster, domain_urls: tc.DomainUrls):
+    """
+    In a steady-state cluster where only one replica node is down, with live
+    messages flowing, the replica node rejoins and attemps to heal itself via
+    the primary.  The concern is that the primary could send live data to the
+    replica, and then re-send that data as recovery data chunks; we would like
+    to make sure our deduplication logic is working correctly to handle this
+    case.
+    """
+
+    cluster = multi_node
+
+    # Starting all nodes except `east2`, which will join later
+    east1 = cluster.start_node("east1")
+    cluster.start_node("west1")
+    cluster.start_node("west2")
+
+    # The cluster will enter a healthy state with quorum of nodes
+    east1.wait_status(wait_leader=True, wait_ready=True)
+
+    producer = east1.create_client("producer")
+    producer.open(domain_urls.uri_priority, flags=["write", "ack"], succeed=True)
+    consumer = east1.create_client("consumer")
+    consumer.open(domain_urls.uri_priority, flags=["read"], succeed=True)
+
+    # Producer will post messages constantly for 30 seconds
+    producer.batch_post(
+        domain_urls.uri_priority,
+        payload="msg",
+        msg_size=1024,
+        event_size=1,
+        events_count=300000,
+        post_interval=0.1,
+        post_rate=1,
+    )
+
+    east2 = cluster.start_node("east2")
+    east2.wait_status(wait_leader=True, wait_ready=True)

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -303,7 +303,7 @@ class Client(BMQProcess):
         self,
         uri: str,
         /,
-        payload: List[str] = None,
+        payload: str = None,
         msg_size: int = 1024,
         event_size: int = 1,
         events_count: int = 0,


### PR DESCRIPTION
In FSM mode, as a healing replica, upon `e_REPLICA_DATA_RQST_PUSH` event, we *must* clear buffered live data because it is possible that the buffered data contains duplicate records as the recovery data primary is about to send us. This PR adds the buffer clearing logic and includes a corresponding integration test for replica late join scenario while live messages are flowing.