### PR TITLE
Fix mqbc::StorageMgr: Do not enqueue message on cluster thread

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -380,14 +380,6 @@ class StorageManager BSLS_KEYWORD_FINAL
     /// Return the dispatcher of the associated cluster.
     mqbi::Dispatcher* dispatcher();
 
-    /// Encode and send the specified schema `message` to the specified peer
-    /// `destination`.
-    ///
-    /// THREAD: This method is invoked in the associated cluster's dispatcher
-    ///         thread.
-    void sendMessage(const bmqp_ctrlmsg::ControlMessage& message,
-                     mqbnet::ClusterNode*                destination);
-
     /// Callback to start the recovery for the specified `partitionId`.
     ///
     /// THREAD: This method is invoked in the associated Queue dispatcher


### PR DESCRIPTION
Fixed the race in `mqbc::StorageManager`'s message sending as described in https://gist.github.com/kaikulimu/2399138ec9f4d71b4a3b7e6e8a87c65d