### PR TITLE
Fix[MQB]: always attempt to process pending open queue requests

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -3812,8 +3812,8 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                 continue;  // CONTINUE;
             }
 
-            BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext.get()));
-            BSLS_ASSERT_SAFE(isQueuePrimaryAvailable(*queueContext.get()));
+            BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext));
+            BSLS_ASSERT_SAFE(isQueuePrimaryAvailable(*queueContext));
 
             // Verify the CSL if needed by comparing it with the Domain config
             if (liveQInfo.d_queue_sp) {
@@ -3850,6 +3850,13 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                         // 'updateAppIds' which is asynchronous (CSL commit)
                         liveQInfo.d_pendingUpdates.push_back(park);
 
+                        park = bdlf::BindUtil::bind(
+                            &ClusterQueueHelper::processPendingContexts,
+                            this,
+                            queueContext);
+
+                        liveQInfo.d_pendingUpdates.push_back(park);
+
                         mqbi::ClusterErrorCode::Enum result =
                             d_clusterStateManager_p->updateAppIds(
                                 added,
@@ -3860,22 +3867,22 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                         if (mqbi::ClusterErrorCode::e_OK == result) {
                             // Cannot continue until 'onQueueUpdated'
                             // Send QueueUpdateAdvisory and _wait_ for commit
-                        }
-                        else {
-                            // An update error is CSL error (in
-                            // 'ClusterStateLedger::apply'). This queue cannot
-                            // convertToLocal
-                            // ('RootQueueEngine::initializeAppId' would assert
-                            // if there is no storage for some app).
 
-                            BSLS_ASSERT_SAFE(false && "Failure to update Apps "
-                                                      "before convertToLocal");
+                            continue;  // CONTINUE
                         }
+
+                        // An update error is CSL error (in
+                        // 'ClusterStateLedger::apply'). This queue cannot
+                        // convertToLocal
+                        // ('RootQueueEngine::initializeAppId' would assert
+                        // if there is no storage for some app).
+
+                        BSLS_ASSERT_SAFE(
+                            false &&
+                            "Failure to update Apps before convertToLocal");
                     }
                     else {
                         convertToLocal(queueContext, domain);
-
-                        processPendingContexts(queueContext);
                     }
                 }
                 else {
@@ -3903,6 +3910,9 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                         // In case of other type of failure, just continue
                         // processing other queues instead of stopping the
                         // 'state restore' sequence.
+
+                        // REVISIT: this code sends pending Open Queue requests
+                        // without waiting for the ReOpen Queue Response.
                     }
                     else {
                         BMQ_LOGTHROTTLE_INFO
@@ -3920,25 +3930,14 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                     // requests were not processed, but appended to the pending
                     // context list, so once we have an active primary, we
                     // should process them.
-                    if (!queueContext->d_liveQInfo.d_pending.empty()) {
-                        // Proceed with pending contexts, if any.
-                        BMQ_LOGTHROTTLE_INFO
-                            << d_cluster_p->description()
-                            << ": Proceeding with "
-                            << queueContext->d_liveQInfo.d_pending.size()
-                            << " associated pending contexts for '"
-                            << queueContext->uri() << "'";
-                        processPendingContexts(queueContext);
-                    }
                 }
             }
-            else {
-                // Queue instance is not created, but the queue is assigned.
-                // Proceed ahead.
-
-                onQueueContextAssigned(queueContext);
-            }
+            // else, Queue instance is not created, but the queue is assigned.
+            // Proceed ahead.
         }
+
+        // In all cases, _attempt_ to process pending open queue requests
+        onQueueContextAssigned(queueContext);
     }
 }
 


### PR DESCRIPTION
There is a race on Replica between 

1. storage recovery 
2. state-restore event for Partition [`N`]
3. state-restore event for Partition [ALL] 


Need to make sure, pending Open Queue request is not stuck as in the case 1. 2. 3.