### PR TITLE
IT[test_connection_loss.py]: fix out of order regex search

### DIFF
--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -69,7 +69,6 @@ def test_broker_client(
 
     # Start a client
     client: Client = broker.create_client(f"client@{broker.name}", port=tproxy_port)
-    client.start_session()
     assert client.capture(r"CONNECTED", 5)
 
     # Kill tproxy to break the connection between broker and client

--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -68,8 +68,11 @@ def test_broker_client(
     tproxy_port, tproxy = cluster.start_tproxy(broker.config)
 
     # Start a client
-    # It verifies that the connection is established
-    client: Client = broker.create_client(f"client@{broker.name}", port=tproxy_port)
+    client: Client = broker.create_client(f"client@{broker.name}", port=tproxy_port, start=False)
+    client.start_session(block=False)
+    # There is a race between "session.start" log line and "CONNECTED" log line.
+    # Due to this, we do not check for "session.start" and only check for "CONNECTED" event.
+    assert client.capture(r"CONNECTED", 5)
 
     # Kill tproxy to break the connection between broker and client
     tproxy.kill()

--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -68,8 +68,8 @@ def test_broker_client(
     tproxy_port, tproxy = cluster.start_tproxy(broker.config)
 
     # Start a client
+    # It verifies that the connection is established
     client: Client = broker.create_client(f"client@{broker.name}", port=tproxy_port)
-    assert client.capture(r"CONNECTED", 5)
 
     # Kill tproxy to break the connection between broker and client
     tproxy.kill()

--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -68,7 +68,9 @@ def test_broker_client(
     tproxy_port, tproxy = cluster.start_tproxy(broker.config)
 
     # Start a client
-    client: Client = broker.create_client(f"client@{broker.name}", port=tproxy_port, start=False)
+    client: Client = broker.create_client(
+        f"client@{broker.name}", port=tproxy_port, start=False
+    )
     client.start_session(block=False)
     # There is a race between "session.start" log line and "CONNECTED" log line.
     # Due to this, we do not check for "session.start" and only check for "CONNECTED" event.


### PR DESCRIPTION
In the corresponding IT, there are 2 regex searches:
`'session.start.*\\((-?\\d+)\\)'` and `'CONNECTED'`

There is a race to print these logs: it is possible to have `CONNECTED` log line before `session.start` log line.

This PR removes check for `session.start` regex and keeps search for `CONNECTED` regex.

Should fix the following flaky test
```
FAILED test_connection_loss.py::test_broker_client[single_node-strong_consistency] - AssertionError: assert None
 +  where None = capture('CONNECTED', 5)
 +    where capture = <blazingmq.dev.it.process.client.Client object at 0x7ff6088a22b0>.capture
```