### PR TITLE
Fix UBSAN errors in unit tests

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -3333,8 +3333,10 @@ static void queueOpenCloseAsync(bsls::Types::Uint64 queueFlags)
     BMQTST_ASSERT_EQ(pQueue->state(), bmqimp::QueueState::e_CLOSED);
     BMQTST_ASSERT_EQ(pQueue->isValid(), false);
 
+    int rc;
+
     PVV_SAFE("Close unopened queue async");
-    int rc = obj.session().closeQueueAsync(pQueue, timeout);
+    rc = obj.session().closeQueueAsync(pQueue, timeout);
 
     // Verify the result
     BMQTST_ASSERT_EQ(rc, bmqt::CloseQueueResult::e_SUCCESS);
@@ -4251,8 +4253,8 @@ static void test21_post_Limit()
 {
     bmqtst::TestHelper::printTestName("POST CHANNEL LIMIT TEST");
 
-    const bsls::TimeInterval timeout     = bsls::TimeInterval(15);
-    const bsls::TimeInterval lwmTimeout  = bsls::TimeInterval(0.1);
+    const bsls::TimeInterval timeout    = bsls::TimeInterval(15);
+    const bsls::TimeInterval lwmTimeout = bsls::TimeInterval(0.1);
     bmqt::SessionOptions     sessionOptions;
     bmqt::QueueOptions       queueOptions;
     bdlmt::EventScheduler    scheduler(bsls::SystemClockType::e_MONOTONIC,
@@ -5375,16 +5377,16 @@ static void test25_sessionFsmTable()
         obj.onStartTimeout();
     }
 
-    {
-        // STOPPED  -> STARTING
-        tcpRc = 11;
+    // STOPPED  -> STARTING
+    tcpRc = 11;
 
+    {
+        // Start failure
         int rc = obj.startAsync();
         BMQTST_ASSERT_EQ(rc, tcpRc);
-
-        // Start failure
-        // STARTING -> STOPPED
     }
+
+    // STARTING -> STOPPED
 
     tcpRc = 0;
 
@@ -6149,9 +6151,9 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
 {
     bmqtst::TestHelper::printTestName("REOPEN ERROR TEST");
 
-    bmqt::SessionOptions     sessionOptions;
-    bmqt::QueueOptions       queueOptions;
-    bdlmt::EventScheduler    scheduler(bsls::SystemClockType::e_MONOTONIC,
+    bmqt::SessionOptions  sessionOptions;
+    bmqt::QueueOptions    queueOptions;
+    bdlmt::EventScheduler scheduler(bsls::SystemClockType::e_MONOTONIC,
                                     bmqtst::TestHelperUtil::allocator());
 
     sessionOptions.setNumProcessingThreads(1);

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -1242,6 +1242,7 @@ static void test4_processDumpCommand_invalidDumpMessage()
         // b. Attempt to process further an *invalid* dump command and verify
         //    that it does not impact the state of the MessageDumper object as
         //    well as that a non-zero error code is returned.
+
         bmqp_ctrlmsg::DumpMessages invalidDumpMessagesCommand;
         invalidDumpMessagesCommand.msgTypeToDump() =
             static_cast<bmqp_ctrlmsg::DumpMsgType::Value>(-1);

--- a/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
@@ -222,7 +222,8 @@ static void test3_printQueueStateTest()
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
@@ -442,9 +442,9 @@ void test1_breathingTest()
         // Populate blob, 0 options
         bsl::vector<bmqp::SubQueueInfo> subQueueInfos(
             bmqtst::TestHelperUtil::allocator());
-        size_t                          numSubQueueIds = 0;
+        size_t             numSubQueueIds = 0;
         NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-        bool                            hasMsgGroupId = false;
+        bool               hasMsgGroupId = false;
 
         populateBlob(&blob,
                      &optionsAreaPosition,
@@ -512,9 +512,9 @@ void test1_breathingTest()
         // Populate blob, 1 option header and 1 sub-queue id
         bsl::vector<bmqp::SubQueueInfo> subQueueInfos(
             bmqtst::TestHelperUtil::allocator());
-        size_t                          numSubQueueIds = 1;
+        size_t             numSubQueueIds = 1;
         NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-        bool                            hasMsgGroupId = false;
+        bool               hasMsgGroupId = false;
 
         populateBlob(&blob,
                      &optionsAreaPosition,
@@ -579,9 +579,9 @@ void test1_breathingTest()
         // Populate blob, 1 option header, multiple sub-queue ids)
         bsl::vector<bmqp::SubQueueInfo> subQueueInfos(
             bmqtst::TestHelperUtil::allocator());
-        size_t                          numSubQueueIds = 3;
+        size_t             numSubQueueIds = 3;
         NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-        bool                            hasMsgGroupId = false;
+        bool               hasMsgGroupId = false;
 
         populateBlob(&blob,
                      &optionsAreaPosition,
@@ -636,9 +636,9 @@ void test1_breathingTest()
         // Populate blob, 1 option header, multiple sub-queue ids)
         bsl::vector<bmqp::SubQueueInfo> subQueueInfos(
             bmqtst::TestHelperUtil::allocator());
-        size_t                          numSubQueueIds = 3;
+        size_t             numSubQueueIds = 3;
         NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-        bool                            hasMsgGroupId = true;
+        bool               hasMsgGroupId = true;
 
         populateBlob(&blob,
                      &optionsAreaPosition,
@@ -740,9 +740,9 @@ void test2_subQueueIdsOld()
     // Populate blob, 1 option header, multiple old sub-queue ids)
     bsl::vector<bdlb::BigEndianUint32> subQueueIdsOld(
         bmqtst::TestHelperUtil::allocator());
-    size_t                             numSubQueueIds = 3;
+    size_t             numSubQueueIds = 3;
     NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    bool                               hasMsgGroupId = false;
+    bool               hasMsgGroupId = false;
 
     populateBlob(&blob,
                  &optionsAreaPosition,
@@ -996,7 +996,6 @@ void test4_invalidOptionsArea()
 
         BMQTST_ASSERT_EQ(false, view.isValid());
     }
-
     {
         // [4]
         PV("OPTION HEADER WITH UNSUPPORTED TYPES");
@@ -1061,7 +1060,6 @@ void test4_invalidOptionsArea()
 
         BMQTST_ASSERT_EQ(false, view2.isValid());
     }
-
     {
         // [5]
         PV("MULTIPLE OPTION HEADERS OF THE SAME TYPE (DUPLICATE)");
@@ -1226,9 +1224,9 @@ void test5_iteratorTest()
     // Populate blob, 1 option header, multiple sub-queue ids
     bsl::vector<bmqp::SubQueueInfo> subQueueIds(
         bmqtst::TestHelperUtil::allocator());
-    size_t                          numSubQueueIds = 3;
+    size_t             numSubQueueIds = 3;
     NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    bool                            hasMsgGroupId = true;
+    bool               hasMsgGroupId = true;
 
     populateBlob(&blob,
                  &optionsAreaPosition,
@@ -1306,9 +1304,9 @@ void test6_iteratorTestSubQueueIdsOld()
     // Populate blob, 1 option header, multiple sub-queue ids
     bsl::vector<bdlb::BigEndianUint32> subQueueIdsOld(
         bmqtst::TestHelperUtil::allocator());
-    size_t                             numSubQueueIds = 3;
+    size_t             numSubQueueIds = 3;
     NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    bool                               hasMsgGroupId = true;
+    bool               hasMsgGroupId = true;
 
     populateBlob(&blob,
                  &optionsAreaPosition,
@@ -1386,9 +1384,9 @@ void test7_dumpBlob()
     // Populate blob, 1 option header, multiple sub-queue ids)
     bsl::vector<bmqp::SubQueueInfo> subQueueIds(
         bmqtst::TestHelperUtil::allocator());
-    size_t                          numSubQueueIds = 3;
+    size_t             numSubQueueIds = 3;
     NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    bool                            hasMsgGroupId = true;
+    bool               hasMsgGroupId = true;
 
     populateBlob(&blob,
                  &optionsAreaPosition,
@@ -1476,9 +1474,9 @@ void test8_dumpBlobSubQueueIdsOld()
     // Populate blob, 1 option header, multiple sub-queue ids)
     bsl::vector<bdlb::BigEndianUint32> subQueueIdsOld(
         bmqtst::TestHelperUtil::allocator());
-    size_t                             numSubQueueIds = 3;
+    size_t             numSubQueueIds = 3;
     NullableMsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
-    bool                               hasMsgGroupId = true;
+    bool               hasMsgGroupId = true;
 
     populateBlob(&blob,
                  &optionsAreaPosition,

--- a/src/groups/bmq/bmqst/bmqst_printutil.cpp
+++ b/src/groups/bmq/bmqst/bmqst_printutil.cpp
@@ -113,7 +113,8 @@ const char* memoryHelper(bsls::Types::Int64* num,
     }
 
     bsls::Types::Int64 shift = level * 10;
-    bsls::Types::Int64 div   = 1LL << shift;
+
+    bsls::Types::Int64 div = 1LL << shift;
     *num                   = bytes >> shift;
     *remainder             = static_cast<int>(
         bsl::floor(((static_cast<double>(bytes - (*num << shift)) /

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.t.cpp
@@ -112,10 +112,7 @@ static void test1_enumPrint()
         PrintTestData k_DATA[] = {
             {L_, bmqt::CompressionAlgorithmType::e_UNKNOWN, "UNKNOWN"},
             {L_, bmqt::CompressionAlgorithmType::e_NONE, "NONE"},
-            {L_, bmqt::CompressionAlgorithmType::e_ZLIB, "ZLIB"},
-            {L_,
-             bmqt::CompressionAlgorithmType::k_HIGHEST_SUPPORTED_TYPE + 1,
-             "(* UNKNOWN *)"}};
+            {L_, bmqt::CompressionAlgorithmType::e_ZLIB, "ZLIB"}};
 
         printEnumHelper<bmqt::CompressionAlgorithmType>(k_DATA);
     }

--- a/src/groups/bmq/bmqt/bmqt_encodingtype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_encodingtype.t.cpp
@@ -47,8 +47,7 @@ static void test1_toAscii()
                   {L_, 4, "XML"},
                   {L_, 5, "JSON"},
                   {L_, 6, "TEXT"},
-                  {L_, 7, "MULTIPARTS"},
-                  {L_, -1, "(* UNKNOWN *)"}};
+                  {L_, 7, "MULTIPARTS"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
@@ -147,14 +146,13 @@ static void test4_printTest()
                   {bmqt::EncodingType::e_XML, "XML"},
                   {bmqt::EncodingType::e_JSON, "JSON"},
                   {bmqt::EncodingType::e_TEXT, "TEXT"},
-                  {bmqt::EncodingType::e_MULTIPARTS, "MULTIPARTS"},
-                  {static_cast<bmqt::EncodingType::Enum>(-1),
-                   "(* UNKNOWN *)"}};
+                  {bmqt::EncodingType::e_MULTIPARTS, "MULTIPARTS"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqt/bmqt_hosthealthstate.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_hosthealthstate.t.cpp
@@ -83,7 +83,8 @@ static void test2_printTest()
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqt/bmqt_messageeventtype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_messageeventtype.t.cpp
@@ -45,10 +45,6 @@ static void test1_breathingTest()
     str = bmqt::MessageEventType::toAscii(bmqt::MessageEventType::e_PUSH);
     BMQTST_ASSERT_EQ(str, "PUSH");
 
-    obj = static_cast<bmqt::MessageEventType::Enum>(-1);
-    str = bmqt::MessageEventType::toAscii(obj);
-    BMQTST_ASSERT_EQ(str, "(* UNKNOWN *)");
-
     PV("Testing fromAscii");
     res = bmqt::MessageEventType::fromAscii(&obj, "PUT");
     BMQTST_ASSERT_EQ(res, true);
@@ -82,14 +78,13 @@ static void test2_printTest()
     } k_DATA[] = {{bmqt::MessageEventType::e_UNDEFINED, "UNDEFINED"},
                   {bmqt::MessageEventType::e_PUT, "PUT"},
                   {bmqt::MessageEventType::e_PUSH, "PUSH"},
-                  {bmqt::MessageEventType::e_ACK, "ACK"},
-                  {static_cast<bmqt::MessageEventType::Enum>(-1),
-                   "(* UNKNOWN *)"}};
+                  {bmqt::MessageEventType::e_ACK, "ACK"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqt/bmqt_propertytype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_propertytype.t.cpp
@@ -41,10 +41,6 @@ static void test1_breathingTest()
     str = bmqt::PropertyType::toAscii(bmqt::PropertyType::e_BINARY);
     BMQTST_ASSERT_EQ(str, "BINARY");
 
-    obj = static_cast<bmqt::PropertyType::Enum>(-1);
-    str = bmqt::PropertyType::toAscii(obj);
-    BMQTST_ASSERT_EQ(str, "(* UNKNOWN *)");
-
     PV("Testing fromAscii");
     res = bmqt::PropertyType::fromAscii(&obj, "STRING");
     BMQTST_ASSERT_EQ(res, true);

--- a/src/groups/bmq/bmqt/bmqt_queueflags.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_queueflags.t.cpp
@@ -181,13 +181,13 @@ static void test3_printTest()
     } k_DATA[] = {{bmqt::QueueFlags::e_ADMIN, "ADMIN"},
                   {bmqt::QueueFlags::e_READ, "READ"},
                   {bmqt::QueueFlags::e_WRITE, "WRITE"},
-                  {bmqt::QueueFlags::e_ACK, "ACK"},
-                  {static_cast<bmqt::QueueFlags::Enum>(-1), "(* UNKNOWN *)"}};
+                  {bmqt::QueueFlags::e_ACK, "ACK"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqt/bmqt_resultcode.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_resultcode.t.cpp
@@ -177,8 +177,7 @@ static void test3_printTest()
             {L_, bmqt::GenericResult::e_REFUSED, "REFUSED"},
             {L_, bmqt::GenericResult::e_INVALID_ARGUMENT, "INVALID_ARGUMENT"},
             {L_, bmqt::GenericResult::e_NOT_READY, "NOT_READY"},
-            {L_, bmqt::GenericResult::e_LAST, "NOT_READY"},
-            {L_, bmqt::GenericResult::e_LAST - 1, "(* UNKNOWN *)"}};
+            {L_, bmqt::GenericResult::e_LAST, "NOT_READY"}};
 
         printEnumHelper<bmqt::GenericResult>(k_DATA);
     }
@@ -205,8 +204,7 @@ static void test3_printTest()
             {L_, bmqt::OpenQueueResult::e_INVALID_FLAGS, "INVALID_FLAGS"},
             {L_,
              bmqt::OpenQueueResult::e_CORRELATIONID_NOT_UNIQUE,
-             "CORRELATIONID_NOT_UNIQUE"},
-            {L_, -1234, "(* UNKNOWN *)"}};
+             "CORRELATIONID_NOT_UNIQUE"}};
 
         printEnumHelper<bmqt::OpenQueueResult>(k_DATA);
     }
@@ -228,8 +226,9 @@ static void test3_printTest()
             {L_,
              bmqt::ConfigureQueueResult::e_ALREADY_IN_PROGRESS,
              "ALREADY_IN_PROGRESS"},
-            {L_, bmqt::ConfigureQueueResult::e_INVALID_QUEUE, "INVALID_QUEUE"},
-            {L_, -1234, "(* UNKNOWN *)"}};
+            {L_,
+             bmqt::ConfigureQueueResult::e_INVALID_QUEUE,
+             "INVALID_QUEUE"}};
 
         printEnumHelper<bmqt::ConfigureQueueResult>(k_DATA);
     }
@@ -253,8 +252,7 @@ static void test3_printTest()
              bmqt::CloseQueueResult::e_ALREADY_IN_PROGRESS,
              "ALREADY_IN_PROGRESS"},
             {L_, bmqt::CloseQueueResult::e_UNKNOWN_QUEUE, "UNKNOWN_QUEUE"},
-            {L_, bmqt::CloseQueueResult::e_INVALID_QUEUE, "INVALID_QUEUE"},
-            {L_, -1234, "(* UNKNOWN *)"}};
+            {L_, bmqt::CloseQueueResult::e_INVALID_QUEUE, "INVALID_QUEUE"}};
 
         printEnumHelper<bmqt::CloseQueueResult>(k_DATA);
     }
@@ -274,13 +272,14 @@ static void test3_printTest()
              bmqt::EventBuilderResult::e_PAYLOAD_TOO_BIG,
              "PAYLOAD_TOO_BIG"},
             {L_, bmqt::EventBuilderResult::e_PAYLOAD_EMPTY, "PAYLOAD_EMPTY"},
-            {L_, bmqt::EventBuilderResult::e_OPTION_TOO_BIG, "OPTION_TOO_BIG"},
+            {L_, bmqt::EventBuilderResult::e_OPTION_TOO_BIG, "OPTION_TOO_BIG"}
 #ifdef BMQ_ENABLE_MSG_GROUPID
+            ,
             {L_,
              bmqt::EventBuilderResult::e_INVALID_MSG_GROUP_ID,
-             "INVALID_MSG_GROUP_ID"},
+             "INVALID_MSG_GROUP_ID"}
 #endif
-            {L_, -1234, "(* UNKNOWN *)"}};
+        };
 
         printEnumHelper<bmqt::EventBuilderResult>(k_DATA);
     }
@@ -305,8 +304,7 @@ static void test3_printTest()
              bmqt::AckResult::e_LIMIT_QUEUE_MESSAGES,
              "LIMIT_QUEUE_MESSAGES"},
             {L_, bmqt::AckResult::e_LIMIT_QUEUE_BYTES, "LIMIT_QUEUE_BYTES"},
-            {L_, bmqt::AckResult::e_STORAGE_FAILURE, "STORAGE_FAILURE"},
-            {L_, -1234, "(* UNKNOWN *)"}};
+            {L_, bmqt::AckResult::e_STORAGE_FAILURE, "STORAGE_FAILURE"}};
 
         printEnumHelper<bmqt::AckResult>(k_DATA);
     }
@@ -323,8 +321,7 @@ static void test3_printTest()
             {L_, bmqt::PostResult::e_REFUSED, "REFUSED"},
             {L_, bmqt::PostResult::e_INVALID_ARGUMENT, "INVALID_ARGUMENT"},
             {L_, bmqt::PostResult::e_NOT_READY, "NOT_READY"},
-            {L_, bmqt::PostResult::e_BW_LIMIT, "BW_LIMIT"},
-            {L_, -1234, "(* UNKNOWN *)"}};
+            {L_, bmqt::PostResult::e_BW_LIMIT, "BW_LIMIT"}};
 
         printEnumHelper<bmqt::PostResult>(k_DATA);
     }

--- a/src/groups/bmq/bmqt/bmqt_sessioneventtype.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessioneventtype.t.cpp
@@ -102,13 +102,13 @@ static void test2_printTest()
          "CHANNEL_LOW_WATERMARK"},
         {bmqt::SessionEventType::e_CHANNEL_HIGH_WATERMARK,
          "CHANNEL_HIGH_WATERMARK"},
-        {static_cast<bmqt::SessionEventType::Enum>(-1234), "(* UNKNOWN *)"},
     };
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test&        test = k_DATA[idx];
+        const Test& test = k_DATA[idx];
+
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         bmqu::MemOutStream expected(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -774,6 +774,43 @@ struct TestHelperUtil {
 
     /// Allocator to use by the components under test.
     static bslma::Allocator*& allocator();
+
+    /// Sanitizers flags
+    /// Set to `true` if test built with the specified sanitizer enabled,
+    /// `false` otherwise.
+
+    /// Asan
+#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
+    static const bool k_ASAN = __has_feature(address_sanitizer);
+#elif defined(__SANITIZE_ADDRESS__)  // GCC-supported macros
+    static const bool k_ASAN = true;
+#else
+    static const bool k_ASAN = false;
+#endif
+    /// Msan
+#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
+    static const bool k_MSAN = __has_feature(memory_sanitizer);
+#elif defined(__SANITIZE_MEMORY__)  // GCC-supported macros
+    static const bool k_MSAN = true;
+#else
+    static const bool k_MSAN = false;
+#endif
+    /// Tsan
+#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
+    static const bool k_TSAN = __has_feature(thread_sanitizer);
+#elif defined(__SANITIZE_THREAD__)  // GCC-supported macros
+    static const bool k_TSAN = true;
+#else
+    static const bool k_TSAN = false;
+#endif
+    /// UBSan
+#if defined(__has_feature)  // Clang-supported method for checking sanitizers.
+    static const bool k_UBSAN = __has_feature(undefined_behavior_sanitizer);
+#elif defined(__SANITIZE_UNDEFINED__)  // GCC-supported macros
+    static const bool k_UBSAN = true;
+#else
+    static const bool k_UBSAN = false;
+#endif
 };
 
 }

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
@@ -106,7 +106,7 @@ class TestBench {
 
   public:
     struct PutEvent {
-        const bmqp::PutHeader        d_header;
+        bmqp::PutHeader              d_header;
         bsl::shared_ptr<bdlbb::Blob> d_appData;
         bsl::shared_ptr<bdlbb::Blob> d_options;
 
@@ -262,7 +262,7 @@ void TestBench::ackPuts(mqbi::Queue* queue, bmqt::AckResult::Enum status)
 
 void TestBench::dropPuts()
 {
-    bsl::queue<PutEvent>().swap(d_puts);
+    d_puts = bsl::queue<PutEvent>(d_allocator_p);
 }
 
 void TestBench::advanceTime(const bsls::TimeInterval& step)

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
@@ -334,8 +334,7 @@ static void test4_commitStatus_print()
         const char* d_expected;
     } k_DATA[] = {{L_, 0, "SUCCESS"},
                   {L_, -1, "CANCELED"},
-                  {L_, -2, "TIMEOUT"},
-                  {L_, -9, "(* UNKNOWN *)"}};
+                  {L_, -2, "TIMEOUT"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
@@ -456,9 +455,7 @@ static void test6_clusterStateLedgerConsistency_toAscii()
         const char* d_expected;
     } k_DATA[] = {
         {L_, mqbc::ClusterStateLedgerConsistency::e_EVENTUAL, "EVENTUAL"},
-        {L_, mqbc::ClusterStateLedgerConsistency::e_STRONG, "STRONG"},
-        {L_, -1, "(* UNKNOWN *)"},
-    };
+        {L_, mqbc::ClusterStateLedgerConsistency::e_STRONG, "STRONG"}};
     // NOTE: Using the 'integer' value instead of the enum to ensure the
     //       numeric values are *never* changed.
 
@@ -506,8 +503,7 @@ static void test7_clusterStateLedgerConsistency_print()
         const char* d_expected;
     } k_DATA[] = {
         {L_, mqbc::ClusterStateLedgerConsistency::e_EVENTUAL, "EVENTUAL"},
-        {L_, mqbc::ClusterStateLedgerConsistency::e_STRONG, "STRONG"},
-        {L_, -1, "(* UNKNOWN *)"}};
+        {L_, mqbc::ClusterStateLedgerConsistency::e_STRONG, "STRONG"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
@@ -195,8 +195,7 @@ static void test2_enumPrint()
             {L_, mqbc::ClusterStateRecordType::e_SNAPSHOT, "SNAPSHOT"},
             {L_, mqbc::ClusterStateRecordType::e_UPDATE, "UPDATE"},
             {L_, mqbc::ClusterStateRecordType::e_COMMIT, "COMMIT"},
-            {L_, mqbc::ClusterStateRecordType::e_ACK, "ACK"},
-            {L_, -1, "(* UNKNOWN *)"}};
+            {L_, mqbc::ClusterStateRecordType::e_ACK, "ACK"}};
 
         printEnumHelper<mqbc::ClusterStateRecordType>(k_DATA);
     }

--- a/src/groups/mqb/mqbs/mqbs_datafileiterator.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datafileiterator.t.cpp
@@ -273,9 +273,12 @@ static void test2_forwardIteration()
 
         it.loadOptions(&data, &length);
         BMQTST_ASSERT_EQ_D(i, bsl::strlen(MESSAGES[i].d_options_p), length);
-        BMQTST_ASSERT_EQ_D(i,
-                           bsl::memcmp(data, MESSAGES[i].d_options_p, length),
-                           0);
+        if (data) {
+            BMQTST_ASSERT_EQ_D(
+                i,
+                bsl::memcmp(data, MESSAGES[i].d_options_p, length),
+                0);
+        }
 
         offset += (dh.messageWords() * bmqp::Protocol::k_WORD_SIZE);
         ++i;
@@ -379,10 +382,12 @@ static void test3_reverseIteration()
         BMQTST_ASSERT_EQ_D(i, rc, 0);
 
         it.loadOptions(&data, &length);
-        rc = bsl::memcmp(data,
-                         MESSAGES[k_NUM_MSGS - i - 2].d_options_p,
-                         length);
-        BMQTST_ASSERT_EQ_D(i, rc, 0);
+        if (data) {
+            rc = bsl::memcmp(data,
+                             MESSAGES[k_NUM_MSGS - i - 2].d_options_p,
+                             length);
+            BMQTST_ASSERT_EQ_D(i, rc, 0);
+        }
 
         ++i;
     }

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.t.cpp
@@ -504,8 +504,8 @@ static void test2_manipulators()
          k_UNSIGNED_CHAR_MIN,
          k_UNSIGNED_CHAR_MIN,
          k_UNSIGNED_CHAR_MIN,
-         k_INT_MAX,
-         127,
+         FileType::e_QLIST,
+         FileType::e_QLIST,
          k_INT_MAX,
          k_INT_MAX},
     };

--- a/src/groups/mqb/mqbu/mqbu_exit.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_exit.t.cpp
@@ -119,8 +119,7 @@ static void test1_exitCode_toAscii()
                   {L_, 10, "STORAGE_OUT_OF_SYNC"},
                   {L_, 11, "UNSUPPORTED_SCENARIO"},
                   {L_, 12, "MEMORY_LIMIT"},
-                  {L_, 13, "REQUESTED"},
-                  {L_, -1, "(* UNKNOWN *)"}};
+                  {L_, 13, "REQUESTED"}};
     // NOTE: Using the 'integer' value instead of the enum to ensure the
     //       numeric values are *never* changed.
 
@@ -236,8 +235,7 @@ static void test3_exitCode_print()
                   {L_, 10, "STORAGE_OUT_OF_SYNC"},
                   {L_, 11, "UNSUPPORTED_SCENARIO"},
                   {L_, 12, "MEMORY_LIMIT"},
-                  {L_, 13, "REQUESTED"},
-                  {L_, -1, "(* UNKNOWN *)"}};
+                  {L_, 13, "REQUESTED"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 

--- a/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.t.cpp
@@ -2449,8 +2449,7 @@ static void test9_print()
         } k_DATA[] = {
             {L_, RUMState::e_STATE_NORMAL, "STATE_NORMAL"},
             {L_, RUMState::e_STATE_HIGH_WATERMARK, "STATE_HIGH_WATERMARK"},
-            {L_, RUMState::e_STATE_FULL, "STATE_FULL"},
-            {L_, static_cast<RUMState::Enum>(-1), "(* UNKNOWN *)"}};
+            {L_, RUMState::e_STATE_FULL, "STATE_FULL"}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
@@ -2484,13 +2483,13 @@ static void test9_print()
             {L_, RUMStateTransition::e_NO_CHANGE, "NO_CHANGE"},
             {L_, RUMStateTransition::e_LOW_WATERMARK, "LOW_WATERMARK"},
             {L_, RUMStateTransition::e_HIGH_WATERMARK, "HIGH_WATERMARK"},
-            {L_, RUMStateTransition::e_FULL, "FULL"},
-            {L_, static_cast<RUMStateTransition::Enum>(-1), "(* UNKNOWN *)"}};
+            {L_, RUMStateTransition::e_FULL, "FULL"}};
 
         const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
         for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
             const Test& test = k_DATA[idx];
+
             bsl::string ascii(bmqtst::TestHelperUtil::allocator());
 
             PVV(test.d_line << ": checking 'RUMStateTransition::toAscii("


### PR DESCRIPTION
This is mostly addressing the outstanding issues in #829. There are a handful of changes:

* Deleted tests that were intentionally invoking UB by casting an out of range int to an enum
* Fixed the status code handling in queue FSM mode to appropriately convert out of range error codes into the `UKNOWN` category
* Fixed other test cases with UB