### PR TITLE
Config mqbconf.xsd: publishAppIdMetrics defaults to true

### DIFF
--- a/src/groups/mqb/mqbconfm/mqbconf.xsd
+++ b/src/groups/mqb/mqbconfm/mqbconf.xsd
@@ -277,7 +277,7 @@
     </annotation>
     <sequence>
       <element name='appIDs'              type='string' maxOccurs='unbounded'/>
-      <element name='publishAppIdMetrics' type='boolean' default='false'/>
+      <element name='publishAppIdMetrics' type='boolean' default='true'/>
     </sequence>
   </complexType>
 

--- a/src/groups/mqb/mqbconfm/mqbconfm_messages.cpp
+++ b/src/groups/mqb/mqbconfm/mqbconfm_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2014-2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1041,7 +1041,7 @@ bsl::ostream& QueueModeBroadcast::print(bsl::ostream& stream, int, int) const
 
 const char QueueModeFanout::CLASS_NAME[] = "QueueModeFanout";
 
-const bool QueueModeFanout::DEFAULT_INITIALIZER_PUBLISH_APP_ID_METRICS = false;
+const bool QueueModeFanout::DEFAULT_INITIALIZER_PUBLISH_APP_ID_METRICS = true;
 
 const bdlat_AttributeInfo QueueModeFanout::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_APP_I_DS,
@@ -3988,7 +3988,7 @@ const char* DomainVariant::selectionName() const
 // VERSION bmqconf:183474-1.0
 // ----------------------------------------------------------------------------
 // NOTICE:
-//      Copyright 2024 Bloomberg Finance L.P. All rights reserved.
+//      Copyright 2025 Bloomberg Finance L.P. All rights reserved.
 //      Property of Bloomberg Finance L.P. (BFLP)
 //      This software is made available solely pursuant to the
 //      terms of a BFLP license agreement which governs its use.

--- a/src/groups/mqb/mqbconfm/mqbconfm_messages.h
+++ b/src/groups/mqb/mqbconfm/mqbconfm_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2014-2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -5584,9 +5584,9 @@ class DomainVariant {
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     mqbconfm::DomainVariant)
 
-//=============================================================================
+// ============================================================================
 //                          INLINE DEFINITIONS
-//=============================================================================
+// ============================================================================
 
 namespace mqbconfm {
 
@@ -9172,7 +9172,7 @@ inline bool DomainVariant::isUndefinedValue() const
 // VERSION bmqconf:183474-1.0
 // ----------------------------------------------------------------------------
 // NOTICE:
-//      Copyright 2024 Bloomberg Finance L.P. All rights reserved.
+//      Copyright 2025 Bloomberg Finance L.P. All rights reserved.
 //      Property of Bloomberg Finance L.P. (BFLP)
 //      This software is made available solely pursuant to the
 //      terms of a BFLP license agreement which governs its use.

--- a/src/python/blazingmq/schemas/mqbconf.py
+++ b/src/python/blazingmq/schemas/mqbconf.py
@@ -299,7 +299,7 @@ class QueueModeFanout:
         },
     )
     publish_app_id_metrics: bool = field(
-        default=False,
+        default=True,
         metadata={
             "name": "publishAppIdMetrics",
             "type": "Element",


### PR DESCRIPTION
Now that we are rolling out this feature everywhere, the default value should be true.