### PR TITLE
Feat[STATS]: Add new metrics for CSL file

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -302,7 +302,8 @@ void Cluster::startDispatched(bsl::ostream* errorDescription, int* rc)
         d_clusterData.clusterConfig().partitionConfig();
     d_clusterData.stats().setPartitionCfgBytes(
         partitionConfig.maxDataFileSize(),
-        partitionConfig.maxJournalFileSize());
+        partitionConfig.maxJournalFileSize(),
+        partitionConfig.maxCSLFileSize());
 
     *rc = rc_SUCCESS;
 }

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
@@ -72,8 +72,8 @@ struct ClusterStatsIndex {
         // Value: Time in nanoseconds it took for replication of a new entry
         //        in CSL file.
         ,
-        e_CSL_OFFSET_BYTES
-        // Value: Offset bytes in the CSL file.
+        e_CSL_LOG_OFFSET_BYTES
+        // Value: Last observed offset bytes in the newest log of the CSL.
         ,
         e_CSL_WRITE_BYTES
         // Value: Bytes written to the CSL file.

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
@@ -182,8 +182,8 @@ bsls::Types::Int64 ClusterStats::getValue(const bmqst::StatContext& context,
                                                                        : value;
     }
 
-    case Stat::e_CSL_OFFSET_BYTES: {
-        return STAT_SINGLE(value, e_CSL_OFFSET_BYTES);
+    case Stat::e_CSL_LOG_OFFSET_BYTES: {
+        return STAT_SINGLE(value, e_CSL_LOG_OFFSET_BYTES);
     }
     case Stat::e_CSL_WRITE_BYTES: {
         return STAT_RANGE(valueDifference, e_CSL_WRITE_BYTES);
@@ -392,14 +392,15 @@ ClusterStats& ClusterStats::setCslReplicationTime(bsls::Types::Int64 value)
 
 ClusterStats& ClusterStats::setCslOffsetBytes(bsls::Types::Int64 value)
 {
-    d_statContext_mp->setValue(ClusterStatsIndex::e_CSL_OFFSET_BYTES, value);
+    d_statContext_mp->setValue(ClusterStatsIndex::e_CSL_LOG_OFFSET_BYTES,
+                               value);
     return *this;
 }
 
 ClusterStats& ClusterStats::addCslOffsetBytes(bsls::Types::Int64 delta)
 {
     d_statContext_mp->adjustValue(ClusterStatsIndex::e_CSL_WRITE_BYTES, delta);
-    d_statContext_mp->adjustValue(ClusterStatsIndex::e_CSL_OFFSET_BYTES,
+    d_statContext_mp->adjustValue(ClusterStatsIndex::e_CSL_LOG_OFFSET_BYTES,
                                   delta);
     return *this;
 }

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
@@ -79,7 +79,7 @@ struct ClusterStatsIndex {
         // Value: Bytes written to the CSL file.
         ,
         e_CSL_CFG_BYTES
-        // Value: Configured size of the CSL file.
+        // Value: Configured maximum size of the CSL file.
         ,
         e_PARTITION_CFG_DATA_BYTES
         // Value: Configured size of partitions' data file

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -87,8 +87,8 @@ class ClusterStats {
             /// Time in nanoseconds it took for replication of a new entry in
             /// CSL file. Maximum observed during the report interval.
             e_CSL_REPLICATION_TIME_NS_MAX,
-            /// Last observed offset bytes in the csl file.
-            e_CSL_OFFSET_BYTES,
+            /// Last observed offset bytes in the newest log of the CSL.
+            e_CSL_LOG_OFFSET_BYTES,
             /// Amount of bytes written to the csl file.
             e_CSL_WRITE_BYTES,
             /// Configured size of the CSL file.

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -95,7 +95,7 @@ class ClusterStats {
             e_CSL_CFG_BYTES,
             /// Configured size of the data file.
             e_PARTITION_CFG_DATA_BYTES,
-            /// Configured size of the journal file.
+            /// Configured maximum size of the journal file.
             e_PARTITION_CFG_JOURNAL_BYTES,
 
             // PartitionStats: those metrics make sense only from the

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -91,7 +91,7 @@ class ClusterStats {
             e_CSL_LOG_OFFSET_BYTES,
             /// Amount of bytes written to the csl file.
             e_CSL_WRITE_BYTES,
-            /// Configured size of the CSL file.
+            /// Configured maximum size of the CSL file.
             e_CSL_CFG_BYTES,
             /// Configured size of the data file.
             e_PARTITION_CFG_DATA_BYTES,

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -81,9 +81,21 @@ class ClusterStats {
             e_CLUSTER_STATUS,
             e_ROLE,
             e_LEADER_STATUS,
+            /// Time in nanoseconds it took for replication of a new entry in
+            /// CSL file. Average observed during the report interval.
             e_CSL_REPLICATION_TIME_NS_AVG,
+            /// Time in nanoseconds it took for replication of a new entry in
+            /// CSL file. Maximum observed during the report interval.
             e_CSL_REPLICATION_TIME_NS_MAX,
+            /// Last observed offset bytes in the csl file.
+            e_CSL_OFFSET_BYTES,
+            /// Amount of bytes written to the csl file.
+            e_CSL_WRITE_BYTES,
+            /// Configured size of the CSL file.
+            e_CSL_CFG_BYTES,
+            /// Configured size of the data file.
             e_PARTITION_CFG_DATA_BYTES,
+            /// Configured size of the journal file.
             e_PARTITION_CFG_JOURNAL_BYTES,
 
             // PartitionStats: those metrics make sense only from the
@@ -241,11 +253,12 @@ class ClusterStats {
     ClusterStats& setIsLeader(LeaderStatus::Enum value);
 
     /// Update the `partition.cfg_data_bytes` field to the specified
-    /// `dataBytes` and the `partition.cfg_journal_bytes` field to the
-    /// specified `journalBytes` in the StatContext being referred to by
-    /// this object.
+    /// `dataBytes`, the `partition.cfg_journal_bytes` field to the specified
+    /// `journalBytes` and the `cluster_csl_cfg_bytes` field to the specified
+    /// `cslBytes` in the StatContext being referred to by this object.
     ClusterStats& setPartitionCfgBytes(bsls::Types::Int64 dataBytes,
-                                       bsls::Types::Int64 journalBytes);
+                                       bsls::Types::Int64 journalBytes,
+                                       bsls::Types::Int64 cslBytes);
 
     /// Set the primary status of the specified `partitionId` to the
     /// specified `value`.
@@ -255,6 +268,14 @@ class ClusterStats {
     /// Set the csl replication time of the StatContext being referred
     /// to by this object to be the specified `value`.
     ClusterStats& setCslReplicationTime(bsls::Types::Int64 value);
+
+    /// Set the csl offset bytes of the StatContext being referred to by this
+    /// object to be the specified `value`.
+    ClusterStats& setCslOffsetBytes(bsls::Types::Int64 value);
+
+    /// Adjust the csl offset bytes of the StatContext being referred to by
+    /// this object by the specified `delta`.
+    ClusterStats& addCslOffsetBytes(bsls::Types::Int64 delta);
 
     /// Set the partition outstanding bytes of the specified data and
     /// journal files for the specified `partitionId` to the corresponding

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -93,7 +93,7 @@ class ClusterStats {
             e_CSL_WRITE_BYTES,
             /// Configured maximum size of the CSL file.
             e_CSL_CFG_BYTES,
-            /// Configured size of the data file.
+            /// Configured maximum size of the data file.
             e_PARTITION_CFG_DATA_BYTES,
             /// Configured maximum size of the journal file.
             e_PARTITION_CFG_JOURNAL_BYTES,

--- a/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.cpp
+++ b/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.cpp
@@ -686,7 +686,9 @@ void PrometheusStatConsumer::captureClusterStats(const LeaderSet& leaders)
                 {"cluster_csl_replication_time_ns_max",
                  Stat::e_CSL_REPLICATION_TIME_NS_MAX,
                  false},
-                {"cluster_csl_offset_bytes", Stat::e_CSL_OFFSET_BYTES, false},
+                {"cluster_csl_offset_bytes",
+                 Stat::e_CSL_LOG_OFFSET_BYTES,
+                 false},
                 {"cluster_csl_write_bytes", Stat::e_CSL_WRITE_BYTES, false},
                 {"cluster_csl_cfg_bytes", Stat::e_CSL_CFG_BYTES, false},
             };

--- a/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.cpp
+++ b/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.cpp
@@ -686,6 +686,9 @@ void PrometheusStatConsumer::captureClusterStats(const LeaderSet& leaders)
                 {"cluster_csl_replication_time_ns_max",
                  Stat::e_CSL_REPLICATION_TIME_NS_MAX,
                  false},
+                {"cluster_csl_offset_bytes", Stat::e_CSL_OFFSET_BYTES, false},
+                {"cluster_csl_write_bytes", Stat::e_CSL_WRITE_BYTES, false},
+                {"cluster_csl_cfg_bytes", Stat::e_CSL_CFG_BYTES, false},
             };
 
             Tagger tagger;


### PR DESCRIPTION
This PR is introducing new csl file related metrics:
`e_CSL_LOG_OFFSET_BYTES` for current offset in the CSL file. This offset is literally the amount of bytes written to the file, as well as the position where the next record will be written.
`e_CSL_WRITE_BYTES` for the amount of bytes written to the CSL file.
`e_CSL_CFG_BYTES` for the configured CSL file size.

