### PR TITLE
Fix[bmqeval]: Correctly store eval error code

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.cpp
@@ -182,8 +182,10 @@ SimpleEvaluator::Property::evaluate(EvaluationContext& context) const
     if (value.isError()) {
         const int rc = value.theError().code();
 
-        if (ErrorType::e_EVALUATION_FIRST <= rc &&
-            rc <= ErrorType::e_EVALUATION_LAST) {
+        // ErrorType::e_EVALUATION_LAST and ErrorType::e_EVALUATION_FIRST are
+        // negative, hence the flipped conditional.
+        if (ErrorType::e_EVALUATION_LAST <= rc &&
+            rc <= ErrorType::e_EVALUATION_FIRST) {
             context.setError(static_cast<ErrorType::Enum>(rc));
         }
         else {


### PR DESCRIPTION
`SimpleEvaluator::Property::evaluate` contains special logic to store evaluation error return codes in the context, using two range sentinel enumerators `ErrorType::e_EVALUATION_FIRST` and
`ErrorType::e_EVALUATION_LAST`.  However, as written, the condition to check whether a return code is an evaluation error code is invariably `false`.  That is to say,

    e_EVALUATION_FIRST <= rc <= e_EVALUATION_LAST

is always false, because `e_EVALUATION_FIRST = -1`, and `e_EVALUATION_LAST = -4`.  Return codes grow in the negative direction, so the condition we want instead is

    e_EVALUATION_LAST <= rc <= e_EVALUATION_FIRST.