### PR TITLE
Fix[BMQ]: cancel heartbeat when `TCPSessionFactory` stops

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1136,8 +1136,9 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
         d_scheduler_p->scheduleRecurringEvent(
             &d_heartbeatSchedulerHandle,
             interval,
-            bdlf::BindUtil::bind(&TCPSessionFactory::onHeartbeatSchedulerEvent,
-                                 this));
+            bmqu::WeakMemFnUtil::weakMemFn(
+                &TCPSessionFactory::onHeartbeatSchedulerEvent,
+                d_self.acquireWeak()));
         d_heartbeatSchedulerActive = true;
     }
     else {
@@ -1290,6 +1291,9 @@ void TCPSessionFactory::stop()
     if (d_tcpChannelFactory_mp) {
         stopChannelFactory(d_tcpChannelFactory_mp.get());
     }
+
+    // Cancel the scheduled heartbeat event
+    d_scheduler_p->cancelEvent(&d_heartbeatSchedulerHandle);
 
     // Wait for all sessions to have been destroyed
     d_mutex.lock();

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1292,14 +1292,14 @@ void TCPSessionFactory::stop()
         stopChannelFactory(d_tcpChannelFactory_mp.get());
     }
 
-    // Cancel the scheduled heartbeat event
-    d_scheduler_p->cancelEvent(&d_heartbeatSchedulerHandle);
-
     // Wait for all sessions to have been destroyed
     d_mutex.lock();
 
     if (d_heartbeatSchedulerActive) {
         d_heartbeatSchedulerActive = false;
+
+        // Cancel the scheduled heartbeat event
+        d_scheduler_p->cancelEventAndWait(&d_heartbeatSchedulerHandle);
 
         d_scheduler_p->scheduleEvent(
             bsls::TimeInterval(0),


### PR DESCRIPTION
# Issue
This is a fix on a segfault occurred during shutting down. `onHeartbeatSchedulerEvent` fires after `TCPSessionFactory` gets destroyed. The map `d_heartbeatChannels` has became invalid, so there's a bad access in a late `onHeartbeatSchedulerEvent`.

# Fix
Make the scheduled event hold a weak pointer to `TCPSessionFactory`, and cancel the scheduled heartbeat event when `TCPSessionFactory` is stopping.

# Log
The log can be found through [github action](https://github.com/bloomberg/blazingmq/actions/runs/17980140590/job/51172731177?pr=773) -> fuzz test -> view raw log