### PR TITLE
CI[Fuzz]: print stack traces on deadlocks, reduce amount of logging to GH Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,7 +179,15 @@ jobs:
         run: |
           pip install -r ${{ github.workspace }}/src/python/requirements.txt
           cd src/python
-          python3 -m blazingmq.dev.fuzztest --broker-dir ${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr --request ${{ matrix.request }}
+          python3 -m blazingmq.dev.fuzztest --broker-dir ${{ github.workspace }}/build/blazingmq/src/applications/bmqbrkr --request ${{ matrix.request }} > ${{ matrix.request}}_fuzz.log
+
+        # Do not print everything, GitHub Actions is not able to handle 100MB+ of logs.
+        # Typically the error found with fuzzer is related to the latest requests and broker state.
+        # If this is not enough, consider running the test on your local machine and get full logs.
+      - name: Print Fuzz Log tail
+        if: failure()
+        run: |
+          cd src/python && tail -n 2000 ${{ matrix.request}}_fuzz.log
 
       - name: Print core information
         if: failure()

--- a/.github/workflows/ext/print_cores.py
+++ b/.github/workflows/ext/print_cores.py
@@ -72,7 +72,7 @@ def main() -> None:
             "-q",
             "-batch",
             "-ex",
-            "bt full",
+            "thread apply all bt full",
             args.bin_path,
             core_path,
         ]

--- a/.github/workflows/ext/print_cores.py
+++ b/.github/workflows/ext/print_cores.py
@@ -67,10 +67,14 @@ def main() -> None:
         print(f"No cores found in directory: {args.cores_dir}")
 
     for core_path in fpaths:
+        # Firstly, print the stack trace of the current thread (useful to debug crashes)
+        # Secondly, print the stack traces of all threads (useful to debug deadlocks)
         cmd = [
             "gdb",
             "-q",
             "-batch",
+            "-ex",
+            "bt full",
             "-ex",
             "thread apply all bt full",
             args.bin_path,

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -683,11 +683,6 @@ int main(int argc, const char* argv[])
         bsl::cerr << "Failed to install SIGINT handler  (rc: " << rc << ")\n"
                   << bsl::flush;
     }
-    rc = ::sigaction(SIGQUIT, &sa, NULL);
-    if (rc != 0) {
-        bsl::cerr << "Failed to install SIGQUIT handler  (rc: " << rc << ")\n"
-                  << bsl::flush;
-    }
     rc = ::sigaction(SIGTERM, &sa, NULL);
     if (rc != 0) {
         bsl::cerr << "Failed to install SIGTERM handler  (rc: " << rc << ")\n"

--- a/src/python/blazingmq/dev/fuzztest/__init__.py
+++ b/src/python/blazingmq/dev/fuzztest/__init__.py
@@ -359,7 +359,7 @@ def fuzz(host: str, port: int, request: Optional[str] = None) -> None:
 
     session = boofuzz.Session(
         target=boofuzz.Target(
-            connection=boofuzz.TCPSocketConnection(host, port, recv_timeout=0.1)
+            connection=boofuzz.TCPSocketConnection(host, port, recv_timeout=0.05)
         ),
         receive_data_after_each_request=True,
         receive_data_after_fuzz=True,

--- a/src/python/blazingmq/dev/processtools.py
+++ b/src/python/blazingmq/dev/processtools.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 import psutil
+import signal
 
 
 def stop_broker(
@@ -42,8 +43,14 @@ def stop_broker(
         broker_process = psutil.Process(pid)
 
         if timeout is not None:
-            broker_process.terminate()
+            # broker_process.terminate()
+            # try:
+            #     return broker_process.wait(timeout=timeout)
+            # except psutil.TimeoutExpired:
+            #     pass
 
+            print("Sending SIGQUIT signal")
+            broker_process.send_signal(signal.SIGQUIT)
             try:
                 return broker_process.wait(timeout=timeout)
             except psutil.TimeoutExpired:

--- a/src/python/blazingmq/dev/processtools.py
+++ b/src/python/blazingmq/dev/processtools.py
@@ -18,48 +18,43 @@ Provide utilities to facilitate launching and manipulating processes.
 """
 
 from pathlib import Path
+import signal
 from typing import Optional
 
 import psutil
-import signal
 
 
-def stop_broker(
-    path: Path, timeout: int = None, error_ok: bool = True
-) -> Optional[int]:
+def stop_broker(broker_dir: Path, timeout: int = None) -> Optional[int]:
     """
-    Stop the broker (using the pid file), first with 'terminate', then, after the
-    specified 'timeout', with 'kill'.  In case when timeout is not specified it
-    is considered that the broker process should be killed instantly with 'kill'.
-    If the specified 'error_ok' flag is True, all exceptions during
-    stopping the broker will be suppressed, in case of False it will be re-raised.
+    Stop the broker (using bmqbrkr.pid file from the `broker_dir` directory):
+    - First with `SIGTERM`
+    - Then, after the specified `timeout`, with `SIGQUIT`
+    - Then, after the specified `timeout`, once more with `SIGKILL`
+    In case when timeout is not specified, it is considered that the broker
+    process should be killed instantly with 'SIGKILL'.
     Return the broker's return code or None if not applicable.
     """
 
-    try:
-        with (path / "bmqbrkr.pid").open("r") as file:
-            pid = int(file.read())
+    with (broker_dir / "bmqbrkr.pid").open("r") as file:
+        pid = int(file.read())
 
-        broker_process = psutil.Process(pid)
+    broker_process = psutil.Process(pid)
 
-        if timeout is not None:
-            # broker_process.terminate()
-            # try:
-            #     return broker_process.wait(timeout=timeout)
-            # except psutil.TimeoutExpired:
-            #     pass
+    if timeout is not None:
+        print("Sending SIGTERM to the broker...", flush=True)
+        broker_process.terminate()
+        try:
+            return broker_process.wait(timeout=timeout)
+        except psutil.TimeoutExpired:
+            print("Broker hasn't exited after the timeout", flush=True)
 
-            print("Sending SIGQUIT signal")
-            broker_process.send_signal(signal.SIGQUIT)
-            try:
-                return broker_process.wait(timeout=timeout)
-            except psutil.TimeoutExpired:
-                pass
+        print("Sending SIGQUIT to the broker...", flush=True)
+        broker_process.send_signal(signal.SIGQUIT)
+        try:
+            return broker_process.wait(timeout=timeout)
+        except psutil.TimeoutExpired:
+            print("Broker hasn't exited after the timeout", flush=True)
 
-        broker_process.kill()
-        return broker_process.wait()
-
-    except Exception:
-        if error_ok:
-            return None
-        raise
+    print("Sending SIGKILL to the broker...", flush=True)
+    broker_process.kill()
+    return broker_process.wait()


### PR DESCRIPTION
- Speed up fuzz test by reducing the time to wait for no response.
- Redirect fuzz test logs to a log file in CI and print at most 2000 latest lines on failure (the full identity request log has 900k+ lines in total). This prevents GitHub Actions web ui from clogging when opening fuzz logs.
- Print both the current thread stack trace and all thread stack traces on core dump, to allow debug both crashes and deadlocks.
- Remove custom SIGQUIT handler in bmqbrkr that prevents the broker from terminating immediately on deadlock.
- When stopping a broker during fuzz test, first try to gracefully terminate, after this try to SIGQUIT to get a stack trace of a possible deadlock, last try to kill immediately.
- Remove access to private `os._exit` function. Instead, pass return code from broker thread to the main thread to allow returning the correct exit code from the main thread.
- Do `join` broker thread when stopping fuzz test.
- Check that broker dir is correct and contains a broker binary before spawning broker thread.
- Simplify `stop_broker` API