### PR TITLE
Fix blp::ClusterOrchestrator: Skip process cluster state event if stopping

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1309,6 +1309,17 @@ void ClusterOrchestrator::processClusterStateEvent(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
+    BSLS_ASSERT_SAFE(event.clusterNode());
+
+    if (bmqp_ctrlmsg::NodeStatus::E_STOPPING ==
+        d_clusterData_p->membership().selfNodeStatus()) {
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Not processing cluster state record event from "
+                      << event.clusterNode()->nodeDescription()
+                      << " since self is stopping";
+
+        return;  // RETURN
+    }
 
     d_stateManager_mp->processClusterStateEvent(event);
 }


### PR DESCRIPTION
Similar to in https://github.com/bloomberg/blazingmq/pull/852, there is no need to process cluster state record event if self is stopping. If we try to process, we get the following false alarm error log:

```
ERROR mqbc_incoreclusterstateledger.cpp:836 IncoreClusterStateLedger (cluster: clusterName): Ignoring cluster state record event from '[node, 00000]'. Reason: Source node is not the leader [source: [node, 00000], leader: ** none **].
```