### PR TITLE
Fix[storagetool] Fix csl file relative path handling

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_filemanager.cpp
@@ -245,7 +245,7 @@ bool FileManagerImpl::CslFileHandler::resetIterator(
         return false;  // RETURN
     }
 
-    // If `location` is empty, use explicitly current directory.
+    // Use current directory when `location` is empty.
     if (location.empty()) {
         location = ".";
     }


### PR DESCRIPTION
Closes #955 

Csl file handling is different from journal/data/qlist, because it is passed by parts (pattern, location) into `LedgerConfig`.
Changed csl path handling as follows: if `location` is empty, set explicitly current directory `"."`.

Manually tested:
```
./bmqstoragetool.tsk --csl-file bmq_csl_20241029_140023_87EDF15DC0.bmq_csl
./bmqstoragetool.tsk --csl-file ./bmq_csl_20241029_140023_87EDF15DC0.bmq_csl
./bmqstoragetool.tsk --csl-file ../bmq_csl_20241029_140023_87EDF15DC0.bmq_csl
./bmqstoragetool.tsk --csl-file <absolute_path>/bmq_csl_20241029_140023_87EDF15DC0.bmq_csl

./bmqstoragetool.tsk --journal-file bmq_0.20241029_140023.bmq_journal
```
