### PR TITLE
close channel when write fails before read

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -288,6 +288,9 @@ void Application::channelStateCallback(
         BALL_LOG_ERROR << id() << "Could not establish session with '"
                        << endpoint << "' [event: " << event
                        << ", status: " << status << "]";
+        if (channel) {
+            channel->close(status);
+        }
     } break;  // BREAK
     default: {
         BALL_LOG_ERROR << id() << "Session with '" << endpoint << "' is now"


### PR DESCRIPTION
If writing nego message fails before read, closing the channel by remote peer does not generate any event, and nothing starts the reconnecting.  
Need to explicitly close the channel in this scenario