### PR TITLE
Feat[mqb]: Add broker stats to stat log

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_brokerstats.h
@@ -30,10 +30,13 @@
 // MQB
 
 // BMQ
+#include <bmqst_basictableinfoprovider.h>
 #include <bmqst_statcontext.h>
+#include <bmqst_table.h>
 #include <bmqt_uri.h>
 
 // BDE
+#include <ball_log.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
@@ -151,6 +154,13 @@ struct BrokerStatsUtil {
     /// specified `allocator` for all stat context and stat values.
     static bsl::shared_ptr<bmqst::StatContext>
     initializeStatContext(int historySize, bslma::Allocator* allocator);
+
+    /// Load in the specified `table` and `tip` the objects to print the
+    /// specified `statContext` for the specified `historySize`.
+    static void initializeTableAndTipBroker(bmqst::Table* table,
+                                            bmqst::BasicTableInfoProvider* tip,
+                                            int                 historySize,
+                                            bmqst::StatContext* statContext);
 };
 
 // ============================================================================

--- a/src/groups/mqb/mqbstat/mqbstat_printer.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.cpp
@@ -18,6 +18,7 @@
 
 #include <mqbscm_version.h>
 // MQB
+#include <mqbstat_brokerstats.h>
 #include <mqbstat_queuestats.h>
 
 #include <bmqio_statchannelfactory.h>
@@ -86,6 +87,12 @@ void Printer::initializeTablesAndTips()
 
     Context* context = d_contexts["domainQueues"].get();
     QueueStatsUtil::initializeTableAndTipDomains(&context->d_table,
+                                                 &context->d_tip,
+                                                 historySize,
+                                                 context->d_statContext_p);
+
+    context = d_contexts["broker"].get();
+    BrokerStatsUtil::initializeTableAndTipBroker(&context->d_table,
                                                  &context->d_tip,
                                                  historySize,
                                                  context->d_statContext_p);
@@ -214,11 +221,19 @@ void Printer::stop()
 void Printer::printStats(bsl::ostream& stream)
 {
     // This must execute in the 'snapshot' thread
+    Context* context;
+
+    // BROKER
+    stream << "\n"
+           << ":::::::::: :::::::::: BROKER >>";
+    context = d_contexts["broker"].get();
+    context->d_table.records().update();
+    bmqst::TableUtil::printTable(stream, context->d_tip);
 
     // DOMAINQUEUES
     stream << "\n"
            << ":::::::::: :::::::::: DOMAINQUEUES >>";
-    Context* context = d_contexts["domainQueues"].get();
+    context = d_contexts["domainQueues"].get();
     context->d_table.records().update();
     bmqst::TableUtil::printTable(stream, context->d_tip);
 


### PR DESCRIPTION
This commit adds the # of clients and queues to the broker's stat log. These values can be derived from existing stats with some legwork; logging them in one line just makes it easier.

Note: These metrics show the number of connected clients and opened queues. If a queue exists in storage but has no clients, it does not count.

**Additional context**
Add any other context about your contribution here.
