### PR TITLE
CI: Use single quotes in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   create-github-prerelease:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && contains(github.ref_name, "rc")
+    if: github.event_name == 'push' && contains(github.ref_name, 'rc')
     permissions:
       contents: write
 
@@ -32,7 +32,7 @@ jobs:
 
   create-github-release:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !contains(github.ref_name, "rc")
+    if: github.event_name == 'push' && !contains(github.ref_name, 'rc')
     permissions:
       contents: write
 


### PR DESCRIPTION
GitHub Actions require string constants to use single quotes, not double quotes.  This means our publish workflow fails with a syntax error:

    Invalid workflow file: .github/workflows/publish.yaml#L1
    (Line: 17, Col: 9): Unexpected symbol: '"rc"'. Located at position 58 within expression: github.event_name == 'push' && contains(github.ref_name, "rc"), (Line: 35, Col: 9): Unexpected symbol: '"rc"'. Located at position 59 within expression: github.event_name == 'push' && !contains(github.ref_name, "rc")

See https://github.com/bloomberg/blazingmq/actions/runs/18323645462 for an example.

This patch replaces all double-quoted string constants in the publish workflow with single-quoted string constants.