### PR TITLE
Remove[bmqeval]: forbid chained expressions

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -190,6 +190,26 @@ static void test1_compilationErrors()
          ErrorType::e_SYNTAX,
          "syntax error, unexpected > at offset 5"},
 
+        // chained expressions
+        {"x == y == z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected = at offset 7"},
+        {"x != y != z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected <> at offset 7"},
+        {"x < y < z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected < at offset 6"},
+        {"x <= y <= z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected <= at offset 7"},
+        {"x > y > z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected > at offset 6"},
+        {"x >= y >= z",
+         ErrorType::e_SYNTAX,
+         "syntax error, unexpected >= at offset 7"},
+
         // unsupported_ints
         {"i_0 != 9223372036854775808",
          ErrorType::e_SYNTAX,

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluatorparser.y
@@ -65,30 +65,30 @@
 %token END 0 "end of expression"
 %token <char> INVALID "invalid character"
 %token <bsl::string> OVERFLOW "overflow"
-%token <bsl::string> PROPERTY "property";
-%token <bsl::string> STRING "string";
-%token <uint64_t> INTEGER "integer";
-%token TRUE "true";
-%token FALSE "false";
-%token LPAR "(";
-%token RPAR ")";
-%token PLUS "+" MINUS "-";
-%token TIMES "*" DIVIDES "/" MODULUS "%";
-%token EQ "=" NE "<>" LT "<" LE "<=" GE ">=" GT ">";
-%token NOT "!";
-%token <bsl::string> EXISTS "exists";
+%token <bsl::string> PROPERTY "property"
+%token <bsl::string> STRING "string"
+%token <uint64_t> INTEGER "integer"
+%token TRUE "true"
+%token FALSE "false"
+%token LPAR "("
+%token RPAR ")"
+%token NOT "!"
+%token PLUS "+" MINUS "-"
+%token TIMES "*" DIVIDES "/" MODULUS "%"
+%token EQ "=" NE "<>" LT "<" LE "<=" GE ">=" GT ">"
+%token <bsl::string> EXISTS "exists"
 
-%left OR;
-%left AND;
-%left EQ NE
-%left LT LE GE GT;
-%left PLUS MINUS;
-%left TIMES DIVIDES MODULUS;
-%precedence NOT;
+%left OR
+%left AND
+%nonassoc EQ NE
+%nonassoc LT LE GE GT
+%left PLUS MINUS
+%left TIMES DIVIDES MODULUS
+%precedence NOT
 
-%type<bsl::string> variable;
-%type<SimpleEvaluator::ExpressionPtr> expression;
-%type<SimpleEvaluator::ExpressionPtr> predicate;
+%type<bsl::string> variable
+%type<SimpleEvaluator::ExpressionPtr> expression
+%type<SimpleEvaluator::ExpressionPtr> predicate
 %start predicate
 
 %%


### PR DESCRIPTION
The previous version of bmqeval parser allowed expressions like `x == y == z`, `x < y < z`, etc.
These expressions might be misleading.

Example
`x == y == z` might look like `x, y, z are equal`, but it's not the case.
Consider `x == 10`, `y == 0`, `z == false`. The result of evaluation is:
`10 == 0 == false` -> `(10 == 0) == false` -> `false == false` -> `true`