### PR TITLE
Fix mqbc::StorageMgr: Buffer artificial primary status adv if not healed

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
@@ -57,6 +57,8 @@ PartitionFSM& PartitionFSM::unregisterObserver(PartitionFSMObserver* observer)
 void PartitionFSM::popEventAndProcess(
     const bsl::shared_ptr<bsl::queue<EventWithData> >& eventsQueue)
 {
+    // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId'
+
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!eventsQueue->empty());
 


### PR DESCRIPTION
Fixes the third crash in Internal Ticket 180066129

In FSM mode, the crash was:
```
03OCT2025_23:04:11.052 FATAL mqbc_recoverymanager.cpp:346 Assertion failed: receiveDataCtx.d_currSeqNum.primaryLeaseId() == fs.primaryLeaseId(), stack trace:
(5): BloombergLP::mqbc::RecoveryManager::setExpectedDataChunkRange(int, BloombergLP::mqbs::FileStore const&, BloombergLP::mqbnet::ClusterNode*, BloombergLP::bmqp_ctrlmsg::PartitionSequenceNumber const&, BloombergLP::bmqp_ctrlmsg::PartitionSequenceNumber const&, int)
(6): BloombergLP::mqbc::StorageManager::do_setExpectedDataChunkRange(bsl::shared_ptr<BloombergLP::mqbc::PartitionFSM::PartitionFSMArgs> const&)
```

Using `gdb`, we see `receiveDataCtx.d_currSeqNum = (92, 8)` while `[fs.d_primaryLeaseId, fs.d_sequenceNum] = (93, 0)`. We can look at logs to see why:
```
03OCT2025_23:04:11.047 INFO mqbc_storagemanager.cpp:1341 In Partition [2]'s FSM, storing self sequence number as [ primaryLeaseId = 92 sequenceNumber = 8 ]
03OCT2025_23:04:11.048 INFO mqbblp_clusterorchestrator.cpp:1668 Partition [2]: received primary status advisory: [ partitionId = 2 primaryLeaseId = 93 status = E_ACTIVE ], from: <primary_node>
03OCT2025_23:04:11.048 INFO mqbs_filestore.cpp:6590 Partition [2]: Primary node is now <primary_node> with primaryLeaseId: 93, and sequence number: 0.
```

The Partition FSM is not healed, and yet we are processing the `PrimaryStatusAdvisory`. We were hoping [the `if` check](https://github.com/bloomberg/blazingmq/blob/169c39da5ecb97605e81d47823696b17f6440b3c/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp#L1543-L1544) would direct us to buffer the advisory, but it doesn't because it checks against the `ClusterState` which is already aware of (93, 0). Therefore, I am adding an additional check before [`d_fileStores[partitionId]->setActivePrimary`](https://github.com/kaikulimu/blazingmq/blob/6a2542b36b167e7ffcf2042c81d79a9b8a3f3bd0/src/groups/mqb/mqbc/mqbc_storagemanager.cpp#L379-L380) to buffer if Partition FSM is not healed. Since the original advisory is not passed in, I am creating an artificial `PrimaryStatusAdvisory` there.

The processing of `PrimaryStatusAdvisory` is convoluted, and I will create follow-up items to simplify it. But this will be too much changes for a hot-fix PR.