### PR TITLE
Docs: Use `dox` mainpage in `Doxyfile` generate documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -943,10 +943,10 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src/groups/bmq/bmqa \
+INPUT                  = docs/mainpage.dox \
+                         src/groups/bmq/bmqa \
                          src/groups/bmq/bmqt \
-                         src/groups/bmq/bmqpi \
-                         README.md
+                         src/groups/bmq/bmqpi
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1032,6 +1032,7 @@ EXCLUDE_PATTERNS       = *.t.cpp \
 
 EXCLUDE_SYMBOLS        = BloombergLP::bmqimp \
                          BloombergLP::bmqp \
+                         BloombergLP::bmqst \
                          BloombergLP::bslmt
 
 # The EXAMPLE_PATH tag can be used to specify one or more files or directories
@@ -1119,7 +1120,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ./README.md
+USE_MDFILE_AS_MAINPAGE =
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
We have two ways of generating API documentation right now: we can either do it through the CMake target `apidocs`, or a user can just run `doxygen` and use our provided `Doxyfile`.  While we’d like to move towards the former exclusively, we still use the latter in CI, to make documentation builds quicker.

Unfortunately, this means that CI has been warning on every PR about README.md having syntax that Doxygen cannot process.  We fixed this when building with CMake earlier.  This patch applies the same fix to the provided `Doxyfile`, silencing these warnings.