### PR TITLE
Fix[MQB]: fix replica skipping reopen context when primary changes

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -733,10 +733,10 @@ void Cluster::continueShutdownDispatched(
 
     // Also update primary status for those partitions in cluster state.
 
-    const bsl::vector<int>& primaryPartitions =
+    const bsl::vector<int>& partitions =
         d_clusterData.membership().selfNodeSession()->primaryPartitions();
-    for (size_t i = 0; i < primaryPartitions.size(); ++i) {
-        const int pid = primaryPartitions[i];
+    for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
+        const int pid = partitions[i];
         BSLS_ASSERT_SAFE(d_state.partition(pid).primaryNode() ==
                          d_clusterData.membership().selfNode());
         d_state.setPartitionPrimaryStatus(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -464,7 +464,7 @@ void ClusterOrchestrator::onNodeUnavailable(mqbnet::ClusterNode* node)
             << " partition(s): [";
         for (unsigned int i = 0; i < ns->primaryPartitions().size(); ++i) {
             BALL_LOG_OUTPUT_STREAM << ns->primaryPartitions()[i];
-            if (i < (ns->primaryPartitions().size() - 1)) {
+            if (i + 1 < ns->primaryPartitions().size()) {
                 BALL_LOG_OUTPUT_STREAM << ", ";
             }
         }
@@ -475,7 +475,6 @@ void ClusterOrchestrator::onNodeUnavailable(mqbnet::ClusterNode* node)
     // followers as well.  Is the correct behavior?  Should this be done only
     // by the leader, and followers should update the info only upon being
     // notified from the leader?
-
     d_stateManager_mp->markOrphan(ns->primaryPartitions(), node);
     ns->removeAllPartitions();
 
@@ -980,7 +979,7 @@ void ClusterOrchestrator::processNodeStoppingNotification(
 
     const bsl::vector<int>& partitions =
         d_clusterData_p->membership().selfNodeSession()->primaryPartitions();
-    for (unsigned int i = 0; i < partitions.size(); ++i) {
+    for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
         d_storageManager_p->processReplicaStatusAdvisory(
             partitions[i],
             ns->clusterNode(),
@@ -1085,7 +1084,7 @@ void ClusterOrchestrator::processNodeStatusAdvisory(
         const bsl::vector<int>& partitions = d_clusterData_p->membership()
                                                  .selfNodeSession()
                                                  ->primaryPartitions();
-        for (unsigned int i = 0; i < partitions.size(); ++i) {
+        for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
             d_storageManager_p->processReplicaStatusAdvisory(
                 partitions[i],
                 source,
@@ -1186,7 +1185,7 @@ void ClusterOrchestrator::processNodeStateChangeEvent(
         const bsl::vector<int>& partitions = d_clusterData_p->membership()
                                                  .selfNodeSession()
                                                  ->primaryPartitions();
-        for (unsigned int i = 0; i < partitions.size(); ++i) {
+        for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
             d_storageManager_p->processReplicaStatusAdvisory(
                 partitions[i],
                 node,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1050,6 +1050,16 @@ void ClusterQueueHelper::processOpenQueueRequest(
             sendOpenQueueRequest(context);
         }
     }
+    else {
+        // Note: this is an extra safeguard.
+        // We do not expect this to happen, consider removing in the future.
+        BMQ_LOGTHROTTLE_ERROR
+            << d_cluster_p->description()
+            << ": unable to send and rebuffering open queue request for "
+            << context->queueContext()->uri();
+
+        context->queueContext()->d_liveQInfo.d_pending.push_back(context);
+    }
 }
 
 void ClusterQueueHelper::sendOpenQueueRequest(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -810,7 +810,8 @@ void ClusterStateManager::markOrphan(const bsl::vector<int>& partitions,
     BSLS_ASSERT_SAFE(dispatcher()->inDispatcherThread(d_cluster_p));
     BSLS_ASSERT_SAFE(primary);
 
-    for (int i = 0; i < static_cast<int>(partitions.size()); ++i) {
+    // Iterate in reversed order: partitions might be removed from the vector
+    for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
         const mqbc::ClusterStatePartitionInfo& pinfo = d_state_p->partition(
             partitions[i]);
         d_state_p->setPartitionPrimary(partitions[i],


### PR DESCRIPTION
<img width="1605" height="1053" alt="Screenshot 2025-10-13 at 16 46 34" src="https://github.com/user-attachments/assets/a9f70345-050c-474b-a1f1-1ede3d5a69ca" />

Bug sequence:
1. Client opens **priority**, **fanout** and **broadcast** queues through proxy `eastp`
2. Proxy `eastp` routes open request to primary `east1`
3. Primary `east1` goes down
4. `west1` becomes the next primary
5. Proxy `eastp` tries to reopen **priority**, **fanout** and **broadcast** through replica `east2` to `west1`
6. Replica `east2` sends open queue requests for **priority** and **broadcast**, but skips sending open queue for **fanout**
7. IT fails because there are no messages received in **fanout** queue

Reason:
1. When primary `east1` goes down, we call `void ClusterOrchestrator::onNodeUnavailable` on replica.
2. There, we try to update all partitions with `markOrphan`, and pass a vector `ns->primaryPartitions()` https://github.com/bloomberg/blazingmq/blob/9a1206e03480664ab739115add6282dd0ef5be24/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp#L479
3. `markOrphan` iterates over the provided vector to notify all partitions that primary is gone https://github.com/bloomberg/blazingmq/blob/9a1206e03480664ab739115add6282dd0ef5be24/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp#L813
4. During this, we call `void ClusterUtil::onPartitionPrimaryAssignment` and execute `ns->removePartitionSafe(partitionId);`, that modifies the vector that we iterate over in step (3)
5. As a result, we skip odd elements in the vector, **not notifying partitions 1, 3, 5, ... that the primary is gone**.
6. This leads to some queues based on odd partitions to skip pending open request, and some queues will never be reopened unless the client restarts.
7. The proxy will also complain `PANIC [CLUSTERPROXY]` because there are pending open contexts that cannot be finalized.