### PR TITLE
Fix[bmqio]: Use largest connection backlog allowed by OS

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
@@ -1579,7 +1579,9 @@ int NtcListener::listen(bmqio::Status*              status,
     int backlog;
     if (!options.properties().load(&backlog,
                                    NtcListenerUtil::listenBacklogProperty())) {
-        backlog = 10;
+        // The magic number 0 means the backlog will be the maximum allowed by
+        // the OS.
+        backlog = 0;
     }
 
     ntsa::Endpoint endpoint;


### PR DESCRIPTION
When listening on a new socket, `bmqio_ntcchannel` sets the connection backlog size to be ten connections.  This allows at most ten connections to the socket to be waiting to be accepted before they are rejected by the OS for us.  Ten is quite a low number, and seems like a mistake. This patch changes the backlog to be determined by NTF, which makes it as large as the OS allows.