### PR TITLE
Fix[bmqtool]: Remove extraneous semicolon

### DIFF
--- a/src/applications/bmqtool/bmqtool.m.cpp
+++ b/src/applications/bmqtool/bmqtool.m.cpp
@@ -84,9 +84,10 @@ class ShutdownContext {
     // CREATORS
     ShutdownContext()
     : d_appSemaphore(0)
-    , d_shutdownCount(0){
-          // NOTHING
-      };
+    , d_shutdownCount(0)
+    {
+        // NOTHING
+    }
 };
 
 static ShutdownContext* s_shutdownContext_p = 0;


### PR DESCRIPTION
This PR removes an unneeded semicolon from bmqtool, fixing a clang warning.

    src/applications/bmqtool/bmqtool.m.cpp:89:8: warning: extra ';' after member function definition [-Wextra-semi]
       89 |       };
          |        ^