### PR TITLE
Perf[MQBS]: sizeof(mqbs::DataStoreRecord) 64 -> 56

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -102,6 +102,9 @@ struct DataStoreRecord {
     // PUBLIC DATA
     RecordType::Enum d_recordType;  // Type of the journal record
 
+    bool d_hasReceipt;
+    // Strong consistency receipt.
+
     bsls::Types::Uint64 d_recordOffset;  // Offset of record in journal
 
     bsls::Types::Uint64 d_messageOffset;
@@ -142,9 +145,6 @@ struct DataStoreRecord {
     bmqp::MessagePropertiesInfo d_messagePropertiesInfo;
     // Used only if d_recordType ==
     // e_MESSAGE
-
-    bool d_hasReceipt;
-    // Strong consistency receipt.
 
     bsls::Types::Int64 d_arrivalTimepoint;
     // Arrival timepoint of the message, in
@@ -709,10 +709,6 @@ class DataStore : public mqbi::DispatcherClient {
     /// Clear the current primary associated with this partition.
     virtual void clearPrimary() = 0;
 
-    /// If the specified `storage` is `true`, flush any buffered replication
-    /// messages to the peers.  If the specified `queues` is `true`, `flush`
-    /// all associated queues.
-
     /// Flush any buffered replication messages to the peers.  Behaviour is
     /// undefined unless this cluster node is the primary for this partition.
     virtual void flushStorage() = 0;
@@ -777,12 +773,12 @@ class DataStore : public mqbi::DispatcherClient {
 
 inline DataStoreRecord::DataStoreRecord()
 : d_recordType(RecordType::e_UNDEFINED)
+, d_hasReceipt(true)
 , d_recordOffset(0)
 , d_messageOffset(0)
 , d_appDataUnpaddedLen(0)
 , d_dataOrQlistRecordPaddedLen(0)
 , d_messagePropertiesInfo()
-, d_hasReceipt(true)
 , d_arrivalTimepoint(0LL)
 , d_arrivalTimestamp(0LL)
 {
@@ -792,12 +788,12 @@ inline DataStoreRecord::DataStoreRecord()
 inline DataStoreRecord::DataStoreRecord(RecordType::Enum    recordType,
                                         bsls::Types::Uint64 recordOffset)
 : d_recordType(recordType)
+, d_hasReceipt(true)
 , d_recordOffset(recordOffset)
 , d_messageOffset(0)
 , d_appDataUnpaddedLen(0)
 , d_dataOrQlistRecordPaddedLen(0)
 , d_messagePropertiesInfo()
-, d_hasReceipt(true)
 , d_arrivalTimepoint(0LL)
 , d_arrivalTimestamp(0LL)
 {
@@ -809,12 +805,12 @@ inline DataStoreRecord::DataStoreRecord(
     bsls::Types::Uint64 recordOffset,
     unsigned int        dataOrQlistRecordPaddedLen)
 : d_recordType(recordType)
+, d_hasReceipt(true)
 , d_recordOffset(recordOffset)
 , d_messageOffset(0)
 , d_appDataUnpaddedLen(0)
 , d_dataOrQlistRecordPaddedLen(dataOrQlistRecordPaddedLen)
 , d_messagePropertiesInfo()
-, d_hasReceipt(true)
 , d_arrivalTimepoint(0LL)
 , d_arrivalTimestamp(0LL)
 {


### PR DESCRIPTION
# Overview

Memory layout of the original `mqbs::DataStoreRecord`:

```
byte(s) offsets:
0..3: RecordType::Enum d_recordType                         (sizeof 4, alignment 4)
4..7: SKIPPED to align the next field by 8 byte offset
8..15: bsls::Types::Uint64 d_recordOffset                   (sizeof 8, alignment 8)
16..23: bsls::Types::Uint64 d_messageOffset                 (sizeof 8, alignment 8)
24..27: unsigned int d_appDataUnpaddedLen                   (sizeof 4, alignment 4)
28..31: unsigned int d_dataOrQlistRecordPaddedLen           (sizeof 4, alignment 4)
32..39: bmqp::MessagePropertiesInfo d_messagePropertiesInfo (sizeof 8, alignment 8)
40..40: bool d_hasReceipt                                   (sizeof 1, alignment 1)
41..47: SKIPPED to align the next field by 8 byte offset
48..55: bsls::Types::Int64 d_arrivalTimepoint               (sizeof 8, alignment 8)
56..63: bsls::Types::Uint64 d_arrivalTimestamp              (sizeof 8, alignment 8)
```

Note that field `d_hasReceipt` takes 1 byte to store its value but it makes us skip 7 bytes just to met alignment requirement of the next field. Moving this field to the first free space `4..7` frees 8 bytes from the struct `sizeof`, slightly reducing the memory usage of the broker:

```
byte(s) offsets:
0..3: RecordType::Enum d_recordType                         (sizeof 4, alignment 4)
4..4: bool d_hasReceipt                                     (sizeof 1, alignment 1)
5..7: SKIPPED to align the next field by 8 byte offset
8..15: bsls::Types::Uint64 d_recordOffset                   (sizeof 8, alignment 8)
16..23: bsls::Types::Uint64 d_messageOffset                 (sizeof 8, alignment 8)
24..27: unsigned int d_appDataUnpaddedLen                   (sizeof 4, alignment 4)
28..31: unsigned int d_dataOrQlistRecordPaddedLen           (sizeof 4, alignment 4)
32..39: bmqp::MessagePropertiesInfo d_messagePropertiesInfo (sizeof 8, alignment 8)
40..47: bsls::Types::Int64 d_arrivalTimepoint               (sizeof 8, alignment 8)
48..55: bsls::Types::Uint64 d_arrivalTimestamp              (sizeof 8, alignment 8)
```

# Testing

```
bsl::cout << sizeof(mqbs::DataStoreRecord) << bsl::endl;
bsl::cout << bsl::alignment_of<mqbs::DataStoreRecord>() << bsl::endl;
```

**Before:**
```
sizeof(mqbs::DataStoreRecord) == 64
bsl::alignment_of<mqbs::DataStoreRecordHandle>() == 8
```

**After:**
```
sizeof(mqbs::DataStoreRecord) == 56
bsl::alignment_of<mqbs::DataStoreRecordHandle>() == 8
```