### PR TITLE
Misc[MQB]: remove log `Stats dumped`; log admin cmd execution time

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_printer.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_printer.cpp
@@ -271,10 +271,6 @@ void Printer::logStats()
 {
     ++d_lastStatId;
 
-    // Put a 'reference' in the main log file. We do that first in case it
-    // crashes/hangs in dump stat, this will help figuring it
-    BALL_LOG_INFO << "Stats dumped [id: " << d_lastStatId << "]";
-
     // Dump to statslog file
     // Prepare the log record and associated attributes
     ball::Record            record;


### PR DESCRIPTION
* Remove log `Stats dumped`. It is not useful for debug, and these log lines take 20% of all logs from brokers.
* Log time used to execute an admin command, and also log the return code. We miss these logs now and cannot tell if some admin operations are slow or not