### PR TITLE
Fix mqbblp::RecoveryMgr: Extend follower wait startup even with avail node

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -489,6 +489,9 @@ void RecoveryManager::recoveryStartupWaitPartitionDispatched(
             << k_STARTUP_WAIT_RETRIES << " times.";
     }
     else {
+        // The sync points always come from the primary, who is more
+        // trustworthy than any other available peer.  Therefore, wait as much
+        // as possible for sync points from the primary.
         BALL_LOG_WARN << d_clusterData_p->identity().description()
                       << ": Partition [" << partitionId
                       << "], extending the wait for sync points.";


### PR DESCRIPTION
Fixes the flaky [`test_replica_late_join`](https://github.com/bloomberg/blazingmq/blob/32601ea3155fefd78a6744310314f5e754b33411/src/integration-tests/test_startup.py#L70) in legacy mode. A couple remarks:
1. Choosing an available peer randomly is **dangerous**, thus I am also guarding this code path behind the retry loop.
2. `k_STARTUP_WAIT_RETRIES  = 10` is insufficient when leader is slow. Bumping up to 20. However, we **do need to** proceed after 20 retries, otherwise [`test_close_while_reopening`](https://github.com/bloomberg/blazingmq/blob/2c19b3d673870cdab725f303492ca146e18590a1/src/integration-tests/test_queue_close.py#L64-L75) fails.