### PR TITLE
CI: Make apidocs push failures an error

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -49,4 +49,5 @@ jobs:
           cd docs/
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
-          git add docs/apidocs/cpp_apidocs/ && git commit -s -am "Update C++ API docs from commit ${{ github.sha }} on main" && git push || true
+          git add docs/apidocs/cpp_apidocs/ && git commit -s -am "Update C++ API docs from commit ${{ github.sha }} on main" || true
+          git push


### PR DESCRIPTION
Our API documentation CI workflow has been failing since September due to an unintended change in the `gh-pages` branch protection settings. We didn’t catch this, because the API documentation CI workflow is configured to invariably pass, even if any command fails.  This change was made in commit 844ba5c as part of a fix for adding untracked generated documentation, but that fix was overzealous.

This PR makes any failure to push to `gh-pages` a CI error.