### PR TITLE
Feat[bmqtool]: Let bmqtool select session timeouts

### DIFF
--- a/src/applications/bmqtool/bmqtool.m.cpp
+++ b/src/applications/bmqtool/bmqtool.m.cpp
@@ -340,6 +340,11 @@ static bool parseArgs(Parameters* parameters, int argc, const char* argv[])
          "autoPubSubModulo",
          "autoPubSubModulo",
          balcl::TypeInfo(&params.autoPubSubModulo()),
+         balcl::OccurrenceInfo::e_OPTIONAL},
+        {"timeout",
+         "timeout",
+         "The timeout to use for session operations with the broker",
+         balcl::TypeInfo(&params.timeoutSec()),
          balcl::OccurrenceInfo::e_OPTIONAL}};
 
     balcl::CommandLine commandLine(specTable);

--- a/src/applications/bmqtool/bmqtoolcmd.xsd
+++ b/src/applications/bmqtool/bmqtoolcmd.xsd
@@ -247,6 +247,7 @@
       <element name='messageProperties'        type='tns:MessageProperty' maxOccurs='unbounded'/>
       <element name='subscriptions'            type='tns:Subscription'    maxOccurs='unbounded'/>
       <element name='autoPubSubModulo'         type='int'     default="0"/>
+      <element name='timeoutSec'               type='int'     default="300"/>
     </sequence>
   </complexType>
   <complexType name='MessageProperty'>

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -556,6 +556,11 @@ int Application::initialize()
     int                  rc = 0;
     bmqt::SessionOptions options;
     options.setBrokerUri(d_parameters.broker())
+        .setConnectTimeout(d_parameters.timeout())
+        .setDisconnectTimeout(d_parameters.timeout())
+        .setOpenQueueTimeout(d_parameters.timeout())
+        .setConfigureQueueTimeout(d_parameters.timeout())
+        .setCloseQueueTimeout(d_parameters.timeout())
         .setNumProcessingThreads(d_parameters.numProcessingThreads())
         .configureEventQueue(1000, 10 * 1000);
 

--- a/src/applications/bmqtool/m_bmqtool_messages.cpp
+++ b/src/applications/bmqtool/m_bmqtool_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2014-2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // m_bmqtool_messages.cpp          *DO NOT EDIT*           @generated -*-C++-*-
 
 #include <m_bmqtool_messages.h>
@@ -23,17 +24,17 @@
 #include <bdlb_string.h>
 
 #include <bdlb_nullablevalue.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslim_printer.h>
+#include <bsls_assert.h>
+#include <bsls_types.h>
+
 #include <bsl_cstring.h>
 #include <bsl_iomanip.h>
 #include <bsl_limits.h>
 #include <bsl_ostream.h>
-#include <bsl_string.h>
 #include <bsl_utility.h>
-#include <bsl_vector.h>
-#include <bsla_annotations.h>
-#include <bslim_printer.h>
-#include <bsls_assert.h>
-#include <bsls_types.h>
 
 namespace BloombergLP {
 namespace m_bmqtool {
@@ -74,32 +75,32 @@ const bdlat_AttributeInfo BatchPostCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "msgSize",
      sizeof("msgSize") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_EVENT_SIZE,
      "eventSize",
      sizeof("eventSize") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_EVENTS_COUNT,
      "eventsCount",
      sizeof("eventsCount") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_POST_INTERVAL,
      "postInterval",
      sizeof("postInterval") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_POST_RATE,
      "postRate",
      sizeof("postRate") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_AUTO_INCREMENTED,
      "autoIncremented",
      sizeof("autoIncremented") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT}};
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
@@ -289,7 +290,7 @@ const bdlat_AttributeInfo CloseQueueCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT}};
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
@@ -410,9 +411,10 @@ const char CloseStorageCommand::CLASS_NAME[] = "CloseStorageCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-CloseStorageCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
-                                         BSLA_UNUSED int         nameLength)
+CloseStorageCommand::lookupAttributeInfo(const char* name, int nameLength)
 {
+    (void)name;
+    (void)nameLength;
     return 0;
 }
 
@@ -1478,9 +1480,10 @@ const char ListQueuesCommand::CLASS_NAME[] = "ListQueuesCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-ListQueuesCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
-                                       BSLA_UNUSED int         nameLength)
+ListQueuesCommand::lookupAttributeInfo(const char* name, int nameLength)
 {
+    (void)name;
+    (void)nameLength;
     return 0;
 }
 
@@ -1704,9 +1707,10 @@ const char MetadataCommand::CLASS_NAME[] = "MetadataCommand";
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
-MetadataCommand::lookupAttributeInfo(BSLA_UNUSED const char* name,
-                                     BSLA_UNUSED int         nameLength)
+MetadataCommand::lookupAttributeInfo(const char* name, int nameLength)
 {
+    (void)name;
+    (void)nameLength;
     return 0;
 }
 
@@ -2448,7 +2452,7 @@ const bdlat_AttributeInfo StartCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT}};
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
@@ -2518,7 +2522,7 @@ const bdlat_AttributeInfo StopCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT}};
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
@@ -2775,22 +2779,22 @@ const bdlat_AttributeInfo ConfigureQueueCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_UNCONFIRMED_MESSAGES,
      "maxUnconfirmedMessages",
      sizeof("maxUnconfirmedMessages") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_UNCONFIRMED_BYTES,
      "maxUnconfirmedBytes",
      sizeof("maxUnconfirmedBytes") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_CONSUMER_PRIORITY,
      "consumerPriority",
      sizeof("consumerPriority") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_SUBSCRIPTIONS,
      "subscriptions",
      sizeof("subscriptions") - 1,
@@ -3856,7 +3860,7 @@ const bdlat_AttributeInfo MessageProperty::ATTRIBUTE_INFO_ARRAY[] = {
      "type",
      sizeof("type") - 1,
      "",
-     bdlat_FormattingMode::e_DEFAULT}};
+     bdlat_FormattingMode::e_DEFAULT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
@@ -4008,22 +4012,22 @@ const bdlat_AttributeInfo OpenQueueCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_UNCONFIRMED_MESSAGES,
      "maxUnconfirmedMessages",
      sizeof("maxUnconfirmedMessages") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_UNCONFIRMED_BYTES,
      "maxUnconfirmedBytes",
      sizeof("maxUnconfirmedBytes") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_CONSUMER_PRIORITY,
      "consumerPriority",
      sizeof("consumerPriority") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_SUBSCRIPTIONS,
      "subscriptions",
      sizeof("subscriptions") - 1,
@@ -4353,122 +4357,124 @@ const char
 
 const int CommandLineParameters::DEFAULT_INITIALIZER_AUTO_PUB_SUB_MODULO = 0;
 
+const int CommandLineParameters::DEFAULT_INITIALIZER_TIMEOUT_SEC = 300;
+
 const bdlat_AttributeInfo CommandLineParameters::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_MODE,
      "mode",
      sizeof("mode") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_BROKER,
      "broker",
      sizeof("broker") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_QUEUE_URI,
      "queueUri",
      sizeof("queueUri") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_QUEUE_FLAGS,
      "queueFlags",
      sizeof("queueFlags") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_LATENCY,
      "latency",
      sizeof("latency") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_LATENCY_REPORT,
      "latencyReport",
      sizeof("latencyReport") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_DUMP_MSG,
      "dumpMsg",
      sizeof("dumpMsg") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_CONFIRM_MSG,
      "confirmMsg",
      sizeof("confirmMsg") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_EVENT_SIZE,
      "eventSize",
      sizeof("eventSize") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MSG_SIZE,
      "msgSize",
      sizeof("msgSize") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_POST_RATE,
      "postRate",
      sizeof("postRate") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_EVENTS_COUNT,
      "eventsCount",
      sizeof("eventsCount") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_UNCONFIRMED,
      "maxUnconfirmed",
      sizeof("maxUnconfirmed") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_POST_INTERVAL,
      "postInterval",
      sizeof("postInterval") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_VERBOSITY,
      "verbosity",
      sizeof("verbosity") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_LOG_FORMAT,
      "logFormat",
      sizeof("logFormat") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MEMORY_DEBUG,
      "memoryDebug",
      sizeof("memoryDebug") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_THREADS,
      "threads",
      sizeof("threads") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_SHUTDOWN_GRACE,
      "shutdownGrace",
      sizeof("shutdownGrace") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_NO_SESSION_EVENT_HANDLER,
      "noSessionEventHandler",
      sizeof("noSessionEventHandler") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_STORAGE,
      "storage",
      sizeof("storage") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_LOG,
      "log",
      sizeof("log") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_SEQUENTIAL_MESSAGE_PATTERN,
      "sequentialMessagePattern",
      sizeof("sequentialMessagePattern") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MESSAGE_PROPERTIES,
      "messageProperties",
      sizeof("messageProperties") - 1,
@@ -4483,14 +4489,19 @@ const bdlat_AttributeInfo CommandLineParameters::ATTRIBUTE_INFO_ARRAY[] = {
      "autoPubSubModulo",
      sizeof("autoPubSubModulo") - 1,
      "",
-     bdlat_FormattingMode::e_DEC}};
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_TIMEOUT_SEC,
+     "timeoutSec",
+     sizeof("timeoutSec") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE}};
 
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
 CommandLineParameters::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 26; ++i) {
+    for (int i = 0; i < 27; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             CommandLineParameters::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -4557,6 +4568,8 @@ const bdlat_AttributeInfo* CommandLineParameters::lookupAttributeInfo(int id)
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SUBSCRIPTIONS];
     case ATTRIBUTE_ID_AUTO_PUB_SUB_MODULO:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO];
+    case ATTRIBUTE_ID_TIMEOUT_SEC:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TIMEOUT_SEC];
     default: return 0;
     }
 }
@@ -4587,6 +4600,7 @@ CommandLineParameters::CommandLineParameters(bslma::Allocator* basicAllocator)
 , d_threads(DEFAULT_INITIALIZER_THREADS)
 , d_shutdownGrace(DEFAULT_INITIALIZER_SHUTDOWN_GRACE)
 , d_autoPubSubModulo(DEFAULT_INITIALIZER_AUTO_PUB_SUB_MODULO)
+, d_timeoutSec(DEFAULT_INITIALIZER_TIMEOUT_SEC)
 , d_dumpMsg(DEFAULT_INITIALIZER_DUMP_MSG)
 , d_confirmMsg(DEFAULT_INITIALIZER_CONFIRM_MSG)
 , d_memoryDebug(DEFAULT_INITIALIZER_MEMORY_DEBUG)
@@ -4620,6 +4634,7 @@ CommandLineParameters::CommandLineParameters(
 , d_threads(original.d_threads)
 , d_shutdownGrace(original.d_shutdownGrace)
 , d_autoPubSubModulo(original.d_autoPubSubModulo)
+, d_timeoutSec(original.d_timeoutSec)
 , d_dumpMsg(original.d_dumpMsg)
 , d_confirmMsg(original.d_confirmMsg)
 , d_memoryDebug(original.d_memoryDebug)
@@ -4653,6 +4668,7 @@ CommandLineParameters::CommandLineParameters(
   d_threads(bsl::move(original.d_threads)),
   d_shutdownGrace(bsl::move(original.d_shutdownGrace)),
   d_autoPubSubModulo(bsl::move(original.d_autoPubSubModulo)),
+  d_timeoutSec(bsl::move(original.d_timeoutSec)),
   d_dumpMsg(bsl::move(original.d_dumpMsg)),
   d_confirmMsg(bsl::move(original.d_confirmMsg)),
   d_memoryDebug(bsl::move(original.d_memoryDebug)),
@@ -4685,6 +4701,7 @@ CommandLineParameters::CommandLineParameters(CommandLineParameters&& original,
 , d_threads(bsl::move(original.d_threads))
 , d_shutdownGrace(bsl::move(original.d_shutdownGrace))
 , d_autoPubSubModulo(bsl::move(original.d_autoPubSubModulo))
+, d_timeoutSec(bsl::move(original.d_timeoutSec))
 , d_dumpMsg(bsl::move(original.d_dumpMsg))
 , d_confirmMsg(bsl::move(original.d_confirmMsg))
 , d_memoryDebug(bsl::move(original.d_memoryDebug))
@@ -4729,6 +4746,7 @@ CommandLineParameters::operator=(const CommandLineParameters& rhs)
         d_messageProperties        = rhs.d_messageProperties;
         d_subscriptions            = rhs.d_subscriptions;
         d_autoPubSubModulo         = rhs.d_autoPubSubModulo;
+        d_timeoutSec               = rhs.d_timeoutSec;
     }
 
     return *this;
@@ -4766,6 +4784,7 @@ CommandLineParameters::operator=(CommandLineParameters&& rhs)
         d_messageProperties        = bsl::move(rhs.d_messageProperties);
         d_subscriptions            = bsl::move(rhs.d_subscriptions);
         d_autoPubSubModulo         = bsl::move(rhs.d_autoPubSubModulo);
+        d_timeoutSec               = bsl::move(rhs.d_timeoutSec);
     }
 
     return *this;
@@ -4801,6 +4820,7 @@ void CommandLineParameters::reset()
     bdlat_ValueTypeFunctions::reset(&d_messageProperties);
     bdlat_ValueTypeFunctions::reset(&d_subscriptions);
     d_autoPubSubModulo = DEFAULT_INITIALIZER_AUTO_PUB_SUB_MODULO;
+    d_timeoutSec       = DEFAULT_INITIALIZER_TIMEOUT_SEC;
 }
 
 // ACCESSORS
@@ -4839,6 +4859,7 @@ bsl::ostream& CommandLineParameters::print(bsl::ostream& stream,
     printer.printAttribute("messageProperties", this->messageProperties());
     printer.printAttribute("subscriptions", this->subscriptions());
     printer.printAttribute("autoPubSubModulo", this->autoPubSubModulo());
+    printer.printAttribute("timeoutSec", this->timeoutSec());
     printer.end();
     return stream;
 }
@@ -5027,17 +5048,17 @@ const bdlat_AttributeInfo PostCommand::ATTRIBUTE_INFO_ARRAY[] = {
      "async",
      sizeof("async") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_GROUPID,
      "groupid",
      sizeof("groupid") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_COMPRESSION_ALGORITHM_TYPE,
      "compressionAlgorithmType",
      sizeof("compressionAlgorithmType") - 1,
      "",
-     bdlat_FormattingMode::e_TEXT},
+     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MESSAGE_PROPERTIES,
      "messageProperties",
      sizeof("messageProperties") - 1,
@@ -6829,6 +6850,6 @@ const char* Command::selectionName() const
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY @BLP_BAS_CODEGEN_VERSION@
+// GENERATED BY BLP_BAS_CODEGEN_2025.10.09.2
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package m_bmqtool --msgComponent messages bmqtoolcmd.xsd

--- a/src/applications/bmqtool/m_bmqtool_messages.h
+++ b/src/applications/bmqtool/m_bmqtool_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2024 Bloomberg Finance L.P.
+// Copyright 2014-2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,23 +19,36 @@
 
 //@PURPOSE: Provide value-semantic attribute classes
 
+#include <bslalg_typetraits.h>
+
 #include <bdlat_attributeinfo.h>
+
 #include <bdlat_enumeratorinfo.h>
+
 #include <bdlat_selectioninfo.h>
+
 #include <bdlat_typetraits.h>
+
+#include <bslh_hash.h>
+#include <bsls_objectbuffer.h>
+
+#include <bslma_default.h>
+
+#include <bsls_assert.h>
+
 #include <bdlb_nullablevalue.h>
+
+#include <bsl_string.h>
+
+#include <bsl_vector.h>
+
+#include <bsls_types.h>
+
 #include <bsl_iosfwd.h>
 #include <bsl_limits.h>
+
 #include <bsl_ostream.h>
 #include <bsl_string.h>
-#include <bsl_vector.h>
-#include <bsla_annotations.h>
-#include <bslalg_typetraits.h>
-#include <bslh_hash.h>
-#include <bslma_default.h>
-#include <bsls_assert.h>
-#include <bsls_objectbuffer.h>
-#include <bsls_types.h>
 
 namespace BloombergLP {
 
@@ -419,6 +432,9 @@ class BatchPostCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::BatchPostCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::BatchPostCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -639,6 +655,9 @@ class CloseQueueCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::CloseQueueCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::CloseQueueCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -786,6 +805,9 @@ class CloseStorageCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::CloseStorageCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::CloseStorageCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -1005,6 +1027,9 @@ class ConfirmCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::ConfirmCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::ConfirmCommand> : bsl::true_type {
+};
 
 namespace m_bmqtool {
 
@@ -1588,6 +1613,9 @@ class DumpQueueCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::DumpQueueCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::DumpQueueCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -1854,6 +1882,8 @@ class ListCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::ListCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::ListCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -2000,6 +2030,9 @@ class ListQueuesCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::ListQueuesCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::ListQueuesCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -2219,6 +2252,9 @@ class LoadPostCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::LoadPostCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::LoadPostCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -2428,6 +2464,9 @@ class MetadataCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::MetadataCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::MetadataCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -2638,6 +2677,9 @@ class OpenStorageCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::OpenStorageCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::OpenStorageCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -3170,6 +3212,8 @@ class StartCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::StartCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::StartCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -3336,6 +3380,8 @@ class StopCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::StopCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::StopCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -3596,6 +3642,8 @@ class Subscription {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::Subscription)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::Subscription> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -3875,6 +3923,9 @@ class ConfigureQueueCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::ConfigureQueueCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::ConfigureQueueCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -4040,6 +4091,8 @@ class DataCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::DataCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::DataCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -4713,6 +4766,9 @@ class MessageProperty {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::MessageProperty)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::MessageProperty>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -5003,6 +5059,9 @@ class OpenQueueCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::OpenQueueCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::OpenQueueCommand>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -5169,6 +5228,8 @@ class QlistCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(m_bmqtool::QlistCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::QlistCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -5200,6 +5261,7 @@ class CommandLineParameters {
     int                          d_threads;
     int                          d_shutdownGrace;
     int                          d_autoPubSubModulo;
+    int                          d_timeoutSec;
     bool                         d_dumpMsg;
     bool                         d_confirmMsg;
     bool                         d_memoryDebug;
@@ -5239,10 +5301,11 @@ class CommandLineParameters {
         ATTRIBUTE_ID_SEQUENTIAL_MESSAGE_PATTERN = 22,
         ATTRIBUTE_ID_MESSAGE_PROPERTIES         = 23,
         ATTRIBUTE_ID_SUBSCRIPTIONS              = 24,
-        ATTRIBUTE_ID_AUTO_PUB_SUB_MODULO        = 25
+        ATTRIBUTE_ID_AUTO_PUB_SUB_MODULO        = 25,
+        ATTRIBUTE_ID_TIMEOUT_SEC                = 26
     };
 
-    enum { NUM_ATTRIBUTES = 26 };
+    enum { NUM_ATTRIBUTES = 27 };
 
     enum {
         ATTRIBUTE_INDEX_MODE                       = 0,
@@ -5270,7 +5333,8 @@ class CommandLineParameters {
         ATTRIBUTE_INDEX_SEQUENTIAL_MESSAGE_PATTERN = 22,
         ATTRIBUTE_INDEX_MESSAGE_PROPERTIES         = 23,
         ATTRIBUTE_INDEX_SUBSCRIPTIONS              = 24,
-        ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO        = 25
+        ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO        = 25,
+        ATTRIBUTE_INDEX_TIMEOUT_SEC                = 26
     };
 
     // CONSTANTS
@@ -5323,6 +5387,8 @@ class CommandLineParameters {
     static const char DEFAULT_INITIALIZER_SEQUENTIAL_MESSAGE_PATTERN[];
 
     static const int DEFAULT_INITIALIZER_AUTO_PUB_SUB_MODULO;
+
+    static const int DEFAULT_INITIALIZER_TIMEOUT_SEC;
 
     static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
 
@@ -5520,6 +5586,10 @@ class CommandLineParameters {
     // Return a reference to the modifiable "AutoPubSubModulo" attribute of
     // this object.
 
+    int& timeoutSec();
+    // Return a reference to the modifiable "TimeoutSec" attribute of this
+    // object.
+
     // ACCESSORS
     bsl::ostream&
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
@@ -5657,6 +5727,9 @@ class CommandLineParameters {
     int autoPubSubModulo() const;
     // Return the value of the "AutoPubSubModulo" attribute of this object.
 
+    int timeoutSec() const;
+    // Return the value of the "TimeoutSec" attribute of this object.
+
     // HIDDEN FRIENDS
     friend bool operator==(const CommandLineParameters& lhs,
                            const CommandLineParameters& rhs)
@@ -5700,6 +5773,9 @@ class CommandLineParameters {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::CommandLineParameters)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::CommandLineParameters>
+: bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -5910,6 +5986,9 @@ class JournalCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::JournalCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::JournalCommand> : bsl::true_type {
+};
 
 namespace m_bmqtool {
 
@@ -6184,6 +6263,8 @@ class PostCommand {
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     m_bmqtool::PostCommand)
+template <>
+struct bdlat_UsesDefaultValueFlag<m_bmqtool::PostCommand> : bsl::true_type {};
 
 namespace m_bmqtool {
 
@@ -7344,17 +7425,17 @@ inline bool CloseQueueCommand::async() const
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int CloseStorageCommand::manipulateAttributes(
-    BSLA_UNUSED t_MANIPULATOR& manipulator)
+int CloseStorageCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
+    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int CloseStorageCommand::manipulateAttribute(
-    BSLA_UNUSED t_MANIPULATOR& manipulator,
-    int                        id)
+int CloseStorageCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                             int            id)
 {
+    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -7380,16 +7461,16 @@ int CloseStorageCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int CloseStorageCommand::accessAttributes(
-    BSLA_UNUSED t_ACCESSOR& accessor) const
+int CloseStorageCommand::accessAttributes(t_ACCESSOR& accessor) const
 {
+    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int CloseStorageCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
-                                         int                     id) const
+int CloseStorageCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
 {
+    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8074,17 +8155,16 @@ inline const bdlb::NullableValue<bsl::string>& ListCommand::uri() const
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int ListQueuesCommand::manipulateAttributes(
-    BSLA_UNUSED t_MANIPULATOR& manipulator)
+int ListQueuesCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
+    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int ListQueuesCommand::manipulateAttribute(
-    BSLA_UNUSED t_MANIPULATOR& manipulator,
-    int                        id)
+int ListQueuesCommand::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
 {
+    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8110,15 +8190,16 @@ int ListQueuesCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int ListQueuesCommand::accessAttributes(BSLA_UNUSED t_ACCESSOR& accessor) const
+int ListQueuesCommand::accessAttributes(t_ACCESSOR& accessor) const
 {
+    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int ListQueuesCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
-                                       int                     id) const
+int ListQueuesCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
 {
+    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8297,17 +8378,16 @@ MessagePropertyType::print(bsl::ostream&              stream,
 // CLASS METHODS
 // MANIPULATORS
 template <typename t_MANIPULATOR>
-int MetadataCommand::manipulateAttributes(
-    BSLA_UNUSED t_MANIPULATOR& manipulator)
+int MetadataCommand::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
+    (void)manipulator;
     return 0;
 }
 
 template <typename t_MANIPULATOR>
-int MetadataCommand::manipulateAttribute(
-    BSLA_UNUSED t_MANIPULATOR& manipulator,
-    int                        id)
+int MetadataCommand::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
 {
+    (void)manipulator;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -8333,15 +8413,16 @@ int MetadataCommand::manipulateAttribute(t_MANIPULATOR& manipulator,
 
 // ACCESSORS
 template <typename t_ACCESSOR>
-int MetadataCommand::accessAttributes(BSLA_UNUSED t_ACCESSOR& accessor) const
+int MetadataCommand::accessAttributes(t_ACCESSOR& accessor) const
 {
+    (void)accessor;
     return 0;
 }
 
 template <typename t_ACCESSOR>
-int MetadataCommand::accessAttribute(BSLA_UNUSED t_ACCESSOR& accessor,
-                                     int                     id) const
+int MetadataCommand::accessAttribute(t_ACCESSOR& accessor, int id) const
 {
+    (void)accessor;
     enum { NOT_FOUND = -1 };
 
     switch (id) {
@@ -10549,6 +10630,7 @@ void CommandLineParameters::hashAppendImpl(
     hashAppend(hashAlgorithm, this->messageProperties());
     hashAppend(hashAlgorithm, this->subscriptions());
     hashAppend(hashAlgorithm, this->autoPubSubModulo());
+    hashAppend(hashAlgorithm, this->timeoutSec());
 }
 
 inline bool
@@ -10578,7 +10660,8 @@ CommandLineParameters::isEqualTo(const CommandLineParameters& rhs) const
                rhs.sequentialMessagePattern() &&
            this->messageProperties() == rhs.messageProperties() &&
            this->subscriptions() == rhs.subscriptions() &&
-           this->autoPubSubModulo() == rhs.autoPubSubModulo();
+           this->autoPubSubModulo() == rhs.autoPubSubModulo() &&
+           this->timeoutSec() == rhs.timeoutSec();
 }
 
 // CLASS METHODS
@@ -10745,6 +10828,12 @@ int CommandLineParameters::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
+    ret = manipulator(&d_timeoutSec,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TIMEOUT_SEC]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -10866,6 +10955,10 @@ int CommandLineParameters::manipulateAttribute(t_MANIPULATOR& manipulator,
         return manipulator(
             &d_autoPubSubModulo,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO]);
+    }
+    case ATTRIBUTE_ID_TIMEOUT_SEC: {
+        return manipulator(&d_timeoutSec,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TIMEOUT_SEC]);
     }
     default: return NOT_FOUND;
     }
@@ -11015,6 +11108,11 @@ inline bsl::vector<Subscription>& CommandLineParameters::subscriptions()
 inline int& CommandLineParameters::autoPubSubModulo()
 {
     return d_autoPubSubModulo;
+}
+
+inline int& CommandLineParameters::timeoutSec()
+{
+    return d_timeoutSec;
 }
 
 // ACCESSORS
@@ -11173,6 +11271,12 @@ int CommandLineParameters::accessAttributes(t_ACCESSOR& accessor) const
         return ret;
     }
 
+    ret = accessor(d_timeoutSec,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TIMEOUT_SEC]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -11287,6 +11391,10 @@ int CommandLineParameters::accessAttribute(t_ACCESSOR& accessor, int id) const
         return accessor(
             d_autoPubSubModulo,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_AUTO_PUB_SUB_MODULO]);
+    }
+    case ATTRIBUTE_ID_TIMEOUT_SEC: {
+        return accessor(d_timeoutSec,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_TIMEOUT_SEC]);
     }
     default: return NOT_FOUND;
     }
@@ -11439,6 +11547,11 @@ CommandLineParameters::subscriptions() const
 inline int CommandLineParameters::autoPubSubModulo() const
 {
     return d_autoPubSubModulo;
+}
+
+inline int CommandLineParameters::timeoutSec() const
+{
+    return d_timeoutSec;
 }
 
 // --------------------
@@ -12400,6 +12513,6 @@ inline bool Command::isUndefinedValue() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY @BLP_BAS_CODEGEN_VERSION@
+// GENERATED BY BLP_BAS_CODEGEN_2025.10.09.2
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package m_bmqtool --msgComponent messages bmqtoolcmd.xsd

--- a/src/applications/bmqtool/m_bmqtool_parameters.cpp
+++ b/src/applications/bmqtool/m_bmqtool_parameters.cpp
@@ -29,6 +29,7 @@
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
+#include <bsls_timeinterval.h>
 #include <bsls_types.h>
 
 namespace BloombergLP {
@@ -307,6 +308,7 @@ Parameters::print(bsl::ostream& stream, int level, int spacesPerLevel) const
                            d_sequentialMessagePattern);
     printer.printAttribute("messageProperties", d_messageProperties);
     printer.printAttribute("subscriptions", d_subscriptions);
+    printer.printAttribute("timeout", d_timeout);
     printer.end();
 
     return stream;
@@ -382,6 +384,12 @@ bool Parameters::from(bsl::ostream&                stream,
         return false;  // RETURN
     }
 
+    if (params.timeoutSec() < 0) {
+        stream << "Negative timeout vaules are not supported" << "\n";
+        return false;  // RETURN
+    }
+    bsls::TimeInterval timeout(params.timeoutSec(), 0);
+
     // Populate output parameters struct
     setVerbosity(paramVerbosity);
     setLogFormat(params.logFormat());
@@ -410,6 +418,7 @@ bool Parameters::from(bsl::ostream&                stream,
     setMessageProperties(params.messageProperties());
     setSubscriptions(params.subscriptions());
     setAutoPubSubModulo(params.autoPubSubModulo());
+    setTimeout(timeout);
 
     return true;
 }

--- a/src/applications/bmqtool/m_bmqtool_parameters.h
+++ b/src/applications/bmqtool/m_bmqtool_parameters.h
@@ -35,6 +35,7 @@
 #include <bsl_iosfwd.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
+#include <bsls_timeinterval.h>
 #include <bsls_types.h>
 
 // MQB
@@ -275,6 +276,10 @@ class Parameters {
 
     int d_autoPubSubModulo;
 
+    bsls::TimeInterval d_timeout;
+    // Timeout for session operations.  This timeout is used for all timeouts
+    // in the `bmqt::SessionOptions` used by the session.
+
   public:
     // CREATORS
 
@@ -311,6 +316,7 @@ class Parameters {
     Parameters& setSubscriptions(const bsl::vector<Subscription>& value);
     Parameters& setAutoIncrementedField(const bsl::string& value);
     Parameters& setAutoPubSubModulo(int autoPubSubModulo);
+    Parameters& setTimeout(const bsls::TimeInterval& value);
 
     // Set the corresponding member to the specified 'value' and return a
     // reference offering modifiable access to this object.
@@ -370,6 +376,7 @@ class Parameters {
     const bsl::vector<Subscription>&    subscriptions() const;
     const bsl::string&                  autoIncrementedField() const;
     int                                 autoPubSubModulo() const;
+    const bsls::TimeInterval&           timeout() const;
 
     const char* autoPubSubPropertyName() const;
 };
@@ -588,6 +595,13 @@ inline Parameters& Parameters::setAutoPubSubModulo(int autoPubSubModulo)
     return *this;
 }
 
+inline Parameters& Parameters::setTimeout(const bsls::TimeInterval& value)
+{
+    d_timeout = value;
+
+    return *this;
+}
+
 // ACCESSORS
 inline ParametersMode::Value Parameters::mode() const
 {
@@ -738,6 +752,11 @@ inline const bsl::string& Parameters::autoIncrementedField() const
 inline int Parameters::autoPubSubModulo() const
 {
     return d_autoPubSubModulo;
+}
+
+inline const bsls::TimeInterval& Parameters::timeout() const
+{
+    return d_timeout;
 }
 
 }  // close package namespace


### PR DESCRIPTION
In order to write integration tests for timeouts in a reasonable way, we need the ability to set the timeouts in `bmqt::SessionOptions` on sessions created with bmqtool.  This patch adds an optional CLI argument to bmqtool `--timeout`, which takes as its single argument the number of seconds to set all timeouts in `bmqt::SessionOptions` to.  This defaults to the same default as `bmqt::SessionOptions`, namely 300 seconds.