### PR TITLE
Fix[MQB]: wait for deconfigure response before close

### DIFF
--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -127,10 +127,6 @@ struct AdminSessionState {
 /// A session with a BlazingMQ admin application
 class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
   private:
-    // PRIVATE TYPES
-    typedef bsl::function<void(void)> VoidFunctor;
-
-  private:
     // DATA
 
     /// This object is used to avoid executing a callback if the session has

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -254,8 +254,6 @@ class ClientSession : public mqbnet::Session,
 
     typedef ClientSessionState::StreamsMap StreamsMap;
 
-    typedef bsl::function<void(void)> VoidFunctor;
-
     /// Enum to signify the session's operation state.
     enum OperationState {
         /// Running normally.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -993,9 +993,7 @@ void ClusterOrchestrator::processNodeStoppingNotification(
             mqbc::ElectorInfoLeaderStatus::e_PASSIVE);
     }
 
-    // Self node needs to issue close-queue requests for all the queues for
-    // which specified 'source' node is the primary.
-
+    // Replica makes all open queues buffer PUTs (by calling 'onOpenUpstream').
     d_queueHelper.processNodeStoppingNotification(ns->clusterNode(),
                                                   request,
                                                   ns);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -4590,6 +4590,7 @@ void ClusterQueueHelper::onUpstreamNodeChange(mqbnet::ClusterNode* node,
         }
 
         if (node == 0) {
+            // Replica makes all open queues buffer PUTs.
             queue->dispatcher()->execute(
                 bdlf::BindUtil::bind(&mqbi::Queue::onLostUpstream, queue),
                 queue);

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -58,6 +58,18 @@
 namespace BloombergLP {
 namespace mqbblp {
 
+namespace {
+
+void onHandleDeconfigured(const bmqp_ctrlmsg::Status&,
+                          const bmqp_ctrlmsg::StreamParameters&,
+                          const bsl::function<void(void)>& cb)
+{
+    BSLS_ASSERT_SAFE(cb);
+    cb();
+}
+
+}
+
 // -----------
 // class Queue
 // -----------
@@ -248,14 +260,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
             bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
                                                     subStreamInfo,
                                                     info.d_counts.d_readCount);
-        if (doDeconfigure) {
-            bmqp_ctrlmsg::StreamParameters nullStreamParameters;
-            nullStreamParameters.appId() = appId;
-
-            configureHandle(handle,
-                            nullStreamParameters,
-                            mqbi::QueueHandle::HandleConfiguredCallback());
-        }
 
         // Set 'isFinal' when releasing the last subStream of this handle
         isFinal = ((++citer) == handle->subStreamInfos().end());
@@ -269,12 +273,36 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
                       << "]. 'isFinal' flag: " << bsl::boolalpha << isFinal
                       << ".";
 
-        // 'releaseHandle' erases from 'handle->subStreamInfos()' invalidating
-        // the iterator.
-        releaseHandleDispatched(handle,
-                                consumerHandleParams,
-                                isFinal,  // isFinal flag
-                                mqbi::QueueHandle::HandleReleasedCallback());
+        if (doDeconfigure) {
+            bmqp_ctrlmsg::StreamParameters nullStreamParameters;
+            nullStreamParameters.appId() = appId;
+
+            // Do not send CloseQueue request without waiting for deconfigure
+            // response.
+            const bsl::function<void(void)> cb = bdlf::BindUtil::bind(
+                &Queue::releaseHandleDispatched,
+                this,
+                handle,
+                consumerHandleParams,
+                isFinal,
+                mqbi::QueueHandle::HandleReleasedCallback());
+
+            configureHandle(handle,
+                            nullStreamParameters,
+                            bdlf::BindUtil::bind(&onHandleDeconfigured,
+                                                 bdlf::PlaceHolders::_1,
+                                                 bdlf::PlaceHolders::_2,
+                                                 cb));
+        }
+        else {
+            // 'releaseHandle' erases from 'handle->subStreamInfos()'
+            // invalidating the iterator.
+            releaseHandleDispatched(
+                handle,
+                consumerHandleParams,
+                isFinal,  // isFinal flag
+                mqbi::QueueHandle::HandleReleasedCallback());
+        }
     }
 }
 


### PR DESCRIPTION
`RemoteQueue` can be in the buffering mode and attempt to retransmit buffered PUTs on deconfigure response.  If it sends Close request together with Deconfigure request, a retransmitted PUT can arrive upstream after Close request causing `LocalQueue::postMessage` assertion failure 
`source->subStreamInfos().find(bmqp::ProtocolUtil::k_DEFAULT_APP_ID) != source->subStreamInfos().end()`

(The reason for the buffering mode can be failed Configure request)

The solution - wait for Deconfigure response before sending Close request