### PR TITLE
Perf[bmqt::Uri]: remove regex dependency for Uri parsing

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_uri.h
+++ b/src/groups/bmq/bmqt/bmqt_uri.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2023 Bloomberg Finance L.P.
+// Copyright 2014-2025 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -196,10 +196,6 @@ class Uri {
     /// Optional application id, part of the URI query if present.
     bslstl::StringRef d_query_id;
 
-    /// Flag indicating whether the URI parser was initialized (and whether
-    /// shutdown should be called on it at destruction)
-    bool d_wasParserInitialized;
-
   private:
     // PRIVATE MANIPULATORS
 
@@ -315,6 +311,20 @@ bsl::ostream& operator<<(bsl::ostream& stream, const Uri& rhs);
 
 /// Utility namespace of methods for parsing URI strings into `Uri` objects.
 struct UriParser {
+    // PUBLIC TYPES
+    struct UriParseResult {
+        enum Enum {
+            e_SUCCESS             = 0,
+            e_INVALID_SCHEME      = -1,
+            e_UNSUPPORTED_CHAR    = -2,
+            e_BAD_QUERY           = -3,
+            e_MISSING_DOMAIN      = -4,
+            e_MISSING_QUEUE       = -5,
+            e_EMPTY_TIER          = -6,
+            e_QUEUE_NAME_TOO_LONG = -7
+        };
+    };
+
     // CLASS METHODS
 
     /// Initialize the `UriParser`.  Note that this will compile the regular


### PR DESCRIPTION
# Benchmarks

Built with `RelWithDebInfo`, each benchmark run tries to parse/construct Uri 100k times per thread

## Darwin Mac M2

```
Running ./tests/bmqt_uri.t
Run on (12 X 24 MHz CPU s)
CPU Caches:
  L1 Data 64 KiB
  L1 Instruction 128 KiB
  L2 Unified 4096 KiB (x12)
Load Average: 6.09, 4.57, 4.05
-------------------------------------------------------------------------------------------
Benchmark                              Time (upstream/main)     Time (this PR)      Speedup
-------------------------------------------------------------------------------------------
bmqt::UriParser::parse threads=1/iterations:1       20.2 ms            3.53 ms        5.72x
bmqt::UriParser::parse threads=2/iterations:1       82.4 ms            3.53 ms       23.34x
bmqt::UriParser::parse threads=4/iterations:1        257 ms            3.54 ms       72.60x
bmqt::UriParser::parse threads=8/iterations:1        358 ms            4.15 ms       86.27x
bmqt::Uri::Uri         threads=1/iterations:1       21.8 ms            4.55 ms        4.79x
bmqt::Uri::Uri         threads=2/iterations:1       85.6 ms            4.67 ms       18.33x
bmqt::Uri::Uri         threads=4/iterations:1       1792 ms            4.83 ms      371.01x
bmqt::Uri::Uri         threads=8/iterations:1       3623 ms            8.71 ms      415.96x
```

## Linux

```
Running ./tests/bmqt_uri.t
Run on (72 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x36)
  L1 Instruction 32 KiB (x36)
  L2 Unified 1024 KiB (x36)
  L3 Unified 25344 KiB (x2)
Load Average: 5.91, 7.73, 13.07
-------------------------------------------------------------------------------------------
Benchmark                              Time (upstream/main)     Time (this PR)      Speedup
-------------------------------------------------------------------------------------------
bmqt::UriParser::parse threads=1/iterations:1       46.8 ms            8.30 ms        5.63x
bmqt::UriParser::parse threads=2/iterations:1        206 ms            8.35 ms       24.67x
bmqt::UriParser::parse threads=4/iterations:1        691 ms            8.40 ms       82.26x
bmqt::UriParser::parse threads=8/iterations:1       2276 ms           17.60 ms      129.32x
bmqt::Uri::Uri         threads=1/iterations:1       54.7 ms           12.60 ms        4.34x
bmqt::Uri::Uri         threads=2/iterations:1        241 ms           13.00 ms       18.54x
bmqt::Uri::Uri         threads=4/iterations:1       2630 ms           12.80 ms      205.47x
bmqt::Uri::Uri         threads=8/iterations:1       5510 ms           21.10 ms      261.14x
```

# Results

- No more thread contention in `bmqt::UriParser::parse` and `bmqt::Uri::Uri` / `bmqt::Uri::~Uri`
- `bmqt::Uri` parsing and construction are at least 4x times faster in the simplest single thread benchmark, speedup becomes more significant when the number of threads increases.
- No intermediate memory allocations when parsing `Uri` due to removed `bdlpcre` match contexts allocations ( https://github.com/bloomberg/bde/blob/866081dff881cc0f668dfc885c2d22d21bec56df/groups/bdl/bdlpcre/bdlpcre_regex.cpp#L20-L21 details)
- Simplified configuration requirements for BlazingMQ clients: no need to call `bmqt::UriParser::initialize` / `bmqt::UriParser::shutdown`.