### PR TITLE
Config[bmqbrkrcfg.json]: use counting allocator by default

### DIFF
--- a/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
+++ b/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
@@ -1,6 +1,6 @@
 {
     "taskConfig": {
-        "allocatorType": "STACKTRACETEST",
+        "allocatorType": "COUNTING",
         "allocationLimit": 34359738368,
         "logController": {
             "fileName": "localBMQ/logs/logs.%T.%p",


### PR DESCRIPTION
Stack trace test allocator is rarely useful for debug, in other cases it is slow. Typically we switch it to COUNTING allocator anyway.
