### PR TITLE
UT[bmqt::UriParser]: add multi-threading benchmark

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -726,7 +726,7 @@ static void testN1_benchmark(benchmark::State& state)
 //  Performance
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("URI CONSTRUCTION PERFORMANCE TEST");
+    bmqtst::TestHelper::printTestName("URI PERFORMANCE TEST");
 
     bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 


### PR DESCRIPTION
```
----------------------------------------------------------------------------------------
Benchmark                                              Time             CPU   Iterations
----------------------------------------------------------------------------------------
bmqt::UriParser::parse threads=1/iterations:1       19.8 ms        0.009 ms            1
bmqt::UriParser::parse threads=2/iterations:1       79.6 ms        0.014 ms            1
bmqt::UriParser::parse threads=4/iterations:1        268 ms        0.016 ms            1
bmqt::UriParser::parse threads=8/iterations:1        357 ms        0.016 ms            1
bmqt::Uri::Uri         threads=1/iterations:1       22.4 ms        0.008 ms            1
bmqt::Uri::Uri         threads=2/iterations:1       91.7 ms        0.009 ms            1
bmqt::Uri::Uri         threads=4/iterations:1       1781 ms        0.016 ms            1
bmqt::Uri::Uri         threads=8/iterations:1       3754 ms        0.014 ms            1
```