### PR TITLE
Perf[BMQP]: minimizing copies in MessageProperties

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_messageproperties.h
+++ b/src/groups/bmq/bmqa/bmqa_messageproperties.h
@@ -101,7 +101,7 @@ class MessageProperties {
     /// Constant representing the maximum size of a
     /// `bmqp::MessageProperties` object, so that the below AlignedBuffer
     /// is big enough.
-    static const int k_MAX_SIZEOF_BMQP_MESSAGEPROPERTIES = 280;
+    static const int k_MAX_SIZEOF_BMQP_MESSAGEPROPERTIES = 184;
 
     // PRIVATE TYPES
     typedef bsls::AlignedBuffer<k_MAX_SIZEOF_BMQP_MESSAGEPROPERTIES>

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -318,13 +318,12 @@ bool MessageProperties::streamInPropertyValue(const Property& p) const
     case bmqt::PropertyType::e_STRING: {
         // Try to avoid copying the string.  'd_blop' already keeps a copy.
         bmqu::BlobPosition end;
-        int                ret =
+        const int          ret =
             bmqu::BlobUtil::findOffset(&end, *d_blob_p, position, p.d_length);
         bool doCopy = true;
         if (ret == 0) {
             // Do not align
-            if (position.buffer() == end.buffer() ||
-                (position.buffer() + 1 == end.buffer() && end.byte() == 0)) {
+            if (bmqu::BlobUtil::isDataContinuous(position, end)) {
                 // Section is good
                 char* start = d_blob_p->buffer(position.buffer()).data() +
                               position.byte();
@@ -372,14 +371,14 @@ MessageProperties::MessageProperties(bslma::Allocator* basicAllocator)
 , d_originalSize(0)
 , d_blob()
 , d_blob_p(d_blob.address())
-, d_isBlobConstructed(false)
-, d_isDirty(true)  // by default, this should be true
 , d_mphSize(0)
 , d_mphOffset(0)
 , d_numProps(0)
 , d_dataOffset(0)
 , d_schema()
 , d_originalNumProps(0)
+, d_isBlobConstructed(false)
+, d_isDirty(true)  // by default, this should be true
 , d_doDeepCopy(true)
 {
 }
@@ -392,14 +391,14 @@ MessageProperties::MessageProperties(const MessageProperties& other,
 , d_originalSize(other.d_originalSize)
 , d_blob()
 , d_blob_p(d_blob.address())
-, d_isBlobConstructed(false)
-, d_isDirty(other.d_isDirty)
 , d_mphSize(other.d_mphSize)
 , d_mphOffset(other.d_mphOffset)
 , d_numProps(other.d_numProps)
 , d_dataOffset(other.d_dataOffset)
 , d_schema(other.d_schema)
 , d_originalNumProps(other.d_originalNumProps)
+, d_isBlobConstructed(false)
+, d_isDirty(other.d_isDirty)
 , d_doDeepCopy(other.d_doDeepCopy)
 {
     if (other.d_isBlobConstructed) {

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -219,16 +219,6 @@ class MessageProperties {
     mutable BlobObjectBuffer d_blob;  // Wire representation.
     mutable const bdlbb::Blob* d_blob_p;  // Wire representation.
 
-    mutable bool d_isBlobConstructed;
-    // Flag indicating if an instance of
-    // the blob has been constructed in
-    // 'd_blob'.
-
-    mutable bool d_isDirty;
-    // Flag indicating if this instance has
-    // been updated since the previous
-    // invocation of 'streamOut()'.
-
     int d_mphSize;
     // Size of MessagePropertyHeader
     int d_mphOffset;
@@ -245,6 +235,16 @@ class MessageProperties {
     // _before_ any property can change.
     // Incremental reading needs it to
     // recognize last property.
+
+    mutable bool d_isBlobConstructed;
+    // Flag indicating if an instance of
+    // the blob has been constructed in
+    // 'd_blob'.
+
+    mutable bool d_isDirty;
+    // Flag indicating if this instance has
+    // been updated since the previous
+    // invocation of 'streamOut()'.
 
     bool d_doDeepCopy;
 

--- a/src/groups/bmq/bmqu/bmqu_blob.h
+++ b/src/groups/bmq/bmqu/bmqu_blob.h
@@ -215,6 +215,9 @@ struct BlobUtil {
     static bool isValidSection(const bdlbb::Blob& blob,
                                const BlobSection& section);
 
+    static bool isDataContinuous(const bmqu::BlobPosition& start,
+                                 const bmqu::BlobPosition& end);
+
     /// Find the distance from the specified `section`s `start()` to the
     /// `section`s `end()` in the specified `blob` and return it in the
     /// specified `size`.  Return `0` on success or a negative value if the
@@ -637,6 +640,13 @@ TYPE* BlobUtil::getAlignedObject(TYPE*               storage,
                           sizeof(TYPE),
                           bsls::AlignmentFromType<TYPE>::VALUE,
                           copyFromBlob));
+}
+
+inline bool BlobUtil::isDataContinuous(const bmqu::BlobPosition& start,
+                                       const bmqu::BlobPosition& end)
+{
+    return (start.buffer() == end.buffer() ||
+            (start.buffer() + 1 == end.buffer() && end.byte() == 0));
 }
 
 }  // close package namespace


### PR DESCRIPTION
1) Introducing `bmqp::MessageProperties ::d_doDeepCopy` (`true` by default).  When `false` , there is no `blob` copy.  Meaning, `MessageProperties` valid only when the original `blob` is alive. This helps `Routers::MessagePropertiesReader` when iterating subscriptions.

2) avoiding extra `bsl::string` copy when reading strings from blob.  Use `bsl::string_view` instead.  Note that `setProperty` still needs to copy strings.  And `getProperty` needs to convert `bsl::string_view` into `bsl::string`.  Again, `Routers::MessagePropertiesReader` does benefit from the use of `bsl::string_view`.