### PR TITLE
Fix[mqbblp]: Fix build on Solaris

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -44,6 +44,7 @@
 #include <bsl_string.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
+#include <bslmf_movableref.h>
 #include <bsls_assert.h>
 #include <bsls_timeinterval.h>
 
@@ -1272,10 +1273,11 @@ void ClusterOrchestrator::processElectorEvent(const bmqp::Event&   event,
 
     (*clusterEvent).setType(mqbi::DispatcherEventType::e_CALLBACK);
 
+    bmqp::Event clonedEvent = event.clone(d_allocator_p);
     clusterEvent->callback()
         .createInplace<ClusterOrchestrator::OnElectorEventFunctor>(
             this,
-            event.clone(d_allocator_p),
+            bslmf::MovableRefUtil::move(clonedEvent),
             source);
 
     dispatcher()->dispatchEvent(clusterEvent, d_cluster_p);


### PR DESCRIPTION
This patch fixes a build error on Solaris/C++03: the new `ElectorEventFunctor` constructor takes a `bslmf::MovableRef<bmqp::Event>`, which in C++11 is an alias for `bmqp::Event&&`.  In C++03, though, temporary objects are not automatically converted into `MovableRef`s, resulting in an invocation of the `createInplace` function template to fail instantiation.  We solve this by explicitly calling `bslmf::MovableRefUtil::move` on this temporary, which is a no-op in C++11 but a necessary call in C++03.