### PR TITLE
Cleanup[bmqt::Uri]: add deprecation note for initialize/shutdown

### DIFF
--- a/src/applications/bmqtool/bmqtool.m.cpp
+++ b/src/applications/bmqtool/bmqtool.m.cpp
@@ -434,9 +434,6 @@ int main(int argc, const char* argv[])
     // Make TimeUtil thread-safe by calling initialize
     bsls::TimeUtil::initialize();
 
-    // Prepare the UriParser regexp
-    bmqt::UriParser::initialize();
-
     // Test allocator
     balst::StackTraceTestAllocator stta;
     stta.setFailureHandler(&stta.failNoop);

--- a/src/groups/bmq/bmqa/bmqa_closequeuestatus.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_closequeuestatus.t.cpp
@@ -269,8 +269,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 3: test3_print(); break;
@@ -281,8 +279,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqa/bmqa_configurequeuestatus.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_configurequeuestatus.t.cpp
@@ -271,8 +271,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 3: test3_print(); break;
@@ -283,8 +281,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -635,7 +635,6 @@ void MockSession::initialize(bslma::Allocator* allocator)
 
     bmqsys::Time::initialize(g_alloc_p);
     bmqp::ProtocolUtil::initialize(g_alloc_p);
-    bmqt::UriParser::initialize(g_alloc_p);
 
     g_bufferFactory_p = new (*g_alloc_p)
         bdlbb::PooledBlobBufferFactory(1024, g_alloc_p);
@@ -653,7 +652,6 @@ void MockSession::shutdown()
         return;  // RETURN
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
     bmqsys::Time::shutdown();
     g_alloc_p->deleteObject(g_bufferFactory_p);

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -1433,8 +1433,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 8: test8_postBlockedToSuspendedQueue(); break;
@@ -1450,8 +1448,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
 }

--- a/src/groups/bmq/bmqa/bmqa_openqueuestatus.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_openqueuestatus.t.cpp
@@ -270,8 +270,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 3: test3_print(); break;
@@ -282,8 +280,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -659,9 +659,7 @@ Application::Application(
         bmqsys::Time::initialize();
     }
 
-    // UriParser and ProtocolUtil initialization/shutdown are thread-safe and
-    // refcounted
-    bmqt::UriParser::initialize();
+    // ProtocolUtil initialization/shutdown is thread-safe and refcounted
     bmqp::ProtocolUtil::initialize();
 
     // Start the EventScheduler.  We do this here in constructor and not in
@@ -718,7 +716,6 @@ Application::~Application()
 
     // ProtocolUtil::shutdown is thread-safe and ref-counted
     bmqp::ProtocolUtil::shutdown();
-    bmqt::UriParser::shutdown();
 }
 
 int Application::start(const bsls::TimeInterval& timeout)

--- a/src/groups/bmq/bmqimp/bmqimp_application.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.t.cpp
@@ -196,8 +196,6 @@ int main(int argc, char* argv[])
     }
 
     TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
-    // Global:  The global allocator is used to initialize the
-    //          bmqt::URIParser RegEx.
     // Default: EventQueue uses bmqc::MonitoredFixedQueue, which uses
     //          'bdlcc::SharedObjectPool' which uses bslmt::Semaphore which
     //          generates a unique name using an ostringstream, hence the

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -10211,7 +10211,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqsys::Time::initialize();
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
@@ -10293,12 +10292,9 @@ int main(int argc, char* argv[])
     }
 
     bmqsys::Time::shutdown();
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
 
-    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
-    // Global:  The global allocator is used to initialize the
-    //          bmqt::URIParser RegEx.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
     // Default: EventQueue uses bmqc::MonitoredFixedQueue, which uses
     //          'bdlcc::SharedObjectPool' which uses bslmt::Semaphore which
     //          generates a unique name using an ostringstream, hence the

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -1620,7 +1620,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -1642,7 +1641,6 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.t.cpp
@@ -755,7 +755,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqsys::Time::initialize();
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -772,7 +771,6 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqsys::Time::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -1921,7 +1921,6 @@ int main(int argc, char** argv)
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -1940,11 +1939,7 @@ int main(int argc, char** argv)
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
 
-    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
-    // For an unidentified reason, 'e_CHECK_DEF_GBL_ALLOC' fails as a
-    // result of initializing 'bmqsys::Time' in the constructor of
-    // 'Tester'.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
@@ -522,8 +522,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 6: test6_statTest(); break;
@@ -537,8 +535,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.t.cpp
@@ -789,7 +789,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -807,7 +806,6 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);

--- a/src/groups/bmq/bmqp/bmqp_queueutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_queueutil.t.cpp
@@ -394,8 +394,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 5: test5_isValidFanoutConsumerSubId(); break;
@@ -408,8 +406,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqt/bmqt_uri.h
+++ b/src/groups/bmq/bmqt/bmqt_uri.h
@@ -73,20 +73,9 @@
 /// Usage Example 1                                             {#bmqt_uri_ex1}
 /// ===============
 ///
-/// First, call the `initialize` method of the @bbref{bmqt::UriParser}.  This
-/// call is only needed one time; you can call it when your task starts.
-///
-/// Note that the `bmq` library takes care of that, so users of `bmq` don't
-/// have to explicitly do it themselves.
-///
-/// ```
-/// bmqt::UriParser::initialize();
-/// ```
-///
-/// Then, parse a URI string created on the stack to populate a
-/// @bbref{bmqt::Uri} object.  The parse function takes an optional error
-/// string which is populated with a short error message if the URI is not
-/// formatted correctly.
+/// Parse a URI string created on the stack to populate a @bbref{bmqt::Uri}
+/// object.  The parse function takes an optional error string which is
+/// populated with a short error message if the URI is not formatted correctly.
 ///
 /// ```
 /// bsl::string input = "bmq://my.domain/queue";
@@ -122,17 +111,13 @@
 ///
 ///   - @bbref{bmqt::UriBuilder} is NOT thread safe.
 ///
-///   - @bbref{bmqt::UriParser} should be thread safe: the component depends on
-///     `bdepcre_regex` that is a wrapper around "pcre.h".  See
-///     http://www.pcre.org/pcre.txt.
-
-// BMQ
+///   - @bbref{bmqt::UriParser} is thread safe.
 
 // BDE
 #include <ball_log.h>
 #include <bsl_cstddef.h>
-#include <bsl_iosfwd.h>
 #include <bsl_string.h>
+#include <bsla_maybeunused.h>
 #include <bslh_hash.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -327,35 +312,26 @@ struct UriParser {
 
     // CLASS METHODS
 
-    /// Initialize the `UriParser`.  Note that this will compile the regular
-    /// expression used by `parseUri`.  This method only needs to be called
-    /// once before any other method, but can be called multiple times
-    /// provided that for each call to `initialize` there is a corresponding
-    /// call to `shutdown`.  Use the optionally specified `allocator` for
-    /// any memory allocation, or the `global` allocator if none is
-    /// provided.  Note that specifying the allocator is provided for test
-    /// drivers only, and therefore users should let it default to the
-    /// global allocator.
-    static void initialize(bslma::Allocator* allocator = 0);
+    /// DEPRECATED: Not needed anymore (no-op).  This method will be marked
+    ///             as `BSLA_DEPRECATED` in future release of libbmq.
+    static void initialize(BSLA_MAYBE_UNUSED bslma::Allocator* allocator = 0)
+    {
+        // NOTHING
+    }
 
-    /// Pendant operation of the `initialize` one.  Note that behaviour
-    /// after calling the `.parse()` method of the `UriParser` after
-    /// `shutdown` has been called is undefined.  The number of calls to
-    /// `shutdown` must equal the number of calls to `initialize`, without
-    /// corresponding `shutdown` calls, to fully destroy the parser.  It is
-    /// safe to call `initialize` after calling `shutdown`.  Behaviour is
-    /// undefined if `shutdown` is called without `initialize` first being
-    /// called.
-    static void shutdown();
+    /// DEPRECATED: Not needed anymore (no-op).  This method will be marked
+    ///             as `BSLA_DEPRECATED` in future release of libbmq.
+    static void shutdown()
+    {
+        // NOTHING
+    }
 
     /// Parse the specified `uriString` into the specified `result` object
     /// if `uriString` is a valid URI, otherwise load the specified
     /// `errorDescription` with a description of the syntax error present in
     /// `uriString`.  Return 0 on success and non-zero if `uriString` does
     /// not have a valid syntax.  Note that `errorDescription` may be null
-    /// if the caller does not care about getting error messages.  The
-    /// behavior is undefined unless `initialize` has been called
-    /// previously.
+    /// if the caller does not care about getting error messages.
     static int parse(Uri*                     result,
                      bsl::string*             errorDescription,
                      const bslstl::StringRef& uriString);

--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -69,8 +69,6 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     int         rc = 0;
     bsl::string error(bmqtst::TestHelperUtil::allocator());
 
@@ -314,15 +312,11 @@ static void test1_breathingTest()
             BMQTST_ASSERT_EQ_D(test.d_line, obj.isValid(), false);
         }
     }
-
-    bmqt::UriParser::shutdown();
 }
 
 static void test2_URIBuilder()
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     bmqt::UriBuilder builder(bmqtst::TestHelperUtil::allocator());
 
@@ -445,8 +439,6 @@ static void test2_URIBuilder()
         BMQTST_ASSERT_EQ(uriBuilder.uri(&tmpUri, 0), 0);
         BMQTST_ASSERT_EQ(tmpUri.asString(), "bmq://my.domain/yourQueue");
     }
-
-    bmqt::UriParser::shutdown();
 }
 
 /// Test same `UriBuilder` object to match various patterns concurrently
@@ -454,8 +446,6 @@ static void test2_URIBuilder()
 static void test3_URIBuilderMultiThreaded()
 {
     bmqtst::TestHelper::printTestName("MULTI-THREADED URI BUILDER TEST");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     const size_t k_NUM_THREADS    = 6;
     const size_t k_NUM_ITERATIONS = 10000;
@@ -531,46 +521,12 @@ static void test3_URIBuilderMultiThreaded()
             BMQTST_ASSERT_EQ_D(i << ", " << j, uris[j], expectedUri);
         }
     }
-
-    bmqt::UriParser::shutdown();
-}
-
-static void test4_initializeShutdown()
-// ------------------------------------------------------------------------
-// Testing:
-//   'UriParser' initialize and shutdown.  Should be able to call
-//   '.initialize()' and '.shutdown()' after the instance has already
-//   started or shutdown, and have no effect.  Shutting down the
-//   'UriParser' without a call to 'initialize' should assert.
-//
-// Plan:
-//   Initialize the 'UriParser' again.  Initialize the 'UriParser' again.
-//   Shutdown the 'UriParser'.  Shutdown the 'UriParser' again.
-//   Shutdown the 'UriParser', destroying it.  Shutdown the 'UriParser'
-//   again.
-//   ----------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("INITIALIZE / SHUTDOWN");
-
-    // Initialize the 'UriParser'.
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
-    // Initialize should be a no-op.
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
-    // Shutdown the parser is a no-op.
-    bmqt::UriParser::shutdown();
-
-    // Shut down the parser is a no-op.
-    bmqt::UriParser::shutdown();
 }
 
 /// Test Uri print method.
-static void test5_testPrint()
+static void test4_testPrint()
 {
     bmqtst::TestHelper::printTestName("PRINT");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     PV("Testing print");
 
@@ -592,11 +548,9 @@ static void test5_testPrint()
     stream.clear(bsl::ios_base::badbit);
     stream << obj;
     BMQTST_ASSERT_EQ(stream.str(), "NO LAYOUT");
-
-    bmqt::UriParser::shutdown();
 }
 
-static void test6_hashAppend()
+static void test5_hashAppend()
 // ------------------------------------------------------------------------
 // TEST HASH APPEND
 //
@@ -616,8 +570,6 @@ static void test6_hashAppend()
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("HASH APPEND");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     PV("HASH FUNCTION DETERMINISTIC");
 
@@ -643,11 +595,9 @@ static void test6_hashAppend()
         PVVV("[" << i << "] hash: " << currHash);
         BMQTST_ASSERT_EQ_D(i, currHash, firstHash);
     }
-
-    bmqt::UriParser::shutdown();
 }
 
-static void test7_testLongUri()
+static void test6_testLongUri()
 {
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
     // Disable the default allocator check. When 'bmqt::Uri'
@@ -656,8 +606,6 @@ static void test7_testLongUri()
     // the default allocator.
 
     bmqtst::TestHelper::printTestName("LONG URI TEST");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     bmqtst::ScopedLogObserver observer(ball::Severity::e_WARN,
                                        bmqtst::TestHelperUtil::allocator());
@@ -674,8 +622,6 @@ static void test7_testLongUri()
     bmqt::Uri obj(stream.str(), bmqtst::TestHelperUtil::allocator());
 
     BMQTST_ASSERT_EQ(obj.isValid(), false);
-
-    bmqt::UriParser::shutdown();
 }
 
 #ifdef BMQTST_BENCHMARK_ENABLED
@@ -753,8 +699,6 @@ static void testN1_benchmark(benchmark::State& state)
 {
     bmqtst::TestHelper::printTestName("URI PERFORMANCE TEST");
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     bslmt::Latch   initThreadLatch(NUM_THREADS);
     bslmt::Barrier startBenchmarkBarrier(NUM_THREADS + 1);
     bslmt::Latch   finishBenchmarkLatch(NUM_THREADS);
@@ -790,7 +734,6 @@ static void testN1_benchmark(benchmark::State& state)
     }
 
     threadGroup.joinAll();
-    bmqt::UriParser::shutdown();
 }
 
 #endif  // BMQTST_BENCHMARK_ENABLED
@@ -805,10 +748,9 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 7: test7_testLongUri(); break;
-    case 6: test6_hashAppend(); break;
-    case 5: test5_testPrint(); break;
-    case 4: test4_initializeShutdown(); break;
+    case 6: test6_testLongUri(); break;
+    case 5: test5_hashAppend(); break;
+    case 4: test4_testPrint(); break;
     case 3: test3_URIBuilderMultiThreaded(); break;
     case 2: test2_URIBuilder(); break;
     case 1: test1_breathingTest(); break;

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -298,8 +298,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     {
         bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
         bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
@@ -321,8 +319,6 @@ int main(int argc, char* argv[])
         bmqsys::Time::shutdown();
         bmqp::ProtocolUtil::shutdown();
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
     // Do not check for default/global allocator usage.

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -120,7 +120,6 @@ void Application::oneTimeInit()
         // Make MessageGUID generation thread-safe by calling initialize
         mqbu::MessageGUIDUtil::initialize();
 
-        bmqt::UriParser::initialize();
         bmqp::ProtocolUtil::initialize();
     }
 }
@@ -130,7 +129,6 @@ void Application::oneTimeShutdown()
     BSLMT_ONCE_DO
     {
         bmqp::ProtocolUtil::shutdown();
-        bmqt::UriParser::shutdown();
         bmqsys::Time::shutdown();
     }
 }

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2485,8 +2485,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     {
         bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
         bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
@@ -2529,8 +2527,6 @@ int main(int argc, char* argv[])
         bmqsys::Time::shutdown();
         bmqp::ProtocolUtil::shutdown();
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
     // Do not check for default/global allocator usage.

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -205,8 +205,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 1: test1_basic(); break;
@@ -216,8 +214,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -790,8 +790,6 @@ int main(int argc, char* argv[])
 
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     ball::LoggerManager::singleton().setDefaultThresholdLevels(
         ball::Severity::e_OFF,
         ball::Severity::e_INFO,
@@ -808,8 +806,6 @@ int main(int argc, char* argv[])
 
         bmqtst::runTest(_testCase);
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
@@ -1915,7 +1915,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     {
-        bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
         bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
 
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
@@ -1956,7 +1955,6 @@ int main(int argc, char* argv[])
         }
 
         bmqp::ProtocolUtil::shutdown();
-        bmqt::UriParser::shutdown();
     }
 
     // Default allocator check is disabled for all UTs:

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.t.cpp
@@ -193,8 +193,6 @@ TestBench::TestBench(bslma::Allocator* allocator_p)
 
 TestBench::~TestBench()
 {
-    bmqt::UriParser::shutdown();
-
     d_cluster.stop();
 
     d_event.reset();
@@ -468,8 +466,6 @@ static void test1_fanoutBasic()
 {
     bmqtst::TestHelper::printTestName("basic tests using fanout");
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     bsl::shared_ptr<bmqst::StatContext> statContext =
         mqbstat::BrokerStatsUtil::initializeStatContext(
             30,
@@ -614,8 +610,6 @@ static void test2_broadcastBasic()
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("basic tests using broadcast");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<bmqst::StatContext> statContext =
         mqbstat::BrokerStatsUtil::initializeStatContext(
@@ -908,8 +902,6 @@ static void test3_close()
 {
     bmqtst::TestHelper::printTestName("close queue with pending messages");
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     bsl::shared_ptr<bmqst::StatContext> statContext =
         mqbstat::BrokerStatsUtil::initializeStatContext(
             30,
@@ -967,8 +959,6 @@ static void test4_buffering()
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("buffering");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<bmqst::StatContext> statContext =
         mqbstat::BrokerStatsUtil::initializeStatContext(
@@ -1069,8 +1059,6 @@ static void test5_reopen_failure()
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("buffering");
-
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     bsl::shared_ptr<bmqst::StatContext> statContext =
         mqbstat::BrokerStatsUtil::initializeStatContext(

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -5145,7 +5145,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
 
     mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
@@ -5224,7 +5223,6 @@ int main(int argc, char* argv[])
     }
 
     bmqp::ProtocolUtil::shutdown();
-    bmqt::UriParser::shutdown();
 
     // Default allocator check is disabled for all UTs:
     // `mqbblp::QueueEngine` and mocks from `mqbi` methods use ball logging

--- a/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
@@ -543,7 +543,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
     mqbcfg::BrokerConfig::set(brokerConfig);
@@ -560,7 +559,6 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.t.cpp
@@ -393,8 +393,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 1: test1_validateState(); break;
@@ -403,8 +401,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
     // Can't ensure no default memory is allocated because

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -2023,7 +2023,6 @@ int main(int argc, char* argv[])
 
     bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -2048,7 +2047,6 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    bmqt::UriParser::shutdown();
     bmqp::ProtocolUtil::shutdown();
     bmqsys::Time::shutdown();
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -3036,7 +3036,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqp::ProtocolUtil::initialize(bmqtst::TestHelperUtil::allocator());
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
 
     switch (_testCase) {
     case 0:
@@ -3078,7 +3077,6 @@ int main(int argc, char* argv[])
     }
 
     bmqp::ProtocolUtil::shutdown();
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
     // Can't ensure no default memory is allocated because

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -1914,7 +1914,6 @@ int main(int argc, char* argv[])
 
     TEST_PROLOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
     bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
 
     mqbu::MessageGUIDUtil::initialize();
@@ -1932,7 +1931,6 @@ int main(int argc, char* argv[])
     }
 
     bmqsys::Time::shutdown();
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -1468,7 +1468,6 @@ int main(int argc, char* argv[])
 
     TEST_PROLOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
     bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
 
     mqbu::MessageGUIDUtil::initialize();
@@ -1486,7 +1485,6 @@ int main(int argc, char* argv[])
     }
 
     bmqsys::Time::shutdown();
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbs/mqbs_qlistfileiterator.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_qlistfileiterator.t.cpp
@@ -714,8 +714,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 4: test4_iteratorAppKeys(); break;
@@ -727,8 +725,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
     // NOTE: for some reason the default allcoator verification never

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
@@ -315,8 +315,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     switch (_testCase) {
     case 0:
     case 2: test2_listMessages(); break;
@@ -326,8 +324,6 @@ int main(int argc, char* argv[])
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbs/mqbs_storageutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageutil.t.cpp
@@ -377,7 +377,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
     bmqsys::Time::initialize();
 
     switch (_testCase) {
@@ -394,7 +393,6 @@ int main(int argc, char* argv[])
     }
 
     bmqsys::Time::shutdown();
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
@@ -693,8 +693,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    bmqt::UriParser::initialize(bmqtst::TestHelperUtil::allocator());
-
     {
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);
@@ -716,8 +714,6 @@ int main(int argc, char* argv[])
         } break;
         }
     }
-
-    bmqt::UriParser::shutdown();
 
     TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
     // Do not check fro default/global allocator usage.

--- a/src/standalones/s_bmqfuzz/s_bmqfuzz_bmqt_uri.fuzz.cpp
+++ b/src/standalones/s_bmqfuzz/s_bmqfuzz_bmqt_uri.fuzz.cpp
@@ -27,7 +27,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     bsl::string fuzz_input(reinterpret_cast<const char*>(data), size);
 
-    bmqt::UriParser::initialize();
     bmqt::Uri   uri;
     bsl::string error;
     int         rc = bmqt::UriParser::parse(&uri, &error, fuzz_input);


### PR DESCRIPTION
1. Update `bmqt::Uri` docs
2. Cleanup headers in `bmqt_uri.h` / `bmqt_uri.cpp`
3. Add future deprecation notes for `bmqt::UriParse::initialize` / `bmqt::UriParse::shutdown`
4. Remove `bmqt::UriParse::initialize` / `bmqt::UriParse::shutdown` usage from the codebase
5. Allow global allocator checks in UTs where it was disabled due to `bmqt::Uri` RegEx usage