### PR TITLE
Refactor[MQBI]: remove e_ALL dispatcher client type

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -637,18 +637,18 @@ bool Application::initiateShutdown()
 
     {
         bslmt::Latch latch(1);
-        d_dispatcher_mp->execute(mqbi::Dispatcher::VoidFunctor(),
-                                 mqbi::DispatcherClientType::e_QUEUE,
-                                 bdlf::BindUtil::bind(&bslmt::Latch::arrive,
-                                                      &latch));
+        d_dispatcher_mp->executeOnAllQueues(
+            mqbi::Dispatcher::VoidFunctor(),
+            mqbi::DispatcherClientType::e_QUEUE,
+            bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
         latch.wait();
     }
     {
         bslmt::Latch latch(1);
-        d_dispatcher_mp->execute(mqbi::Dispatcher::VoidFunctor(),
-                                 mqbi::DispatcherClientType::e_CLUSTER,
-                                 bdlf::BindUtil::bind(&bslmt::Latch::arrive,
-                                                      &latch));
+        d_dispatcher_mp->executeOnAllQueues(
+            mqbi::Dispatcher::VoidFunctor(),
+            mqbi::DispatcherClientType::e_CLUSTER,
+            bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
         latch.wait();
     }
 

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -752,7 +752,7 @@ void ClientSession::tearDownImpl(bslmt::Semaphore*            semaphore,
     // processed.  We do so by enqueuing an event to all queues dispatchers
     // with the 'tearDownAllQueuesDone' finalize callback having the 'handle'
     // bound to it (so that the session is not yet destroyed).
-    dispatcher()->execute(
+    dispatcher()->executeOnAllQueues(
         mqbi::Dispatcher::VoidFunctor(),  // empty
         mqbi::DispatcherClientType::e_QUEUE,
         bdlf::BindUtil::bind(&ClientSession::tearDownAllQueuesDone,
@@ -1012,7 +1012,7 @@ void ClientSession::processDisconnectAllQueues(
     // drained.  Note, this must be using an 'e_DISPATCHER' dispatcher event
     // type, refer to top level documention for explanation (paragraph about
     // the bmqu::SharedResource).
-    dispatcher()->execute(
+    dispatcher()->executeOnAllQueues(
         mqbi::Dispatcher::VoidFunctor(),  // empty
         mqbi::DispatcherClientType::e_QUEUE,
         bdlf::BindUtil::bind(

--- a/src/groups/mqb/mqba/mqba_dispatcher.h
+++ b/src/groups/mqb/mqba/mqba_dispatcher.h
@@ -114,7 +114,7 @@ class Dispatcher_Executor {
     /// on a processor owned by the specified `dispacher` and in charge of
     /// the specified `client`.  The behavior is undefined unless the
     /// specified `client` is registered on the specified `dispacher` and
-    /// the client type is not `e_UNDEFINED` or `e_ALL`.
+    /// the client type is not `e_UNDEFINED`.
     Dispatcher_Executor(const Dispatcher*             dispacher,
                         const mqbi::DispatcherClient* client)
         BSLS_CPP11_NOEXCEPT;
@@ -175,8 +175,7 @@ class Dispatcher_ClientExecutor {
     /// objects by the specified `client` on a processor in charge of that
     /// client owned by the specified `dispacher`.  The behavior is
     /// undefined unless the specified `client` is registered on the
-    /// specified `dispacher` and the client type is not `e_UNDEFINED` or
-    /// `e_ALL`.
+    /// specified `dispacher` and the client type is not `e_UNDEFINED`.
     Dispatcher_ClientExecutor(const Dispatcher*             dispacher,
                               const mqbi::DispatcherClient* client)
         BSLS_CPP11_NOEXCEPT;
@@ -430,10 +429,11 @@ class Dispatcher BSLS_CPP11_FINAL : public mqbi::Dispatcher {
     /// clients of the specified `type`, and invoke the optionally specified
     /// `doneCallback` (if any) when all the relevant processors are done
     /// executing the `functor`.
-    void execute(const mqbi::Dispatcher::VoidFunctor& functor,
-                 mqbi::DispatcherClientType::Enum     type,
-                 const mqbi::Dispatcher::VoidFunctor& doneCallback =
-                     mqbi::Dispatcher::VoidFunctor()) BSLS_KEYWORD_OVERRIDE;
+    void executeOnAllQueues(const mqbi::Dispatcher::VoidFunctor& functor,
+                            mqbi::DispatcherClientType::Enum     type,
+                            const mqbi::Dispatcher::VoidFunctor& doneCallback =
+                                mqbi::Dispatcher::VoidFunctor())
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Execute the specified `functor`, using the specified dispatcher `type`,
     /// in the processor associated with the specified `client`.  The behavior
@@ -488,7 +488,7 @@ class Dispatcher BSLS_CPP11_FINAL : public mqbi::Dispatcher {
     /// Return an executor object suitable for executing function objects on
     /// the processor in charge of the specified `client`.  The behavior is
     /// undefined unless the specified `client` is registered on this
-    /// dispatcher and the client type is not `e_UNDEFINED` or `e_ALL`.
+    /// dispatcher and the client type is not `e_UNDEFINED`.
     ///
     /// Note that submitting work on the returned executor is undefined
     /// behavior unless this dispatcher is started.
@@ -501,9 +501,8 @@ class Dispatcher BSLS_CPP11_FINAL : public mqbi::Dispatcher {
 
     /// Return an executor object suitable for executing function objects by
     /// the specified `client` on the processor in charge of that client.
-    /// The behavior is undefined unless the specified `client` is
-    /// registered on this dispatcher and the client type is not
-    /// `e_UNDEFINED` or `e_ALL`.
+    /// The behavior is undefined unless the specified `client` is registered
+    /// on this dispatcher and the client type is not `e_UNDEFINED`.
     ///
     /// Note that submitting work on the returned executor is undefined
     /// behavior unless this dispatcher is started or if the specified
@@ -525,8 +524,7 @@ inline mqbi::DispatcherEvent*
 Dispatcher::getEvent(mqbi::DispatcherClientType::Enum type)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(type != mqbi::DispatcherClientType::e_UNDEFINED &&
-                     type != mqbi::DispatcherClientType::e_ALL);
+    BSLS_ASSERT_SAFE(type != mqbi::DispatcherClientType::e_UNDEFINED);
 
     return &d_contexts[type]
                 ->d_processorPool_mp->getUnmanagedEvent()
@@ -569,7 +567,6 @@ inline void Dispatcher::dispatchEvent(mqbi::DispatcherEvent*            event,
         d_contexts[type]->d_processorPool_mp->enqueueEvent(event, handle);
     } break;
     case mqbi::DispatcherClientType::e_UNDEFINED:
-    case mqbi::DispatcherClientType::e_ALL:
     default: {
         BSLS_ASSERT_OPT(false && "Invalid destination type");
     }
@@ -622,11 +619,6 @@ Dispatcher::numProcessors(mqbi::DispatcherClientType::Enum type) const
     }  // break;
     case mqbi::DispatcherClientType::e_CLUSTER: {
         return d_config.clusters().numProcessors();  // RETURN
-    }  // break;
-    case mqbi::DispatcherClientType::e_ALL: {
-        return d_config.sessions().numProcessors() +
-               d_config.queues().numProcessors() +
-               d_config.clusters().numProcessors();  // RETURN
     }  // break;
     case mqbi::DispatcherClientType::e_UNDEFINED: {
         BSLS_ASSERT_OPT(false && "Invalid type");

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -5675,7 +5675,7 @@ void ClusterQueueHelper::checkUnconfirmedV2Dispatched(
 
     // Synchronize with all Queue Dispatcher threads
     bslmt::Latch latch(1);
-    d_cluster_p->dispatcher()->execute(
+    d_cluster_p->dispatcher()->executeOnAllQueues(
         mqbi::Dispatcher::VoidFunctor(),  // empty
         mqbi::DispatcherClientType::e_QUEUE,
         bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -610,12 +610,12 @@ void QueueEngineUtil_ReleaseHandleProctor::invokeCallback()
             // represents 'mqba::ClientSession') as well as e_CLUSTER (which
             // represents 'mqbblp::ClusterNodeSession').
 
-            d_queueState_p->queue()->dispatcher()->execute(
+            d_queueState_p->queue()->dispatcher()->executeOnAllQueues(
                 mqbi::Dispatcher::VoidFunctor(),
                 mqbi::DispatcherClientType::e_SESSION,
                 bdlf::BindUtil::bind(&queueHandleHolderDummy, d_handleSp));
 
-            d_queueState_p->queue()->dispatcher()->execute(
+            d_queueState_p->queue()->dispatcher()->executeOnAllQueues(
                 mqbi::Dispatcher::VoidFunctor(),
                 mqbi::DispatcherClientType::e_CLUSTER,
                 bdlf::BindUtil::bind(&queueHandleHolderDummy, d_handleSp));

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.cpp
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.cpp
@@ -61,7 +61,6 @@ const char* DispatcherClientType::toAscii(DispatcherClientType::Enum value)
         CASE(SESSION)
         CASE(QUEUE)
         CASE(CLUSTER)
-        CASE(ALL)
     default: return "(* UNKNOWN *)";
     }
 
@@ -82,7 +81,6 @@ bool DispatcherClientType::fromAscii(DispatcherClientType::Enum* out,
     CHECKVALUE(SESSION)
     CHECKVALUE(QUEUE)
     CHECKVALUE(CLUSTER)
-    CHECKVALUE(ALL)
 
     // Invalid string
     return false;

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.h
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.h
@@ -154,18 +154,14 @@ class QueueHandle;
 struct DispatcherClientType {
     // TYPES
     enum Enum {
-        e_UNDEFINED = -1  // type has not been specified
-        ,
-        e_SESSION = 0  // client is assimilated to a session
-        ,
-        e_QUEUE = 1  // client is assimilated to a queue
-        ,
-        e_CLUSTER = 2  // client is assimilated to a cluster
-        ,
-        e_ALL = 3  // represents all of the possible types (see below)
+        /// Unspecified client type
+        e_UNDEFINED = -1,
+
+        /// Specified client types
+        e_SESSION = 0,
+        e_QUEUE   = 1,
+        e_CLUSTER = 2
     };
-    // NOTE: the 'e_ALL' type is used by certain Dispatcher methods to indicate
-    //        they should be applied to all types of clients.
 
     // CONSTANTS
     static const int k_COUNT = 3;  // Total number of different ClientTypes.
@@ -416,9 +412,10 @@ class Dispatcher {
     /// clients of the specified `type`, and invoke the specified
     /// `doneCallback` (if any) when all the relevant processors are done
     /// executing the `functor`.
-    virtual void execute(const VoidFunctor&         functor,
-                         DispatcherClientType::Enum type,
-                         const VoidFunctor& doneCallback = VoidFunctor()) = 0;
+    virtual void
+    executeOnAllQueues(const VoidFunctor&         functor,
+                       DispatcherClientType::Enum type,
+                       const VoidFunctor& doneCallback = VoidFunctor()) = 0;
 
     /// Enqueue an event to the processor associated to the specified
     /// `client` or pair of the specified `type` and `handle` and block
@@ -451,7 +448,7 @@ class Dispatcher {
     /// Return an executor object suitable for executing function objects on
     /// the processor in charge of the specified `client`.  The behavior is
     /// undefined unless the specified `client` is registered on this
-    /// dispatcher and the client type is not `e_UNDEFINED` or `e_ALL`.
+    /// dispatcher and the client type is not `e_UNDEFINED`.
     ///
     /// Note that the returned executor can be used to submit work even
     /// after the specified `client` has been unregistered from this
@@ -462,7 +459,7 @@ class Dispatcher {
     /// the specified `client` on the processor in charge of that client.
     /// The behavior is undefined unless the specified `client` is
     /// registered on this dispatcher and the client type is not
-    /// `e_UNDEFINED` or `e_ALL`.
+    /// `e_UNDEFINED`.
     ///
     /// Note that submitting work on the returned executor is undefined
     /// behavior if the specified `client` was unregistered from this

--- a/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp
@@ -107,9 +107,10 @@ void Dispatcher::execute(const mqbi::Dispatcher::VoidFunctor& functor,
     _execute(functor);
 }
 
-void Dispatcher::execute(const mqbi::Dispatcher::VoidFunctor& functor,
-                         BSLA_UNUSED mqbi::DispatcherClientType::Enum type,
-                         const mqbi::Dispatcher::VoidFunctor& doneCallback)
+void Dispatcher::executeOnAllQueues(
+    const mqbi::Dispatcher::VoidFunctor& functor,
+    BSLA_UNUSED mqbi::DispatcherClientType::Enum type,
+    const mqbi::Dispatcher::VoidFunctor&         doneCallback)
 {
     if (functor) {
         _execute(functor);

--- a/src/groups/mqb/mqbmock/mqbmock_dispatcher.h
+++ b/src/groups/mqb/mqbmock/mqbmock_dispatcher.h
@@ -186,9 +186,9 @@ class Dispatcher : public mqbi::Dispatcher {
     /// clients of the specified `type`, and invoke the specified
     /// `doneCallback` (if any) when all the relevant processors are done
     /// executing the `functor`.
-    void execute(const mqbi::Dispatcher::VoidFunctor& functor,
-                 mqbi::DispatcherClientType::Enum     type,
-                 const mqbi::Dispatcher::VoidFunctor& doneCallback)
+    void executeOnAllQueues(const mqbi::Dispatcher::VoidFunctor& functor,
+                            mqbi::DispatcherClientType::Enum     type,
+                            const mqbi::Dispatcher::VoidFunctor& doneCallback)
         BSLS_KEYWORD_OVERRIDE;
 
     void synchronize(mqbi::DispatcherClient* client) BSLS_KEYWORD_OVERRIDE;


### PR DESCRIPTION
1. Remove enum value `mqbi::DispatcherClientType::e_ALL` that is not actually used
2. Improve performance of `Dispatcher` by doing less checks with `e_ALL` gone
3. Rename `execute` -> `executeOnAllQueues` variant that enqueues an event to all queues for better search and visibility in the codebase. This helps with the future refactor