### PR TITLE
Feat[BMQ]: add reserved property name

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_messageproperties.h
+++ b/src/groups/bmq/bmqa/bmqa_messageproperties.h
@@ -42,6 +42,9 @@
 ///
 ///   - First character of the property name must be alpha-numeric.
 ///
+///   - Property names starting with the prefix "bmq." are reserved for
+///     internal use and cannot be set by users.
+///
 /// Restrictions on Property Values {#bmqa_messageproperties_valuerestrictions}
 /// ===============================
 ///

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -363,6 +363,9 @@ bool MessageProperties::streamInPropertyValue(const Property& p) const
     return rc == 0;
 }
 
+// PUBLIC CONSTANTS
+const char MessageProperties::k_RESERVED_PROPERTY_PREFIX[] = "bmq.";
+
 // CREATORS
 MessageProperties::MessageProperties(bslma::Allocator* basicAllocator)
 : d_allocator_p(bslma::Default::allocator(basicAllocator))

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -349,6 +349,10 @@ class MessageProperties {
     // there is only one property and property's name has maximum allowable
     // length, and also takes into consideration the protocol overhead.
 
+    /// Reserved property name prefix. Property names starting with this
+    /// prefix are reserved for internal use and cannot be set by users.
+    static const char k_RESERVED_PROPERTY_PREFIX[];
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(MessageProperties,
@@ -621,6 +625,13 @@ inline bool MessageProperties::isValidPropertyName(const bsl::string& name)
     }
 
     if (k_MAX_PROPERTY_NAME_LENGTH < name.length()) {
+        return false;  // RETURN
+    }
+
+    // Check if the name starts with the reserved prefix
+    const size_t reservedPrefixLen = bsl::strlen(k_RESERVED_PROPERTY_PREFIX);
+    if (name.length() >= reservedPrefixLen &&
+        name.compare(0, reservedPrefixLen, k_RESERVED_PROPERTY_PREFIX) == 0) {
         return false;  // RETURN
     }
 

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
@@ -1243,6 +1243,48 @@ static void test10_empty()
     BMQTST_ASSERT(!p.hasProperty("z"));
 }
 
+static void test11_reservedPropertyNames()
+// ------------------------------------------------------------------------
+// RESERVED PROPERTY NAMES
+//
+// Concerns:
+//   Verify that property names starting with the reserved prefix
+//   "bmq." cannot be set by users.
+//
+// Testing:
+//   - Setting properties with reserved prefix should fail
+//   - Setting properties without reserved prefix should succeed
+//   - Specifically test "bmq.traceparent" as it's reserved for
+//     distributed tracing
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("RESERVED PROPERTY NAMES");
+
+    bmqp::MessageProperties obj(bmqtst::TestHelperUtil::allocator());
+
+    // Test setting property with reserved prefix should fail
+    BMQTST_ASSERT_NE(0, obj.setPropertyAsString("bmq.traceparent", "test"));
+    BMQTST_ASSERT_NE(0, obj.setPropertyAsString("bmq.test", "value"));
+    BMQTST_ASSERT_NE(0, obj.setPropertyAsInt32("bmq.count", 42));
+
+    // Verify that no properties were added
+    BMQTST_ASSERT_EQ(0, obj.numProperties());
+    BMQTST_ASSERT(!obj.hasProperty("bmq.traceparent"));
+    BMQTST_ASSERT(!obj.hasProperty("bmq.test"));
+    BMQTST_ASSERT(!obj.hasProperty("bmq.count"));
+
+    // Test that properties without reserved prefix work normally
+    BMQTST_ASSERT_EQ(0, obj.setPropertyAsString("traceparent", "test"));
+    BMQTST_ASSERT_EQ(0, obj.setPropertyAsString("myProperty", "value"));
+    BMQTST_ASSERT_EQ(0, obj.setPropertyAsInt32("count", 42));
+
+    // Verify properties were added successfully
+    BMQTST_ASSERT_EQ(3, obj.numProperties());
+    BMQTST_ASSERT(obj.hasProperty("traceparent"));
+    BMQTST_ASSERT(obj.hasProperty("myProperty"));
+    BMQTST_ASSERT(obj.hasProperty("count"));
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -1255,6 +1297,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 11: test11_reservedPropertyNames(); break;
     case 10: test10_empty(); break;
     case 9: test9_copyAssignTest(); break;
     case 8: test8_printTest(); break;


### PR DESCRIPTION
Reserve "bmq.*" property name for internal use only.