### PR TITLE
Perf[BMQP]: replace `bdlb::ScopeExitAny` with inline cleaner

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -29,7 +29,6 @@
 // BDE
 #include <bdlb_bigendian.h>
 #include <bdlb_print.h>
-#include <bdlb_scopeexit.h>
 #include <bdlbb_blobutil.h>
 #include <bdlf_bind.h>
 #include <bdlma_localsequentialallocator.h>
@@ -801,8 +800,28 @@ int MessageProperties::streamIn(const bdlbb::Blob& blob,
 {
     clear();
 
-    bdlb::ScopeExitAny cleaner(
-        bdlf::BindUtil::bind(&MessageProperties::clear, this));
+    // Use stack-constructed object for scoped cleanup if there are any errors.
+    // Avoid using `bdlb::ScopeExitAny` because it requires constructing and
+    // destructing a `bsl::function` and it harms performance.
+    class MessageProperties_Cleaner {
+        MessageProperties* d_properties_p;
+
+      public:
+        explicit MessageProperties_Cleaner(MessageProperties* properties)
+        : d_properties_p(properties)
+        {
+            // NOTHING
+        }
+
+        ~MessageProperties_Cleaner()
+        {
+            if (d_properties_p) {
+                d_properties_p->clear();
+            }
+        }
+
+        inline void release() { d_properties_p = NULL; }
+    } cleanOnFailure(this);
 
     int rc = streamInHeader(blob);
 
@@ -822,7 +841,7 @@ int MessageProperties::streamIn(const bdlbb::Blob& blob,
         return rc;  // RETURN
     }
 
-    cleaner.release();
+    cleanOnFailure.release();
 
     return rc_SUCCESS;
 }


### PR DESCRIPTION
`perf` output with unnecessary constructions/destructions:

<img width="709" height="257" alt="Screenshot 2025-11-21 at 18 29 04" src="https://github.com/user-attachments/assets/c56f7722-b681-4244-8814-90d2059686fa" />

This should free ~10% of CPU cycles spent on `bmqp::MessageProperties::streamIn` based on `perf` output, the actual results are the following:

# Benchmarks

Built with `RelWithDebInfo`

## Mac M2

Before:
```
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     427 ms        0.015 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     427 ms        0.015 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     426 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     426 ms        0.008 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     431 ms        0.010 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     431 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     447 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     440 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     431 ms        0.008 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     433 ms        0.010 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_mean                432 ms        0.010 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_median              431 ms        0.009 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_stddev             6.67 ms        0.003 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_cv                 1.54 %         25.65 %            10
```

After:
```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     334 ms        0.012 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     333 ms        0.008 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     334 ms        0.008 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     335 ms        0.011 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     334 ms        0.014 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     336 ms        0.011 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     334 ms        0.010 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     335 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     334 ms        0.008 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                     336 ms        0.009 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_mean                335 ms        0.010 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_median              334 ms        0.009 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_stddev             1.02 ms        0.002 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_cv                 0.30 %         20.00 %            10
```

median `431 ms` -> `344 ms` (-20%)

## Linux

Before:
```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1553 ms        0.020 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1540 ms        0.014 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1539 ms        0.013 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1566 ms        0.018 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1548 ms        0.019 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1542 ms        0.018 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1556 ms        0.017 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1541 ms        0.013 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1541 ms        0.013 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1541 ms        0.010 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_mean               1547 ms        0.016 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_median             1541 ms        0.016 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_stddev             8.87 ms        0.003 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_cv                 0.57 %         21.41 %            10
```

After:
```
-----------------------------------------------------------------------------------------------------------------
Benchmark                                                                       Time             CPU   Iterations
-----------------------------------------------------------------------------------------------------------------
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1124 ms        0.018 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1124 ms        0.017 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1123 ms        0.015 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1146 ms        0.018 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1124 ms        0.017 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1151 ms        0.018 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1124 ms        0.017 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1128 ms        0.017 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1122 ms        0.015 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10                    1124 ms        0.013 ms            1
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_mean               1129 ms        0.016 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_median             1124 ms        0.017 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_stddev             10.4 ms        0.002 ms           10
bmqp::MessageProperties::streamIn/iterations:1/repeats:10_cv                 0.93 %         11.42 %            10
```

median `1541 ms` -> `1124 ms` (-27%)