### PR TITLE
Test[mqbc]: reproduce CSL advisory get stuck

### DIFF
--- a/src/integration-tests/test_cluster_node_shutdown.py
+++ b/src/integration-tests/test_cluster_node_shutdown.py
@@ -20,6 +20,7 @@ go to the relevant section in the README.md, in this directory.
 """
 
 import queue
+import re
 from time import sleep
 from typing import List
 
@@ -29,6 +30,7 @@ from blazingmq.dev.it.fixtures import (  # pylint: disable=unused-import
     order,
     multi_node,
 )
+from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.client import Client
 from blazingmq.dev.it.util import wait_until
 
@@ -287,3 +289,87 @@ class TestClusterNodeShutdown:
         # Having a new client to open that queue a second time should succeed
         self.producer3 = self.proxy2.create_client("producer3")
         self.producer3.open(du.uri_priority_2, flags=["write", "ack"], block=True)
+
+    def test_open_queue_after_quorum_bump_up(
+        self, multi_node: Cluster, domain_urls: tc.DomainUrls
+    ):
+        """
+        Test that if we bump up elector quorum with admin command so that it becomes higher than the number of nodes,
+        open queue request and the corresponding csl advisory, will get stuck. If we set quorum back, clients still
+        can't open queues.
+        """
+        du = domain_urls
+        cluster = multi_node
+        primary = cluster.last_known_leader
+        proxy = next(cluster.proxy_cycle())
+        active_replica = cluster.process(self.proxy2.get_active_node())
+
+        # Set quorum to unreachable number more than the number of nodes
+        for n in cluster.nodes():
+            n.set_quorum(5, cluster.config.name, True)
+
+        res = self.producer1.open(
+            du.uri_priority_2,
+            flags=["write", "ack"],
+            block=True,
+            timeout=10,
+            no_except=True,
+        )
+        # 10 seconds is enough. The request has got stuck
+        assert res != Client.e_SUCCESS
+
+        # Check that the cluster is still in healthy state
+        admin = AdminClient()
+        admin.connect(primary.config.host, int(primary.config.port))
+        res = admin.send_admin(f"CLUSTERS CLUSTER {cluster.config.name} STATUS")
+        healthy = False
+        for line in res.splitlines():
+            mm = re.search(r"Is Healthy.*\s+(\w+)", line)
+            if mm:
+                if mm.group(1) == "Yes":
+                    healthy = True
+                break
+        assert healthy
+
+        # Set quorum back to its default value (nodes_count/2 + 1)
+        for n in cluster.nodes():
+            n.set_quorum(3, cluster.config.name, True)
+
+        # The advisory is still stuck. It doesn't "know" that the quorum is already less than the number of ACKS it has
+        res = self.producer2.open(
+            du.uri_priority_2,
+            flags=["write", "ack"],
+            block=True,
+            timeout=10,
+            no_except=True,
+        )
+        # 10 seconds is enough. The request has got stuck
+        assert res != Client.e_SUCCESS
+
+        # Restart a node. This must finally trigger the stuck advisory to complete
+        for n in cluster.nodes():
+            if n not in [primary, active_replica]:
+                n.exit_gracefully()
+                rc = n.wait()
+                assert rc == 0
+                n.start()
+                n.wait_until_started()
+                break
+
+        # Now the replica should receive an openQueueReponse
+        assert active_replica.outputs_regex(
+            f"OpenQueueResponse.*{du.uri_priority_2}", timeout=10
+        ), (
+            f"Replica did not receive OpenQueueResponse for {du.uri_priority_2} after quorum restored"
+        )
+
+        # Having a new client to open that queue again should succeed
+        self.producer3 = cluster.create_client("producer3", proxy)
+        res = self.producer3.open(
+            du.uri_priority_2,
+            flags=["write", "ack"],
+            block=True,
+            timeout=10,
+            no_except=True,
+        )
+        assert res == Client.e_SUCCESS


### PR DESCRIPTION
This test demonstrates how we can get a CSL advisory stuck forever so that only restart of a node can help. We should either keep it in mind or improve handling of the admin command that sets elector quorum.
Suggestion: after every quorum change, review [the uncommitted csl advisories](https://github.com/bloomberg/blazingmq/blob/eba490bf1da17c9a1c3db84ace9bb21e1835b67f/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h#L202) to see if some of them already have more ACKs than the new quorum.
We have similar mechanism for unreceipted records when we handle ReplicationFactor change:
https://github.com/bloomberg/blazingmq/blob/eba490bf1da17c9a1c3db84ace9bb21e1835b67f/src/groups/mqb/mqbs/mqbs_filestore.cpp#L7283-L7285