### PR TITLE
Fix[IT]: Decrease startupWaitDurationMs for multi cluster mode 

### DIFF
--- a/docker/cluster/config/clusters.json
+++ b/docker/cluster/config/clusters.json
@@ -69,7 +69,7 @@
                     "partitionSyncEventSize": 4194304,
                     "partitionSyncStateReqTimeoutMs": 120000,
                     "startupRecoveryMaxDurationMs": 1200000,
-                    "startupWaitDurationMs": 60000,
+                    "startupWaitDurationMs": 0,
                     "storageSyncReqTimeoutMs": 300000
                 }
             },


### PR DESCRIPTION
By default startupWaitDurationMs = 60 seconds. This time is given for the a node on start up for search for active leader to synchronize with.

However in the test scenarios all nodes are started at once and they all waste initial 60 seconds, because there is no active leader. Only after this timeout, one of the node becomes a new leader.

So proposal is to set startupWaitDurationMs = 0, so no time is wasted on whole cluster startup.

Total run time for ITs for legacy/multi case if decreased from 45 minutes to 35 minutes.