### PR TITLE
Feat[BMQ]: add struct AuthnCredential

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_authncredential.cpp
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.cpp
@@ -1,0 +1,125 @@
+// Copyright 2021-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_authncredential.cpp                                         -*-C++-*-
+#include <bmqt_authncredential.h>
+
+#include <bmqscm_version.h>
+// BDE
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// ---------------------
+// class AuthnCredential
+// ---------------------
+
+// CREATORS
+
+AuthnCredential::AuthnCredential(bslma::Allocator* allocator)
+: d_mechanism(allocator)
+, d_data(allocator)
+{
+    // NOTHING
+}
+
+AuthnCredential::AuthnCredential(const bsl::string&       mechanism,
+                                 const bsl::vector<char>& data,
+                                 bslma::Allocator*        allocator)
+: d_mechanism(mechanism, allocator)
+, d_data(data, allocator)
+{
+    // NOTHING
+}
+
+AuthnCredential::AuthnCredential(const AuthnCredential& other,
+                                 bslma::Allocator*      allocator)
+: d_mechanism(other.d_mechanism, allocator)
+, d_data(other.d_data, allocator)
+{
+    // NOTHING
+}
+
+AuthnCredential::AuthnCredential(bslmf::MovableRef<AuthnCredential> otherRef,
+                                 bslma::Allocator*                  allocator)
+: d_mechanism(bslmf::MovableRefUtil::move(
+                  bslmf::MovableRefUtil::access(otherRef).d_mechanism),
+              allocator)
+, d_data(bslmf::MovableRefUtil::move(
+             bslmf::MovableRefUtil::access(otherRef).d_data),
+         allocator)
+{
+    // NOTHING
+}
+
+// ASSIGNMENT
+
+AuthnCredential& AuthnCredential::operator=(const AuthnCredential& rhs)
+{
+    if (this != &rhs) {
+        d_mechanism = rhs.d_mechanism;
+        d_data      = rhs.d_data;
+    }
+    return *this;
+}
+
+AuthnCredential&
+AuthnCredential::operator=(bslmf::MovableRef<AuthnCredential> rhsRef)
+{
+    AuthnCredential& rhs = bslmf::MovableRefUtil::access(rhsRef);
+    if (this != &rhs) {
+        d_mechanism = bslmf::MovableRefUtil::move(rhs.d_mechanism);
+        d_data      = bslmf::MovableRefUtil::move(rhs.d_data);
+    }
+    return *this;
+}
+
+AuthnCredential::~AuthnCredential()
+{
+    // NOTHING
+}
+
+// MANIPULATORS
+
+AuthnCredential& AuthnCredential::setMechanism(const bsl::string& mechanism)
+{
+    d_mechanism = mechanism;
+    return *this;
+}
+
+AuthnCredential& AuthnCredential::setData(const bsl::vector<char>& data)
+{
+    d_data = data;
+    return *this;
+}
+
+// ACCESSORS
+
+const bsl::string& AuthnCredential::mechanism() const
+{
+    return d_mechanism;
+}
+
+const bsl::vector<char>& AuthnCredential::data() const
+{
+    return d_data;
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqt/bmqt_authncredential.h
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.h
@@ -1,0 +1,86 @@
+// Copyright 2021-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_authncredential.h                                         -*-C++-*-
+#ifndef INCLUDED_BMQT_AUTHNCREDENTIAL
+#define INCLUDED_BMQT_AUTHNCREDENTIAL
+
+/// @file bmqt_authncredential.h
+///
+/// @brief Provide a value-semantic type for credentials used for
+/// authentication.
+
+// BDE
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslmf_nestedtraitdeclaration.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// =====================
+// class AuthnCredential
+// =====================
+
+class AuthnCredential {
+  private:
+    bsl::string       d_mechanism;  // authentication mechanism
+    bsl::vector<char> d_data;       // authentication data
+
+  private:
+    // NOT IMPLEMENTED (delete non-allocator creators)
+    AuthnCredential(const AuthnCredential&) BSLS_KEYWORD_DELETED;
+    AuthnCredential(AuthnCredential&&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(AuthnCredential, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+    AuthnCredential(bslma::Allocator* allocator = 0);
+
+    AuthnCredential(const AuthnCredential& other,
+                    bslma::Allocator*      allocator = 0);
+
+    AuthnCredential(bslmf::MovableRef<AuthnCredential> other,
+                    bslma::Allocator*                  allocator = 0);
+
+    /// Create an `AuthnCredential` object with the specified `mechanism`
+    /// and `data`, using the specified `allocator` to supply memory.  If
+    /// `allocator` is 0, the currently installed default allocator is used.
+    AuthnCredential(const bsl::string&       mechanism,
+                    const bsl::vector<char>& data,
+                    bslma::Allocator*        allocator = 0);
+
+    ~AuthnCredential();
+
+    // ASSIGNMENT (no allocator parameters)
+    AuthnCredential& operator=(const AuthnCredential& rhs);
+    AuthnCredential& operator=(bslmf::MovableRef<AuthnCredential> rhs);
+
+    // MANIPULATORS
+    AuthnCredential& setMechanism(const bsl::string& mechanism);
+    AuthnCredential& setData(const bsl::vector<char>& data);
+
+    // ACCESSORS
+    const bsl::string&       mechanism() const;
+    const bsl::vector<char>& data() const;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqt/bmqt_authncredential.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.t.cpp
@@ -1,0 +1,122 @@
+// Copyright 2014-2025 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_authncredential.t.cpp                                   -*-C++-*-
+#include <bmqt_authncredential.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_breathingTest()
+// ------------------------------------------------------------------------
+// BREATHING TEST
+//
+// Concerns:
+//   Exercise the basic functionality of the component.
+//
+// Plan:
+//
+// Testing:
+//   Basic functionality
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    PV("Test default constructor");
+    {
+        bmqt::AuthnCredential cred;
+        ASSERT(cred.mechanism().empty());
+        ASSERT(cred.data().empty());
+    }
+
+    PV("Test parameterized constructor");
+    {
+        bsl::string           mechanism("BMQ");
+        bsl::vector<char>     data{'d', 'a', 't', 'a'};
+        bmqt::AuthnCredential cred(mechanism, data);
+
+        ASSERT(cred.mechanism() == mechanism);
+        ASSERT(cred.data() == data);
+    }
+
+    PV("Test setMechanism and setData");
+    {
+        bmqt::AuthnCredential cred;
+        bsl::string           mechanism("BMQ");
+        bsl::vector<char>     data{'d', 'a', 't', 'a'};
+
+        cred.setMechanism(mechanism);
+        cred.setData(data);
+
+        ASSERT(cred.mechanism() == mechanism);
+        ASSERT(cred.data() == data);
+    }
+
+    PV("Test allocator usage");
+    {
+        bslma::Allocator*     allocator = bmqtst::TestHelperUtil::allocator();
+        bmqt::AuthnCredential cred(allocator);
+        ASSERT(cred.mechanism().get_allocator() == allocator);
+        ASSERT(cred.data().get_allocator() == allocator);
+
+        bsl::string           mechanism("BMQ", allocator);
+        bsl::vector<char>     data({'d', 'a', 't', 'a'}, allocator);
+        bmqt::AuthnCredential cred2(mechanism, data, allocator);
+
+        ASSERT(cred2.mechanism() == mechanism);
+        ASSERT(cred2.data() == data);
+    }
+
+    PV("Test empty credential");
+    {
+        bmqt::AuthnCredential cred;
+        ASSERT(cred.mechanism().empty());
+        ASSERT(cred.data().empty());
+    }
+
+    PV("Test destructor");
+    {
+        bmqt::AuthnCredential* credPtr = new bmqt::AuthnCredential();
+        delete credPtr;  // Ensure no memory leaks
+    }
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 1: test1_breathingTest(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqt/package/bmqt.mem
+++ b/src/groups/bmq/bmqt/package/bmqt.mem
@@ -1,3 +1,4 @@
+bmqt_authncredential
 bmqt_compressionalgorithmtype
 bmqt_correlationid
 bmqt_encodingtype


### PR DESCRIPTION
`AuthnCredential` is a struct including authentication mechanism and data. Users who authenticate should provide this to the `SessionOptions`.