### PR TITLE
Fix: `MovableRef` on C++03

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
@@ -996,7 +996,7 @@ MultiQueueThreadPool<TYPE>::enqueueEvent(bslmf::MovableRef<EventSp> event,
                                          int                        queueId)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(event);
+    BSLS_ASSERT_SAFE(bslmf::MovableRefUtil::access(event));
     BSLS_ASSERT(0 <= queueId && queueId < numQueues());
     BSLS_ASSERT_SAFE(isStarted() && "MQTP has not been started");
 
@@ -1010,7 +1010,7 @@ inline int MultiQueueThreadPool<TYPE>::enqueueEventOnAllQueues(
     bslmf::MovableRef<EventSp> event)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(event);
+    BSLS_ASSERT_SAFE(bslmf::MovableRefUtil::access(event));
     BSLS_ASSERT_SAFE(isStarted() && "MQTP has not been started");
 
     EventSp eventObj(bslmf::MovableRefUtil::move(event));


### PR DESCRIPTION
Pull request #1037 introduced a build regression for C++03 compilers:

    blazingmq/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h", line 999: Error: The operation "! BloombergLP::bslmf::MovableRef<bsl::shared_ptr<TestItem>>" is illegal.

This expression `! movableRef` is expanded from
`BSLS_ASSERT_SAFE(movableRef)`.  In C++11 and later, `bslmf::MovableRef<T>` is a type alias for `T&&`, so an expression of the form `! movableRef` is well-defined, when `T` supports `operator!`. In C++03, though, `MovableRef<T>` is a type template which does not support `operator!`.

This PR fixes this by calling `bslmf::MovableRefUtil::access` function in the assertion expression.