### PR TITLE
IT: Lower reruns from 3->2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,7 +117,7 @@ jobs:
             --bmq-log-level=INFO                \
             --junitxml=integration-tests.xml    \
             --tb long                           \
-            --reruns=3                          \
+            --reruns=2                          \
             --durations=0                       \
             -n logical -v
 

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -126,7 +126,7 @@ jobs:
             --bmq-log-level=INFO                \
             --junitxml=integration-tests.xml    \
             --tb long                           \
-            --reruns=3                          \
+            --reruns=2                          \
             -n 0                                \
             -v
 
@@ -227,7 +227,7 @@ jobs:
             --bmq-log-level=INFO                \
             --junitxml=integration-tests.xml    \
             --tb long                           \
-            --reruns=3                          \
+            --reruns=2                          \
             -n logical -v
 
       - name: Upload failure-logs as artifacts

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: IT [c++,${{ github.job }}]
         if: ${{ matrix.fuzz == 'off' }}
         run: |
-          docker run --rm sanitizer-${{ github.job }} /blazingmq/cmake.bld/Linux/run-it.sh -k breathing --reruns=3 --bmq-tolerate-dirty-shutdown
+          docker run --rm sanitizer-${{ github.job }} /blazingmq/cmake.bld/Linux/run-it.sh -k breathing --reruns=2 --bmq-tolerate-dirty-shutdown

--- a/docker/sanitizers/README.md
+++ b/docker/sanitizers/README.md
@@ -38,6 +38,6 @@ root@923efd7529a4:/blazingmq# BLAZINGMQ_IT_PRESET="fsm_mode and strong_consisten
 --bmq-log-level=INFO                \
 --junitxml=integration-tests.xml    \
 --tb long                           \
---reruns=3                          \
+--reruns=2                          \
 -n logical -v
 ```


### PR DESCRIPTION
**Describe your changes**
In an effort to harden our flaky tests, speed up CI, and reduce the size of CI artifacts from failures, this commit reduces the number of reruns performed to allow flaky tests to pass.

Ideally, ITs should not need to be rerun at all. Or if we run tests multiple times, it's to ensure they're *not* flaky, rather than retry because they are flaky.
