### PR TITLE
Fix[MQB]: call releaseHandleDispatched after configure callback

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -280,7 +280,7 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
             // Do not send CloseQueue request without waiting for deconfigure
             // response.
             const bsl::function<void(void)> cb = bdlf::BindUtil::bind(
-                &Queue::releaseHandleDispatched,
+                &Queue::releaseHandle,
                 this,
                 handle,
                 consumerHandleParams,

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -92,6 +92,7 @@ void RootQueueEngine::deliverMessages(AppState* app)
         d_queueState_p->queue()));
 
     BSLS_ASSERT_SAFE(d_queueState_p->storage());
+    BSLS_ASSERT_SAFE(d_apps.find(app->appId()) != d_apps.end());
 
     if (!app->isAuthorized()) {
         return;  // RETURN


### PR DESCRIPTION
Cannot call `Queue::releaseHandleDispatched` as (de)configure callback because after the callback the engine calls `deliverMessages(affectedApp.get());` while `releaseHandleDispatched` can erase unauthorized App.  This results in use after free.
A solution is to call `Queue::releaseHandle` which schedules `Queue::releaseHandleDispatched` thus executing it after the callback.