### PR TITLE
Fix[mqb]: isFinal race when dropping handle

### DIFF
--- a/src/integration-tests/test_heartbeat.py
+++ b/src/integration-tests/test_heartbeat.py
@@ -41,7 +41,7 @@ def _verify_delivery(consumer, uri, messages, timeout=2):
 def _verify_delivery_to_new_consumer(proxy, uri, messages, timeout=2):
     consumer = proxy.create_client("consumer")
     consumer.open(uri, flags=["read"], succeed=True)
-    _verify_delivery(consumer, uri, ["msg1", "masg2"], timeout=2)
+    _verify_delivery(consumer, uri, ["msg1", "msg2"], timeout=2)
     consumer.exit_gracefully()
 
 
@@ -112,7 +112,7 @@ def test_dead_leader(
 
     # post new message and verify delivery
     producer.post(tc.URI_FANOUT_SC, ["msg2"], succeed=True, wait_ack=True)
-    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2)
+    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2)
 
     # since the leader is still suspended (see above), kill it to stop the
     # cluster gracefully
@@ -123,7 +123,7 @@ def test_dead_leader(
     consumer.exit_gracefully()
 
     _verify_delivery_to_new_consumer(
-        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2
+        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2
     )
 
     producer.exit_gracefully()
@@ -174,14 +174,14 @@ def test_dead_proxy(
     producer.capture(r"RECONNECTED", 5)
     consumer.capture(r"RECONNECTED", 5)
 
-    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2)
+    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2)
 
     consumer.exit_gracefully()
     consumer.wait()
 
     # verify delivery for a new consumer
     _verify_delivery_to_new_consumer(
-        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2
+        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2
     )
 
     producer.exit_gracefully()
@@ -232,14 +232,14 @@ def test_dead_replica(
 
     producer.post(tc.URI_FANOUT_SC, ["msg2"], succeed=True, wait_ack=True)
 
-    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2)
+    _verify_delivery(consumer, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2)
 
     consumer.exit_gracefully()
     consumer.wait()
 
     # verify delivery for a new consumer
     _verify_delivery_to_new_consumer(
-        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "masg2"], timeout=2
+        proxy, tc.URI_FANOUT_SC_FOO, ["msg1", "msg2"], timeout=2
     )
 
     producer.exit_gracefully()


### PR DESCRIPTION
1.
When dropping `QueueHandle`, `mqbblp::Queue` sends deconfigure request for each subStream followed by close request.
After [https://github.com/bloomberg/blazingmq/pull/1002](https://github.com/bloomberg/blazingmq/pull/1002), queue needs to wait for deconfigure response before sending close request

2.  
Close requests have `isFinal` parameter which enforces zeroing out all counters even if Close request counters do not match existing one.  (we do not use `isFinal` inside clusters, there is some use in the SDK).

3.  
Producers do not need (de)configuration, and attempt to deconfigure results in an immediate response.

There is a race - if a producer is the last subStream, its close request has `isFinal` as `true`.  But, since it is short circuited, the producer close could get processed before the previous consumer close.   After `RelayQueueEngine` sees `isFinal`, it ignores subsequent consumer close resulting in failure to redeliver all pending data for this consumer.

Multiple runs of `test_dead_replica` can expose this race.

Surprisingly, unconditionally using `false` as `isFinal` did not pass fuzz testing.  Switching to plan B, using a counter for the decision on `isFinal` value.
