### PR TITLE
Misc mqbc::StorageMgr: Relax assert when process live data

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2757,7 +2757,6 @@ void StorageManager::do_processLiveData(const PartitionFSMArgsSp& args)
     BSLS_ASSERT_SAFE(rawEvent.isStorageEvent());
 
     const PartitionInfo& pinfo = d_partitionInfoVec[partitionId];
-    BSLS_ASSERT_SAFE(pinfo.primary() == source);
 
     bool skipAlarm = partitionHealthState(partitionId) ==
                      PartitionFSM::State::e_UNKNOWN;


### PR DESCRIPTION
[Internal Ticket 182146228]

`StorageUtil::validateStorageEvent` will alarm if source is not primary. That is sufficient. Asserting and crashing the broker is overkill.
