### PR TITLE
Fix[mqb]: queue/client broker stat config order

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_brokerstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_brokerstats.cpp
@@ -116,8 +116,8 @@ BrokerStatsUtil::initializeStatContext(int               historySize,
         .defaultHistorySize(historySize)
         .statValueAllocator(allocator)
         .storeExpiredSubcontextValues(true)
-        .value("queue_count")
-        .value("client_count");
+        .value("client_count")
+        .value("queue_count");
 
     bsl::shared_ptr<bmqst::StatContext> statContext =
         bsl::shared_ptr<bmqst::StatContext>(


### PR DESCRIPTION
**Describe your changes**
In b536f50e9d43abacb499ee9a927ca84f6eabfa33, I made the enum values consistent which fixed one bug. Namely, these stats now printed correctly in the broker stat log file.

Stat consumer plugins consuming these stats via the getValue() interface worked correctly, no issues there.

However, the positional collection of stat names and the defined enums remained mismatched. A hypothetical stat consumer reading values by name rather than by enum would see the values swapped. This commit fixes this mismatch.