### PR TITLE
Fix[mqbnet] never incorrectly identify loopback endpoint

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1535,10 +1535,13 @@ bool TCPSessionFactory::isEndpointLoopback(const bslstl::StringRef& uri) const
 {
     bmqio::TCPEndpoint endpoint(uri);
 
+    if (!bmqio::ChannelUtil::isLocalHost(endpoint.host())) {
+        return false;
+    }
+
     // Use the original port specification method
     if (d_config.listeners().empty()) {
-        return (endpoint.port() == d_config.port()) &&
-               bmqio::ChannelUtil::isLocalHost(endpoint.host());
+        return endpoint.port() == d_config.port();
     }
 
     PortMatcher portMatcher(endpoint.port());

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -642,8 +642,6 @@ void* TransportManager::getClusterNodeAndState(
 bool TransportManager::isEndpointLoopback(const bslstl::StringRef& uri) const
 {
     if (bmqu::StringUtil::startsWith(uri, "tcp://")) {
-        // NOTE: If we ever will listen to multiple TCP interfaces, we should
-        //       update here and return true if *any* one returns true.
         return d_tcpSessionFactory_mp &&
                d_tcpSessionFactory_mp->isEndpointLoopback(uri);  // RETURN
     }


### PR DESCRIPTION
**Describe your changes**
When running a proxy broker with multiple listeners, we found a bug where the proxy broker failed to connect to a cluster when the proxy and cluster are configured with the same port number. Previously, the broker only checked the URI's host in the legacy port configuration to determine if the endpoint is the loopback address. Now, the broker checks the host in both configurations.

On the proxy, the hint was this log:

> mqbnet_transportmanager.cpp:502 Creating new cluster 'test' (selfNodeId: 123)

The error is that the proxy should be identifying itself as nodeId -1.


On the cluster, session negotiation fails with logs like:
> 'The node already has a channel associated [cluster: 'test', nodeId: 123]'

which indicates the broker is rejecting the connection because it already has a connection from nodeId 123.