### PR TITLE
Fix[mqb]: Translate queueid for inline PUTs unconditionally

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -384,12 +384,12 @@ void Cluster::stopDispatched()
     d_clusterData.membership().netCluster()->closeChannels();
 }
 
-void Cluster::sendAck(bmqt::AckResult::Enum     status,
-                      int                       correlationId,
-                      const bmqt::MessageGUID&  messageGUID,
-                      int                       queueId,
-                      const bslstl::StringRef&  source,
-                      mqbc::ClusterNodeSession* nodeSession)
+void Cluster::sendAck(bmqt::AckResult::Enum           status,
+                      int                             correlationId,
+                      const bmqt::MessageGUID&        messageGUID,
+                      int                             queueId,
+                      const bslstl::StringRef&        source,
+                      const mqbc::ClusterNodeSession* nodeSession)
 {
     // executed by the *DISPATCHER* thread
 
@@ -763,7 +763,8 @@ void Cluster::onPutEvent(const mqbi::DispatcherPutEvent& event)
     while ((rc = putIt.next()) == 1) {
         const bmqp::QueueId queueId(putIt.header().queueId(),
                                     bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID);
-        QueueHandleMapIter  queueIt = ns->queueHandles().find(queueId.id());
+        QueueHandleMapConstIter queueIt = ns->queueHandles().find(
+            queueId.id());
 
         // Check if queueId represents a valid queue
         if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(queueIt ==
@@ -1173,10 +1174,10 @@ void Cluster::onRejectEvent(const mqbi::DispatcherRejectEvent& event)
 }
 
 Cluster::ValidationResult::Enum
-Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
-                         const bmqp::QueueId&      queueId,
-                         mqbc::ClusterNodeSession* ns,
-                         bmqp::EventType::Enum     eventType)
+Cluster::validateMessage(mqbi::QueueHandle**             queueHandle,
+                         const bmqp::QueueId&            queueId,
+                         const mqbc::ClusterNodeSession* ns,
+                         bmqp::EventType::Enum           eventType)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE((eventType == bmqp::EventType::e_CONFIRM ||
@@ -1184,8 +1185,8 @@ Cluster::validateMessage(mqbi::QueueHandle**       queueHandle,
                      "Unsupported eventType");
     BSLS_ASSERT_SAFE(queueHandle);
 
-    QueueHandleMap&    queueHandles = ns->queueHandles();
-    QueueHandleMapIter queueIt      = queueHandles.find(queueId.id());
+    const QueueHandleMap&   queueHandles = ns->queueHandles();
+    QueueHandleMapConstIter queueIt      = queueHandles.find(queueId.id());
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(queueIt == queueHandles.end())) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -161,7 +161,8 @@ class Cluster : public mqbi::Cluster,
 
     typedef mqbc::ClusterNodeSession::QueueHandleMap QueueHandleMap;
 
-    typedef mqbc::ClusterNodeSession::QueueHandleMapIter QueueHandleMapIter;
+    typedef mqbc::ClusterNodeSession::QueueHandleMapConstIter
+        QueueHandleMapConstIter;
 
     typedef bdlmt::EventScheduler::EventHandle SchedulerEventHandle;
 
@@ -343,12 +344,12 @@ class Cluster : public mqbi::Cluster,
     /// the cluster node identified by the specified cluster `nodeSession`.
     /// The specified `source` is used when logging, to indicate the origin
     /// of the ACK.
-    void sendAck(bmqt::AckResult::Enum     status,
-                 int                       correlationId,
-                 const bmqt::MessageGUID&  messageGUID,
-                 int                       queueId,
-                 const bslstl::StringRef&  source,
-                 mqbc::ClusterNodeSession* nodeSession);
+    void sendAck(bmqt::AckResult::Enum           status,
+                 int                             correlationId,
+                 const bmqt::MessageGUID&        messageGUID,
+                 int                             queueId,
+                 const bslstl::StringRef&        source,
+                 const mqbc::ClusterNodeSession* nodeSession);
 
     void processCommandDispatched(mqbcmd::ClusterResult*        result,
                                   const mqbcmd::ClusterCommand& command);
@@ -385,7 +386,7 @@ class Cluster : public mqbi::Cluster,
     /// the specified `queueHandle` if the queue is found.
     ValidationResult::Enum validateMessage(mqbi::QueueHandle**  queueHandle,
                                            const bmqp::QueueId& queueId,
-                                           mqbc::ClusterNodeSession* ns,
+                                           const mqbc::ClusterNodeSession* ns,
                                            bmqp::EventType::Enum eventType);
 
     /// Validate a relay message using the specified `pid`. Return true if the

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -794,12 +794,7 @@ void RelayQueueEngine::configureApp(
         applyConfiguration(appState, *context);
         return;  // RETURN
     }
-
-    // Send a configure stream request upstream.
-    d_queueState_p->domain()->cluster()->configureQueue(
-        d_queueState_p->queue(),
-        streamParamsToSend,
-        appState.upstreamSubQueueId(),  // upstream subQueueId
+    const QueueHandle::HandleConfiguredCallback& callback =
         bdlf::BindUtil::bind(&RelayQueueEngine::onHandleConfigured,
                              this,
                              d_self.acquireWeak(),
@@ -807,7 +802,14 @@ void RelayQueueEngine::configureApp(
                              bdlf::PlaceHolders::_2,  // upStreamParameters
                              handle,
                              streamParameters,  // downStreamParameters
-                             context));
+                             context);
+
+    // Send a configure stream request upstream.
+    d_queueState_p->domain()->cluster()->configureQueue(
+        d_queueState_p->queue(),
+        streamParamsToSend,
+        appState.upstreamSubQueueId(),  // upstream subQueueId
+        callback);
 
     // 'onHandleConfigured' is now responsible for calling the callback
 }

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -1024,9 +1024,11 @@ void RemoteQueue::postMessage(const bmqp::PutHeader&              putHeaderIn,
 
     mqbi::InlineResult::Enum rc = mqbi::InlineResult::e_UNAVAILABLE;
 
-    if (ctx.d_state == SubStreamContext::e_OPENED) {
-        putHeader.setQueueId(d_state_p->id());
+    // This is going to be an Inline PUT and its queueId needs a translation
+    // from downstream to upstream unconditionally.
+    putHeader.setQueueId(d_state_p->id());
 
+    if (ctx.d_state == SubStreamContext::e_OPENED) {
         mqbi::Cluster* cluster = d_state_p->domain()->cluster();
 
         rc = cluster->sendPutInline(d_state_p->partitionId(),


### PR DESCRIPTION
Bugfix `RemoteQueue` did not translate queueid for inline PUTs unless `ctx.d_state == SubStreamContext::e_OPENED`
 