### PR TITLE
Fix: Clean up command line directory inconsistencies

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -90,7 +90,7 @@ struct TaskEnvironment {
     // otherwise)
 
     bsl::string d_bmqPrefix;
-    // BMQ_PREFIX directory path
+    // Directory path to store PID, HIST, and CTL files under.
 
     bsl::string d_configJson;
     // JSON content ouput of the generated
@@ -414,7 +414,7 @@ static int initializeTask(bsl::ostream&    errorDescription,
                              bdlf::PlaceHolders::_1,    // prefix
                              bdlf::PlaceHolders::_2));  // istream
 
-    // Save the PID of the process in the '${BMQ_PREFIX}/bmqbrkr.pid' file
+    // Save the PID of the process in the '{prefix}/bmqbrkr.pid' file
     const bsl::string pidFile = taskEnv->d_bmqPrefix + "/bmqbrkr.pid";
     bsl::ofstream     pidFd(pidFile.c_str());
     if (!pidFd) {
@@ -499,9 +499,9 @@ static void shutdownApplication(TaskEnvironment* taskEnv)
     app.mqba::Application::~Application();
 }
 
-/// Update the `bmqbrkr.hist` file (in the BMQ_PREFIX directory) using the
+/// Update the `bmqbrkr.hist` file (in the prefix directory) using the
 /// specified `taskEnv`.  This file contains information about the last `n`
-/// successfull start of the broker, in reverse time order.
+/// successful starts of the broker, in reverse time order.
 /// Each line entry has the following format:
 ///    <currentTime_UTC>|<brokerVersion>|<configVersion>|<brokerId>
 ///
@@ -598,6 +598,7 @@ int main(int argc, const char* argv[])
 {
     // Parse command line parameters
     bsl::string configDir;
+    bsl::string prefixDir;
     bsl::string instanceId = "default";
     bsl::string hostName;
     bsl::string hostTags;
@@ -611,6 +612,11 @@ int main(int argc, const char* argv[])
          "Path to the configuration directory",
          balcl::TypeInfo(&configDir),
          balcl::OccurrenceInfo::e_REQUIRED},
+        {"",
+         "prefixDir",
+         "Path to the prefix directory (where PID, HIST, and CTL files live)",
+         balcl::TypeInfo(&prefixDir),
+         balcl::OccurrenceInfo::e_OPTIONAL},
         {"i|instanceId",
          "instanceId",
          "The instance ID ('default' if not provided)",
@@ -687,8 +693,11 @@ int main(int argc, const char* argv[])
     TaskEnvironment taskEnv;
     s_taskEnv_p = &taskEnv;
 
-    const char* prefixEnvVar = bsl::getenv("BMQ_PREFIX");
-    taskEnv.d_bmqPrefix      = (prefixEnvVar != 0 ? prefixEnvVar : "./");
+    // Default prefix directory to `BMQ_PREFIX` or ./
+    if (prefixDir.empty()) {
+        prefixDir = bsl::getenv("BMQ_PREFIX");
+    }
+    taskEnv.d_bmqPrefix      = (!prefixDir.empty() ? prefixDir : "./");
     taskEnv.d_instanceId     = instanceId;
 
     bmqu::MemOutStream errorDescription;

--- a/src/applications/bmqbrkr/m_bmqbrkr_task.h
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.h
@@ -199,7 +199,7 @@ class Task {
     // True is this object has been initialized.
 
     bsl::string d_bmqPrefix;
-    // BMQ_PREFIX directory
+    // Directory path to store PID, HIST, and CTL files under.
 
     bdlmt::EventScheduler d_scheduler;
     // EventScheduler


### PR DESCRIPTION
We noticed two inconsistencies while reviewing the `bmqbrkr` main function:

  1. `--config` was parsed as an optional argument, but if it was not given on the command line, we would detect and fail after parsing.  We can just make it required.
  
  2. All environment variables that the BlazingMQ broker knows about can be overridden by command line arguments, *except* `BMQ_PREFIX`.  We can add a new command line argument to do that.