### PR TITLE
Feat[mqba,mqbstat] Add dispatcher queue stats

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -323,6 +323,7 @@ int Application::start(bsl::ostream& errorDescription)
     // Start dispatcher
     d_dispatcher_mp.load(new (*d_allocator_p) Dispatcher(
                              mqbcfg::BrokerConfig::get().dispatcherConfig(),
+                             d_statController_mp->dispatcherStatContext(),
                              d_scheduler_p,
                              d_allocators.get("Dispatcher")),
                          d_allocator_p);

--- a/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
@@ -19,6 +19,7 @@
 // MQB
 #include <mqbcfg_messages.h>
 #include <mqbmock_dispatcher.h>
+#include <mqbstat_dispatcherstats.h>
 
 #include <bmqex_bindutil.h>
 #include <bmqex_executionpolicy.h>
@@ -237,8 +238,13 @@ static void test1_breathingTest()
 
     {
         // Create Dispatcher
+        bsl::shared_ptr<bmqst::StatContext> statContext =
+            mqbstat::DispatcherStatsUtil::initializeStatContext(
+                0,
+                bmqtst::TestHelperUtil::allocator());
         mqbcfg::DispatcherConfig dispatcherConfig = makeConfig();
         mqba::Dispatcher         dispatcher(dispatcherConfig,
+                                    statContext.get(),
                                     &eventScheduler,
                                     bmqtst::TestHelperUtil::allocator());
     }
@@ -306,8 +312,13 @@ static void test3_executorsSupport()
     BSLS_ASSERT_OPT(rc == 0);
 
     // create the dispatcher
+    bsl::shared_ptr<bmqst::StatContext> statContext =
+        mqbstat::DispatcherStatsUtil::initializeStatContext(
+            0,
+            bmqtst::TestHelperUtil::allocator());
     mqbcfg::DispatcherConfig dispatcherConfig = makeConfig();
-    mqba::Dispatcher dispatcher(dispatcherConfig,
+    mqba::Dispatcher         dispatcher(dispatcherConfig,
+                                statContext.get(),
                                 &eventScheduler,
                                 bmqtst::TestHelperUtil::allocator());
 
@@ -495,8 +506,13 @@ static void test4_eventSource()
 
     {
         // Create Dispatcher
+        bsl::shared_ptr<bmqst::StatContext> statContext =
+            mqbstat::DispatcherStatsUtil::initializeStatContext(0, alloc);
         mqbcfg::DispatcherConfig dispatcherConfig = makeConfig();
-        mqba::Dispatcher dispatcher(dispatcherConfig, &eventScheduler, alloc);
+        mqba::Dispatcher         dispatcher(dispatcherConfig,
+                                    statContext.get(),
+                                    &eventScheduler,
+                                    alloc);
 
         // Start the dispatcher
         bsl::stringstream startErr(alloc);
@@ -593,8 +609,13 @@ static void testN1_inDispatcherThread()
 
     {
         // Create dispatcher
+        bsl::shared_ptr<bmqst::StatContext> statContext =
+            mqbstat::DispatcherStatsUtil::initializeStatContext(
+                0,
+                bmqtst::TestHelperUtil::allocator());
         mqbcfg::DispatcherConfig dispatcherConfig = makeConfig();
-        mqba::Dispatcher obj(dispatcherConfig,
+        mqba::Dispatcher         obj(dispatcherConfig,
+                             statContext.get(),
                              &eventScheduler,
                              bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.cpp
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.cpp
@@ -312,6 +312,7 @@ DispatcherEvent::DispatcherEvent(bslma::Allocator* allocator)
 , d_genCount(0)
 , d_callback(allocator)
 , d_finalizeCallback(allocator)
+, d_enqueueTime(0)
 {
     // NOTHING
 }
@@ -412,6 +413,7 @@ void DispatcherEvent::reset()
     d_type          = DispatcherEventType::e_UNDEFINED;
     d_source_p      = 0;
     d_destination_p = 0;
+    d_enqueueTime   = 0;
 }
 
 bsl::ostream& DispatcherEvent::print(bsl::ostream& stream,

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.h
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.h
@@ -961,6 +961,9 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
     /// processing it.
     bmqu::ManagedCallback d_finalizeCallback;
 
+    /// Enqueue time.
+    bsls::Types::Int64 d_enqueueTime;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(DispatcherEvent, bslma::UsesBslmaAllocator)
@@ -1065,6 +1068,9 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
 
     DispatcherEvent& setState(const bsl::shared_ptr<bmqu::AtomicState>& state);
 
+    /// Set the enqueue time.
+    DispatcherEvent& setEnqueueTime(bsls::Types::Int64 time);
+
     /// Reset all members of this `DispatcherEvent` to a default value.
     void reset();
 
@@ -1080,6 +1086,9 @@ class DispatcherEvent : public DispatcherDispatcherEvent,
     /// Return the DispatcherClient destination target (`consumer`) of this
     /// event.
     DispatcherClient* destination() const;
+
+    /// Return the enqueue time.
+    bsls::Types::Int64 enqueueTime() const;
 
     const DispatcherDispatcherEvent*     asDispatcherEvent() const;
     const DispatcherControlMessageEvent* asControlMessageEvent() const;
@@ -1599,6 +1608,13 @@ DispatcherEvent::setState(const bsl::shared_ptr<bmqu::AtomicState>& state)
     return *this;
 }
 
+inline DispatcherEvent&
+DispatcherEvent::setEnqueueTime(bsls::Types::Int64 time)
+{
+    d_enqueueTime = time;
+    return *this;
+}
+
 inline DispatcherEventType::Enum DispatcherEvent::type() const
 {
     return d_type;
@@ -1612,6 +1628,11 @@ inline DispatcherClient* DispatcherEvent::source() const
 inline DispatcherClient* DispatcherEvent::destination() const
 {
     return d_destination_p;
+}
+
+inline bsls::Types::Int64 DispatcherEvent::enqueueTime() const
+{
+    return d_enqueueTime;
 }
 
 inline const DispatcherDispatcherEvent*

--- a/src/groups/mqb/mqbstat/mqbstat_dispatcherstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_dispatcherstats.cpp
@@ -1,0 +1,183 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbstat_dispatcherstats.cpp                                        -*-C++-*-
+#include <mqbstat_dispatcherstats.h>
+
+// BMQ
+#include <bmqst_statcontext.h>
+#include <bmqst_statutil.h>
+
+// BDE
+#include <ball_log.h>
+#include <bdld_datummapbuilder.h>
+
+namespace BloombergLP {
+namespace mqbstat {
+
+namespace {
+
+/// Name of the stat context to create (holding all dispatcher's statistics)
+static const char k_DISPATCHER_STAT_NAME[] = "dispatcher";
+
+}  // close unnamed namespace
+
+// ---------------------
+// class DispatcherStats
+// ---------------------
+
+bsls::Types::Int64 DispatcherStats::getValue(const bmqst::StatContext& context,
+                                             int        snapshotId,
+                                             Stat::Enum stat)
+
+{
+    // invoked from the SNAPSHOT thread
+
+    const bmqst::StatValue::SnapshotLocation latestSnapshot(0, 0);
+
+#define OLDEST_SNAPSHOT(STAT)                                                 \
+    (bmqst::StatValue::SnapshotLocation(                                      \
+        0,                                                                    \
+        (snapshotId >= 0)                                                     \
+            ? snapshotId                                                      \
+            : (context.value(bmqst::StatContext::e_DIRECT_VALUE, (STAT))      \
+                   .historySize(0) -                                          \
+               1)))
+
+#define STAT_SINGLE(OPERATION, STAT)                                          \
+    bmqst::StatUtil::OPERATION(                                               \
+        context.value(bmqst::StatContext::e_DIRECT_VALUE, STAT),              \
+        latestSnapshot)
+
+#define STAT_SINGLE_ABS(OPERATION, STAT)                                      \
+    bmqst::StatUtil::OPERATION(                                               \
+        context.value(bmqst::StatContext::e_DIRECT_VALUE, STAT))
+
+#define STAT_RANGE(OPERATION, STAT)                                           \
+    bmqst::StatUtil::OPERATION(                                               \
+        context.value(bmqst::StatContext::e_DIRECT_VALUE, STAT),              \
+        latestSnapshot,                                                       \
+        OLDEST_SNAPSHOT(STAT))
+
+    switch (stat) {
+    case Stat::e_ENQUEUE_DELTA: {
+        return STAT_RANGE(incrementsDifference,
+                          DispatcherStatsIndex::e_STAT_QUEUE);
+    }
+    case Stat::e_DEQUEUE_DELTA: {
+        return STAT_RANGE(decrementsDifference,
+                          DispatcherStatsIndex::e_STAT_QUEUE);
+    }
+    case Stat::e_QUEUE_SIZE: {
+        return STAT_SINGLE(value, DispatcherStatsIndex::e_STAT_QUEUE);
+    }
+    case Stat::e_QUEUE_SIZE_MAX: {
+        return STAT_RANGE(rangeMax, DispatcherStatsIndex::e_STAT_QUEUE);
+    }
+    case Stat::e_QUEUE_SIZE_ABS_MAX: {
+        return STAT_SINGLE_ABS(absoluteMax,
+                               DispatcherStatsIndex::e_STAT_QUEUE);
+    }
+    case Stat::e_QUEUE_TIME_MIN: {
+        const bsls::Types::Int64 min =
+            STAT_RANGE(rangeMin, DispatcherStatsIndex::e_STAT_TIME);
+        return min == bsl::numeric_limits<bsls::Types::Int64>::max() ? 0 : min;
+    }
+    case Stat::e_QUEUE_TIME_AVG: {
+        const bsls::Types::Int64 avg =
+            STAT_RANGE(averagePerEvent, DispatcherStatsIndex::e_STAT_TIME);
+        return avg == bsl::numeric_limits<bsls::Types::Int64>::max() ? 0 : avg;
+    }
+    case Stat::e_QUEUE_TIME_MAX: {
+        const bsls::Types::Int64 max =
+            STAT_RANGE(rangeMax, DispatcherStatsIndex::e_STAT_TIME);
+        return max == bsl::numeric_limits<bsls::Types::Int64>::min() ? 0 : max;
+    }
+    case Stat::e_QUEUE_TIME_ABS_MAX: {
+        return STAT_SINGLE_ABS(absoluteMax, DispatcherStatsIndex::e_STAT_TIME);
+    }
+    default: {
+        BSLS_ASSERT_SAFE(false && "Attempting to access an unknown stat");
+    }
+    }
+
+    return 0;
+
+#undef STAT_RANGE
+#undef STAT_SINGLE_ABS
+#undef STAT_SINGLE
+#undef OLDEST_SNAPSHOT
+}
+
+// -------------------------
+// class DispatcherStatsUtil
+// -------------------------
+
+bsl::shared_ptr<bmqst::StatContext>
+DispatcherStatsUtil::initializeStatContext(int               historySize,
+                                           bslma::Allocator* allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(allocator);
+
+    bmqst::StatContextConfiguration config(k_DISPATCHER_STAT_NAME, allocator);
+    config.isTable(true)
+        .defaultHistorySize(historySize)
+        .statValueAllocator(allocator)
+        .storeExpiredSubcontextValues(true)
+        .value("queued_count")
+        .value("queued_time", bmqst::StatValue::e_DISCRETE);
+
+    return bsl::shared_ptr<bmqst::StatContext>(
+        new (*allocator) bmqst::StatContext(config, allocator),
+        allocator);
+}
+
+bslma::ManagedPtr<bmqst::StatContext>
+DispatcherStatsUtil::initializeClientStatContext(bmqst::StatContext* parent,
+                                                 bsl::string_view    name,
+                                                 bslma::Allocator*   allocator)
+{
+    bmqst::StatContextConfiguration statConfig(name, allocator);
+    return parent->addSubcontext(statConfig);
+}
+
+bsl::shared_ptr<bmqst::StatContext>
+DispatcherStatsUtil::initializeQueueStatContext(bmqst::StatContext* parent,
+                                                bsl::string_view    name,
+                                                bsl::string_view    client,
+                                                unsigned int      processorId,
+                                                bslma::Allocator* allocator)
+{
+    bmqst::StatContextConfiguration statConfig(name, allocator);
+
+    bslma::ManagedPtr<bmqst::StatContext> statContext_sp =
+        parent->addSubcontext(statConfig);
+
+    // Build a datum map containing the following values:
+    //: o client: the name of client associated with the queue
+    //: o processorId: the processor Id associated with the queue
+    bslma::ManagedPtr<bdld::ManagedDatum> datum = statContext_sp->datum();
+    bslma::Allocator*     alloc = statContext_sp->datumAllocator();
+    bdld::DatumMapBuilder builder(alloc);
+    builder.pushBack("client", bdld::Datum::copyString(client, alloc));
+    builder.pushBack("processorId", bdld::Datum::createInteger(processorId));
+    datum->adopt(builder.commit());
+
+    return statContext_sp;
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbstat/mqbstat_dispatcherstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_dispatcherstats.h
@@ -1,0 +1,175 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbstat_dispatcherstats.h                                          -*-C++-*-
+#ifndef INCLUDED_MQBSTAT_DISPATCHERSTATS
+#define INCLUDED_MQBSTAT_DISPATCHERSTATS
+
+//@PURPOSE: Provide mechanism to keep track of Dispatcher statistics.
+//
+//@CLASSES:
+//  mqbstat::DispatcherStats: Mechanism to maintain stats of a dispatcher
+//  mqbstat::DispatcherStatsUtil: Utilities to initialize statistics
+//
+//@DESCRIPTION: 'mqbstat::DispatcherStats' provides a mechanism to keep track
+// of dispatcher level statistics.  'mqbstat::DispatcherStatsUtil' is a utility
+// namespace exposing methods to initialize the stat contexts.
+
+// BMQ
+#include <bmqst_statcontext.h>
+
+// BDE
+#include <bsl_memory.h>
+#include <bslma_allocator.h>
+#include <bslma_managedptr.h>
+#include <bsls_keyword.h>
+#include <bsls_types.h>
+
+namespace BloombergLP {
+namespace mqbstat {
+
+// =====================
+// class DispatcherStats
+// =====================
+
+/// Mechanism to keep track of individual overall statistics of a dispatcher
+class DispatcherStats {
+  public:
+    // TYPES
+
+    /// Enum representing the various type of stats that can be obtained
+    /// from this object.
+    struct Stat {
+        // TYPES
+        enum Enum {
+            e_ENQUEUE_DELTA      = 0,
+            e_DEQUEUE_DELTA      = 1,
+            e_QUEUE_SIZE         = 2,
+            e_QUEUE_SIZE_MAX     = 3,
+            e_QUEUE_SIZE_ABS_MAX = 4,
+            e_QUEUE_TIME_MIN     = 5,
+            e_QUEUE_TIME_AVG     = 6,
+            e_QUEUE_TIME_MAX     = 7,
+            e_QUEUE_TIME_ABS_MAX = 8
+        };
+    };
+
+    // CLASS METHODS
+
+    /// Get the value of the specified `stat` reported to the dispatcher
+    /// represented by its associated specified `context` as the difference
+    /// between the latest snapshot-ed value (i.e., `snapshotId == 0`) and
+    /// the value that was recorded at the specified `snapshotId` snapshots
+    /// ago.
+    ///
+    /// THREAD: This method can only be invoked from the `snapshot` thread.
+    static bsls::Types::Int64 getValue(const bmqst::StatContext& context,
+                                       int                       snapshotId,
+                                       Stat::Enum                stat);
+
+    /// Update the `queued_count` field of the specified `queueStatContext`.
+    static void onEnqueue(bmqst::StatContext* queueStatContext);
+
+    /// Update the `queued_count` and `queued_time` fields of the specified
+    /// `queueStatContext`.
+    static void onDequeue(bmqst::StatContext* queueStatContext,
+                          bsls::Types::Int64  queuedTime);
+
+  private:
+    // PRIVATE TYPES
+
+    /// Namespace for the constants of stat values that applies to the
+    /// dispatcher queues from the clients.
+    struct DispatcherStatsIndex {
+        enum Enum {
+            e_STAT_QUEUE = 0,  // Queue/Dequeue
+            e_STAT_TIME  = 1   // Event queued time
+        };
+    };
+
+    // NOT IMPLEMENTED
+    DispatcherStats(const DispatcherStats&) BSLS_CPP11_DELETED;
+
+    /// Copy constructor and assignment operator are not implemented.
+    DispatcherStats& operator=(const DispatcherStats&) BSLS_CPP11_DELETED;
+};
+
+// ==========================
+// struct DispatcherStatsUtil
+// ==========================
+
+/// Utility namespace of methods to initialize dispatcher stats.
+struct DispatcherStatsUtil {
+    // CLASS METHODS
+
+    /// Initialize the statistics for the dispatcher stat context, keeping the
+    /// specified `historySize` of history.  Return the created top level
+    /// stat context to use for all dispatcher level statistics.  Use the
+    /// specified `allocator` for all stat context and stat values.
+    static bsl::shared_ptr<bmqst::StatContext>
+    initializeStatContext(int historySize, bslma::Allocator* allocator);
+
+    /// Initialize the statistics for the dispatcher client stat context,
+    /// with the specified `parent` context and `name`.
+    /// Return the created stat context to use for all dispatcher client
+    /// level statistics.  Use the specified `allocator` for all
+    /// stat context and stat values.
+    static bslma::ManagedPtr<bmqst::StatContext>
+    initializeClientStatContext(bmqst::StatContext* parent,
+                                bsl::string_view    name,
+                                bslma::Allocator*   allocator);
+
+    /// Initialize the statistics for the dispatcher queue stat context,
+    /// with the specified `parent` context `name`, `client`, and
+    /// `processorId`. Return the created stat context to use for all
+    /// dispatcher queue level statistics.  Use the specified `allocator` for
+    /// all stat context and stat values.
+    static bsl::shared_ptr<bmqst::StatContext>
+    initializeQueueStatContext(bmqst::StatContext* parent,
+                               bsl::string_view    name,
+                               bsl::string_view    client,
+                               unsigned int        processorId,
+                               bslma::Allocator*   allocator);
+};
+
+// ============================================================================
+//                             INLINE DEFINITIONS
+// ============================================================================
+
+// ---------------------
+// class DispatcherStats
+// ---------------------
+
+inline void DispatcherStats::onEnqueue(bmqst::StatContext* queueStatContext)
+{
+    BSLS_ASSERT_SAFE(queueStatContext && "Stat context is not initialized");
+
+    queueStatContext->adjustValue(DispatcherStatsIndex::e_STAT_QUEUE, 1);
+}
+
+inline void DispatcherStats::onDequeue(bmqst::StatContext* queueStatContext,
+                                       bsls::Types::Int64  queuedTime)
+{
+    BSLS_ASSERT_SAFE(queueStatContext && "Stat context is not initialized");
+
+    queueStatContext->adjustValue(DispatcherStatsIndex::e_STAT_QUEUE, -1);
+    queueStatContext->reportValue(DispatcherStatsIndex::e_STAT_TIME,
+                                  queuedTime);
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -28,6 +28,7 @@
 #include <mqbscm_versiontag.h>
 #include <mqbstat_brokerstats.h>
 #include <mqbstat_clusterstats.h>
+#include <mqbstat_dispatcherstats.h>
 #include <mqbstat_domainstats.h>
 #include <mqbstat_queuestats.h>
 
@@ -187,6 +188,17 @@ void StatController::initializeStats()
         StatContextDetails(
             BrokerStatsUtil::initializeStatContext(historySize,
                                                    brokerAllocator),
+            false)));
+
+    // ----------
+    // Dispatcher
+    bslma::Allocator* dispatcherAllocator = d_allocators.get(
+        "DispatcherStats");
+    d_statContextsMap.insert(bsl::make_pair(
+        bsl::string("dispatcher"),
+        StatContextDetails(
+            DispatcherStatsUtil::initializeStatContext(historySize,
+                                                       dispatcherAllocator),
             false)));
 
     // -------

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -322,6 +322,9 @@ class StatController {
                        const mqbcmd::StatCommand&           command,
                        const mqbcmd::EncodingFormat::Value& encoding);
 
+    /// Retrieve the dispatcher top-level stat context.
+    bmqst::StatContext* dispatcherStatContext();
+
     /// Retrieve the domains top-level stat context.
     bmqst::StatContext* domainsStatContext();
 
@@ -349,6 +352,11 @@ class StatController {
 // --------------------
 // class StatController
 // --------------------
+
+inline bmqst::StatContext* StatController::dispatcherStatContext()
+{
+    return d_statContextsMap["dispatcher"].d_statContext_sp.get();
+}
 
 inline bmqst::StatContext* StatController::domainsStatContext()
 {

--- a/src/groups/mqb/mqbstat/package/mqbstat.mem
+++ b/src/groups/mqb/mqbstat/package/mqbstat.mem
@@ -1,5 +1,6 @@
 mqbstat_brokerstats
 mqbstat_clusterstats
+mqbstat_dispatcherstats
 mqbstat_domainstats
 mqbstat_jsonprinter
 mqbstat_printer

--- a/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.h
+++ b/src/plugins/bmqprometheus/bmqprometheus_prometheusstatconsumer.h
@@ -128,6 +128,9 @@ class PrometheusStatConsumer : public mqbplug::StatConsumer {
     const bmqst::StatContext* d_channelsStatContext_p;
     // The channels stat context
 
+    const bmqst::StatContext* d_dispatcherStatContext_p;
+    // The dispatcher stat context
+
     StatContextsMap d_contextsMap;
     // Map of stat contexts
 
@@ -197,6 +200,10 @@ class PrometheusStatConsumer : public mqbplug::StatConsumer {
     /// Capture all queue related data points, and store them in Prometheus
     /// Registry for further publishing to Prometheus.
     void captureDomainStats(const LeaderSet& leaders);
+
+    /// Capture all dispatcher related data points, and store them in
+    /// Prometheus Registry for further publishing to Prometheus.
+    void captureDispatcherStats();
 
     /// Set internal action counter based on Prometheus publish interval.
     void setActionCounter();


### PR DESCRIPTION
Add stat context to `mqba::Dispatcher` class to gather metrics per each dispatcher client queue.
The set of metrics is the same as in [bmqimp::EventQueue](https://github.com/bloomberg/blazingmq/blob/main/src/groups/bmq/bmqimp/bmqimp_eventqueue.cpp#L328) :

- enqueue_delta
- dequeue_delta
- size
- size_max
- size_abs_max
- time_min
- time_avg
- time_max
- time_absmax

Prometheus plugin is enhanced to report dispatcher metrics to Prometheus.