### PR TITLE
bcast queues do not stick to partition thread

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2374,8 +2374,16 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
         // fail.
     }
 
+    // Must check 'd_cluster_p->isRemote()' first
+    const bool canDetachFromPartition = d_cluster_p->isRemote()
+                                            ? true
+                                            : context.d_domain_p->config()
+                                                  .storage()
+                                                  .config()
+                                                  .isInMemoryValue();
+
     // Register this queue to the dispatcher.
-    if (d_cluster_p->isRemote()) {
+    if (canDetachFromPartition) {
         d_cluster_p->dispatcher()->registerClient(
             queueSp.get(),
             mqbi::DispatcherClientType::e_QUEUE);

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -126,8 +126,7 @@ static void test2_iterations()
                                 bmqtst::TestHelperUtil::allocator());
     mqbconfm::Domain dummyDomainConfig(bmqtst::TestHelperUtil::allocator());
 
-    mqbs::InMemoryStorage dummyStorage(0,  // No FileStore
-                                       dummyUri,
+    mqbs::InMemoryStorage dummyStorage(dummyUri,
                                        mqbu::StorageKey::k_NULL_KEY,
                                        &dummyDomain,
                                        mqbi::Storage::k_INVALID_PARTITION_ID,

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -280,8 +280,7 @@ Test::Test()
                                  bdlf::PlaceHolders::_1,   // appId
                                  bdlf::PlaceHolders::_2),  // oldestMsgIt
             d_allocator_p)
-, d_storage(0,  // No FileStore
-            d_queue.uri(),
+, d_storage(d_queue.uri(),
             mqbu::StorageKey::k_NULL_KEY,
             &d_domain,
             mqbi::Storage::k_INVALID_PARTITION_ID,

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -552,8 +552,7 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig,
     // Create Storage
 
     mqbi::Storage* storage_p = new (*d_allocator_p)
-        mqbs::InMemoryStorage(0,  // No FileStore
-                              d_mockQueue_sp->uri(),
+        mqbs::InMemoryStorage(d_mockQueue_sp->uri(),
                               k_NULL_QUEUE_KEY,
                               d_mockDomain_mp.get(),
                               k_PARTITION_ID,

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -113,7 +113,6 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     // 'mqbi::Storage::k_INVALID_PARTITION_ID' indicates the case of Proxy.
     bsl::shared_ptr<mqbi::Storage> storageSp;
     storageSp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
-                       0,  // No FileStore
                        d_state_p->uri(),
                        d_state_p->key(),
                        d_state_p->domain(),

--- a/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
@@ -76,8 +76,7 @@ struct TestStorage {
     , d_cluster(d_allocator_p)
     , d_domain(&d_cluster,
                d_allocator_p)  // Use domain only to hold mqbstat::StatContext
-    , d_storage(0,             // No FileStore
-                bmqt::Uri("uri", d_allocator_p),
+    , d_storage(bmqt::Uri("uri", d_allocator_p),
                 d_storageKey,
                 &d_domain,
                 1,

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5377,8 +5377,7 @@ void FileStore::createStorage(bsl::shared_ptr<ReplicatedStorage>* storageSp,
     bslma::Allocator* storageAlloc = d_storageAllocatorStore.baseAllocator();
     if (storageCfg.isInMemoryValue()) {
         storageSp->reset(new (*storageAlloc)
-                             InMemoryStorage(this,
-                                             queueUri,
+                             InMemoryStorage(queueUri,
                                              queueKey,
                                              domain,
                                              config().partitionId(),

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -48,8 +48,7 @@ const int k_GC_HISTORY_BATCH_SIZE = 1000;
 // ---------------------
 
 // CREATORS
-InMemoryStorage::InMemoryStorage(DataStore*              dataStore_p,
-                                 const bmqt::Uri&        uri,
+InMemoryStorage::InMemoryStorage(const bmqt::Uri&        uri,
                                  const mqbu::StorageKey& queueKey,
                                  mqbi::Domain*           domain,
                                  int                     partitionId,
@@ -58,7 +57,6 @@ InMemoryStorage::InMemoryStorage(DataStore*              dataStore_p,
                                  bslma::Allocator*       allocator,
                                  bmqma::CountingAllocatorStore* allocatorStore)
 : d_allocator_p(allocator)
-, d_store_p(dataStore_p)
 , d_key(queueKey)
 , d_uri(uri, d_allocator_p)
 , d_partitionId(partitionId)
@@ -498,20 +496,21 @@ int InMemoryStorage::gcExpiredMessages(const bdlt::Datetime& currentTimeUtc,
             ->onEvent<mqbstat::QueueStatsDomain::EventType::e_UPDATE_HISTORY>(
                 d_items.historySize());
 
-        BALL_LOG_INFO
-            << (d_store_p ? d_store_p->description() : "Partition [Unknown]: ")
-            << "For storage for queue [" << queueUri() << "] and queueKey ["
-            << queueKey() << "] configured with TTL value of [" << d_ttlSeconds
-            << "] seconds, garbage-collected [" << numMsgsDeleted
-            << "] messages due to TTL expiration. "
-            << "Timestamp (UTC) of the latest encountered message: "
-            << bdlt::EpochUtil::convertFromTimeT64(latestMsgTimestampEpoch)
-            << " (Epoch: " << latestMsgTimestampEpoch
-            << "). Current time (UTC): " << currentTimeUtc
-            << " (Epoch: " << secondsFromEpoch << ")."
-            << " Num messages remaining in the storage: "
-            << numMessages(mqbu::StorageKey::k_NULL_KEY) << ". Storage type: "
-            << (isPersistent() ? "persistent." : "in-memory.");
+        BALL_LOG_INFO << "For storage for queue [" << queueUri()
+                      << "] and queueKey [" << queueKey()
+                      << "] configured with TTL value of [" << d_ttlSeconds
+                      << "] seconds, garbage-collected [" << numMsgsDeleted
+                      << "] messages due to TTL expiration. "
+                      << "Timestamp (UTC) of the latest encountered message: "
+                      << bdlt::EpochUtil::convertFromTimeT64(
+                             latestMsgTimestampEpoch)
+                      << " (Epoch: " << latestMsgTimestampEpoch
+                      << "). Current time (UTC): " << currentTimeUtc
+                      << " (Epoch: " << secondsFromEpoch << ")."
+                      << " Num messages remaining in the storage: "
+                      << numMessages(mqbu::StorageKey::k_NULL_KEY)
+                      << ". Storage type: "
+                      << (isPersistent() ? "persistent." : "in-memory.");
     }
 
     if (d_items.empty()) {

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -176,13 +176,6 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     // DATA
     bslma::Allocator* d_allocator_p;
 
-    /// The pointer to the parent DataStore object that contains this storage.
-    /// Held, not owned.
-    /// Might be NULL:
-    /// - On a proxy (in this case `gcExpired` is not called)
-    /// - In UTs (in this case `gcExpired` might be called)
-    DataStore* d_store_p;
-
     mqbu::StorageKey d_key;
 
     bmqt::Uri d_uri;
@@ -251,8 +244,7 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     /// Constructor of a new object associated to the queue having specified
     /// `uri` and using the specified `parentCapacityMeter`, and
     /// `allocator`.
-    InMemoryStorage(DataStore*                     dataStore_p,
-                    const bmqt::Uri&               uri,
+    InMemoryStorage(const bmqt::Uri&               uri,
                     const mqbu::StorageKey&        queueKey,
                     mqbi::Domain*                  domain,
                     int                            partitionId,

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -197,7 +197,6 @@ struct Tester {
         domainCfg.messageTtl()          = k_INT64_MAX;
 
         d_replicatedStorage_mp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
-                                        0,  // No FileStore
                                         bmqt::Uri(k_URI_STR, d_allocator_p),
                                         k_QUEUE_KEY,
                                         &d_mockDomain,

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
@@ -147,7 +147,6 @@ struct Tester {
 
         const bsl::string uri("my.domain/myqueue", d_allocator_p);
         d_storage_mp.load(new (*d_allocator_p) mqbs::InMemoryStorage(
-                              0,  // No FileStore
                               bmqt::Uri(uri, d_allocator_p),
                               k_QUEUE_KEY,
                               &d_domain,


### PR DESCRIPTION
There is no reason for bcast queue to run on partition thread since it does not write/replicate/rollover.
So, the idea is to assign it to any thread for the Actor.  Note that the dispatcher does load balancing when assigning thread.
We do need to create storage (`InMemoryStorage`) and register it with the `StorageManager` and write queue creation record to the journal.  That is done before queue creation.  We do need to wait (`synchronize`) since this is done in another thread.