### PR TITLE
Refactor[BMQ,MQB]: move `AtomicGate`/`GateKeeper` to `bmqu`

### DIFF
--- a/src/groups/bmq/bmqu/bmqu_atomicgate.cpp
+++ b/src/groups/bmq/bmqu/bmqu_atomicgate.cpp
@@ -1,0 +1,48 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqu_atomicgate.cpp                                                -*-C++-*-
+#include <bmqu_atomicgate.h>
+
+#include <bmqscm_version.h>
+
+// BDE
+#include <bslmt_threadutil.h>
+
+namespace BloombergLP {
+namespace bmqu {
+
+// ----------------
+// class AtomicGate
+// ----------------
+
+// MANIPULATORS
+void AtomicGate::closeAndDrain()
+{
+    int result = d_value.add(e_CLOSE);
+
+    BSLS_ASSERT_SAFE(result & e_CLOSE);
+    // Do not support more than one writer
+
+    // Spin while locked result > e_CLOSE
+
+    while (result > e_CLOSE) {
+        bslmt::ThreadUtil::yield();
+        result = d_value;
+    }
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqu/bmqu_atomicgate.h
+++ b/src/groups/bmq/bmqu/bmqu_atomicgate.h
@@ -1,0 +1,248 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqu_atomicgate.h                                                  -*-C++-*-
+#ifndef INCLUDED_BMQU_ATOMICGATE
+#define INCLUDED_BMQU_ATOMICGATE
+
+/// @file bmqu_atomicgate.h
+/// @brief Thread-safe binary state (gate) mechanism.
+
+// BDE
+#include <bsla_annotations.h>
+#include <bsls_assert.h>
+#include <bsls_atomic.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+namespace bmqu {
+
+// ================
+// class AtomicGate
+// ================
+
+/// @brief Thread-safe binary state (open/close) mechanism.
+///
+/// This mechanism maintains binary state (open/close) allowing efficiently
+/// check the state (`tryEnter`/`leave`), change it to open (`open`), and to
+/// close (`closeAndDrain`) waiting for all `leave` calls matching `tryEnter`
+/// calls.
+class AtomicGate {
+  private:
+    // PRIVATE TYPES
+
+    /// The Enum values have arithmetical meaning and cannot be changed, or
+    /// extended, or reordered.
+    enum Enum { e_INIT = 0, e_CLOSE = 1, e_ENTER = 2 };
+
+    // PRIVATE DATA
+    bsls::AtomicInt d_value;
+
+  public:
+    // CREATORS
+
+    /// Create an `AtomicGate` object with the specified `isOpen` initial
+    /// state.
+    AtomicGate(bool isOpen);
+
+    /// Destroy this object.  The behavior is undefined if `tryEnter` calls
+    /// are not matched by `leave` calls.
+    ~AtomicGate();
+
+    // MANIPULATORS
+
+    /// Close the gate and wait for all `tryEnter` calls to be matched by
+    /// `leave` calls.  The behavior is undefined if called more than once
+    /// without an intervening `open` call.
+    void closeAndDrain();
+
+    /// Open the gate.  Undo `closeAndDrain`.
+    void open();
+
+    /// Return true if `closeAndDrain` has not been called, and increment
+    /// the internal counter.
+    bool tryEnter();
+
+    /// Undo `tryEnter`.  The behavior is undefined if `tryEnter` has
+    /// returned `false`, or if called more than once per successful
+    /// `tryEnter`.
+    void leave();
+};
+
+// ================
+// class GateKeeper
+// ================
+
+/// @brief RAII wrapper around `AtomicGate`.
+///
+/// This mechanism is a wrapper around `AtomicGate` allowing `tryEnter` and
+/// `leave` using RAII (`Status`). `open` and `close` are not thread-safe
+/// and can be called from the thread maintaining the status, while `Status`
+/// (`tryEnter`/`leave`) is thread-safe and can be called from any thread
+/// attempting to `enter` the gate.
+class GateKeeper {
+  private:
+    // DATA
+    AtomicGate d_gate;
+    bool       d_isOpen;
+
+  public:
+    // TYPES
+
+    /// RAII wrapper for `AtomicGate::tryEnter` and `AtomicGate::leave`.
+    class Status {
+      private:
+        // DATA
+        AtomicGate& d_gate;
+        bool        d_isOpen;
+
+      private:
+        // NOT IMPLEMENTED
+        Status(const Status& other) BSLS_KEYWORD_DELETED;
+        Status& operator=(const Status& other) BSLS_KEYWORD_DELETED;
+
+      public:
+        // CREATORS
+
+        /// Create a `Status` object that attempts to enter the specified
+        /// `gateKeeper`.  If successful, `isOpen` will return true.
+        explicit Status(GateKeeper& gateKeeper);
+
+        /// Destroy this object.  If `isOpen` returns true, leave the gate.
+        ~Status();
+
+        // ACCESSORS
+
+        /// Return true if the gate was successfully entered.
+        bool isOpen() const;
+    };
+
+  public:
+    // CREATORS
+
+    /// Create a `GateKeeper` object with the gate initially closed.
+    GateKeeper();
+
+    // MANIPULATORS
+
+    /// Open the gate.  Has no effect if the gate is already open.
+    void open();
+
+    /// Close the gate and wait for all outstanding `Status` objects to be
+    /// destroyed.  Has no effect if the gate is already closed.
+    void close();
+};
+
+// ============================================================================
+//                             INLINE DEFINITIONS
+// ============================================================================
+
+// ----------------
+// class AtomicGate
+// ----------------
+
+inline AtomicGate::AtomicGate(bool isOpen)
+: d_value(isOpen ? e_INIT : e_CLOSE)
+{
+    // NOTHING
+}
+
+inline AtomicGate::~AtomicGate()
+{
+    BSLS_ASSERT_SAFE(d_value <= e_CLOSE);
+}
+
+inline bool AtomicGate::tryEnter()
+{
+    const int result = d_value.add(e_ENTER);
+
+    if (result & e_CLOSE) {
+        d_value.subtract(e_ENTER);
+        return false;  // RETURN
+    }
+    else {
+        return true;  // RETURN
+    }
+}
+
+inline void AtomicGate::open()
+{
+    BSLA_MAYBE_UNUSED const int result = d_value.subtract(e_CLOSE);
+
+    BSLS_ASSERT_SAFE(result >= e_INIT);
+    BSLS_ASSERT_SAFE((result & e_CLOSE) == 0);
+}
+
+inline void AtomicGate::leave()
+{
+    BSLA_MAYBE_UNUSED const int result = d_value.subtract(e_ENTER);
+
+    BSLS_ASSERT_SAFE(result >= e_INIT);
+}
+
+// ------------------------
+// class GateKeeper::Status
+// ------------------------
+
+inline GateKeeper::Status::Status(GateKeeper& gateKeeper)
+: d_gate(gateKeeper.d_gate)
+, d_isOpen(d_gate.tryEnter())
+{
+    // NOTHING
+}
+
+inline GateKeeper::Status::~Status()
+{
+    if (d_isOpen) {
+        d_gate.leave();
+    }
+}
+
+inline bool GateKeeper::Status::isOpen() const
+{
+    return d_isOpen;
+}
+
+// ----------------
+// class GateKeeper
+// ----------------
+
+inline GateKeeper::GateKeeper()
+: d_gate(false)
+, d_isOpen(false)
+{
+    // NOTHING
+}
+
+inline void GateKeeper::open()
+{
+    if (!d_isOpen) {
+        d_isOpen = true;
+        d_gate.open();
+    }
+}
+
+inline void GateKeeper::close()
+{
+    if (d_isOpen) {
+        d_isOpen = false;
+        d_gate.closeAndDrain();
+    }
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqu/bmqu_atomicgate.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_atomicgate.t.cpp
@@ -1,0 +1,312 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqu_atomicgate.t.cpp                                              -*-C++-*-
+#include <bmqu_atomicgate.h>
+
+// BDE
+#include <bdlf_bind.h>
+#include <bslmt_semaphore.h>
+#include <bslmt_threadutil.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+namespace {
+
+void enterThreadFn(bmqu::AtomicGate* gate,
+                   bslmt::Semaphore* startSemaphore,
+                   bslmt::Semaphore* doneSemaphore)
+{
+    const int k_NUM_ITERATIONS = 1000;
+
+    startSemaphore->post();
+
+    for (int i = 0; i < k_NUM_ITERATIONS; ++i) {
+        BMQTST_ASSERT(gate->tryEnter());
+        gate->leave();
+    }
+
+    doneSemaphore->post();
+
+    // After this point, the gate might be closed at any moment.
+    // Continue execution until we see that the gate is closed:
+    while (true) {
+        if (gate->tryEnter()) {
+            gate->leave();
+        }
+        else {
+            break;
+        }
+    }
+}
+
+void gateKeeperThreadFn(bmqu::GateKeeper* gateKeeper,
+                        bslmt::Semaphore* startSemaphore,
+                        bslmt::Semaphore* doneSemaphore)
+{
+    const int k_NUM_ITERATIONS = 1000;
+
+    startSemaphore->post();
+
+    for (int i = 0; i < k_NUM_ITERATIONS; ++i) {
+        bmqu::GateKeeper::Status status(*gateKeeper);
+        BMQTST_ASSERT(status.isOpen());
+    }
+
+    doneSemaphore->post();
+
+    // After this point, the gate might be closed at any moment.
+    // Continue execution until we see that the gate is closed:
+    while (true) {
+        bmqu::GateKeeper::Status status(*gateKeeper);
+        if (!status.isOpen()) {
+            break;
+        }
+    }
+}
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_atomicGate_breathingTest()
+{
+    // ------------------------------------------------------------------------
+    //
+    // BREATHING TEST - AtomicGate
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("BREATHING TEST - AtomicGate");
+
+    // Test open gate
+    {
+        bmqu::AtomicGate gate(true);  // open
+        BMQTST_ASSERT_EQ(gate.tryEnter(), true);
+        gate.leave();
+    }
+
+    // Test closed gate
+    {
+        bmqu::AtomicGate gate(false);  // closed
+        BMQTST_ASSERT_EQ(gate.tryEnter(), false);
+    }
+}
+
+static void test2_atomicGate_openCloseSequence()
+{
+    // ------------------------------------------------------------------------
+    //
+    // Test open/close sequence
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("OPEN/CLOSE SEQUENCE");
+
+    bmqu::AtomicGate gate(false);  // closed
+
+    // Try to enter closed gate
+    BMQTST_ASSERT_EQ(gate.tryEnter(), false);
+
+    // Open the gate
+    gate.open();
+
+    // Now should be able to enter
+    BMQTST_ASSERT_EQ(gate.tryEnter(), true);
+    gate.leave();
+
+    // Close and drain
+    gate.closeAndDrain();
+
+    // Should not be able to enter
+    BMQTST_ASSERT_EQ(gate.tryEnter(), false);
+}
+
+static void test3_atomicGate_closeAndDrain()
+{
+    // ------------------------------------------------------------------------
+    //
+    // Test closeAndDrain waits for leave
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("CLOSE AND DRAIN");
+
+    bmqu::AtomicGate          gate(true);  // open
+    bslmt::Semaphore          startSemaphore;
+    bslmt::Semaphore          doneSemaphore;
+    bslmt::ThreadUtil::Handle threadHandle;
+
+    // Enter the gate
+    BMQTST_ASSERT_EQ(gate.tryEnter(), true);
+
+    // Start a thread that will also try to enter
+    bslmt::ThreadUtil::createWithAllocator(
+        &threadHandle,
+        bdlf::BindUtil::bind(&enterThreadFn,
+                             &gate,
+                             &startSemaphore,
+                             &doneSemaphore),
+        bmqtst::TestHelperUtil::allocator());
+
+    // Wait for thread to start
+    startSemaphore.wait();
+
+    // Wait until thread performs the minimum work
+    doneSemaphore.wait();
+
+    // Release this thread's gate usage
+    gate.leave();
+
+    // This should break the loop in the thread function
+    gate.closeAndDrain();
+
+    // Join thread
+    bslmt::ThreadUtil::join(threadHandle);
+}
+
+static void test4_gateKeeper_breathingTest()
+{
+    // ------------------------------------------------------------------------
+    //
+    // BREATHING TEST - GateKeeper
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("BREATHING TEST - GateKeeper");
+
+    bmqu::GateKeeper gateKeeper;
+
+    // Gate starts closed
+    {
+        bmqu::GateKeeper::Status status(gateKeeper);
+        BMQTST_ASSERT_EQ(status.isOpen(), false);
+    }
+
+    // Open the gate
+    gateKeeper.open();
+    {
+        bmqu::GateKeeper::Status status(gateKeeper);
+        BMQTST_ASSERT_EQ(status.isOpen(), true);
+    }
+
+    // Close the gate
+    gateKeeper.close();
+    {
+        bmqu::GateKeeper::Status status(gateKeeper);
+        BMQTST_ASSERT_EQ(status.isOpen(), false);
+    }
+}
+
+static void test5_gateKeeper_multipleOpen()
+{
+    // ------------------------------------------------------------------------
+    //
+    // Test multiple open/close calls
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("MULTIPLE OPEN/CLOSE");
+
+    bmqu::GateKeeper gateKeeper;
+
+    // Multiple open calls should be safe
+    gateKeeper.open();
+    gateKeeper.open();  // no-op
+
+    {
+        bmqu::GateKeeper::Status status(gateKeeper);
+        BMQTST_ASSERT_EQ(status.isOpen(), true);
+    }
+
+    // Multiple close calls should be safe
+    gateKeeper.close();
+    gateKeeper.close();  // no-op
+
+    {
+        bmqu::GateKeeper::Status status(gateKeeper);
+        BMQTST_ASSERT_EQ(status.isOpen(), false);
+    }
+}
+
+static void test6_gateKeeper_threadSafety()
+{
+    // ------------------------------------------------------------------------
+    //
+    // Test GateKeeper thread safety
+    //
+    // ------------------------------------------------------------------------
+
+    bmqtst::TestHelper::printTestName("GATEKEEPER THREAD SAFETY");
+
+    bmqu::GateKeeper          gateKeeper;
+    bslmt::Semaphore          startSemaphore;
+    bslmt::Semaphore          doneSemaphore;
+    bslmt::ThreadUtil::Handle threadHandle;
+
+    gateKeeper.open();
+
+    // Start a thread that will try to enter
+    bslmt::ThreadUtil::createWithAllocator(
+        &threadHandle,
+        bdlf::BindUtil::bind(&gateKeeperThreadFn,
+                             &gateKeeper,
+                             &startSemaphore,
+                             &doneSemaphore),
+        bmqtst::TestHelperUtil::allocator());
+
+    // Wait for thread to start
+    startSemaphore.wait();
+
+    // Wait until thread performs the minimum work
+    doneSemaphore.wait();
+
+    // This should break the loop in the thread function
+    gateKeeper.close();
+
+    bslmt::ThreadUtil::join(threadHandle);
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+
+    switch (_testCase) {
+    case 0:
+    case 1: test1_atomicGate_breathingTest(); break;
+    case 2: test2_atomicGate_openCloseSequence(); break;
+    case 3: test3_atomicGate_closeAndDrain(); break;
+    case 4: test4_gateKeeper_breathingTest(); break;
+    case 5: test5_gateKeeper_multipleOpen(); break;
+    case 6: test6_gateKeeper_threadSafety(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqu/package/bmqu.mem
+++ b/src/groups/bmq/bmqu/package/bmqu.mem
@@ -1,4 +1,5 @@
 bmqu_alignedprinter
+bmqu_atomicgate
 bmqu_atomicstate
 bmqu_atomicvalidator
 bmqu_blob

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -1285,7 +1285,7 @@ Cluster::sendConfirmInline(int                         partitionId,
         return mqbi::InlineResult::e_INVALID_PARTITION;  // RETURN
     }
 
-    mqbc::GateKeeper::Status primaryStatus(d_state.gatePrimary(partitionId));
+    bmqu::GateKeeper::Status primaryStatus(d_state.gatePrimary(partitionId));
 
     if (!primaryStatus.isOpen()) {
         return mqbi::InlineResult::e_INVALID_PRIMARY;  // RETURN
@@ -1297,7 +1297,7 @@ Cluster::sendConfirmInline(int                         partitionId,
     mqbc::ClusterNodeSession*        ns    = pinfo.primaryNodeSession();
     BSLS_ASSERT_SAFE(ns);
 
-    mqbc::GateKeeper::Status nodeStatus(ns->gateConfirm());
+    bmqu::GateKeeper::Status nodeStatus(ns->gateConfirm());
 
     if (!nodeStatus.isOpen()) {
         return mqbi::InlineResult::e_UNAVAILABLE;  // RETURN
@@ -1349,7 +1349,7 @@ Cluster::sendPutInline(int                                 partitionId,
         return mqbi::InlineResult::e_INVALID_PARTITION;  // RETURN
     }
 
-    mqbc::GateKeeper::Status primaryStatus(d_state.gatePrimary(partitionId));
+    bmqu::GateKeeper::Status primaryStatus(d_state.gatePrimary(partitionId));
 
     if (!primaryStatus.isOpen()) {
         return mqbi::InlineResult::e_INVALID_PRIMARY;  // RETURN
@@ -1373,7 +1373,7 @@ Cluster::sendPutInline(int                                 partitionId,
 
     BSLS_ASSERT_SAFE(primaryNodeSession);
 
-    mqbc::GateKeeper::Status nodeStatus(primaryNodeSession->gatePut());
+    bmqu::GateKeeper::Status nodeStatus(primaryNodeSession->gatePut());
 
     if (!nodeStatus.isOpen()) {
         // This checks both self status and the destination status

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -1159,7 +1159,7 @@ ClusterProxy::sendConfirmInline(BSLA_UNUSED int             partitionId,
     // This event is invoked as a result of RemoteQueue asking cluster proxy to
     // relay CONFIRM message to cluster on it's behalf.
 
-    mqbc::GateKeeper::Status primaryStatus(d_gateActiveNode);
+    bmqu::GateKeeper::Status primaryStatus(d_gateActiveNode);
 
     if (!primaryStatus.isOpen()) {
         return mqbi::InlineResult::e_INVALID_PRIMARY;  // RETURN
@@ -1199,7 +1199,7 @@ mqbi::InlineResult::Enum ClusterProxy::sendPutInline(
     // This event is invoked as a result of RemoteQueue asking cluster proxy to
     // relay CONFIRM message to cluster on it's behalf.
 
-    mqbc::GateKeeper::Status primaryStatus(d_gateActiveNode);
+    bmqu::GateKeeper::Status primaryStatus(d_gateActiveNode);
 
     if (!primaryStatus.isOpen()) {
         return mqbi::InlineResult::e_INVALID_PRIMARY;  // RETURN

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -66,6 +66,7 @@
 
 #include <bmqio_status.h>
 #include <bmqst_statcontext.h>
+#include <bmqu_atomicgate.h>
 #include <bmqu_operationchain.h>
 #include <bmqu_throttledaction.h>
 
@@ -240,11 +241,11 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
 
     mqbnet::ClusterNode* d_activeNode_p;
     // Protected by d_gateActiveNode - it is safe to use while
-    // 'mqbc::GateKeeper::Status(d_gateActiveNode).isOpen()'
+    // 'bmqu::GateKeeper::Status(d_gateActiveNode).isOpen()'
     // 'd_activeNodeManager.activeNode()' does not provide such guarantee.
     // Also, updated after 'd_clusterData.electorInfo().setElectorInfo'
 
-    mqbc::GateKeeper d_gateActiveNode;
+    bmqu::GateKeeper d_gateActiveNode;
 
   private:
     // PRIVATE MANIPULATORS

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
@@ -210,7 +210,7 @@ mqbi::InlineResult::Enum ClusterNodeSession::sendPush(
     // payload, and so, primary (this node) sends only the guid and, if
     // applicable, the associated subQueueIds.
 
-    GateKeeper::Status status(d_gatePush);
+    bmqu::GateKeeper::Status status(d_gatePush);
 
     if (!status.isOpen()) {
         // Target node (or self) is not AVAILABLE, so we don't send this PUSH
@@ -267,7 +267,7 @@ ClusterNodeSession::sendAck(int queueId, const bmqp::AckMessage& ackMessage)
     // This ACK message is enqueued by mqbblp::Queue on this node, and needs to
     // be forwarded to 'clusterNode()' (the replica node).
 
-    GateKeeper::Status status(d_gateAck);
+    bmqu::GateKeeper::Status status(d_gateAck);
 
     if (!status.isOpen()) {
         // Drop the ACK because downstream node (or self) is either starting,

--- a/src/groups/mqb/mqbc/mqbc_clusterstate.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstate.h
@@ -567,7 +567,7 @@ class ClusterState {
     /// Observers of the cluster state.
     ObserversSet d_observers;
 
-    bsl::vector<GateKeeper> d_gatePrimary;
+    bsl::vector<bmqu::GateKeeper> d_gatePrimary;
 
     PartitionIdExtractor d_partitionIdExtractor;
 
@@ -697,7 +697,7 @@ class ClusterState {
     /// Clear this cluster state object, without firing any observers.
     void clear();
 
-    GateKeeper& gatePrimary(int partitionId);
+    bmqu::GateKeeper& gatePrimary(int partitionId);
 
     /// TODO (FSM); remove after switching to FSM
     bool cacheDoubleAssignment(const bmqt::Uri& uri, int partitionId);
@@ -1062,7 +1062,7 @@ inline ClusterState::QueueKeys& ClusterState::queueKeys()
     return d_queueKeys;
 }
 
-inline GateKeeper& ClusterState::gatePrimary(int partitionId)
+inline bmqu::GateKeeper& ClusterState::gatePrimary(int partitionId)
 {
     // This assumes thread-safe access to d_gatePrimary vector.
     return d_gatePrimary[partitionId];

--- a/src/groups/mqb/mqbc/package/mqbc.dep
+++ b/src/groups/mqb/mqbc/package/mqbc.dep
@@ -1,3 +1,4 @@
+bmqu
 mqbcfg
 mqbcmd
 mqbconfm


### PR DESCRIPTION
- `AtomicGate`/`GateKeeper` do not belong to cluster node session, they might be a separate component.
- Introduce UTs for these classes.