### PR TITLE
Cleanup[bmqc::MultiQueueThreadPool]: remove unused queue context

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.cpp
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.cpp
@@ -17,36 +17,11 @@
 #include <bmqc_multiqueuethreadpool.h>
 
 #include <bmqscm_version.h>
-// BDE
-#include <bslma_managedptr.h>
 
 namespace BloombergLP {
 namespace bmqc {
 
-// ------------------------------------------
-// class MultiQueueThreadPool_QueueCreatorRet
-// ------------------------------------------
-
-// CREATORS
-MultiQueueThreadPool_QueueCreatorRet::MultiQueueThreadPool_QueueCreatorRet(
-    bslma::Allocator* basicAllocator)
-: d_context_mp()
-, d_name(basicAllocator)
-{
-    // NOTHING
-}
-
-// MANIPULATORS
-bslma::ManagedPtr<void>& MultiQueueThreadPool_QueueCreatorRet::context()
-{
-    return d_context_mp;
-}
-
-// ACCESSORS
-const bsl::string& MultiQueueThreadPool_QueueCreatorRet::name()
-{
-    return d_name;
-}
+// NOTHING
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -222,15 +222,13 @@ int Dispatcher::startContext(bsl::ostream&                    errorDescription,
                              this,
                              type,
                              bdlf::PlaceHolders::_1,   // processorId
-                             bdlf::PlaceHolders::_2,   // context*
-                             bdlf::PlaceHolders::_3),  // event*
+                             bdlf::PlaceHolders::_2),  // event*
         bdlf::BindUtil::bind(&Dispatcher::queueCreator,
                              this,
                              type,
                              config.processorConfig(),
-                             bdlf::PlaceHolders::_1,   // qCreatorRet*
-                             bdlf::PlaceHolders::_2,   // processorId
-                             bdlf::PlaceHolders::_3),  // allocator*
+                             bdlf::PlaceHolders::_1,   // processorId
+                             bdlf::PlaceHolders::_2),  // allocator*
         d_allocator_p);
 
     processorPoolConfig.setName(mqbi::DispatcherClientType::toAscii(type))
@@ -262,7 +260,6 @@ int Dispatcher::startContext(bsl::ostream&                    errorDescription,
 Dispatcher::ProcessorPool::Queue*
 Dispatcher::queueCreator(mqbi::DispatcherClientType::Enum             type,
                          const mqbcfg::DispatcherProcessorParameters& config,
-                         BSLA_UNUSED ProcessorPool::QueueCreatorRet* ret,
                          int               processorId,
                          bslma::Allocator* allocator)
 {
@@ -290,7 +287,6 @@ Dispatcher::queueCreator(mqbi::DispatcherClientType::Enum             type,
 
 void Dispatcher::queueEventCb(mqbi::DispatcherClientType::Enum type,
                               int                              processorId,
-                              BSLA_UNUSED void*                context,
                               const ProcessorPool::EventSp&    event)
 {
     if (event) {

--- a/src/groups/mqb/mqba/mqba_dispatcher.h
+++ b/src/groups/mqb/mqba/mqba_dispatcher.h
@@ -312,22 +312,18 @@ class Dispatcher BSLS_KEYWORD_FINAL : public mqbi::Dispatcher {
     /// Create a queue for the multi-fixed queue thread pool in charge of
     /// dispatcher client of the specified `type` and using the specified
     /// `config`.  This queue corresponds to the specified `processorId` and
-    /// the specified `allocator` should be used to create it.  The
-    /// specified `ret` can be used to set a context for the queue.
+    /// the specified `allocator` should be used to create it.
     ProcessorPool::Queue*
     queueCreator(mqbi::DispatcherClientType::Enum             type,
                  const mqbcfg::DispatcherProcessorParameters& config,
-                 ProcessorPool::QueueCreatorRet*              ret,
                  int                                          processorId,
                  bslma::Allocator*                            allocator);
 
-    /// Callback when a new object in the specified `event` and having the
-    /// specified associated `context` is dispatched for the queue in charge of
-    /// dispatcher client of the specified `type`, having the specified
-    /// `processorId`.
+    /// Callback when a new object in the specified `event` is dispatched
+    /// for the queue in charge of dispatcher client of the specified `type`,
+    /// having the specified `processorId`.
     void queueEventCb(mqbi::DispatcherClientType::Enum type,
                       int                              processorId,
-                      void*                            context,
                       const ProcessorPool::EventSp&    event);
 
     /// Flush clients of the specified `type` for the specified


### PR DESCRIPTION
`MultiQueueThreadPool_QueueCreatorRet` is never populated and never used in `mqba::Dispatcher`. It is also marked as `BSLA_UNUSED`. We don't want to provide it on any dispatcher queue event, and the interface can be simplified.