### PR TITLE
Refactor[build-darwin]: Remove support for Intel Darwin systems

### DIFF
--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -140,14 +140,8 @@ if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     touch "${DIR_BUILD}/ntf/.complete"
 fi
 
-# Determine paths based on Intel vs Apple Silicon CPU
-if [ "$(uname -p)" == 'arm' ]; then
-    BREW_PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/zlib/lib/pkgconfig:/opt/homebrew/opt/googletest/lib/pkgconfig"
-    FLEX_ROOT="/opt/homebrew/opt/flex"
-else
-    BREW_PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:/usr/local/opt/zlib/lib/pkgconfig:/usr/local/opt/googletest/lib/pkgconfig"
-    FLEX_ROOT="/usr/local/opt/flex"
-fi
+BREW_PKG_CONFIG_PATH="/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/zlib/lib/pkgconfig:/opt/homebrew/opt/googletest/lib/pkgconfig"
+FLEX_ROOT="/opt/homebrew/opt/flex"
 
 
 # :: Build the BlazingMQ repo :::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
We do not test Intel Macs anymore, so we might as well drop support and clean up this branch.  This will make it a little easier for us to use CMakePresets in this script as well.