### PR TITLE
CI[macox] Improve OSX Build Job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -258,7 +258,9 @@ jobs:
         env:
           CXXFLAGS: "-Wno-poison-system-directories"
         run: |
+          echo "::add-matcher::.github/workflows/problem-matchers/cpp.json"
           bin/build-darwin.sh
+          echo "::remove-matcher owner=cpp"
 
   build_and_test_bmqprometheus_plugin:
     name: "Build Prometheus plugin [ubuntu]"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -255,7 +255,8 @@ jobs:
             zlib
 
       - name: Build BlazingMQ
-
+        env:
+          CXXFLAGS: "-Wno-poison-system-directories"
         run: |
           bin/build-darwin.sh
 

--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -114,29 +114,38 @@ fi
 PATH="${DIR_THIRDPARTY}/bde-tools/bin:$PATH"
 
 if [ ! -e "${DIR_BUILD}/bde/.complete" ]; then
-    pushd "${DIR_THIRDPARTY}/bde"
-    eval "$(bbs_build_env -p clang -u opt_64_cpp17 -b "${DIR_BUILD}/bde" -i "${DIR_INSTALL}")"
-    bbs_build configure --prefix="${DIR_INSTALL}"
-    bbs_build build --prefix="${DIR_INSTALL}"
-    bbs_build install --install_dir="/" --prefix="${DIR_INSTALL}"
-    eval "$(bbs_build_env unset)"
-    popd
+    # Build and install BDE
+    (
+        # Suppress warnings from BDE build (scoped to this subshell)
+        # shellcheck disable=SC2030
+        export CXXFLAGS="-w" CFLAGS="-w"
+        cd "${DIR_THIRDPARTY}/bde"
+        eval "$(bbs_build_env -p clang -u opt_64_cpp17 -b "${DIR_BUILD}/bde" -i "${DIR_INSTALL}")"
+        bbs_build configure --prefix="${DIR_INSTALL}"
+        bbs_build build --prefix="${DIR_INSTALL}"
+        bbs_build install --install_dir="/" --prefix="${DIR_INSTALL}"
+        eval "$(bbs_build_env unset)"
+    )
     touch "${DIR_BUILD}/bde/.complete"
 fi
 
 if [ ! -e "${DIR_BUILD}/ntf/.complete" ]; then
     # Build and install NTF
-    pushd "${DIR_THIRDPARTY}/ntf-core"
-    ./configure --prefix "${DIR_INSTALL}" \
-                --output "${DIR_BUILD}/ntf" \
-                --toolchain "${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/darwin/clang-default.cmake" \
-                --without-warnings-as-errors \
-                --without-usage-examples \
-                --without-applications \
-                --ufid opt_64_cpp17
-    make -j 16
-    make install
-    popd
+    (
+        # Suppress warnings from NTF build (scoped to this subshell)
+        # shellcheck disable=SC2031
+        export CXXFLAGS="-w" CFLAGS="-w"
+        cd "${DIR_THIRDPARTY}/ntf-core"
+        ./configure --prefix "${DIR_INSTALL}" \
+                    --output "${DIR_BUILD}/ntf" \
+                    --toolchain "${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/darwin/clang-default.cmake" \
+                    --without-warnings-as-errors \
+                    --without-usage-examples \
+                    --without-applications \
+                    --ufid opt_64_cpp17
+        make -j 16
+        make install
+    )
     touch "${DIR_BUILD}/ntf/.complete"
 fi
 


### PR DESCRIPTION
This pull request improves the OSX build job, by silencing any build warnings from building BDE and NTF (which are not ours to fix), suppressing a very noisy cross-compilation warning that is shown on every translation unit, and adding GitHub annotations for warnings and errors from the clang/OSX workflow.