### PR TITLE
Fix[cmake]: Remove `bmqu` from `mqbc` deps

### DIFF
--- a/src/groups/mqb/mqbc/package/mqbc.dep
+++ b/src/groups/mqb/mqbc/package/mqbc.dep
@@ -1,4 +1,3 @@
-bmqu
 mqbcfg
 mqbcmd
 mqbconfm


### PR DESCRIPTION
During CMake configuration time, we get this warning:

    CMake Warning at thirdparty/bde-tools/BdeBuildSystem/BdeMetadataUtils.cmake:188 (message):
      Package "mqbc" has "bmqu" dependency outside of package group
      (mqba;mqbauthn;mqbblp;mqbc;mqbcfg;mqbcmd;mqbconfm;mqbi;mqbmock;mqbnet;mqbplug;mqbs;mqbscm;mqbsi;mqbsl;mqbstat;mqbu).
      Check mqbc/package/mqbc.dep file.

The package group `mqb` already depends on the package group `bmq`, so we do not need this extra package-level dependency.  This patch removes it, fixing this warning.
