### PR TITLE
Fix[mqbs::FileStore]: cancel scheduled events on destruction

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5313,8 +5313,6 @@ void FileStore::close(bool flush)
     d_flushWhenClosing   = flush;
     d_lastSyncPtReceived = false;
 
-    // Ok to ignore rc above
-
     BALL_LOG_INFO << partitionDesc() << "Closing partition. ";
 
     // Clear 'd_records' so that gc logic is invoked on all mapped data files.


### PR DESCRIPTION
ASAN found that `issueSyncPointCb` might be executed just when we destruct `FileStore`.

We have `cancelTimersAndWait` call here, but it is not enough:
https://github.com/bloomberg/blazingmq/blob/09ed7e66644728f1b4f0b9f81285621bcd5b853f/src/groups/mqb/mqbc/mqbc_storageutil.cpp#L3364

east1            19:36:22.523 (139873260402368) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:130     #1 0x55d884ec5354 in BloombergLP::bsls::AtomicBool::operator bool() const /opt/bb/include/bsls_atomic.h:2433:12

east1            19:36:22.523 (139873260402368) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:130     #2 0x55d8860ba0a2 in BloombergLP::mqbs::FileStore::issueSyncPointCb() /blazingmq/src/groups/mqb/mqbs/mqbs_filestore.cpp:3831:10

east1            19:36:22.523 (139873260402368) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:130     #3 0x55d885a2144a in void BloombergLP::bdlf::MemFn<void (BloombergLP::mqbs::FileStore::*)()>::operator()<BloombergLP::mqbs::FileStore*>(BloombergLP::mqbs::FileStore* const&) const /opt/bb/include/bdlf_memfn.h:557:16

east1            19:36:22.524 (139873260402368) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:130     #4 0x55d885a21348 in void BloombergLP::bdlf::Bind_Invoker<void, 1>::invoke<BloombergLP::bdlf::MemFn<void (BloombergLP::mqbs::FileStore::*)()> const, BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbs::FileStore*> const, BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::MemFn<void (BloombergLP::mqbs::FileStore::*)()> const*, BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbs::FileStore*> const*, BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:8610:9
