### PR TITLE
Style: Fix badly formatted enumerations

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
@@ -290,16 +290,14 @@ class MultiQueueThreadPool BSLS_KEYWORD_FINAL {
   private:
     // PRIVATE TYPES
     enum MonitorEventState {
-        e_MONITOR_PENDING  // an event has been enqueued on the queue but the
-                           // next 'processMonitorEvents' hasn't been called
-                           // yet
-
-        ,
-        e_MONITOR_PROCESSED  // a monitor event has been processed by the queue
-
-        ,
-        e_MONITOR_STUCK  // the queue hasn't processed its event in at
-                         // least one timeout interval
+        /// An event has been enqueued on the queue but the next
+        /// `processMonitorEvents` hasn't been called yet
+        e_MONITOR_PENDING,
+        /// A monitor event has been processed by the queue
+        e_MONITOR_PROCESSED,
+        // the queue hasn't processed its event in at least one timeout
+        // interval
+        e_MONITOR_STUCK
     };
 
     struct QueueInfo {

--- a/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmap.h
@@ -492,9 +492,10 @@ class OrderedHashMap {
     typedef OrderedHashMap_Bucket          Bucket;
 
     enum {
-        e_NODE_SIZE = sizeof(Node)  // For NodePool
-        ,
-        e_INITIAL_NUM_BUCKET = 13  // Must be prime
+        /// For NodePool
+        e_NODE_SIZE = sizeof(Node),
+        /// Must be prime
+        e_INITIAL_NUM_BUCKET = 13
     };
 
   public:

--- a/src/groups/bmq/bmqc/bmqc_twokeyhashmap.h
+++ b/src/groups/bmq/bmqc/bmqc_twokeyhashmap.h
@@ -241,20 +241,22 @@ class TwoKeyHashMap {
     enum KeyIndex {
         // Defines a numeric type to be used as the key index.
 
-        e_FIRST_KEY = 1  // ALWAYS 1
-        ,
-        e_SECOND_KEY = 2  // ALWAYS 2
+        /// ALWAYS 1
+        e_FIRST_KEY = 1,
+        /// ALWAYS 2
+        e_SECOND_KEY = 2
     };
 
     enum InsertResult {
         // Defines a numeric type to be used as the result of the 'insert()'
         // member function.
 
-        e_INSERTED = 0  // ALWAYS 0
-        ,
-        e_FIRST_KEY_EXISTS = 1  // ALWAYS 1
-        ,
-        e_SECOND_KEY_EXISTS = 2  // ALWAYS 2
+        /// ALWAYS 0
+        e_INSERTED = 0,
+        /// ALWAYS 1
+        e_FIRST_KEY_EXISTS = 1,
+        /// ALWAYS 2
+        e_SECOND_KEY_EXISTS = 2
     };
 
     typedef K1                                first_key_type;

--- a/src/groups/bmq/bmqex/bmqex_future.h
+++ b/src/groups/bmq/bmqex/bmqex_future.h
@@ -417,9 +417,10 @@ class Future_Callback {
 /// functions of `bmqex::Future` and `bmqex::FutureSharedState`.
 struct FutureStatus {
     enum Enum {
-        e_READY  // the shared state is ready
-        ,
-        e_TIMEOUT  // the shared state did not become ready before timeout
+        /// the shared state is ready
+        e_READY,
+        /// the shared state did not become ready before timeout
+        e_TIMEOUT
     };
 };
 
@@ -839,16 +840,16 @@ class FutureSharedState {
   private:
     // PRIVATE TYPES
     enum State {
-        e_NOT_READY = 0  // shared state not ready
-        ,
-        e_READY_VALUE = 1  // shared state contains a value
+        /// shared state not ready
+        e_NOT_READY = 0,
+        /// shared state contains a value
+        e_READY_VALUE = 1,
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
-        ,
-        e_READY_EXCEPTION_PTR =
-            2  // shared state contains an exception pointer
+        /// shared state contains an exception pointer
+        e_READY_EXCEPTION_PTR = 2,
 #endif
-        ,
-        e_READY_EXCEPTION_OBJ = 3  // shared state contains an exception object
+        /// shared state contains an exception object
+        e_READY_EXCEPTION_OBJ = 3
     };
 
     typedef typename bsl::remove_const<R>::type ValueType;

--- a/src/groups/bmq/bmqex/bmqex_future_cpp03.h
+++ b/src/groups/bmq/bmqex/bmqex_future_cpp03.h
@@ -302,9 +302,10 @@ class Future_Callback {
 /// functions of `bmqex::Future` and `bmqex::FutureSharedState`.
 struct FutureStatus {
     enum Enum {
-        e_READY  // the shared state is ready
-        ,
-        e_TIMEOUT  // the shared state did not become ready before timeout
+        /// the shared state is ready
+        e_READY,
+        /// the shared state did not become ready before timeout
+        e_TIMEOUT
     };
 };
 
@@ -724,16 +725,16 @@ class FutureSharedState {
   private:
     // PRIVATE TYPES
     enum State {
-        e_NOT_READY = 0  // shared state not ready
-        ,
-        e_READY_VALUE = 1  // shared state contains a value
+        /// shared state not ready
+        e_NOT_READY = 0,
+        /// shared state contains a value
+        e_READY_VALUE = 1,
 #ifdef BSLS_LIBRARYFEATURES_HAS_CPP11_EXCEPTION_HANDLING
-        ,
-        e_READY_EXCEPTION_PTR =
-            2  // shared state contains an exception pointer
+        /// shared state contains an exception pointer
+        e_READY_EXCEPTION_PTR = 2,
 #endif
-        ,
-        e_READY_EXCEPTION_OBJ = 3  // shared state contains an exception object
+        /// shared state contains an exception object
+        e_READY_EXCEPTION_OBJ = 3
     };
 
     typedef typename bsl::remove_const<R>::type ValueType;

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.h
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.h
@@ -148,21 +148,20 @@ class BrokerSession BSLS_CPP11_FINAL {
     struct State {
         // TYPES
         enum Enum {
-            e_STARTING = 0  // The session has been started, but the
-                            // channel is not yet connected
-            ,
-            e_STARTED = 1  // The session is started
-            ,
-            e_RECONNECTING = 2  // The connection is lost without user
-                                // request
-            ,
-            e_CLOSING_SESSION = 3  // The disconnect request is sent to the
-                                   // broker, waiting for the response
-            ,
-            e_CLOSING_CHANNEL = 4  // The channel is closing, waiting for the
-                                   // operation to complete
-            ,
-            e_STOPPED = 5  // The session is stopped
+            /// The session has been started, but the channel is not yet
+            /// connected
+            e_STARTING = 0,
+            /// The session is started
+            e_STARTED = 1,
+            /// The connection is lost without user request
+            e_RECONNECTING = 2,
+            /// The disconnect request is sent to the broker, waiting for the
+            /// response
+            e_CLOSING_SESSION = 3,
+            /// The channel is closing, waiting for the operation to complete
+            e_CLOSING_CHANNEL = 4,
+            /// The session is stopped
+            e_STOPPED = 5
         };
 
         // CLASS METHODS
@@ -194,27 +193,28 @@ class BrokerSession BSLS_CPP11_FINAL {
     struct FsmEvent {
         // TYPES
         enum Enum {
-            e_START = 0  // User start request
-            ,
-            e_START_FAILURE = 1  // Session start has failed
-            ,
-            e_START_TIMEOUT = 2  // Session start timeout
-            ,
-            e_STOP = 3  // User stop request
-            ,
-            e_CHANNEL_UP = 4  // Network channel is up
-            ,
-            e_CHANNEL_DOWN = 5  // Network channel is down
-            ,
-            e_SESSION_DOWN = 6  // BlazingMQ broker is disconnected
+            /// User start request
+            e_START = 0,
+            /// Session start has failed
+            e_START_FAILURE = 1,
+            /// Session start timeout
+            e_START_TIMEOUT = 2,
+            /// User stop request
+            e_STOP = 3,
+            /// Network channel is up
+            e_CHANNEL_UP = 4,
+            /// Network channel is down
+            e_CHANNEL_DOWN = 5,
+            /// BlazingMQ broker is disconnected
+            e_SESSION_DOWN = 6,
 
             // Host Health events.
-            ,
-            e_HOST_UNHEALTHY = 7  // Host running application is unhealthy
-            ,
-            e_HOST_HEALTHY = 8  // Host has become healthy again
-            ,
-            e_ALL_QUEUES_RESUMED = 9  // All queues have been resumed
+            /// Host running application is unhealthy
+            e_HOST_UNHEALTHY = 7,
+            /// Host has become healthy again
+            e_HOST_HEALTHY = 8,
+            /// All queues have been resumed
+            e_ALL_QUEUES_RESUMED = 9
         };
 
         // CLASS METHODS
@@ -258,38 +258,38 @@ class BrokerSession BSLS_CPP11_FINAL {
     struct QueueFsmEvent {
         // TYPES
         enum Enum {
-            e_OPEN_CMD = 1  // Open queue request
-            ,
-            e_CONFIG_CMD = 2  // Configure queue request
-            ,
-            e_CLOSE_CMD = 3  // Close queue request
-            ,
-            e_REQ_NOT_SENT = 4  // Request is not sent to the broker
-            ,
-            e_RESP_OK = 5  // Successful response
-            ,
-            e_LATE_RESP = 6  // Late response
-            ,
-            e_RESP_BAD = 7  // Response with error
-            ,
-            e_RESP_TIMEOUT = 8  // Response timeout
-            ,
-            e_RESP_EXPIRED = 9  // Response timeout when channel is down
-            ,
-            e_CHANNEL_DOWN = 10  // Network channel is down
-            ,
-            e_CHANNEL_UP = 11  // Network channel is up
+            /// Open queue request
+            e_OPEN_CMD = 1,
+            /// Configure queue request
+            e_CONFIG_CMD = 2,
+            /// Close queue request
+            e_CLOSE_CMD = 3,
+            /// Request is not sent to the broker
+            e_REQ_NOT_SENT = 4,
+            /// Successful response
+            e_RESP_OK = 5,
+            /// Late response
+            e_LATE_RESP = 6,
+            /// Response with error
+            e_RESP_BAD = 7,
+            /// Response timeout
+            e_RESP_TIMEOUT = 8,
+            /// Response timeout when channel is down
+            e_RESP_EXPIRED = 9,
+            /// Network channel is down
+            e_CHANNEL_DOWN = 10,
+            /// Network channel is up
+            e_CHANNEL_UP = 11,
             // Host health events.
-            ,
-            e_SUSPEND = 12  // Queue has been asked to suspend
-            ,
-            e_RESUME = 13  // Queue has been asked to resume
+            /// Queue has been asked to suspend
+            e_SUSPEND = 12,
+            /// Queue has been asked to resume
+            e_RESUME = 13,
             // Locally cancelled.
-            ,
-            e_REQ_CANCELED = 14  // Request is canceled by the SDK
-            ,
-            e_SESSION_DOWN = 15  // Request is canceled due to the session
-                                 // goes down
+            /// Request is canceled by the SDK
+            e_REQ_CANCELED = 14,
+            /// Request is canceled due to the session goes down
+            e_SESSION_DOWN = 15
         };
 
         // CLASS METHODS

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -344,41 +344,43 @@ struct TestSession BSLS_CPP11_FINAL {
     // enumerators:
 
     enum QueueTestStep {
-        e_OPEN_OPENING = 0  // pending open queue request
-        ,
-        e_OPEN_CONFIGURING = 1  // pending config queue request
-        ,
-        e_OPEN_OPENED = 2  // no pending requests
-        ,
-        e_REOPEN_OPENING = 3  // pending open queue request
-        ,
-        e_REOPEN_CONFIGURING = 4  // pending config queue request
-        ,
-        e_REOPEN_REOPENED = 5  // no pending requests
-        ,
-        e_CONFIGURING = 6  // pending config queue request
-        ,
-        e_CONFIGURING_RECONFIGURING = 7  // pending config queue request
-        ,
-        e_CONFIGURED = 8  // no pending requests
-        ,
-        e_CLOSE_CONFIGURING = 9  // pending config queue request
-        ,
-        e_CLOSE_CLOSING = 10  // pending close queue request
-        ,
-        e_CLOSE_CLOSED = 11  // no pending requests
+        /// pending open queue request
+        e_OPEN_OPENING = 0,
+        /// pending config queue request
+        e_OPEN_CONFIGURING = 1,
+        /// no pending requests
+        e_OPEN_OPENED = 2,
+        /// pending open queue request
+        e_REOPEN_OPENING = 3,
+        /// pending config queue request
+        e_REOPEN_CONFIGURING = 4,
+        /// no pending requests
+        e_REOPEN_REOPENED = 5,
+        /// pending config queue request
+        e_CONFIGURING = 6,
+        /// pending config queue request
+        e_CONFIGURING_RECONFIGURING = 7,
+        /// no pending requests
+        e_CONFIGURED = 8,
+        /// pending config queue request
+        e_CLOSE_CONFIGURING = 9,
+        /// pending close queue request
+        e_CLOSE_CLOSING = 10,
+        /// no pending requests
+        e_CLOSE_CLOSED = 11
     };
 
     enum LateResponseTestStep {
-        e_LATE_OPEN_OPENING = 0  // late open 1st part respose
-        ,
-        e_LATE_OPEN_CONFIGURING_CFG = 1  // late open 2nd part respose
-        ,
-        e_LATE_RECONFIGURING = 2  // expired reconfigure request
-        ,
-        e_LATE_CLOSE_CONFIGURING = 3  // late close 1st part response
-        ,
-        e_LATE_CLOSE_CLOSING = 4  // late close 2st part response
+        /// late open 1st part respose
+        e_LATE_OPEN_OPENING = 0,
+        /// late open 2nd part respose
+        e_LATE_OPEN_CONFIGURING_CFG = 1,
+        /// expired reconfigure request
+        e_LATE_RECONFIGURING = 2,
+        /// late close 1st part response
+        e_LATE_CLOSE_CONFIGURING = 3,
+        /// late close 2st part response
+        e_LATE_CLOSE_CLOSING = 4
     };
 
     typedef bdlcc::Deque<bsl::shared_ptr<bmqimp::Event> > EventQueue;

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -147,15 +147,16 @@ class Event {
     struct EventType {
         // TYPES
         enum Enum {
-            e_UNINITIALIZED  // Uninitialized event
-            ,
-            e_RAW  // Raw event wrapper
-            ,
-            e_SESSION  // Session event
-            ,
-            e_MESSAGE  // Message event
-            ,
-            e_REQUEST  // User request event
+            /// Uninitialized event
+            e_UNINITIALIZED,
+            /// Raw event wrapper
+            e_RAW,
+            /// Session event
+            e_SESSION,
+            /// Message event
+            e_MESSAGE,
+            /// User request event
+            e_REQUEST
         };
     };
 

--- a/src/groups/bmq/bmqimp/bmqimp_eventqueue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventqueue.cpp
@@ -56,9 +56,10 @@ const char k_STAT_NAME[] = "EventQueue";
 
 enum {
     // Index of the different stat values
-    k_STAT_QUEUE = 0  // Queue/Dequeue
-    ,
-    k_STAT_TIME = 1  // Event queued time
+    /// Queue/Dequeue
+    k_STAT_QUEUE = 0,
+    /// Event queued time
+    k_STAT_TIME = 1
 };
 
 }  // close unnamed namespace

--- a/src/groups/bmq/bmqimp/bmqimp_eventsstats.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_eventsstats.cpp
@@ -35,9 +35,10 @@ namespace {
 const char k_STAT_NAME[] = "events";
 
 enum {
-    k_STAT_EVENT = 0  // value = bytes ; increments = number of events
-    ,
-    k_STAT_MESSAGE = 1  // value = number of messages
+    /// value = bytes ; increments = number of events
+    k_STAT_EVENT = 0,
+    /// value = number of messages
+    k_STAT_MESSAGE = 1
 };
 }  // close unnamed namespace
 

--- a/src/groups/bmq/bmqimp/bmqimp_queue.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.cpp
@@ -55,14 +55,12 @@ const double k_COMPRESSION_RATIO_PRECISION_FACTOR_INV =
     1 / k_COMPRESSION_RATIO_PRECISION_FACTOR;
 
 enum {
-    k_STAT_IN = 0  // value = bytes received ; increments =
-                   // messages received
-    ,
-    k_STAT_OUT = 1  // value = bytes sent     ; increments =
-                    // messages sent
-    ,
-    k_STAT_COMPRESSION_RATIO = 2  // value = sum of all compression ratio for
-                                  // compressed packed messages
+    /// value = bytes received ; increments = messages received
+    k_STAT_IN = 0,
+    /// value = bytes sent     ; increments = messages sent
+    k_STAT_OUT = 1,
+    /// value = sum of all compression ratio for compressed packed messages
+    k_STAT_COMPRESSION_RATIO = 2
 };
 
 double

--- a/src/groups/bmq/bmqimp/bmqimp_queue.h
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.h
@@ -68,23 +68,24 @@ namespace bmqimp {
 struct QueueState {
     // TYPES
     enum Enum {
-        e_OPENING_OPN = 1  // The queue is being opened, 1st phase
-        ,
-        e_OPENING_CFG = 2  // The queue is being opened, 2nd phase
-        ,
-        e_REOPENING_OPN = 3  // The queue is being reopened, 1st phase
-        ,
-        e_REOPENING_CFG = 4  // The queue is being reopened, 2nd phase
-        ,
-        e_OPENED = 5  // The queue is fully opened
-        ,
-        e_CLOSING_CFG = 6  // The queue is being closed, 1st phase
-        ,
-        e_CLOSING_CLS = 7  // The queue is being closed, 2nd phase
-        ,
-        e_CLOSED = 8  // The queue is fully closed
-        ,
-        e_PENDING = 9  // The queue is pending, channel is down
+        /// The queue is being opened, 1st phase
+        e_OPENING_OPN = 1,
+        /// The queue is being opened, 2nd phase
+        e_OPENING_CFG = 2,
+        /// The queue is being reopened, 1st phase
+        e_REOPENING_OPN = 3,
+        /// The queue is being reopened, 2nd phase
+        e_REOPENING_CFG = 4,
+        /// The queue is fully opened
+        e_OPENED = 5,
+        /// The queue is being closed, 1st phase
+        e_CLOSING_CFG = 6,
+        /// The queue is being closed, 2nd phase
+        e_CLOSING_CLS = 7,
+        /// The queue is fully closed
+        e_CLOSED = 8,
+        /// The queue is pending, channel is down
+        e_PENDING = 9
     };
 
     // PUBLIC CONSTANTS

--- a/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queuemanager.cpp
@@ -332,16 +332,14 @@ int QueueManager::onPushEvent(QueueManager::EventInfos* eventInfos,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // No error
-        ,
-        rc_ITERATION_ERROR = -1  // An error was encountered while
-                                 // iterating
-        ,
-        rc_OPTIONS_LOAD_ERROR = -2  // An error occurred while loading the
-                                    // options of a message
-        ,
-        rc_SUB_QUEUE_IDS_LOAD_ERROR = -3  // An error occurred while loading a
-                                          // SubQueueId option
+        /// No error
+        rc_SUCCESS = 0,
+        /// An error was encountered while iterating
+        rc_ITERATION_ERROR = -1,
+        /// An error occurred while loading the options of a message
+        rc_OPTIONS_LOAD_ERROR = -2,
+        /// An error occurred while loading a SubQueueId option
+        rc_SUB_QUEUE_IDS_LOAD_ERROR = -3
     };
 
     *messageCount                      = 0;
@@ -459,12 +457,12 @@ int QueueManager::updateStatsOnPutEvent(
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // No error
-        ,
-        rc_ITERATION_ERROR = -1  // An error was encountered while iterating
-        ,
-        rc_INVALID_QUEUE = -2  // Queue not valid or not opened with write
-                               // flags
+        /// No error
+        rc_SUCCESS = 0,
+        /// An error was encountered while iterating
+        rc_ITERATION_ERROR = -1,
+        /// Queue not valid or not opened with write flags
+        rc_INVALID_QUEUE = -2
     };
 
     *messageCount = 0;

--- a/src/groups/bmq/bmqp/bmqp_ackmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackmessageiterator.cpp
@@ -59,15 +59,15 @@ int AckMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_NOT_ENOUGH_BYTES = -2  // The number of bytes in the blob is less
-                                  // than the payload size of the message
-                                  // declared in the header
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// The number of bytes in the blob is less than the payload size of
+        /// the message declared in the header
+        rc_NOT_ENOUGH_BYTES = -2
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -111,18 +111,16 @@ int AckMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob doesn't contain a complete
-                                     // EventHeader, or is not followed by an
-                                     // AckHeader
-        ,
-        rc_INVALID_ACKHEADER = -2  // The blob doesn't contain a complete
-                                   // AckHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the blob is less
-                                  // than the header size declared in the
-                                  // header
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob doesn't contain a complete EventHeader, or is not followed
+        /// by an AckHeader
+        rc_INVALID_EVENTHEADER = -1,
+        /// The blob doesn't contain a complete AckHeader
+        rc_INVALID_ACKHEADER = -2,
+        /// The number of bytes in the blob is less than the header size
+        /// declared in the header
+        rc_NOT_ENOUGH_BYTES = -3
     };
 
     d_blobIter.reset(blob, bmqu::BlobPosition(), blob->length(), true);

--- a/src/groups/bmq/bmqp/bmqp_confirmmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_confirmmessageiterator.cpp
@@ -60,18 +60,17 @@ int ConfirmMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this
-                         // one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_NOT_ENOUGH_BYTES = -2  // The number of bytes in the blob is
-                                  // less than the payload size of the
-                                  // message declared in the header
-        ,
-        rc_INVALID_ADVANCE_LENGTH = -3  // Advance length is not positive
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// The number of bytes in the blob is less than the payload size of
+        /// the message declared in the header
+        rc_NOT_ENOUGH_BYTES = -2,
+        /// Advance length is not positive
+        rc_INVALID_ADVANCE_LENGTH = -3
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -122,18 +121,16 @@ int ConfirmMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob doesn't contain a complete
-                                     // EventHeader, or is not followed by a
-                                     // ConfirmHeader
-        ,
-        rc_INVALID_CONFIRMHEADER = -2  // The blob doesn't contain a complete
-                                       // ConfirmHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the blob is
-                                  // less than the header size declared
-                                  // in the header
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob doesn't contain a complete EventHeader, or is not followed
+        /// by a ConfirmHeader
+        rc_INVALID_EVENTHEADER = -1,
+        /// The blob doesn't contain a complete ConfirmHeader
+        rc_INVALID_CONFIRMHEADER = -2,
+        /// The number of bytes in the blob is less than the header size
+        /// declared in the header
+        rc_NOT_ENOUGH_BYTES = -3
     };
 
     d_blobIter.reset(blob, bmqu::BlobPosition(), blob->length(), true);

--- a/src/groups/bmq/bmqp/bmqp_controlmessageutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_controlmessageutil.cpp
@@ -49,11 +49,12 @@ int ControlMessageUtil::validate(
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_ID = -1  // Invalid id
-        ,
-        rc_INVALID_CHOICE_SELECTION = -2  // Invalid choice selection
+        /// Success
+        rc_SUCCESS = 0,
+        /// Invalid id
+        rc_INVALID_ID = -1,
+        /// Invalid choice selection
+        rc_INVALID_CHOICE_SELECTION = -2
     };
 
     if (controlMessage.choice().isClusterMessageValue()) {

--- a/src/groups/bmq/bmqp/bmqp_eventutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_eventutil.cpp
@@ -65,26 +65,22 @@ class Flattener {
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // No error
-        ,
-        rc_ITERATION_ERROR = -1  // An error was encountered while
-                                 // iterating
-        ,
-        rc_OPTIONS_LOAD_ERROR = -2  // An error occurred while loading
-                                    // the options of a message
-        ,
-        rc_SUB_QUEUE_IDS_LOAD_ERROR = -3  // An error occurred while loading a
-                                          // SubQueueId option
-        ,
-        rc_APP_DATA_LOAD_ERROR = -4  // An error occurred while loading
-                                     // application data
-        ,
-        rc_ADD_OPTION_ERROR = -5  // Failed to add an option
-        ,
-        rc_PACK_MESSAGE_ERROR = -6  // Failed to pack a message
-        ,
-        rc_SUBSEQUENT_RETRIES_ERROR =
-            -7  // Too many subsequent failed attempts
+        /// No error
+        rc_SUCCESS = 0,
+        /// An error was encountered while iterating
+        rc_ITERATION_ERROR = -1,
+        /// An error occurred while loading the options of a message
+        rc_OPTIONS_LOAD_ERROR = -2,
+        /// An error occurred while loading a SubQueueId option
+        rc_SUB_QUEUE_IDS_LOAD_ERROR = -3,
+        /// An error occurred while loading application data
+        rc_APP_DATA_LOAD_ERROR = -4,
+        /// Failed to add an option
+        rc_ADD_OPTION_ERROR = -5,
+        /// Failed to pack a message
+        rc_PACK_MESSAGE_ERROR = -6,
+        /// Too many subsequent failed attempts
+        rc_SUBSEQUENT_RETRIES_ERROR = -7
     };
 
     /// Convenience alias of type type

--- a/src/groups/bmq/bmqp/bmqp_optionsview.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionsview.cpp
@@ -48,18 +48,16 @@ int OptionsView::resetImpl(const bdlbb::Blob*        blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_OPTIONS_AREA = -1  // The blob does not contain a valid
-                                      // options area at the specified
-                                      // 'optionsAreaPos'.
-        ,
-        rc_INVALID_OPTIONS_AREA_SIZE = -2  // The blob does not contain an
-                                           // options area of the specified
-                                           // size 'optionsAreaSize'.
-        ,
-        rc_DUPLICATE_OPTION_TYPE = -3  // The blob contains a duplicate
-                                       // option type.
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob does not contain a valid options area at the specified
+        /// 'optionsAreaPos'.
+        rc_INVALID_OPTIONS_AREA = -1,
+        /// The blob does not contain an options area of the specified size
+        /// 'optionsAreaSize'.
+        rc_INVALID_OPTIONS_AREA_SIZE = -2,
+        /// The blob contains a duplicate option type.
+        rc_DUPLICATE_OPTION_TYPE = -3
 
     };
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -546,9 +546,9 @@ struct EncodingType {
     // TYPES
     enum Enum {
         e_UNKNOWN = -1,
-        e_BER     = 0  // For backward compatibility, 'BER' needs to be
-                       // assigned a value of zero.
-        ,
+        /// For backward compatibility, 'BER' needs to be assigned a value of
+        /// zero.
+        e_BER  = 0,
         e_JSON = 1
     };
 
@@ -1622,12 +1622,12 @@ struct PutHeader {
 struct PutHeaderFlags {
     // TYPES
     enum Enum {
-        e_ACK_REQUESTED = (1 << 0)  // Ack for PUT msg is requested
-        ,
-        e_MESSAGE_PROPERTIES = (1 << 1)  // Contains message properties
-        ,
-        e_UNUSED3 = (1 << 2),
-        e_UNUSED4 = (1 << 3)
+        /// Ack for PUT msg is requested
+        e_ACK_REQUESTED = (1 << 0),
+        /// Contains message properties
+        e_MESSAGE_PROPERTIES = (1 << 1),
+        e_UNUSED3            = (1 << 2),
+        e_UNUSED4            = (1 << 3)
     };
 
     // PUBLIC CONSTANTS
@@ -2953,11 +2953,11 @@ struct StorageHeader {
 struct StorageHeaderFlags {
     // TYPES
     enum Enum {
-        e_RECEIPT_REQUESTED = (1 << 0)  // Ack for STORAGE msg is requested
-        ,
-        e_UNUSED2 = (1 << 1),
-        e_UNUSED3 = (1 << 2),
-        e_UNUSED4 = (1 << 3)
+        /// Ack for STORAGE msg is requested
+        e_RECEIPT_REQUESTED = (1 << 0),
+        e_UNUSED2           = (1 << 1),
+        e_UNUSED3           = (1 << 2),
+        e_UNUSED4           = (1 << 3)
     };
 
     // PUBLIC CONSTANTS

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
@@ -153,9 +153,10 @@ int PushMessageIterator::loadApplicationDataPosition(
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_IMPLICIT_APP_DATA = -1  // App payload is implicit
+        /// Success
+        rc_SUCCESS = 0,
+        /// App payload is implicit
+        rc_IMPLICIT_APP_DATA = -1
     };
 
     if (isApplicationDataImplicit()) {
@@ -173,15 +174,14 @@ int PushMessageIterator::loadApplicationData(bdlbb::Blob* blob) const
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_IMPLICIT_APP_DATA = -1  // App payload is implicit
-        ,
-        rc_INVALID_APP_DATA_OFFSET = -2  // The appData offset isn't within
-                                         // range of the blob data
-        ,
-        rc_INVALID_APP_DATA_LENGTH = -3  // The appData size from the header
-                                         // isn't with range of the blob data
+        /// Success
+        rc_SUCCESS = 0,
+        /// App payload is implicit
+        rc_IMPLICIT_APP_DATA = -1,
+        /// The appData offset isn't within range of the blob data
+        rc_INVALID_APP_DATA_OFFSET = -2,
+        /// The appData size from the header isn't with range of the blob data
+        rc_INVALID_APP_DATA_LENGTH = -3
     };
 
     if (isApplicationDataImplicit()) {
@@ -480,23 +480,17 @@ int PushMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message
-                         // after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid
-                         // state
-        ,
-        rc_NO_PUSH_HEADER = -2  // PushHeader is missing or
-                                // incomplete
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the
-                                  // blob is less than the
-                                  // header size OR payload size
-                                  // OR options size declared in
-                                  // the header
-        ,
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// PushHeader is missing or incomplete
+        rc_NO_PUSH_HEADER = -2,
+        /// The number of bytes in the blob is less than the header size OR
+        /// payload size OR options size declared in the header
+        rc_NOT_ENOUGH_BYTES                = -3,
         rc_INVALID_APPLICATION_DATA_OFFSET = -4,
         rc_PARSING_ERROR                   = -5,
         rc_INVALID_OPTIONS_OFFSET          = -6,
@@ -658,11 +652,11 @@ int PushMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob contains only an event header
-                                     // (maybe not event complete); i.e., there
-                                     // are no messages in it
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob contains only an event header (maybe not event complete);
+        /// i.e., there are no messages in it
+        rc_INVALID_EVENTHEADER = -1
     };
 
     clear();

--- a/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
@@ -176,13 +176,12 @@ int PutMessageIterator::loadApplicationData(bdlbb::Blob* blob) const
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_APP_DATA_OFFSET = -1  // The appData offset isn't within
-                                         // range of the blob data
-        ,
-        rc_INVALID_APP_DATA_LENGTH = -2  // The appData size from the header
-                                         // isn't with range of the blob data
+        /// Success
+        rc_SUCCESS = 0,
+        /// The appData offset isn't within range of the blob data
+        rc_INVALID_APP_DATA_OFFSET = -1,
+        /// The appData size from the header isn't with range of the blob data
+        rc_INVALID_APP_DATA_LENGTH = -2
     };
 
     if (d_applicationDataSize > -1) {
@@ -218,10 +217,10 @@ int PutMessageIterator::loadOptions(bdlbb::Blob* blob) const
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_OPTIONS_DATA = -1  // The options size from the header isn't
-                                      // valid
+        /// Success
+        rc_SUCCESS = 0,
+        /// The options size from the header isn't valid
+        rc_INVALID_OPTIONS_DATA = -1
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!hasOptions())) {
@@ -467,22 +466,17 @@ int PutMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message
-                         // after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid
-                         // state
-        ,
-        rc_NO_PUTHEADER = -2  // PutHeader is missing or
-                              // incomplete
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the
-                                  // blob is less than the
-                                  // header size OR payload size
-                                  // declared in the header
-        ,
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// PutHeader is missing or incomplete
+        rc_NO_PUTHEADER = -2,
+        /// The number of bytes in the blob is less than the header size OR
+        /// payload size declared in the header
+        rc_NOT_ENOUGH_BYTES                 = -3,
         rc_INVALID_APPLICATION_DATA_OFFSET  = -4,
         rc_PARSING_ERROR                    = -5,
         rc_INVALID_OPTIONS_OFFSET           = -6,
@@ -683,11 +677,11 @@ int PutMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob contains only an event header
-                                     // (maybe not event complete); i.e., there
-                                     // are no messages in it
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob contains only an event header (maybe not event complete);
+        /// i.e., there are no messages in it
+        rc_INVALID_EVENTHEADER = -1
     };
 
     clear();

--- a/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.cpp
@@ -50,17 +50,17 @@ int RecoveryMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is in invalid state
-        ,
-        rc_NO_RECOVERYHEADER = -2  // RecoveryHeader is missing or incomplete
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the blob is less
-                                  // than the header size OR payload size
-                                  // declared in the header
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is in invalid state
+        rc_INVALID = -1,
+        /// RecoveryHeader is missing or incomplete
+        rc_NO_RECOVERYHEADER = -2,
+        /// The number of bytes in the blob is less than the header size OR
+        /// payload size declared in the header
+        rc_NOT_ENOUGH_BYTES = -3
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -125,11 +125,11 @@ int RecoveryMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob contains only an event header
-                                     // (maybe not event complete); i.e., there
-                                     // are no messages in it
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob contains only an event header (maybe not event complete);
+        /// i.e., there are no messages in it
+        rc_INVALID_EVENTHEADER = -1
     };
 
     d_blobIter.reset(blob, bmqu::BlobPosition(), blob->length(), true);

--- a/src/groups/bmq/bmqp/bmqp_rejectmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_rejectmessageiterator.cpp
@@ -54,15 +54,15 @@ int RejectMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_NOT_ENOUGH_BYTES = -2  // The number of bytes in the blob is less
-                                  // than the payload size of the message
-                                  // declared in the header
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// The number of bytes in the blob is less than the payload size of
+        /// the message declared in the header
+        rc_NOT_ENOUGH_BYTES = -2
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -104,18 +104,16 @@ int RejectMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob doesn't contain a complete
-                                     // EventHeader, or is not followed by a
-                                     // RejectHeader
-        ,
-        rc_INVALID_REJECTHEADER = -2  // The blob doesn't contain a complete
-                                      // RejectHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the blob is less
-                                  // than the header size declared in the
-                                  // header
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob doesn't contain a complete EventHeader, or is not followed
+        /// by a RejectHeader
+        rc_INVALID_EVENTHEADER = -1,
+        /// The blob doesn't contain a complete RejectHeader
+        rc_INVALID_REJECTHEADER = -2,
+        /// The number of bytes in the blob is less than the header size
+        /// declared in the header
+        rc_NOT_ENOUGH_BYTES = -3
     };
 
     d_blobIter.reset(blob, bmqu::BlobPosition(), blob->length(), true);

--- a/src/groups/bmq/bmqp/bmqp_storagemessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storagemessageiterator.cpp
@@ -49,17 +49,17 @@ int StorageMessageIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is in invalid state
-        ,
-        rc_NO_STORAGEHEADER = -2  // StorageHeader is missing or incomplete
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // The number of bytes in the blob is less
-                                  // than the header size OR payload size
-                                  // declared in the header
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is in invalid state
+        rc_INVALID = -1,
+        /// StorageHeader is missing or incomplete
+        rc_NO_STORAGEHEADER = -2,
+        /// The number of bytes in the blob is less than the header size OR
+        /// payload size declared in the header
+        rc_NOT_ENOUGH_BYTES = -3
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -123,11 +123,11 @@ int StorageMessageIterator::reset(const bdlbb::Blob* blob,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_EVENTHEADER = -1  // The blob contains only an event header
-                                     // (maybe not event complete); i.e., there
-                                     // are no messages in it
+        /// Success
+        rc_SUCCESS = 0,
+        /// The blob contains only an event header (maybe not event complete);
+        /// i.e., there are no messages in it
+        rc_INVALID_EVENTHEADER = -1
     };
 
     d_blobIter.reset(blob, bmqu::BlobPosition(), blob->length(), true);

--- a/src/groups/bmq/bmqsys/bmqsys_statmonitor.cpp
+++ b/src/groups/bmq/bmqsys/bmqsys_statmonitor.cpp
@@ -65,50 +65,37 @@ enum {
     // Constants for the index of each stat value in their respective context
 
     // SYSTEM (top-level)
-    k_STAT_SYSTEM_UPTIME = 0
+    k_STAT_SYSTEM_UPTIME = 0,
 
     // CPU (in percent times k_CPU_MULTIPLIER, for example, if value is 5.13%,
     // stat will hold '5.13 * k_CPU_MULTIPLIER')
-    ,
     k_STAT_CPU_SYSTEM = 0,
     k_STAT_CPU_USER   = 1,
-    k_STAT_CPU_ALL    = 2
+    k_STAT_CPU_ALL    = 2,
 
     // MEM (in bytes)
-    ,
     k_STAT_MEM_RESIDENT = 0,
-    k_STAT_MEM_VIRTUAL  = 1
+    k_STAT_MEM_VIRTUAL  = 1,
 
     // OPERATING-SYSTEM (in absolute number)
-    ,
-    k_STAT_OS_MINOR_PAGE_FAULTS = 0
-    // Number of page faults serviced without any
-    // I/O activity.  In this case, I/O activity is
-    // avoided by reclaiming a page frame from the
-    // list of pages awaiting reallocation.
+    /// Number of page faults serviced without any I/O activity.  In this case,
+    /// I/O activity is avoided by reclaiming a page frame from the list of
+    /// pages awaiting reallocation.
+    k_STAT_OS_MINOR_PAGE_FAULTS = 0,
 
-    ,
-    k_STAT_OS_MAJOR_PAGE_FAULTS = 1
-    // Number of page faults serviced that required
-    // I/O activity
+    /// Number of page faults serviced that required I/O activity
+    k_STAT_OS_MAJOR_PAGE_FAULTS = 1,
 
-    ,
-    k_STAT_OS_NUM_SWAPS = 2
-    // Number of times process was swapped out of
-    // main memory
+    /// Number of times process was swapped out of main memory
+    k_STAT_OS_NUM_SWAPS = 2,
 
-    ,
-    k_STAT_OS_VOLUNTARY_CTX_SWITCHES = 3
-    // Number of times a context switch resulted
-    // because a process voluntarily gave up the
-    // processor before its time slice was completed
+    /// Number of times a context switch resulted because a process voluntarily
+    /// gave up the processor before its time slice was completed
+    k_STAT_OS_VOLUNTARY_CTX_SWITCHES = 3,
 
-    ,
+    /// Number of times a context switch resulted because a higher priority
+    /// process ran or because the current process exceeded its time slice
     k_STAT_OS_INVOLUNTARY_CTX_SWITCHES = 4
-    // Number of times a context switch resulted
-    // because a higher priority process ran or
-    // because the current process exceeded its time
-    // slice
 };
 
 typedef bsl::function<

--- a/src/groups/bmq/bmqt/bmqt_correlationid.h
+++ b/src/groups/bmq/bmqt/bmqt_correlationid.h
@@ -229,15 +229,16 @@ class CorrelationId {
   public:
     // TYPES
     enum Type {
-        e_NUMERIC  // the 'CorrelationId' holds a 64-bit integer
-        ,
-        e_POINTER  // the 'CorrelationId' holds a raw pointer
-        ,
-        e_SHARED_PTR  // the 'CorrelationId' holds a shared pointer
-        ,
-        e_AUTO_VALUE  // the 'CorrelationId' holds an auto value
-        ,
-        e_UNSET  // the 'CorrelationId' is not set
+        /// the 'CorrelationId' holds a 64-bit integer
+        e_NUMERIC,
+        /// the 'CorrelationId' holds a raw pointer
+        e_POINTER,
+        /// the 'CorrelationId' holds a shared pointer
+        e_SHARED_PTR,
+        /// the 'CorrelationId' holds an auto value
+        e_AUTO_VALUE,
+        /// the 'CorrelationId' is not set
+        e_UNSET
     };
 
     // CLASS METHOD

--- a/src/groups/bmq/bmqt/bmqt_messageguid.h
+++ b/src/groups/bmq/bmqt/bmqt_messageguid.h
@@ -107,9 +107,8 @@ class MessageGUID {
     /// Enum representing the size of a buffer needed to represent a GUID
     enum Enum {
         /// Binary format of the GUID
-        e_SIZE_BINARY = 16
+        e_SIZE_BINARY = 16,
 
-        ,
         /// Hexadecimal string representation of the GUID
         e_SIZE_HEX = 2 * e_SIZE_BINARY
     };

--- a/src/groups/bmq/bmqt/bmqt_queueflags.h
+++ b/src/groups/bmq/bmqt/bmqt_queueflags.h
@@ -44,15 +44,16 @@ namespace bmqt {
 struct QueueFlags {
     // TYPES
     enum Enum {
-        e_ADMIN = (1 << 0)  // The queue is opened in admin mode (Valid only
-                            // for BlazingMQ admin tasks)
-        ,
-        e_READ = (1 << 1)  // The queue is opened for consuming messages
-        ,
-        e_WRITE = (1 << 2)  // The queue is opened for posting messages
-        ,
-        e_ACK = (1 << 3)  // Set to indicate interested in receiving
-                          // 'ACK' events for all message posted
+        /// The queue is opened in admin mode (Valid only for BlazingMQ admin
+        /// tasks)
+        e_ADMIN = (1 << 0),
+        /// The queue is opened for consuming messages
+        e_READ = (1 << 1),
+        /// The queue is opened for posting messages
+        e_WRITE = (1 << 2),
+        /// Set to indicate interested in receiving 'ACK' events for all
+        /// message posted
+        e_ACK = (1 << 3)
     };
 
     // PUBLIC CONSTANTS

--- a/src/groups/bmq/bmqt/bmqt_resultcode.h
+++ b/src/groups/bmq/bmqt/bmqt_resultcode.h
@@ -60,28 +60,27 @@ namespace bmqt {
 struct GenericResult {
     // TYPES
     enum Enum {
-        e_SUCCESS = 0  // Operation was success
-        ,
-        e_UNKNOWN = -1  // Operation failed for unknown reason
-        ,
-        e_TIMEOUT = -2  // Operation timedout
-        ,
-        e_NOT_CONNECTED = -3  // Cant process, not connected to the broker
-        ,
-        e_CANCELED = -4  // Operation was canceled
-        ,
-        e_NOT_SUPPORTED = -5  // Operation is not supported
-        ,
-        e_REFUSED = -6  // Operation was refused
-        ,
-        e_INVALID_ARGUMENT = -7  // An invalid argument was provided
-        ,
-        e_NOT_READY = -8  // Not ready to process the request
-        ,
+        /// Operation was success
+        e_SUCCESS = 0,
+        /// Operation failed for unknown reason
+        e_UNKNOWN = -1,
+        /// Operation timedout
+        e_TIMEOUT = -2,
+        /// Cant process, not connected to the broker
+        e_NOT_CONNECTED = -3,
+        /// Operation was canceled
+        e_CANCELED = -4,
+        /// Operation is not supported
+        e_NOT_SUPPORTED = -5,
+        /// Operation was refused
+        e_REFUSED = -6,
+        /// An invalid argument was provided
+        e_INVALID_ARGUMENT = -7,
+        /// Not ready to process the request
+        e_NOT_READY = -8,
+        /// Used in test driver only, to validate consistency between this enum
+        /// and the 'bmqp_ctrlmsg.xsd::StatusCategory' one
         e_LAST = e_NOT_READY
-        // Used in test driver only, to validate
-        // consistency between this enum and the
-        // 'bmqp_ctrlmsg.xsd::StatusCategory' one
     };
 
     // CLASS METHODS
@@ -144,22 +143,22 @@ struct OpenQueueResult {
         e_NOT_SUPPORTED    = GenericResult::e_NOT_SUPPORTED,
         e_REFUSED          = GenericResult::e_REFUSED,
         e_INVALID_ARGUMENT = GenericResult::e_INVALID_ARGUMENT,
-        e_NOT_READY        = GenericResult::e_NOT_READY
+        e_NOT_READY        = GenericResult::e_NOT_READY,
 
         // SPECIALIZED
         // WARNINGS
-        ,
-        e_ALREADY_OPENED = 100  // The queue is already opened
-        ,
-        e_ALREADY_IN_PROGRESS = 101  // The queue is already being opened
+        /// The queue is already opened
+        e_ALREADY_OPENED = 100,
+        /// The queue is already being opened
+        e_ALREADY_IN_PROGRESS = 101,
 
         // ERRORS
-        ,
-        e_INVALID_URI = -100  // The queue uri is invalid
-        ,
-        e_INVALID_FLAGS = -101  // The flags provided are invalid
-        ,
-        e_CORRELATIONID_NOT_UNIQUE = -102  // The correlationdId is not unique
+        /// The queue uri is invalid
+        e_INVALID_URI = -100,
+        /// The flags provided are invalid
+        e_INVALID_FLAGS = -101,
+        /// The correlationdId is not unique
+        e_CORRELATIONID_NOT_UNIQUE = -102
     };
 
     // CLASS METHODS
@@ -222,14 +221,13 @@ struct ConfigureQueueResult {
         e_NOT_SUPPORTED    = GenericResult::e_NOT_SUPPORTED,
         e_REFUSED          = GenericResult::e_REFUSED,
         e_INVALID_ARGUMENT = GenericResult::e_INVALID_ARGUMENT,
-        e_NOT_READY        = GenericResult::e_NOT_READY
+        e_NOT_READY        = GenericResult::e_NOT_READY,
 
         // SPECIALIZED WARNINGS
-        ,
-        e_ALREADY_IN_PROGRESS = 100  // The queue is already being configured
+        /// The queue is already being configured
+        e_ALREADY_IN_PROGRESS = 100,
 
         // ERRORS
-        ,
         e_INVALID_QUEUE = -101
     };
 
@@ -294,20 +292,20 @@ struct CloseQueueResult {
         e_NOT_SUPPORTED    = GenericResult::e_NOT_SUPPORTED,
         e_REFUSED          = GenericResult::e_REFUSED,
         e_INVALID_ARGUMENT = GenericResult::e_INVALID_ARGUMENT,
-        e_NOT_READY        = GenericResult::e_NOT_READY
+        e_NOT_READY        = GenericResult::e_NOT_READY,
 
         // SPECIALIZED
         // WARNINGS
-        ,
-        e_ALREADY_CLOSED = 100  // The queue is already closed
-        ,
-        e_ALREADY_IN_PROGRESS = 101  // The queue is already being closed
+        /// The queue is already closed
+        e_ALREADY_CLOSED = 100,
+        /// The queue is already being closed
+        e_ALREADY_IN_PROGRESS = 101,
 
         // ERRORS
-        ,
-        e_UNKNOWN_QUEUE = -100  // The queue doesn't exist
-        ,
-        e_INVALID_QUEUE = -101  // The queue provided is invalid
+        /// The queue doesn't exist
+        e_UNKNOWN_QUEUE = -100,
+        /// The queue provided is invalid
+        e_INVALID_QUEUE = -101
     };
 
     // CLASS METHODS
@@ -364,23 +362,20 @@ struct EventBuilderResult {
     enum Enum {
         // GENERIC
         e_SUCCESS = GenericResult::e_SUCCESS,
-        e_UNKNOWN = GenericResult::e_UNKNOWN
+        e_UNKNOWN = GenericResult::e_UNKNOWN,
 
         // SPECIALIZED
         // ERRORS
-        ,
         e_QUEUE_INVALID          = -100,
         e_QUEUE_READONLY         = -101,
         e_MISSING_CORRELATION_ID = -102,
         e_EVENT_TOO_BIG          = -103,
         e_PAYLOAD_TOO_BIG        = -104,
         e_PAYLOAD_EMPTY          = -105,
-        e_OPTION_TOO_BIG         = -106
+        e_OPTION_TOO_BIG         = -106,
 #ifdef BMQ_ENABLE_MSG_GROUPID
-        ,
-        e_INVALID_MSG_GROUP_ID = -107
+        e_INVALID_MSG_GROUP_ID = -107,
 #endif
-        ,
         e_QUEUE_SUSPENDED = -108
     };
 
@@ -444,30 +439,30 @@ struct AckResult {
         e_NOT_SUPPORTED    = GenericResult::e_NOT_SUPPORTED,
         e_REFUSED          = GenericResult::e_REFUSED,
         e_INVALID_ARGUMENT = GenericResult::e_INVALID_ARGUMENT,
-        e_NOT_READY        = GenericResult::e_NOT_READY
+        e_NOT_READY        = GenericResult::e_NOT_READY,
 
         // SPECIALIZED
         // ERRORS
-        ,
-        e_LIMIT_MESSAGES = -100  // Messages limit reached
-        ,
-        e_LIMIT_BYTES = -101  // Bytes limit reached
+        /// Messages limit reached
+        e_LIMIT_MESSAGES = -100,
+        /// Bytes limit reached
+        e_LIMIT_BYTES = -101,
 
         // TBD:DEPRECATED >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         // >libbmq-1.3.5
         // The below 4 values are deprecated in favor of the above two ones
-        ,
-        e_LIMIT_DOMAIN_MESSAGES = -100  // The domain is full (messages)
-        ,
-        e_LIMIT_DOMAIN_BYTES = -101  // The domain is full (bytes)
-        ,
-        e_LIMIT_QUEUE_MESSAGES = -102  // The queue is full (messages)
-        ,
-        e_LIMIT_QUEUE_BYTES = -103  // The queue is full (bytes)
+        /// The domain is full (messages)
+        e_LIMIT_DOMAIN_MESSAGES = -100,
+        /// The domain is full (bytes)
+        e_LIMIT_DOMAIN_BYTES = -101,
+        /// The queue is full (messages)
+        e_LIMIT_QUEUE_MESSAGES = -102,
+        /// The queue is full (bytes)
+        e_LIMIT_QUEUE_BYTES = -103,
         // TBD:DEPRECATED >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
         // >libbmq-1.3.5
-        ,
-        e_STORAGE_FAILURE = -104  // The storage (on disk) is full
+        /// The storage (on disk) is full
+        e_STORAGE_FAILURE = -104
     };
 
     // CLASS METHODS
@@ -529,14 +524,13 @@ struct PostResult {
         e_NOT_SUPPORTED    = GenericResult::e_NOT_SUPPORTED,
         e_REFUSED          = GenericResult::e_REFUSED,
         e_INVALID_ARGUMENT = GenericResult::e_INVALID_ARGUMENT,
-        e_NOT_READY        = GenericResult::e_NOT_READY
+        e_NOT_READY        = GenericResult::e_NOT_READY,
 
         // SPECIALIZED
         // WARNINGS
-        ,
-        e_BW_LIMIT = 100  // The application has been posting too much
-                          // data, and the IO or broker are temporarily
-                          // rejecting new messages.
+        /// The application has been posting too much data, and the IO or
+        /// broker are temporarily rejecting new messages.
+        e_BW_LIMIT = 100
     };
 
     // CLASS METHODS

--- a/src/groups/bmq/bmqt/bmqt_sessioneventtype.h
+++ b/src/groups/bmq/bmqt/bmqt_sessioneventtype.h
@@ -114,48 +114,49 @@ namespace bmqt {
 struct SessionEventType {
     // TYPES
     enum Enum {
-        e_ERROR = -1  // Generic error
-        ,
-        e_TIMEOUT = -2  // Time out of the operation
-        ,
-        e_CANCELED = -3  // The operation was canceled
-        ,
+        /// Generic error
+        e_ERROR = -1,
+        /// Time out of the operation
+        e_TIMEOUT = -2,
+        /// The operation was canceled
+        e_CANCELED  = -3,
         e_UNDEFINED = 0,
-        e_CONNECTED = 1  // Session started
-        ,
-        e_DISCONNECTED = 2  // Session terminated
-        ,
-        e_CONNECTION_LOST = 3  // Lost connection to the broker
-        ,
-        e_RECONNECTED = 4  // Reconnected with the broker
-        ,
-        e_STATE_RESTORED = 5  // Client's state has been restored
-        ,
-        e_CONNECTION_TIMEOUT = 6  // The connection to broker timedOut
-        ,
-        e_QUEUE_OPEN_RESULT = 7  // Result of openQueue operation
-        ,
-        e_QUEUE_REOPEN_RESULT = 8  // Result of re-openQueue operation
-        ,
-        e_QUEUE_CLOSE_RESULT = 9  // Result of closeQueue operation
-        ,
-        e_SLOWCONSUMER_NORMAL = 10  // EventQueue is at lowWatermark
-        ,
-        e_SLOWCONSUMER_HIGHWATERMARK = 11  // EventQueue is at highWatermark
-        ,
-        e_QUEUE_CONFIGURE_RESULT = 12  // Result of configureQueue
-        ,
-        e_HOST_UNHEALTHY = 13  // Host has become unhealthy
-        ,
-        e_HOST_HEALTH_RESTORED = 14  // Host's health has been restored
-        ,
-        e_QUEUE_SUSPENDED = 15  // Queue has suspended operation
-        ,
-        e_QUEUE_RESUMED = 16  // Queue has resumed operation
-        ,
-        e_CHANNEL_LOW_WATERMARK = 17  // Channel is at the low watermark
-        ,
-        e_CHANNEL_HIGH_WATERMARK = 18  // Channel is at the high watermark
+        /// Session started
+        e_CONNECTED = 1,
+        /// Session terminated
+        e_DISCONNECTED = 2,
+        /// Lost connection to the broker
+        e_CONNECTION_LOST = 3,
+        /// Reconnected with the broker
+        e_RECONNECTED = 4,
+        /// Client's state has been restored
+        e_STATE_RESTORED = 5,
+        /// The connection to broker timedOut
+        e_CONNECTION_TIMEOUT = 6,
+        /// Result of openQueue operation
+        e_QUEUE_OPEN_RESULT = 7,
+        /// Result of re-openQueue operation
+        e_QUEUE_REOPEN_RESULT = 8,
+        /// Result of closeQueue operation
+        e_QUEUE_CLOSE_RESULT = 9,
+        /// EventQueue is at lowWatermark
+        e_SLOWCONSUMER_NORMAL = 10,
+        /// EventQueue is at highWatermark
+        e_SLOWCONSUMER_HIGHWATERMARK = 11,
+        /// Result of configureQueue
+        e_QUEUE_CONFIGURE_RESULT = 12,
+        /// Host has become unhealthy
+        e_HOST_UNHEALTHY = 13,
+        /// Host's health has been restored
+        e_HOST_HEALTH_RESTORED = 14,
+        /// Queue has suspended operation
+        e_QUEUE_SUSPENDED = 15,
+        /// Queue has resumed operation
+        e_QUEUE_RESUMED = 16,
+        /// Channel is at the low watermark
+        e_CHANNEL_LOW_WATERMARK = 17,
+        /// Channel is at the high watermark
+        e_CHANNEL_HIGH_WATERMARK = 18
     };
 
     // CLASS METHODS

--- a/src/groups/bmq/bmqt/bmqt_subscription.h
+++ b/src/groups/bmq/bmqt/bmqt_subscription.h
@@ -127,9 +127,7 @@ class SubscriptionExpression {
     /// Enum representing criteria format
     enum Enum {
         /// EMPTY
-        e_NONE = 0
-
-        ,
+        e_NONE = 0,
         /// Simple Evaluator
         e_VERSION_1 = 1
     };

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -885,16 +885,14 @@ class TestHelper_Printer {
 /// Namespace for a set of utilities.
 struct TestHelper {
     // TYPES
+    /// Flags to provide to `TEST_PROLOG` and `TEST_EPILOG` macros.
     enum e_FLAGS {
-        /// Flags to provide to `TEST_PROLOG` and `TEST_EPILOG` macros.
-        e_DEFAULT = 0
+        e_DEFAULT = 0,
 
         // PROLOG FLAGS
-        ,
-        e_USE_STACKTRACE_ALLOCATOR = 1 << 0
+        e_USE_STACKTRACE_ALLOCATOR = 1 << 0,
 
         // EPILOG FLAGS
-        ,
         e_CHECK_DEF_ALLOC     = 1 << 0,
         e_CHECK_GBL_ALLOC     = 1 << 1,
         e_CHECK_DEF_GBL_ALLOC = e_CHECK_DEF_ALLOC | e_CHECK_GBL_ALLOC

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder.h
@@ -47,8 +47,8 @@
 // Include version that can be compiled with C++03
 // Generated on Wed Jun 18 14:44:06 2025
 // Command line: sim_cpp11_features.pl bmqu_objectplaceholder.h
-# define COMPILING_BMQU_OBJECTPLACEHOLDER_H
-# include <bmqu_objectplaceholder_cpp03.h>
+#define COMPILING_BMQU_OBJECTPLACEHOLDER_H
+#include <bmqu_objectplaceholder_cpp03.h>
 #undef COMPILING_BMQU_OBJECTPLACEHOLDER_H
 #else
 
@@ -98,11 +98,12 @@ class ObjectPlaceHolder {
     enum State {
         // State of the placeholder.
 
-        e_EMPTY = 0  // The placeholder is empty.
-        ,
-        e_FULL_INT = 1  // The placeholder contains an internal object.
-        ,
-        e_FULL_EXT = 2  // The placeholder contains an external object.
+        /// The placeholder is empty.
+        e_EMPTY = 0,
+        /// The placeholder contains an internal object.
+        e_FULL_INT = 1,
+        /// The placeholder contains an external object.
+        e_FULL_EXT = 2
     };
 
     /// An aligned buffer large enough to hold two pointers - the allocator

--- a/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
+++ b/src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
@@ -87,11 +87,12 @@ class ObjectPlaceHolder {
     enum State {
         // State of the placeholder.
 
-        e_EMPTY = 0  // The placeholder is empty.
-        ,
-        e_FULL_INT = 1  // The placeholder contains an internal object.
-        ,
-        e_FULL_EXT = 2  // The placeholder contains an external object.
+        /// The placeholder is empty.
+        e_EMPTY = 0,
+        /// The placeholder contains an internal object.
+        e_FULL_INT = 1,
+        /// The placeholder contains an external object.
+        e_FULL_EXT = 2
     };
 
     /// An aligned buffer large enough to hold two pointers - the allocator

--- a/src/groups/bmq/bmqu/bmqu_tlsbool.h
+++ b/src/groups/bmq/bmqu/bmqu_tlsbool.h
@@ -63,28 +63,26 @@ class TLSBool {
     enum State {
         // Enum representing the state of the value, as stored in the thread
         // local variable.
-        e_UNINITIALIZED = 0  // The 'd_key' failed to be created - must remain
-                             // 0 (see comment in the constructor).
-
-        ,
-        e_FALSE = 1  // The value is false
-
-        ,
-        e_TRUE = 2  // The value is true
+        /// The 'd_key' failed to be created - must remain 0 (see comment in
+        /// the constructor).
+        e_UNINITIALIZED = 0,
+        /// The value is false
+        e_FALSE = 1,
+        /// The value is true
+        e_TRUE = 2
     };
 
     enum BitFlags {
         // Enum representing the index of the bit for the various flags stored
         // in the 'd_flags' member (for efficient memory footprint).
-        e_CREATED = 0  // Has the thread key been successfully created ?
-
-        ,
-        e_INITIAL_VALUE = 1  // Value to use as initial value, if querying
-                             // before setting the value.
-
-        ,
-        e_DEFAULT_VALUE = 2  // Default value to return by default in case the
-                             // thread key failed to be created.
+        /// Has the thread key been successfully created ?
+        e_CREATED = 0,
+        /// Value to use as initial value, if querying before setting the
+        /// value.
+        e_INITIAL_VALUE = 1,
+        /// Default value to return by default in case the thread key failed to
+        /// be created.
+        e_DEFAULT_VALUE = 2
     };
 
     // DATA

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.h
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.h
@@ -84,10 +84,10 @@ class PushStream {
     struct Element;
 
     enum ElementList {
-        e_GUID = 0  // column
-        ,
-        e_APP = 1  // row
-        ,
+        /// column
+        e_GUID = 0,
+        /// row
+        e_APP   = 1,
         e_TOTAL = 2
     };
 

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -355,14 +355,14 @@ int RootQueueEngine::configure(bsl::ostream& errorDescription,
 {
     enum RcEnum {
         // Return values
-        rc_SUCCESS = 0  // No error
-        ,
-        rc_APP_INITIALIZATION_ERROR = -1  // No Virtual Storage
-        ,
-        rc_APP_SUBSCRIPTION_ERROR = -2  // Wrong expression
-        ,
-        rc_APP_SUBSCRIPTIONS_ERROR = -3  // Wrong number of application
-                                         // subscriptions
+        /// No error
+        rc_SUCCESS = 0,
+        /// No Virtual Storage
+        rc_APP_INITIALIZATION_ERROR = -1,
+        /// Wrong expression
+        rc_APP_SUBSCRIPTION_ERROR = -2,
+        /// Wrong number of application subscriptions
+        rc_APP_SUBSCRIPTIONS_ERROR = -3
     };
 
     // Populate map of appId to appKey for statically registered consumers

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -2167,9 +2167,10 @@ int ClusterUtil::latestLedgerLSN(bmqp_ctrlmsg::LeaderMessageSequence* out,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // No error
-        ,
-        rc_LEDGER_NOT_OPENED = -1  // The ledger is not opened
+        /// No error
+        rc_SUCCESS = 0,
+        /// The ledger is not opened
+        rc_LEDGER_NOT_OPENED = -1
     };
 
     if (!ledger.isOpen()) {

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -213,9 +213,10 @@ int IncoreClusterStateLedger::cleanupLog(const bsl::string& logPath)
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_REMOVE_FILE_FAILURE = -1  // Fail to remove log file
+        /// Success
+        rc_SUCCESS = 0,
+        /// Fail to remove log file
+        rc_REMOVE_FILE_FAILURE = -1
     };
 
     const bsl::string& cluster = d_clusterData_p->cluster().name();
@@ -243,14 +244,14 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_WRITE_HEADER_FAILURE = -1  // Fail to write CSL file header to
-                                      // ledger
-        ,
-        rc_CREATE_RECORD_FAILURE = -2  // Fail to create record
-        ,
-        rc_WRITE_RECORD_FAILURE = -3  // Fail to write record to ledger
+        /// Success
+        rc_SUCCESS = 0,
+        /// Fail to write CSL file header to ledger
+        rc_WRITE_HEADER_FAILURE = -1,
+        /// Fail to create record
+        rc_CREATE_RECORD_FAILURE = -2,
+        /// Fail to write record to ledger
+        rc_WRITE_RECORD_FAILURE = -3
     };
 
     BALL_LOG_INFO << description() << ": Rolling over from log with logId ["
@@ -391,15 +392,16 @@ int IncoreClusterStateLedger::applyAdvisoryInternal(
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_ADVISORY_STALE = -1  // Advisory is stale
-        ,
-        rc_ADVISORY_ALREADY_APPLIED = -2  // Advisory was already applied
-        ,
-        rc_CREATE_RECORD_FAILURE = -3  // Fail to create advisory record
-        ,
-        rc_APPLY_RECORD_FAILURE = -4  // Fail to apply advisory record
+        /// Success
+        rc_SUCCESS = 0,
+        /// Advisory is stale
+        rc_ADVISORY_STALE = -1,
+        /// Advisory was already applied
+        rc_ADVISORY_ALREADY_APPLIED = -2,
+        /// Fail to create advisory record
+        rc_CREATE_RECORD_FAILURE = -3,
+        /// Fail to apply advisory record
+        rc_APPLY_RECORD_FAILURE = -4
     };
 
     if (sequenceNumber <
@@ -454,23 +456,22 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_UNKNOWN = -1  // Unknown result
-        ,
-        rc_WRITE_FAILURE = -2  // Fail to write record to ledger
-        ,
-        rc_CREATE_ACK_FAILURE = -3  // Fail to create leader advisory ack
-        ,
-        rc_COMMIT_FAILURE = -4  // Fail to create leader advisory
-                                // commit
-        ,
-        rc_APPLY_ACK_FAILURE = -5  // Fail to apply leader advisory ack
-        ,
-        rc_SEND_ACK_FAILURE = -6  // Fail to send leader advisory ack
-                                  // back to leader
-        ,
-        rc_ADVISORY_NOT_FOUND = -7  // Advisory not found
+        /// Success
+        rc_SUCCESS = 0,
+        /// Unknown result
+        rc_UNKNOWN = -1,
+        /// Fail to write record to ledger
+        rc_WRITE_FAILURE = -2,
+        /// Fail to create leader advisory ack
+        rc_CREATE_ACK_FAILURE = -3,
+        /// Fail to create leader advisory commit
+        rc_COMMIT_FAILURE = -4,
+        /// Fail to apply leader advisory ack
+        rc_APPLY_ACK_FAILURE = -5,
+        /// Fail to send leader advisory ack back to leader
+        rc_SEND_ACK_FAILURE = -6,
+        /// Advisory not found
+        rc_ADVISORY_NOT_FOUND = -7
     };
 
     int rc = rc_UNKNOWN;
@@ -774,11 +775,12 @@ int IncoreClusterStateLedger::applyCommit(
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_CREATE_COMMIT_FAILURE = -1  // Fail to create leader advisory
-        ,
-        rc_APPLY_COMMIT_FAILURE = -2  // Fail to apply leader advisory commit
+        /// Success
+        rc_SUCCESS = 0,
+        /// Fail to create leader advisory
+        rc_CREATE_COMMIT_FAILURE = -1,
+        /// Fail to apply leader advisory commit
+        rc_APPLY_COMMIT_FAILURE = -2
     };
 
     // Consistency level reached. Apply a commit message for the
@@ -903,26 +905,26 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_SOURCE = -1  // Source is not leader
-        ,
-        rc_MISSING_HEADER = -2  // Event or record header is missing
-        ,
-        rc_INVALID_HEADER = -3  // Event or record header is invalid
-        ,
-        rc_UNEXPECTED_RECORD_TYPE = -4  // Unexpected record type
-        ,
-        rc_RECORD_ALREADY_APPLIED = -5  // Record was already applied
-        ,
-        rc_RECORD_STALE = -6  // Record is stale
-        ,
-        rc_LOAD_MESSAGE_FAILURE = -7  // Fail to load cluster message
-        ,
-        rc_ADVISORY_INVALID = -8  // Advisory is invalid, as determined
-                                  // by type-specific validation
-        ,
-        rc_APPLY_RECORD_FAILURE = -9  // Fail to apply record
+        /// Success
+        rc_SUCCESS = 0,
+        /// Source is not leader
+        rc_INVALID_SOURCE = -1,
+        /// Event or record header is missing
+        rc_MISSING_HEADER = -2,
+        /// Event or record header is invalid
+        rc_INVALID_HEADER = -3,
+        /// Unexpected record type
+        rc_UNEXPECTED_RECORD_TYPE = -4,
+        /// Record was already applied
+        rc_RECORD_ALREADY_APPLIED = -5,
+        /// Record is stale
+        rc_RECORD_STALE = -6,
+        /// Fail to load cluster message
+        rc_LOAD_MESSAGE_FAILURE = -7,
+        /// Advisory is invalid, as determined by type-specific validation
+        rc_ADVISORY_INVALID = -8,
+        /// Fail to apply record
+        rc_APPLY_RECORD_FAILURE = -9
     };
 
     BALL_LOG_INFO << "Applying cluster state record event from node '"
@@ -1320,13 +1322,14 @@ int IncoreClusterStateLedger::open()
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_ALREADY_OPENED = -1  // CSL Already opened
-        ,
-        rc_OPEN_FAILURE = -2  // Failure to open ledger
-        ,
-        rc_INTERNAL_LEDGER_ERROR = -3  // Internal ledger error
+        /// Success
+        rc_SUCCESS = 0,
+        /// CSL Already opened
+        rc_ALREADY_OPENED = -1,
+        /// Failure to open ledger
+        rc_OPEN_FAILURE = -2,
+        /// Internal ledger error
+        rc_INTERNAL_LEDGER_ERROR = -3
     };
 
     if (d_isOpen) {
@@ -1374,11 +1377,12 @@ int IncoreClusterStateLedger::close()
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_NOT_OPENED = -1  // CSL is not opened
-        ,
-        rc_CLOSE_FAILURE = -2  // Failure to close ledger
+        /// Success
+        rc_SUCCESS = 0,
+        /// CSL is not opened
+        rc_NOT_OPENED = -1,
+        /// Failure to close ledger
+        rc_CLOSE_FAILURE = -2
     };
 
     if (!d_isOpen) {

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.cpp
@@ -83,18 +83,18 @@ int IncoreClusterStateLedgerIterator::next()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_END_OF_LEDGER = 1  // End of ledger is reached
-        ,
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_RECORD_ALIAS_FAILURE = -1  // Failure to alias a record
-        ,
-        rc_INVALID_FILE_HEADER = -2  // Invalid file header
-        ,
-        rc_INVALID_RECORD_HEADER = -3  // Invalid record header
-        ,
-        rc_OUT_OF_LEDGER_RANGE = -4  // An offset outside of the ledger's
-                                     // range is reached
+        /// End of ledger is reached
+        rc_END_OF_LEDGER = 1,
+        /// Success
+        rc_SUCCESS = 0,
+        /// Failure to alias a record
+        rc_RECORD_ALIAS_FAILURE = -1,
+        /// Invalid file header
+        rc_INVALID_FILE_HEADER = -2,
+        /// Invalid record header
+        rc_INVALID_RECORD_HEADER = -3,
+        /// An offset outside of the ledger's range is reached
+        rc_OUT_OF_LEDGER_RANGE = -4
     };
 
     bdlb::ScopeExitAny guard(bdlf::BindUtil::bind(onInvalidNext, &d_isValid));

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -1084,15 +1084,15 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_NO_FILE_SETS_TO_RECOVER = 1  // Special rc, do not change
-        ,
-        rc_SUCCESS               = 0,
-        rc_OPEN_FILE_SET_FAILURE = -1,
-        rc_INVALID_FILE_SET      = -2,
-        rc_FILE_ITERATOR_FAILURE = -3,
-        rc_INVALID_DATA_OFFSET   = -4,
-        rc_INVALID_QLIST_OFFSET  = -5,
-        rc_INVALID_QLIST_RECORD  = -6
+        /// Special rc, do not change
+        rc_NO_FILE_SETS_TO_RECOVER = 1,
+        rc_SUCCESS                 = 0,
+        rc_OPEN_FILE_SET_FAILURE   = -1,
+        rc_INVALID_FILE_SET        = -2,
+        rc_FILE_ITERATOR_FAILURE   = -3,
+        rc_INVALID_DATA_OFFSET     = -4,
+        rc_INVALID_QLIST_OFFSET    = -5,
+        rc_INVALID_QLIST_RECORD    = -6
     };
 
     const int        k_MAX_NUM_FILE_SETS_TO_CHECK = 2;

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -107,51 +107,39 @@ struct ClusterErrorCode {
         // - - - -
         e_OK = 0,
 
-        e_UNKNOWN = -10
-        // Operation failed for unknown reason
-        ,
-        e_STOPPING = -11
-        // The node (either current or remote) is being stopped
+        /// Operation failed for unknown reason
+        e_UNKNOWN = -10,
+        /// The node (either current or remote) is being stopped
+        e_STOPPING = -11,
 
         // ClusterProxy specific
         // - - - - - - - - - - -
-        ,
-        e_ACTIVE_LOST = -100
-        // The connection to the active node was lost
+        /// The connection to the active node was lost
+        e_ACTIVE_LOST = -100,
 
         // Cluster specific
         // - - - - - - - -
-        ,
-        e_NOT_LEADER = -200
-        // The node is not the leader of the cluster
-        ,
-        e_NOT_PRIMARY = -201
-        // The node is not the primary of the partition
-        ,
-        e_NO_PARTITION = -202
-        // Unable to find a partition for the queue
-        ,
-        e_NODE_DOWN = -203
-        // The connection with the remote node went down
-        ,
-        e_UNKNOWN_QUEUE = -204
-        // The node is not aware of that queue
-        ,
-        e_LIMIT = -205
-        // A limit has been reached, currently:
-        //: o too many active queues in the domain
-        ,
-        e_NOT_FOLLOWER = -206
-        // The node is not a follower in the cluster
-        ,
-        e_NOT_REPLICA = -207
-        // The node is not a replica of the partition
-        ,
-        e_CSL_FAILURE = -208
-        // Failure to apply to the CSL
-        ,
+        /// The node is not the leader of the cluster
+        e_NOT_LEADER = -200,
+        /// The node is not the primary of the partition
+        e_NOT_PRIMARY = -201,
+        /// Unable to find a partition for the queue
+        e_NO_PARTITION = -202,
+        /// The connection with the remote node went down
+        e_NODE_DOWN = -203,
+        /// The node is not aware of that queue
+        e_UNKNOWN_QUEUE = -204,
+        /// A limit has been reached, currently:
+        ///   - too many active queues in the domain
+        e_LIMIT = -205,
+        /// The node is not a follower in the cluster
+        e_NOT_FOLLOWER = -206,
+        /// The node is not a replica of the partition
+        e_NOT_REPLICA = -207,
+        /// Failure to apply to the CSL
+        e_CSL_FAILURE = -208,
+        /// Storage failure other than CSL failure
         e_STORAGE_FAILURE = -209
-        // Storage failure other than CSL failure
     };
 
     // CLASS METHODS

--- a/src/groups/mqb/mqbi/mqbi_dispatcher.h
+++ b/src/groups/mqb/mqbi/mqbi_dispatcher.h
@@ -215,52 +215,53 @@ bsl::ostream& operator<<(bsl::ostream&              stream,
 /// Enumeration for the different types of dispatcher events.
 struct DispatcherEventType {
     // TYPES
+
+    /// @note Events of type 'e_DISPATCHER' are similar to those of type
+    ///       'e_CALLBACK' in the sense that they both represent a callback to
+    ///       be invoked on the thread associated to the target destination
+    ///       dispatcher client.  However, the major difference resides in when
+    ///       that callback is invoked: unlike all other types, 'e_DISPATCHER'
+    ///       events are handled internally by the dispatcher itself, and not
+    ///       sent to the 'onDispatcherEvent()' method of the targeted
+    ///       destination dispatcher client.  This will also not trigger the
+    ///       destination to be added to the flush list.
+    ///
+    ///       The purpose is that this event can be used for operations such as
+    ///       'finalize' (i.e., destroy) of a client where calling any method
+    ///       on the destination object might be undefined due to the object no
+    ///       longer being alive.
+    ///
+    ///       Unless needed, always prefer to use the 'e_CALLBACK' type to give
+    ///       more control over to the target destination dispatcher client:
+    ///       the client will be able to do some pre and post callback
+    ///       invocation duty (such as flushing some state).
     enum Enum {
-        e_UNDEFINED = 0  // invalid event
-        ,
-        e_DISPATCHER = 1  // dispatcher event, see note below
-        ,
-        e_CALLBACK = 2  // event is a 'callback' event
-        ,
-        e_CONTROL_MSG = 3  // event is a 'controlMessage' event
-        ,
-        e_CONFIRM = 4  // event is a 'confirm' event
-        ,
-        e_REJECT = 5  // event is a 'reject' event
-        ,
-        e_PUSH = 6  // event is a 'push' event
-        ,
-        e_PUT = 7  // event is a 'put' event
-        ,
-        e_ACK = 8  // event is a 'ack' event
-        ,
-        e_CLUSTER_STATE = 9  // event is a 'clusterState' event
-        ,
-        e_STORAGE = 10  // event is a 'storage' event
-        ,
-        e_RECOVERY = 11  // event is a 'recovery' event
-        ,
+        /// invalid event
+        e_UNDEFINED = 0,
+        /// dispatcher event, see note above
+        e_DISPATCHER = 1,
+        /// event is a 'callback' event
+        e_CALLBACK = 2,
+        /// event is a 'controlMessage' event
+        e_CONTROL_MSG = 3,
+        /// event is a 'confirm' event
+        e_CONFIRM = 4,
+        /// event is a 'reject' event
+        e_REJECT = 5,
+        /// event is a 'push' event
+        e_PUSH = 6,
+        /// event is a 'put' event
+        e_PUT = 7,
+        /// event is a 'ack' event
+        e_ACK = 8,
+        /// event is a 'clusterState' event
+        e_CLUSTER_STATE = 9,
+        /// event is a 'storage' event
+        e_STORAGE = 10,
+        /// event is a 'recovery' event
+        e_RECOVERY            = 11,
         e_REPLICATION_RECEIPT = 12
     };
-    // NOTE: Events of type 'e_DISPATCHER' are similar to those of type
-    //       'e_CALLBACK' in the sense that they both represent a callback to
-    //       be invoked on the thread associated to the target destination
-    //       dispatcher client.  However, the major difference resides in when
-    //       that callback is invoked: unlike all other types, 'e_DISPATCHER'
-    //       events are handled internally by the dispatcher itself, and not
-    //       sent to the 'onDispatcherEvent()' method of the targeted
-    //       destination dispatcher client.  This will also not trigger the
-    //       destination to be added to the flush list.
-    //
-    //       The purpose is that this event can be used for operations such as
-    //       'finalize' (i.e., destroy) of a client where calling any method on
-    //       the destination object might be undefined due to the object no
-    //       longer being alive.
-    //
-    //       Unless needed, always prefer to use the 'e_CALLBACK' type to give
-    //       more control over to the target destination dispatcher client: the
-    //       client will be able to do some pre and post callback invocation
-    //       duty (such as flushing some state).
 
     // CLASS METHODS
 

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -367,26 +367,21 @@ struct QueueHandleReleaseResult {
     enum ReleaseResultFlags {
         // Handle release event processing
 
-        e_NONE = 0
+        e_NONE = 0,
 
         /// no more consumers or producers for all subStream for this handle
-        ,
-        e_NO_HANDLE_CLIENTS = (1 << 0)
+        e_NO_HANDLE_CLIENTS = (1 << 0),
 
         /// no more consumers for this subStream for this handle
-        ,
-        e_NO_HANDLE_STREAM_CONSUMERS = (1 << 1)
+        e_NO_HANDLE_STREAM_CONSUMERS = (1 << 1),
 
         /// no more producers for this subStream for this handle
-        ,
-        e_NO_HANDLE_STREAM_PRODUCERS = (1 << 2)
+        e_NO_HANDLE_STREAM_PRODUCERS = (1 << 2),
 
         /// no more consumers for this subStream across all handles
-        ,
-        e_NO_QUEUE_STREAM_CONSUMERS = (1 << 3)
+        e_NO_QUEUE_STREAM_CONSUMERS = (1 << 3),
 
         /// no more producers for this subStream across all handles
-        ,
         e_NO_QUEUE_STREAM_PRODUCERS = (1 << 4)
     };
 
@@ -1123,8 +1118,7 @@ InlineResult::toAckResult(InlineResult::Enum value)
     case InlineResult::e_INVALID_PRIMARY:
     case InlineResult::e_CHANNEL_ERROR:
     case InlineResult::e_SELF_PRIMARY:
-    default:
-        return bmqt::AckResult::e_UNKNOWN;
+    default: return bmqt::AckResult::e_UNKNOWN;
     }
 }
 

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -88,13 +88,13 @@ struct StorageResult {
         e_GUID_NOT_FOUND    = -3,
         e_LIMIT_MESSAGES    = -4,
         e_LIMIT_BYTES       = -5,
-        e_ZERO_REFERENCES   = -6  // Reference count has gone to zero
-        ,
-        e_NON_ZERO_REFERENCES = -7  // Reference count is not yet zero
-        ,
-        e_WRITE_FAILURE    = -8,
-        e_APPKEY_NOT_FOUND = -9,
-        e_DUPLICATE        = -10
+        /// Reference count has gone to zero
+        e_ZERO_REFERENCES = -6,
+        /// Reference count is not yet zero
+        e_NON_ZERO_REFERENCES = -7,
+        e_WRITE_FAILURE       = -8,
+        e_APPKEY_NOT_FOUND    = -9,
+        e_DUPLICATE           = -10
     };
 
     // CLASS METHODS

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -349,16 +349,17 @@ class Channel {
   public:
     // PUBLIC TYPES
     enum EnumState {
-        e_INITIAL = 0  // Not connected
-        ,
-        e_RESET = 1  // Need resetting because of a connection change
-        ,
-        e_CLOSE = 2  // Between 'Channel::close; and 'resetChannel'
-        ,
+        /// Not connected
+        e_INITIAL = 0,
+        /// Need resetting because of a connection change
+        e_RESET = 1,
+        /// Between 'Channel::close; and 'resetChannel'
+        e_CLOSE = 2,
         e_READY = 3,
-        e_LWM   = 4  // LWM
-        ,
-        e_HWM = 5  // HWM
+        /// LWM
+        e_LWM = 4,
+        /// HWM
+        e_HWM = 5
     };
 
   private:

--- a/src/groups/mqb/mqbnet/mqbnet_elector.h
+++ b/src/groups/mqb/mqbnet/mqbnet_elector.h
@@ -295,10 +295,9 @@ struct ElectorTransitionReason {
     // TYPES
     enum Enum {
         // Valid with all 4 ElectorStates
-        e_NONE = 0
+        e_NONE = 0,
 
         // Valid only with ElectorState::e_FOLLOWER
-        ,
         e_STARTED             = 1,
         e_LEADER_NO_HEARTBEAT = 2,
         e_LEADER_UNAVAILABLE  = 3,

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
@@ -114,10 +114,11 @@ class TransportManager {
     enum ConnectionMode {
         // Enum describing how the cluster should establish connection with the
         // nodes of the cluster.
-        e_CONNECT_ALL = 0  // Connect out to all nodes
-        ,
-        e_MIXED = 1  // Connect out to higher node Ids only, expect
-                     // incoming connection from lower node Ids
+        /// Connect out to all nodes
+        e_CONNECT_ALL = 0,
+        /// Connect out to higher node Ids only, expect incoming connection
+        /// from lower node Ids
+        e_MIXED = 1
     };
 
   private:

--- a/src/groups/mqb/mqbs/mqbs_datafileiterator.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datafileiterator.cpp
@@ -37,17 +37,18 @@ int DataFileIterator::reset(const MappedFileDescriptor* mfd,
     BSLS_ASSERT_SAFE(mfd);
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_NO_FILE_HEADER = -1  // Not enough bytes for FileHeader
-        ,
-        rc_CORRUPT_FILE_HEADER = -2  // Corrupt FileHeader
-        ,
-        rc_NO_DATA_HEADER = -3  // Not enough bytes for DataFileHeader
-        ,
-        rc_CORRUPT_DATA_HEADER = -4  // Corrupt DataFileHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -5  // Not enough bytes
+        /// Success
+        rc_SUCCESS = 0,
+        /// Not enough bytes for FileHeader
+        rc_NO_FILE_HEADER = -1,
+        /// Corrupt FileHeader
+        rc_CORRUPT_FILE_HEADER = -2,
+        /// Not enough bytes for DataFileHeader
+        rc_NO_DATA_HEADER = -3,
+        /// Corrupt DataFileHeader
+        rc_CORRUPT_DATA_HEADER = -4,
+        /// Not enough bytes
+        rc_NOT_ENOUGH_BYTES = -5
     };
 
     // Clear earlier state.
@@ -138,17 +139,18 @@ int DataFileIterator::nextRecord()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // Another message exists
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_NOT_ENOUGH_BYTES_FOR_HDR = -2  // Not enough bytes for DataHeader
-        ,
-        rc_NOT_ENOUGH_BYTES_FOR_MSG = -3  // Not enough bytes for the payload
-        ,
-        rc_CORRUPT_HEADER = -4  // Corrupt DataHeader
+        /// Another message exists
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// Not enough bytes for DataHeader
+        rc_NOT_ENOUGH_BYTES_FOR_HDR = -2,
+        /// Not enough bytes for the payload
+        rc_NOT_ENOUGH_BYTES_FOR_MSG = -3,
+        /// Corrupt DataHeader
+        rc_CORRUPT_HEADER = -4
     };
 
     if (!isValid()) {

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -364,8 +364,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&          errorDescription,
     BSLS_ASSERT_SAFE(inDispatcherThread());
 
     enum {
-        rc_NO_FILES_TO_RECOVER = 1  // Reserved rc
-        ,
+        /// Reserved rc
+        rc_NO_FILES_TO_RECOVER                 = 1,
         rc_SUCCESS                             = 0,
         rc_RECOVERY_FILE_SET_RETRIEVAL_FAILURE = -1,
         rc_FILE_ITERATOR_FAILURE               = -2,
@@ -6107,11 +6107,12 @@ int FileStore::removeRecord(const DataStoreRecordHandle& handle)
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_INVALID_HANDLE = -1  // Invalid handle
-        ,
-        rc_HANDLE_NOT_FOUND = -2  // Handle not found
+        /// Success
+        rc_SUCCESS = 0,
+        /// Invalid handle
+        rc_INVALID_HANDLE = -1,
+        /// Handle not found
+        rc_HANDLE_NOT_FOUND = -2
     };
 
     if (!handle.isValid()) {

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocol.h
@@ -606,15 +606,15 @@ struct QlistFileHeader {
 struct DataHeaderFlags {
     // TYPES
     enum Enum {
-        e_MESSAGE_PROPERTIES = (1 << 0)  // Contains message properties
-        ,
-        e_UNUSED2 = (1 << 1),
-        e_UNUSED3 = (1 << 2),
-        e_UNUSED4 = (1 << 3),
-        e_UNUSED5 = (1 << 4),
-        e_UNUSED6 = (1 << 5),
-        e_UNUSED7 = (1 << 6),
-        e_UNUSED8 = (1 << 7)
+        /// Contains message properties
+        e_MESSAGE_PROPERTIES = (1 << 0),
+        e_UNUSED2            = (1 << 1),
+        e_UNUSED3            = (1 << 2),
+        e_UNUSED4            = (1 << 3),
+        e_UNUSED5            = (1 << 4),
+        e_UNUSED6            = (1 << 5),
+        e_UNUSED7            = (1 << 6),
+        e_UNUSED8            = (1 << 7)
     };
 
     // CLASS METHODS
@@ -1636,13 +1636,14 @@ struct QueueOpType {
     // TYPES
     enum Enum {
         e_UNDEFINED = 0,
-        e_PURGE     = 1  // A queue (or a specific appId) is purged
-        ,
-        e_CREATION = 2  // A new queue is created
-        ,
-        e_DELETION = 3  // A queue (or a specific appId) is deleted
-        ,
-        e_ADDITION = 4  // New appId(s) have been added to existing queue
+        /// A queue (or a specific appId) is purged
+        e_PURGE = 1,
+        /// A new queue is created
+        e_CREATION = 2,
+        /// A queue (or a specific appId) is deleted
+        e_DELETION = 3,
+        /// New appId(s) have been added to existing queue
+        e_ADDITION = 4
     };
 
     // CLASS METHODS
@@ -1846,8 +1847,8 @@ struct JournalOpType {
     // TYPES
     enum Enum {
         e_UNDEFINED = 0,
-        e_UNUSED    = 1  // Can be used in future.
-        ,
+        /// Can be used in future.
+        e_UNUSED    = 1,
         e_SYNCPOINT = 2
     };
 

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -248,12 +248,11 @@ int FileStoreUtil::findFileStoreSetsFromPaths(
     BSLS_ASSERT_SAFE(fileSetMap);
 
     enum {
-        rc_SUCCESS                = 0,
-        rc_FILE_EXTENSION_UNKNOWN = -1  // Failed to recognize file
-        // extension
-        ,
-        rc_TIMESTAMP_EXTRACTION_FAILURE = -2  // Failed to extract timestamp
-                                              // from file name
+        rc_SUCCESS = 0,
+        /// Failed to recognize file extension
+        rc_FILE_EXTENSION_UNKNOWN = -1,
+        /// Failed to extract timestamp from file name
+        rc_TIMESTAMP_EXTRACTION_FAILURE = -2
     };
 
     int localRC  = rc_SUCCESS;
@@ -1062,14 +1061,13 @@ int FileStoreUtil::openRecoveryFileSet(bsl::ostream&         errorDescription,
     BSLS_ASSERT_SAFE((!qlistFd && !qlistFilePos) || (qlistFd && qlistFilePos));
 
     enum {
-        rc_NO_FILE_SETS_TO_RECOVER = 1  // Special rc, do not change
-        ,
-        rc_SUCCESS                    = 0,
-        rc_FILE_SET_RETRIEVAL_FAILURE = -1  // Failed to retrieve file sets
-        ,
-        rc_RECOVERY_SET_RETRIEVAL_FAILURE = -2  // Failed to retrieve file set
-                                                // from which recovery could be
-                                                // performed
+        /// Special rc, do not change
+        rc_NO_FILE_SETS_TO_RECOVER = 1,
+        rc_SUCCESS                 = 0,
+        /// Failed to retrieve file sets
+        rc_FILE_SET_RETRIEVAL_FAILURE = -1,
+        /// Failed to retrieve file set from which recovery could be performed
+        rc_RECOVERY_SET_RETRIEVAL_FAILURE = -2
     };
 
     const int                 k_INVALID_INDEX = -1;

--- a/src/groups/mqb/mqbs/mqbs_journalfileiterator.cpp
+++ b/src/groups/mqb/mqbs/mqbs_journalfileiterator.cpp
@@ -44,19 +44,20 @@ int JournalFileIterator::reset(const MappedFileDescriptor* mfd,
 
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_NO_FILE_HEADER = -1  // Not enough bytes for FileHeader
-        ,
-        rc_CORRUPT_FILE_HEADER = -2  // Corrupt FileHeader
-        ,
-        rc_NO_JOURNAL_HEADER = -3  // Not enough bytes for JournalHeader
-        ,
-        rc_CORRUPT_JOURNAL_HEADER = -4  // Corrupt JournalHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -5  // Not enough bytes
-        ,
-        rc_NO_VALID_RECORD = -6  // No valid record in the journal
+        /// Success
+        rc_SUCCESS = 0,
+        /// Not enough bytes for FileHeader
+        rc_NO_FILE_HEADER = -1,
+        /// Corrupt FileHeader
+        rc_CORRUPT_FILE_HEADER = -2,
+        /// Not enough bytes for JournalHeader
+        rc_NO_JOURNAL_HEADER = -3,
+        /// Corrupt JournalHeader
+        rc_CORRUPT_JOURNAL_HEADER = -4,
+        /// Not enough bytes
+        rc_NOT_ENOUGH_BYTES = -5,
+        /// No valid record in the journal
+        rc_NO_VALID_RECORD = -6
     };
 
     // Clear earlier state
@@ -191,17 +192,18 @@ int JournalFileIterator::advance(const bsls::Types::Uint64 distance)
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_INVALID_RECORD_TYPE = -2  // Invalid record type
-        ,
-        rc_INVALID_SEQ_NUM = -3  // Invalid sequence number
-        ,
-        rc_MAGIC_MISMATCH = -4  // Magic mismatch
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// Invalid record type
+        rc_INVALID_RECORD_TYPE = -2,
+        /// Invalid sequence number
+        rc_INVALID_SEQ_NUM = -3,
+        /// Magic mismatch
+        rc_MAGIC_MISMATCH = -4
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {

--- a/src/groups/mqb/mqbs/mqbs_qlistfileiterator.cpp
+++ b/src/groups/mqb/mqbs/mqbs_qlistfileiterator.cpp
@@ -43,17 +43,18 @@ int QlistFileIterator::reset(const MappedFileDescriptor* mfd,
     BSLS_ASSERT_SAFE(mfd);
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_NO_FILE_HEADER = -1  // Not enough bytes for FileHeader
-        ,
-        rc_CORRUPT_FILE_HEADER = -2  // Corrupt FileHeader
-        ,
-        rc_NO_QLIST_HEADER = -3  // Not enough bytes for QlistFileHeader
-        ,
-        rc_CORRUPT_QLIST_HEADER = -4  // Corrupt QlistFileHeader
-        ,
-        rc_NOT_ENOUGH_BYTES = -5  // Not enough bytes
+        /// Success
+        rc_SUCCESS = 0,
+        /// Not enough bytes for FileHeader
+        rc_NO_FILE_HEADER = -1,
+        /// Corrupt FileHeader
+        rc_CORRUPT_FILE_HEADER = -2,
+        /// Not enough bytes for QlistFileHeader
+        rc_NO_QLIST_HEADER = -3,
+        /// Corrupt QlistFileHeader
+        rc_CORRUPT_QLIST_HEADER = -4,
+        /// Not enough bytes
+        rc_NOT_ENOUGH_BYTES = -5
     };
 
     // Clear earlier state
@@ -135,19 +136,18 @@ int QlistFileIterator::nextRecord()
 {
     enum RcEnum {
         // Value for the various RC error categories
-        rc_HAS_NEXT = 1  // There is another message after this
-                         // one
-        ,
-        rc_AT_END = 0  // This is the last message
-        ,
-        rc_INVALID = -1  // The Iterator is an invalid state
-        ,
-        rc_MAGIC_MISMATCH = -2  // Magic mismatch
-        ,
-        rc_NOT_ENOUGH_BYTES = -3  // Not enough bytes for QueueRecordHeader
-                                  // and QueueRecord
-        ,
-        rc_CORRUPT_RECORD_HEADER = -4  // Queue record header is corrupt
+        /// There is another message after this one
+        rc_HAS_NEXT = 1,
+        /// This is the last message
+        rc_AT_END = 0,
+        /// The Iterator is an invalid state
+        rc_INVALID = -1,
+        /// Magic mismatch
+        rc_MAGIC_MISMATCH = -2,
+        /// Not enough bytes for QueueRecordHeader and QueueRecord
+        rc_NOT_ENOUGH_BYTES = -3,
+        /// Queue record header is corrupt
+        rc_CORRUPT_RECORD_HEADER = -4
     };
 
     if (!isValid()) {

--- a/src/groups/mqb/mqbs/mqbs_storagecollectionutil.h
+++ b/src/groups/mqb/mqbs/mqbs_storagecollectionutil.h
@@ -57,12 +57,11 @@ struct StorageCollectionUtilSortMetric {
     // TYPES
     enum Enum {
         /// Alphanumeric order of its queue's URI
-        e_QUEUE_URI     = 0,
-        e_MESSAGE_COUNT = 1
-        // Number of messages in its queue, in descending order
-        ,
+        e_QUEUE_URI = 0,
+        /// Number of messages in its queue, in descending order
+        e_MESSAGE_COUNT = 1,
+        /// Number of bytes in its queue, in descending order
         e_BYTE_COUNT = 2
-        // Number of bytes in its queue, in descending order
 
     };
 

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.cpp
@@ -58,9 +58,10 @@ int StoragePrintUtil::listMessage(mqbcmd::Message*             message,
     BSLS_ASSERT_SAFE(storage);
     enum RcEnum {
         // Value for the various RC error categories
-        rc_SUCCESS = 0  // Success
-        ,
-        rc_ITER_AT_END = -1  // Iterator is pointing at the end of the queue
+        /// Success
+        rc_SUCCESS = 0,
+        /// Iterator is pointing at the end of the queue
+        rc_ITER_AT_END = -1
     };
 
     if (storageIter.atEnd()) {

--- a/src/groups/mqb/mqbsi/mqbsi_ledger.h
+++ b/src/groups/mqb/mqbsi/mqbsi_ledger.h
@@ -76,15 +76,14 @@ struct LedgerOpResult {
     enum Enum {
         // Generic
         // - - - -
-        e_SUCCESS = 0  // Operation was successful
-        ,
+        /// Operation was successful
+        e_SUCCESS                 = 0,
         e_UNKNOWN                 = -1,
         e_LEDGER_NOT_EXIST        = -2,
-        e_LEDGER_UNGRACEFUL_CLOSE = -3
+        e_LEDGER_UNGRACEFUL_CLOSE = -3,
 
         // File specific
         // - - - - - - - - - - - - - - - - - - - - - -
-        ,
         e_LEDGER_READ_ONLY        = -6,
         e_LOG_CREATE_FAILURE      = -7,
         e_LOG_OPEN_FAILURE        = -8,
@@ -408,10 +407,10 @@ class Ledger {
     typedef bsl::vector<LogSp>   Logs;
 
     enum Enum {
-        e_READ_ONLY = (1 << 0)  // Whether the ledger is read-only
-        ,
-        e_CREATE_IF_MISSING = (1 << 1)  // Whether to create the ledger when
-                                        // opening if it does not exist
+        /// Whether the ledger is read-only
+        e_READ_ONLY = (1 << 0),
+        /// Whether to create the ledger when opening if it does not exist
+        e_CREATE_IF_MISSING = (1 << 1)
     };
 
   public:

--- a/src/groups/mqb/mqbsi/mqbsi_log.h
+++ b/src/groups/mqb/mqbsi/mqbsi_log.h
@@ -83,93 +83,74 @@ struct LogOpResult {
     enum Enum {
         // Generic
         // - - - -
-        e_SUCCESS = 0
-        // Operation was successful
+        /// Operation was successful
+        e_SUCCESS = 0,
 
         /// Unknown result
-        ,
-        e_UNKNOWN = -1
+        e_UNKNOWN = -1,
 
         /// Operation is *not* supported for this type of log
-        ,
-        e_UNSUPPORTED_OPERATION = -2
+        e_UNSUPPORTED_OPERATION = -2,
 
         /// Log was already opened
-        ,
-        e_LOG_ALREADY_OPENED = -3
+        e_LOG_ALREADY_OPENED = -3,
 
         /// Log was already closed
-        ,
-        e_LOG_ALREADY_CLOSED = -4
+        e_LOG_ALREADY_CLOSED = -4,
 
         /// Read-only contract is violated
-        ,
-        e_LOG_READONLY = -5
+        e_LOG_READONLY = -5,
 
         // File specific, only relevant to on-disk logs
         // - - - - - - - - - - - - - - - - - - - - - -
 
         /// File does not exist
-        ,
-        e_FILE_NOT_EXIST = -6
+        e_FILE_NOT_EXIST = -6,
 
         /// Error when opening the file
-        ,
-        e_FILE_OPEN_FAILURE = -7
+        e_FILE_OPEN_FAILURE = -7,
 
         /// Error when closing the file
-        ,
-        e_FILE_CLOSE_FAILURE = -8
+        e_FILE_CLOSE_FAILURE = -8,
 
         /// Error when growing the size of the file
-        ,
-        e_FILE_GROW_FAILURE = -9
+        e_FILE_GROW_FAILURE = -9,
 
         /// Error when truncating the file
-        ,
-        e_FILE_TRUNCATE_FAILURE = -10
+        e_FILE_TRUNCATE_FAILURE = -10,
 
         /// Error when seeking in the file
-        ,
-        e_FILE_SEEK_FAILURE = -11
+        e_FILE_SEEK_FAILURE = -11,
 
         /// Error when flushing file changes to disk
-        ,
-        e_FILE_FLUSH_FAILURE = -12
+        e_FILE_FLUSH_FAILURE = -12,
 
         /// Error when synchronizing the memory map back to the filesystem
-        ,
-        e_FILE_MSYNC_FAILURE = -13
+        e_FILE_MSYNC_FAILURE = -13,
 
         // Range checks for log, record, and blob
         // - - - - - - - - - - - - - - - - - - -
 
         /// The offset input argument is out of range of valid offsets
-        ,
-        e_OFFSET_OUT_OF_RANGE = -14
+        e_OFFSET_OUT_OF_RANGE = -14,
 
-        /// Operation would result in the log exceeding the configured
-        /// maximum size
-        ,
-        e_REACHED_END_OF_LOG = -15
+        /// Operation would result in the log exceeding the configured maximum
+        /// size
+        e_REACHED_END_OF_LOG = -15,
 
         /// Operation would exceed the end of the record
-        ,
-        e_REACHED_END_OF_RECORD = -16
+        e_REACHED_END_OF_RECORD = -16,
 
         /// An invalid blob section was provided
-        ,
-        e_INVALID_BLOB_SECTION = -17
+        e_INVALID_BLOB_SECTION = -17,
 
         // Byte read/write
         // - - - - - - - -
 
         /// Failed to read bytes from the log
-        ,
-        e_BYTE_READ_FAILURE = -18
+        e_BYTE_READ_FAILURE = -18,
 
         /// Failed to write bytes into the log
-        ,
         e_BYTE_WRITE_FAILURE = -19
     };
 
@@ -338,10 +319,10 @@ class Log {
     typedef bsls::Types::Uint64 UnsignedOffset;
 
     enum Enum {
-        e_READ_ONLY = (1 << 0)  // Whether the log is read-only
-        ,
-        e_CREATE_IF_MISSING = (1 << 1)  // Whether to create the log when
-                                        // opening if it does not exist
+        /// Whether the log is read-only
+        e_READ_ONLY = (1 << 0),
+        /// Whether to create the log when opening if it does not exist
+        e_CREATE_IF_MISSING = (1 << 1)
     };
 
     // CLASS DATA

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -440,88 +440,70 @@ struct DomainQueueStats {
     enum Enum {
         /// Value:      Current number of clients who opened the queue with
         ///             the `WRITE` flag
-        e_STAT_NB_PRODUCER
+        e_STAT_NB_PRODUCER,
 
-        ,
         /// Value:      Current number of clients who opened the queue with
         ///             the 'READ' flag
-        e_STAT_NB_CONSUMER
+        e_STAT_NB_CONSUMER,
 
-        ,
         /// Value:      Current number of messages in the queue
-        e_STAT_MESSAGES
+        e_STAT_MESSAGES,
 
-        ,
         /// Value:      Accumulated bytes of all messages currently in the
         ///             queue
-        e_STAT_BYTES
+        e_STAT_BYTES,
 
-        ,
         /// Value:      Number of ack messages delivered by this queue
-        e_STAT_ACK
+        e_STAT_ACK,
 
-        ,
         /// Value:      The time between PUT and ACK (in nanoseconds).
-        e_STAT_ACK_TIME
+        e_STAT_ACK_TIME,
 
-        ,
         /// Value:      Number of NACK messages generated for this queue
-        e_STAT_NACK
+        e_STAT_NACK,
 
-        ,
         /// Value:      Number of CONFIRM messages received by this queue
-        e_STAT_CONFIRM
+        e_STAT_CONFIRM,
 
-        ,
         /// Value:      The time between PUSH and CONFIRM (in nanoseconds).
-        e_STAT_CONFIRM_TIME
+        e_STAT_CONFIRM_TIME,
 
-        ,
         /// Value:      Number of messages rejected by this queue (RDA
         ///             reaching zero)
-        e_STAT_REJECT
+        e_STAT_REJECT,
 
-        ,
         /// Value:      The time spent by the message in the queue (in
         ///             nanoseconds).
-        e_STAT_QUEUE_TIME
+        e_STAT_QUEUE_TIME,
 
-        ,
         /// Value:      Accumulated bytes of all messages ever pushed from
         ///             the queue
         /// Increment:  Number of messages ever pushed from the queue
-        e_STAT_PUSH
+        e_STAT_PUSH,
 
-        ,
         /// Value:      Accumulated bytes of all messages ever put in the
         ///             queue
         /// Increment:  Number of messages ever put in the queue
-        e_STAT_PUT
+        e_STAT_PUT,
 
-        ,
         /// Value:      Accumulated number of messages ever GC'ed in the
         ///             queue
-        e_STAT_GC_MSGS
+        e_STAT_GC_MSGS,
 
-        ,
         /// Value:      Role (Unknown, Primary, Replica, Proxy)
-        e_STAT_ROLE
+        e_STAT_ROLE,
 
-        ,
         /// Value:      The configured queue messages capacity
-        e_CFG_MSGS
+        e_CFG_MSGS,
 
-        ,
         /// Value:      The configured queue bytes capacity
-        e_CFG_BYTES
+        e_CFG_BYTES,
 
-        ,
         /// Value:      Accumulated number of messages in the strong
         ///             consistency queue expired before receiving quorum
         ///             Receipts
-        e_STAT_NO_SC_MSGS
+        e_STAT_NO_SC_MSGS,
 
-        ,
         /// Value:      Current number of GUIDs stored in queue's history
         ///             (does not include messages in the queue)
         e_STAT_HISTORY

--- a/src/groups/mqb/mqbu/mqbu_capacitymeter.h
+++ b/src/groups/mqb/mqbu/mqbu_capacitymeter.h
@@ -184,11 +184,12 @@ class CapacityMeter {
         // Enum representing the possible result value of the
         // 'commitUnreserved' operation.
 
-        e_SUCCESS = 0  // operation was success
-        ,
-        e_LIMIT_MESSAGES = 1  // messages limit was hit
-        ,
-        e_LIMIT_BYTES = 2  // bytes limit was hit
+        /// operation was success
+        e_SUCCESS = 0,
+        /// messages limit was hit
+        e_LIMIT_MESSAGES = 1,
+        /// bytes limit was hit
+        e_LIMIT_BYTES = 2
     };
 
     // Callback function to log enhanced storage info into the

--- a/src/groups/mqb/mqbu/mqbu_exit.h
+++ b/src/groups/mqb/mqbu/mqbu_exit.h
@@ -49,65 +49,55 @@ struct ExitCode {
   public:
     // TYPES
     enum Enum {
-        e_SUCCESS = 0  // Clean exit
+        /// Clean exit
+        e_SUCCESS = 0,
 
-        ,
-        e_COMMAND_LINE = 1  // Error while parsing the command line
-                            // parameters, this typically mean that an
-                            // invalid argument was provided.
+        /// Error while parsing the command line parameters, this typically
+        /// mean that an invalid argument was provided.
+        e_COMMAND_LINE = 1,
 
-        ,
-        e_CONFIG_GENERATION = 2  // Error while generating the
-                                 // configuration, or parsing the generated
-                                 // configuration: this could mean the
-                                 // python failed to execute, the generated
-                                 // output was invalid JSON syntax, or
-                                 // didn't match the expected schema.
+        /// Error while generating the configuration, or parsing the generated
+        /// configuration: this could mean the python failed to execute, the
+        /// generated output was invalid JSON syntax, or didn't match the
+        /// expected schema.
+        e_CONFIG_GENERATION = 2,
 
-        ,
-        e_TASK_INITIALIZE = 3  // Failed to initialize the task.  Possible
-                               // cause are invalid configuration, failed
-                               // to create threads, unable to open the
-                               // pipe control channel, ..
+        /// Failed to initialize the task.  Possible cause are invalid
+        /// configuration, failed to create threads, unable to open the pipe
+        /// control channel, ..
+        e_TASK_INITIALIZE = 3,
 
-        ,
-        e_BENCH_START = 4  // Unable to start the bench application.
+        /// Unable to start the bench application.
+        e_BENCH_START = 4,
 
-        ,
-        e_APP_INITIALIZE = 5  // Failed to initialize the application.
+        /// Failed to initialize the application.
+        e_APP_INITIALIZE = 5,
 
-        ,
-        e_RUN = 6  // Failed to start the application (many
-                   // reasons such as failed to listen to TCP
-                   // port, ...).
+        /// Failed to start the application (many reasons such as failed to
+        /// listen to TCP port, ...).
+        e_RUN = 6,
 
-        ,
-        e_QUEUEID_FULL = 7  // The upstream queueId counter has reached
-                            // capacity limit.
+        /// The upstream queueId counter has reached capacity limit.
+        e_QUEUEID_FULL = 7,
 
-        ,
-        e_SUBQUEUEID_FULL = 8  // The upstream subQueueId counter has
-                               // reached capacity limit for a particular
-                               // queue
+        /// The upstream subQueueId counter has reached capacity limit for a
+        /// particular queue
+        e_SUBQUEUEID_FULL = 8,
 
-        ,
-        e_RECOVERY_FAILURE = 9  // A fatal error was encountered while
-                                // attempting storage recovery.
+        /// A fatal error was encountered while attempting storage recovery.
+        e_RECOVERY_FAILURE = 9,
 
-        ,
-        e_STORAGE_OUT_OF_SYNC = 10  // Storage on this node has gone out of
-                                    // sync.
+        /// Storage on this node has gone out of sync.
+        e_STORAGE_OUT_OF_SYNC = 10,
 
-        ,
-        e_UNSUPPORTED_SCENARIO = 11  // An supported scenario was encountered.
+        /// An supported scenario was encountered.
+        e_UNSUPPORTED_SCENARIO = 11,
 
-        ,
-        e_MEMORY_LIMIT = 12  // The configured maximum memory allocation
-                             // has been reached.
+        /// The configured maximum memory allocation has been reached.
+        e_MEMORY_LIMIT = 12,
 
-        ,
-        e_REQUESTED = 13  // The broker was requested, through a
-                          // command, to stop.
+        /// The broker was requested, through a command, to stop.
+        e_REQUESTED = 13
     };
 
     // CLASS METHODS

--- a/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.h
+++ b/src/groups/mqb/mqbu/mqbu_resourceusagemonitor.h
@@ -134,11 +134,12 @@ namespace mqbu {
 struct ResourceUsageMonitorState {
     // TYPES
     enum Enum {
-        e_STATE_NORMAL = 0  // Monitor is in normal state
-        ,
-        e_STATE_HIGH_WATERMARK = 1  // Monitor is in high watermark state
-        ,
-        e_STATE_FULL = 2  // Monitor is full
+        /// Monitor is in normal state
+        e_STATE_NORMAL = 0,
+        /// Monitor is in high watermark state
+        e_STATE_HIGH_WATERMARK = 1,
+        /// Monitor is full
+        e_STATE_FULL = 2
     };
 
     // CLASS METHODS
@@ -187,13 +188,14 @@ bsl::ostream& operator<<(bsl::ostream&                   stream,
 struct ResourceUsageMonitorStateTransition {
     // TYPES
     enum Enum {
-        e_NO_CHANGE  // The state of the monitor hasn't changed
-        ,
-        e_LOW_WATERMARK  // The value is back to low watermark
-        ,
-        e_HIGH_WATERMARK  // The value has reached the high watermark
-        ,
-        e_FULL  // The monitored resource is full
+        /// The state of the monitor hasn't changed
+        e_NO_CHANGE,
+        /// The value is back to low watermark
+        e_LOW_WATERMARK,
+        /// The value has reached the high watermark
+        e_HIGH_WATERMARK,
+        /// The monitored resource is full
+        e_FULL
     };
 
     // CLASS METHODS

--- a/src/groups/mqb/mqbu/mqbu_storagekey.h
+++ b/src/groups/mqb/mqbu/mqbu_storagekey.h
@@ -64,11 +64,11 @@ class StorageKey {
         // Enum representing the size of a buffer needed to represent a
         // StorageKey.
 
-        e_KEY_LENGTH_BINARY = 5  // Number of bytes in a binary representation
+        /// Number of bytes in a binary representation
+        e_KEY_LENGTH_BINARY = 5,
 
-        ,
+        /// Number of bytes in a hex representation
         e_KEY_LENGTH_HEX = 2 * e_KEY_LENGTH_BINARY
-        // Number of bytes in a hex representation
     };
 
     // PUBLIC CONSTANTS


### PR DESCRIPTION
We originally used a Haskell-like style for enumerations, with commas preceding the next enumerator on the same line:

    enum Enum {
        e_READY                 // the shared state is ready
      , e_TIMEOUT               // the shared state did not become ready before timeout
    };

After applying `clang-format`, though, this style was turned into the decidedly ugly formatting with commas having their own separate line:

    enum Enum {
        e_READY  // the shared state is ready
        ,
        e_TIMEOUT  // the shared state did not become ready before timeout
    };

This also broke the automated Doxygen conversion, which has resulted in all enumerations that we haven’t manually converted having undocumented enumerators.

This patch performs a big but targeted reformatting of enumerations, so that they use the more common (and `clang-format` approved) trailing comma style.  It also converts all trailing documentation comments into preceding Doxygen-style, resulting in documented enumerators.  From the above example, this patch renders:

    enum Enum {
        /// the shared state is ready
        e_READY,
        /// the shared state did not become ready before timeout
        e_TIMEOUT
    };