### PR TITLE
CI: disable reruns in ITs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,7 +125,6 @@ jobs:
             --bmq-log-level=INFO                \
             --junitxml=integration-tests.xml    \
             --tb long                           \
-            --reruns=2                          \
             --durations=0                       \
             -n logical -v
 


### PR DESCRIPTION
Useful logs are being overridden during reruns and we have mismatch between cores and logs
