### PR TITLE
IT: fix reruns hook

### DIFF
--- a/src/groups/bmq/bmqtst/bmqtst_table.h
+++ b/src/groups/bmq/bmqtst/bmqtst_table.h
@@ -68,7 +68,6 @@ namespace bmqtst {
 // class Table
 // ===========
 
-/// @class Table
 /// @brief Class for aggregation and pretty printing simple stats.
 ///
 /// This class provides a mechanism to create and format tabular data with

--- a/src/python/blazingmq/dev/it/testhooks.py
+++ b/src/python/blazingmq/dev/it/testhooks.py
@@ -29,12 +29,14 @@ def is_test_reported_failed(request):
     To decide if test failed
     """
 
-    report = request.node.stash[PHASE_REPORT_KEY]
-    if report["setup"].failed:
+    report = request.node.stash.get(PHASE_REPORT_KEY, {})
+    if not report:
+        return False
+    if report.get("setup") and report["setup"].failed:
         return True
-    if report["setup"].skipped:
+    if report.get("setup") and report["setup"].skipped:
         return True
-    if ("call" not in report) or report["call"].failed:
+    if ("call" not in report) or (report.get("call") and report["call"].failed):
         return True
 
     return False


### PR DESCRIPTION
- Reruns hook causes IT errors when reruns are disabled
- Also fix docs from the previous PR

Should fix CI errors like
`ERROR test_admin_res_log.py::test_adminsession_res_log_purge[multi_node_fsm-strong_consistency] - KeyError: <_pytest.stash.StashKey object at 0x7f75c1cd0400>`