### PR TITLE
Fix[bmqio::NtcChannelFactory]: acquire/release `d_resourceMonitor`

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
@@ -130,10 +130,6 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
         const bsl::shared_ptr<bmqio::Channel>&       channel,
         const bmqio::ChannelFactory::ResultCallback& callback);
 
-    /// Process the closure of the channel identified by the specified
-    /// `handle`.
-    void processListenerClosed(int handle);
-
     /// Process the specified `event` having the specified `status` for
     /// the specified `channel` and invoke the specified `callback`.
     void processChannelResult(
@@ -142,9 +138,31 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
         const bsl::shared_ptr<bmqio::Channel>&       channel,
         const bmqio::ChannelFactory::ResultCallback& callback);
 
-    /// Process the closure of the listener identified by the specified
-    /// `handle`.
-    void processChannelClosed(int handle);
+    /// @brief Remove the listener identified by the specified @p handle
+    ///        from the catalog and decrement the resource usage count.
+    ///
+    /// @param handle Catalog handle of the listener to remove.
+    void removeListener(int handle);
+
+    /// @brief Remove the channel identified by the specified @p handle
+    ///        from the catalog and decrement the resource usage count.
+    ///
+    /// @param handle Catalog handle of the channel to remove.
+    void removeChannel(int handle);
+
+    /// @brief Add the specified @p listener to the catalog and increment
+    ///        the resource usage count.
+    ///
+    /// @param listener Shared pointer to the listener to add.
+    /// @return Catalog handle for the added listener.
+    int addListener(const bsl::shared_ptr<bmqio::NtcListener>& listener);
+
+    /// @brief Add the specified @p channel to the catalog and increment
+    ///        the resource usage count.
+    ///
+    /// @param channel Shared pointer to the channel to add.
+    /// @return Catalog handle for the added channel.
+    int addChannel(const bsl::shared_ptr<bmqio::NtcChannel>& channel);
 
   public:
     // PUBLIC TYPES


### PR DESCRIPTION
Fixes out of order acquire/release of `d_resourceMonitor`:

```
  #8  0x0000555e211a1962 in BloombergLP::bmqu::AtomicValidator::release (this=0x555e33eb1150) at /home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqu/bmqu_atomicvalidator.h:245
          violation = {d_comment_p = 0x555e2209cc61 "d_count >= 2", d_fileName_p = 0x555e2209cc10 "/home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqu/bmqu_atomicvalidator.h", d_lineNumber = 245, d_assertLevel_p = 0x555e221f20e0 <BloombergLP::bsls::Assert::k_LEVEL_SAFE> "SAF"}
  #9  0x0000555e2195a518 in BloombergLP::bmqio::NtcChannelFactory::processChannelClosed (this=0x555e33eb0fb0, handle=8388609) at /home/runner/work/blazingmq/blazingmq/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp:165
          channel = {d_ptr_p = 0x7f7c400023d0, d_rep_p = 0x7f7c400023b0}
          rc = 0
```

The problem was with registering `NtcChannelFactory::processChannelClosed` (that releases resource monitor on triggering) **before** acquiring resource monitor.