### PR TITLE
IT: wait for all nodes to complete rollover

### DIFF
--- a/src/integration-tests/test_restart_between_modes.py
+++ b/src/integration-tests/test_restart_between_modes.py
@@ -745,6 +745,9 @@ def with_rollover_admin_cmd(
     res = leader.trigger_rollover(all_partition_id, succeed=True)
     assert not res is None
 
+    for node in cluster.nodes():
+        node.wait_rollover_complete()
+
 
 @pytest.fixture(params=[without_rollover, with_rollover, with_rollover_admin_cmd])
 def optional_rollover(request):


### PR DESCRIPTION
Note that `with_rollover` waits for **all** nodes to finish rollover:
https://github.com/bloomberg/blazingmq/blob/a8ee6161b79bd2501bc7b4fe13e939fb8acf57a0/src/integration-tests/test_restart_between_modes.py#L726-L727

`with_rollover_admin_cmd` on the other hand just triggers it on leader and doesn't wait for all nodes to complete, after this IT just continues execution.