### PR TITLE
IT: fix rollover and admin cmd check order

### DIFF
--- a/src/integration-tests/test_restart_between_modes.py
+++ b/src/integration-tests/test_restart_between_modes.py
@@ -742,8 +742,9 @@ def with_rollover_admin_cmd(
     leader = cluster.last_known_leader
 
     all_partition_id = -1  # use -1 to rollover all partitions
-    res = leader.trigger_rollover(all_partition_id, succeed=True)
-    assert not res is None
+    # Do not wait for admin command result because "ROLLOVER COMPLETE" log record appears *before* admin command
+    # result record, and it breaks the regex search. Instead, check for ROLLOVER COMPLETE *after*
+    leader.trigger_rollover(all_partition_id, succeed=None)
 
     for node in cluster.nodes():
         node.wait_rollover_complete()


### PR DESCRIPTION
Do not wait for admin command result because "ROLLOVER COMPLETE" log record appears *before* admin command result record, and it breaks the regex search. Instead, check for ROLLOVER COMPLETE *after*