### PR TITLE
Fix[mqba::DomainManager]: clear cache before doing anything with DOMAIN RECONFIGURE

### DIFF
--- a/src/groups/mqb/mqba/mqba_configprovider.cpp
+++ b/src/groups/mqb/mqba/mqba_configprovider.cpp
@@ -198,9 +198,12 @@ void ConfigProvider::clearCache(bsl::string_view domainName)
         d_cache.clear();
     }
     else {
-        BALL_LOG_INFO << "Clearing up conf cache for '" << domainName << "'";
         CacheMap::iterator it = d_cache.find(domainName);
-        d_cache.erase(it);
+        if (it != d_cache.end()) {
+            BALL_LOG_INFO << "Clearing up conf cache for '" << domainName
+                          << "'";
+            d_cache.erase(it);
+        }
     }
 }
 

--- a/src/groups/mqb/mqba/mqba_domainmanager.cpp
+++ b/src/groups/mqb/mqba/mqba_domainmanager.cpp
@@ -677,6 +677,11 @@ int DomainManager::processCommand(mqbcmd::DomainsResult*        result,
     else if (command.isReconfigureValue()) {
         const bsl::string& name = command.reconfigure().domain();
 
+        // Clear the cache before attempting to locate or create the domain
+        // so that fresh configuration is fetched from disk, even if the
+        // domain doesn't exist yet due to previous configuration failures.
+        d_configProvider_p->clearCache(name);
+
         DomainSp domainSp;
 
         if (0 != locateOrCreateDomain(&domainSp, name)) {
@@ -687,7 +692,6 @@ int DomainManager::processCommand(mqbcmd::DomainsResult*        result,
         }
 
         DecodeAndUpsertValue configureResult;
-        d_configProvider_p->clearCache(domainSp->name());
         d_configProvider_p->getDomainConfig(
             domainSp->name(),
             bdlf::BindUtil::bind(


### PR DESCRIPTION
We need to clear cache **before** calling `locateOrCreateDomain`, because it might be using cached incorrect configuration.

This causes failures in IT `test_invalid_configuration` after I fixed regex timeouts.
In that IT, we first start brokers with incorrect configuration, try to open a queue (and fail), and try to reconfigure with good configuration.

The problem is that bad domain still exists in cache.