### PR TITLE
IT: wait push event before trying to confirm

### DIFF
--- a/src/integration-tests/test_reconfigure_domains.py
+++ b/src/integration-tests/test_reconfigure_domains.py
@@ -394,6 +394,7 @@ class TestReconfigureDomains:
             client = proxy.create_client("reader-stable")
             client.open(URI, flags=["read"], succeed=True)
             if expect_success:
+                client.wait_push_event(timeout=5)
                 client.confirm(URI, "+1", succeed=True)
             else:
                 assert not client.wait_push_event(timeout=5)
@@ -440,6 +441,7 @@ class TestReconfigureDomains:
             client = proxy.create_client("reader-stable")
             client.open(URI, flags=["read"], succeed=True)
             if expect_success:
+                client.wait_push_event(timeout=5)
                 client.confirm(URI, "+1", succeed=True)
             else:
                 assert not client.wait_push_event(timeout=5)


### PR DESCRIPTION
Should fix flaky tests that produce error like this:
`FAILED test_restart_between_modes.py::test_restart_between_legacy_and_fsm_add_remove_app[multi_node_fsm-strong_consistency-to_fsm/from_legacy-with_rollover_admin_cmd] - blazingmq.dev.it.process.client.ITError: confirm uri="bmq://bmq.test.mmap.priority.sc/qqq1" guid="+1" did not complete within 15s`