### PR TITLE
CI[macosx]: Treat warnings as errors

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -276,7 +276,7 @@ jobs:
 
       - name: Build BlazingMQ
         env:
-          CXXFLAGS: "-Wno-poison-system-directories"
+          CXXFLAGS: "-Werror -Wno-poison-system-directories"
         run: |
           echo "::add-matcher::.github/workflows/problem-matchers/cpp.json"
           bin/build-darwin.sh


### PR DESCRIPTION
As part of our goal of reaching zero warnings in both Clang and GCC, we need to make sure that we stay there as BlazingMQ changes.  We’ve had a number of regressions in this regard recently.  While we’re not at the point yet where we can make CI build with warnings as errors globally, we can do on our OS X build.  This pull request turns on `-Werror` on OS X/Clang builds.