### PR TITLE
Fix[IT]: also execute tests that do not have a consistency mark

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -93,7 +93,7 @@ jobs:
       matrix:
         mode: ["legacy_mode", "fsm_mode"]
         cluster: ["single", "multi"]
-        consistency: ["eventual_consistency", "strong_consistency"]
+        consistency: ["eventual_consistency", "strong_consistency", "not (eventual_consistency or strong_consistency)"]
       fail-fast: false
     runs-on: ubuntu-latest
     needs: build_ubuntu


### PR DESCRIPTION
10 tests (atm) don't have a consistency mark, thus they were skipped by CI. These tests are:
```
<Package integration-tests>
  <Module test_breathing.py>
    <Function test_client_user_agent[single_node]>
    <Function test_client_user_agent[single_node_fsm]>
    <Function test_client_user_agent[multi_node]>
    <Function test_client_user_agent[multi_node_fsm]>
    <Function test_broker_user_agent[multi_node]>
    <Function test_broker_user_agent[multi_node_fsm]>
  <Module test_create_new_domain.py>
    <Function test_deploy_new_domain_existing_cluster[multi_node]>
    <Function test_deploy_new_domain_existing_cluster[multi_node_fsm]>
    <Function test_deploy_new_domain_new_cluster[multi_node]>
    <Function test_deploy_new_domain_new_cluster[multi_node_fsm]>
```