### PR TITLE
Fix[mqbc::ClusterStateMgr]: Retry watchdog N times before exiting 

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -591,6 +591,8 @@ ClusterOrchestrator::ClusterOrchestrator(
                             &d_clusterData_p->blobSpPool())),
                     clusterConfig.clusterAttributes()
                         .clusterFsmWatchdogTimeoutSec(),
+                    clusterConfig.clusterAttributes()
+                        .clusterFsmWatchdogNumRetries(),
                     d_allocators.get("ClusterStateManager")))
           : static_cast<mqbi::ClusterStateManager*>(
                 new(*d_allocator_p) ClusterStateManager(

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -55,12 +55,14 @@ ClusterStateManager::ClusterStateManager(
     mqbc::ClusterData*               clusterData,
     mqbc::ClusterState*              clusterState,
     ClusterStateLedgerMp             clusterStateLedger,
-    bsls::Types::Int64               watchDogTimeoutDuration,
+    bsls::Types::Int64               watchdogTimeoutDuration,
+    int                              watchdogNumRetries,
     bslma::Allocator*                allocator)
 : d_allocator_p(allocator)
 , d_allocators(d_allocator_p)
-, d_watchDogEventHandle()
-, d_watchDogTimeoutInterval(watchDogTimeoutDuration)
+, d_watchdogCtx()
+, d_watchdogTimeoutInterval(watchdogTimeoutDuration)
+, d_watchdogNumRetries(watchdogNumRetries)
 , d_clusterConfig(clusterConfig)
 , d_cluster_p(cluster)
 , d_clusterData_p(clusterData)
@@ -78,6 +80,8 @@ ClusterStateManager::ClusterStateManager(
     BSLS_ASSERT_SAFE(d_clusterData_p);
     BSLS_ASSERT_SAFE(d_state_p);
     BSLS_ASSERT_SAFE(d_clusterStateLedger_mp);
+
+    d_watchdogCtx.d_retriesRemaining = d_watchdogNumRetries;
 
     d_clusterStateLedger_mp->setCommitCb(
         bdlf::BindUtil::bind(&ClusterStateManager::onCommit,
@@ -117,10 +121,21 @@ void ClusterStateManager::do_startWatchDog(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
 
+    if (d_watchdogCtx.d_active) {
+        return;  // RETURN
+    }
+
+    d_watchdogCtx.d_eventHandle.release();
+
+    const int generation = d_watchdogCtx.d_generation;
     d_clusterData_p->scheduler().scheduleEvent(
-        &d_watchDogEventHandle,
-        d_clusterData_p->scheduler().now() + d_watchDogTimeoutInterval,
-        bdlf::BindUtil::bind(&ClusterStateManager::onWatchDog, this));
+        &d_watchdogCtx.d_eventHandle,
+        d_clusterData_p->scheduler().now() + d_watchdogTimeoutInterval,
+        bdlf::BindUtil::bind(&ClusterStateManager::onWatchdog,
+                             this,
+                             generation));
+
+    d_watchdogCtx.d_active = true;
 }
 
 void ClusterStateManager::do_stopWatchDog(
@@ -131,9 +146,18 @@ void ClusterStateManager::do_stopWatchDog(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
 
-    if (d_clusterData_p->scheduler().cancelEvent(d_watchDogEventHandle) != 0) {
+    // Increment generation to invalidate any in-flight stale watchdog
+    // triggers from the previous healing session and reset the retry counter
+    // for the next healing session.
+    ++d_watchdogCtx.d_generation;
+    d_watchdogCtx.d_retriesRemaining = d_watchdogNumRetries;
+    d_watchdogCtx.d_active           = false;
+
+    const int rc = d_clusterData_p->scheduler().cancelEvent(
+        d_watchdogCtx.d_eventHandle);
+    if (rc != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << ": Failed to cancel WatchDog.";
+                       << ": Failed to cancel Watchdog, rc: " << rc;
     }
 }
 
@@ -145,11 +169,19 @@ void ClusterStateManager::do_triggerWatchDog(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
 
+    if (!d_watchdogCtx.d_active) {
+        BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                       << ": Attempting to trigger watchdog while watchdog is "
+                       << "not active.  Please review Cluster FSM logic.";
+
+        return;  // RETURN
+    }
+
     if (d_clusterData_p->scheduler().rescheduleEvent(
-            d_watchDogEventHandle,
+            d_watchdogCtx.d_eventHandle,
             d_clusterData_p->scheduler().now()) != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << ": Failed to trigger WatchDog.";
+                       << ": Failed to trigger Watchdog.";
     }
 }
 
@@ -1196,32 +1228,60 @@ int ClusterStateManager::loadClusterStateSnapshot(
     return 0;
 }
 
-void ClusterStateManager::onWatchDog()
+void ClusterStateManager::onWatchdog(int generation)
 {
     // executed by the *SCHEDULER* thread
 
     dispatcher()->execute(
-        bdlf::BindUtil::bind(&ClusterStateManager::onWatchDogDispatched, this),
+        bdlf::BindUtil::bind(&ClusterStateManager::onWatchdogDispatched,
+                             this,
+                             generation),
         d_cluster_p);
 }
 
-void ClusterStateManager::onWatchDogDispatched()
+void ClusterStateManager::onWatchdogDispatched(int generation)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
 
-    if (d_clusterFSM.isSelfHealed()) {
+    // Check if this watchdog is stale
+    if (generation != d_watchdogCtx.d_generation) {
+        BALL_LOG_WARN << d_clusterData_p->identity().description()
+                      << ": Ignoring stale watchdog event with generation "
+                      << generation << ", current generation is "
+                      << d_watchdogCtx.d_generation;
         return;  // RETURN
     }
 
-    BALL_LOG_WARN << d_clusterData_p->identity().description()
-                  << ": Watchdog triggered because node startup healing "
-                  << "sequence was not completed in the configured time of "
-                  << d_watchDogTimeoutInterval.totalSeconds() << " seconds.";
+    // Decrement retry counter
+    const int retriesRemaining = d_watchdogCtx.d_retriesRemaining--;
 
-    applyFSMEvent(ClusterFSM::Event::e_WATCH_DOG, ClusterFSMEventMetadata());
+    // Mark that watchdog has fired so that `do_startWatchDog` will schedule
+    // a fresh timer on the next invocation.
+    d_watchdogCtx.d_active = false;
+
+    BMQTSK_ALARMLOG_ALARM("RECOVERY")
+        << d_clusterData_p->identity().description()
+        << ": Watchdog triggered because cluster startup healing "
+        << "sequence was not completed in the configured time of "
+        << d_watchdogTimeoutInterval.totalSeconds() << " seconds. "
+        << "Retries remaining: " << retriesRemaining << " of "
+        << d_watchdogNumRetries << BMQTSK_ALARMLOG_END;
+
+    if (retriesRemaining > 0) {
+        applyFSMEvent(ClusterFSM::Event::e_WATCH_DOG,
+                      ClusterFSMEventMetadata());
+    }
+    else {
+        BMQTSK_ALARMLOG_ALARM("RECOVERY")
+            << d_clusterData_p->identity().description()
+            << ": Watchdog retries exhausted after " << d_watchdogNumRetries
+            << " attempts. Terminating broker." << BMQTSK_ALARMLOG_END;
+
+        mqbu::ExitUtil::shutdown(mqbu::ExitCode::e_RECOVERY_FAILURE);
+    }
 }
 
 void ClusterStateManager::onFollowerLSNResponse(

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -38,6 +38,7 @@
 #include <mqbc_clusterstateledger.h>
 #include <mqbc_clusterstatetable.h>
 #include <mqbc_electorinfo.h>
+#include <mqbc_watchdogcontext.h>
 #include <mqbcfg_messages.h>
 #include <mqbi_clusterstatemanager.h>
 
@@ -131,11 +132,15 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     /// Allocator store to spawn new allocators for sub-components.
     bmqma::CountingAllocatorStore d_allocators;
 
-    /// Event handle for the watchdog.
-    bdlmt::EventSchedulerEventHandle d_watchDogEventHandle;
+    /// Watchdog context.
+    WatchdogContext d_watchdogCtx;
 
     /// Timeout interval for the watchdog.
-    bsls::TimeInterval d_watchDogTimeoutInterval;
+    const bsls::TimeInterval d_watchdogTimeoutInterval;
+
+    /// Number of watchdog retries per FSM healing session, before terminating
+    /// the broker.
+    const int d_watchdogNumRetries;
 
     /// Cluster configuration to use.
     const mqbcfg::ClusterDefinition& d_clusterConfig;
@@ -319,18 +324,22 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     int loadClusterStateSnapshot(ClusterState* out);
     int loadClusterStateSnapshot(bmqp_ctrlmsg::LeaderAdvisory* out);
 
-    /// Process the watchdog trigger event, indicating unhealthiness in the
-    /// Cluster FSM.
+    /// Process the watchdog trigger event for the specified watchdog
+    /// `generation, indicating unhealthiness in the Cluster FSM.  If the
+    /// generation does not match the current generation, the event is ignored
+    /// as stale.
     ///
     /// THREAD: Executed by the scheduler thread.
-    void onWatchDog();
+    void onWatchdog(int generation);
 
-    /// Process the watchdog trigger event, indicating unhealthiness in the
-    /// Cluster FSM.
+    /// Process the watchdog trigger event for the specified watchdog
+    /// `generation, indicating unhealthiness in the Cluster FSM.  If the
+    /// generation does not match the current generation, the event is ignored
+    /// as stale.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void onWatchDogDispatched();
+    void onWatchdogDispatched(int generation);
 
     /// Process the follower LSN response contained in the specified
     /// `requestContext`.
@@ -365,13 +374,14 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
 
     /// Create an instance with the specified `clusterConfig`, `cluster`,
     /// `clusterData`, `clusterState`, `clusterStateLedger`,
-    /// `watchDogTimeoutDuration` and `allocator`.
+    /// `watchdogTimeoutDuration`, `watchdogNumRetries` and `allocator`.
     ClusterStateManager(const mqbcfg::ClusterDefinition& clusterConfig,
                         mqbi::Cluster*                   cluster,
                         mqbc::ClusterData*               clusterData,
                         mqbc::ClusterState*              clusterState,
                         ClusterStateLedgerMp             clusterStateLedger,
-                        bsls::Types::Int64 watchDogTimeoutDuration,
+                        bsls::Types::Int64 watchdogTimeoutDuration,
+                        int                watchdogNumRetries,
                         bslma::Allocator*  allocator);
 
     /// Destroy this instance.  Behavior is undefined unless this instance
@@ -643,6 +653,21 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
 
     /// Get the quorum value.
     unsigned int getLsnQuorum() const;
+
+    /// Return the number of watchdog retries remaining.
+    ///
+    /// @note Used for testing purposes only.
+    int watchdogRetriesRemaining() const;
+
+    /// Return the current watchdog generation.
+    ///
+    /// @note Used for testing purposes only.
+    int watchdogGeneration() const;
+
+    /// Return whether the watchdog timer is currently active.
+    ///
+    /// @note Used for testing purposes only.
+    bool isWatchdogActive() const;
 };
 
 // ============================================================================
@@ -693,6 +718,21 @@ ClusterStateManager::nodeToLSNMap() const
 inline unsigned int ClusterStateManager::getLsnQuorum() const
 {
     return d_clusterData_p->quorumManager().quorum();
+}
+
+inline int ClusterStateManager::watchdogRetriesRemaining() const
+{
+    return d_watchdogCtx.d_retriesRemaining;
+}
+
+inline int ClusterStateManager::watchdogGeneration() const
+{
+    return d_watchdogCtx.d_generation;
+}
+
+inline bool ClusterStateManager::isWatchdogActive() const
+{
+    return d_watchdogCtx.d_active;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -47,6 +47,9 @@
 #include <bsls_systemtime.h>
 #include <bsls_types.h>
 
+// SYS
+#include <bsl_c_signal.h>  // sigaction, sig_atomic_t
+
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
 
@@ -63,6 +66,22 @@ static const char* k_REFUSAL_MESSAGE = "Not a follower";
 
 static const bsls::Types::Int64 k_WATCHDOG_TIMEOUT_DURATION = 5 * 60;
 // 5 minutes
+
+static const bsls::Types::Int64 k_WATCHDOG_TIMEOUT_DURATION_SHORT = 5;
+// 5 seconds, used for retry tests
+
+static const int k_WATCHDOG_NUM_RETRIES = 5;
+
+/// Flag set by `testSigintHandler` when SIGINT is received.  Used to
+/// verify that `mqbu::ExitUtil::shutdown` was invoked (which sends
+/// SIGINT to the process) without actually terminating the test.
+static volatile sig_atomic_t s_sigintReceived = 0;
+
+/// Signal handler that captures SIGINT instead of terminating.
+static void testSigintHandler(int /* signum */)
+{
+    s_sigintReceived = 1;
+}
 
 // TYPES
 typedef mqbmock::Cluster::TestChannelMapCIter TestChannelMapCIter;
@@ -94,7 +113,9 @@ struct Tester {
 
   public:
     // CREATORS
-    Tester(bool isLeader)
+    Tester(bool               isLeader,
+           int                numRetries      = k_WATCHDOG_NUM_RETRIES,
+           bsls::Types::Int64 watchdogTimeout = k_WATCHDOG_TIMEOUT_DURATION)
     : d_isLeader(isLeader)
     , d_tempDir(bmqtst::TestHelperUtil::allocator())
     , d_cluster_mp(0)
@@ -174,7 +195,8 @@ struct Tester {
                                           d_cluster_mp->_clusterData(),
                                           d_cluster_mp->_state(),
                                           clusterStateLedger_mp,
-                                          k_WATCHDOG_TIMEOUT_DURATION,
+                                          watchdogTimeout,
+                                          numRetries,
                                           bmqtst::TestHelperUtil::allocator()),
             bmqtst::TestHelperUtil::allocator());
         d_clusterStateManager_mp->setStorageManager(&d_storageManager);
@@ -2455,17 +2477,33 @@ static void test23_selectLeaderFromFollower()
     tester.verifyFollowerLSNRequestsSent();
 }
 
-static void test24_watchDogLeader()
+static void test24_watchdogLeader()
 // ------------------------------------------------------------------------
 // WATCHDOG LEADER
 //
 // Concerns:
-//   Verify that the watchdog triggers upon timeout when the leader is
-//   healing.
+//   When the watchdog fires with retries remaining for a leader, healing
+//   restarts (FSM cycles through UNKNOWN back to LDR_HEALING_STG1) and
+//   the retry counter decrements.  After healing succeeds, the watchdog
+//   is stopped and its state is reset.
+//
+// Plan:
+//  1) Create a ClusterStateManager with numRetries = 5
+//  2) Elect leader -> LDR_HEALING_STG1
+//  3) Verify initial watchdog context (retries = 5, generation = 0,
+//     active = true)
+//  4) Advance time -> watchdog fires -> verify state cycled back to
+//     LDR_HEALING_STG1, retries = 4
+//  5) Transition to LDR_HEALING_STG2 via follower LSN responses
+//  6) Advance time -> watchdog fires -> verify state cycled back to
+//     LDR_HEALING_STG1, retries = 3
+//  7) Transition to LDR_HEALED via follower LSN responses + CSL commit
+//  8) Verify watchdog stopped (generation = 1, retries reset, active =
+//     false)
+//  9) Advance time -> verify watchdog does not trigger
 //
 // Testing:
-//   Watchdog for healing leader
-// ------------------------------------------------------------------------
+//   Watchdog retry and state reset for healing leader.
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("CLUSTER STATE MANAGER - "
@@ -2481,14 +2519,22 @@ static void test24_watchDogLeader()
     selfLSN.sequenceNumber() = 8U;
     tester.setSelfLedgerLSN(selfLSN);
 
-    // 1.a.) Transition to Leader Healing Stage 1
+    // Transition to Leader Healing Stage 1
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_LDR_HEALING_STG1);
     tester.verifyFollowerLSNRequestsSent();
     tester.clearChannels();
 
-    // 1.b.) Trigger watchdog via timeout
+    // Verify initial watchdog state
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
+    // Trigger watchdog via timeout
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION);
     tester.d_cluster_mp->waitForScheduler();
 
@@ -2499,11 +2545,19 @@ static void test24_watchDogLeader()
     tester.verifyFollowerLSNRequestsSent();
     tester.clearChannels();
 
+    // Verify watchdog retry counter decremented
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES - 1);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
     const NodeToLSNMap& lsnMap =
         tester.d_clusterStateManager_mp->nodeToLSNMap();
     BMQTST_ASSERT_EQ(lsnMap.size(), 1U);
 
-    // 2.a.) Transition to Leader Healing Stage 2
+    // Transition to Leader Healing Stage 2
     bmqp_ctrlmsg::ControlMessage         followerLSNResponse;
     bmqp_ctrlmsg::LeaderMessageSequence& lms =
         followerLSNResponse.choice()
@@ -2526,7 +2580,7 @@ static void test24_watchDogLeader()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_LDR_HEALING_STG2);
 
-    // 2.b.) Trigger watchdog via timeout
+    // Trigger watchdog via timeout
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION);
     tester.d_cluster_mp->waitForScheduler();
 
@@ -2538,7 +2592,15 @@ static void test24_watchDogLeader()
     tester.clearChannels();
     BMQTST_ASSERT_EQ(lsnMap.size(), 1U);
 
-    // 3.a.) Transition to Leader Healed
+    // Verify watchdog retry counter decremented again
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES - 2);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
+    // Transition to Leader Healed
     followerLSNResponse.rId() = 7;
     tester.d_cluster_mp->requestManager().processResponse(followerLSNResponse);
     followerLSNResponse.rId() = 8;
@@ -2552,7 +2614,15 @@ static void test24_watchDogLeader()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_LDR_HEALED);
 
-    // 3.b.) Attempt to trigger watchdog via timeout, but should fail
+    // Verify watchdog stopped: generation incremented, retries reset, inactive
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 1);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     false);
+
+    // Attempt to trigger watchdog via timeout, but should fail
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION);
     tester.d_cluster_mp->waitForScheduler();
 
@@ -2561,17 +2631,30 @@ static void test24_watchDogLeader()
                      mqbc::ClusterStateTableState::e_LDR_HEALED);
 }
 
-static void test25_watchDogFollower()
+static void test25_watchdogFollower()
 // ------------------------------------------------------------------------
 // WATCHDOG FOLLOWER
 //
 // Concerns:
-//   Verify that the watchdog triggers upon timeout when the follower is
-//   healing.
+//   When the watchdog fires with retries remaining for a follower,
+//   healing restarts (FSM cycles through UNKNOWN back to FOL_HEALING)
+//   and the retry counter decrements.  After healing succeeds, the
+//   watchdog is stopped and its state is reset.
+//
+// Plan:
+//  1) Create a ClusterStateManager with numRetries = 5
+//  2) Elect leader (self is follower) -> FOL_HEALING
+//  3) Verify initial watchdog context (retries = 5, generation = 0,
+//     active = true)
+//  4) Advance time -> watchdog fires -> verify state cycled back to
+//     FOL_HEALING, retries = 4
+//  5) Transition to FOL_HEALED via CSL advisory + commit
+//  6) Verify watchdog stopped (generation = 1, retries reset, active =
+//     false)
+//  7) Advance time -> verify watchdog does not trigger
 //
 // Testing:
-//   Watchdog for healing follower
-// ------------------------------------------------------------------------
+//   Watchdog retry and state reset for healing follower.
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("CLUSTER STATE MANAGER - "
@@ -2584,25 +2667,41 @@ static void test25_watchDogFollower()
     selfLSN.sequenceNumber() = 3U;
     tester.setSelfLedgerLSN(selfLSN);
 
-    // 1.a.) Transition to Follower Healing
+    // Transition to Follower Healing
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_FOL_HEALING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
-    // 1.b.) Trigger watch dog via timeout
+    // Verify initial watchdog state
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
+    // Trigger watchdog via timeout
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION);
     tester.d_cluster_mp->waitForScheduler();
 
-    // Verify that the watch dog triggers re-transition to Follower Healing.
+    // Verify that the watchdog triggers re-transition to Follower Healing.
     // where we send registration request again.
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
                      mqbc::ClusterStateTableState::e_FOL_HEALING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
-    // 2.a.) Transition to Follower Healed
+    // Verify watchdog retry counter decremented
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES - 1);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
+    // Transition to Follower Healed
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
     cslAdvisory.sequenceNumber().electorTerm()    = 2U;
     cslAdvisory.sequenceNumber().sequenceNumber() = 1U;
@@ -2614,13 +2713,222 @@ static void test25_watchDogFollower()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_FOL_HEALED);
 
-    // 2.b.) Attempt to trigger watch dog via timeout, but should fail
+    // Verify watchdog stopped: generation incremented, retries reset, inactive
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_WATCHDOG_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 1);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     false);
+
+    // Attempt to trigger watchdog via timeout, but should fail
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION);
     tester.d_cluster_mp->waitForScheduler();
 
-    // Verify that watch dog did not trigger
+    // Verify that watchdog did not trigger
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
                      mqbc::ClusterStateTableState::e_FOL_HEALED);
+}
+
+static void test26_watchdogStopResetsState()
+// ------------------------------------------------------------------------
+// WATCHDOG STOP RESETS STATE
+//
+// Concerns:
+//   do_stopWatchDog (via stop / STOP_NODE) increments generation and
+//   resets retries.
+//
+// Plan:
+//  1) Create a ClusterStateManager with numRetries = 2
+//  2) Elect leader -> LDR_HEALING_STG1
+//  3) Verify initial watchdog context (retries = 2, generation = 0,
+//     active = true)
+//  4) Call stop() -> triggers STOP_NODE -> calls do_stopWatchDog
+//  5) Verify generation incremented, retries reset, active = false,
+//     state = STOPPED
+//
+// Testing:
+//   Watchdog state reset on stop.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CLUSTER STATE MANAGER - "
+                                      "WATCHDOG STOP RESETS STATE");
+
+    static const int k_NUM_RETRIES = 2;
+
+    Tester tester(true,  // isLeader
+                  k_NUM_RETRIES);
+
+    // Transition to Leader Healing Stage 1
+    tester.electLeader(2U);
+    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                    mqbc::ClusterStateTableState::e_LDR_HEALING_STG1);
+    tester.clearChannels();
+
+    // Verify initial watchdog state
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 0);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     true);
+
+    // Stop -> triggers STOP_NODE -> calls do_stopWatchDog
+    tester.d_clusterStateManager_mp->stop();
+
+    // Verify state transitioned to STOPPED
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
+                     mqbc::ClusterStateTableState::e_STOPPED);
+
+    // Verify watchdog state was reset
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        k_NUM_RETRIES);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->watchdogGeneration(), 1);
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->isWatchdogActive(),
+                     false);
+}
+
+static void test27_watchdogFollowerRetryExhaustion()
+// ------------------------------------------------------------------------
+// WATCHDOG FOLLOWER RETRY EXHAUSTION
+//
+// Concerns:
+//   With numRetries = 1, the watchdog fires once (counter: 1 -> 0),
+//   healing restarts.  On the second fire (retries exhausted),
+//   ExitUtil::shutdown is called, which sends SIGINT to the process.
+//
+// Plan:
+//  1) Create a ClusterStateManager with numRetries = 1
+//  2) Elect leader (self is follower) -> FOL_HEALING
+//  3) Advance time -> watchdog fires -> verify retries = 0, state
+//     restarts to FOL_HEALING
+//  4) Install a SIGINT handler
+//  5) Advance time -> watchdog fires -> retries exhausted ->
+//     ExitUtil::shutdown -> verify SIGINT received
+//  6) Restore original SIGINT handler
+//
+// Testing:
+//   Watchdog retry exhaustion and broker shutdown for follower.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CLUSTER STATE MANAGER - "
+                                      "WATCHDOG FOLLOWER RETRY EXHAUSTION");
+
+    Tester tester(false,  // isLeader
+                  1,      // numRetries
+                  k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+
+    bmqp_ctrlmsg::LeaderMessageSequence selfLSN;
+    selfLSN.electorTerm()    = 1U;
+    selfLSN.sequenceNumber() = 3U;
+    tester.setSelfLedgerLSN(selfLSN);
+
+    // 1.) Transition to Follower Healing
+    tester.electLeader(2U);
+    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+    tester.verifyRegistrationRequestSent(selfLSN);
+    tester.clearChannels();
+
+    // 2.) First watchdog fire -> retries=0, state restarts
+    tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+    tester.d_cluster_mp->waitForScheduler();
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
+                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        0);
+    tester.verifyRegistrationRequestSent(selfLSN);
+    tester.clearChannels();
+
+    // 3.) Second watchdog fire -> retries exhausted -> ExitUtil::shutdown
+    s_sigintReceived = 0;
+
+    struct sigaction sa, oldSa;
+    sa.sa_handler = testSigintHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, &oldSa);
+
+    tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+    tester.d_cluster_mp->waitForScheduler();
+
+    BMQTST_ASSERT_EQ(static_cast<int>(s_sigintReceived), 1);
+
+    // Restore original handler
+    sigaction(SIGINT, &oldSa, NULL);
+}
+
+static void test28_watchdogLeaderRetryExhaustion()
+// ------------------------------------------------------------------------
+// WATCHDOG LEADER RETRY EXHAUSTION
+//
+// Concerns:
+//   With numRetries = 1, the leader watchdog fires once (counter:
+//   1 -> 0), healing restarts.  On the second fire (retries exhausted),
+//   ExitUtil::shutdown is called, which sends SIGINT to the process.
+//
+// Plan:
+//  1) Create a ClusterStateManager with numRetries = 1
+//  2) Elect leader -> LDR_HEALING_STG1
+//  3) Advance time -> watchdog fires -> verify retries = 0, state
+//     restarts to LDR_HEALING_STG1
+//  4) Install a SIGINT handler
+//  5) Advance time -> watchdog fires -> retries exhausted ->
+//     ExitUtil::shutdown -> verify SIGINT received
+//  6) Restore original SIGINT handler
+//
+// Testing:
+//   Watchdog retry exhaustion and broker shutdown for leader.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CLUSTER STATE MANAGER - "
+                                      "WATCHDOG LEADER RETRY EXHAUSTION");
+
+    Tester tester(true,  // isLeader
+                  1,     // numRetries
+                  k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+
+    bmqp_ctrlmsg::LeaderMessageSequence selfLSN;
+    selfLSN.electorTerm()    = 1U;
+    selfLSN.sequenceNumber() = 8U;
+    tester.setSelfLedgerLSN(selfLSN);
+
+    // 1.) Transition to Leader Healing Stage 1
+    tester.electLeader(2U);
+    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                    mqbc::ClusterStateTableState::e_LDR_HEALING_STG1);
+    tester.verifyFollowerLSNRequestsSent();
+    tester.clearChannels();
+
+    // 2.) First watchdog fire -> retries=0, state restarts
+    tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+    tester.d_cluster_mp->waitForScheduler();
+    BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
+                     mqbc::ClusterStateTableState::e_LDR_HEALING_STG1);
+    BMQTST_ASSERT_EQ(
+        tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
+        0);
+    tester.verifyFollowerLSNRequestsSent();
+    tester.clearChannels();
+
+    // 3.) Second watchdog fire -> retries exhausted -> ExitUtil::shutdown
+    s_sigintReceived = 0;
+
+    struct sigaction sa, oldSa;
+    sa.sa_handler = testSigintHandler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    sigaction(SIGINT, &sa, &oldSa);
+
+    tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION_SHORT);
+    tester.d_cluster_mp->waitForScheduler();
+
+    BMQTST_ASSERT_EQ(static_cast<int>(s_sigintReceived), 1);
+
+    // Restore original handler
+    sigaction(SIGINT, &oldSa, NULL);
 }
 
 // ============================================================================
@@ -2635,8 +2943,11 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 25: test25_watchDogFollower(); break;
-    case 24: test24_watchDogLeader(); break;
+    case 28: test28_watchdogLeaderRetryExhaustion(); break;
+    case 27: test27_watchdogFollowerRetryExhaustion(); break;
+    case 26: test26_watchdogStopResetsState(); break;
+    case 25: test25_watchdogFollower(); break;
+    case 24: test24_watchdogLeader(); break;
     case 23: test23_selectLeaderFromFollower(); break;
     case 22: test22_selectFollowerFromLeader(); break;
     case 21: test21_resetUnknownFollower(); break;

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -1415,8 +1415,9 @@ static void test14_leaderCSLCommitFailure()
 // LEADER CSL COMMIT FAILURE
 //
 // Concerns:
-//   Verify that the leader transitions back to unknown upon CSL commit
-//   callback failure.
+//   Verify that the leader restarts healing upon CSL commit callback
+//   failure.  CSL_CMT_FAIL triggers the watchdog, which fires and
+//   transitions through UNKNOWN back to LDR_HEALING_STG1.
 //
 // Testing:
 //   Leader upon CSL commit callback failure
@@ -1474,17 +1475,27 @@ static void test14_leaderCSLCommitFailure()
     tester.d_clusterStateLedger_p->_commitAdvisories(
         mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
 
-    // Verify that self transitions back to unknown
+    // CSL_CMT_FAIL triggers the watchdog (reschedules to now) but stays in
+    // LDR_HEALING_STG2.  Advance time so the triggered watchdog fires.
+    // The e_WATCH_DOG transition goes to UNKNOWN, which re-applies
+    // SLCT_LDR, landing in LDR_HEALING_STG1.
+    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                    mqbc::ClusterStateTableState::e_LDR_HEALING_STG2);
+    tester.d_cluster_mp->advanceTime(1);
+    tester.d_cluster_mp->waitForScheduler();
+
+    // Verify that self restarts healing
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_UNKNOWN);
+                     mqbc::ClusterStateTableState::e_LDR_HEALING_STG1);
 }
 
 static void test15_followerCSLCommitFailure()
 // FOLLOWER CSL COMMIT FAILURE
 //
 // Concerns:
-//   Verify that the follower transitions back to unknown upon CSL commit
-//   callback failure.
+//   Verify that the follower restarts healing upon CSL commit callback
+//   failure.  CSL_CMT_FAIL triggers the watchdog, which fires and
+//   transitions through UNKNOWN back to FOL_HEALING.
 //
 // Testing:
 //   Follower upon CSL commit callback failure
@@ -1514,9 +1525,18 @@ static void test15_followerCSLCommitFailure()
     tester.d_clusterStateLedger_p->_commitAdvisories(
         mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
 
-    // Verify that self transitions back to unknown
+    // CSL_CMT_FAIL triggers the watchdog (reschedules to now) but stays in
+    // FOL_HEALING.  Advance time so the triggered watchdog fires.
+    // The e_WATCH_DOG transition goes to UNKNOWN, which re-applies
+    // SLCT_FOL, landing back in FOL_HEALING.
+    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+    tester.d_cluster_mp->advanceTime(1);
+    tester.d_cluster_mp->waitForScheduler();
+
+    // Verify that self restarts healing
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_UNKNOWN);
+                     mqbc::ClusterStateTableState::e_FOL_HEALING);
 }
 
 static void test16_followerClusterStateRespFailureLeaderNext()

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -490,7 +490,7 @@ class ClusterStateTable
                 CSL_CMT_SUCCESS,
                 stopWatchDog_initializeQueueKeyInfoMap_updatePrimaryInPFSMs,
                 FOL_HEALED);
-        CST_CFG(FOL_HEALING, CSL_CMT_FAIL, triggerWatchDog, UNKNOWN);
+        CST_CFG(FOL_HEALING, CSL_CMT_FAIL, triggerWatchDog, FOL_HEALING);
         CST_CFG(FOL_HEALING,
                 RST_UNKNOWN,
                 stopWatchDog_cancelRequests,
@@ -617,7 +617,10 @@ class ClusterStateTable
                 CSL_CMT_SUCCESS,
                 stopWatchDog_initializeQueueKeyInfoMap_updatePrimaryInPFSMs,
                 LDR_HEALED);
-        CST_CFG(LDR_HEALING_STG2, CSL_CMT_FAIL, triggerWatchDog, UNKNOWN);
+        CST_CFG(LDR_HEALING_STG2,
+                CSL_CMT_FAIL,
+                triggerWatchDog,
+                LDR_HEALING_STG2);
         CST_CFG(LDR_HEALING_STG2,
                 RST_UNKNOWN,
                 stopWatchDog_cleanupLSNs_cancelRequests,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -222,7 +222,8 @@ class StorageManager BSLS_KEYWORD_FINAL
     /// Timeout interval for the watchdog.
     const bsls::TimeInterval d_watchdogTimeoutInterval;
 
-    /// Number of watchdog retries before terminating the broker.
+    /// Number of watchdog retries per FSM healing session, before terminating
+    /// the broker.
     const int d_watchdogNumRetries;
 
     /// Flag to denote if a low disk space warning was issued.  This flag is

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -39,6 +39,7 @@
 #include <mqbc_partitionfsmobserver.h>
 #include <mqbc_partitionstatetable.h>
 #include <mqbc_storageutil.h>
+#include <mqbc_watchdogcontext.h>
 #include <mqbcfg_messages.h>
 #include <mqbi_dispatcher.h>
 #include <mqbi_storagemanager.h>
@@ -160,49 +161,6 @@ class StorageManager BSLS_KEYWORD_FINAL
 
     typedef bsl::vector<PrimaryStatusAdvisoryInfos>
         PrimaryStatusAdvisoryInfosVec;
-
-    /// Per-partition watchdog context.
-    class WatchdogContext {
-      public:
-        // DATA
-
-        /// Generation count to detect and ignore stale watchdog triggers.
-        /// Incremented each time a watchdog is stopped
-        ///
-        /// THREAD: Except during the ctor, this data member is modified in the
-        ///         partition thread and accessed in both the cluster thread
-        ///         and the partition thread.
-        bsls::AtomicInt d_generation;
-
-        /// Whether the watchdog timer is currently active.  Since the event
-        /// handle does not invalidate upon watchdog firing, we must rely on
-        /// this flag.
-        ///
-        /// THREAD: Used in both the cluster thread and the partition thread.
-        bsls::AtomicBool d_active;
-
-        /// Event handle for the scheduled watchdog timer.
-        ///
-        /// THREAD: Used in the partition thread.
-        bdlmt::EventSchedulerEventHandle d_eventHandle;
-
-        /// Number of retries remaining before terminating the broker,
-        /// reset for each generation.
-        ///
-        /// THREAD: Used in both the cluster thread and the partition thread.
-        bsls::AtomicInt d_retriesRemaining;
-
-        // CREATORS
-
-        /// Create a default `WatchdogContext` with no active timer, zero
-        /// generation and zero retries remaining.
-        WatchdogContext();
-
-        // NOT IMPLEMENTED
-        WatchdogContext(const WatchdogContext&) BSLS_KEYWORD_DELETED;
-        WatchdogContext&
-        operator=(const WatchdogContext&) BSLS_KEYWORD_DELETED;
-    };
 
     /// VST representing node's sequence number, first sync point after
     /// rollover sequence number.
@@ -1327,20 +1285,6 @@ inline bool StorageManager::isWatchdogActive(int partitionId) const
 inline unsigned int StorageManager::getSeqNumQuorum() const
 {
     return d_clusterData_p->quorumManager().quorum();
-}
-
-// =====================================
-// class StorageManager::WatchdogContext
-// =====================================
-
-// CREATORS
-inline StorageManager::WatchdogContext::WatchdogContext()
-: d_generation(0)
-, d_active(false)
-, d_eventHandle()
-, d_retriesRemaining(0)
-{
-    // NOTHING
 }
 
 // =======================================

--- a/src/groups/mqb/mqbc/mqbc_watchdogcontext.cpp
+++ b/src/groups/mqb/mqbc/mqbc_watchdogcontext.cpp
@@ -1,0 +1,19 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbc_watchdogcontext.cpp                                           -*-C++-*-
+#include <mqbc_watchdogcontext.h>
+
+#include <mqbscm_version.h>

--- a/src/groups/mqb/mqbc/mqbc_watchdogcontext.h
+++ b/src/groups/mqb/mqbc/mqbc_watchdogcontext.h
@@ -1,0 +1,98 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbc_watchdogcontext.h                                             -*-C++-*-
+#ifndef INCLUDED_MQBC_WATCHDOGCONTEXT
+#define INCLUDED_MQBC_WATCHDOGCONTEXT
+
+/// @file mqbc_watchdogcontext.h
+///
+/// @brief Watchdog timer context used by FSM components.
+///
+/// @bbref{mqbc::WatchdogContext} is a class that holds the context for a
+/// single watchdog timer instance, including generation count, active flag,
+/// event handle, and retry counter.
+///
+/// Thread Safety                                {#mqbc_watchdogcontext_thread}
+/// =============
+///
+/// Not thread safe.
+
+// BDE
+#include <bdlmt_eventscheduler.h>
+#include <bsls_atomic.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+namespace mqbc {
+
+// =====================
+// class WatchdogContext
+// =====================
+
+/// Per-partition or per-cluster watchdog context.
+class WatchdogContext {
+  public:
+    // DATA
+
+    /// Generation count to detect and ignore stale watchdog triggers.
+    /// Should be incremented each time the watchdog is stopped
+    bsls::AtomicInt d_generation;
+
+    /// Whether the watchdog timer is currently active.  Since the event
+    /// handle does not invalidate upon watchdog firing, we must rely on
+    /// this flag.
+    bsls::AtomicBool d_active;
+
+    /// Event handle for the scheduled watchdog timer.
+    bdlmt::EventSchedulerEventHandle d_eventHandle;
+
+    /// Number of retries remaining before terminating the broker, reset for
+    /// each generation.
+    bsls::AtomicInt d_retriesRemaining;
+
+    // CREATORS
+
+    /// Create a default `WatchdogContext` with no active timer, zero
+    /// generation and zero retries remaining.
+    WatchdogContext();
+
+    // NOT IMPLEMENTED
+    WatchdogContext(const WatchdogContext&) BSLS_KEYWORD_DELETED;
+    WatchdogContext& operator=(const WatchdogContext&) BSLS_KEYWORD_DELETED;
+};
+
+// ============================================================================
+//                           INLINE DEFINITIONS
+// ============================================================================
+
+// ---------------------
+// class WatchdogContext
+// ---------------------
+
+// CREATORS
+inline WatchdogContext::WatchdogContext()
+: d_generation(0)
+, d_active(false)
+, d_eventHandle()
+, d_retriesRemaining(0)
+{
+    // NOTHING
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbc/package/mqbc.mem
+++ b/src/groups/mqb/mqbc/package/mqbc.mem
@@ -20,3 +20,4 @@ mqbc_recoverymanager
 mqbc_recoveryutil
 mqbc_storagemanager
 mqbc_storageutil
+mqbc_watchdogcontext


### PR DESCRIPTION
  ## Summary                                                                                                                                 
  - **Extract `WatchdogContext` into a shared component** (`mqbc_watchdogcontext`) so it can be reused by both `StorageManager` (Partition FSM) and `ClusterStateManager` (Cluster FSM), eliminating the duplicated nested class.                                                     
  - **Add watchdog retry logic to `ClusterStateManager`**: configurable retry count, generation-based stale event detection, active-flag guard against duplicate timers, and broker shutdown (`mqbu::ExitUtil::shutdown`) when retries are exhausted — matching the mechanism already in `StorageManager` from PR #1218.
  - **Fix `triggerWatchDog` state transitions** in the Cluster FSM state table: `CSL_CMT_FAIL` now stays in the current healing state (`FOL_HEALING` / `LDR_HEALING_STG2`) instead of immediately jumping to `UNKNOWN`, letting the triggered watchdog timer handle the transition with proper cleanup actions.

  ## Changes

  ### New component: `mqbc_watchdogcontext`
  - `mqbc_watchdogcontext.h` / `.cpp` — Shared `WatchdogContext` class with `d_generation`, `d_active`, `d_eventHandle`, `d_retriesRemaining`.
  - `mqbc.mem` — Added to package member list.

  ### `mqbc_storagemanager.h`
  - Removed nested `WatchdogContext` class and its inline constructor (~55 lines).
  - Added `#include <mqbc_watchdogcontext.h>` — existing `bsl::vector<WatchdogContext>` now resolves to the shared class.

  ### `mqbc_clusterstatetable.h`
  - `CST_CFG(FOL_HEALING, CSL_CMT_FAIL, triggerWatchDog, UNKNOWN)` → `FOL_HEALING`
  - `CST_CFG(LDR_HEALING_STG2, CSL_CMT_FAIL, triggerWatchDog, UNKNOWN)` → `LDR_HEALING_STG2`

  ### `mqbc_clusterstatemanager.h` / `.cpp`
  - Replaced `d_watchDogEventHandle` with `WatchdogContext d_watchdogCtx`.
  - Added `d_watchdogNumRetries` member and constructor parameter.
  - `do_startWatchDog`: guards against duplicate start via `d_active`, captures generation.
  - `do_stopWatchDog`: increments generation, resets retries, clears active flag.
  - `do_triggerWatchDog`: guards against trigger when inactive, reschedules to "now".
  - `onWatchdogDispatched`: stale-generation check, retry decrement, calls `ExitUtil::shutdown` on exhaustion.
  - Added test accessors: `watchdogRetriesRemaining()`, `watchdogGeneration()`, `isWatchdogActive()`.

  ### `mqbblp_clusterorchestrator.cpp`
  - Passes `clusterFsmWatchdogNumRetries()` config to `ClusterStateManager` constructor.

  ### `mqbc_clusterstatemanager.t.cpp`
  - Updated tests 14–15 (CSL commit failure) for new state-table behavior (stays in healing, watchdog fires, healing restarts).
  - Updated tests 24–25 with watchdog state verification at each step (retries, generation, active flag).
  - Added test 26: `watchdogStopResetsState` — verifies `stop()` / `STOP_NODE` increments generation and resets retries.
  - Added tests 27–28: `watchdogFollowerRetryExhaustion` / `watchdogLeaderRetryExhaustion` — verifies `ExitUtil::shutdown` fires (SIGINT) when retries are exhausted.

  ## Testing
  - `mqbc_clusterstatemanager.t` tests 14, 15, 24, 25, 26, 27, 28 — all pass.
  - `mqbc_storagemanager.t` tests 18, 19, 20, 21 — regression, all pass (shared `WatchdogContext` extraction).