### PR TITLE
Fix[mqb]: send Receipts on data sync

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6353,7 +6353,8 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
     rawEvent.loadStorageMessageIterator(&iter);
     BSLS_ASSERT_SAFE(iter.isValid());
 
-    bool hasValidLeaseIdSeqNum = false;
+    FileStore::NodeContext* nodeContext           = 0;
+    bool                    hasValidLeaseIdSeqNum = false;
 
     if (0 < d_primaryLeaseId) {
         // File store encountered valid primaryLeaseId and sequence number in
@@ -6467,6 +6468,14 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
 
         if (bmqp::StorageMessageType::e_DATA == header.messageType()) {
             rc = writeMessageRecord(header, *recHeader, blob, recordPosition);
+
+            if (0 == rc && (header.flags() &
+                            bmqp::StorageHeaderFlags::e_RECEIPT_REQUESTED)) {
+                nodeContext = generateReceipt(nodeContext,
+                                              d_primaryNode_p,
+                                              recHeader->primaryLeaseId(),
+                                              recHeader->sequenceNumber());
+            }
         }
         else if (bmqp::StorageMessageType::e_QLIST == header.messageType()) {
             rc = writeQueueCreationRecord(header,
@@ -6494,6 +6503,8 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
             return 10 * rc + rc_WRITE_FAILURE;  // RETURN
         }
     }
+
+    sendReceipt(d_primaryNode_p, nodeContext);
 
     return rc_SUCCESS;
 }
@@ -6560,6 +6571,13 @@ void FileStore::sendReceipt(mqbnet::ClusterNode* node,
                             NodeContext*         nodeContext)
 {
     if (nodeContext == 0) {
+        return;  // RETURN
+    }
+
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!node)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        BALL_LOG_ERROR << partitionDesc()
+                       << "Cannot send Receipt: primary node is null.";
         return;  // RETURN
     }
 


### PR DESCRIPTION
After primary failover, the new primary writes SC messages and adds them to d_unreceipted. It replicates to all replicas. A replica that is still recovering buffers these
   replication events. When recovery completes, the buffered events are applied via processRecoveryEvent, which — unlike processStorageEvent — doesn't check
  `e_RECEIPT_REQUESTED `and doesn't send receipts. The new primary never accumulates enough receipts to reach quorum, so ACKs are never delivered.