### PR TITLE
Perf[mqb]: fix `RECEIPT` flood with low nagle

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -217,7 +217,7 @@ class Cluster {
                           bmqp::EventType::Enum               type) = 0;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).
+    /// (with the exception of the current node).
     virtual void broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) = 0;
 
     /// Close the channels associated to all nodes in this cluster.

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -213,15 +213,12 @@ class Cluster {
 
     /// Write the specified `blob` of the specified `type` to all connected
     /// nodes of this cluster (with the exception of the current node).
-    /// Return the maximum number of pending items across all cluster
-    /// channels prior to broadcasting.
-    virtual int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                         bmqp::EventType::Enum               type) = 0;
+    virtual void writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                          bmqp::EventType::Enum               type) = 0;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).  Return the maximum number of
-    /// pending items across all cluster channels prior to broadcasting.
-    virtual int broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) = 0;
+    /// (exception of the current node).
+    virtual void broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) = 0;
 
     /// Close the channels associated to all nodes in this cluster.
     virtual void closeChannels() = 0;

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
@@ -130,17 +130,17 @@ struct ClusterTestImp : bsls::ProtocolTestImp<mqbnet::Cluster> {
         return markDone();
     }
 
-    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                 bmqp::EventType::Enum type = bmqp::EventType::e_CONTROL)
+    void writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                  bmqp::EventType::Enum type = bmqp::EventType::e_CONTROL)
         BSLS_KEYWORD_OVERRIDE
     {
-        return markDone();
+        markDone();
     }
 
-    int
+    void
     broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE
     {
-        return markDone();
+        markDone();
     }
 
     void closeChannels() BSLS_KEYWORD_OVERRIDE { markDone(); }

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -232,28 +232,14 @@ Cluster* ClusterImp::unregisterObserver(ClusterObserver* observer)
     return this;
 }
 
-int ClusterImp::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                         bmqp::EventType::Enum               type)
+void ClusterImp::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                          bmqp::EventType::Enum               type)
 {
-    unsigned int maxPushChannelPendingItems = 0;
-    unsigned int maxChannelPendingItems     = 0;
     for (bsl::list<ClusterNodeImp>::iterator it = d_nodes.begin();
          it != d_nodes.end();
          ++it) {
         // Write to all peers (except self)
         if (it->nodeId() != selfNodeId()) {
-            unsigned int numItems = it->channel().numItems();
-            if (numItems > maxPushChannelPendingItems) {
-                // Ignore replicas to which we do not send PUSH data
-                // Note that PUSH data get written after Storage
-                if (it->channel().numItems(bmqp::EventType::e_PUSH)) {
-                    maxPushChannelPendingItems = numItems;
-                }
-                else if (numItems > maxChannelPendingItems) {
-                    maxChannelPendingItems = numItems;
-                }
-            }
-
             bmqt::GenericResult::Enum rc = it->write(blob, type);
 
             if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
@@ -271,17 +257,11 @@ int ClusterImp::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
             }
         }
     }
-
-    if (0 == maxPushChannelPendingItems) {
-        maxPushChannelPendingItems = maxChannelPendingItems;
-    }
-
-    return maxPushChannelPendingItems;
 }
 
-int ClusterImp::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
+void ClusterImp::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
-    return writeAll(blob, bmqp::EventType::e_STORAGE);
+    writeAll(blob, bmqp::EventType::e_STORAGE);
 }
 
 void ClusterImp::closeChannels()

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -294,15 +294,12 @@ class ClusterImp : public Cluster {
 
     /// Write the specified `blob` of the specified `type` to all connected
     /// nodes of this cluster (with the exception of the current node).
-    /// Return the maximum number of pending items across all cluster
-    /// channels prior to broadcasting.
-    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                 bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
+    void writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                  bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).  Return the maximum number of
-    /// pending items across all cluster channels prior to broadcasting.
-    int
+    /// (exception of the current node).
+    void
     broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 
     /// Close the channels associated to all nodes in this cluster.

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
@@ -197,8 +197,8 @@ Cluster* MockCluster::unregisterObserver(ClusterObserver* observer)
     return this;
 }
 
-int MockCluster::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                          bmqp::EventType::Enum               type)
+void MockCluster::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                           bmqp::EventType::Enum               type)
 {
     for (bsl::list<MockClusterNode>::iterator it = d_nodes.begin();
          it != d_nodes.end();
@@ -208,19 +208,17 @@ int MockCluster::writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
             it->write(blob, type);
         }
     }
-
-    return 0;
 }
 
-int MockCluster::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
+void MockCluster::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
     if (d_disableBroadcast) {
-        return 0;  // RETURN
+        return;  // RETURN
     }
 
     // No multicast support in mock cluster, just forward to the individual
     // nodes.
-    return writeAll(blob, bmqp::EventType::e_STORAGE);
+    writeAll(blob, bmqp::EventType::e_STORAGE);
 }
 
 void MockCluster::closeChannels()

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -269,15 +269,12 @@ class MockCluster : public Cluster {
 
     /// Write the specified `blob` of the specified `type` to all connected
     /// nodes of this cluster (with the exception of the current node).
-    /// Return the maximum number of pending items across all cluster
-    /// channels prior to broadcasting.
-    int writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                 bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
+    void writeAll(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                  bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).  Return the maximum number of
-    /// pending items across all cluster channels prior to broadcasting.
-    int
+    /// (exception of the current node).
+    void
     broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 
     /// Close the channels associated to all nodes in this cluster.

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5150,7 +5150,7 @@ void FileStore::aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
 void FileStore::flushIfNeeded(bool immediateFlush)
 {
     if (immediateFlush ||
-        d_storageEventBuilder.messageCount() >= d_naglePacketCount) {
+        d_storageEventBuilder.messageCount() >= k_NAGLE_PACKET_COUNT) {
         // Should notify weak consistency queues after replicated batch
         flushStorage();
         notifyQueuesOnReplicatedBatch();
@@ -5205,7 +5205,6 @@ FileStore::FileStore(
 , d_isFSMWorkflow(isFSMWorkflow)
 , d_qListAware(!d_isFSMWorkflow || doesFSMwriteQLIST)
 , d_ignoreCrc32c(false)
-, d_naglePacketCount(k_NAGLE_PACKET_COUNT)
 , d_storageEventBuilder(FileStoreProtocol::k_VERSION,
                         bmqp::EventType::e_STORAGE,
                         d_blobSpPool_p,
@@ -6947,17 +6946,7 @@ void FileStore::flushStorage()
     BALL_LOG_TRACE << partitionDesc() << "Flushing "
                    << d_storageEventBuilder.messageCount()
                    << " STORAGE messages.";
-    const int maxChannelPendingItems = d_cluster_p->broadcast(
-        d_storageEventBuilder.blob());
-    if (maxChannelPendingItems > 0) {
-        if (d_naglePacketCount < k_NAGLE_PACKET_COUNT) {
-            // back off
-            ++d_naglePacketCount;
-        }
-    }
-    else if (d_naglePacketCount) {
-        --d_naglePacketCount;
-    }
+    d_cluster_p->broadcast(d_storageEventBuilder.blob());
     d_storageEventBuilder.reset();
 }
 
@@ -7322,7 +7311,7 @@ void FileStore::loadSummary(mqbcmd::FileStore* fileStore) const
                                     d_sequenceNum,
                                     d_records.size(),
                                     d_unreceipted.size(),
-                                    d_naglePacketCount,
+                                    k_NAGLE_PACKET_COUNT,
                                     d_fileSets,
                                     d_storages);
 }

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -393,13 +393,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     // calculations.  We should only set
     // this to true during testing.
 
-    int d_naglePacketCount;
-    // Max number of messages in the
-    // 'd_storageEventBuilder' before
-    // flushing the builder.  Depending
-    // the cluster channels load, it can
-    // grow or shrink.
-
     bmqp::StorageEventBuilder d_storageEventBuilder;
     // Storage event builder to use.
 
@@ -670,7 +663,7 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
         bsls::Types::Uint64            recordOffset);
 
     /// Flush the storage if the specified `immediateFlush` is `true` or the
-    /// `d_storageEventBuilder` is over the `d_naglePacketCount` limit.
+    /// `d_storageEventBuilder` is over the `k_NAGLE_PACKET_COUNT` limit.
     void flushIfNeeded(bool immediateFlush);
 
     // PRIVATE ACCESSORS


### PR DESCRIPTION
# Overview

The existing implementation flushes `FileStore`'s storage event builder when the dynamic nagle count is reached. This dynamic nagle is incremented when `mqbnet::Channel` has something in its write queue (meaning, `mqbnet::Channel` is slow to send), and dynamic nagle is decremented when `mqbnet::Channel` has an empty write queue. The code assumed that slow cluster means that the `mqbnet::Channel` itself is slow, and vice versa.

The experiments show that nagle count is close to 0 in all situations: under pressure and without pressure. It happens because `mqbnet::Channel` is fast to move messages from its input queue to NTC. This also means that `FileStore` will mostly try to send only a few messages at a time, in many cases just 1 message.

Upon receiving these small messages, each replica processes it fast and sends a `RECEIPT` event. So if we have **N** nodes in a cluster, **N-1** `RECEIPT` will be sent to primary. Primary has to enqueue a dispatcher event per each `RECEIPT` from IO thread, and this results in **K x (N-1)** events per **K** `DATA` messages. `RECEIPT` optimization doesn't help here because it only happens after enqueueing these events.

This `RECEIPT` flood lowers the maximum throughput of the cluster. With 1 queue and dynamic nagle, it is possible to process at most 80k msgs/s in a strong consistency domain without NACKs. The same scenario with constant nagle (100), it is possible to process 120k msgs/s.

# Solution

Keep the default maximum nagle under pressure.
Rely on idleness to flush storage early without pressure.

# Nagle logs

**Dynamic nagle under pressure (100k msgs/s):**
**Note that a busy QUEUE dispatcher thread doesn't guarantee that mqbnet::Channel is also busy.**

<img width="1040" height="495" alt="Screenshot 2026-04-07 at 13 25 44" src="https://github.com/user-attachments/assets/bdb714df-ec68-4d1d-b85f-b9ec84c29951" />


**Dynamic nagle without pressure (1k msgs/s):**

<img width="1052" height="495" alt="Screenshot 2026-04-07 at 13 38 12" src="https://github.com/user-attachments/assets/8fe119d3-d7d4-485c-8145-a3def34bad7a" />

# perf

IO thread mostly processing `RECEIPT` events:

<img width="1134" height="565" alt="Screenshot 2026-04-07 at 10 39 29" src="https://github.com/user-attachments/assets/e64bcfe5-d898-4ad5-a4cd-0dfcc65091fa" />

IO thread allocating much more callback events to handle `RECEIPT` than the number of `PUT` events.

<img width="1138" height="302" alt="Screenshot 2026-04-07 at 11 50 47" src="https://github.com/user-attachments/assets/57d76a96-575f-48cd-a090-5ef84fb51799" />

# Experiment 1

Strong consistency, 1 queue, 1 consumer, 1 producer.
Produce rate: 100k msgs/s.

OY axis: the number of unconfirmed messages.
OX axis: time, seconds.
Blue line: `main` (dynamic nagle)
Orange line: this PR (const nagle)

<img width="1461" height="559" alt="Screenshot 2026-04-07 at 14 27 58" src="https://github.com/user-attachments/assets/12e899e1-e7d8-448c-8da2-81361dce3421" />

# Experiment 2

Strong consistency, 1 queue, 1 consumer, 1 producer.
Produce rate: 120k msgs/s.
This PR.

The cluster is able to process 120k strong consistent msgs/s with good latency. This is 1.5x increase compared to `main` (that is able to process 80k msgs/s before NACKs).

<img width="2008" height="1042" alt="Screenshot 2026-04-10 at 13 12 40" src="https://github.com/user-attachments/assets/af3c1cd9-826f-48ca-b087-0796aa3c4820" />

