### PR TITLE
Refactor: Implement a channel factory pipeline

### DIFF
--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -45,6 +45,7 @@ function(bmq_add_test target)
     foreach(pkg ${${uor_name}_PACKAGES})
       bbs_configure_target_tests(${pkg}
         SOURCES ${${pkg}_TEST_SOURCES}
+        GTEST_SOURCES ${${pkg}_GTEST_SOURCES}
         TEST_DEPS ${${pkg}_DEPENDS}
         ${${pkg}_TEST_DEPENDS}
         ${${uor_name}_PCDEPS}
@@ -74,6 +75,7 @@ function(bmq_add_test target)
     # Configure standalone library ( no packages ) and tests from BDE metadata
     bbs_configure_target_tests(${target}
       SOURCES ${${uor_name}_TEST_SOURCES}
+      GTEST_SOURCES ${${uor_name}_GTEST_SOURCES}
       TEST_DEPS ${${uor_name}_PCDEPS}
       ${${uor_name}_TEST_PCDEPS}
       LABELS "unit;all" ${target})
@@ -118,6 +120,7 @@ function(bmq_add_application_test target)
 
   bbs_configure_target_tests(${lib_target}
     SOURCES    ${${uor_name}_TEST_SOURCES}
+    GTEST_SOURCES ${${uor_name}_GTEST_SOURCES}
     TEST_DEPS  ${${uor_name}_PCDEPS}
                ${${uor_name}_TEST_PCDEPS}
     LABELS     "unit;all" ${target})

--- a/src/groups/bmq/CMakeLists.txt
+++ b/src/groups/bmq/CMakeLists.txt
@@ -43,6 +43,12 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang")
   set_property(SOURCE "bmqu/bmqu_weakmemfn.t.cpp"
     APPEND
     PROPERTY COMPILE_FLAGS "-Wno-ignored-qualifiers")
+
+  # Turn off warnings in generated GMock classes.
+  set_property(SOURCE "bmqio/bmqio_channelfactorypipeline.g.cpp"
+                APPEND
+                PROPERTY COMPILE_OPTIONS "-Wno-unused-member-function"
+  )
 endif()
 
 set(BMQ_PRIVATE_PACKAGES

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -21,8 +21,13 @@
 #include <bmqex_systemexecutor.h>
 #include <bmqimp_authenticatedchannelfactory.h>
 #include <bmqimp_negotiatedchannelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_channelutil.h>
 #include <bmqio_connectoptions.h>
+#include <bmqio_reconnectingchannelfactory.h>
+#include <bmqio_resolvingchannelfactory.h>
+#include <bmqio_statchannel.h>
+#include <bmqio_statchannelfactory.h>
 #include <bmqio_status.h>
 #include <bmqio_tcpendpoint.h>
 #include <bmqma_countingallocatorutil.h>
@@ -38,6 +43,7 @@
 #include <bmqu_time.h>
 
 // BDE
+#include <ball_log.h>
 #include <bdlb_scopeexit.h>
 #include <bdlf_bind.h>
 #include <bdlf_memfn.h>
@@ -53,6 +59,7 @@
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
+#include <bslmf_movableref.h>
 #include <bslmt_lockguard.h>
 #include <bslmt_mutexassert.h>
 #include <bslmt_once.h>
@@ -135,6 +142,127 @@ ntcCreateInterfaceConfig(const bmqt::SessionOptions& sessionOptions,
     config.setKeepHalfOpen(false);
 
     return config;
+}
+
+bslma::ManagedPtr<bmqio::ChannelFactoryPipeline> makeChannelFactoryPipeline(
+    bslma::Allocator*                           allocator,
+    bdlbb::BlobBufferFactory*                   blobBufferFactory,
+    bdlmt::EventScheduler*                      scheduler,
+    NegotiatedChannelFactoryConfig::BlobSpPool* blobSpPool,
+    const bmqt::SessionOptions&                 sessionOptions,
+    const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+                                            statContextCreator,
+    const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage)
+{
+    typedef bmqio::ChannelFactoryPipeline::ChannelFactorySP ChannelFactorySP;
+
+    struct Builders {
+        static ChannelFactorySP
+        resolvingChannelFactory(bslma::Allocator* allocator,
+                                ChannelFactorySP& prev)
+        {
+            return bsl::allocate_shared<bmqio::ResolvingChannelFactory>(
+                allocator,
+                bmqio::ResolvingChannelFactoryConfig(
+                    prev.get(),
+                    bmqex::ExecutionPolicyUtil::alwaysBlocking().useExecutor(
+                        bmqex::SystemExecutor())));
+        }
+
+        static ChannelFactorySP
+        reconnectingChannelFactory(bslma::Allocator*      allocator,
+                                   ChannelFactorySP&      prev,
+                                   bdlmt::EventScheduler* scheduler)
+        {
+            return bsl::allocate_shared<bmqio::ReconnectingChannelFactory>(
+                allocator,
+                bmqio::ReconnectingChannelFactoryConfig(prev.get(),
+                                                        scheduler));
+        }
+
+        static ChannelFactorySP statChannelFactory(
+            bslma::Allocator* allocator,
+            ChannelFactorySP& prev,
+            const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+                statContextCreator)
+        {
+            return bsl::allocate_shared<bmqio::StatChannelFactory>(
+                allocator,
+                bmqio::StatChannelFactoryConfig(prev.get(),
+                                                statContextCreator));
+        }
+
+        static ChannelFactorySP authenticatedChannelFactory(
+            bslma::Allocator*                              allocator,
+            ChannelFactorySP&                              prev,
+            bdlmt::EventScheduler*                         scheduler,
+            const bmqt::SessionOptions::AuthnCredentialCb& credentialCb,
+            const bsls::TimeInterval&                      connectTimeout,
+            AuthenticatedChannelFactoryConfig::BlobSpPool* blobSpPool)
+        {
+            return bsl::allocate_shared<AuthenticatedChannelFactory>(
+                allocator,
+                AuthenticatedChannelFactoryConfig(prev.get(),
+                                                  scheduler,
+                                                  credentialCb,
+                                                  connectTimeout,
+                                                  blobSpPool));
+        }
+
+        static ChannelFactorySP negotiatedChannelFactory(
+            bslma::Allocator*                           allocator,
+            ChannelFactorySP&                           prev,
+            const bmqp_ctrlmsg::NegotiationMessage&     negotiationMessage,
+            const bsls::TimeInterval&                   negotiationTimeout,
+            NegotiatedChannelFactoryConfig::BlobSpPool* blobSpPool)
+        {
+            return bsl::allocate_shared<NegotiatedChannelFactory>(
+                allocator,
+                NegotiatedChannelFactoryConfig(prev.get(),
+                                               negotiationMessage,
+                                               negotiationTimeout,
+                                               blobSpPool));
+        }
+    };
+
+    bsl::shared_ptr<bmqio::NtcChannelFactory> channelFactory =
+        bsl::make_shared<bmqio::NtcChannelFactory>(
+            ntcCreateInterfaceConfig(sessionOptions, allocator),
+            blobBufferFactory,
+            allocator);
+
+    using bdlf::PlaceHolders::_1;
+    bmqio::ChannelFactoryPipeline::Config builder(channelFactory, allocator);
+    builder
+        .addWith(bdlf::BindUtil::bind(Builders::resolvingChannelFactory,
+                                      allocator,
+                                      _1))
+        .addWith(bdlf::BindUtil::bind(Builders::reconnectingChannelFactory,
+                                      allocator,
+                                      _1,
+                                      scheduler))
+        .addWith(bdlf::BindUtil::bind(Builders::statChannelFactory,
+                                      allocator,
+                                      _1,
+                                      bsl::cref(statContextCreator)))
+        .addWith(
+            bdlf::BindUtil::bind(Builders::authenticatedChannelFactory,
+                                 allocator,
+                                 _1,
+                                 scheduler,
+                                 bsl::cref(sessionOptions.authnCredentialCb()),
+                                 bsl::cref(sessionOptions.connectTimeout()),
+                                 blobSpPool))
+        .addWith(
+            bdlf::BindUtil::bind(Builders::negotiatedChannelFactory,
+                                 allocator,
+                                 _1,
+                                 bsl::cref(negotiationMessage),
+                                 bsl::cref(sessionOptions.connectTimeout()),
+                                 blobSpPool));
+    return bslma::ManagedPtrUtil::allocateManaged<
+        bmqio::ChannelFactoryPipeline>(allocator,
+                                       bslmf::MovableRefUtil::move(builder));
 }
 
 }  // close unnamed namespace
@@ -223,7 +351,16 @@ void Application::readCb(
             // Application received a broker response to an re-authentication
             // request.  The callback function `channelStateCallback` should
             // only be called for failed cases.
-            d_authenticatedChannelFactory.processAuthenticationEvent(
+
+            // TODO(tfoxhall): This is a code smell to me, the factory should
+            // probably only be responsible for making channels. Handling
+            // request logic should probably be elsewhere.
+            AuthenticatedChannelFactory* authenticatedChannelFactory_p =
+                d_channelFactoryPipeline_mp
+                    ->get<AuthenticatedChannelFactory>();
+            BSLS_ASSERT(authenticatedChannelFactory_p);
+
+            authenticatedChannelFactory_p->processAuthenticationEvent(
                 event,
                 bdlf::BindUtil::bindS(&d_allocator,
                                       &Application::channelStateCallback,
@@ -342,7 +479,7 @@ void Application::brokerSessionStopped(
         // This code assumes that there is no need to stop both factories upon
         // e_START_FAILURE.
         // If we wanted that, we would need another event.
-        d_negotiatedChannelFactory.stop();
+        d_channelFactoryPipeline_mp->stop();
     }
 
     d_scheduler.cancelAllEventsAndWait();
@@ -365,21 +502,7 @@ bmqt::GenericResult::Enum Application::startChannel()
     BSLS_ASSERT_SAFE(d_brokerSession.state() ==
                      bmqimp::BrokerSession::State::e_STARTING);
 
-    int rc = 0;
-
-    // Start the channel factories.
-    rc = d_negotiatedChannelFactory.start();
-    if (rc != 0) {
-        BALL_LOG_ERROR << id()
-                       << "Failed to start negotiatedChannelFactory [rc: "
-                       << rc << "]";
-        return bmqt::GenericResult::e_UNKNOWN;  // RETURN
-    }
-    bdlb::ScopeExitAny negotiatedScopeGuard(
-        bdlf::BindUtil::bind(&NegotiatedChannelFactory::stop,
-                             &d_negotiatedChannelFactory));
-
-    // Connect to the broker.
+    // 1. Prepare and validate connection parameters
     bmqio::TCPEndpoint endpoint(d_sessionOptions.brokerUri());
     if (!endpoint) {
         BALL_LOG_ERROR << id() << "Invalid brokerURI '"
@@ -394,14 +517,27 @@ bmqt::GenericResult::Enum Application::startChannel()
     bsls::TimeInterval attemptInterval;
     attemptInterval.setTotalMilliseconds(k_RECONNECT_INTERVAL_MS);
 
-    bmqio::Status         status(&d_allocator);
     bmqio::ConnectOptions options(&d_allocator);
     options.setEndpoint(out.str())
         .setNumAttempts(k_RECONNECT_COUNT)
         .setAttemptInterval(attemptInterval)
         .setAutoReconnect(true);
 
-    d_negotiatedChannelFactory.connect(
+    // 2. Start channelFactoryPipeline
+    const int rc = d_channelFactoryPipeline_mp->start();
+    if (rc != 0) {
+        BALL_LOG_ERROR << "Failed to start channelFactoryPipeline [rc: " << rc
+                       << "]";
+        return bmqt::GenericResult::e_UNKNOWN;  // RETURN
+    }
+
+    bdlb::ScopeExitAny pipelineScopeGuard(
+        bdlf::BindUtil::bind(&bmqio::ChannelFactoryPipeline::stop,
+                             d_channelFactoryPipeline_mp.get()));
+
+    // 3. Connect to the broker
+    bmqio::Status status(&d_allocator);
+    d_channelFactoryPipeline_mp->connect(
         &status,
         &d_connectHandle_mp,
         options,
@@ -435,7 +571,7 @@ bmqt::GenericResult::Enum Application::startChannel()
             bdlf::MemFnUtil::memFn(&Application::snapshotStats, this));
     }
 
-    negotiatedScopeGuard.release();
+    pipelineScopeGuard.release();
 
     return bmqt::GenericResult::e_SUCCESS;
 }
@@ -590,45 +726,17 @@ Application::Application(
       bmqp::BlobPoolUtil::createBlobPool(&d_blobBufferFactory,
                                          d_allocators.get("BlobSpPool")))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC, &d_allocator)
-, d_channelFactory(ntcCreateInterfaceConfig(sessionOptions, &d_allocator),
-                   &d_blobBufferFactory,
-                   &d_allocator)
-, d_resolvingChannelFactory(
-      bmqio::ResolvingChannelFactoryConfig(
-          &d_channelFactory,
-          bmqex::ExecutionPolicyUtil::alwaysBlocking().useExecutor(
-              bmqex::SystemExecutor()),
-          allocator),
-      allocator)
-, d_reconnectingChannelFactory(
-      bmqio::ReconnectingChannelFactoryConfig(&d_resolvingChannelFactory,
-                                              &d_scheduler,
-                                              allocator),
-      allocator)
-, d_statChannelFactory(
-      bmqio::StatChannelFactoryConfig(
-          &d_reconnectingChannelFactory,
-          bdlf::BindUtil::bind(&Application::channelStatContextCreator,
-                               this,
-                               bdlf::PlaceHolders::_1,   // channel
-                               bdlf::PlaceHolders::_2),  // handle
-          allocator),
-      allocator)
-, d_authenticatedChannelFactory(
-      AuthenticatedChannelFactoryConfig(&d_statChannelFactory,
-                                        &d_scheduler,
-                                        sessionOptions.authnCredentialCb(),
-                                        sessionOptions.connectTimeout(),
-                                        d_blobSpPool_sp.get(),
-                                        allocator),
-      allocator)
-, d_negotiatedChannelFactory(
-      NegotiatedChannelFactoryConfig(&d_authenticatedChannelFactory,
-                                     negotiationMessage,
-                                     sessionOptions.connectTimeout(),
-                                     d_blobSpPool_sp.get(),
-                                     allocator),
-      allocator)
+, d_channelFactoryPipeline_mp(makeChannelFactoryPipeline(
+      &d_allocator,
+      &d_blobBufferFactory,
+      &d_scheduler,
+      d_blobSpPool_sp.get(),
+      sessionOptions,
+      bdlf::BindUtil::bind(&Application::channelStatContextCreator,
+                           this,
+                           bdlf::PlaceHolders::_1,   // channel
+                           bdlf::PlaceHolders::_2),  // handle
+      negotiationMessage))
 , d_connectHandle_mp()
 , d_brokerSession(&d_scheduler,
                   &d_blobBufferFactory,

--- a/src/groups/bmq/bmqimp/bmqimp_application.h
+++ b/src/groups/bmq/bmqimp/bmqimp_application.h
@@ -34,7 +34,6 @@
 // Thread safe.
 
 // BMQ
-
 #include <bmqimp_authenticatedchannelfactory.h>
 #include <bmqimp_brokersession.h>
 #include <bmqimp_eventqueue.h>
@@ -45,6 +44,7 @@
 
 #include <bmqio_channel.h>
 #include <bmqio_channelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_ntcchannelfactory.h>
 #include <bmqio_reconnectingchannelfactory.h>
 #include <bmqio_resolvingchannelfactory.h>
@@ -126,17 +126,10 @@ class Application {
     /// Scheduler
     bdlmt::EventScheduler d_scheduler;
 
-    bmqio::NtcChannelFactory d_channelFactory;
-
-    bmqio::ResolvingChannelFactory d_resolvingChannelFactory;
-
-    bmqio::ReconnectingChannelFactory d_reconnectingChannelFactory;
-
-    bmqio::StatChannelFactory d_statChannelFactory;
-
-    AuthenticatedChannelFactory d_authenticatedChannelFactory;
-
-    NegotiatedChannelFactory d_negotiatedChannelFactory;
+    /// The stack of channel factories used for customizing
+    /// connection/listening logic
+    bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
+        d_channelFactoryPipeline_mp;
 
     ChannelFactoryOpHandleMp d_connectHandle_mp;
 

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.cpp
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.cpp
@@ -1,0 +1,140 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqio_channelfactorypipeline.h>
+#include <bslma_allocator.h>
+#include <bslma_managedptr.h>
+
+namespace BloombergLP {
+namespace bmqio {
+
+ChannelFactoryPipeline::Config::Config(const ChannelFactorySP& baseFactory,
+                                       const allocator_type&   allocator)
+: d_pipeline(1, baseFactory, allocator)
+{
+    BSLS_ASSERT(baseFactory != NULL);
+}
+
+ChannelFactoryPipeline::Config::Config(bslmf::MovableRef<Config> other)
+    BSLS_KEYWORD_NOEXCEPT
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline),
+             MoveUtil::access(other).d_pipeline.get_allocator())
+{
+}
+
+ChannelFactoryPipeline::Config::Config(bslmf::MovableRef<Config> other,
+                                       const allocator_type&     allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline), allocator)
+{
+}
+
+ChannelFactoryPipeline::Config::allocator_type
+ChannelFactoryPipeline::Config::get_allocator() const
+{
+    return d_pipeline.get_allocator();
+}
+
+ChannelFactoryPipeline::Config&
+ChannelFactoryPipeline::Config::add(const ChannelFactorySP& channelFactory)
+{
+    BSLS_ASSERT(channelFactory != NULL);
+
+    d_pipeline.push_back(channelFactory);
+
+    return *this;
+}
+
+ChannelFactoryPipeline::Config&
+ChannelFactoryPipeline::Config::addWith(const ChannelFactoryBuilder& builder)
+{
+    ChannelFactorySP last;
+    if (!d_pipeline.empty()) {
+        last = d_pipeline.back();
+    }
+    ChannelFactorySP channelFactory = builder(last);
+    add(channelFactory);
+
+    return *this;
+}
+
+size_t ChannelFactoryPipeline::Config::size() const
+{
+    return d_pipeline.size();
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<ChannelFactoryPipeline> other) BSLS_KEYWORD_NOEXCEPT
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline),
+             MoveUtil::access(other).get_allocator())
+{
+    BSLS_ASSERT(!d_pipeline.empty());
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<ChannelFactoryPipeline> other,
+    const allocator_type&                     allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(other).d_pipeline), allocator)
+{
+    BSLS_ASSERT(!d_pipeline.empty());
+}
+
+ChannelFactoryPipeline::ChannelFactoryPipeline(
+    bslmf::MovableRef<Config> builder,
+    const allocator_type&     allocator)
+: d_pipeline(MoveUtil::move(MoveUtil::access(builder).d_pipeline), allocator)
+{
+    BSLS_ASSERT(!d_pipeline.empty());
+}
+
+ChannelFactoryPipeline::allocator_type
+ChannelFactoryPipeline::get_allocator() const
+{
+    return d_pipeline.get_allocator();
+}
+
+const ChannelFactoryPipeline::ChannelFactorySP&
+ChannelFactoryPipeline::top() const
+{
+    return d_pipeline.back();
+}
+
+void ChannelFactoryPipeline::listen(bmqio::Status*               status,
+                                    bslma::ManagedPtr<OpHandle>* handle,
+                                    const bmqio::ListenOptions&  options,
+                                    const ResultCallback&        cb)
+{
+    top()->listen(status, handle, options, cb);
+}
+
+void ChannelFactoryPipeline::connect(bmqio::Status*               status,
+                                     bslma::ManagedPtr<OpHandle>* handle,
+                                     const bmqio::ConnectOptions& options,
+                                     const ResultCallback&        cb)
+{
+    top()->connect(status, handle, options, cb);
+}
+
+int ChannelFactoryPipeline::start()
+{
+    return top()->start();
+}
+
+void ChannelFactoryPipeline::stop()
+{
+    top()->stop();
+}
+
+}
+}

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
@@ -1,0 +1,436 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqio_channelfactorypipeline.h>
+
+// BMQ
+#include <bmqio_channelfactory.h>
+#include <bmqio_connectoptions.h>
+#include <bmqio_listenoptions.h>
+#include <bmqio_ntcchannel.h>
+#include <bmqio_ntcchannelfactory.h>
+#include <bmqio_testchannelfactory.h>
+
+// BDE
+#include <bdlf_bind.h>
+#include <bdlf_placeholder.h>
+#include <bsl_memory.h>
+#include <bsla_annotations.h>
+#include <bslmf_movableref.h>
+#include <bsls_asserttestexception.h>
+
+// TEST_DRIVER
+#include <bmqtst_testhelper.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+
+namespace {
+
+class MockChannelFactory : public bmqio::ChannelFactory {
+  public:
+    MOCK_METHOD4(listen,
+                 void(bmqio::Status*               status,
+                      bslma::ManagedPtr<OpHandle>* handle,
+                      const bmqio::ListenOptions&  options,
+                      const ResultCallback&        cb));
+    MOCK_METHOD4(connect,
+                 void(bmqio::Status*               status,
+                      bslma::ManagedPtr<OpHandle>* handle,
+                      const bmqio::ConnectOptions& options,
+                      const ResultCallback&        cb));
+    MOCK_METHOD0(start, int());
+    MOCK_METHOD0(stop, void());
+};
+
+class WrappedChannelFactory : public bmqio::ChannelFactory {
+  private:
+    bmqio::ChannelFactory* d_wrapped;
+
+  public:
+    WrappedChannelFactory(bmqio::ChannelFactory* wrapped)
+    : d_wrapped(wrapped)
+    {
+        BSLS_ASSERT(d_wrapped != NULL);
+    }
+
+    void listen(bmqio::Status*               status,
+                bslma::ManagedPtr<OpHandle>* handle,
+                const bmqio::ListenOptions&  options,
+                const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE
+    {
+        d_wrapped->listen(status, handle, options, cb);
+    }
+
+    void connect(bmqio::Status*               status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ConnectOptions& options,
+                 const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE
+    {
+        d_wrapped->connect(status, handle, options, cb);
+    }
+
+    int start() BSLS_KEYWORD_OVERRIDE { return 0; }
+
+    void stop() BSLS_KEYWORD_OVERRIDE {}
+};
+
+}
+
+// ========================================================================
+//                                  TESTS
+// ------------------------------------------------------------------------
+
+class ChannelFactoryPipelineConfigTest : public ::testing::Test {
+  protected:
+    ChannelFactoryPipelineConfigTest() {}
+    ~ChannelFactoryPipelineConfigTest() BSLS_KEYWORD_OVERRIDE;
+
+    typedef bsl::allocator<unsigned char>         allocator_type;
+    typedef bmqio::ChannelFactoryPipeline::Config Config;
+    typedef bslmf::MovableRefUtil                 MoveUtil;
+
+    allocator_type get_allocator() const
+    {
+        return bmqtst::TestHelperUtil::allocator();
+    }
+
+    bsl::shared_ptr<bmqio::ChannelFactory> testFactory() const
+    {
+        return bsl::allocate_shared<bmqio::TestChannelFactory>(
+            get_allocator());
+    }
+};
+
+ChannelFactoryPipelineConfigTest::~ChannelFactoryPipelineConfigTest()
+{
+    // Here to suppress a -Wweak-vtables warning
+
+    // NOTHING
+}
+
+TEST_F(ChannelFactoryPipelineConfigTest, breathingTest)
+{
+    Config builder(testFactory(), get_allocator());
+}
+
+TEST_F(ChannelFactoryPipelineConfigTest, add)
+{
+    Config builder(testFactory(), get_allocator());
+    builder.add(testFactory());
+
+    EXPECT_EQ(2, builder.size());
+}
+
+TEST_F(ChannelFactoryPipelineConfigTest, addWith)
+{
+    Config builder(testFactory(), get_allocator());
+
+    struct FactoryFunctor {
+        static bsl::shared_ptr<bmqio::ChannelFactory>
+        make(allocator_type allocator,
+             BSLA_UNUSED bsl::shared_ptr<bmqio::ChannelFactory>& prev)
+        {
+            return bsl::allocate_shared<bmqio::TestChannelFactory>(allocator);
+        }
+    };
+
+    using bdlf::PlaceHolders::_1;
+    builder.addWith(
+        bdlf::BindUtil::bindS(bslma::AllocatorUtil::adapt(get_allocator()),
+                              FactoryFunctor::make,
+                              get_allocator(),
+                              _1));
+
+    EXPECT_EQ(2, builder.size());
+}
+
+TEST_F(ChannelFactoryPipelineConfigTest, addWithFails)
+{
+    Config builder(testFactory(), get_allocator());
+
+    struct FactoryFunctor {
+        static bsl::shared_ptr<bmqio::ChannelFactory>
+        make(BSLA_UNUSED bsl::shared_ptr<bmqio::ChannelFactory>& prev)
+        {
+            // This is a contract failure.
+            return NULL;
+        }
+    };
+
+    using bdlf::PlaceHolders::_1;
+    EXPECT_THROW(builder.addWith(bdlf::BindUtil::bindS(
+                     bslma::AllocatorUtil::adapt(get_allocator()),
+                     FactoryFunctor::make,
+                     _1)),
+                 bsls::AssertTestException);
+}
+
+TEST_F(ChannelFactoryPipelineConfigTest, canMove)
+{
+    Config builder(testFactory(), get_allocator());
+    Config builder2(MoveUtil::move(builder), get_allocator());
+}
+
+class ChannelFactoryPipelineTest : public ::testing::Test {
+  protected:
+    ChannelFactoryPipelineTest() {}
+    ~ChannelFactoryPipelineTest() BSLS_KEYWORD_OVERRIDE;
+
+    typedef bsl::allocator<unsigned char>         allocator_type;
+    typedef bslmf::MovableRefUtil                 MoveUtil;
+    typedef bsl::shared_ptr<MockChannelFactory>   MockFactorySP;
+    typedef bmqio::ChannelFactoryPipeline::Config Config;
+
+    allocator_type get_allocator() const
+    {
+        return bmqtst::TestHelperUtil::allocator();
+    }
+
+    MockFactorySP mockFactory() const
+    {
+        using ::testing::NiceMock;
+        MockFactorySP factory =
+            bsl::allocate_shared<NiceMock<MockChannelFactory> >(
+                get_allocator());
+
+        using ::testing::Return;
+        ON_CALL(*factory, start()).WillByDefault(Return(0));
+        ON_CALL(*factory, stop()).WillByDefault(Return());
+
+        return factory;
+    }
+
+    bmqio::ChannelFactoryPipeline::Config::ChannelFactoryBuilder
+    wrappedFactoryConfig() const
+    {
+        struct Config {
+            static bsl::shared_ptr<bmqio::ChannelFactory>
+            make(allocator_type                          allocator,
+                 bsl::shared_ptr<bmqio::ChannelFactory>& prev)
+            {
+                return bsl::allocate_shared<WrappedChannelFactory>(allocator,
+                                                                   prev.get());
+            }
+        };
+
+        using bdlf::PlaceHolders::_1;
+        return bdlf::BindUtil::bindS(
+            bslma::AllocatorUtil::adapt(get_allocator()),
+            Config::make,
+            get_allocator(),
+            _1);
+    }
+};
+
+ChannelFactoryPipelineTest::~ChannelFactoryPipelineTest()
+{
+    // Here to suppress a -Wweak-vtables warning
+
+    // NOTHING
+}
+
+TEST_F(ChannelFactoryPipelineTest, breathingTest)
+{
+    Config                        config(mockFactory(), get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+}
+
+TEST_F(ChannelFactoryPipelineTest, stopOnDestructor)
+{
+    MockFactorySP factory = mockFactory();
+    EXPECT_CALL(*factory, stop());
+
+    Config                        config(factory, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+}
+
+TEST_F(ChannelFactoryPipelineTest, listenFollowsChain)
+{
+    MockFactorySP                                      factory = mockFactory();
+    bmqio::Status                                      status;
+    bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> handle;
+    bmqio::ListenOptions                               options;
+    const bmqio::ChannelFactory::ResultCallback        cb;
+
+    using ::testing::_;
+    using ::testing::Ref;
+
+    EXPECT_CALL(*factory, listen(&status, &handle, Ref(options), Ref(cb)));
+
+    Config                        config(factory, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    pipeline.start();
+    pipeline.listen(&status, &handle, options, cb);
+}
+
+TEST_F(ChannelFactoryPipelineTest, connectFollowsChain)
+{
+    MockFactorySP                                      factory = mockFactory();
+    bmqio::Status                                      status;
+    bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> handle;
+    bmqio::ConnectOptions                              options;
+    const bmqio::ChannelFactory::ResultCallback        cb;
+
+    using ::testing::_;
+    using ::testing::Ref;
+
+    EXPECT_CALL(*factory, connect(&status, &handle, Ref(options), Ref(cb)));
+
+    Config                        config(factory, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(
+        MoveUtil::move(config.addWith(wrappedFactoryConfig())),
+        get_allocator());
+
+    pipeline.connect(&status, &handle, options, cb);
+}
+
+TEST_F(ChannelFactoryPipelineTest, startIsForwarded)
+{
+    using ::testing::Return;
+
+    MockFactorySP factory1 = mockFactory();
+
+    EXPECT_CALL(*factory1, start()).WillRepeatedly(Return(0));
+
+    Config                        config(factory1, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    EXPECT_EQ(0, pipeline.start());
+}
+
+TEST_F(ChannelFactoryPipelineTest, startFailureIsForwarded)
+{
+    using ::testing::Return;
+
+    MockFactorySP factory1 = mockFactory();
+
+    EXPECT_CALL(*factory1, start()).WillRepeatedly(Return(1));
+
+    Config                        config(factory1, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    EXPECT_NE(0, pipeline.start());
+}
+
+TEST_F(ChannelFactoryPipelineTest, startIsForwardedToLastFactory)
+{
+    using ::testing::Return;
+
+    MockFactorySP factory1 = mockFactory();
+    MockFactorySP factory2 = mockFactory();
+
+    EXPECT_CALL(*factory2, start()).WillRepeatedly(Return(0));
+
+    Config config(factory1, get_allocator());
+    config.add(factory2);
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    EXPECT_EQ(0, pipeline.start());
+}
+
+TEST_F(ChannelFactoryPipelineTest, stopIsForwarded)
+{
+    MockFactorySP factory1 = mockFactory();
+
+    EXPECT_CALL(*factory1, stop());
+
+    Config                        config(factory1, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    pipeline.stop();
+    ASSERT_TRUE(::testing::Mock::VerifyAndClearExpectations(factory1.get()));
+}
+
+TEST_F(ChannelFactoryPipelineTest, stopIsForwardedToLastFactory)
+{
+    using ::testing::AnyNumber;
+    using ::testing::Return;
+
+    MockFactorySP factory1 = mockFactory();
+    MockFactorySP factory2 = mockFactory();
+
+    EXPECT_CALL(*factory2, stop()).Times(AnyNumber());
+
+    Config config(factory1, get_allocator());
+    config.add(factory2);
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    pipeline.stop();
+}
+
+TEST_F(ChannelFactoryPipelineTest, stopIsCalledOnDestruction)
+{
+    MockFactorySP factory1 = mockFactory();
+
+    EXPECT_CALL(*factory1, stop());
+
+    Config                        config(factory1, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+}
+
+TEST_F(ChannelFactoryPipelineTest, getFindsChannelFactorySubtype)
+{
+    MockFactorySP factory = mockFactory();
+
+    Config                        config(factory, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    MockChannelFactory* result = pipeline.get<MockChannelFactory>();
+
+    EXPECT_EQ(result, factory.get());
+}
+
+TEST_F(ChannelFactoryPipelineTest, getDoesntFindNonexistantSubtype)
+{
+    MockFactorySP factory = mockFactory();
+
+    Config                        config(factory, get_allocator());
+    bmqio::ChannelFactoryPipeline pipeline(MoveUtil::move(config),
+                                           get_allocator());
+
+    bmqio::NtcChannelFactory* result =
+        pipeline.get<bmqio::NtcChannelFactory>();
+
+    EXPECT_EQ(NULL, result);
+}
+
+// ========================================================================
+//                                  MAIN
+// ------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bmqtst::TestHelperUtil::testStatus() = RUN_ALL_TESTS();
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.h
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.h
@@ -1,0 +1,184 @@
+// Copyright 2019-2023 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_BMQIO_CHANNELFACTORYPIPELINE
+#define INCLUDED_BMQIO_CHANNELFACTORYPIPELINE
+
+#include <bmqio_channelfactory.h>
+
+#include <bsl_memory.h>
+#include <bsl_vector.h>
+#include <bslma_managedptr.h>
+#include <bslmf_movableref.h>
+#include <bsls_keyword.h>
+#include <bslstl_sharedptr.h>
+
+namespace BloombergLP {
+namespace bmqio {
+
+class ChannelFactoryPipeline : public bmqio::ChannelFactory {
+  private:
+    // PRIVATE TYPES
+    typedef bslmf::MovableRefUtil MoveUtil;
+
+  public:
+    /// The allocator type.
+    typedef bsl::allocator<unsigned char> allocator_type;
+
+    // TYPES
+    typedef bsl::shared_ptr<bmqio::ChannelFactory> ChannelFactorySP;
+
+    /// A builder class for constructing `ChannelFactoryPipelines`.
+    class Config {
+      private:
+        // PRIVATE DATA
+        bsl::vector<ChannelFactorySP> d_pipeline;
+
+        // FRIENDS
+        friend class ChannelFactoryPipeline;
+
+      public:
+        /// The allocator type.
+        typedef bsl::allocator<unsigned char> allocator_type;
+
+        /// A builder for channel factories.
+        typedef bsl::function<ChannelFactorySP(ChannelFactorySP&)>
+            ChannelFactoryBuilder;
+
+        // CONSTRUCTORS
+
+        // Create a pipeline builder based on `baseFactory`
+        explicit Config(const ChannelFactorySP& baseFactory,
+                        const allocator_type&   allocator = allocator_type());
+        Config(bslmf::MovableRef<Config> other) BSLS_KEYWORD_NOEXCEPT;
+        Config(bslmf::MovableRef<Config> other,
+               const allocator_type&     allocator);
+
+      private:
+        // PRIVATE CONSTRUCTORS
+
+        Config(const Config& other) BSLS_KEYWORD_DELETED;
+        Config& operator=(const Config& other) BSLS_KEYWORD_DELETED;
+
+      public:
+        // ACESSORS
+
+        /// Get the allocator for this object.
+        allocator_type get_allocator() const;
+
+        // MANIPULATORS
+
+        /// Add a `ChannelFactory` as the next step in the pipeline.
+        ///
+        /// @pre `channelFactory` must not be null.
+        Config& add(const ChannelFactorySP& channelFactory);
+
+        /// Add a `ChannelFactory` as the next step in the pipeline,
+        /// constructed from the provided factory. The parameter is a reference
+        /// to the previous factory in the pipeline. If there are no factories
+        /// in the pipeline, the parameter is NULL.
+        ///
+        /// @pre `builder(previous)` must not return null
+        Config& addWith(const ChannelFactoryBuilder& builder);
+
+        /// Get the current size of the pipeline.
+        size_t size() const;
+    };
+
+  private:
+    // PRIVATE DATA
+    bsl::vector<ChannelFactorySP> d_pipeline;
+
+  public:
+    // CONSTRUCTORS
+    ChannelFactoryPipeline(bslmf::MovableRef<ChannelFactoryPipeline> other)
+        BSLS_KEYWORD_NOEXCEPT;
+
+    ChannelFactoryPipeline(bslmf::MovableRef<ChannelFactoryPipeline> other,
+                           const allocator_type& allocator);
+
+    ChannelFactoryPipeline(bslmf::MovableRef<Config> builder,
+                           const allocator_type& allocator = allocator_type());
+
+    ~ChannelFactoryPipeline() BSLS_KEYWORD_NOEXCEPT BSLS_KEYWORD_OVERRIDE;
+
+  private:
+    // PRIVATE CONSTRUCTORS
+
+    ChannelFactoryPipeline(const ChannelFactoryPipeline& other)
+        BSLS_KEYWORD_DELETED;
+
+    // PRIVATE ACCESSORS
+
+    /// Get the top of the stack of channel factories.
+    const ChannelFactorySP& top() const;
+
+  public:
+    // ACESSORS
+
+    /// Get the allocator for this object.
+    allocator_type get_allocator() const;
+
+    // MANIPULATORS
+
+    void listen(bmqio::Status*               status,
+                bslma::ManagedPtr<OpHandle>* handle,
+                const bmqio::ListenOptions&  options,
+                const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    void connect(bmqio::Status*               status,
+                 bslma::ManagedPtr<OpHandle>* handle,
+                 const bmqio::ConnectOptions& options,
+                 const ResultCallback&        cb) BSLS_KEYWORD_OVERRIDE;
+
+    /// Enable this factory to start creating connections.
+    int start() BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop this factory from creating connections and clean up any pending
+    /// connections.
+    void stop() BSLS_KEYWORD_OVERRIDE;
+
+    /// Search the channel factory stack for a ChannelFactory matching subtype
+    /// T. If no such type is found, return NULL.
+    ///
+    /// @pre The behavior is undefined unless T is a unique subtype among all
+    /// `ChannelFactory` objects managed by this object.
+    template <typename T>
+    T* get();
+};
+
+inline ChannelFactoryPipeline::~ChannelFactoryPipeline() BSLS_KEYWORD_NOEXCEPT
+{
+    this->stop();
+}
+
+template <typename T>
+inline T* ChannelFactoryPipeline::get()
+{
+    for (bsl::vector<ChannelFactorySP>::iterator it  = d_pipeline.begin(),
+                                                 end = d_pipeline.end();
+         it != end;
+         ++it) {
+        T* test = dynamic_cast<T*>(it->get());
+        if (test != NULL) {
+            return test;
+        }
+    }
+    return NULL;
+}
+
+}
+}
+#endif

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bmqu_atomicvalidator.h"
 #include <bmqio_ntcchannelfactory.h>
 
 #include <bmqscm_version.h>
@@ -230,8 +231,7 @@ void NtcChannelFactory::stop()
         return;  // RETURN
     }
 
-    valGuard.release()->release();
-    d_validator.invalidate();  // Disallow new listen/connect
+    bmqu::AtomicValidatorGuardUtil::releaseAndInvalidate(&valGuard);
 
     BALL_LOG_TRACE << "NTC factory is stopping" << BALL_LOG_END;
 

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "bmqu_atomicvalidator.h"
 #include <bmqio_reconnectingchannelfactory.h>
 
 #include <bmqscm_version.h>
@@ -487,9 +488,16 @@ int ReconnectingChannelFactory::start()
 
 void ReconnectingChannelFactory::stop()
 {
-    d_validator.invalidate();
+    // Support multiple 'stop'
+    {
+        bmqu::AtomicValidatorGuard guard(&d_validator);
 
-    cancelAllHandles();
+        if (guard.isValid()) {
+            bmqu::AtomicValidatorGuardUtil::releaseAndInvalidate(&guard);
+
+            cancelAllHandles();
+        }
+    }
 
     d_config.d_base_p->stop();
 }

--- a/src/groups/bmq/bmqio/package/bmqio.mem
+++ b/src/groups/bmq/bmqio/package/bmqio.mem
@@ -1,6 +1,7 @@
 bmqio_basechannelpartialimp
 bmqio_channel
 bmqio_channelfactory
+bmqio_channelfactorypipeline
 bmqio_channelutil
 bmqio_connectoptions
 bmqio_decoratingchannelpartialimp

--- a/src/groups/bmq/bmqu/bmqu_atomicvalidator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_atomicvalidator.cpp
@@ -82,5 +82,19 @@ AtomicValidator* AtomicValidatorGuard::release()
     return 0;
 }
 
+void AtomicValidatorGuardUtil::releaseAndInvalidate(
+    AtomicValidatorGuard* guard)
+{
+    BSLS_ASSERT(guard);
+
+    if (guard->isValid()) {
+        AtomicValidator* validator = guard->release();
+        if (validator) {
+            validator->release();
+            validator->invalidate();
+        }
+    }
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqu/bmqu_atomicvalidator.h
+++ b/src/groups/bmq/bmqu/bmqu_atomicvalidator.h
@@ -211,6 +211,14 @@ class AtomicValidatorGuard {
     bool isValid() const;
 };
 
+struct AtomicValidatorGuardUtil {
+    /// Release the underlying validator from management by the provided
+    /// `guard` and, if the underlying validator is still valid, invalidate it.
+    ///
+    /// @pre The behavior is undefined if `guard` is null.
+    static void releaseAndInvalidate(AtomicValidatorGuard* guard);
+};
+
 // ============================================================================
 //                             INLINE DEFINITIONS
 // ============================================================================

--- a/src/groups/bmq/group/bmq.t.dep
+++ b/src/groups/bmq/group/bmq.t.dep
@@ -1,2 +1,4 @@
 benchmark
 bmq
+gtest
+gmock

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -40,12 +40,17 @@
 // BMQ
 #include <bmqex_executionutil.h>
 #include <bmqex_systemexecutor.h>
+#include <bmqio_channelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_channelutil.h>
 #include <bmqio_connectoptions.h>
 #include <bmqio_ntcchannel.h>
 #include <bmqio_ntcchannelfactory.h>
+#include <bmqio_reconnectingchannelfactory.h>
 #include <bmqio_resolveutil.h>
 #include <bmqio_statchannel.h>
+#include <bmqio_statchannelfactory.h>
+#include <bmqio_status.h>
 #include <bmqio_tcpendpoint.h>
 #include <bmqp_event.h>
 #include <bmqp_protocol.h>
@@ -69,7 +74,9 @@
 #include <bsl_cstdlib.h>
 #include <bsl_iostream.h>
 #include <bsl_limits.h>
+#include <bsl_memory.h>
 #include <bsl_utility.h>
+#include <bsl_vector.h>
 #include <bsla_annotations.h>
 #include <bslalg_swaputil.h>
 #include <bslmf_movableref.h>
@@ -86,7 +93,7 @@
 #include <bsls_types.h>
 
 // NTC
-#include <bsl_vector.h>
+#include <ntcf_system.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
 
@@ -259,6 +266,74 @@ struct PortMatcher {
     bool operator()(const mqbcfg::TcpInterfaceListener& listener)
     {
         return listener.port() == d_port;
+    }
+};
+
+/// Helpers for building ChannelFactoryPipeline's
+struct ChannelFactoryBuilders {
+    typedef bmqio::ChannelFactoryPipeline::ChannelFactorySP ChannelFactorySP;
+
+    static bsl::shared_ptr<bmqio::NtcChannelFactory>
+    ntcChannelFactory(bslma::Allocator*            allocator,
+                      const ntca::InterfaceConfig& interfaceConfig,
+                      bdlbb::BlobBufferFactory*    blobBufferFactory)
+    {
+        bsl::shared_ptr<bmqio::NtcChannelFactory> factory =
+            bsl::allocate_shared<bmqio::NtcChannelFactory>(allocator,
+                                                           interfaceConfig,
+                                                           blobBufferFactory);
+        factory->onCreate(bdlf::BindUtil::bind(&ntcChannelPreCreation,
+                                               bdlf::PlaceHolders::_1,
+                                               bdlf::PlaceHolders::_2));
+        return factory;
+    }
+
+    static ChannelFactorySP
+    resolvingChannelFactory(bslma::Allocator*               allocator,
+                            ChannelFactorySP&               prev,
+                            const bmqex::SequentialContext& resolutionContext)
+    {
+        return bsl::allocate_shared<bmqio::ResolvingChannelFactory>(
+            allocator,
+            bmqio::ResolvingChannelFactoryConfig(
+                prev.get(),
+                bmqex::ExecutionPolicyUtil::neverBlocking().useExecutor(
+                    resolutionContext.executor()))
+                .resolutionFn(bdlf::BindUtil::bind(
+                    &monitoredDNSResolution,
+                    bdlf::PlaceHolders::_1,   // resolvedUri
+                    bdlf::PlaceHolders::_2))  // channel
+        );
+    }
+
+    static ChannelFactorySP
+    reconnectingChannelFactory(bslma::Allocator*      allocator,
+                               ChannelFactorySP&      prev,
+                               bdlmt::EventScheduler* scheduler)
+    {
+        return bsl::allocate_shared<bmqio::ReconnectingChannelFactory>(
+            allocator,
+            bmqio::ReconnectingChannelFactoryConfig(prev.get(), scheduler)
+                .setReconnectIntervalFn(bdlf::BindUtil::bind(
+                    &bmqio::ReconnectingChannelFactoryUtil::
+                        defaultConnectIntervalFn,
+                    bdlf::PlaceHolders::_1,        // interval
+                    bdlf::PlaceHolders::_2,        // options
+                    bdlf::PlaceHolders::_3,        // timeSinceLastAttempt
+                    bsls::TimeInterval(3 * 60.0),  // resetReconnectTime
+                    bsls::TimeInterval(30.0)))     // maxInterval
+        );
+    }
+
+    static ChannelFactorySP statChannelFactory(
+        bslma::Allocator* allocator,
+        ChannelFactorySP& prev,
+        const bmqio::StatChannelFactoryConfig::StatContextCreatorFn&
+            statContextCreator)
+    {
+        return bsl::allocate_shared<bmqio::StatChannelFactory>(
+            allocator,
+            bmqio::StatChannelFactoryConfig(prev.get(), statContextCreator));
     }
 };
 
@@ -1067,11 +1142,8 @@ TCPSessionFactory::TCPSessionFactory(
 , d_authenticator_p(authenticator)
 , d_negotiator_p(negotiator)
 , d_statController_p(statController)
-, d_tcpChannelFactory_mp()
 , d_resolutionContext(allocator)
-, d_resolvingChannelFactory_mp()
-, d_reconnectingChannelFactory_mp()
-, d_statChannelFactory_mp()
+, d_channelFactoryPipeline_mp()
 , d_threadName(allocator)
 , d_nbActiveChannels(0)
 , d_nbOpenClients(0)
@@ -1169,69 +1241,58 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
 
     ntca::InterfaceConfig interfaceConfig = ntcCreateInterfaceConfig(d_config);
 
-    bslma::ManagedPtr<bmqio::NtcChannelFactory> channelFactory;
-    channelFactory.load(new (*d_allocator_p)
-                            bmqio::NtcChannelFactory(interfaceConfig,
-                                                     d_blobBufferFactory_p,
-                                                     d_allocator_p),
-                        d_allocator_p);
-
-    channelFactory->onCreate(bdlf::BindUtil::bind(&ntcChannelPreCreation,
-                                                  bdlf::PlaceHolders::_1,
-                                                  bdlf::PlaceHolders::_2));
-
-    d_tcpChannelFactory_mp = channelFactory;
-
     bslmt::ThreadAttributes attributes;
     attributes.setThreadName("bmqDNSResolver");
     rc = d_resolutionContext.start(attributes);
     BSLS_ASSERT_SAFE(rc == 0);
 
-    d_resolvingChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::ResolvingChannelFactory(
-            bmqio::ResolvingChannelFactoryConfig(
-                d_tcpChannelFactory_mp.get(),
-                bmqex::ExecutionPolicyUtil::neverBlocking().useExecutor(
-                    d_resolutionContext.executor()),
-                d_allocator_p)
-                .resolutionFn(bdlf::BindUtil::bind(
-                    &monitoredDNSResolution,
-                    bdlf::PlaceHolders::_1,    // resolvedUri
-                    bdlf::PlaceHolders::_2)),  // channel
-            d_allocator_p),
-        d_allocator_p);
+    bmqio::StatChannelFactoryConfig::StatContextCreatorFn statContextCreator(
+        bdlf::BindUtil::bind(&TCPSessionFactory::channelStatContextCreator,
+                             this,
+                             bdlf::PlaceHolders::_1,  // channel
+                             bdlf::PlaceHolders::_2)  // handle
+    );
 
-    d_reconnectingChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::ReconnectingChannelFactory(
-            bmqio::ReconnectingChannelFactoryConfig(
-                d_resolvingChannelFactory_mp.get(),
-                d_scheduler_p,
-                d_allocator_p)
-                .setReconnectIntervalFn(bdlf::BindUtil::bind(
-                    &bmqio::ReconnectingChannelFactoryUtil ::
-                        defaultConnectIntervalFn,
-                    bdlf::PlaceHolders::_1,        // interval
-                    bdlf::PlaceHolders::_2,        // options
-                    bdlf::PlaceHolders::_3,        // timeSinceLastAttempt
-                    bsls::TimeInterval(3 * 60.0),  // resetReconnectTime
-                    bsls::TimeInterval(30.0))),    // maxInterval
-            d_allocator_p),
-        d_allocator_p);
+    typedef bmqio::ChannelFactoryPipeline::Config::ChannelFactoryBuilder
+        ChannelFactoryBuilder;
 
-    d_statChannelFactory_mp.load(
-        new (*d_allocator_p) bmqio::StatChannelFactory(
-            bmqio::StatChannelFactoryConfig(
-                d_reconnectingChannelFactory_mp.get(),
-                bdlf::BindUtil::bind(
-                    &TCPSessionFactory::channelStatContextCreator,
-                    this,
-                    bdlf::PlaceHolders::_1,   // channel
-                    bdlf::PlaceHolders::_2),  // handle
-                d_allocator_p),
-            d_allocator_p),
-        d_allocator_p);
+    bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory =
+        ChannelFactoryBuilders::ntcChannelFactory(d_allocator_p,
+                                                  interfaceConfig,
+                                                  d_blobBufferFactory_p);
+    ChannelFactoryBuilder resolvingChannelFactoryBuilder =
+        bdlf::BindUtil::bind(ChannelFactoryBuilders::resolvingChannelFactory,
+                             d_allocator_p,
+                             bdlf::PlaceHolders::_1,
+                             bsl::cref(d_resolutionContext));
+    ChannelFactoryBuilder reconnectingChannelFactoryBuilder =
+        bdlf::BindUtil::bind(
+            ChannelFactoryBuilders::reconnectingChannelFactory,
+            d_allocator_p,
+            bdlf::PlaceHolders::_1,
+            d_scheduler_p);
+    ChannelFactoryBuilder statChannelFactoryBuilder = bdlf::BindUtil::bind(
+        ChannelFactoryBuilders::statChannelFactory,
+        d_allocator_p,
+        bdlf::PlaceHolders::_1,
+        statContextCreator);
 
-    rc = d_statChannelFactory_mp->start();
+    {
+        bmqio::ChannelFactoryPipeline::Config config(ntcChannelFactory,
+                                                     d_allocator_p);
+        config.addWith(resolvingChannelFactoryBuilder)
+            .addWith(reconnectingChannelFactoryBuilder)
+            .addWith(statChannelFactoryBuilder);
+        bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
+            channelFactoryPipeline_mp = bslma::ManagedPtrUtil::allocateManaged<
+                bmqio::ChannelFactoryPipeline>(
+                d_allocator_p,
+                bslmf::MovableRefUtil::move(config));
+
+        d_channelFactoryPipeline_mp = channelFactoryPipeline_mp;
+    }
+
+    rc = d_channelFactoryPipeline_mp->start();
 
     if (rc != 0) {
         errorDescription << "Failed starting stat channel factory for "
@@ -1404,8 +1465,8 @@ void TCPSessionFactory::stop()
     d_resolutionContext.stop();
     d_resolutionContext.join();
 
-    if (d_statChannelFactory_mp) {
-        d_statChannelFactory_mp->stop();
+    if (d_channelFactoryPipeline_mp) {
+        d_channelFactoryPipeline_mp->stop();
     }
 
     // Wait for all sessions to have been destroyed
@@ -1451,20 +1512,7 @@ void TCPSessionFactory::stop()
     d_mutex.unlock();
 
     // DESTROY
-    // We destroy the channel factories here for symmetry since it's created in
-    // 'start'.
-    if (d_statChannelFactory_mp) {
-        d_statChannelFactory_mp.clear();
-    }
-    if (d_reconnectingChannelFactory_mp) {
-        d_reconnectingChannelFactory_mp.clear();
-    }
-    if (d_resolvingChannelFactory_mp) {
-        d_resolvingChannelFactory_mp.clear();
-    }
-    if (d_tcpChannelFactory_mp) {
-        d_tcpChannelFactory_mp.clear();
-    }
+    d_channelFactoryPipeline_mp.reset();
 
     BALL_LOG_INFO << "Stopped TCPSessionFactory '" << d_config.name() << "'";
 }
@@ -1498,7 +1546,7 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
 
     bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> listeningHandle_mp;
     bmqio::Status                                      status;
-    d_statChannelFactory_mp->listen(
+    d_channelFactoryPipeline_mp->listen(
         &status,
         &listeningHandle_mp,
         listenOptions,
@@ -1556,7 +1604,7 @@ int TCPSessionFactory::connect(const bslstl::StringRef& endpoint,
         .setAutoReconnect(shouldAutoReconnect);
 
     bmqio::Status status;
-    d_statChannelFactory_mp->connect(
+    d_channelFactoryPipeline_mp->connect(
         &status,
         0,  // no handle ..
         options,
@@ -1585,34 +1633,17 @@ int TCPSessionFactory::connect(const bslstl::StringRef& endpoint,
 bool TCPSessionFactory::setNodeWriteQueueWatermarks(const Session& session)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_tcpChannelFactory_mp);
     BSLS_ASSERT_SAFE(d_config.nodeLowWatermark() > 0);
     BSLS_ASSERT_SAFE(d_config.nodeLowWatermark() <=
                      d_config.nodeHighWatermark());
 
-    int channelId;
+    bsl::shared_ptr<bmqio::NtcChannel> ntcChannel =
+        bsl::dynamic_pointer_cast<bmqio::NtcChannel>(session.channel());
 
-    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
-            !session.channel()->properties().load(
-                &channelId,
-                k_CHANNEL_PROPERTY_CHANNEL_ID))) {
-        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
-        BALL_LOG_ERROR << "TCPSessionFactory '" << d_config.name() << "' "
-                       << "failed to get channel id out of '"
-                       << session.description() << "'";
-        return false;  // RETURN
-    }
-
-    bmqio::NtcChannelFactory* factory =
-        dynamic_cast<bmqio::NtcChannelFactory*>(d_tcpChannelFactory_mp.get());
-    BSLS_ASSERT_SAFE(factory);
-
-    bsl::shared_ptr<bmqio::NtcChannel> ntcChannel;
-    int rc = factory->lookupChannel(&ntcChannel, channelId);
-    if (rc != 0) {
+    if (ntcChannel == NULL) {
         BALL_LOG_ERROR << "TCPSessionFactory '" << d_config.name() << "' "
                        << "failed to set watermarks for '"
-                       << session.description() << "' [rc: " << rc << "]";
+                       << session.description() << "'";
         return false;  // RETURN
     }
 

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -84,6 +84,7 @@
 #include <bmqex_sequentialcontext.h>
 #include <bmqio_channel.h>
 #include <bmqio_channelfactory.h>
+#include <bmqio_channelfactorypipeline.h>
 #include <bmqio_reconnectingchannelfactory.h>
 #include <bmqio_resolvingchannelfactory.h>
 #include <bmqio_statchannelfactory.h>
@@ -111,6 +112,11 @@
 #include <bsls_atomic.h>
 
 namespace BloombergLP {
+
+namespace bmqio {
+class NtcChannelFactory;
+class NtcChannel;
+}
 
 namespace mqbnet {
 
@@ -274,9 +280,6 @@ class TCPSessionFactory {
     typedef bsl::unordered_map<const bmqio::Channel*, ChannelInfoSp>
         ChannelMap;
 
-    /// Shortcut for a managedPtr to the `bmqio::TCPChannelFactory`
-    typedef bslma::ManagedPtr<bmqio::ChannelFactory> TCPChannelFactoryMp;
-
     typedef bslma::ManagedPtr<bmqio::ResolvingChannelFactory>
         ResolvingChannelFactoryMp;
 
@@ -299,15 +302,15 @@ class TCPSessionFactory {
     typedef bsl::unordered_map<int, OpHandleSp> ListeningHandleMap;
 
   private:
-    // DATA
+    // PRIVATE DATA
 
-    /// Used to make sure no callback is invoked on a destroyed object.
+    // Used to make sure no callback is invoked on a destroyed object.
     bmqu::SharedResource<TCPSessionFactory> d_self;
 
-    /// Has this component been started?
+    // Has this component been started ?
     bool d_isStarted;
 
-    /// Config to use for setting up this SessionFactory
+    // Config to use for setting up this SessionFactory
     mqbcfg::TcpInterfaceConfig d_config;
 
     /// Event scheduler held not owned
@@ -330,13 +333,11 @@ class TCPSessionFactory {
     /// Channels' stat context (passed to TCPSessionFactory)
     mqbstat::StatController* d_statController_p;
 
-    /// ChannelFactory
-    TCPChannelFactoryMp d_tcpChannelFactory_mp;
-
     /// Executor context used for performing DNS resolution
     bmqex::SequentialContext d_resolutionContext;
 
-    ResolvingChannelFactoryMp d_resolvingChannelFactory_mp;
+    bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
+        d_channelFactoryPipeline_mp;
 
     ReconnectingChannelFactoryMp d_reconnectingChannelFactory_mp;
 


### PR DESCRIPTION
We currently manage several ChannelFactory implementations in mqbnet_tcpsessionfactory and bmqimp_application that are designed to decorate each other. The bottom of this decorator stack is the real ChannelFactory implementation, bmqio::NtcChannelFactory, and we add behaviors on top of that factory's listen() and connect() functions through classes like bmqio::ReconnectingChannelFactory, bmqio::ResolvingChannelFactory, bmqio::StatChannelFactory, bmpimp::NegotiatedChannelFactory, and bmqimp::AuthenticatedChannelFactory.

Though different components need different combinations of these decorators, their lifetimes are all managed in the same way: the channel factories are created in order from the bottom to the top of the decorator stack, then destructed in the opposite order. This is currently being managed by the class that uses these factories manually. With the introduction of a TlsChannelFactory incoming, yet another set of ChannelFactory stacks will be needed, and so we need something a little more generic.

Enter ChannelFactoryPipeline, an object whose role is to provide such a generic API for constructing and combining these deocrators in a custom order. The API is mostly driven by the addWith function, which requires a builder function to construct consecutive items in the decorator stack. Ideally in a mdoern C++ world this would just be a nice lambda, but until we get there we have a series of nasty bldf::BindUtil::bind calls. You can also directly add constructed ChannelFactory objects with the add method, but in practice this ends up not being needed all that often. Since ChannelFactoryPipeline is really just a container for several factories, it also implements the ChannelFactory interface.