### PR TITLE
Fix[bmqp::PushMessageIterator]: validate padding byte

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.t.cpp
@@ -221,11 +221,9 @@ appendMessage(size_t                    iteration,
 #endif
 
     bdlbb::Blob payload(bufferFactory, allocator);
-#ifdef BMQ_ENABLE_MSG_GROUPID
-    const int                        blobSize = generateRandomInteger(0, 1024);
-    const bmqp::Protocol::MsgGroupId str(blobSize, 'x', allocator);
+    const int         blobSize = generateRandomInteger(1, 1024);
+    const bsl::string str(blobSize, 'x', allocator);
     bdlbb::BlobUtil::append(&payload, str.c_str(), blobSize);
-#endif
 
     data.d_payload = payload;
 

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
@@ -36,6 +36,25 @@
 namespace BloombergLP {
 namespace bmqp {
 
+namespace {
+
+inline bool isValidWordPaddingByte(char value)
+{
+    switch (value) {
+    case 1: BSLA_FALLTHROUGH;
+    case 2: BSLA_FALLTHROUGH;
+    case 3: BSLA_FALLTHROUGH;
+    case 4: {
+        return true;  // RETURN
+    }
+    default: {
+        return false;  // RETURN
+    }
+    }
+}
+
+}  // close unnamed namespace
+
 // -------------------------
 // class PushMessageIterator
 // -------------------------
@@ -114,6 +133,13 @@ int PushMessageIterator::compressedApplicationDataSize() const
     char lastByte = d_blobIter.blob()
                         ->buffer(lastBytePos.buffer())
                         .data()[lastBytePos.byte()];
+
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+            !isValidWordPaddingByte(lastByte))) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        // If the 'lastByte' is not a padding byte then message is malformed
+        return -1;  // RETURN
+    }
 
     const int appDataLenPadded = (d_header.messageWords() -
                                   d_header.optionsWords() -

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
@@ -524,7 +524,8 @@ int PushMessageIterator::next()
         rc_INVALID_APPLICATION_DATA_OFFSET = -4,
         rc_PARSING_ERROR                   = -5,
         rc_INVALID_OPTIONS_OFFSET          = -6,
-        rc_INVALID_MESSAGE_SIZE            = -7
+        rc_INVALID_MESSAGE_SIZE            = -7,
+        rc_INVALID_APPLICATION_DATA_SIZE   = -8
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -639,7 +640,16 @@ int PushMessageIterator::next()
         d_header.flags(),
         PushHeaderFlags::e_MESSAGE_PROPERTIES);
     const bool haveNewMPs = MessagePropertiesInfo::hasSchema(d_header);
-    int        length     = compressedApplicationDataSize();
+    const int  length     = compressedApplicationDataSize();
+
+    // Validation: 'length' is an unpadded application data size, with
+    // substracted size of the padding bytes section.
+    //: o Negative 'length' is a sign that packet is malformed.
+    //: o Zero 'length' is not supported.
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(length <= 0)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        return rc_INVALID_APPLICATION_DATA_SIZE;  // RETURN
+    }
 
     rc = ProtocolUtil::parse(0,  // do not separate MPs from data
                              &d_messagePropertiesSize,


### PR DESCRIPTION
Similar to `PutMessageIterator`:

https://github.com/bloomberg/blazingmq/blob/04c376636ed844e6ba586ba93e6df3c6c0510f03/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp#L128-L133