### PR TITLE
Refactor[bmqbrkr.m.cpp]: replace Bind with functor

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -356,6 +356,23 @@ struct MTrapHandler {
         cmd.erase(0, 1);  // cmd starts by a space, remove it
 
         if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
+            // The functor-based callback execution (from MTrapHandler)
+            // is more efficient than the previous bind-based approach, but it
+            // creates a race condition during shutdown. When EXIT is received,
+            // any pending admin commands like domain reconfigurations may
+            // still be queued in the thread pool but not yet dequeued. If we
+            // immediately post the shutdown semaphore, the main thread will
+            // unblock and call Application::stop(), which stops thread pools
+            // before pending jobs are processed, causing commands like
+            // domainReconfigure to never execute. The following sleep ensures
+            // the thread pool has time to pick up queued jobs before we
+            // initiate shutdown. See GitHub issue #678098.
+            static const int k_SHUTDOWN_DELAY_MS = 100;  // milliseconds
+            bsl::cout << "Waiting " << k_SHUTDOWN_DELAY_MS
+                      << "ms for pending commands to be dequeued...\n"
+                      << bsl::flush;
+            usleep(k_SHUTDOWN_DELAY_MS * 1000);  // Convert ms to microseconds
+
             d_taskEnv_p->d_shutdownSemaphore.post();
             // Return now because as a consequence of the Task::shutdown()
             // call, the BALL log system has been torn down.

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -119,61 +119,6 @@ struct TaskEnvironment {
 /// Raw pointer to the TaskEnvironment, used so that the signal handler, and
 /// the assert handler can access the needed data.
 static TaskEnvironment* s_taskEnv_p = 0;
-
-// forward declaration
-static void onProcessedAdminCommand(const bsl::string&       prefix,
-                                    const bsl::string&       command,
-                                    const bsls::Types::Int64 start,
-                                    int                      rc,
-                                    const bsl::string&       results);
-
-/// Handler functor for incoming commands
-struct MTrapHandler {
-    TaskEnvironment* d_taskEnv_p;
-
-    explicit MTrapHandler(TaskEnvironment* taskEnv)
-    : d_taskEnv_p(taskEnv)
-    {
-        // PRECONDITIONS
-        BSLS_ASSERT(d_taskEnv_p);
-    }
-
-    void operator()(const bsl::string& prefix, bsl::istream& stream) const
-    {
-        BSLS_ASSERT_SAFE(d_taskEnv_p);
-
-        bsl::string cmd;
-
-        bsl::getline(stream, cmd);
-        cmd.erase(0, 1);  // cmd starts by a space, remove it
-
-        if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
-            d_taskEnv_p->d_shutdownSemaphore.post();
-            // Return now because as a consequence of the Task::shutdown()
-            // call, the BALL log system has been torn down.
-            return;  // RETURN
-        }
-        else if (bdlb::String::areEqualCaseless(prefix, "CMD")) {
-            const bsls::Types::Int64 start =
-                bmqsys::Time::highResolutionTimer();
-            d_taskEnv_p->d_app.object().enqueueCommand(
-                "MTRAP",
-                cmd,
-                bdlf::BindUtil::bind(
-                    onProcessedAdminCommand,
-                    prefix,
-                    cmd,
-                    start,
-                    bdlf::PlaceHolders::_1,    // rc
-                    bdlf::PlaceHolders::_2));  // commandExecResults
-            return;                            // RETURN
-        }
-
-        BALL_LOG_ERROR << "Unknown command '" << prefix << "'\n"
-                       << "Send 'HELP' to see a list of commands supported by "
-                       << "bmqbrkr.";
-    }
-};
 }  // close unnamed namespace
 
 extern "C" {
@@ -389,6 +334,54 @@ static void onProcessedAdminCommand(const bsl::string&       prefix,
                       << results;
     }
 }
+
+/// Handler functor for incoming commands
+struct MTrapHandler {
+    TaskEnvironment* d_taskEnv_p;
+
+    explicit MTrapHandler(TaskEnvironment* taskEnv)
+    : d_taskEnv_p(taskEnv)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT(d_taskEnv_p);
+    }
+
+    void operator()(const bsl::string& prefix, bsl::istream& stream) const
+    {
+        BSLS_ASSERT_SAFE(d_taskEnv_p);
+
+        bsl::string cmd;
+
+        bsl::getline(stream, cmd);
+        cmd.erase(0, 1);  // cmd starts by a space, remove it
+
+        if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
+            d_taskEnv_p->d_shutdownSemaphore.post();
+            // Return now because as a consequence of the Task::shutdown()
+            // call, the BALL log system has been torn down.
+            return;  // RETURN
+        }
+        else if (bdlb::String::areEqualCaseless(prefix, "CMD")) {
+            const bsls::Types::Int64 start =
+                bmqsys::Time::highResolutionTimer();
+            d_taskEnv_p->d_app.object().enqueueCommand(
+                "MTRAP",
+                cmd,
+                bdlf::BindUtil::bind(
+                    onProcessedAdminCommand,
+                    prefix,
+                    cmd,
+                    start,
+                    bdlf::PlaceHolders::_1,    // rc
+                    bdlf::PlaceHolders::_2));  // commandExecResults
+            return;                            // RETURN
+        }
+
+        BALL_LOG_ERROR << "Unknown command '" << prefix << "'\n"
+                       << "Send 'HELP' to see a list of commands supported by "
+                       << "bmqbrkr.";
+    }
+};
 
 /// Create and initialize the Task object from the specified `taskEnv`.
 /// Return 0 on success, or a non-zero error code and populate the specified

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -120,6 +120,53 @@ struct TaskEnvironment {
 /// the assert handler can access the needed data.
 static TaskEnvironment* s_taskEnv_p = 0;
 
+/// Handler functor for incoming commands
+struct MTrapHandler {
+    TaskEnvironment* d_taskEnv_p;
+
+    explicit MTrapHandler(TaskEnvironment* taskEnv)
+    : d_taskEnv_p(taskEnv)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT(d_taskEnv_p);
+    }
+
+    void operator()(const bsl::string& prefix, bsl::istream& stream) const
+    {
+        BSLS_ASSERT_SAFE(d_taskEnv_p);
+
+        bsl::string cmd;
+
+        bsl::getline(stream, cmd);
+        cmd.erase(0, 1);  // cmd starts by a space, remove it
+
+        if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
+            d_taskEnv_p->d_shutdownSemaphore.post();
+            // Return now because as a consequence of the Task::shutdown()
+            // call, the BALL log system has been torn down.
+            return;  // RETURN
+        }
+        else if (bdlb::String::areEqualCaseless(prefix, "CMD")) {
+            const bsls::Types::Int64 start =
+                bmqsys::Time::highResolutionTimer();
+            d_taskEnv_p->d_app.object().enqueueCommand(
+                "MTRAP",
+                cmd,
+                bdlf::BindUtil::bind(
+                    onProcessedAdminCommand,
+                    prefix,
+                    cmd,
+                    start,
+                    bdlf::PlaceHolders::_1,    // rc
+                    bdlf::PlaceHolders::_2));  // commandExecResults
+            return;                            // RETURN
+        }
+
+        BALL_LOG_ERROR << "Unknown command '" << prefix << "'\n"
+                       << "Send 'HELP' to see a list of commands supported by "
+                       << "bmqbrkr.";
+    }
+};
 }  // close unnamed namespace
 
 extern "C" {
@@ -336,46 +383,6 @@ static void onProcessedAdminCommand(const bsl::string&       prefix,
     }
 }
 
-/// Callback when an M-Trap command is received for the specified `taskEnv`,
-/// with the specified `input` command having the specified `prefix` (being
-/// the command type).
-static void onMTrap(TaskEnvironment*   taskEnv,
-                    const bsl::string& prefix,
-                    bsl::istream&      input)
-{
-    BSLS_ASSERT_SAFE(taskEnv);
-
-    bsl::string cmd;
-
-    bsl::getline(input, cmd);
-    cmd.erase(0, 1);  // cmd starts by a space, remove it
-
-    if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
-        taskEnv->d_shutdownSemaphore.post();
-        // Return now because as a consequence of the Task::shutdown() call,
-        // the BALL log system has been torn down.
-        return;  // RETURN
-    }
-    else if (bdlb::String::areEqualCaseless(prefix, "CMD")) {
-        const bsls::Types::Int64 start = bmqsys::Time::highResolutionTimer();
-        taskEnv->d_app.object().enqueueCommand(
-            "MTRAP",
-            cmd,
-            bdlf::BindUtil::bind(
-                onProcessedAdminCommand,
-                prefix,
-                cmd,
-                start,
-                bdlf::PlaceHolders::_1,    // rc
-                bdlf::PlaceHolders::_2));  // commandExecResults
-        return;                            // RETURN
-    }
-
-    BALL_LOG_ERROR << "Unknown command '" << prefix << "'\n"
-                   << "Send 'HELP' to see a list of commands supported by "
-                   << "bmqbrkr.";
-}
-
 /// Create and initialize the Task object from the specified `taskEnv`.
 /// Return 0 on success, or a non-zero error code and populate the specified
 /// `errorDescription` with a description of the error otherwise.
@@ -398,9 +405,8 @@ static int initializeTask(bsl::ostream&    errorDescription,
         localError,
         taskEnv->d_config.taskConfig());
     if (rc != 0) {
-        errorDescription << "Failed to initialize task "
-                         << "[rc: " << rc << ", reason: '" << localError.str()
-                         << "']";
+        errorDescription << "Failed to initialize task " << "[rc: " << rc
+                         << ", reason: '" << localError.str() << "']";
 
         // Destroy the task
         taskEnv->d_task.object().m_bmqbrkr::Task::~Task();
@@ -412,10 +418,7 @@ static int initializeTask(bsl::ostream&    errorDescription,
         "EXIT",
         "",
         "Gracefully terminate bmqbrkr",
-        bdlf::BindUtil::bind(onMTrap,
-                             taskEnv,
-                             bdlf::PlaceHolders::_1,    // prefix
-                             bdlf::PlaceHolders::_2));  // istream
+        MTrapHandler(taskEnv));
 
     // Save the PID of the process in the '${BMQ_PREFIX}/bmqbrkr.pid' file
     const bsl::string pidFile = taskEnv->d_bmqPrefix + "/bmqbrkr.pid";
@@ -473,21 +476,6 @@ initializeApplication(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
         mqba::Application(task.scheduler(),
                           task.allocatorStatContext(),
                           task.allocatorStore().get("Application"));
-
-    // Local functor replacing Bind
-    struct MTrapHandler {
-        TaskEnvironment* d_taskEnv_p;
-
-        explicit MTrapHandler(TaskEnvironment* taskEnv)
-        : d_taskEnv_p(taskEnv)
-        {
-        }
-
-        void operator()(const bsl::string& prefix, bsl::istream& stream) const
-        {
-            onMTrap(d_taskEnv_p, prefix, stream);
-        }
-    };
 
     // Register 'CMD' M-Trap
     taskEnv->d_task.object().registerMTrapHandler("CMD",

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -356,23 +356,6 @@ struct MTrapHandler {
         cmd.erase(0, 1);  // cmd starts by a space, remove it
 
         if (bdlb::String::areEqualCaseless(prefix, "EXIT")) {
-            // The functor-based callback execution (from MTrapHandler)
-            // is more efficient than the previous bind-based approach, but it
-            // creates a race condition during shutdown. When EXIT is received,
-            // any pending admin commands like domain reconfigurations may
-            // still be queued in the thread pool but not yet dequeued. If we
-            // immediately post the shutdown semaphore, the main thread will
-            // unblock and call Application::stop(), which stops thread pools
-            // before pending jobs are processed, causing commands like
-            // domainReconfigure to never execute. The following sleep ensures
-            // the thread pool has time to pick up queued jobs before we
-            // initiate shutdown. See GitHub issue #678098.
-            static const int k_SHUTDOWN_DELAY_MS = 100;  // milliseconds
-            bsl::cout << "Waiting " << k_SHUTDOWN_DELAY_MS
-                      << "ms for pending commands to be dequeued...\n"
-                      << bsl::flush;
-            usleep(k_SHUTDOWN_DELAY_MS * 1000);  // Convert ms to microseconds
-
             d_taskEnv_p->d_shutdownSemaphore.post();
             // Return now because as a consequence of the Task::shutdown()
             // call, the BALL log system has been torn down.

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -120,6 +120,13 @@ struct TaskEnvironment {
 /// the assert handler can access the needed data.
 static TaskEnvironment* s_taskEnv_p = 0;
 
+// forward declaration
+static void onProcessedAdminCommand(const bsl::string&       prefix,
+                                    const bsl::string&       command,
+                                    const bsls::Types::Int64 start,
+                                    int                      rc,
+                                    const bsl::string&       results);
+
 /// Handler functor for incoming commands
 struct MTrapHandler {
     TaskEnvironment* d_taskEnv_p;

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -348,8 +348,6 @@ struct MTrapHandler {
 
     void operator()(const bsl::string& prefix, bsl::istream& stream) const
     {
-        BSLS_ASSERT_SAFE(d_taskEnv_p);
-
         bsl::string cmd;
 
         bsl::getline(stream, cmd);

--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -474,15 +474,26 @@ initializeApplication(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
                           task.allocatorStatContext(),
                           task.allocatorStore().get("Application"));
 
+    // Local functor replacing Bind
+    struct MTrapHandler {
+        TaskEnvironment* d_taskEnv_p;
+
+        explicit MTrapHandler(TaskEnvironment* taskEnv)
+        : d_taskEnv_p(taskEnv)
+        {
+        }
+
+        void operator()(const bsl::string& prefix, bsl::istream& stream) const
+        {
+            onMTrap(d_taskEnv_p, prefix, stream);
+        }
+    };
+
     // Register 'CMD' M-Trap
-    taskEnv->d_task.object().registerMTrapHandler(
-        "CMD",
-        "",
-        "bmqbrkr specific commands",
-        bdlf::BindUtil::bind(onMTrap,
-                             taskEnv,
-                             bdlf::PlaceHolders::_1,    // prefix
-                             bdlf::PlaceHolders::_2));  // istream
+    taskEnv->d_task.object().registerMTrapHandler("CMD",
+                                                  "",
+                                                  "bmqbrkr specific commands",
+                                                  MTrapHandler(taskEnv));
     return 0;
 }
 

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -201,13 +201,9 @@ def stop_cluster_and_compare_journal_files(
     for node in cluster.nodes():
         if node.is_alive():
             node.set_quorum(5)
-
-    leader = cluster.last_known_leader
-    if leader:
-        leader.stop()
-        _wait_for_passive_advisories(leader, cluster)
-        cluster.make_sure_node_stopped(leader)
-    cluster.stop_nodes()
+    if cluster.last_known_leader:
+        cluster.last_known_leader.stop()
+        cluster.make_sure_node_stopped(cluster.last_known_leader)
 
     leader_journal_files = glob.glob(
         str(cluster.work_dir.joinpath(leader_name, "storage")) + "/*journal*"
@@ -238,22 +234,12 @@ def stop_cluster_and_compare_journal_files(
             f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
         )
 
-        leader_out = clean_storage_output(leader_res.stdout)
-        replica_out = clean_storage_output(replica_res.stdout)
-        if leader_out != replica_out:
-            diff = "\n".join(
-                difflib.unified_diff(
-                    leader_out.splitlines(),
-                    replica_out.splitlines(),
-                    fromfile=str(leader_file),
-                    tofile=str(replica_file),
-                    lineterm="",
-                )
-            )
-            assert False, (
-                f"Leader and replica journal file contents differ for "
-                f"{leader_file} and {replica_file}\n{diff}"
-            )
+        assert clean_storage_output(leader_res.stdout) == clean_storage_output(
+            replica_res.stdout
+        ), (
+            f"Leader and replica journal file contents differ for "
+            f"{leader_file} and {replica_file}"
+        )
 
         leader_res = run_storage_tool(leader_file, "summary")
         assert leader_res.returncode == 0, (
@@ -265,22 +251,12 @@ def stop_cluster_and_compare_journal_files(
             f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
         )
 
-        leader_out = clean_storage_output(leader_res.stdout)
-        replica_out = clean_storage_output(replica_res.stdout)
-        if leader_out != replica_out:
-            diff = "\n".join(
-                difflib.unified_diff(
-                    leader_out.splitlines(),
-                    replica_out.splitlines(),
-                    fromfile=str(leader_file),
-                    tofile=str(replica_file),
-                    lineterm="",
-                )
-            )
-            assert False, (
-                f"Leader and replica journal file summary differ for "
-                f"{leader_file} and {replica_file}\n{diff}"
-            )
+        assert clean_storage_output(leader_res.stdout) == clean_storage_output(
+            replica_res.stdout
+        ), (
+            f"Leader and replica journal file summary differ for "
+            f"{leader_file} and {replica_file}"
+        )
 
 
 def wipe_files(file_patterns: list, storage_dir: str) -> None:

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -65,9 +65,7 @@ def ensure_message_at_storage_layer(
         assert wait_until(
             check,
             timeout=3,
-        ), (
-            f"Node {node.name} does not have {expected_count} messages for queue {queue_uri} in partition {partition_id} at storage layer"
-        )
+        ), f"Node {node.name} does not have {expected_count} messages for queue {queue_uri} in partition {partition_id} at storage layer"
 
         # Above regex is to match line:
         # C1E2A44527    0      1      68  B      bmq://bmq.test.mmap.priority.~tst/qqq
@@ -95,9 +93,9 @@ def simulate_csl_rollover(du: tc.DomainUrls, leader: Broker, producer: Client):
             # do not wait for success, otherwise the following capture will fail
             leader.force_gc_queues(block=False)
 
-        assert i < 10000, (
-            "Failed to detect rollover after opening a reasonable number of queues"
-        )
+        assert (
+            i < 10000
+        ), "Failed to detect rollover after opening a reasonable number of queues"
     test_logger.info(f"Rollover detected after opening {i} queues")
 
     # Rollover and queueUnAssignmentAdvisory interleave
@@ -185,38 +183,6 @@ def clean_storage_output(output_str: str) -> str:
     return json.dumps(data, indent=2)
 
 
-def _wait_for_passive_advisories(leader: Broker, cluster: Cluster, timeout: int = 10):
-    """
-    Wait until every non-leader node has received a PASSIVE primary status
-    advisory from the leader for every partition.
-
-    During leader shutdown, each partition's queue dispatcher issues a forced
-    sync point and then broadcasts a PASSIVE advisory (flushing the sync point
-    first per PR #1202).  However, ``closeChannels()`` can tear down the TCP
-    connection before the channel thread drains all buffered data.  Waiting for
-    the PASSIVE advisory on each replica confirms that the preceding forced
-    sync point was also delivered (same TCP stream, guaranteed ordering).
-    """
-    num_partitions = cluster.config.definition.partition_config.num_partitions
-    patterns = [
-        (
-            f"received primary status advisory: "
-            f"\\[ partitionId = {pid} primaryLeaseId = \\d+ "
-            f"status = E_PASSIVE \\], from: \\[{re.escape(leader.name)}"
-        )
-        for pid in range(num_partitions)
-    ]
-    for node in cluster.nodes(exclude=leader):
-        if not node.is_alive():
-            continue
-        results = node.capture_n(patterns, timeout=timeout)
-        missing = [pid for pid, match in enumerate(results) if match is None]
-        assert not missing, (
-            f"Node {node.name} did not receive PASSIVE advisory from leader "
-            f"{leader.name} for partition(s) {missing} within {timeout}s"
-        )
-
-
 def stop_cluster_and_compare_journal_files(
     leader_name: str, replica_name: str, cluster: Cluster
 ) -> None:
@@ -249,26 +215,26 @@ def stop_cluster_and_compare_journal_files(
     )
 
     num_partitions = cluster.config.definition.partition_config.num_partitions
-    assert len(leader_journal_files) == num_partitions, (
-        f"Expected {num_partitions} leader journal files, got {len(leader_journal_files)}"
-    )
-    assert len(replica_journal_files) == num_partitions, (
-        f"Expected {num_partitions} replica journal files, got {len(replica_journal_files)}"
-    )
+    assert (
+        len(leader_journal_files) == num_partitions
+    ), f"Expected {num_partitions} leader journal files, got {len(leader_journal_files)}"
+    assert (
+        len(replica_journal_files) == num_partitions
+    ), f"Expected {num_partitions} replica journal files, got {len(replica_journal_files)}"
 
     for leader_file, replica_file in zip(
         sorted(leader_journal_files),
         sorted(replica_journal_files),
     ):
         leader_res = run_storage_tool(leader_file, "details")
-        assert leader_res.returncode == 0, (
-            f"Leader storage tool failed on {leader_file} with rc {leader_res.returncode}"
-        )
+        assert (
+            leader_res.returncode == 0
+        ), f"Leader storage tool failed on {leader_file} with rc {leader_res.returncode}"
 
         replica_res = run_storage_tool(replica_file, "details")
-        assert replica_res.returncode == 0, (
-            f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
-        )
+        assert (
+            replica_res.returncode == 0
+        ), f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
 
         leader_out = clean_storage_output(leader_res.stdout)
         replica_out = clean_storage_output(replica_res.stdout)
@@ -288,14 +254,14 @@ def stop_cluster_and_compare_journal_files(
             )
 
         leader_res = run_storage_tool(leader_file, "summary")
-        assert leader_res.returncode == 0, (
-            f"Leader storage tool (summary) failed on {leader_file} with rc {leader_res.returncode}"
-        )
+        assert (
+            leader_res.returncode == 0
+        ), f"Leader storage tool (summary) failed on {leader_file} with rc {leader_res.returncode}"
 
         replica_res = run_storage_tool(replica_file, "summary")
-        assert replica_res.returncode == 0, (
-            f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
-        )
+        assert (
+            replica_res.returncode == 0
+        ), f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
 
         leader_out = clean_storage_output(leader_res.stdout)
         replica_out = clean_storage_output(replica_res.stdout)

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -65,7 +65,9 @@ def ensure_message_at_storage_layer(
         assert wait_until(
             check,
             timeout=3,
-        ), f"Node {node.name} does not have {expected_count} messages for queue {queue_uri} in partition {partition_id} at storage layer"
+        ), (
+            f"Node {node.name} does not have {expected_count} messages for queue {queue_uri} in partition {partition_id} at storage layer"
+        )
 
         # Above regex is to match line:
         # C1E2A44527    0      1      68  B      bmq://bmq.test.mmap.priority.~tst/qqq
@@ -93,9 +95,9 @@ def simulate_csl_rollover(du: tc.DomainUrls, leader: Broker, producer: Client):
             # do not wait for success, otherwise the following capture will fail
             leader.force_gc_queues(block=False)
 
-        assert (
-            i < 10000
-        ), "Failed to detect rollover after opening a reasonable number of queues"
+        assert i < 10000, (
+            "Failed to detect rollover after opening a reasonable number of queues"
+        )
     test_logger.info(f"Rollover detected after opening {i} queues")
 
     # Rollover and queueUnAssignmentAdvisory interleave
@@ -215,26 +217,26 @@ def stop_cluster_and_compare_journal_files(
     )
 
     num_partitions = cluster.config.definition.partition_config.num_partitions
-    assert (
-        len(leader_journal_files) == num_partitions
-    ), f"Expected {num_partitions} leader journal files, got {len(leader_journal_files)}"
-    assert (
-        len(replica_journal_files) == num_partitions
-    ), f"Expected {num_partitions} replica journal files, got {len(replica_journal_files)}"
+    assert len(leader_journal_files) == num_partitions, (
+        f"Expected {num_partitions} leader journal files, got {len(leader_journal_files)}"
+    )
+    assert len(replica_journal_files) == num_partitions, (
+        f"Expected {num_partitions} replica journal files, got {len(replica_journal_files)}"
+    )
 
     for leader_file, replica_file in zip(
         sorted(leader_journal_files),
         sorted(replica_journal_files),
     ):
         leader_res = run_storage_tool(leader_file, "details")
-        assert (
-            leader_res.returncode == 0
-        ), f"Leader storage tool failed on {leader_file} with rc {leader_res.returncode}"
+        assert leader_res.returncode == 0, (
+            f"Leader storage tool failed on {leader_file} with rc {leader_res.returncode}"
+        )
 
         replica_res = run_storage_tool(replica_file, "details")
-        assert (
-            replica_res.returncode == 0
-        ), f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
+        assert replica_res.returncode == 0, (
+            f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
+        )
 
         leader_out = clean_storage_output(leader_res.stdout)
         replica_out = clean_storage_output(replica_res.stdout)
@@ -254,14 +256,14 @@ def stop_cluster_and_compare_journal_files(
             )
 
         leader_res = run_storage_tool(leader_file, "summary")
-        assert (
-            leader_res.returncode == 0
-        ), f"Leader storage tool (summary) failed on {leader_file} with rc {leader_res.returncode}"
+        assert leader_res.returncode == 0, (
+            f"Leader storage tool (summary) failed on {leader_file} with rc {leader_res.returncode}"
+        )
 
         replica_res = run_storage_tool(replica_file, "summary")
-        assert (
-            replica_res.returncode == 0
-        ), f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
+        assert replica_res.returncode == 0, (
+            f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
+        )
 
         leader_out = clean_storage_output(leader_res.stdout)
         replica_out = clean_storage_output(replica_res.stdout)

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import difflib
 import glob
 import json
 import os
@@ -204,6 +203,7 @@ def stop_cluster_and_compare_journal_files(
     if cluster.last_known_leader:
         cluster.last_known_leader.stop()
         cluster.make_sure_node_stopped(cluster.last_known_leader)
+    cluster.stop_nodes()
 
     leader_journal_files = glob.glob(
         str(cluster.work_dir.joinpath(leader_name, "storage")) + "/*journal*"

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import difflib
 import glob
 import json
 import os
@@ -184,6 +185,38 @@ def clean_storage_output(output_str: str) -> str:
     return json.dumps(data, indent=2)
 
 
+def _wait_for_passive_advisories(leader: Broker, cluster: Cluster, timeout: int = 10):
+    """
+    Wait until every non-leader node has received a PASSIVE primary status
+    advisory from the leader for every partition.
+
+    During leader shutdown, each partition's queue dispatcher issues a forced
+    sync point and then broadcasts a PASSIVE advisory (flushing the sync point
+    first per PR #1202).  However, ``closeChannels()`` can tear down the TCP
+    connection before the channel thread drains all buffered data.  Waiting for
+    the PASSIVE advisory on each replica confirms that the preceding forced
+    sync point was also delivered (same TCP stream, guaranteed ordering).
+    """
+    num_partitions = cluster.config.definition.partition_config.num_partitions
+    patterns = [
+        (
+            f"received primary status advisory: "
+            f"\\[ partitionId = {pid} primaryLeaseId = \\d+ "
+            f"status = E_PASSIVE \\], from: \\[{re.escape(leader.name)}"
+        )
+        for pid in range(num_partitions)
+    ]
+    for node in cluster.nodes(exclude=leader):
+        if not node.is_alive():
+            continue
+        results = node.capture_n(patterns, timeout=timeout)
+        missing = [pid for pid, match in enumerate(results) if match is None]
+        assert not missing, (
+            f"Node {node.name} did not receive PASSIVE advisory from leader "
+            f"{leader.name} for partition(s) {missing} within {timeout}s"
+        )
+
+
 def stop_cluster_and_compare_journal_files(
     leader_name: str, replica_name: str, cluster: Cluster
 ) -> None:
@@ -200,9 +233,12 @@ def stop_cluster_and_compare_journal_files(
     for node in cluster.nodes():
         if node.is_alive():
             node.set_quorum(5)
-    if cluster.last_known_leader:
-        cluster.last_known_leader.stop()
-        cluster.make_sure_node_stopped(cluster.last_known_leader)
+
+    leader = cluster.last_known_leader
+    if leader:
+        leader.stop()
+        _wait_for_passive_advisories(leader, cluster)
+        cluster.make_sure_node_stopped(leader)
     cluster.stop_nodes()
 
     leader_journal_files = glob.glob(
@@ -234,12 +270,22 @@ def stop_cluster_and_compare_journal_files(
             f"Replica storage tool failed on {replica_file} with rc {replica_res.returncode}"
         )
 
-        assert clean_storage_output(leader_res.stdout) == clean_storage_output(
-            replica_res.stdout
-        ), (
-            f"Leader and replica journal file contents differ for "
-            f"{leader_file} and {replica_file}"
-        )
+        leader_out = clean_storage_output(leader_res.stdout)
+        replica_out = clean_storage_output(replica_res.stdout)
+        if leader_out != replica_out:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    leader_out.splitlines(),
+                    replica_out.splitlines(),
+                    fromfile=str(leader_file),
+                    tofile=str(replica_file),
+                    lineterm="",
+                )
+            )
+            assert False, (
+                f"Leader and replica journal file contents differ for "
+                f"{leader_file} and {replica_file}\n{diff}"
+            )
 
         leader_res = run_storage_tool(leader_file, "summary")
         assert leader_res.returncode == 0, (
@@ -251,12 +297,22 @@ def stop_cluster_and_compare_journal_files(
             f"Replica storage tool (summary) failed on {replica_file} with rc {replica_res.returncode}"
         )
 
-        assert clean_storage_output(leader_res.stdout) == clean_storage_output(
-            replica_res.stdout
-        ), (
-            f"Leader and replica journal file summary differ for "
-            f"{leader_file} and {replica_file}"
-        )
+        leader_out = clean_storage_output(leader_res.stdout)
+        replica_out = clean_storage_output(replica_res.stdout)
+        if leader_out != replica_out:
+            diff = "\n".join(
+                difflib.unified_diff(
+                    leader_out.splitlines(),
+                    replica_out.splitlines(),
+                    fromfile=str(leader_file),
+                    tofile=str(replica_file),
+                    lineterm="",
+                )
+            )
+            assert False, (
+                f"Leader and replica journal file summary differ for "
+                f"{leader_file} and {replica_file}\n{diff}"
+            )
 
 
 def wipe_files(file_patterns: list, storage_dir: str) -> None:


### PR DESCRIPTION
Replace bdlf::BindUtil::bind usage in registerMTrapHandler with a local functor to eliminate unnecessary indirection and improve stack trace readability. This avoids intermediate Bind frames and reduces callback overhead without changing behavior.

*Issue number of the reported bug or feature request: #1288*

**Describe your changes**
Replace bdlf::BindUtil::bind usage in registerMTrapHandler with a
local functor to reduce callback overhead and improve stack trace
readability.

**Testing performed**
No functional changes were introduced. This refactor replaces
bdlf::BindUtil::bind with a functor while preserving the same
callback signature and behavior.
The project was successfully built and the broker started
without errors after the change. Existing functionality is
expected to remain unchanged.

**Additional context**
This change simplifies the callback implementation by removing
Bind usage and aligning with existing functor patterns in the
codebase.
