### PR TITLE
UT[bmqc]: get rid of libbenchmark, add benchmarks

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_orderedhashmap.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmap.t.cpp
@@ -28,12 +28,8 @@
 #include <bsls_timeutil.h>
 
 // TEST DRIVER
+#include <bmqtst_table.h>
 #include <bmqtst_testhelper.h>
-
-// BENCHMARKING LIBRARY
-#ifdef BMQTST_BENCHMARK_ENABLED
-#include <benchmark/benchmark.h>
-#endif
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -953,19 +949,23 @@ static void test15_eraseRange()
     BMQTST_ASSERT_EQ(true, map.empty());
 }
 
-BSLA_MAYBE_UNUSED static void testN1_insertPerformanceOrdered()
+static void testN1_insertPerformance()
 // ------------------------------------------------------------------------
 // INSERT PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of insert() between OrderedHashMap and
+//   bsl::unordered_map.
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("INSERT PERFORMANCE");
 
-    // Performance comparison of insert() with bsl::unordered_map
-    const size_t       k_NUM_ELEMENTS = 5000000;
-    bsls::Types::Int64 ohmTime;
+    const size_t k_NUM_ELEMENTS = 5000000;
 
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
+
+    // OrderedHashMap
     {
-        // OrderedHashMap
         typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
 
         MyMapType map(k_NUM_ELEMENTS, bmqtst::TestHelperUtil::allocator());
@@ -975,23 +975,19 @@ BSLA_MAYBE_UNUSED static void testN1_insertPerformanceOrdered()
             map.insert(bsl::make_pair(i, i));
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
-        ohmTime                = end - begin;
-        cout << "Time diff (OrderedHashMap): " << ohmTime << endl;
+
+        table.column("Map").insertValue("bmqc::OrderedHashMap");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
     }
-}
 
-BSLA_MAYBE_UNUSED static void testN1_insertPerformanceUnordered()
-// ------------------------------------------------------------------------
-// INSERT PERFORMANCE
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("INSERT PERFORMANCE");
-
-    // Performance comparison of insert() with bsl::unordered_map
-    const size_t       k_NUM_ELEMENTS = 5000000;
-    bsls::Types::Int64 umTime;
+    // bsl::unordered_map
     {
-        // bsl::unordered_map
         typedef bsl::unordered_map<size_t, size_t> MyMapType;
 
         MyMapType map(bmqtst::TestHelperUtil::allocator());
@@ -1002,223 +998,166 @@ BSLA_MAYBE_UNUSED static void testN1_insertPerformanceUnordered()
             map.insert(bsl::make_pair(i, i));
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
-        umTime                 = end - begin;
-        cout << "Time diff (unordered_map) : " << umTime << endl;
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
     }
+
+    table.print(bsl::cout);
 }
 
-BSLA_MAYBE_UNUSED static void testN2_erasePerformanceOrdered()
+static void testN2_erasePerformance()
 // ------------------------------------------------------------------------
 // ERASE PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of erase() between OrderedHashMap and
+//   bsl::unordered_map.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("ERASE");
+    bmqtst::TestHelper::printTestName("ERASE PERFORMANCE");
 
-    // Performance comparison of erase() with bsl::unordered_map
+    const size_t k_NUM_ELEMENTS = 5000000;
 
-    // Insert elements, iterate and erase while iterating
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
 
-    const size_t       k_NUM_ELEMENTS = 5000000;
-    bsls::Types::Int64 ohmTime;
+    // OrderedHashMap
     {
         typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
         typedef MyMapType::iterator                  IterType;
         typedef bsl::pair<IterType, bool>            RcType;
 
         MyMapType map(bmqtst::TestHelperUtil::allocator());
-        // Insert 1M elements
         for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             BMQTST_ASSERT_EQ_D(i, i, rc.first->first);
             BMQTST_ASSERT_EQ_D(i, i, rc.first->second);
         }
 
-        // Iterate and erase
         IterType           it    = map.begin();
         bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
         while (it != map.end()) {
             map.erase(it++);
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
-        ohmTime                = end - begin;
-        cout << "Time diff (OrderedHashMap): " << ohmTime << endl;
+
+        table.column("Map").insertValue("bmqc::OrderedHashMap");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
     }
-}
 
-BSLA_MAYBE_UNUSED static void testN2_erasePerformanceUnordered()
-// ------------------------------------------------------------------------
-// ERASE PERFORMANCE
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("ERASE");
-
-    // Performance comparison of erase() with bsl::unordered_map
-
-    // Insert elements, iterate and erase while iterating
-
-    const size_t       k_NUM_ELEMENTS = 5000000;
-    bsls::Types::Int64 umTime;
+    // bsl::unordered_map
     {
         typedef bsl::unordered_map<size_t, size_t> MyMapType;
         typedef MyMapType::iterator                IterType;
         typedef bsl::pair<IterType, bool>          RcType;
 
         MyMapType map(bmqtst::TestHelperUtil::allocator());
-        // Insert 1M elements
         for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             RcType rc = map.insert(bsl::make_pair(i, i));
             BMQTST_ASSERT_EQ_D(i, i, rc.first->first);
             BMQTST_ASSERT_EQ_D(i, i, rc.first->second);
         }
 
-        // Iterate and erase
         IterType           it    = map.begin();
         bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
         while (it != map.end()) {
             map.erase(it++);
         }
         bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
-        umTime                 = end - begin;
-        cout << "Time diff (unordered_map) : " << umTime << endl;
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
     }
+
+    table.print(bsl::cout);
 }
 
-BSLA_MAYBE_UNUSED static void testN3_profile()
+static void testN3_findPerformance()
 // ------------------------------------------------------------------------
-// PROFILE
+// FIND PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of find() between OrderedHashMap and
+//   bsl::unordered_map.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("PROFILE");
+    bmqtst::TestHelper::printTestName("FIND PERFORMANCE");
 
-    // A simple snippet which inserts elements in the ordered hash map.
-    // This case can be used to profile the component.
     const size_t k_NUM_ELEMENTS = 5000000;
 
-    typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
-    MyMapType map(k_NUM_ELEMENTS, bmqtst::TestHelperUtil::allocator());
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
 
-    // Insert elements.
-    for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
-        map.insert(bsl::make_pair(i, i));
-    }
-}
-
-#ifdef BMQTST_BENCHMARK_ENABLED
-static void
-testN1_insertPerformanceUnordered_GoogleBenchmark(benchmark::State& state)
-{
-    bmqtst::TestHelper::printTestName("INSERT PERFORMANCE");
-
-    // Performance comparison of insert() with bsl::unordered_map
+    // bmqc::OrderedHashMap
     {
-        // UnorderedMap
-        typedef bsl::unordered_map<size_t, size_t> MyMapType;
-        MyMapType map(state.range(0), bmqtst::TestHelperUtil::allocator());
-        for (auto _ : state) {
-            for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
-                map.insert(bsl::make_pair(i, i));
-            }
-        }
-    }
-}
-
-static void
-testN1_insertPerformanceOrdered_GoogleBenchmark(benchmark::State& state)
-{
-    bmqtst::TestHelper::printTestName("INSERT PERFORMANCE");
-
-    // Performance comparison of insert() with bsl::unordered_map
-    {
-        // OrderedHashMap
         typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
 
-        MyMapType map(static_cast<int>(state.range(0)),
-                      bmqtst::TestHelperUtil::allocator());
-        for (auto _ : state) {
-            for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
-                map.insert(bsl::make_pair(i, i));
-            }
-        }
-    }
-}
-
-static void
-testN2_erasePerformanceUnordered_GoogleBenchmark(benchmark::State& state)
-{
-    // Unordered Map Erase Performance Test
-    typedef bsl::unordered_map<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator                IterType;
-    typedef bsl::pair<IterType, bool>          RcType;
-
-    MyMapType map(bmqtst::TestHelperUtil::allocator());
-    for (auto _ : state) {
-        state.PauseTiming();
-        for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
-            RcType rc = map.insert(bsl::make_pair(i, i));
-            BMQTST_ASSERT_EQ_D(i, i, rc.first->first);
-            BMQTST_ASSERT_EQ_D(i, i, rc.first->second);
-        }
-        // Iterate and erase
-        IterType it = map.begin();
-        state.ResumeTiming();
-        while (it != map.end()) {
-            map.erase(it++);
-        }
-    }
-}
-
-static void
-testN2_erasePerformanceOrdered_GoogleBenchmark(benchmark::State& state)
-{
-    bmqtst::TestHelper::printTestName("ERASE");
-
-    // Performance comparison of erase() with bsl::unordered_map
-
-    // Insert elements, iterate and erase while iterating
-    typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
-    typedef MyMapType::iterator                  IterType;
-    typedef bsl::pair<IterType, bool>            RcType;
-
-    MyMapType map(bmqtst::TestHelperUtil::allocator());
-    // Insert 1M elements
-    for (auto _ : state) {
-        state.PauseTiming();
-        for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
-            RcType rc = map.insert(bsl::make_pair(i, i));
-            BMQTST_ASSERT_EQ_D(i, i, rc.first->first);
-            BMQTST_ASSERT_EQ_D(i, i, rc.first->second);
-        }
-        // Iterate and erase
-        IterType it = map.begin();
-        state.ResumeTiming();
-        while (it != map.end()) {
-            map.erase(it++);
-        }
-    }
-}
-
-static void testN3_profile_GoogleBenchmark(benchmark::State& state)
-// ------------------------------------------------------------------------
-// PROFILE
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("PROFILE");
-
-    // A simple snippet which inserts elements in the ordered hash map.
-    // This case can be used to profile the component.
-
-    typedef bmqc::OrderedHashMap<size_t, size_t> MyMapType;
-    MyMapType map(static_cast<int>(state.range(0)),
-                  bmqtst::TestHelperUtil::allocator());
-
-    // Insert elements.
-    for (auto _ : state) {
-        for (size_t i = 0; i < static_cast<size_t>(state.range(0)); ++i) {
+        MyMapType map(k_NUM_ELEMENTS, bmqtst::TestHelperUtil::allocator());
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
             map.insert(bsl::make_pair(i, i));
         }
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.find(i);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bmqc::OrderedHashMap");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
     }
+
+    // bsl::unordered_map
+    {
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
+
+        MyMapType map(bmqtst::TestHelperUtil::allocator());
+        map.reserve(k_NUM_ELEMENTS);
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i));
+        }
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.find(i);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    table.print(bsl::cout);
 }
-#endif  // BMQTST_BENCHMARK_ENABLED
 
 //=============================================================================
 //                              MAIN PROGRAM
@@ -1248,43 +1187,14 @@ int main(int argc, char* argv[])
     case 3: test3_insert(); break;
     case 2: test2_impDetails_nextPrime(); break;
     case 1: test1_breathingTest(); break;
-    case -1:
-        BMQTST_BENCHMARK_WITH_ARGS(testN1_insertPerformanceOrdered,
-                                   RangeMultiplier(10)
-                                       ->Range(10, 5000000)
-                                       ->Unit(benchmark::kMillisecond));
-        BMQTST_BENCHMARK_WITH_ARGS(testN1_insertPerformanceUnordered,
-                                   RangeMultiplier(10)
-                                       ->Range(10, 5000000)
-                                       ->Unit(benchmark::kMillisecond));
-        break;
-    case -2:
-        BMQTST_BENCHMARK_WITH_ARGS(testN2_erasePerformanceUnordered,
-                                   RangeMultiplier(10)
-                                       ->Range(100, 50000000)
-                                       ->Unit(benchmark::kMillisecond));
-        BMQTST_BENCHMARK_WITH_ARGS(testN2_erasePerformanceOrdered,
-                                   RangeMultiplier(10)
-                                       ->Range(100, 50000000)
-                                       ->Unit(benchmark::kMillisecond));
-        break;
-    case -3:
-        BMQTST_BENCHMARK_WITH_ARGS(testN3_profile,
-                                   RangeMultiplier(10)
-                                       ->Range(10, 5000000)
-                                       ->Unit(benchmark::kMillisecond));
-        break;
+    case -1: testN1_insertPerformance(); break;
+    case -2: testN2_erasePerformance(); break;
+    case -3: testN3_findPerformance(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-#ifdef BMQTST_BENCHMARK_ENABLED
-    if (_testCase < 0) {
-        benchmark::Initialize(&argc, argv);
-        benchmark::RunSpecifiedBenchmarks();
-    }
-#endif
 
     TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqc/bmqc_orderedhashmapwithhistory.t.cpp
+++ b/src/groups/bmq/bmqc/bmqc_orderedhashmapwithhistory.t.cpp
@@ -15,7 +15,12 @@
 
 #include <bmqc_orderedhashmapwithhistory.h>
 
+// BDE
+#include <bsl_unordered_map.h>
+#include <bsls_timeutil.h>
+
 // TEST DRIVER
+#include <bmqtst_table.h>
 #include <bmqtst_testhelper.h>
 
 // CONVENIENCE
@@ -362,23 +367,235 @@ static void test7_gcThenInsert()
     setup(obj, 1, timeout);
 }
 
+static void testN1_insertPerformance()
+// ------------------------------------------------------------------------
+// INSERT PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of insert() between OrderedHashMapWithHistory
+//   and bsl::unordered_map.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("INSERT PERFORMANCE");
+
+    const size_t k_NUM_ELEMENTS = 5000000;
+
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
+
+    // bmqc::OrderedHashMapWithHistory
+    {
+        typedef bmqc::OrderedHashMapWithHistory<size_t, size_t> MyMapType;
+
+        MyMapType          map(1, bmqtst::TestHelperUtil::allocator());
+        bsls::Types::Int64 now = 1;
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i), now);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bmqc::OrderedHashMapWithHistory");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    // bsl::unordered_map
+    {
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
+
+        MyMapType map(bmqtst::TestHelperUtil::allocator());
+        map.reserve(k_NUM_ELEMENTS);
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i));
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    table.print(bsl::cout);
+}
+
+static void testN2_erasePerformance()
+// ------------------------------------------------------------------------
+// ERASE PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of erase() between OrderedHashMapWithHistory
+//   and bsl::unordered_map.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("ERASE PERFORMANCE");
+
+    const size_t k_NUM_ELEMENTS = 5000000;
+
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
+
+    // bmqc::OrderedHashMapWithHistory
+    {
+        typedef bmqc::OrderedHashMapWithHistory<size_t, size_t> MyMapType;
+        typedef MyMapType::iterator                             IterType;
+
+        MyMapType          map(1, bmqtst::TestHelperUtil::allocator());
+        bsls::Types::Int64 now = 1;
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i), now);
+        }
+
+        IterType           it    = map.begin();
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        while (it != map.end()) {
+            map.erase(it++);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bmqc::OrderedHashMapWithHistory");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    // bsl::unordered_map
+    {
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
+        typedef MyMapType::iterator                IterType;
+
+        MyMapType map(bmqtst::TestHelperUtil::allocator());
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i));
+        }
+
+        IterType           it    = map.begin();
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        while (it != map.end()) {
+            map.erase(it++);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    table.print(bsl::cout);
+}
+
+static void testN3_findPerformance()
+// ------------------------------------------------------------------------
+// FIND PERFORMANCE
+//
+// Concerns:
+//   Performance comparison of find() between OrderedHashMapWithHistory
+//   and bsl::unordered_map.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("FIND PERFORMANCE");
+
+    const size_t k_NUM_ELEMENTS = 5000000;
+
+    bmqtst::Table table(bmqtst::TestHelperUtil::allocator());
+
+    // bmqc::OrderedHashMapWithHistory
+    {
+        typedef bmqc::OrderedHashMapWithHistory<size_t, size_t> MyMapType;
+
+        MyMapType          map(1, bmqtst::TestHelperUtil::allocator());
+        bsls::Types::Int64 now = 1;
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i), now);
+        }
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.find(i);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bmqc::OrderedHashMapWithHistory");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    // bsl::unordered_map
+    {
+        typedef bsl::unordered_map<size_t, size_t> MyMapType;
+
+        MyMapType map(bmqtst::TestHelperUtil::allocator());
+        map.reserve(k_NUM_ELEMENTS);
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.insert(bsl::make_pair(i, i));
+        }
+
+        bsls::Types::Int64 begin = bsls::TimeUtil::getTimer();
+        for (size_t i = 0; i < k_NUM_ELEMENTS; ++i) {
+            map.find(i);
+        }
+        bsls::Types::Int64 end = bsls::TimeUtil::getTimer();
+
+        table.column("Map").insertValue("bsl::unordered_map");
+        table.column("Elements")
+            .insertValue(static_cast<bsls::Types::Uint64>(k_NUM_ELEMENTS));
+        table.column("Time (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>(end - begin));
+        table.column("Per op (ns)")
+            .insertValue(static_cast<bsls::Types::Uint64>((end - begin) /
+                                                          k_NUM_ELEMENTS));
+    }
+
+    table.print(bsl::cout);
+}
+
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
 
 int main(int argc, char* argv[])
 {
+    bsls::TimeUtil::initialize();
+
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     switch (_testCase) {
     case 0:
-    case 1: test1_insert(); break;
-    case 2: test2_eraseMiddleToEnd(); break;
-    case 3: test3_eraseMiddleToBegin(); break;
-    case 4: test4_gc(); break;
-    case 5: test5_insertAfterEnd(); break;
-    case 6: test6_eraseThenGc(); break;
     case 7: test7_gcThenInsert(); break;
+    case 6: test6_eraseThenGc(); break;
+    case 5: test5_insertAfterEnd(); break;
+    case 4: test4_gc(); break;
+    case 3: test3_eraseMiddleToBegin(); break;
+    case 2: test2_eraseMiddleToEnd(); break;
+    case 1: test1_insert(); break;
+    case -1: testN1_insertPerformance(); break;
+    case -2: testN2_erasePerformance(); break;
+    case -3: testN3_findPerformance(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;

--- a/src/groups/bmq/bmqtst/bmqtst_table.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_table.cpp
@@ -113,9 +113,10 @@ void Table::print(bsl::ostream& os) const
 // -----------------------
 
 // MANIPULATORS
-void Table::ColumnView::insertValue(const bsl::string& value)
+void Table::ColumnView::insertValue(bsl::string_view value)
 {
-    d_table.d_columns.at(d_columnIndex).push_back(value);
+    d_table.d_columns.at(d_columnIndex)
+        .push_back(bsl::string(value, d_table.d_allocator_p));
 }
 
 void Table::ColumnView::insertValue(const bsls::Types::Uint64& value)

--- a/src/groups/bmq/bmqtst/bmqtst_table.h
+++ b/src/groups/bmq/bmqtst/bmqtst_table.h
@@ -130,7 +130,7 @@ class Table {
 
         /// @brief Insert the specified value to the end of the column.
         /// @param value The string value to insert
-        void insertValue(const bsl::string& value);
+        void insertValue(bsl::string_view value);
 
         /// @brief Insert the specified value to the end of the column.
         /// @param value The unsigned 64-bit value to insert


### PR DESCRIPTION
## Benchmarks (darwin)

```
                    Map::insert | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 | 903171583 |         180
           bmqc::OrderedHashMap |  5000000 | 325063542 |          65
             bsl::unordered_map |  5000000 | 588688667 |         117

                     Map::erase | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 | 410941709 |          82
           bmqc::OrderedHashMap |  5000000 | 217761750 |          43
             bsl::unordered_map |  5000000 | 319221833 |          63

                      Map::find | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 | 116258417 |          23
           bmqc::OrderedHashMap |  5000000 |  68910958 |          13
             bsl::unordered_map |  5000000 | 174589125 |          34
```

## Benchmarks (amd64)

```
                    Map::insert | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 | 425424329 |          85
           bmqc::OrderedHashMap |  5000000 | 186027201 |          37
             bsl::unordered_map |  5000000 | 208801395 |          41

                     Map::erase | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 |  48612615 |           9
           bmqc::OrderedHashMap |  5000000 |  62562121 |          12
             bsl::unordered_map |  5000000 |  85976257 |          17

                      Map::find | Elements | Time (ns) | Per op (ns)
====================================================================
bmqc::OrderedHashMapWithHistory |  5000000 |  35090884 |           7
           bmqc::OrderedHashMap |  5000000 |  35050472 |           7
             bsl::unordered_map |  5000000 |  50849005 |          10
```
