### PR TITLE
UT: Reduce stack frame noise in crash dumps by scoping heavy objects

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -390,10 +390,13 @@ static int initializeTask(bsl::ostream&    errorDescription,
 
     // Create the Task
     new (taskEnv->d_task.buffer())
-        m_bmqbrkr::Task(taskEnv->d_bmqPrefix, taskEnv->d_config.taskConfig());
+        m_bmqbrkr::Task(taskEnv->d_bmqPrefix,
+                        taskEnv->d_config.taskConfig().allocatorType());
 
     bmqu::MemOutStream localError;
-    const int          rc = taskEnv->d_task.object().initialize(localError);
+    const int          rc = taskEnv->d_task.object().initialize(
+        localError,
+        taskEnv->d_config.taskConfig());
     if (rc != 0) {
         errorDescription << "Failed to initialize task "
                          << "[rc: " << rc << ", reason: '" << localError.str()
@@ -605,64 +608,66 @@ int main(int argc, const char* argv[])
     int         port    = 0;
     bool        version = false;
 
-    balcl::OptionInfo specTable[] = {
-        {"",
-         "config",
-         "Path to the configuration directory",
-         balcl::TypeInfo(&configDir),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"i|instanceId",
-         "instanceId",
-         "The instance ID ('default' if not provided)",
-         balcl::TypeInfo(&instanceId),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"h|hostName",
-         "hostName",
-         "Override host name",
-         balcl::TypeInfo(&hostName),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"t|hostTags",
-         "hostTags",
-         "Override host tags",
-         balcl::TypeInfo(&hostTags),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"d|hostDataCenter",
-         "hostDataCenter",
-         "Override host data center",
-         balcl::TypeInfo(&hostDataCenter),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"p|port",
-         "port",
-         "Override port",
-         balcl::TypeInfo(&port),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-        {"v|version",
-         "version",
-         "Show broker version number",
-         balcl::TypeInfo(&version),
-         balcl::OccurrenceInfo::e_OPTIONAL},
-    };
+    {
+        balcl::OptionInfo specTable[] = {
+            {"",
+             "config",
+             "Path to the configuration directory",
+             balcl::TypeInfo(&configDir),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"i|instanceId",
+             "instanceId",
+             "The instance ID ('default' if not provided)",
+             balcl::TypeInfo(&instanceId),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"h|hostName",
+             "hostName",
+             "Override host name",
+             balcl::TypeInfo(&hostName),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"t|hostTags",
+             "hostTags",
+             "Override host tags",
+             balcl::TypeInfo(&hostTags),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"d|hostDataCenter",
+             "hostDataCenter",
+             "Override host data center",
+             balcl::TypeInfo(&hostDataCenter),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"p|port",
+             "port",
+             "Override port",
+             balcl::TypeInfo(&port),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+            {"v|version",
+             "version",
+             "Show broker version number",
+             balcl::TypeInfo(&version),
+             balcl::OccurrenceInfo::e_OPTIONAL},
+        };
 
-    balcl::CommandLine commandLine(specTable);
+        balcl::CommandLine commandLine(specTable);
 
-    if (commandLine.parse(argc, argv)) {
-        bsl::cerr << "PANIC [STARTUP] Failed to parse command line\n"
-                  << bsl::flush;
-        commandLine.printUsage();
-        return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
-    }
+        if (commandLine.parse(argc, argv)) {
+            bsl::cerr << "PANIC [STARTUP] Failed to parse command line\n"
+                      << bsl::flush;
+            commandLine.printUsage();
+            return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
+        }
 
-    if (version) {
-        bsl::cout << "BlazingMQ broker version: "
-                  << bmqbrkrscm::Version::version() << "\n";
-        return 0;
-    }
+        if (version) {
+            bsl::cout << "BlazingMQ broker version: "
+                      << bmqbrkrscm::Version::version() << "\n";
+            return 0;
+        }
 
-    if (configDir.empty()) {
-        bsl::cerr << "Error: No value supplied for the non-option argument "
-                     "\"config\".\n";
-        return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
-    }
+        if (configDir.empty()) {
+            bsl::cerr << "Error: No value supplied for the non-option "
+                         "argument \"config\".\n";
+            return mqbu::ExitCode::e_COMMAND_LINE;  // RETURN
+        }
+    }  // specTable and commandLine are destroyed here
 
     printStartStopTrace("STARTING");
 

--- a/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
@@ -229,9 +229,9 @@ void Task::onLogCommand(const bsl::string& prefix, bsl::istream& input)
     }
 }
 
-Task::Task(const bsl::string& bmqPrefix, const mqbcfg::TaskConfig& config)
-: d_allocatorManager(config.allocatorType())
-, d_config(config)
+Task::Task(const bsl::string&           bmqPrefix,
+           mqbcfg::AllocatorType::Value allocatorType)
+: d_allocatorManager(allocatorType)
 , d_isInitialized(false)
 , d_bmqPrefix(bmqPrefix, d_allocatorManager.store().get("Task"))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC,
@@ -253,7 +253,8 @@ Task::~Task()
                     "shutdown() must be called before destroying this object");
 }
 
-int Task::initialize(bsl::ostream& errorDescription)
+int Task::initialize(bsl::ostream&             errorDescription,
+                     const mqbcfg::TaskConfig& config)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(!d_isInitialized &&
@@ -287,7 +288,7 @@ int Task::initialize(bsl::ostream& errorDescription)
     // -------------
     // LogController
     bmqtsk::LogControllerConfig logConfig;
-    rc = logConfig.fromObj(localError, d_config.logController());
+    rc = logConfig.fromObj(localError, config.logController());
     if (rc != 0) {
         d_scheduler.stop();
         errorDescription << "failed to initialize LogControllerConfig from "
@@ -307,13 +308,13 @@ int Task::initialize(bsl::ostream& errorDescription)
     // Allocation limit
     // Set allocation limit if enabled and using counting allocator
     if (d_allocatorManager.type() == mqbcfg::AllocatorType::COUNTING) {
-        if (d_config.allocationLimit() == 0) {
+        if (config.allocationLimit() == 0) {
             BALL_LOG_INFO << "No memory allocation limit set!";
         }
         else {
             BALL_LOG_INFO << "Memory allocation limit set to "
                           << bmqu::PrintUtil::prettyBytes(
-                                 d_config.allocationLimit());
+                                 config.allocationLimit());
 
             bmqma::CountingAllocator* topAllocator =
                 dynamic_cast<bmqma::CountingAllocator*>(
@@ -322,9 +323,9 @@ int Task::initialize(bsl::ostream& errorDescription)
 
             BSLS_ASSERT_OPT(topAllocator);
             topAllocator->setAllocationLimit(
-                d_config.allocationLimit(),
+                config.allocationLimit(),
                 bdlf::BindUtil::bind(&onAllocationLimit,
-                                     d_config.allocationLimit()));
+                                     config.allocationLimit()));
         }
     }
 

--- a/src/applications/bmqbrkr/m_bmqbrkr_task.h
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.h
@@ -191,10 +191,6 @@ class Task {
     // member so that other members can be
     // initialized with a proper allocator from it.
 
-    const mqbcfg::TaskConfig& d_config;
-    // Configuration to use, const reference to the
-    // one held in main.
-
     bool d_isInitialized;
     // True is this object has been initialized.
 
@@ -239,8 +235,10 @@ class Task {
     // CREATORS
 
     /// Create a new task, creating the pipe control channel in the
-    /// specified `bmqPrefix` directory and using the specified `config`.
-    Task(const bsl::string& bmqPrefix, const mqbcfg::TaskConfig& config);
+    /// specified `bmqPrefix` directory.  Use the specified `allocatorType`
+    /// for memory allocations.
+    Task(const bsl::string&           bmqPrefix,
+         mqbcfg::AllocatorType::Value allocatorType);
 
     /// Destroy this object.  If the task was successfully initialized,
     /// `shutdown()` must be called prior to destruction of this object.
@@ -251,9 +249,9 @@ class Task {
     /// Initialize this object.  Return 0 on success and a non-zero value
     /// otherwise, populating the specified `errorDescription` with a
     /// description of the error.  The initialization leverages the
-    /// properties from the `config` parameter supplied at construction of
-    /// this object.
-    int initialize(bsl::ostream& errorDescription);
+    /// properties from the `config` argument.
+    int initialize(bsl::ostream&             errorDescription,
+                   const mqbcfg::TaskConfig& config);
 
     /// Shutdown the object, effectively closing the pipe control channel
     /// and doing a teardown of the logging system.


### PR DESCRIPTION
#1286

When the broker crashes during `run()`, the main thread's stack trace is
flooded with large local variables that are no longer needed, making
crash triage harder. This PR limits the lifetime of three heavy objects:

1. Wrap `specTable` and `commandLine` in a scoped block in `main()` so
  they destruct before `run()`.
2. Reset `d_config` in `TaskEnvironment` to a default-constructed state
  before entering `run()`.
3. Remove the cached `const mqbcfg::TaskConfig& d_config` member from
  `Task` and pass it as a parameter to `initialize()` instead, which is
  the only place it was used.

**Testing performed**

1. Verified the broker builds and starts successfully with all three
  changes applied.
2. Confirmed CLI argument parsing still works correctly after scoping
  `specTable`/`commandLine`.
3. Confirmed `Task::initialize()` receives and uses the config parameter
  identically to the previous cached reference.

closes: #1286 