### PR TITLE
Fix: Allow `SessionEvent::queueId()` on suspend/resume events

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_sessionevent.cpp
+++ b/src/groups/bmq/bmqa/bmqa_sessionevent.cpp
@@ -20,6 +20,7 @@
 // BMQ
 #include <bmqimp_brokersession.h>
 #include <bmqimp_event.h>
+#include <bmqt_sessioneventtype.h>
 
 // BDE
 #include <bsl_memory.h>
@@ -90,7 +91,11 @@ QueueId SessionEvent::queueId() const
                      d_impl_sp->sessionEventType() ==
                          bmqt::SessionEventType::e_QUEUE_REOPEN_RESULT ||
                      d_impl_sp->sessionEventType() ==
-                         bmqt::SessionEventType::e_QUEUE_CLOSE_RESULT);
+                         bmqt::SessionEventType::e_QUEUE_CLOSE_RESULT ||
+                     d_impl_sp->sessionEventType() ==
+                         bmqt::SessionEventType::e_QUEUE_SUSPENDED ||
+                     d_impl_sp->sessionEventType() ==
+                         bmqt::SessionEventType::e_QUEUE_RESUMED);
 
     QueueId                         queueId;
     const bmqimp::Event::QueuesMap& queues = d_impl_sp->queues();

--- a/src/groups/bmq/bmqa/bmqa_sessionevent.h
+++ b/src/groups/bmq/bmqa/bmqa_sessionevent.h
@@ -107,9 +107,9 @@ class SessionEvent {
     /// Return the correlationId associated to this event, if any.
     const bmqt::CorrelationId& correlationId() const;
 
-    /// Return the queueId associated to this event, if any.  The behavior
-    /// is undefined unless this event corresponds to a queue related event
-    /// (i.e. `OPEN`, `CONFIGURE`, `CLOSE`, `REOPEN`).
+    /// Return the queueId associated to this event, if any.  The behavior is
+    /// undefined unless this event corresponds to a queue related event
+    /// (i.e. `OPEN`, `CONFIGURE`, `CLOSE`, `REOPEN`, `SUSPENDED`, `RESUMED`).
     QueueId queueId() const;
 
     /// Return the status code that indicates success or the cause of a


### PR DESCRIPTION
`bmqa::SessionEvent::queueId()` has a `BSLS_ASSERT_SAFE` precondition that restricts it to `e_QUEUE_OPEN_RESULT`, `e_QUEUE_CONFIGURE_RESULT`, `e_QUEUE_REOPEN_RESULT`, and `e_QUEUE_CLOSE_RESULT`.  However, `e_QUEUE_SUSPENDED` and `e_QUEUE_RESUMED` events also carry valid queue data, and callers of `onSessionEvent` need the queueId to identify which queue was suspended or resumed.

We found this issue upon upgrading to the latest version of libbmq in the BlazingMQ Python SDK.  When building with the new libbmq, the `test_queue_suspension` test aborts at the safe-level assert in `queueId()`.  A little digging shows that the Python SDK is calling `queueId()` on `e_QUEUE_SUSPENDED` and `e_QUEUE_RESUMED` events out-of-contract to try to determine which queue was suspended and which queue was resumed.  Since the new libbmq builds with SAFE asserts enabled by default for non-release builds, this out-of-contract behavior is now being caught.

Despite being out-of-contract, what the Python SDK is doing is not only the reasonable way to figure out which queue a given suspend or resume event fired for, it is in fact the *only* way to figure this out using the API `bmqa::SessionEvent` exposes.  So, it seems the right thing to change is libbmq, not the Python SDK.

This patch relaxes the precondition of `queueId()` to include `e_QUEUE_SUSPENDED` and `e_QUEUE_RESUMED`.  These events are constructed and enqueued with a valid queue in `bmqimp::BrokerSession::onSuspendQueueConfigured` and `bmqimp::BrokerSession::onResumeQueueConfigured`, respectively, so it is safe to retrieve the `queueId` from them.  This is, in fact, the behavior that the Python SDK has been using and testing for a long time.