### PR TITLE
Feat: Introduce `BMQ_ASSERT_LEVEL` cache variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,28 @@ if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU|(Apple)?Clang" )
   endif()
 endif()
 
-if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  # In Debug/RelWithDebInfo build, ensure that BSLS_ASSERT_SAFE macro is enabled
+# Set BSLS assert level.  Defaults to SAFE for non-Release builds and OPT for
+# Release builds.  Can be overridden via the BMQ_ASSERT_LEVEL cache variable.
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(_bmq_assert_level_default "OPT")
+else()
+  set(_bmq_assert_level_default "SAFE")
+endif()
+set(BMQ_ASSERT_LEVEL "${_bmq_assert_level_default}" CACHE STRING
+  "BSLS assert level (SAFE, ASSERT, OPT, NONE, or empty for BDE default).")
+string(TOUPPER "${BMQ_ASSERT_LEVEL}" _bmq_assert_level_upper)
+if (_bmq_assert_level_upper STREQUAL "SAFE")
   add_definitions("-DBSLS_ASSERT_LEVEL_ASSERT_SAFE")
+elseif (_bmq_assert_level_upper STREQUAL "ASSERT")
+  add_definitions("-DBSLS_ASSERT_LEVEL_ASSERT")
+elseif (_bmq_assert_level_upper STREQUAL "OPT")
+  add_definitions("-DBSLS_ASSERT_LEVEL_ASSERT_OPT")
+elseif (_bmq_assert_level_upper STREQUAL "NONE")
+  add_definitions("-DBSLS_ASSERT_LEVEL_NONE")
+elseif (NOT _bmq_assert_level_upper STREQUAL "")
+  message(FATAL_ERROR
+    "Invalid BMQ_ASSERT_LEVEL '${BMQ_ASSERT_LEVEL}'."
+    "  Valid values: SAFE, ASSERT, OPT, NONE, or empty.")
 endif()
 
 # This repo contains the canonical source of multiple, independently released,

--- a/etc/presets/default.json
+++ b/etc/presets/default.json
@@ -10,7 +10,7 @@
                 "CMAKE_EXPORT_COMPILE_COMMANDS": "1",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "BDE_BUILD_TARGET_64": "1",
-                "BDE_BUILD_TARGET_SAFE": true,
+                "BMQ_ASSERT_LEVEL": "SAFE",
                 "CMAKE_CXX_STANDARD": "23",
                 "BDE_BUILD_TARGET_CPP23": "ON",
                 "CMAKE_INSTALL_LIBDIR": "lib64"

--- a/etc/presets/gh-ci.json
+++ b/etc/presets/gh-ci.json
@@ -8,7 +8,7 @@
             "generator": "Ninja",
             "binaryDir": "${sourceDir}/build/blazingmq",
             "cacheVariables": {
-                "BDE_BUILD_TARGET_SAFE": "ON",
+                "BMQ_ASSERT_LEVEL": "SAFE",
                 "BDE_BUILD_TARGET_64": "ON",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_PREFIX_PATH":


### PR DESCRIPTION
Rather than invariably setting the assert level we compile at based on the build mode (release or non-release), this patch introduces a new cache variable `BMQ_ASSERT_LEVEL`, which can override the default assert level computed based on the build mode.  For explicitness’s sake, we set this to SAFE in our CMakePresets, but users can now override this.

Supercedes: #1243