### PR TITLE
Revert: Remove unused BMQTest CMake module function

### DIFF
--- a/etc/cmake/BMQTest.cmake
+++ b/etc/cmake/BMQTest.cmake
@@ -1,9 +1,88 @@
 # This module provides functions to support generating test targets compatible
 # with BlazingMQ CI.
 #
-# bmq_add_application_test( TARGET )
+# add_bmq_test( TARGET )
 
 include_guard()
+
+# :: bmq_add_test :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+# This function searches for the test drivers of a UOR-style TARGET within the
+# `tests` directory of each package. For each component, it generates a target
+# named ${UOR_component}.t for each component found.
+function(bmq_add_test target)
+  cmake_parse_arguments(PARSE_ARGV 1
+    ""
+    "SKIP_TESTS;NO_GEN_BDE_METADATA;NO_EMIT_PKG_CONFIG_FILE;COMPAT"
+    "SOURCE_DIR"
+    "CUSTOM_PACKAGES")
+
+  find_package(BdeBuildSystem REQUIRED)
+
+  # Get the name of the unit from the target
+  get_target_property(uor_name ${target} NAME)
+
+  # Use the current source directory if none is specified
+  if(NOT _SOURCE_DIR)
+    set(_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  # Check that BDE metadata exists and load it
+  if(NOT DEFINED ${uor_name}_PACKAGES)
+    if(EXISTS ${_SOURCE_DIR}/group)
+      bbs_read_metadata(GROUP ${uor_name}
+        SOURCE_DIR ${_SOURCE_DIR}
+        CUSTOM_PACKAGES "${_CUSTOM_PACKAGES}")
+    else()
+      if(EXISTS ${_SOURCE_DIR}/package)
+        bbs_read_metadata(PACKAGE ${uor_name}
+          SOURCE_DIR ${_SOURCE_DIR})
+      endif()
+    endif()
+  endif()
+
+  # Each package in the groups
+  if(${uor_name}_PACKAGES)
+    foreach(pkg ${${uor_name}_PACKAGES})
+      bbs_configure_target_tests(${pkg}
+        SOURCES ${${pkg}_TEST_SOURCES}
+        TEST_DEPS ${${pkg}_DEPENDS}
+        ${${pkg}_TEST_DEPENDS}
+        ${${uor_name}_PCDEPS}
+        ${${uor_name}_TEST_PCDEPS}
+        LABELS "unit;all" ${target} ${pkg})
+    endforeach()
+
+    set(import_test_deps ON)
+
+    foreach(pkg ${${uor_name}_PACKAGES})
+      if(${pkg}_TEST_TARGETS)
+        if(NOT TARGET ${target}.t)
+          add_custom_target(${target}.t)
+        endif()
+
+        add_dependencies(${target}.t ${${pkg}_TEST_TARGETS})
+
+        if(import_test_deps)
+          # Import UOR test dependencies only once and only if we have at least
+          # one generated test target
+          bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
+          set(import_test_deps OFF)
+        endif()
+      endif()
+    endforeach()
+  else()
+    # Configure standalone library ( no packages ) and tests from BDE metadata
+    bbs_configure_target_tests(${target}
+      SOURCES ${${uor_name}_TEST_SOURCES}
+      TEST_DEPS ${${uor_name}_PCDEPS}
+      ${${uor_name}_TEST_PCDEPS}
+      LABELS "unit;all" ${target})
+
+    if(${target}_TEST_TARGETS)
+      bbs_import_target_dependencies(${target} ${${uor_name}_TEST_PCDEPS})
+    endif()
+  endif()
+endfunction()
 
 # :: bmq_add_application_test :::::::::::::::::::::::::::::::::::::::::::::::::
 # This function searches for the test drivers of an 'application' TARGET.  It

--- a/etc/cmake/TargetBMQStyleUor.cmake
+++ b/etc/cmake/TargetBMQStyleUor.cmake
@@ -59,6 +59,7 @@ function(target_bmq_style_uor TARGET)
   add_library(${TARGET}-flags INTERFACE IMPORTED)
 
   bbs_setup_target_uor(${TARGET}
+    SKIP_TESTS
     PRIVATE_PACKAGES "${_PRIVATE_PACKAGES}")
 
   get_target_property(uor_name ${TARGET} NAME)
@@ -83,6 +84,9 @@ function(target_bmq_style_uor TARGET)
       target_link_libraries(${pkg}-iface PUBLIC ${TARGET}-flags)
     endforeach()
   endif()
+
+  include(BMQTest)
+  bmq_add_test(${TARGET} COMPAT)
 endfunction()
 
 # :: bmq_install_target_headers ::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
This reverts commit eee387f80b9180c6fb82abf33b971f4e4fa87e26, adding unit tests back to non-application components.  We can do smarter refactoring of this function later.