### PR TITLE
Fix[bmqp]: use static buffered allocator for globals

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_heartbeatmonitor.cpp
+++ b/src/groups/bmq/bmqp/bmqp_heartbeatmonitor.cpp
@@ -16,9 +16,11 @@
 // bmqp_heartbeatmonitor.cpp                                          -*-C++-*-
 #include <bmqp_heartbeatmonitor.h>
 
+// BMQ
+#include <bmqu_singletonallocator.h>
+
 // BDE
 #include <bsl_memory.h>
-#include <bslma_default.h>
 #include <bslmt_once.h>
 #include <bsls_objectbuffer.h>
 
@@ -34,8 +36,8 @@ const bdlbb::Blob& HeartbeatMonitor::heartbeatReqBlob()
     static bsls::ObjectBuffer<bdlbb::Blob> blob;
     BSLMT_ONCE_DO
     {
+        bslma::Allocator*        alloc = bmqu::SingletonAllocator::allocator();
         static const EventHeader header(EventType::e_HEARTBEAT_REQ);
-        bslma::Allocator*        alloc = bslma::Default::globalAllocator();
         bsl::shared_ptr<char>    data;
         data.reset(static_cast<char*>(
                        const_cast<void*>(static_cast<const void*>(&header))),
@@ -53,8 +55,8 @@ const bdlbb::Blob& HeartbeatMonitor::heartbeatRspBlob()
     static bsls::ObjectBuffer<bdlbb::Blob> blob;
     BSLMT_ONCE_DO
     {
+        bslma::Allocator*        alloc = bmqu::SingletonAllocator::allocator();
         static const EventHeader header(EventType::e_HEARTBEAT_RSP);
-        bslma::Allocator*        alloc = bslma::Default::globalAllocator();
         bsl::shared_ptr<char>    data;
         data.reset(static_cast<char*>(
                        const_cast<void*>(static_cast<const void*>(&header))),

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
@@ -23,6 +23,7 @@
 #include <bmqu_blobiterator.h>
 #include <bmqu_blobobjectproxy.h>
 #include <bmqu_memoutstream.h>
+#include <bmqu_singletonallocator.h>
 
 // BDE
 #include <bdlb_stringrefutil.h>
@@ -32,7 +33,6 @@
 #include <bsl_cstring.h>
 #include <bsl_memory.h>
 #include <bsl_utility.h>
-#include <bslma_default.h>
 #include <bslmt_once.h>
 #include <bsls_objectbuffer.h>
 
@@ -65,7 +65,7 @@ const bdlbb::BlobBuffer& getPaddingBlobBuffer(int numPaddingBytes)
     static bsls::ObjectBuffer<bdlbb::BlobBuffer> buffers[9];
     BSLMT_ONCE_DO
     {
-        bslma::Allocator* alloc = bslma::Default::globalAllocator();
+        bslma::Allocator* alloc = bmqu::SingletonAllocator::allocator();
         for (int i = 0; i < 9; ++i) {
             bsl::shared_ptr<char> data;
             data.reset(const_cast<char*>(k_PADDING_DATA[i]),

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -1,0 +1,52 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqu_singletonallocator.cpp                                        -*-C++-*-
+#include <bmqu_singletonallocator.h>
+
+#include <bmqscm_version.h>
+
+// BDE
+#include <bdlma_bufferedsequentialallocator.h>
+#include <bsl_new.h>
+#include <bslma_default.h>
+#include <bslmt_once.h>
+#include <bsls_objectbuffer.h>
+
+namespace BloombergLP {
+namespace bmqu {
+
+// -------------------------
+// struct SingletonAllocator
+// -------------------------
+
+bslma::Allocator* SingletonAllocator::allocator()
+{
+    typedef bdlma::BufferedSequentialAllocator AllocType;
+
+    static char                          buffer[4096];
+    static bsls::ObjectBuffer<AllocType> alloc;
+    BSLMT_ONCE_DO
+    {
+        new (static_cast<void*>(alloc.buffer()))
+            AllocType(buffer,
+                      sizeof(buffer),
+                      bslma::Default::globalAllocator());
+    }
+    return &alloc.object();
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.h
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.h
@@ -1,0 +1,57 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqu_singletonallocator.h                                          -*-C++-*-
+#ifndef INCLUDED_BMQU_SINGLETONALLOCATOR
+#define INCLUDED_BMQU_SINGLETONALLOCATOR
+
+//@PURPOSE: Provide a process-lifetime allocator for static initialization.
+//
+//@CLASSES:
+//  bmqu::SingletonAllocator: accessor to a process-lifetime allocator
+//
+//@DESCRIPTION: This component provides a utility struct,
+// 'bmqu::SingletonAllocator', exposing a single static method 'allocator()'
+// that returns a pointer to a process-lifetime
+// 'bdlma::BufferedSequentialAllocator'.  The allocator is lazily initialized
+// on first call in a thread-safe manner and is backed by a fixed-size static
+// buffer.  It is intended for one-time static initialization of lightweight
+// objects (e.g., shared_ptr control blocks) that live for the duration of the
+// process and should not allocate from the global allocator.
+
+// BDE
+#include <bslma_allocator.h>
+
+namespace BloombergLP {
+namespace bmqu {
+
+// =========================
+// struct SingletonAllocator
+// =========================
+
+/// Utility struct providing access to a process-lifetime allocator.
+struct SingletonAllocator {
+    // CLASS METHODS
+
+    /// Return a pointer to a process-lifetime allocator backed by a
+    /// fixed-size static buffer.  The allocator is lazily initialized on
+    /// first call in a thread-safe manner.
+    static bslma::Allocator* allocator();
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqu/doc/bmqu.txt
+++ b/src/groups/bmq/bmqu/doc/bmqu.txt
@@ -9,7 +9,7 @@ reused through various applications.
 
 /Hierarchical Synopsis
 /---------------------
-The 'bmqu' package currently has 18 components having 2 level of physical
+The 'bmqu' package currently has 19 components having 2 level of physical
 dependency.  The list below shows the hierarchal ordering of the components.
 ..
   2. bmqu_blobiterator
@@ -26,6 +26,7 @@ dependency.  The list below shows the hierarchal ordering of the components.
      bmqu_outstreamformatsaver
      bmqu_sharedresource
      bmqu_samethreadchecker
+     bmqu_singletonallocator
      bmqu_stringutil
      bmqu_tempfile
      bmqu_temputil
@@ -70,6 +71,9 @@ dependency.  The list below shows the hierarchal ordering of the components.
 :
 : 'bmqu_sharedresource':
 :      Provide a mechanism to manage the lifetime of a shared resource.
+:
+: 'bmqu_singletonallocator':
+:      Provide a process-lifetime allocator for static initialization.
 :
 : 'bmqu_stringutil':
 :      Provide utility functions for string manipulation.

--- a/src/groups/bmq/bmqu/package/bmqu.mem
+++ b/src/groups/bmq/bmqu/package/bmqu.mem
@@ -17,6 +17,7 @@ bmqu_outstreamformatsaver
 bmqu_printutil
 bmqu_samethreadchecker
 bmqu_sharedresource
+bmqu_singletonallocator
 bmqu_stringutil
 bmqu_tempdirectory
 bmqu_tempfile


### PR DESCRIPTION
- Implement a new component `bmqu::SingletonAllocator` that provides a static buffered allocator
- Update `bmqp` global variables to use `bmqu::SingletonAllocator`