### PR TITLE
Fix[mqb]: write failure transitions REOPENING->PENDING

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -336,7 +336,8 @@ BrokerSession::QueueFsmEvent::toAscii(BrokerSession::QueueFsmEvent::Enum value)
         CASE(OPEN_CMD)
         CASE(CONFIG_CMD)
         CASE(CLOSE_CMD)
-        CASE(REQ_NOT_SENT)
+        CASE(REQ_WRITE_ERROR)
+        CASE(REQ_BAD)
         CASE(RESP_OK)
         CASE(LATE_RESP)
         CASE(RESP_BAD)
@@ -1410,14 +1411,15 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
         {S::e_CLOSED, E::e_OPEN_CMD, S::e_OPENING_OPN},
         //
         {S::e_OPENING_OPN, E::e_RESP_OK, S::e_OPENING_CFG},
-        {S::e_OPENING_OPN, E::e_REQ_NOT_SENT, S::e_CLOSED},
+        {S::e_OPENING_OPN, E::e_REQ_BAD, S::e_CLOSED},
         {S::e_OPENING_OPN, E::e_RESP_BAD, S::e_CLOSED},
         {S::e_OPENING_OPN, E::e_RESP_TIMEOUT, S::e_CLOSED},
         {S::e_OPENING_OPN, E::e_RESP_EXPIRED, S::e_CLOSED},
         {S::e_OPENING_OPN, E::e_SESSION_DOWN, S::e_CLOSED},
         //
         {S::e_REOPENING_OPN, E::e_RESP_OK, S::e_REOPENING_CFG},
-        {S::e_REOPENING_OPN, E::e_REQ_NOT_SENT, S::e_CLOSED},
+        {S::e_REOPENING_OPN, E::e_REQ_WRITE_ERROR, S::e_PENDING},
+        {S::e_REOPENING_OPN, E::e_REQ_BAD, S::e_CLOSED},
         {S::e_REOPENING_OPN, E::e_RESP_BAD, S::e_CLOSED},
         {S::e_REOPENING_OPN, E::e_RESP_TIMEOUT, S::e_REOPENING_OPN},
         {S::e_REOPENING_OPN, E::e_REQ_CANCELED, S::e_REOPENING_OPN},
@@ -1425,14 +1427,15 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
         {S::e_REOPENING_OPN, E::e_SESSION_DOWN, S::e_CLOSED},
         //
         {S::e_OPENING_CFG, E::e_RESP_OK, S::e_OPENED},
-        {S::e_OPENING_CFG, E::e_REQ_NOT_SENT, S::e_CLOSING_CLS},
+        {S::e_OPENING_CFG, E::e_REQ_BAD, S::e_CLOSING_CLS},
         {S::e_OPENING_CFG, E::e_RESP_BAD, S::e_CLOSING_CLS},
         {S::e_OPENING_CFG, E::e_RESP_TIMEOUT, S::e_CLOSED},
         {S::e_OPENING_CFG, E::e_RESP_EXPIRED, S::e_CLOSED},
         {S::e_OPENING_CFG, E::e_SESSION_DOWN, S::e_CLOSED},
         //
         {S::e_REOPENING_CFG, E::e_RESP_OK, S::e_OPENED},
-        {S::e_REOPENING_CFG, E::e_REQ_NOT_SENT, S::e_CLOSING_CLS},
+        {S::e_REOPENING_CFG, E::e_REQ_WRITE_ERROR, S::e_PENDING},
+        {S::e_REOPENING_CFG, E::e_REQ_BAD, S::e_CLOSING_CLS},
         {S::e_REOPENING_CFG, E::e_RESP_BAD, S::e_CLOSING_CLS},
         {S::e_REOPENING_CFG, E::e_RESP_TIMEOUT, S::e_REOPENING_CFG},
         {S::e_REOPENING_CFG, E::e_REQ_CANCELED, S::e_REOPENING_CFG},
@@ -1441,7 +1444,8 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
         //
         {S::e_OPENED, E::e_CLOSE_CMD, S::e_CLOSING_CFG},
         {S::e_OPENED, E::e_CONFIG_CMD, S::e_OPENED},
-        {S::e_OPENED, E::e_REQ_NOT_SENT, S::e_OPENED},
+        {S::e_OPENED, E::e_REQ_WRITE_ERROR, S::e_OPENED},
+        {S::e_OPENED, E::e_REQ_BAD, S::e_OPENED},
         {S::e_OPENED, E::e_REQ_CANCELED, S::e_OPENED},
         {S::e_OPENED, E::e_RESP_OK, S::e_OPENED},
         {S::e_OPENED, E::e_RESP_BAD, S::e_OPENED},
@@ -1453,14 +1457,16 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
         {S::e_OPENED, E::e_SESSION_DOWN, S::e_CLOSED},
         //
         {S::e_CLOSING_CFG, E::e_RESP_OK, S::e_CLOSING_CLS},
-        {S::e_CLOSING_CFG, E::e_REQ_NOT_SENT, S::e_CLOSED},
+        {S::e_CLOSING_CFG, E::e_REQ_WRITE_ERROR, S::e_CLOSED},
+        {S::e_CLOSING_CFG, E::e_REQ_BAD, S::e_CLOSED},
         {S::e_CLOSING_CFG, E::e_RESP_BAD, S::e_CLOSING_CLS},
         {S::e_CLOSING_CFG, E::e_RESP_TIMEOUT, S::e_CLOSED},
         {S::e_CLOSING_CFG, E::e_REQ_CANCELED, S::e_CLOSED},
         {S::e_CLOSING_CFG, E::e_SESSION_DOWN, S::e_CLOSED},
         //
         {S::e_CLOSING_CLS, E::e_RESP_OK, S::e_CLOSED},
-        {S::e_CLOSING_CLS, E::e_REQ_NOT_SENT, S::e_CLOSED},
+        {S::e_CLOSING_CLS, E::e_REQ_WRITE_ERROR, S::e_CLOSED},
+        {S::e_CLOSING_CLS, E::e_REQ_BAD, S::e_CLOSED},
         {S::e_CLOSING_CLS, E::e_RESP_BAD, S::e_CLOSED},
         {S::e_CLOSING_CLS, E::e_RESP_TIMEOUT, S::e_CLOSED},
         {S::e_CLOSING_CLS, E::e_REQ_CANCELED, S::e_CLOSED},
@@ -1554,8 +1560,117 @@ void BrokerSession::QueueFsm::handleRequestNotSent(
 
     BSLS_ASSERT_SAFE(d_session.d_fsmThreadChecker.inSameThread());
 
+    if (status == static_cast<bmqp_ctrlmsg::StatusCategory::Value>(
+                      bmqt::GenericResult::e_NOT_CONNECTED)) {
+        handleRequestWriteError(queue, context, status);
+    }
+    else {
+        handleRequestBad(queue, context, status);
+    }
+}
+
+void BrokerSession::QueueFsm::handleRequestWriteError(
+    const bsl::shared_ptr<Queue>&        queue,
+    const RequestManagerType::RequestSp& context,
+    bmqp_ctrlmsg::StatusCategory::Value  status)
+{
+    // executed by the FSM thread
+
+    BSLS_ASSERT_SAFE(d_session.d_fsmThreadChecker.inSameThread());
+
+    (void)context;
+    (void)status;
+
     const QueueState::Enum    state = queue->state();
-    const QueueFsmEvent::Enum event = QueueFsmEvent::e_REQ_NOT_SENT;
+    const QueueFsmEvent::Enum event = QueueFsmEvent::e_REQ_WRITE_ERROR;
+
+    BALL_LOG_INFO << id() << "Queue FSM Event: " << event << " ["
+                  << "QueueState: " << state << "]";
+
+    switch (state) {
+    case QueueState::e_REOPENING_OPN:
+    case QueueState::e_REOPENING_CFG: {
+        // Transport error during reopen.  Go to PENDING so the queue will
+        // be retried on the next CHANNEL_UP.
+        setQueueState(queue, QueueState::e_PENDING, event);
+
+        // This reopen attempt is done from the counter's perspective.
+        // Decrement but do NOT fire STATE_RESTORED.
+        BSLS_ASSERT_SAFE(0 < d_session.d_numPendingReopenQueues);
+        --d_session.d_numPendingReopenQueues;
+    } break;
+    case QueueState::e_OPENED: {
+        // Failed to send standalone configure queue request
+        BSLS_ASSERT_SAFE(isConfigure(context->request(), context->response()));
+        BSLS_ASSERT_SAFE(context->response().choice().isStatusValue());
+
+        // Keep the OPENED state
+        setQueueState(queue, QueueState::e_OPENED, event);
+
+        logOperationTime(queue->uri().asString(), "Configure queue");
+
+        // Notify about configure queue result
+        context->signal();
+    } break;
+    case QueueState::e_CLOSING_CFG: {
+        BSLS_ASSERT_SAFE(context->request().choice().isCloseQueueValue());
+        BSLS_ASSERT_SAFE(bmqt::QueueFlagsUtil::isReader(queue->flags()));
+
+        setQueueState(queue, QueueState::e_CLOSED, event);
+
+        injectErrorResponse(
+            context,
+            status,
+            "The request was canceled [reason: connection was lost]");
+
+        logOperationTime(queue->uri().asString(), "Close queue");
+
+        actionRemoveQueue(queue);
+
+        context->signal();
+
+        d_session.d_channel_sp->close();
+    } break;
+    case QueueState::e_CLOSING_CLS: {
+        BSLS_ASSERT_SAFE(context->request().choice().isCloseQueueValue());
+
+        setQueueState(queue, QueueState::e_CLOSED, event);
+
+        injectErrorResponse(
+            context,
+            status,
+            "Failed to send close queue request to the broker");
+
+        logOperationTime(queue->uri().asString(), "Close queue");
+
+        actionRemoveQueue(queue);
+
+        context->signal();
+
+        d_session.d_channel_sp->close();
+    } break;
+    case QueueState::e_OPENING_OPN:
+    case QueueState::e_OPENING_CFG:
+    case QueueState::e_PENDING:
+    case QueueState::e_CLOSED: {
+        // OPENING_OPN and OPENING_CFG are unreachable: initial opens use
+        // buffered requests, so write errors are swallowed.
+        BSLS_ASSERT_SAFE(false && "Unexpected Queue state for write error");
+    } break;
+    }
+}
+
+void BrokerSession::QueueFsm::handleRequestBad(
+    const bsl::shared_ptr<Queue>&        queue,
+    const RequestManagerType::RequestSp& context,
+    bmqp_ctrlmsg::StatusCategory::Value  status)
+{
+    // executed by the FSM thread
+
+    BSLS_ASSERT_SAFE(d_session.d_fsmThreadChecker.inSameThread());
+
+    const QueueState::Enum    state = queue->state();
+    const QueueFsmEvent::Enum event = QueueFsmEvent::e_REQ_BAD;
 
     BALL_LOG_INFO << id() << "Queue FSM Event: " << event << " ["
                   << "QueueState: " << state << "]";

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.h
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.h
@@ -264,8 +264,8 @@ class BrokerSession BSLS_CPP11_FINAL {
             e_CONFIG_CMD = 2,
             /// Close queue request
             e_CLOSE_CMD = 3,
-            /// Request is not sent to the broker
-            e_REQ_NOT_SENT = 4,
+            /// Request failed due to non-transport error
+            e_REQ_BAD = 4,
             /// Successful response
             e_RESP_OK = 5,
             /// Late response
@@ -289,7 +289,9 @@ class BrokerSession BSLS_CPP11_FINAL {
             /// Request is canceled by the SDK
             e_REQ_CANCELED = 14,
             /// Request is canceled due to the session goes down
-            e_SESSION_DOWN = 15
+            e_SESSION_DOWN = 15,
+            /// Request failed due to transport/write error
+            e_REQ_WRITE_ERROR = 16
         };
 
         // CLASS METHODS
@@ -650,9 +652,24 @@ class BrokerSession BSLS_CPP11_FINAL {
 
         /// Handle a case when a request to the broker has not been sent
         /// due to some error described with the specified `status`.
+        /// Dispatches to `handleRequestWriteError` for transport errors
+        /// or `handleRequestBad` for non-transport errors.
         void handleRequestNotSent(const bsl::shared_ptr<Queue>&        queue,
                                   const RequestManagerType::RequestSp& context,
                                   bmqp_ctrlmsg::StatusCategory::Value  status);
+
+        /// Handle a transport/write error when sending a request.  The
+        /// queue stays in its current state, waiting for CHANNEL_DOWN.
+        void
+        handleRequestWriteError(const bsl::shared_ptr<Queue>&        queue,
+                                const RequestManagerType::RequestSp& context,
+                                bmqp_ctrlmsg::StatusCategory::Value  status);
+
+        /// Handle a non-transport error when sending a request (e.g.,
+        /// session stopped, invalid state).
+        void handleRequestBad(const bsl::shared_ptr<Queue>&        queue,
+                              const RequestManagerType::RequestSp& context,
+                              bmqp_ctrlmsg::StatusCategory::Value  status);
 
         /// Handle response error.
         void handleResponseError(const bsl::shared_ptr<Queue>&        queue,

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -6150,7 +6150,6 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
 {
     bmqtst::TestHelper::printTestName("REOPEN ERROR TEST");
 
-    const bsls::TimeInterval timeout = bsls::TimeInterval(15);
     bmqt::SessionOptions     sessionOptions;
     bmqt::QueueOptions       queueOptions;
     bdlmt::EventScheduler    scheduler(bsls::SystemClockType::e_MONOTONIC,
@@ -6169,7 +6168,7 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
     PVV_SAFE("Step 1. Start the session");
     obj.startAndConnect();
 
-    PVV_SAFE("Step 2. Check reopen 1st part error");
+    PVV_SAFE("Step 2. Check reopen 1st part write error (retryable)");
     {
         PVV_SAFE("Step 3. Open the queue");
         obj.openQueue(queue);
@@ -6191,24 +6190,32 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
 
         BMQTST_ASSERT(obj.waitReconnectedEvent());
 
-        PVV_SAFE("Step 5. Verify reopen request was sent");
+        PVV_SAFE("Step 5. Verify reopen request was attempted");
         obj.verifyRequestSent(TestSession::e_REQ_OPEN_QUEUE);
 
-        BMQTST_ASSERT(obj.waitStateRestoredEvent());
+        PVV_SAFE("Step 5a. Queue goes to PENDING (write error is retryable)");
+        BMQTST_ASSERT(
+            obj.waitForQueueState(queue, bmqimp::QueueState::e_PENDING));
+        BMQTST_ASSERT(queue->isValid());
 
-        PVV_SAFE("Step 6. Verify the queue gets closed");
-        BMQTST_ASSERT(obj.waitForQueueRemoved(queue, timeout));
+        PVV_SAFE("Step 5b. Channel close triggers another reconnect cycle");
+        BMQTST_ASSERT(obj.waitForChannelClose());
+        BMQTST_ASSERT(obj.waitConnectionLostEvent());
 
         // Set normal write status
         obj.channel().setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
+
+        PVV_SAFE("Step 6. Reconnect and verify queue reopens successfully");
+        obj.setChannel();
+        BMQTST_ASSERT(obj.waitReconnectedEvent());
+        obj.reopenQueue(queue);
+        BMQTST_ASSERT(obj.waitStateRestoredEvent());
+        BMQTST_ASSERT_EQ(queue->state(), bmqimp::QueueState::e_OPENED);
     }
 
-    PVV_SAFE("Step 7. Check reopen 2st part error");
+    PVV_SAFE("Step 7. Check reopen 2nd part write error (retryable)");
     {
-        PVV_SAFE("Step 8. Open the queue");
-        obj.openQueue(queue);
-
-        PVV_SAFE("Step 9. Reset the channel");
+        PVV_SAFE("Step 8. Reset the channel");
         obj.session().setChannel(bsl::shared_ptr<bmqio::Channel>());
 
         BMQTST_ASSERT(obj.waitConnectionLostEvent());
@@ -6222,30 +6229,39 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
 
         BMQTST_ASSERT(obj.waitReconnectedEvent());
 
-        PVV_SAFE("Step 10. Verify reopen request was sent");
+        PVV_SAFE("Step 9. Verify reopen request was sent");
         bmqp_ctrlmsg::ControlMessage request = obj.getNextOutboundRequest(
             TestSession::e_REQ_OPEN_QUEUE);
 
         // Set write error condition
         obj.channel().setWriteStatus(bmqio::StatusCategory::e_GENERIC_ERROR);
 
-        PVV_SAFE("Step 11. Send reopen response");
+        PVV_SAFE("Step 10. Send reopen response");
         obj.sendResponse(request);
 
         // Configuring is applicable only for the reader
         if (bmqt::QueueFlagsUtil::isReader(queue->flags())) {
-            PVV_SAFE("Step 12. Verify configure request was sent");
+            PVV_SAFE("Step 11. Verify configure request was attempted");
             obj.verifyRequestSent(TestSession::e_REQ_CONFIG_QUEUE);
 
-            BMQTST_ASSERT(obj.waitStateRestoredEvent());
-
-            PVV_SAFE("Step 13. Verify the queue is e_CLOSING_CLS");
-            obj.verifyRequestSent(TestSession::e_REQ_CLOSE_QUEUE);
-
+            PVV_SAFE("Step 11a. Queue goes to PENDING (write error)");
             BMQTST_ASSERT(
-                obj.waitForQueueState(queue,
-                                      bmqimp::QueueState::e_CLOSING_CLS));
-            BMQTST_ASSERT_EQ(queue->isValid(), false);
+                obj.waitForQueueState(queue, bmqimp::QueueState::e_PENDING));
+            BMQTST_ASSERT(queue->isValid());
+
+            PVV_SAFE("Step 11b. Channel close triggers reconnect cycle");
+            BMQTST_ASSERT(obj.waitForChannelClose());
+            BMQTST_ASSERT(obj.waitConnectionLostEvent());
+
+            // Set normal write status
+            obj.channel().setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
+
+            PVV_SAFE("Step 12. Reconnect and reopen successfully");
+            obj.setChannel();
+            BMQTST_ASSERT(obj.waitReconnectedEvent());
+            obj.reopenQueue(queue);
+            BMQTST_ASSERT(obj.waitStateRestoredEvent());
+            BMQTST_ASSERT_EQ(queue->state(), bmqimp::QueueState::e_OPENED);
         }
         else {
             BMQTST_ASSERT(obj.verifyOperationResult(
@@ -6255,10 +6271,10 @@ static void reopenError(bsls::Types::Uint64 queueFlags)
             BMQTST_ASSERT(
                 obj.waitForQueueState(queue, bmqimp::QueueState::e_OPENED));
             BMQTST_ASSERT(queue->isValid());
-        }
 
-        // Set normal write status
-        obj.channel().setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
+            // Set normal write status
+            obj.channel().setWriteStatus(bmqio::StatusCategory::e_SUCCESS);
+        }
     }
 
     PVV_SAFE("Step 14. Stop the session");


### PR DESCRIPTION
⏺ When the connection flaps during queue reopen, a channel write error causes the queue to transition to CLOSED and NACK all pending messages. The fix
  splits e_REQ_NOT_SENT into e_REQ_WRITE_ERROR (transport) and e_REQ_BAD (logical). On write error during reopen, the queue goes to PENDING instead of
  CLOSED, preserving pending messages for the next reconnect cycle.
