### PR TITLE
Refactor[mqb] make authenticate() plugin API allocator aware

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -266,11 +266,12 @@ void Authenticator::authenticate(
             : authenticationRequest.data().value(),
         channel->peerUri());
     const bsls::Types::Int64 start   = bmqsys::Time::highResolutionTimer();
-    const int authnRc = d_authnController_p->authenticate(
+    const int                authnRc = d_authnController_p->authenticate(
         authnErrStream,
         &result,
         authenticationRequest.mechanism(),
-        authenticationData);
+        authenticationData,
+        d_allocator_p);
     const bsls::Types::Int64 elapsed = bmqsys::Time::highResolutionTimer() -
                                        start;
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.cpp
@@ -71,9 +71,8 @@ AnonAuthenticationResult::lifetimeMs() const
 
 AnonAuthenticator::AnonAuthenticator(
     const mqbcfg::AuthenticatorPluginConfig* config,
-    bslma::Allocator*                        allocator)
-: d_allocator_p(allocator)
-, d_isStarted(false)
+    BSLA_MAYBE_UNUSED bslma::Allocator* allocator)
+: d_isStarted(false)
 , d_shouldPass(true)
 {
     if (!config) {
@@ -133,7 +132,8 @@ bsl::string_view AnonAuthenticator::mechanism() const
 int AnonAuthenticator::authenticate(
     bsl::ostream&                                   errorDescription,
     bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-    BSLA_MAYBE_UNUSED const mqbplug::AuthenticationData& input) const
+    BSLA_MAYBE_UNUSED const mqbplug::AuthenticationData& input,
+    bslma::Allocator*                                    allocator) const
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(result);
@@ -146,7 +146,7 @@ int AnonAuthenticator::authenticate(
         // No `lifetime` is returned since we don't expect a user to
         // reauthenticate if they don't know how to authenticate in the first
         // place.
-        *result = bsl::allocate_shared<AnonAuthenticationResult>(d_allocator_p,
+        *result = bsl::allocate_shared<AnonAuthenticationResult>(allocator,
                                                                  k_PRINCIPAL,
                                                                  bsl::nullopt);
         return 0;  // RETURN

--- a/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.h
@@ -118,8 +118,6 @@ class AnonAuthenticator : public mqbplug::Authenticator {
     BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.ANONAUTHENTICATOR");
 
     // DATA
-    bslma::Allocator* d_allocator_p;
-
     bool d_isStarted;
 
     /// If true, authentication always succeeds; if false, always fails.
@@ -161,8 +159,8 @@ class AnonAuthenticator : public mqbplug::Authenticator {
     /// Behavior depends on the `shouldPass` configuration.
     int authenticate(bsl::ostream& errorDescription,
                      bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-                     const mqbplug::AuthenticationData& input) const
-        BSLS_KEYWORD_OVERRIDE;
+                     const mqbplug::AuthenticationData&              input,
+                     bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
@@ -451,7 +451,8 @@ int AuthenticationController::authenticate(
     bsl::ostream&                                   errorDescription,
     bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
     bsl::string_view                                mechanism,
-    const mqbplug::AuthenticationData&              input)
+    const mqbplug::AuthenticationData&              input,
+    bslma::Allocator*                               allocator)
 {
     // executed by an *AUTHENTICATION* thread
 
@@ -475,7 +476,8 @@ int AuthenticationController::authenticate(
                        << "')";
 
         bmqu::MemOutStream errorStream(d_allocator_p);
-        const int rc = authenticator->authenticate(errorStream, result, input);
+        const int          rc =
+            authenticator->authenticate(errorStream, result, input, allocator);
         if (rc != rc_SUCCESS) {
             errorDescription << "Failed to authenticate with mechanism '"
                              << normMech << "'. (rc = " << rc

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
@@ -161,10 +161,13 @@ class AuthenticationController {
     /// Return 0 on success, or a non-zero return code on error and fill in the
     /// specified `errorDescription` stream with the description of the error.
     /// Note that the `mechanism` is case insensitive.
+    /// Any memory allocated for the specified `result` uses the specified
+    /// `allocator`.
     int authenticate(bsl::ostream& errorDescription,
                      bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
                      bsl::string_view                                mechanism,
-                     const mqbplug::AuthenticationData&              input);
+                     const mqbplug::AuthenticationData&              input,
+                     bslma::Allocator* allocator);
 
     /// Return the anonymous credential used for authentication.
     /// If no anonymous credential is set, return an empty optional.

--- a/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.cpp
@@ -135,7 +135,8 @@ bsl::string_view BasicAuthenticator::mechanism() const
 int BasicAuthenticator::authenticate(
     bsl::ostream&                                   errorDescription,
     bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-    const mqbplug::AuthenticationData&              input) const
+    const mqbplug::AuthenticationData&              input,
+    bslma::Allocator*                               allocator) const
 {
     BALL_LOG_DEBUG << "Authentication using mechanism '" << mechanism()
                    << "'.";
@@ -166,7 +167,7 @@ int BasicAuthenticator::authenticate(
                    << "'";
 
     *result = bsl::allocate_shared<BasicAuthenticationResult>(
-        d_allocator_p,
+        allocator,
         "BASIC_USER-" + bsl::string(username, d_allocator_p),
         k_AUTHN_DURATION_SECONDS *
             bdlt::TimeUnitRatio::k_MILLISECONDS_PER_SECOND);

--- a/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.h
@@ -146,8 +146,8 @@ class BasicAuthenticator : public mqbplug::Authenticator {
     ///   logging purposes.
     int authenticate(bsl::ostream& errorDescription,
                      bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-                     const mqbplug::AuthenticationData& input) const
-        BSLS_KEYWORD_OVERRIDE;
+                     const mqbplug::AuthenticationData&              input,
+                     bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.cpp
@@ -81,10 +81,8 @@ TestAuthenticationResult::lifetimeMs() const
 // -----------------------
 
 TestAuthenticator::TestAuthenticator(
-    const mqbcfg::AuthenticatorPluginConfig* config,
-    bslma::Allocator*                        allocator)
-: d_allocator_p(allocator)
-, d_isStarted(false)
+    const mqbcfg::AuthenticatorPluginConfig* config)
+: d_isStarted(false)
 , d_sleepTimeMs(0)
 {
     if (!config) {
@@ -129,7 +127,8 @@ bsl::string_view TestAuthenticator::mechanism() const
 int TestAuthenticator::authenticate(
     BSLA_MAYBE_UNUSED bsl::ostream&                 errorDescription,
     bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-    BSLA_MAYBE_UNUSED const mqbplug::AuthenticationData& input) const
+    BSLA_MAYBE_UNUSED const mqbplug::AuthenticationData& input,
+    bslma::Allocator*                                    allocator) const
 {
     BALL_LOG_INFO << "TestAuthenticator: authentication using mechanism '"
                   << mechanism() << "'.";
@@ -147,7 +146,7 @@ int TestAuthenticator::authenticate(
     BALL_LOG_INFO << "TestAuthenticator: authentication successful";
 
     *result = bsl::allocate_shared<TestAuthenticationResult>(
-        d_allocator_p,
+        allocator,
         "TEST_USER",
         k_AUTHN_DURATION_SECONDS *
             bdlt::TimeUnitRatio::k_MILLISECONDS_PER_SECOND);
@@ -209,7 +208,7 @@ TestAuthenticatorPluginFactory::create(bslma::Allocator* allocator)
     allocator = bslma::Default::allocator(allocator);
 
     return bslma::ManagedPtr<mqbplug::Authenticator>(
-        new (*allocator) TestAuthenticator(config, allocator),
+        new (*allocator) TestAuthenticator(config),
         allocator);
 }
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.h
@@ -101,8 +101,6 @@ class TestAuthenticator : public mqbplug::Authenticator {
     BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.TESTAUTHENTICATOR");
 
     // DATA
-    bslma::Allocator* d_allocator_p;
-
     bool d_isStarted;
 
     int d_sleepTimeMs;  // Sleep time in milliseconds before authentication
@@ -120,8 +118,7 @@ class TestAuthenticator : public mqbplug::Authenticator {
 
     // CREATORS
 
-    TestAuthenticator(const mqbcfg::AuthenticatorPluginConfig* config,
-                      bslma::Allocator*                        allocator = 0);
+    TestAuthenticator(const mqbcfg::AuthenticatorPluginConfig* config);
 
     /// Destructor.
     ~TestAuthenticator() BSLS_KEYWORD_OVERRIDE;
@@ -143,8 +140,8 @@ class TestAuthenticator : public mqbplug::Authenticator {
     ///   logging purposes.
     int authenticate(bsl::ostream& errorDescription,
                      bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-                     const mqbplug::AuthenticationData& input) const
-        BSLS_KEYWORD_OVERRIDE;
+                     const mqbplug::AuthenticationData&              input,
+                     bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
 

--- a/src/groups/mqb/mqbplug/mqbplug_authenticator.h
+++ b/src/groups/mqb/mqbplug/mqbplug_authenticator.h
@@ -44,6 +44,7 @@
 #include <bsl_string.h>
 #include <bsl_string_view.h>
 #include <bsl_vector.h>
+#include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -132,13 +133,16 @@ class Authenticator {
     /// - Return `0` on success, and populate the specified `result` with
     ///   client identity and its remaining lifetime if it has a fixed
     ///   duration.
+    /// - Allocate any memory used by the specified `result` using the
+    ///   specified non-null `allocator`.
     /// - Return a non-zero plugin-specific return code upon failure, and
     ///   populate the specified `errorDescription` with a brief reason for
     ///   logging purposes.
     virtual int
     authenticate(bsl::ostream& errorDescription,
                  bsl::shared_ptr<mqbplug::AuthenticationResult>* result,
-                 const AuthenticationData& input) const = 0;
+                 const AuthenticationData&                       input,
+                 bslma::Allocator* allocator) const = 0;
 
     // MANIPULATORS
 


### PR DESCRIPTION
**Describe your changes**
`authenticate()` is expected to populate an output object. In BDE-style, output allocations are controlled by the caller, so the caller needs to explicitly pass an allocator. This change makes the memory ownership clear to plugin authors.