### PR TITLE
fix: spelling typos 'overriden' -> 'overridden' and 'COMPARISION' -> 'COMPARISON'

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_abstractsession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_abstractsession.t.cpp
@@ -416,13 +416,13 @@ static void test2_instanceInvariants()
 // INSTANCE INVARIANTS:
 //   Ensure that 'AbstractSession' and deriving classes can yield an
 //   instance, and that any method of that instance that has not been
-//   overriden fires an assert upon attempted use.
+//   overridden fires an assert upon attempted use.
 //
 // Concerns:
 //: 1 The protocol is NOT abstract: objects of it can be created.
 //:
 //: 2 Instances of the class are dysfunctional: methods that have not been
-//:   overriden fire an assert upon attempted usage.
+//:   overridden fire an assert upon attempted usage.
 //:
 // Plan:
 //: 1 Define a concrete derived implementation, 'AbstractSessionDummyImp',
@@ -431,9 +431,9 @@ static void test2_instanceInvariants()
 //: 2 Create an object of the 'AbstractSessionDummyImp' and use it to
 //:   verify that:
 //:
-//:   1 Methods that have not been overriden fire an assert.
+//:   1 Methods that have not been overridden fire an assert.
 //:
-//:   2 Methods that have been overriden do not fire an assert.
+//:   2 Methods that have been overridden do not fire an assert.
 //:
 // Testing:
 //   INSTANCE INVARIANTS
@@ -450,7 +450,7 @@ static void test2_instanceInvariants()
     PV("Creating a test object");
     AbstractSessionDummyImp testObj;
 
-    PV("Verify that non-overriden methods fire an assert");
+    PV("Verify that non-overridden methods fire an assert");
 
     bmqa::ConfirmEventBuilder*      dummyConfirmEventBuilderPtr = 0;
     bmqa::Message                   dummyMessage;
@@ -602,7 +602,7 @@ static void test2_instanceInvariants()
     BMQTST_ASSERT_OPT_FAIL(
         testObj.confirmMessages(dummyConfirmEventBuilderPtr));
 
-    PV("Verify that overriden methods execute as intended");
+    PV("Verify that overridden methods execute as intended");
 
     BMQTST_ASSERT_OPT_PASS(testObj.configureMessageDumping(""));
     BMQTST_ASSERT_EQ(testObj.configureMessageDumping(""), -1497);

--- a/src/groups/bmq/bmqa/bmqa_configurequeuestatus.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_configurequeuestatus.t.cpp
@@ -135,7 +135,7 @@ static void test1_breathingTest()
 
 static void test2_comparison()
 // ------------------------------------------------------------------------
-// COMPARISION
+// COMPARISON
 //
 // Concerns:
 //   Exercise 'bmqa::ConfigureQueueStatus' comparison operators

--- a/src/groups/bmq/bmqa/bmqa_openqueuestatus.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_openqueuestatus.t.cpp
@@ -135,7 +135,7 @@ static void test1_breathingTest()
 
 static void test2_comparison()
 // ------------------------------------------------------------------------
-// COMPARISION
+// COMPARISON
 //
 // Concerns:
 //   Exercise 'bmqa::OpenQueueStatus' comparison operators

--- a/src/groups/bmq/bmqa/bmqa_queueid.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_queueid.t.cpp
@@ -183,7 +183,7 @@ static void test1_breathingTest()
 
 static void test2_comparison()
 // ------------------------------------------------------------------------
-// COMPARISION
+// COMPARISON
 //
 // Concerns:
 //   Exercise 'bmqa::QueueId' comparison operators

--- a/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
@@ -339,9 +339,9 @@ static void test4_printTest()
     BMQTST_ASSERT_EQ(out.str(), expected.str());
 }
 
-static void test5_comparisionTest()
+static void test5_comparisonTest()
 // --------------------------------------------------------------------
-// COMPARISION TEST
+// COMPARISON TEST
 //
 // Concerns:
 //   Exercise bmqimp::Queue comparison
@@ -357,7 +357,7 @@ static void test5_comparisionTest()
 //   bool operator==(const bmqimp::Queue& lhs, const bmqimp::Queue& rhs);
 // --------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("COMPARISION TEST");
+    bmqtst::TestHelper::printTestName("COMPARISON TEST");
 
     bmqimp::Queue obj1(bmqtst::TestHelperUtil::allocator());
     bmqimp::Queue obj2(bmqtst::TestHelperUtil::allocator());
@@ -525,7 +525,7 @@ int main(int argc, char* argv[])
     switch (_testCase) {
     case 0:
     case 6: test6_statTest(); break;
-    case 5: test5_comparisionTest(); break;
+    case 5: test5_comparisonTest(); break;
     case 4: test4_printTest(); break;
     case 3: test3_printQueueStateTest(); break;
     case 2: test2_settersTest(); break;

--- a/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_alarmlog.h
@@ -211,7 +211,7 @@ class AlarmLog : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
-    /// Note: this member is overriden to get rid of the "hides the virtual
+    /// Note: this member is overridden to get rid of the "hides the virtual
     ///       function" warning.
     inline void publish(const bsl::shared_ptr<const ball::Record>& record,
                         const ball::Context& context) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h
@@ -241,7 +241,7 @@ class ConsoleObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
-    /// Note: this member is overriden to get rid of the "hides the virtual
+    /// Note: this member is overridden to get rid of the "hides the virtual
     ///       function" warning.
     inline void publish(const bsl::shared_ptr<const ball::Record>& record,
                         const ball::Context& context) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
+++ b/src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h
@@ -167,7 +167,7 @@ class SyslogObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
-    /// Note: this member is overriden to get rid of the "hides the virtual
+    /// Note: this member is overridden to get rid of the "hides the virtual
     ///       function" warning.
     inline void publish(const bsl::shared_ptr<const ball::Record>& record,
                         const ball::Context& context) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
+++ b/src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h
@@ -147,7 +147,7 @@ class ScopedLogObserver : public ball::ObserverAdapter {
     void publish(const ball::Record&  record,
                  const ball::Context& context) BSLS_KEYWORD_OVERRIDE;
 
-    /// Note: this member is overriden to get rid of the "hides the virtual
+    /// Note: this member is overridden to get rid of the "hides the virtual
     ///       function" warning.
     inline void publish(const bsl::shared_ptr<const ball::Record>& record,
                         const ball::Context& context) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -240,7 +240,7 @@ class InitialConnectionContext {
     /// implementation before invoking the
     /// 'InitialConnectionCompleteCb'.  This is used to bind low level
     /// data (from transport layer) to the session; and
-    /// can be overriden/set by the negotiation
+    /// can be overridden/set by the negotiation
     /// implementation (typically for the case of
     /// 'listen' sessions, since those are
     /// 'sporadically' happening and there is not enough


### PR DESCRIPTION
Closes #1270 and #1272.

Two spelling typos flagged as good first issues:

- `overriden` -> `overridden` (#1270)
- `COMPARISION` / `comparision` -> `COMPARISON` / `comparison` (#1272)

Both are comment-only and test-name changes - no behavior change.

## Files changed

`overriden` -> `overridden` (in comments):
- `src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h`
- `src/groups/bmq/bmqtst/bmqtst_scopedlogobserver.h`
- `src/groups/bmq/bmqa/bmqa_abstractsession.t.cpp` (8 occurrences)
- `src/groups/bmq/bmqtsk/bmqtsk_alarmlog.h`
- `src/groups/bmq/bmqtsk/bmqtsk_syslogobserver.h`
- `src/groups/bmq/bmqtsk/bmqtsk_consoleobserver.h`

`COMPARISION` -> `COMPARISON` (test files):
- `src/groups/bmq/bmqa/bmqa_queueid.t.cpp` (comment)
- `src/groups/bmq/bmqa/bmqa_configurequeuestatus.t.cpp` (comment)
- `src/groups/bmq/bmqa/bmqa_openqueuestatus.t.cpp` (comment)
- `src/groups/bmq/bmqimp/bmqimp_queue.t.cpp`:
  - Comment header `// COMPARISION` -> `// COMPARISON`
  - Function `test5_comparisionTest` -> `test5_comparisonTest`
  - Dispatch `case 5: test5_comparisionTest()` -> `test5_comparisonTest()`
  - Printed test name `"COMPARISION TEST"` -> `"COMPARISON TEST"`

Function rename and the dispatch are kept consistent in the same commit, so the test still wires up under case 5.

Verified `grep` finds no remaining instances of `overriden`, `Overriden`, `OVERRIDEN`, `comparision`, `Comparision`, `COMPARISION` across the repo.

Commit is DCO-signed.