### PR TITLE
Remove: Execution Policy Direction Polymorphism

### DIFF
--- a/src/groups/bmq/bmqex/bmqex_bdlmteventschedulerexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_bdlmteventschedulerexecutor.h
@@ -43,8 +43,7 @@
 //  bmqex::BdlmtEventSchedulerExecutor ex(&d_eventScheduler);
 //
 //  // use it
-//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-//                                                           .neverBlocking()
+//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::neverBlocking()
 //                                                           .useExecutor(ex),
 //                                [](){ bsl::cout << "Hello World!\n"; });
 //..

--- a/src/groups/bmq/bmqex/bmqex_bdlmtfixedthreadpoolexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtfixedthreadpoolexecutor.h
@@ -43,8 +43,7 @@
 //  bmqex::BdlmtFixedThreadPoolExecutor ex(&d_threadPool);
 //
 //  // use it
-//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-//                                                           .neverBlocking()
+//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::neverBlocking()
 //                                                           .useExecutor(ex),
 //                                [](){ bsl::cout << "Hello World!\n"; });
 //..

--- a/src/groups/bmq/bmqex/bmqex_bdlmtmultiprioritythreadpoolexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtmultiprioritythreadpoolexecutor.h
@@ -45,8 +45,7 @@
 //  bmqex::BdlmtMultipriorityThreadPoolExecutor ex(&d_threadPool, d_priority);
 //
 //  // use it
-//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-//                                                           .neverBlocking()
+//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::neverBlocking()
 //                                                           .useExecutor(ex),
 //                                [](){ bsl::cout << "Hello World!\n"; });
 //..

--- a/src/groups/bmq/bmqex/bmqex_bdlmtmultiqueuethreadpoolexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtmultiqueuethreadpoolexecutor.h
@@ -45,8 +45,7 @@
 //  bmqex::BdlmtMultiQueueThreadPoolExecutor ex(&d_threadPool, d_queueId);
 //
 //  // use it
-//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-//                                                           .neverBlocking()
+//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::neverBlocking()
 //                                                           .useExecutor(ex),
 //                                [](){ bsl::cout << "Hello World!\n"; });
 //..

--- a/src/groups/bmq/bmqex/bmqex_bdlmtthreadpoolexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_bdlmtthreadpoolexecutor.h
@@ -43,8 +43,7 @@
 //  bmqex::BdlmtThreadPoolExecutor ex(&d_threadPool);
 //
 //  // use it
-//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-//                                                           .neverBlocking()
+//  bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::neverBlocking()
 //                                                           .useExecutor(ex),
 //                                [](){ bsl::cout << "Hello World!\n"; });
 //..

--- a/src/groups/bmq/bmqex/bmqex_bindutil.h
+++ b/src/groups/bmq/bmqex/bmqex_bindutil.h
@@ -39,8 +39,7 @@
 //  {
 //      // execute 'doHeavyStuff' in a separate thread (use system executor)
 //      bmqex::ExecutionUtil::execute(
-//                                 bmqex::ExecutionPolicyUtil::oneWay()
-//                                                            .neverBlocking(),
+//                                 bmqex::ExecutionPolicyUtil::neverBlocking(),
 //                                 &doHeavyStuff);
 //  }
 //
@@ -68,8 +67,7 @@
 //                             &g_heavyStuffEvent,
 //                             bsls::TimeInterval(10.0), // 10 sec
 //                             bmqex::BindUtil::bindExecute(
-//                                 bmqex::ExecutionPolicyUtil::oneWay()
-//                                                            .neverBlocking(),
+//                                 bmqex::ExecutionPolicyUtil::neverBlocking(),
 //                                 &doHeavyStuff));
 //..
 //
@@ -102,8 +100,7 @@
 //  {
 //      // execute 'processEvent' in a separate thread (use system executor)
 //      bmqex::ExecutionUtil::execute(
-//                             bmqex::ExecutionPolicyUtil::oneWay()
-//                                                        .neverBlocking(),
+//                             bmqex::ExecutionPolicyUtil::neverBlocking(),
 //                             bdlf::BindUtil::bind(&processEvent, eventCode));
 //  }
 //
@@ -125,8 +122,7 @@
 //..
 //  // subscribe to notifications
 //  g_observable_p->subscribe(bmqex::BindUtil::bindExecute(
-//                                 bmqex::ExecutionPolicyUtil::oneWay()
-//                                                            .neverBlocking(),
+//                                 bmqex::ExecutionPolicyUtil::neverBlocking(),
 //                                 &processEvent));
 //..
 //

--- a/src/groups/bmq/bmqex/bmqex_executionpolicy.h
+++ b/src/groups/bmq/bmqex/bmqex_executionpolicy.h
@@ -63,8 +63,7 @@
 // 'ExecutionPolicyUtil' namespace, they mirror each transformation operation
 // accessible on a policy object. For example:
 //..
-//  bmqex::ExecutionPolicyUtil::oneWay()
-//                             .neverBlocking()
+//  bmqex::ExecutionPolicyUtil::neverBlocking()
 //                             .useExecutor(myExecutor)
 //                             .useAllocator(myAllocator);
 //..
@@ -91,8 +90,7 @@
 //
 //  auto myFunction = []() -> void { bsl::cout << "It works!\n"; };
 //
-//  ExecutionUtil::execute(ExecutionPolicyUtil::oneWay()
-//                                             .neverBlocking()
+//  ExecutionUtil::execute(ExecutionPolicyUtil::neverBlocking()
 //                                             .useExecutor(myExecutor),
 //                         myFunction);
 //..
@@ -194,10 +192,6 @@ class ExecutionPolicy {
     // ACCESSORS
 
     /// Return a policy object having the same properties as this one,
-    /// except that it is One-Way.
-    typename RebindOneWay::Type oneWay() const;
-
-    /// Return a policy object having the same properties as this one,
     /// except that it is Never Blocking.
     ExecutionPolicy neverBlocking() const;
 
@@ -241,10 +235,6 @@ struct ExecutionPolicyUtil {
     /// Blocking policy using a default-constructed `bmqex::SystemExecutor`
     /// and the currently installed default allocator.
     static ExecutionPolicy<> defaultPolicy();
-
-    /// Return a One-Way execution policy as if by
-    /// `return defaultPolicy().oneWay()`.
-    static ExecutionPolicy<>::RebindOneWay::Type oneWay();
 
     /// Return a Never Blocking execution policy as if by
     /// `return defaultPolicy().neverBlocking()`.
@@ -305,13 +295,6 @@ ExecutionPolicy<DIRECTION, EXECUTOR>::ExecutionPolicy(
 }
 
 // ACCESSORS
-template <class DIRECTION, class EXECUTOR>
-inline typename ExecutionPolicy<DIRECTION, EXECUTOR>::RebindOneWay::Type
-ExecutionPolicy<DIRECTION, EXECUTOR>::oneWay() const
-{
-    return typename RebindOneWay::Type(d_blocking, d_executor, d_allocator_p);
-}
-
 template <class DIRECTION, class EXECUTOR>
 inline ExecutionPolicy<DIRECTION, EXECUTOR>
 ExecutionPolicy<DIRECTION, EXECUTOR>::neverBlocking() const
@@ -393,11 +376,6 @@ inline ExecutionPolicy<> ExecutionPolicyUtil::defaultPolicy()
     return ExecutionPolicy<>(ExecutionProperty::e_POSSIBLY_BLOCKING,
                              SystemExecutor(),
                              bslma::Default::allocator());
-}
-
-inline ExecutionPolicy<>::RebindOneWay::Type ExecutionPolicyUtil::oneWay()
-{
-    return defaultPolicy().oneWay();
 }
 
 inline ExecutionPolicy<> ExecutionPolicyUtil::neverBlocking()

--- a/src/groups/bmq/bmqex/bmqex_executionpolicy.h
+++ b/src/groups/bmq/bmqex/bmqex_executionpolicy.h
@@ -31,9 +31,6 @@
 // used to customize the behavior of execution functions provided by the
 // 'bmqex_executionutil' component. A policy object contains the following
 // properties:
-//: o Directionality. Is One-Way (for more information see package
-//:   documentation).
-//:
 //: o Blocking behavior. Is Never Blocking, Possibly Blocking or Always
 //:   Blocking (for more information see package documentation).
 //:
@@ -50,9 +47,9 @@
 // Policies are lightweight immutable objects. Given a policy object 'p1'
 // having some set of properties, a new policy 'p2' having a different set of
 // properties can be "built" from the first one by applying transformation
-// operations to it. For example, lets say we have a One-Way Never Blocking
-// policy 'p', and we want to transform it to a One-Way Always Blocking policy.
-// The corresponding expression looks like:
+// operations to it. For example, lets say we have a Never Blocking policy
+// 'p', and we want to transform it to an Always Blocking policy. The
+// corresponding expression looks like:
 //..
 //  p.alwaysBlocking();
 //..
@@ -67,9 +64,9 @@
 //                             .useExecutor(myExecutor)
 //                             .useAllocator(myAllocator);
 //..
-// The result of the expression below is a One-Way Never Blocking execution
-// policy that has its associated executor and its associated allocator set to
-// the specified 'myExecutor' and 'myAllocator' respectively.
+// The result of the expression below is a Never Blocking execution policy
+// that has its associated executor and its associated allocator set to the
+// specified 'myExecutor' and 'myAllocator' respectively.
 //
 /// Using policies to execute function objects
 ///------------------------------------------
@@ -77,14 +74,14 @@
 // 'bmqex_executionutil' component that provides a set of execution functions
 // named 'execute', defined in the 'bmqex::ExecutionUtil' namespace. 'execute'
 // accepts an execution policy and a function object to be executed according
-// to the specified policy. One-Way execution functions return 'void'. The
-// exact type of the execution function return value can be obtained at compile
-// time using the 'bmqex::ExecutionUtil::ExecuteResult' metafunction (see
+// to the specified policy. Execution functions return 'void'. The exact type
+// of the execution function return value can be obtained at compile time
+// using the 'bmqex::ExecutionUtil::ExecuteResult' metafunction (see
 // 'bmqex_executionutil').
 //
 // Lets say we are to execute a function object 'myFunction' on an unspecified
 // execution context associated with an executor object 'myExecutor'. If what
-// we desire is "fire and forget", then we would use a One-Way policy:
+// we desire is "fire and forget":
 //..
 //  using bmqex;
 //
@@ -101,7 +98,6 @@
 // BDE
 #include <bslma_allocator.h>
 #include <bslma_default.h>
-#include <bslmf_issame.h>
 #include <bslmf_movableref.h>
 #include <bslmf_util.h>
 #include <bsls_assert.h>
@@ -115,14 +111,12 @@ namespace bmqex {
 // class ExecutionPolicy
 // =====================
 
-/// Provides an execution policy having its direction property and
-/// associated executor type defined by the types of the specified
-/// `DIRECTION` and `EXECUTOR` template parameters.
+/// Provides an execution policy having its associated executor type
+/// defined by the type of the specified `EXECUTOR` template parameter.
 ///
 /// Note that instances of this class should not be created explicitly,
 /// instead use the `ExecutionPolicyUtil` factory methods.
-template <class DIRECTION = ExecutionProperty::OneWay,
-          class EXECUTOR  = SystemExecutor>
+template <class EXECUTOR = SystemExecutor>
 class ExecutionPolicy {
   public:
     // TYPES
@@ -130,28 +124,14 @@ class ExecutionPolicy {
     /// Defines the type of the associated executor.
     typedef EXECUTOR ExecutorType;
 
-    /// Provides a way to obtain the type of a One-Way execution policy
-    /// otherwise having the same properties as this one.
-    struct RebindOneWay {
-        // TYPES
-        typedef ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR> Type;
-    };
-
     /// Provides a way to obtain the type of an execution policy having
     /// the specified associated `EXECUTOR_T` type and otherwise having
     /// the same properties as this one.
     template <class EXECUTOR_T>
     struct RebindExecutor {
         // TYPES
-        typedef ExecutionPolicy<DIRECTION, EXECUTOR_T> Type;
+        typedef ExecutionPolicy<EXECUTOR_T> Type;
     };
-
-  public:
-    // CLASS DATA
-
-    /// Defines if this policy is One-Way.
-    static BSLS_KEYWORD_CONSTEXPR_MEMBER bool k_IS_ONE_WAY =
-        bsl::is_same<DIRECTION, ExecutionProperty::OneWay>::value;
 
   private:
     // PRIVATE DATA
@@ -162,7 +142,7 @@ class ExecutionPolicy {
     bslma::Allocator* d_allocator_p;
 
     // FRIENDS
-    template <class, class>
+    template <class>
     friend class ExecutionPolicy;
 
   private:
@@ -185,8 +165,8 @@ class ExecutionPolicy {
     ///
     /// `EXECUTOR` shall be constructible from `OTHER_EXECUTOR`.
     template <class OTHER_EXECUTOR>
-    BSLS_KEYWORD_CONSTEXPR_CPP14 ExecutionPolicy(
-        const ExecutionPolicy<DIRECTION, OTHER_EXECUTOR>& original);
+    BSLS_KEYWORD_CONSTEXPR_CPP14
+    ExecutionPolicy(const ExecutionPolicy<OTHER_EXECUTOR>& original);
 
   public:
     // ACCESSORS
@@ -231,9 +211,9 @@ class ExecutionPolicy {
 struct ExecutionPolicyUtil {
     // CLASS METHODS
 
-    /// Return the default execution policy, that is a One-Way Possibly
-    /// Blocking policy using a default-constructed `bmqex::SystemExecutor`
-    /// and the currently installed default allocator.
+    /// Return the default execution policy, that is a Possibly Blocking
+    /// policy using a default-constructed `bmqex::SystemExecutor` and the
+    /// currently installed default allocator.
     static ExecutionPolicy<> defaultPolicy();
 
     /// Return a Never Blocking execution policy as if by
@@ -268,9 +248,8 @@ struct ExecutionPolicyUtil {
 // ---------------------
 
 // CREATORS
-template <class DIRECTION, class EXECUTOR>
-inline BSLS_KEYWORD_CONSTEXPR_CPP14
-ExecutionPolicy<DIRECTION, EXECUTOR>::ExecutionPolicy(
+template <class EXECUTOR>
+inline BSLS_KEYWORD_CONSTEXPR_CPP14 ExecutionPolicy<EXECUTOR>::ExecutionPolicy(
     ExecutionProperty::Blocking blocking,
     EXECUTOR                    executor,
     bslma::Allocator*           allocator)
@@ -282,11 +261,10 @@ ExecutionPolicy<DIRECTION, EXECUTOR>::ExecutionPolicy(
     BSLS_ASSERT(allocator);
 }
 
-template <class DIRECTION, class EXECUTOR>
+template <class EXECUTOR>
 template <class OTHER_EXECUTOR>
-inline BSLS_KEYWORD_CONSTEXPR_CPP14
-ExecutionPolicy<DIRECTION, EXECUTOR>::ExecutionPolicy(
-    const ExecutionPolicy<DIRECTION, OTHER_EXECUTOR>& original)
+inline BSLS_KEYWORD_CONSTEXPR_CPP14 ExecutionPolicy<EXECUTOR>::ExecutionPolicy(
+    const ExecutionPolicy<OTHER_EXECUTOR>& original)
 : d_blocking(original.d_blocking)
 , d_executor(original.d_executor)
 , d_allocator_p(original.d_allocator_p)
@@ -295,39 +273,38 @@ ExecutionPolicy<DIRECTION, EXECUTOR>::ExecutionPolicy(
 }
 
 // ACCESSORS
-template <class DIRECTION, class EXECUTOR>
-inline ExecutionPolicy<DIRECTION, EXECUTOR>
-ExecutionPolicy<DIRECTION, EXECUTOR>::neverBlocking() const
+template <class EXECUTOR>
+inline ExecutionPolicy<EXECUTOR>
+ExecutionPolicy<EXECUTOR>::neverBlocking() const
 {
     return ExecutionPolicy(ExecutionProperty::e_NEVER_BLOCKING,
                            d_executor,
                            d_allocator_p);
 }
 
-template <class DIRECTION, class EXECUTOR>
-inline ExecutionPolicy<DIRECTION, EXECUTOR>
-ExecutionPolicy<DIRECTION, EXECUTOR>::possiblyBlocking() const
+template <class EXECUTOR>
+inline ExecutionPolicy<EXECUTOR>
+ExecutionPolicy<EXECUTOR>::possiblyBlocking() const
 {
     return ExecutionPolicy(ExecutionProperty::e_POSSIBLY_BLOCKING,
                            d_executor,
                            d_allocator_p);
 }
 
-template <class DIRECTION, class EXECUTOR>
-inline ExecutionPolicy<DIRECTION, EXECUTOR>
-ExecutionPolicy<DIRECTION, EXECUTOR>::alwaysBlocking() const
+template <class EXECUTOR>
+inline ExecutionPolicy<EXECUTOR>
+ExecutionPolicy<EXECUTOR>::alwaysBlocking() const
 {
     return ExecutionPolicy(ExecutionProperty::e_ALWAYS_BLOCKING,
                            d_executor,
                            d_allocator_p);
 }
 
-template <class DIRECTION, class EXECUTOR>
+template <class EXECUTOR>
 template <class EXECUTOR_PARAM>
-inline typename ExecutionPolicy<DIRECTION, EXECUTOR>::template RebindExecutor<
+inline typename ExecutionPolicy<EXECUTOR>::template RebindExecutor<
     EXECUTOR_PARAM>::Type
-ExecutionPolicy<DIRECTION, EXECUTOR>::useExecutor(
-    EXECUTOR_PARAM executor) const
+ExecutionPolicy<EXECUTOR>::useExecutor(EXECUTOR_PARAM executor) const
 {
     return typename RebindExecutor<EXECUTOR_PARAM>::Type(
         d_blocking,
@@ -335,10 +312,9 @@ ExecutionPolicy<DIRECTION, EXECUTOR>::useExecutor(
         d_allocator_p);
 }
 
-template <class DIRECTION, class EXECUTOR>
-inline ExecutionPolicy<DIRECTION, EXECUTOR>
-ExecutionPolicy<DIRECTION, EXECUTOR>::useAllocator(
-    bslma::Allocator* allocator) const
+template <class EXECUTOR>
+inline ExecutionPolicy<EXECUTOR>
+ExecutionPolicy<EXECUTOR>::useAllocator(bslma::Allocator* allocator) const
 {
     // PRECONDITIONS
     BSLS_ASSERT(allocator);
@@ -346,23 +322,23 @@ ExecutionPolicy<DIRECTION, EXECUTOR>::useAllocator(
     return ExecutionPolicy(d_blocking, d_executor, allocator);
 }
 
-template <class DIRECTION, class EXECUTOR>
+template <class EXECUTOR>
 inline ExecutionProperty::Blocking
-ExecutionPolicy<DIRECTION, EXECUTOR>::blocking() const BSLS_KEYWORD_NOEXCEPT
+ExecutionPolicy<EXECUTOR>::blocking() const BSLS_KEYWORD_NOEXCEPT
 {
     return d_blocking;
 }
 
-template <class DIRECTION, class EXECUTOR>
+template <class EXECUTOR>
 inline const EXECUTOR&
-ExecutionPolicy<DIRECTION, EXECUTOR>::executor() const BSLS_KEYWORD_NOEXCEPT
+ExecutionPolicy<EXECUTOR>::executor() const BSLS_KEYWORD_NOEXCEPT
 {
     return d_executor;
 }
 
-template <class DIRECTION, class EXECUTOR>
+template <class EXECUTOR>
 inline bslma::Allocator*
-ExecutionPolicy<DIRECTION, EXECUTOR>::allocator() const BSLS_KEYWORD_NOEXCEPT
+ExecutionPolicy<EXECUTOR>::allocator() const BSLS_KEYWORD_NOEXCEPT
 {
     return d_allocator_p;
 }

--- a/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
@@ -56,7 +56,7 @@ static void test1_policy_constructor()
     bslma::TestAllocator allocator;
 
     // construct
-    bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType> p(
+    bmqex::ExecutionPolicy<ExecutorType> p(
         bmqex::ExecutionProperty::e_NEVER_BLOCKING,
         executor,
         &allocator);
@@ -92,14 +92,13 @@ static void test2_policy_copyConstructor()
     // regular copy
     {
         // make original
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            original(bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
-                     executor,
-                     &allocator);
+        bmqex::ExecutionPolicy<ExecutorType1> original(
+            bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
+            executor,
+            &allocator);
 
         // make a copy
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            copy = original;
+        bmqex::ExecutionPolicy<ExecutorType1> copy = original;
 
         // check the copy
         BMQTST_ASSERT_EQ(copy.blocking(), original.blocking());
@@ -110,14 +109,13 @@ static void test2_policy_copyConstructor()
     // executor-converting copy
     {
         // make original
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            original(bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
-                     executor,
-                     &allocator);
+        bmqex::ExecutionPolicy<ExecutorType1> original(
+            bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
+            executor,
+            &allocator);
 
         // make a copy
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType2>
-            copy = original;
+        bmqex::ExecutionPolicy<ExecutorType2> copy = original;
 
         // check the copy
         BMQTST_ASSERT_EQ(copy.blocking(), original.blocking());
@@ -159,13 +157,12 @@ static void test3_policy_transformations()
 
     // neverBlocking
     {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
-               executor1,
-               &allocator1);
+        bmqex::ExecutionPolicy<ExecutorType1> p1(
+            bmqex::ExecutionProperty::e_ALWAYS_BLOCKING,
+            executor1,
+            &allocator1);
 
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p2 = p1.neverBlocking();
+        bmqex::ExecutionPolicy<ExecutorType1> p2 = p1.neverBlocking();
 
         BMQTST_ASSERT_EQ(p2.blocking(),
                          bmqex::ExecutionProperty::e_NEVER_BLOCKING);
@@ -175,13 +172,12 @@ static void test3_policy_transformations()
 
     // possiblyBlocking
     {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_NEVER_BLOCKING,
-               executor1,
-               &allocator1);
+        bmqex::ExecutionPolicy<ExecutorType1> p1(
+            bmqex::ExecutionProperty::e_NEVER_BLOCKING,
+            executor1,
+            &allocator1);
 
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p2 = p1.possiblyBlocking();
+        bmqex::ExecutionPolicy<ExecutorType1> p2 = p1.possiblyBlocking();
 
         BMQTST_ASSERT_EQ(p2.blocking(),
                          bmqex::ExecutionProperty::e_POSSIBLY_BLOCKING);
@@ -191,13 +187,12 @@ static void test3_policy_transformations()
 
     // alwaysBlocking
     {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_NEVER_BLOCKING,
-               executor1,
-               &allocator1);
+        bmqex::ExecutionPolicy<ExecutorType1> p1(
+            bmqex::ExecutionProperty::e_NEVER_BLOCKING,
+            executor1,
+            &allocator1);
 
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p2 = p1.alwaysBlocking();
+        bmqex::ExecutionPolicy<ExecutorType1> p2 = p1.alwaysBlocking();
 
         BMQTST_ASSERT_EQ(p2.blocking(),
                          bmqex::ExecutionProperty::e_ALWAYS_BLOCKING);
@@ -207,13 +202,12 @@ static void test3_policy_transformations()
 
     // useExecutor
     {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_NEVER_BLOCKING,
-               executor1,
-               &allocator1);
+        bmqex::ExecutionPolicy<ExecutorType1> p1(
+            bmqex::ExecutionProperty::e_NEVER_BLOCKING,
+            executor1,
+            &allocator1);
 
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType2>
-            p2 = p1.useExecutor(executor2);
+        bmqex::ExecutionPolicy<ExecutorType2> p2 = p1.useExecutor(executor2);
 
         BMQTST_ASSERT_EQ(p2.blocking(), p1.blocking());
         BMQTST_ASSERT_EQ(static_cast<int>(p2.executor()),
@@ -224,13 +218,13 @@ static void test3_policy_transformations()
 
     // useAllocator
     {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_NEVER_BLOCKING,
-               executor1,
-               &allocator1);
+        bmqex::ExecutionPolicy<ExecutorType1> p1(
+            bmqex::ExecutionProperty::e_NEVER_BLOCKING,
+            executor1,
+            &allocator1);
 
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p2 = p1.useAllocator(&allocator2);
+        bmqex::ExecutionPolicy<ExecutorType1> p2 = p1.useAllocator(
+            &allocator2);
 
         BMQTST_ASSERT_EQ(p2.blocking(), p1.blocking());
         BMQTST_ASSERT_EQ(p2.executor(), p1.executor());
@@ -238,27 +232,7 @@ static void test3_policy_transformations()
     }
 }
 
-static void test4_policy_traits()
-// ------------------------------------------------------------------------
-// POLICY TRAITS
-//
-// Concerns:
-//   Ensure proper behavior of policy's traits.
-//
-// Plan:
-//   Check that each policy traits returns the right value.
-//
-// Testing:
-//   bmqex::ExecutionPolicy::k_IS_ONE_WAY
-// ------------------------------------------------------------------------
-{
-    typedef bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay>
-        OneWayPolicy;
-
-    BMQTST_ASSERT(OneWayPolicy::k_IS_ONE_WAY);
-}
-
-static void test5_util()
+static void test4_util()
 // ------------------------------------------------------------------------
 // UTIL
 //
@@ -281,9 +255,7 @@ static void test5_util()
     // NOTE: This is not a real executor type, but for the purpose of this
     //       test it will do.
 
-    typedef bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay,
-                                   bmqex::SystemExecutor>
-        DefaultPolicyType;
+    typedef bmqex::ExecutionPolicy<bmqex::SystemExecutor> DefaultPolicyType;
 
     ExecutorType         executor = 42;
     bslma::TestAllocator allocator;
@@ -362,8 +334,7 @@ int main(int argc, char* argv[])
     case 1: test1_policy_constructor(); break;
     case 2: test2_policy_copyConstructor(); break;
     case 3: test3_policy_transformations(); break;
-    case 4: test4_policy_traits(); break;
-    case 5: test5_util(); break;
+    case 4: test4_util(); break;
 
     default: {
         bsl::cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND."

--- a/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
@@ -140,7 +140,6 @@ static void test3_policy_transformations()
 //   the transformed property.
 //
 // Testing:
-//   bmqex::ExecutionPolicy::oneWay
 //   bmqex::ExecutionPolicy::neverBlocking
 //   bmqex::ExecutionPolicy::possiblyBlocking
 //   bmqex::ExecutionPolicy::alwaysBlocking
@@ -157,21 +156,6 @@ static void test3_policy_transformations()
     ExecutorType2        executor2 = 24;
     bslma::TestAllocator allocator1;
     bslma::TestAllocator allocator2;
-
-    // oneWay
-    {
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p1(bmqex::ExecutionProperty::e_NEVER_BLOCKING,
-               executor1,
-               &allocator1);
-
-        bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay, ExecutorType1>
-            p2 = p1.oneWay();
-
-        BMQTST_ASSERT_EQ(p2.blocking(), p1.blocking());
-        BMQTST_ASSERT_EQ(p2.executor(), p1.executor());
-        BMQTST_ASSERT_EQ(p2.allocator(), p1.allocator());
-    }
 
     // neverBlocking
     {
@@ -286,7 +270,6 @@ static void test5_util()
 //
 // Testing:
 //   bmqex::ExecutionPolicyUtil::defaultPolicy
-//   bmqex::ExecutionPolicyUtil::oneWay
 //   bmqex::ExecutionPolicyUtil::neverBlocking
 //   bmqex::ExecutionPolicyUtil::possiblyBlocking
 //   bmqex::ExecutionPolicyUtil::alwaysBlocking
@@ -314,16 +297,6 @@ static void test5_util()
         BMQTST_ASSERT(defaultPolicy.executor() == bmqex::SystemExecutor());
         BMQTST_ASSERT_EQ(defaultPolicy.allocator(),
                          bslma::Default::allocator());
-    }
-
-    // oneWay
-    {
-        DefaultPolicyType::RebindOneWay::Type p =
-            bmqex::ExecutionPolicyUtil::oneWay();
-
-        BMQTST_ASSERT_EQ(p.blocking(), defaultPolicy.blocking());
-        BMQTST_ASSERT(p.executor() == defaultPolicy.executor());
-        BMQTST_ASSERT_EQ(p.allocator(), defaultPolicy.allocator());
     }
 
     // neverBlocking

--- a/src/groups/bmq/bmqex/bmqex_executionproperty.h
+++ b/src/groups/bmq/bmqex/bmqex_executionproperty.h
@@ -17,19 +17,19 @@
 #ifndef INCLUDED_BMQEX_EXECUTIONPROPERTY
 #define INCLUDED_BMQEX_EXECUTIONPROPERTY
 
-//@PURPOSE: Provides utility tag types to be used with 'bmqex::ExecutionPolicy'
+//@PURPOSE: Provides utility types to be used with 'bmqex::ExecutionPolicy'
 //
 //@CLASSES:
-//  ExecutionProperty: a namespace for utility tag types and enumeration values
+//  ExecutionProperty: a namespace for enumeration values
 //
 //@SEE ALSO:
 //  bmqex::ExecutionPolicy
 //
 //@DESCRIPTION:
 // This component provides a struct, 'bmqex::ExecutionProperty', that serves as
-// a namespace for utility tag types and enumeration values to be used with
-// 'bmqex::ExecutionPolicy' to specify the execution policy direction and
-// blocking properties.
+// a namespace for enumeration values to be used with
+// 'bmqex::ExecutionPolicy' to specify the execution policy blocking
+// properties.
 
 namespace BloombergLP {
 namespace bmqex {
@@ -38,14 +38,11 @@ namespace bmqex {
 // struct ExecutionProperty
 // ========================
 
-/// Provides a namespace for utility tag types and enumeration values to be
-/// used with `bmqex::ExecutionPolicy` to specify the execution policy
-/// direction and blocking properties.
+/// Provides a namespace for enumeration values to be used with
+/// `bmqex::ExecutionPolicy` to specify the execution policy blocking
+/// properties.
 struct ExecutionProperty {
     // TYPES
-
-    /// Provides a tag type defining the One-Way direction property.
-    struct OneWay {};
 
     enum Blocking {
         // Provides a enumeration type defining the blocking behavior property.

--- a/src/groups/bmq/bmqex/bmqex_executionutil.h
+++ b/src/groups/bmq/bmqex/bmqex_executionutil.h
@@ -98,7 +98,7 @@ namespace BloombergLP {
 namespace bmqex {
 
 // FORWARD DECLARATION
-template <class, class>
+template <class>
 class ExecutionPolicy;
 
 // ==================================
@@ -108,14 +108,7 @@ class ExecutionPolicy;
 /// Provides a metafunction that determines, at compile time, the type
 /// returned by `bmqex::ExecutionUtil::execute`.
 template <class POLICY, class FUNCTION>
-struct ExecutionUtil_ExecuteResult {};
-
-/// Provides a specialization of `ExecutionUtil_ExecuteResult` for One-Way
-/// policies.
-template <class EXECUTOR, class FUNCTION>
-struct ExecutionUtil_ExecuteResult<
-    ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR>,
-    FUNCTION> {
+struct ExecutionUtil_ExecuteResult {
     // TYPES
     typedef void Type;
 };
@@ -270,7 +263,7 @@ class ExecutionUtil_OneOffFunction {
 };
 
 // ====================================
-// class ExecutionUtil_UniqueOneWayTask
+// class ExecutionUtil_UniqueTask
 // ====================================
 
 /// Provides a wrapper for a function object allowing to synchronize with
@@ -280,7 +273,7 @@ class ExecutionUtil_OneOffFunction {
 /// standard. Given an object `f` of type `F`, `f()` shall be a valid
 /// expression.
 template <class F>
-class ExecutionUtil_UniqueOneWayTask {
+class ExecutionUtil_UniqueTask {
   public:
     // TYPES
 
@@ -303,24 +296,23 @@ class ExecutionUtil_UniqueOneWayTask {
 
   private:
     // NOT IMPLEMENTED
-    ExecutionUtil_UniqueOneWayTask(const ExecutionUtil_UniqueOneWayTask&)
+    ExecutionUtil_UniqueTask(const ExecutionUtil_UniqueTask&)
         BSLS_KEYWORD_DELETED;
-    ExecutionUtil_UniqueOneWayTask&
-    operator=(const ExecutionUtil_UniqueOneWayTask&) BSLS_KEYWORD_DELETED;
+    ExecutionUtil_UniqueTask&
+    operator=(const ExecutionUtil_UniqueTask&) BSLS_KEYWORD_DELETED;
 
   public:
     // CREATORS
 
-    /// Create a `ExecutionUtil_UniqueOneWayTask` object containing an
+    /// Create a `ExecutionUtil_UniqueTask` object containing an
     /// object of type `F` direct-non-list-initialized with
     /// `bsl::forward<F_PARAM>(f)`. Specify an `allocator` used to supply
     /// memory.
     ///
     /// `F` must be constructible from `bsl::forward<F_PARAM>(f)`.
     template <class F_PARAM>
-    ExecutionUtil_UniqueOneWayTask(BSLS_COMPILERFEATURES_FORWARD_REF(F_PARAM)
-                                       f,
-                                   bslma::Allocator* allocator);
+    ExecutionUtil_UniqueTask(BSLS_COMPILERFEATURES_FORWARD_REF(F_PARAM) f,
+                             bslma::Allocator* allocator);
 
   public:
     // MANIPULATORS
@@ -376,7 +368,7 @@ struct ExecutionUtil {
     // CLASS METHODS
 
     /// Execute the specified function object `f` according to the specified
-    /// One-Way execution `policy`, as if by 'ExecutorTraits<EXECUTOR>::
+    /// execution `policy`, as if by 'ExecutorTraits<EXECUTOR>::
     /// post(policy.executor(), bsl::forward<FUNCTION>(f))' if the policy is
     /// Never Blocking, and as if 'ExecutorTraits<EXECUTOR>::dispatch(
     /// policy.executor(), bsl::forward<FUNCTION>(f))' otherwise. Use the
@@ -396,10 +388,8 @@ struct ExecutionUtil {
     /// and MoveConstructible as specified in the C++ standard. 'DECAY_COPY(
     /// bsl::forward<FUNCTION>(f))()' shall be a valid expression.
     template <class EXECUTOR, class FUNCTION>
-    static typename ExecuteResult<
-        ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR>,
-        FUNCTION>::Type
-    execute(const ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR>& policy,
+    static typename ExecuteResult<ExecutionPolicy<EXECUTOR>, FUNCTION>::Type
+    execute(const ExecutionPolicy<EXECUTOR>& policy,
             BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) f);
 };
 
@@ -518,13 +508,13 @@ inline ExecutionUtil_OneOffFunction<R, F>::DestroyFunctionOnScopeExit ::
 }
 
 // ------------------------------------
-// class ExecutionUtil_UniqueOneWayTask
+// class ExecutionUtil_UniqueTask
 // ------------------------------------
 
 // CREATORS
 template <class F>
 template <class F_PARAM>
-inline ExecutionUtil_UniqueOneWayTask<F>::ExecutionUtil_UniqueOneWayTask(
+inline ExecutionUtil_UniqueTask<F>::ExecutionUtil_UniqueTask(
     BSLS_COMPILERFEATURES_FORWARD_REF(F_PARAM) f,
     bslma::Allocator* allocator)
 : d_latch(1)
@@ -536,7 +526,7 @@ inline ExecutionUtil_UniqueOneWayTask<F>::ExecutionUtil_UniqueOneWayTask(
 
 // MANIPULATORS
 template <class F>
-inline void ExecutionUtil_UniqueOneWayTask<F>::operator()()
+inline void ExecutionUtil_UniqueTask<F>::operator()()
 {
     try {
         // invoke and destroy the function object
@@ -559,8 +549,7 @@ inline void ExecutionUtil_UniqueOneWayTask<F>::operator()()
 
 // ACCESSORS
 template <class F>
-inline void
-ExecutionUtil_UniqueOneWayTask<F>::wait() const BSLS_KEYWORD_NOEXCEPT
+inline void ExecutionUtil_UniqueTask<F>::wait() const BSLS_KEYWORD_NOEXCEPT
 {
     d_latch.wait();
 }
@@ -571,12 +560,10 @@ ExecutionUtil_UniqueOneWayTask<F>::wait() const BSLS_KEYWORD_NOEXCEPT
 
 // CLASS METHODS
 template <class EXECUTOR, class FUNCTION>
-inline typename ExecutionUtil::ExecuteResult<
-    ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR>,
-    FUNCTION>::Type
-ExecutionUtil::execute(
-    const ExecutionPolicy<ExecutionProperty::OneWay, EXECUTOR>& policy,
-    BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) f)
+inline typename ExecutionUtil::ExecuteResult<ExecutionPolicy<EXECUTOR>,
+                                             FUNCTION>::Type
+ExecutionUtil::execute(const ExecutionPolicy<EXECUTOR>& policy,
+                       BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) f)
 {
     switch (policy.blocking()) {
     case ExecutionProperty::e_NEVER_BLOCKING: {
@@ -596,8 +583,7 @@ ExecutionUtil::execute(
     }
 
     case ExecutionProperty::e_ALWAYS_BLOCKING: {
-        typedef ExecutionUtil_UniqueOneWayTask<
-            typename bsl::decay<FUNCTION>::type>
+        typedef ExecutionUtil_UniqueTask<typename bsl::decay<FUNCTION>::type>
             Task;
 
         // create a "task" to synchronize with the completion of the

--- a/src/groups/bmq/bmqex/bmqex_executionutil.h
+++ b/src/groups/bmq/bmqex/bmqex_executionutil.h
@@ -53,24 +53,22 @@
 //
 // 1. All we want is the function object to be executed. Don't want to wait
 //    for the function object completion. That use-case is commonly referred
-//    as "fire and forget". For that we may use a One-Way Never Blocking
-//    execution policy.
+//    as "fire and forget". For that we may use a Never Blocking execution
+//    policy.
 //..
 //  using bmqex;
 //
 //  // initiate the execution and "forget" about it
-//  ExecutionUtil::execute(ExecutionPolicyUtil::oneWay()
-//                                             .neverBlocking(),
+//  ExecutionUtil::execute(ExecutionPolicyUtil::neverBlocking(),
 //                         myFunction);
 //..
 // 2. We want to execute a function object and wait for its completion. In that
-//    case, we may use a One-Way Always Blocking execution policy.
+//    case, we may use an Always Blocking execution policy.
 //..
 //  using bmqex;
 //
 //  // initiate the execution and wait for completion
-//  ExecutionUtil::execute(ExecutionPolicyUtil::oneWay()
-//                                             .alwaysBlocking(),
+//  ExecutionUtil::execute(ExecutionPolicyUtil::alwaysBlocking(),
 //                         myFunction);
 //..
 

--- a/src/groups/bmq/bmqex/bmqex_executionutil.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executionutil.t.cpp
@@ -327,53 +327,49 @@ static void test1_executeResult()
 //:    'DECAY_COPY(std::forward<F>(f))()'.
 //
 //   The type of 'bmqex::ExecutionUtil::ExecuteResult<P, F>::Type'
-//   expression is 'void' for One-Way policies.
+//   expression is 'void'.
 //
 // Testing:
 //   bmqex::ExecutionUtil::ExecuteResult
 // ------------------------------------------------------------------------
 {
-    // One-Way policy
-    {
-        typedef bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay>
-            PolicyType;
+    typedef bmqex::ExecutionPolicy<> PolicyType;
 
-        BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
-                                        PolicyType,
-                                        DummyNullaryFunction<void> >::Type,
-                                    void>::value));
+    BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
+                                    PolicyType,
+                                    DummyNullaryFunction<void> >::Type,
+                                void>::value));
 
-        BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
-                                        PolicyType,
-                                        DummyNullaryFunction<int> >::Type,
-                                    void>::value));
+    BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
+                                    PolicyType,
+                                    DummyNullaryFunction<int> >::Type,
+                                void>::value));
 
-        BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
-                                        PolicyType,
-                                        DummyNullaryFunction<int&> >::Type,
-                                    void>::value));
-    }
+    BMQTST_ASSERT((bsl::is_same<bmqex::ExecutionUtil::ExecuteResult<
+                                    PolicyType,
+                                    DummyNullaryFunction<int&> >::Type,
+                                void>::value));
 }
 
-static void test2_execute_one_way_never_blocking()
+static void test2_execute_never_blocking()
 // ------------------------------------------------------------------------
-// EXECUTE ONE WAY NEVER BLOCKING
+// EXECUTE NEVER BLOCKING
 //
 // Concerns:
-//   Ensure proper behavior of the 'execute' function accepting a One-Way
-//   Never Blocking execution policy.
+//   Ensure proper behavior of the 'execute' function accepting a Never
+//   Blocking execution policy.
 //
 // Plan:
 //   1. Execute a function object 'f' on an executor 'ex' specifying a
-//      One-Way Never Blocking execution policy. Check that:
+//      Never Blocking execution policy. Check that:
 //:     o The execution function does not block the calling thread pending
 //:       completion of the submitted function object invocation;
 //:     o The function object is executed as if by a call to 'ex.post(f)'.
 //
-//   2. Execute a function object 'f', according to a One-Way Never
-//      Blocking execution policy, and such that 'f()' throws an exception.
-//      Check that the execution was propagated to the caller of 'f' (but
-//      not to the caller of the execution function).
+//   2. Execute a function object 'f', according to a Never Blocking
+//      execution policy, and such that 'f()' throws an exception. Check
+//      that the execution was propagated to the caller of 'f' (but not to
+//      the caller of the execution function).
 //
 // Testing:
 //   bmqex::ExecutionUtil::execute
@@ -437,26 +433,26 @@ static void test2_execute_one_way_never_blocking()
     }
 }
 
-static void test3_execute_one_way_possibly_blocking()
+static void test3_execute_possibly_blocking()
 // ------------------------------------------------------------------------
-// EXECUTE ONE WAY POSSIBLY BLOCKING
+// EXECUTE POSSIBLY BLOCKING
 //
 // Concerns:
-//   Ensure proper behavior of the 'execute' function accepting a One-Way
-//   Possibly Blocking execution policy.
+//   Ensure proper behavior of the 'execute' function accepting a Possibly
+//   Blocking execution policy.
 //
 // Plan:
 //   1. Execute a function object 'f' on an executor 'ex' specifying a
-//      One-Way Possibly Blocking execution policy. Check that:
+//      Possibly Blocking execution policy. Check that:
 //:     o The execution function does not block the calling thread pending
 //:       completion of the submitted function object invocation;
 //:     o The function object is executed as if by a call to
 //:       'ex.dispatch(f)'.
 //
-//   2. Execute a function object 'f', according to a One-Way Possibly
-//      Blocking execution policy, and such that 'f()' throws an exception.
-//      Check that the execution was propagated to the caller of 'f' (but
-//      not to the caller of the execution function).
+//   2. Execute a function object 'f', according to a Possibly Blocking
+//      execution policy, and such that 'f()' throws an exception. Check
+//      that the execution was propagated to the caller of 'f' (but not to
+//      the caller of the execution function).
 //
 // Testing:
 //   bmqex::ExecutionUtil::execute
@@ -520,26 +516,26 @@ static void test3_execute_one_way_possibly_blocking()
     }
 }
 
-static void test4_execute_one_way_always_blocking()
+static void test4_execute_always_blocking()
 // ------------------------------------------------------------------------
-// EXECUTE ONE WAY ALWAYS BLOCKING
+// EXECUTE ALWAYS BLOCKING
 //
 // Concerns:
-//   Ensure proper behavior of the 'execute' function accepting a One-Way
-//   Always Blocking execution policy..
+//   Ensure proper behavior of the 'execute' function accepting an Always
+//   Blocking execution policy.
 //
 // Plan:
-//   1. Execute a function object 'f' on an executor 'ex' specifying a
-//      One-Way Always Blocking execution policy. Check that:
+//   1. Execute a function object 'f' on an executor 'ex' specifying an
+//      Always Blocking execution policy. Check that:
 //:     o The execution function does block the calling thread pending
 //:       completion of the submitted function object invocation;
 //:     o The function object is executed as if by a call to
 //:       'ex.dispatch(f)'.
 //
-//   2. Execute a function object 'f', according to a One-Way Always
-//      Blocking execution policy, and such that 'f()' throws an exception.
-//      Check that the execution was propagated to the caller of 'f' (but
-//      not to the caller of the execution function).
+//   2. Execute a function object 'f', according to an Always Blocking
+//      execution policy, and such that 'f()' throws an exception. Check
+//      that the execution was propagated to the caller of 'f' (but not to
+//      the caller of the execution function).
 //
 // Testing:
 //   bmqex::ExecutionUtil::execute
@@ -603,10 +599,10 @@ int main(int argc, char* argv[])
     // traits
     case 1: test1_executeResult(); break;
 
-    // One-Way execution
-    case 2: test2_execute_one_way_never_blocking(); break;
-    case 3: test3_execute_one_way_possibly_blocking(); break;
-    case 4: test4_execute_one_way_always_blocking(); break;
+    // execution
+    case 2: test2_execute_never_blocking(); break;
+    case 3: test3_execute_possibly_blocking(); break;
+    case 4: test4_execute_always_blocking(); break;
 
     default: {
         bsl::cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND."

--- a/src/groups/bmq/bmqex/bmqex_executionutil.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executionutil.t.cpp
@@ -393,8 +393,7 @@ static void test2_execute_one_way_never_blocking()
 
         // submit function object for execution
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .neverBlocking()
+            bmqex::ExecutionPolicyUtil::neverBlocking()
                 .useExecutor(context.executor())
                 .useAllocator(&alloc),
             bdlf::BindUtil::bind(SynchronizeCallable(),
@@ -424,11 +423,11 @@ static void test2_execute_one_way_never_blocking()
     // 2. Submitted function object throws an exception.
     {
         // submit function object for execution
-        bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-                                          .neverBlocking()
-                                          .useExecutor(context.executor())
-                                          .useAllocator(&alloc),
-                                      ThrowOnCall());
+        bmqex::ExecutionUtil::execute(
+            bmqex::ExecutionPolicyUtil::neverBlocking()
+                .useExecutor(context.executor())
+                .useAllocator(&alloc),
+            ThrowOnCall());
 
         // make sure all postconditions on the context are established
         context.drain();
@@ -477,8 +476,7 @@ static void test3_execute_one_way_possibly_blocking()
 
         // submit function object for execution
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .possiblyBlocking()
+            bmqex::ExecutionPolicyUtil::possiblyBlocking()
                 .useExecutor(context.executor())
                 .useAllocator(&alloc),
             bdlf::BindUtil::bind(SynchronizeCallable(),
@@ -508,11 +506,11 @@ static void test3_execute_one_way_possibly_blocking()
     // 2. Submitted function object throws an exception.
     {
         // submit function object for execution
-        bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-                                          .possiblyBlocking()
-                                          .useExecutor(context.executor())
-                                          .useAllocator(&alloc),
-                                      ThrowOnCall());
+        bmqex::ExecutionUtil::execute(
+            bmqex::ExecutionPolicyUtil::possiblyBlocking()
+                .useExecutor(context.executor())
+                .useAllocator(&alloc),
+            ThrowOnCall());
 
         // make sure all postconditions on the context are established
         context.drain();
@@ -556,11 +554,11 @@ static void test4_execute_one_way_always_blocking()
         SetFlagOnCall toBeExecuted(&executed);
 
         // submit function object for execution
-        bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-                                          .alwaysBlocking()
-                                          .useExecutor(context.executor())
-                                          .useAllocator(&alloc),
-                                      toBeExecuted);
+        bmqex::ExecutionUtil::execute(
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
+                .useExecutor(context.executor())
+                .useAllocator(&alloc),
+            toBeExecuted);
 
         // function object was submitted for execution via a call to
         // 'dispatch()' on the specified executor
@@ -579,11 +577,11 @@ static void test4_execute_one_way_always_blocking()
     // 2. Submitted function object throws an exception.
     {
         // submit function object for execution
-        bmqex::ExecutionUtil::execute(bmqex::ExecutionPolicyUtil::oneWay()
-                                          .alwaysBlocking()
-                                          .useExecutor(context.executor())
-                                          .useAllocator(&alloc),
-                                      ThrowOnCall());
+        bmqex::ExecutionUtil::execute(
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
+                .useExecutor(context.executor())
+                .useAllocator(&alloc),
+            ThrowOnCall());
 
         // make sure all postconditions on the context are established
         context.drain();

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -598,7 +598,7 @@ Application::Application(
 , d_resolvingChannelFactory(
       bmqio::ResolvingChannelFactoryConfig(
           &d_channelFactory,
-          bmqex::ExecutionPolicyUtil::oneWay().alwaysBlocking().useExecutor(
+          bmqex::ExecutionPolicyUtil::alwaysBlocking().useExecutor(
               bmqex::SystemExecutor()),
           allocator),
       allocator)

--- a/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.h
@@ -76,9 +76,7 @@ class ResolvingChannelFactoryConfig {
 
     /// An execution policy defining how the resolution callback is to be
     /// executed.
-    typedef bmqex::ExecutionPolicy<bmqex::ExecutionProperty::OneWay,
-                                   bmqex::Executor>
-        ExecutionPolicy;
+    typedef bmqex::ExecutionPolicy<bmqex::Executor> ExecutionPolicy;
 
   private:
     // PRIVATE DATA

--- a/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_resolvingchannelfactory.t.cpp
@@ -206,7 +206,7 @@ static void test2_channelFactory()
 
     ResolvingChannelFactoryConfig cfg(
         &baseFactory,
-        bmqex::ExecutionPolicyUtil::oneWay().neverBlocking().useExecutor(
+        bmqex::ExecutionPolicyUtil::neverBlocking().useExecutor(
             TestExecutor(&execStore)),
         bmqtst::TestHelperUtil::allocator());
     cfg.resolutionFn(

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -1387,8 +1387,7 @@ bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
         &(request->d_timeoutSchedulerHandle),
         bmqsys::Time::nowMonotonicClock() + timeout,
         bmqex::BindUtil::bindExecute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .possiblyBlocking()
+            bmqex::ExecutionPolicyUtil::possiblyBlocking()
                 .useExecutor(d_executor)
                 .useAllocator(d_allocator_p),
             bdlf::BindUtil::bind(&RequestManager::onRequestTimeout,

--- a/src/groups/bmq/bmqtsk/bmqtsk_logcleaner.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcleaner.cpp
@@ -165,7 +165,7 @@ int LogCleaner::start(bslstl::StringRef         pattern,
         &d_logsCleaningEvent,
         cleanupPeriod,
         bmqex::BindUtil::bindExecute(
-            bmqex::ExecutionPolicyUtil::oneWay().neverBlocking().useExecutor(
+            bmqex::ExecutionPolicyUtil::neverBlocking().useExecutor(
                 d_logsCleaningContext.executor()),
             bdlf::MemFnUtil::memFn(&LogCleaner::cleanLogs, this)),
         bsls::SystemTime::now(d_scheduler_p->clockType()));

--- a/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
@@ -420,15 +420,13 @@ static void test3_executorsSupport()
         // submit two functors to be executed on the same processor, and wait
         // for the completion of submitted functors
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .alwaysBlocking()
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
                 .useExecutor(executor1)
                 .useAllocator(bmqtst::TestHelperUtil::allocator()),
             bdlf::BindUtil::bind(LoadSelfThreadId(), &threadId1));
 
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .alwaysBlocking()
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
                 .useExecutor(executor1)
                 .useAllocator(bmqtst::TestHelperUtil::allocator()),
             bdlf::BindUtil::bind(LoadSelfThreadId(), &threadId2));
@@ -455,15 +453,13 @@ static void test3_executorsSupport()
         // executor's 'dispatch' function, and wait for the completion of
         // submitted functors
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .alwaysBlocking()
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
                 .useExecutor(executor2)
                 .useAllocator(bmqtst::TestHelperUtil::allocator()),
             bdlf::BindUtil::bind(LoadSelfThreadId(), &threadId1));
 
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .alwaysBlocking()
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
                 .useExecutor(executor2)
                 .useAllocator(bmqtst::TestHelperUtil::allocator()),
             bdlf::BindUtil::bind(LoadSelfThreadId(), &threadId2));
@@ -481,13 +477,11 @@ static void test3_executorsSupport()
         // via the executor's 'dispatch' function and block the calling thread
         // until the nested functor completes
         bmqex::ExecutionUtil::execute(
-            bmqex::ExecutionPolicyUtil::oneWay()
-                .alwaysBlocking()
+            bmqex::ExecutionPolicyUtil::alwaysBlocking()
                 .useExecutor(executor1)
                 .useAllocator(bmqtst::TestHelperUtil::allocator()),
             bmqex::BindUtil::bindExecute(
-                bmqex::ExecutionPolicyUtil::oneWay()
-                    .alwaysBlocking()
+                bmqex::ExecutionPolicyUtil::alwaysBlocking()
                     .useExecutor(executor3)
                     .useAllocator(bmqtst::TestHelperUtil::allocator()),
                 bdlf::BindUtil::bind(LoadSelfThreadId(), &threadId1)));

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1171,9 +1171,8 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
         new (*d_allocator_p) bmqio::ResolvingChannelFactory(
             bmqio::ResolvingChannelFactoryConfig(
                 d_tcpChannelFactory_mp.get(),
-                bmqex::ExecutionPolicyUtil::oneWay()
-                    .neverBlocking()
-                    .useExecutor(d_resolutionContext.executor()),
+                bmqex::ExecutionPolicyUtil::neverBlocking().useExecutor(
+                    d_resolutionContext.executor()),
                 d_allocator_p)
                 .resolutionFn(bdlf::BindUtil::bind(
                     &monitoredDNSResolution,


### PR DESCRIPTION
Now that the only direction execution policies support is `OneWay`, we might as well remove that template parameter and make `OneWay` behavior the only possible behavior.  This PR does two things:

1. Remove the useless `oneWay()` transformers, the only dynamic uses of the `OneWay` tag.
2. Remove the `OneWay` tag and the `DIRECTION` template argument wherever it is used.