### PR TITLE
Fix[mqb]: Make sure drain is complete before TCP stop

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -526,8 +526,8 @@ void Application::stop()
     // any DispatcherClient that might be in the middle of its destruction.
     d_dispatcher_mp->disableFlushClients();
 
-    // Stop TransportManager since 'Application::initiateShutdown' closed all
-    // client sessions and 'Cluster::initiateShutdown' closes all cluster nodes
+    // 'Application::initiateShutdown' had closed all client sessions.
+    // 'Cluster::initiateShutdown' had drained and closed all cluster nodes
     // sessions.
     STOP_OBJ(d_transportManager_mp, "TransportManager");
     STOP_OBJ(d_clusterCatalog_mp, "ClusterCatalog");

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -80,12 +80,12 @@ Channel::Channel(bdlbb::BlobBufferFactory* blobBufferFactory,
              bsls::BlockGrowth::BSLS_CONSTANT,
              d_allocators.get("ItemPool"))
 , d_buffer(1024, allocator)
-, d_doStop(false)
+, d_isStopped(false)
 , d_state(e_RESET)
 , d_description(name + " - ", d_allocator_p)
 , d_name(name, d_allocator_p)
 , d_stats()
-, d_isClosing(false)
+, d_isStopping(false)
 {
     bslmt::ThreadAttributes attr = bmqsys::ThreadUtil::defaultAttributes();
     bsl::string             threadName("bmqNet-");
@@ -103,9 +103,28 @@ Channel::Channel(bdlbb::BlobBufferFactory* blobBufferFactory,
 
 Channel::~Channel()
 {
-    d_doStop = true;
+    if (!d_isStopping.load()) {
+        // Did not bother to call requestToStop()
+        requestToStop();
+        stop();
+    }
+    BSLS_ASSERT_SAFE(d_isStopped.load());
+}
 
-    resetChannel();
+void Channel::stop()
+{
+    BSLS_ASSERT_SAFE(d_isStopping.load());
+
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+
+        // Signal, in case the channel is waiting on 'd_stateCondition'.
+        // Do not 'e_RESET' the state to let the drain finish.
+
+        d_stateCondition.signal();
+    }
+
+    BALL_LOG_INFO << "Stopped " << d_description;
 
     BSLA_MAYBE_UNUSED const int rc = bslmt::ThreadUtil::join(d_threadHandle);
     BSLS_ASSERT_SAFE(rc == 0);
@@ -260,9 +279,9 @@ void Channel::resetChannel()
     wakeUp();
 }
 
-void Channel::closeChannel()
+void Channel::requestToStop()
 {
-    d_isClosing.store(true);
+    d_isStopping.store(true);
 
     // No need to 'signal' to interrupt the waiting.
     // Waiting means there is no connection and therefore nothing to close.
@@ -742,10 +761,11 @@ void Channel::threadFn()
     bsl::shared_ptr<bmqio::Channel> channel;
     bsl::string                     description;
     int                             mode = e_BLOCK;
+    bool                            doStop = false;
 
     BSLS_ASSERT(d_state == e_RESET);
 
-    while (!d_doStop) {
+    while (!doStop) {
         bmqc::MonitoredQueueState::Enum queueState;
         while (d_queueStates.tryPopFront(&queueState) == 0) {
             switch (queueState) {
@@ -792,9 +812,7 @@ void Channel::threadFn()
                 item.reset();
                 reset();
 
-                mode    = e_BLOCK;
-                d_isClosing.store(false);
-
+                mode        = e_BLOCK;
                 channel     = d_channel_wp.lock();
                 description = d_description;
 
@@ -818,6 +836,9 @@ void Channel::threadFn()
                               << " with " << numItems() << " items and "
                               << bmqu::PrintUtil::prettyBytes(numBytes())
                               << " pending bytes";
+            }
+            else if (d_isStopping) {
+                doStop = true;
             }
             else {
                 // wait for 'setChannel' or LWM
@@ -851,7 +872,7 @@ void Channel::threadFn()
                 }
                 // if draining, this is where it stops.
                 // Does not matter if 'flushAll' has failed; must close
-                if (d_isClosing) {
+                if (d_isStopping) {
                     channel->close();
                     d_state.testAndSwap(e_READY, e_CLOSE);
                     // bmqio::Channel observer will trigger 'resetChannel'
@@ -909,6 +930,7 @@ void Channel::threadFn()
         }
     }
     reset();
+    d_isStopped.store(true);
 }
 
 void Channel::onBufferStateChange(bmqc::MonitoredQueueState::Enum state)

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -393,7 +393,7 @@ class Channel {
 
     mutable bslmt::Mutex d_mutex;
 
-    bsls::AtomicBool d_doStop;
+    bsls::AtomicBool d_isStopped;
 
     bsls::AtomicInt d_state;
 
@@ -421,7 +421,7 @@ class Channel {
 
     /// Indicates graceful shutdown.  Drain the buffer if possible and then
     /// close the channel.
-    bsls::AtomicBool d_isClosing;
+    bsls::AtomicBool d_isStopping;
 
   private:
     // NOT IMPLEMENTED
@@ -521,8 +521,11 @@ class Channel {
     /// Reset the channel associated to this node.
     void resetChannel();
 
-    /// Close the channel associated to this node, if any.
-    void closeChannel();
+    /// Start draining the channel associated to this node, if any.
+    void requestToStop();
+
+    /// Stop the channel thread once all draining is done.
+    void stop();
 
     /// Write PUT message using the specified `ph`, `data`, and `state`.
     /// Return e_SUCCESS even if the channel is in HWM.
@@ -1086,7 +1089,7 @@ Channel::enqueue(bslma::ManagedPtr<Item>& item)
 // ACCESSORS
 inline bool Channel::isAvailable() const
 {
-    return d_state != e_RESET && d_state != e_CLOSE && !d_isClosing;
+    return d_state != e_RESET && d_state != e_CLOSE && !d_isStopping;
 }
 
 inline const bsl::shared_ptr<bmqio::Channel> Channel::channel() const

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -139,9 +139,6 @@ class ClusterNode {
     /// Reset the channel associated to this node.
     virtual ClusterNode* resetChannel() = 0;
 
-    /// Close the channel associated to this node, if any.
-    virtual void closeChannel() = 0;
-
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on
     /// success, and a non-zero value otherwise.  Note that success does not

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
@@ -74,8 +74,6 @@ struct ClusterNodeTestImp : bsls::ProtocolTestImp<mqbnet::ClusterNode> {
         return markDone();
     }
 
-    void closeChannel() BSLS_KEYWORD_OVERRIDE { markDone(); }
-
     bmqt::GenericResult::Enum
     write(const bsl::shared_ptr<bdlbb::Blob>& blob,
           bmqp::EventType::Enum type = bmqp::EventType::e_CONTROL)
@@ -314,7 +312,6 @@ static void test2_ClusterNode()
                                             identity,
                                             bmqio::Channel::ReadCallback()));
         BSLS_PROTOCOLTEST_ASSERT(testObj, enableRead());
-        BSLS_PROTOCOLTEST_ASSERT(testObj, closeChannel());
         BSLS_PROTOCOLTEST_ASSERT(testObj, resetChannel());
         BSLS_PROTOCOLTEST_ASSERT(testObj,
                                  write(dummyBlob_sp,

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -137,11 +137,6 @@ ClusterNode* ClusterNodeImp::resetChannel()
     return this;
 }
 
-void ClusterNodeImp::closeChannel()
-{
-    d_channel.closeChannel();
-}
-
 bmqt::GenericResult::Enum
 ClusterNodeImp::write(const bsl::shared_ptr<bdlbb::Blob>& blob,
                       bmqp::EventType::Enum               type)
@@ -286,10 +281,17 @@ int ClusterImp::broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob)
 
 void ClusterImp::closeChannels()
 {
+    // first, start draining all channels
     for (bsl::list<ClusterNodeImp>::iterator it = d_nodes.begin();
          it != d_nodes.end();
          ++it) {
-        it->closeChannel();
+        it->channel().requestToStop();
+    }
+    // then, join all channels threads
+    for (bsl::list<ClusterNodeImp>::iterator it = d_nodes.begin();
+         it != d_nodes.end();
+         ++it) {
+        it->channel().stop();
     }
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -142,9 +142,6 @@ class ClusterNodeImp : public ClusterNode {
     /// Reset the channel associated to this node.
     ClusterNode* resetChannel() BSLS_KEYWORD_OVERRIDE;
 
-    /// Close the channel associated to this node, if any.
-    void closeChannel() BSLS_KEYWORD_OVERRIDE;
-
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on
     /// success, and a non-zero value otherwise.  Note that success does not

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
@@ -114,11 +114,6 @@ ClusterNode* MockClusterNode::resetChannel()
     return this;
 }
 
-void MockClusterNode::closeChannel()
-{
-    d_channel.closeChannel();
-}
-
 bmqt::GenericResult::Enum
 MockClusterNode::write(const bsl::shared_ptr<bdlbb::Blob>& blob,
                        bmqp::EventType::Enum               type)
@@ -228,7 +223,12 @@ void MockCluster::closeChannels()
     for (bsl::list<MockClusterNode>::iterator it = d_nodes.begin();
          it != d_nodes.end();
          ++it) {
-        it->closeChannel();
+        it->channel().requestToStop();
+    }
+    for (bsl::list<MockClusterNode>::iterator it = d_nodes.begin();
+         it != d_nodes.end();
+         ++it) {
+        it->channel().stop();
     }
 }
 

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -127,9 +127,6 @@ class MockClusterNode : public ClusterNode {
     /// Reset the channel associated to this node.
     ClusterNode* resetChannel() BSLS_KEYWORD_OVERRIDE;
 
-    /// Close the channel associated to this node, if any.
-    void closeChannel() BSLS_KEYWORD_OVERRIDE;
-
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on
     /// success, and a non-zero value otherwise.  Note that success does not

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -80,8 +80,8 @@ void TransportManager::onClusterReleased(void* object, void* transportManager)
         }
     }  // mutex guard scope
 
-    // Close all cluster channels
-    cluster->closeChannels();
+    // Cluster had already stopped all channels in
+    // 'Cluster::continueShutdownDispatched'
 
     // And delete the cluster
     self->d_allocators.get(cluster->name())->deleteObject(cluster);


### PR DESCRIPTION
`mqbnet::Channel::closeChannel()` is non-blocking.  When `Application` continues to stop, it calls `CPSessionFactory::stop()` which calls `StatChannelFactory::stop()` which results in TCP disconnects.  This creates a race with draining `mqbnet::Channel`.

Solution:
Add `mqbnet::Channel::stop()` which blocks (`join`) until the thread exits.  `mqbnet::Channel::d_isStopping` is a must to stop the channel.
Call `mqbnet::Channel::stop()` after calling non-blocking `mqbnet::Channel::requestToStop()` - to drain in parallel.