### PR TITLE
Fix[bmqp]: Remove dependency on bmqp from bmqa header

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -556,7 +556,6 @@
 #include <bmqa_openqueuestatus.h>
 #include <bmqa_queueid.h>
 #include <bmqa_session.h>  // for 'bmqa::SessionEventHandler'
-#include <bmqp_blobpoolutil.h>
 #include <bmqt_queueoptions.h>
 #include <bmqt_sessionoptions.h>
 
@@ -695,9 +694,9 @@ struct MockSessionUtil {
     /// Create and return an `Event` configured as a message event of type
     /// `e_ACK` with the specified `acks` params using the specified
     /// `bufferFactory` and the specified `allocator` to supply memory.
-    static Event createAckEvent(const bsl::vector<AckParams>&   acks,
-                                bmqp::BlobPoolUtil::BlobSpPool* blobSpPool,
-                                bslma::Allocator*               allocator);
+    static Event createAckEvent(const bsl::vector<AckParams>& acks,
+                                BlobSpPool*                   blobSpPool,
+                                bslma::Allocator*             allocator);
 
     /// Create and return an `Event` configured as a message event of type
     /// `e_PUSH` and with the specified `pushEventParams`, using the
@@ -705,7 +704,7 @@ struct MockSessionUtil {
     /// memory.
     static Event
     createPushEvent(const bsl::vector<PushMessageParams>& pushEventParams,
-                    bmqp::BlobPoolUtil::BlobSpPool*       blobSpPool,
+                    BlobSpPool*                           blobSpPool,
                     bdlbb::BlobBufferFactory*             bufferFactory,
                     bslma::Allocator*                     allocator);
 


### PR DESCRIPTION
Only bmqa, bmqt, and bmqpi are part of the public interface of libbmq, so the introduction of a dependency on a bmqp header file causes clients to fail to compile.  Luckily, the issue is only an imported typedef, of which we have a local copy anyway.  This patch removes the dependency on bmqp by switching to the local typedef.