### PR TITLE
Fix[mqb]: proxies must copy rda

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -2111,7 +2111,10 @@ void RelayQueueEngine::storePushIfProxy(
                  cit != subQueueIds.end();
                  ++cit) {
                 if (cit->id() > 0) {
-                    dataStreamMessage->app(cit->id() - 1).setPushState();
+                    const int         ordinal = cit->id() - 1;
+                    mqbi::AppMessage& appMsg = dataStreamMessage->app(ordinal);
+                    appMsg.setPushState();
+                    appMsg.d_rdaInfo = cit->rdaInfo();
                 }
             }
         }


### PR DESCRIPTION
`storePushIfProxy` doesn't copy the RDA counter from the PUSH message into the storage's `AppMessage`. As the result, it has `isUnlimited = true`. Then, the message stays in the proxy's redelivery list and it is a race between redelivering the poisonous message on reconnect and primary purging it.

