### PR TITLE
Fix[mqb]: Re-read counter after de-configure response

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1195,14 +1195,12 @@ void ClusterOrchestrator::processNodeStateChangeEvent(
             // are seeing this 'available' event for *this* instance of the
             // peer for the first time.  Bump up peer's instance ID.
 
-            int oldInstanceId = ns->peerInstanceId();
-            ns->setPeerInstanceId(oldInstanceId + 1);
+            ns->createQueueHandleRequesterContext();
 
             BALL_LOG_INFO << d_clusterData_p->identity().description()
-                          << ": bumped up instance ID of peer node "
-                          << node->nodeDescription()
-                          << " from: " << oldInstanceId
-                          << " to: " << ns->peerInstanceId();
+                          << ": bumped up requesterId of peer node "
+                          << node->nodeDescription() << " to: "
+                          << ns->handleRequesterContext()->requesterId();
         }
 
         // Node is connected, but we don't know its status as of yet so we mark

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2579,7 +2579,7 @@ void ClusterQueueHelper::onGetDomain(
     mqbi::Domain*                       domain,
     const bmqp_ctrlmsg::ControlMessage& request,
     mqbc::ClusterNodeSession*           requester,
-    const int                           peerInstanceId)
+    const int                           requesterId)
 {
     // executed by *ANY* thread
 
@@ -2591,7 +2591,7 @@ void ClusterQueueHelper::onGetDomain(
                               domain,
                               request,
                               requester,
-                              peerInstanceId),
+                              requesterId),
         d_cluster_p);
 }
 
@@ -2600,7 +2600,7 @@ void ClusterQueueHelper::onGetDomainDispatched(
     mqbi::Domain*                       domain,
     const bmqp_ctrlmsg::ControlMessage& request,
     mqbc::ClusterNodeSession*           requester,
-    const int                           peerInstanceId)
+    const int                           requesterId)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -2680,7 +2680,7 @@ void ClusterQueueHelper::onGetDomainDispatched(
                               bdlf::PlaceHolders::_4,  // confCookie
                               request,
                               requester,
-                              peerInstanceId));
+                              requesterId));
 }
 
 void ClusterQueueHelper::onGetQueueHandle(
@@ -2740,8 +2740,8 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
             << ", because either the peer is down, or new instance "
             << "of the peer has come up. Peer node status: "
             << requester->nodeStatus()
-            << ", initial peerInstanceId: " << requesterId
-            << ", current peerInstanceId: "
+            << ", initial requesterId: " << requesterId
+            << ", current requesterId: "
             << requester->handleRequesterContext()->requesterId() << ".";
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2713,7 +2713,7 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
     const mqbi::OpenQueueConfirmationCookieSp& confirmationCookie,
     const bmqp_ctrlmsg::ControlMessage&        request,
     mqbc::ClusterNodeSession*                  requester,
-    const int                                  peerInstanceId)
+    const int                                  requesterId)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -2722,7 +2722,7 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
     BSLS_ASSERT_SAFE(request.choice().isOpenQueueValue());
     BSLS_ASSERT_SAFE(d_cluster_p->isClusterMember());
 
-    if (peerInstanceId != requester->peerInstanceId() ||
+    if (requesterId != requester->handleRequesterContext()->requesterId() ||
         requester->nodeStatus() == bmqp_ctrlmsg::NodeStatus::E_UNAVAILABLE) {
         // Either a new instance of the peer is up, or old instance is no
         // longer available (ie, channel with old instance went down but has
@@ -2740,9 +2740,9 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
             << ", because either the peer is down, or new instance "
             << "of the peer has come up. Peer node status: "
             << requester->nodeStatus()
-            << ", initial peerInstanceId: " << peerInstanceId
-            << ", current peerInstanceId: " << requester->peerInstanceId()
-            << ".";
+            << ", initial peerInstanceId: " << requesterId
+            << ", current peerInstanceId: "
+            << requester->handleRequesterContext()->requesterId() << ".";
         return;  // RETURN
     }
 
@@ -2789,8 +2789,8 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
             << d_cluster_p->description()
             << ": Reused handle when processing peer "
             << "openQueueRequest [requester: " << requester->description()
-            << ", request: " << request
-            << ", peerInstanceId: " << peerInstanceId << "].";
+            << ", request: " << request << ", requesterId: " << requesterId
+            << "].";
 
         BSLS_ASSERT_SAFE(queueHandle == iter->second.d_handle_p);
 
@@ -2811,8 +2811,8 @@ void ClusterQueueHelper::onGetQueueHandleDispatched(
             << d_cluster_p->description()
             << ": Inserting handle to nodeSession, when processing "
             << "peer openQueueRequest [requester: " << requester->description()
-            << ", request: " << request
-            << ", peerInstanceId: " << peerInstanceId << "].";
+            << ", request: " << request << ", requesterId: " << requesterId
+            << "].";
 
         CNSQueueState queueContext;
         queueContext.d_handle_p = queueHandle;
@@ -3727,9 +3727,10 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
         BALL_LOG_OUTPUT_STREAM << "].";
     }
 
-    if (!d_cluster_p->isFSMWorkflow() &&
-        d_clusterData_p->membership().selfNodeStatus() !=
-            bmqp_ctrlmsg::NodeStatus::E_AVAILABLE) {
+    // A node cannot go out of AVAILABLE state other than by stopping.
+    // A node should not attempt to reopen queues if it is not AVAILABLE.
+    if (d_clusterData_p->membership().selfNodeStatus() !=
+        bmqp_ctrlmsg::NodeStatus::E_AVAILABLE) {
         BALL_LOG_INFO << d_cluster_p->description()
                       << ": Not going ahead with restoring partition state "
                       << "because self is not AVAILABLE.  Self status: "
@@ -3737,6 +3738,7 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
         return;  // RETURN
     }
 
+    // TODO: revisit
     if (!d_clusterData_p->electorInfo().hasActiveLeader() &&
         (allPartitions || d_cluster_p->isFSMWorkflow())) {
         // 'allPartitions' indicate this is a transition due to a leader
@@ -5064,14 +5066,15 @@ void ClusterQueueHelper::processPeerOpenQueueRequest(
     BSLS_ASSERT_SAFE(d_clusterData_p->domainFactory());
     d_clusterData_p->domainFactory()->createDomain(
         bmqt::Uri(handleParams.uri()).qualifiedDomain(),
-        bdlf::BindUtil::bindS(d_allocator_p,
-                              &ClusterQueueHelper::onGetDomain,
-                              this,
-                              bdlf::PlaceHolders::_1,  // status
-                              bdlf::PlaceHolders::_2,  // domain
-                              request,
-                              requester,
-                              requester->peerInstanceId()));
+        bdlf::BindUtil::bindS(
+            d_allocator_p,
+            &ClusterQueueHelper::onGetDomain,
+            this,
+            bdlf::PlaceHolders::_1,  // status
+            bdlf::PlaceHolders::_2,  // domain
+            request,
+            requester,
+            requester->handleRequesterContext()->requesterId()));
 }
 
 void ClusterQueueHelper::processPeerConfigureStreamRequest(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -694,11 +694,11 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
                      mqbi::Domain*                       domain,
                      const bmqp_ctrlmsg::ControlMessage& request,
                      mqbc::ClusterNodeSession*           requester,
-                     int                                 peerInstanceId);
+                     int                                 requesterId);
 
     /// Callback invoked in response to an open domain query (in the
     /// specified `request`) made to the domain factory on behalf of the
-    /// specified `requester` with the specified `peerInstanceId`.  If the
+    /// specified `requester` with the specified `requesterId`.  If the
     /// specified `status` is SUCCESS, the request was success and the
     /// specified `domain` contains a pointer to the result; otherwise
     /// `status` contains the category, error code and description of the
@@ -707,7 +707,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
                                mqbi::Domain*                       domain,
                                const bmqp_ctrlmsg::ControlMessage& request,
                                mqbc::ClusterNodeSession*           requester,
-                               const int peerInstanceId);
+                               const int requesterId);
 
     void onGetQueueHandle(
         const bmqp_ctrlmsg::Status&                status,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -720,7 +720,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// (in the specified `request`).  If the specified `status` is SUCCESS,
     /// the request was success and the specified `queueHandle` contains the
     /// handle representing the queue that was allocated for this specified
-    /// `requester` session having the specified `peerInstanceId`, and the
+    /// `requester` session having the specified `requesterId`, and the
     /// specified `confirmationCookie` a cookie that must be set to `true`
     /// to indicate receiving and processing of that response; otherwise
     /// `status` contains the category, error code and description of the
@@ -732,7 +732,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         const mqbi::OpenQueueConfirmationCookieSp& confirmationCookie,
         const bmqp_ctrlmsg::ControlMessage&        request,
         mqbc::ClusterNodeSession*                  requester,
-        const int                                  peerInstanceId);
+        const int                                  requesterId);
 
     void
     reconfigureCallback(const bmqp_ctrlmsg::Status&           status,

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -77,21 +77,45 @@ struct Counter {
 
 void onHandleDeconfigured(
     const bmqp_ctrlmsg::Status&,
-    const bmqp_ctrlmsg::StreamParameters&,
-    mqbi::Queue*                               queue,
-    mqbi::QueueHandle*                         handle,
-    const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-    const bsl::shared_ptr<Counter>&            counter)
+    const bmqp_ctrlmsg::StreamParameters& streamParameters,
+    mqbi::Queue*                          queue,
+    mqbi::QueueHandle*                    handle,
+
+    const bsl::shared_ptr<Counter>& counter)
 {
     BSLS_ASSERT_SAFE(queue);
     BSLS_ASSERT_SAFE(handle);
 
-    const bool isFinal = (counter->decrement() == 0);
+    // Re-read current counts from the handle because cookie rollback may have
+    // already decremented some counts between de-confgigure request and now.
+    mqbi::QueueHandle::SubStreams::const_iterator cit =
+        handle->subStreamInfos().find(streamParameters.appId());
 
-    queue->releaseHandle(handle,
-                         handleParameters,
-                         isFinal,
-                         mqbi::QueueHandle::HandleReleasedCallback());
+    if (cit == handle->subStreamInfos().end()) {
+        // Already fully released by cookie rollback — nothing to do.
+        return;
+    }
+
+    const bool                           isFinal = (counter->decrement() == 0);
+    const bsl::string&                   appId   = cit->first;
+    const mqbi::QueueHandle::StreamInfo& info    = cit->second;
+
+    BSLS_ASSERT_SAFE(appId != bmqp::ProtocolUtil::k_NULL_APP_ID);
+
+    if (info.d_counts.d_readCount == 0) {
+        // Already fully released by cookie rollback — nothing to do.
+    }
+
+    bmqp_ctrlmsg::SubQueueIdInfo subStreamInfo;
+    subStreamInfo.appId() = appId;
+    subStreamInfo.subId() = info.d_downstreamSubQueueId;
+    queue->releaseHandle(
+        handle,
+        bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
+                                                subStreamInfo,
+                                                info.d_counts.d_readCount),
+        isFinal,
+        mqbi::QueueHandle::HandleReleasedCallback());
 }
 
 }
@@ -277,7 +301,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
     // Execute the 'configureHandle' & 'releaseHandle' sequence to drop each
     // subStream of the handle in turn.
 
-    int totalReadCount = handle->handleParameters().readCount();
     mqbi::QueueHandle::SubStreams::const_iterator citer =
         handle->subStreamInfos().begin();
     bool isFinal = (citer == handle->subStreamInfos().end());
@@ -291,13 +314,7 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
         subStreamInfo.appId() = appId;
         subStreamInfo.subId() = info.d_downstreamSubQueueId;
 
-        bmqp_ctrlmsg::QueueHandleParameters consumerHandleParams =
-            bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
-                                                    subStreamInfo,
-                                                    info.d_counts.d_readCount);
-
         isFinal = ((++citer) == handle->subStreamInfos().end());
-        totalReadCount -= consumerHandleParams.readCount();
 
         BALL_LOG_INFO << "Dropping subStream for queue ["
                       << handle->queue()->description() << "] and handle ["
@@ -320,7 +337,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
                                                  bdlf::PlaceHolders::_2,
                                                  this,
                                                  handle,
-                                                 consumerHandleParams,
                                                  counter));
         }
         else {
@@ -328,13 +344,14 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
             // invalidating the iterator.
             releaseHandleDispatched(
                 handle,
-                consumerHandleParams,
+                bmqp::QueueUtil::createHandleParameters(
+                    handle->handleParameters(),
+                    subStreamInfo,
+                    info.d_counts.d_readCount),
                 isFinal,  // isFinal flag
                 mqbi::QueueHandle::HandleReleasedCallback());
         }
     }
-
-    BSLS_ASSERT_SAFE(0 == totalReadCount);
 }
 
 void Queue::closeDispatched()

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -76,21 +76,45 @@ struct Counter {
 
 void onHandleDeconfigured(
     const bmqp_ctrlmsg::Status&,
-    const bmqp_ctrlmsg::StreamParameters&,
-    mqbi::Queue*                               queue,
-    mqbi::QueueHandle*                         handle,
-    const bmqp_ctrlmsg::QueueHandleParameters& handleParameters,
-    const bsl::shared_ptr<Counter>&            counter)
+    const bmqp_ctrlmsg::StreamParameters& streamParameters,
+    mqbi::Queue*                          queue,
+    mqbi::QueueHandle*                    handle,
+
+    const bsl::shared_ptr<Counter>& counter)
 {
     BSLS_ASSERT_SAFE(queue);
     BSLS_ASSERT_SAFE(handle);
 
-    const bool isFinal = (counter->decrement() == 0);
+    // Re-read current counts from the handle because cookie rollback may have
+    // already decremented some counts between de-confgigure request and now.
+    mqbi::QueueHandle::SubStreams::const_iterator cit =
+        handle->subStreamInfos().find(streamParameters.appId());
 
-    queue->releaseHandle(handle,
-                         handleParameters,
-                         isFinal,
-                         mqbi::QueueHandle::HandleReleasedCallback());
+    if (cit == handle->subStreamInfos().end()) {
+        // Already fully released by cookie rollback — nothing to do.
+        return;
+    }
+
+    const bool                           isFinal = (counter->decrement() == 0);
+    const bsl::string&                   appId   = cit->first;
+    const mqbi::QueueHandle::StreamInfo& info    = cit->second;
+
+    BSLS_ASSERT_SAFE(appId != bmqp::ProtocolUtil::k_NULL_APP_ID);
+
+    if (info.d_counts.d_readCount == 0) {
+        // Already fully released by cookie rollback — nothing to do.
+    }
+
+    bmqp_ctrlmsg::SubQueueIdInfo subStreamInfo;
+    subStreamInfo.appId() = appId;
+    subStreamInfo.subId() = info.d_downstreamSubQueueId;
+    queue->releaseHandle(
+        handle,
+        bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
+                                                subStreamInfo,
+                                                info.d_counts.d_readCount),
+        isFinal,
+        mqbi::QueueHandle::HandleReleasedCallback());
 }
 
 }
@@ -276,7 +300,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
     // Execute the 'configureHandle' & 'releaseHandle' sequence to drop each
     // subStream of the handle in turn.
 
-    int totalReadCount = handle->handleParameters().readCount();
     mqbi::QueueHandle::SubStreams::const_iterator citer =
         handle->subStreamInfos().begin();
     bool isFinal = (citer == handle->subStreamInfos().end());
@@ -290,13 +313,7 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
         subStreamInfo.appId() = appId;
         subStreamInfo.subId() = info.d_downstreamSubQueueId;
 
-        bmqp_ctrlmsg::QueueHandleParameters consumerHandleParams =
-            bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
-                                                    subStreamInfo,
-                                                    info.d_counts.d_readCount);
-
         isFinal = ((++citer) == handle->subStreamInfos().end());
-        totalReadCount -= consumerHandleParams.readCount();
 
         BALL_LOG_INFO << "Dropping subStream for queue ["
                       << handle->queue()->description() << "] and handle ["
@@ -319,7 +336,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
                                                  bdlf::PlaceHolders::_2,
                                                  this,
                                                  handle,
-                                                 consumerHandleParams,
                                                  counter));
         }
         else {
@@ -327,13 +343,14 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
             // invalidating the iterator.
             releaseHandleDispatched(
                 handle,
-                consumerHandleParams,
+                bmqp::QueueUtil::createHandleParameters(
+                    handle->handleParameters(),
+                    subStreamInfo,
+                    info.d_counts.d_readCount),
                 isFinal,  // isFinal flag
                 mqbi::QueueHandle::HandleReleasedCallback());
         }
     }
-
-    BSLS_ASSERT_SAFE(0 == totalReadCount);
 }
 
 void Queue::closeDispatched()

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -57,31 +57,19 @@
 namespace BloombergLP {
 namespace mqbblp {
 
-namespace {
+// -----------
+// class Queue
+// -----------
 
-struct Counter {
-    bsls::AtomicUint d_count;
-
-    explicit Counter(unsigned count)
-    : d_count(count)
-    {
-        // NOTHING
-    }
-    unsigned decrement()
-    {
-        BSLS_ASSERT_SAFE(d_count.load());
-        return d_count.subtract(1);
-    }
-};
-
-void onHandleDeconfigured(
+void Queue::onHandleDeconfigured(
     const bmqp_ctrlmsg::Status&,
     const bmqp_ctrlmsg::StreamParameters& streamParameters,
-    mqbi::Queue*                          queue,
-    mqbi::QueueHandle*                    handle,
-    const bsl::shared_ptr<Counter>&       counter)
+    mqbi::QueueHandle*                    handle)
 {
-    BSLS_ASSERT_SAFE(queue);
+    // executed by the *QUEUE* dispatcher thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(inDispatcherThread());
     BSLS_ASSERT_SAFE(handle);
 
     // Re-read current counts from the handle because cookie rollback may have
@@ -94,9 +82,12 @@ void onHandleDeconfigured(
         return;
     }
 
-    const bool                           isFinal = (counter->decrement() == 0);
-    const bsl::string&                   appId   = cit->first;
-    const mqbi::QueueHandle::StreamInfo& info    = cit->second;
+    // This is handle drop which results in erasing handle->subStreamInfos()
+    // Use the size as an indication of the last (final) one.
+
+    const bool         isFinal = (handle->subStreamInfos().size() == 1);
+    const bsl::string& appId   = cit->first;
+    const mqbi::QueueHandle::StreamInfo& info = cit->second;
 
     BSLS_ASSERT_SAFE(appId != bmqp::ProtocolUtil::k_NULL_APP_ID);
 
@@ -109,7 +100,7 @@ void onHandleDeconfigured(
     bmqp_ctrlmsg::SubQueueIdInfo subStreamInfo;
     subStreamInfo.appId() = appId;
     subStreamInfo.subId() = info.d_downstreamSubQueueId;
-    queue->releaseHandle(
+    releaseHandleDispatched(
         handle,
         bmqp::QueueUtil::createHandleParameters(handle->handleParameters(),
                                                 subStreamInfo,
@@ -117,12 +108,6 @@ void onHandleDeconfigured(
         isFinal,
         mqbi::QueueHandle::HandleReleasedCallback());
 }
-
-}
-
-// -----------
-// class Queue
-// -----------
 
 void Queue::configureDispatchedAndPost(int*              result,
                                        bsl::ostream*     errorDescription,
@@ -278,10 +263,6 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
         return;  // RETURN
     }
 
-    bsl::shared_ptr<Counter> counter(
-        new (*d_allocator_p) Counter(handle->subStreamInfos().size()),
-        d_allocator_p);
-
     BALL_LOG_INFO << "Dropping QueueHandle [" << handle << "] for queue ["
                   << description() << "] having "
                   << handle->subStreamInfos().size() << " subStreams.";
@@ -332,12 +313,11 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
             // response.
             configureHandle(handle,
                             nullStreamParameters,
-                            bdlf::BindUtil::bind(&onHandleDeconfigured,
+                            bdlf::BindUtil::bind(&Queue::onHandleDeconfigured,
+                                                 this,
                                                  bdlf::PlaceHolders::_1,
                                                  bdlf::PlaceHolders::_2,
-                                                 this,
-                                                 handle,
-                                                 counter));
+                                                 handle));
         }
         else {
             // 'releaseHandle' erases from 'handle->subStreamInfos()'

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -79,14 +79,13 @@ void onHandleDeconfigured(
     const bmqp_ctrlmsg::StreamParameters& streamParameters,
     mqbi::Queue*                          queue,
     mqbi::QueueHandle*                    handle,
-
-    const bsl::shared_ptr<Counter>& counter)
+    const bsl::shared_ptr<Counter>&       counter)
 {
     BSLS_ASSERT_SAFE(queue);
     BSLS_ASSERT_SAFE(handle);
 
     // Re-read current counts from the handle because cookie rollback may have
-    // already decremented some counts between de-confgigure request and now.
+    // already decremented some counts between de-configure request and now.
     mqbi::QueueHandle::SubStreams::const_iterator cit =
         handle->subStreamInfos().find(streamParameters.appId());
 
@@ -101,8 +100,10 @@ void onHandleDeconfigured(
 
     BSLS_ASSERT_SAFE(appId != bmqp::ProtocolUtil::k_NULL_APP_ID);
 
-    if (info.d_counts.d_readCount == 0) {
+    if (info.d_counts.d_readCount == 0 && info.d_counts.d_writeCount == 0) {
         // Already fully released by cookie rollback — nothing to do.
+
+        return;  // RETURN
     }
 
     bmqp_ctrlmsg::SubQueueIdInfo subStreamInfo;

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -121,6 +121,11 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
 
   private:
     // PRIVATE MANIPULATORS
+    void onHandleDeconfigured(
+        const bmqp_ctrlmsg::Status&,
+        const bmqp_ctrlmsg::StreamParameters& streamParameters,
+        mqbi::QueueHandle*                    handle);
+
     void configureDispatchedAndPost(int*              result,
                                     bsl::ostream*     errorDescription,
                                     bool              isReconfigure,

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -159,7 +159,6 @@ void RootQueueEngine::deliverMessages(AppState* app)
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->inDispatcherThread());
 
     BSLS_ASSERT_SAFE(d_queueState_p->storage());
-    BSLS_ASSERT_SAFE(d_apps.find(app->appId()) != d_apps.end());
 
     if (!app->isAuthorized()) {
         return;  // RETURN
@@ -169,6 +168,8 @@ void RootQueueEngine::deliverMessages(AppState* app)
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         return;  // RETURN
     }
+
+    BSLS_ASSERT_SAFE(d_apps.find(app->appId()) != d_apps.end());
 
     bsls::TimeInterval delay;
     size_t             numMessages = app->processDeliveryLists(&delay,

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
@@ -166,6 +166,12 @@ void ClusterNodeSession::createQueueHandleRequesterContext()
 {
     BSLS_ASSERT_SAFE(d_queueHandleRequesterContext_sp);
 
+    // Copy before `createInplace` destroys the old object.
+    const bmqp_ctrlmsg::ClientIdentity identity =
+        d_queueHandleRequesterContext_sp->identity();
+    const bsl::shared_ptr<bmqst::StatContext> statContext =
+        d_queueHandleRequesterContext_sp->statContext();
+
     createQueueHandleRequesterContextImpl(
         d_queueHandleRequesterContext_sp->identity(),
         d_queueHandleRequesterContext_sp->statContext());
@@ -187,7 +193,7 @@ void ClusterNodeSession::createQueueHandleRequesterContextImpl(
         .setDescription(bsl::string(description(), d_allocator_p))
         .setIsClusterMember(true)
         .setRequesterId(
-            mqbi::QueueHandleRequesterContext ::generateUniqueRequesterId())
+            mqbi::QueueHandleRequesterContext::generateUniqueRequesterId())
         .setInlineClient(this)
         .setStatContext(statContext);
 }

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
@@ -40,10 +40,7 @@ ClusterNodeSession::ClusterNodeSession(
     bslma::Allocator*                          allocator)
 : d_cluster_p(cluster)
 , d_clusterNode_p(netNode)
-, d_peerInstanceId(0)  // There is no invalid value for this field
-, d_queueHandleRequesterContext_sp(
-      new(*allocator) mqbi::QueueHandleRequesterContext(allocator),
-      allocator)
+, d_queueHandleRequesterContext_sp()
 , d_nodeStatus(bmqp_ctrlmsg::NodeStatus::E_UNAVAILABLE)  // See note in ctor
 , d_statContext_sp(statContext)
 , d_primaryPartitions(allocator)
@@ -52,19 +49,13 @@ ClusterNodeSession::ClusterNodeSession(
 , d_gateAck()
 , d_gatePut()
 , d_gateConfirm()
+, d_allocator_p(allocator)
 {
     // Note regarding 'd_nodeStatus': it must be initialized with E_UNAVAILABLE
     // because this value indicates that self node is not connected to this
     // peer, and some startup logic depends on this value being E_UNAVAILABLE.
 
-    d_queueHandleRequesterContext_sp->setClient(this)
-        .setIdentity(identity)
-        .setDescription(bsl::string(description(), allocator))
-        .setIsClusterMember(true)
-        .setRequesterId(
-            mqbi::QueueHandleRequesterContext ::generateUniqueRequesterId())
-        .setInlineClient(this)
-        .setStatContext(statContext);
+    createQueueHandleRequesterContextImpl(identity, statContext);
     // TBD: The passed in 'queueHandleRequesterIdentity' is currently the
     //      'clusterState->identity()' (representing the identity of self node
     //      in the cluster); and it should instead represent the identity of
@@ -169,6 +160,36 @@ bool ClusterNodeSession::removePartitionSafe(int partitionId)
                   << "]: removed self as primary in ClusterNodeSession";
 
     return true;
+}
+
+void ClusterNodeSession::createQueueHandleRequesterContext()
+{
+    BSLS_ASSERT_SAFE(d_queueHandleRequesterContext_sp);
+
+    createQueueHandleRequesterContextImpl(
+        d_queueHandleRequesterContext_sp->identity(),
+        d_queueHandleRequesterContext_sp->statContext());
+}
+
+void ClusterNodeSession::createQueueHandleRequesterContextImpl(
+    const bmqp_ctrlmsg::ClientIdentity&        identity,
+    const bsl::shared_ptr<bmqst::StatContext>& statContext)
+{
+    // executed by the *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(inDispatcherThread());
+    d_queueHandleRequesterContext_sp.createInplace(d_allocator_p,
+                                                   d_allocator_p);
+
+    d_queueHandleRequesterContext_sp->setClient(this)
+        .setIdentity(identity)
+        .setDescription(bsl::string(description(), d_allocator_p))
+        .setIsClusterMember(true)
+        .setRequesterId(
+            mqbi::QueueHandleRequesterContext ::generateUniqueRequesterId())
+        .setInlineClient(this)
+        .setStatContext(statContext);
 }
 
 bool ClusterNodeSession::isPrimaryForPartition(int partitionId) const

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.h
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.h
@@ -144,19 +144,17 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
     /// The corresponding cluster node.
     mqbnet::ClusterNode* d_clusterNode_p;
 
-    /// ID of the peer's instance.  This ID is changed everytime the channel
-    /// with the peer is reset.  This instance ID is used to discriminate
-    /// against old instance of the peer.  Note that unlike
+    /// Context used to uniquely identify this client when requesting a queue
+    /// handle.
+    /// Changes every time the channel with the peer is reset.  `requesterId`
+    /// discriminates against old instance of the peer.  Note that unlike
     /// @bbref{mqba::ClientSession}, an instance of `ClusterNodeSession` is not
     /// destroyed every time channel b/w self node and peer goes down, and thus
     /// self node may contain state associated with peer's old instance.  Also
     /// note that there is no invalid value for this ID, and its value alone
     /// cannot be used to determine if the channel with the peer is up or not.
-    int d_peerInstanceId;
 
-    /// Context used to uniquely identify this client when requesting a queue
-    /// handle.
-    const bsl::shared_ptr<mqbi::QueueHandleRequesterContext>
+    bsl::shared_ptr<mqbi::QueueHandleRequesterContext>
         d_queueHandleRequesterContext_sp;
 
     /// Node status.
@@ -176,10 +174,17 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
     bmqu::GateKeeper d_gatePut;
     bmqu::GateKeeper d_gateConfirm;
 
+    /// Allocator to use.
+    bslma::Allocator* d_allocator_p;
+
   private:
     // NOT IMPLEMENTED
     ClusterNodeSession(const ClusterNodeSession&);             // = delete;
     ClusterNodeSession& operator=(const ClusterNodeSession&);  // = delete;
+
+    void createQueueHandleRequesterContextImpl(
+        const bmqp_ctrlmsg::ClientIdentity&        identity,
+        const bsl::shared_ptr<bmqst::StatContext>& statContext);
 
   public:
     // TRAITS
@@ -226,8 +231,6 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
     /// @param self Node status of the node this session belongs to.
     void setNodeStatus(bmqp_ctrlmsg::NodeStatus::Value other,
                        bmqp_ctrlmsg::NodeStatus::Value self);
-
-    void setPeerInstanceId(int value);
 
     /// Return a reference to the modifiable list of queue handles.
     QueueHandleMap& queueHandles();
@@ -276,6 +279,8 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
     bmqu::GateKeeper& gatePut();
     bmqu::GateKeeper& gateConfirm();
 
+    void createQueueHandleRequesterContext();
+
     // ACCESSORS
 
     /// Return a pointer to the dispatcher this client is associated with.
@@ -296,9 +301,6 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
 
     /// Return the node status.
     bmqp_ctrlmsg::NodeStatus::Value nodeStatus() const;
-
-    /// Return the instance ID of the peer.
-    int peerInstanceId() const;
 
     /// Return the associated stat context.
     const bsl::shared_ptr<bmqst::StatContext>& statContext() const;
@@ -431,11 +433,6 @@ ClusterNodeSession::setNodeStatus(bmqp_ctrlmsg::NodeStatus::Value other,
     }
 }
 
-inline void ClusterNodeSession::setPeerInstanceId(int value)
-{
-    d_peerInstanceId = value;
-}
-
 inline void
 ClusterNodeSession::onDispatcherEvent(const mqbi::DispatcherEvent& event)
 {
@@ -534,11 +531,6 @@ inline mqbnet::ClusterNode* ClusterNodeSession::clusterNode() const
 inline bmqp_ctrlmsg::NodeStatus::Value ClusterNodeSession::nodeStatus() const
 {
     return d_nodeStatus;
-}
-
-inline int ClusterNodeSession::peerInstanceId() const
-{
-    return d_peerInstanceId;
 }
 
 inline const bsl::shared_ptr<bmqst::StatContext>&

--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.h
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.h
@@ -279,6 +279,8 @@ class ClusterNodeSession : public mqbi::DispatcherClient,
     bmqu::GateKeeper& gatePut();
     bmqu::GateKeeper& gateConfirm();
 
+    /// Create new instance of `QueueHandleRequesterContext` with the same
+    /// `identity` and `statContext` but a unique `requesterId`.
     void createQueueHandleRequesterContext();
 
     // ACCESSORS


### PR DESCRIPTION
Concurrent cookie rollback (`onOpenQueueConfirmationCookieReleased`) may decrement the same count as `dropHandleDispatched` resulting in double decrement.
Solution: re-read current counts from handle->subStreamInfos() upon de-configure response.
