### PR TITLE
Cleanup[mqb]: Remove all mentions of 'isCSLModeEnabled' flag

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -3234,13 +3234,6 @@ void Cluster::printClusterStateSummary(bsl::ostream& out,
     mqbcmd::HumanPrinter::print(out, result, level, spacesPerLevel);
 }
 
-bool Cluster::isCSLModeEnabled() const
-{
-    return d_clusterData.clusterConfig()
-        .clusterAttributes()
-        .isCSLModeEnabled();
-}
-
 bool Cluster::isFSMWorkflow() const
 {
     return d_clusterData.clusterConfig().clusterAttributes().isFSMWorkflow();

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -775,9 +775,6 @@ class Cluster : public mqbi::Cluster,
                                   int           spacesPerLevel = 0) const
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Return boolean flag indicating if CSL Mode is enabled.
-    bool isCSLModeEnabled() const BSLS_KEYWORD_OVERRIDE;
-
     /// Return boolean flag indicating if CSL FSM workflow is in effect.
     bool isFSMWorkflow() const BSLS_KEYWORD_OVERRIDE;
 

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -151,18 +151,6 @@ int ClusterCatalog::createCluster(bsl::ostream& errorDescription,
         // 1. Fetch the cluster definition
         const mqbcfg::ClusterDefinition& clusterDefinition =
             *clusterDefinitionIter;
-        if (clusterDefinition.clusterAttributes().isFSMWorkflow() !=
-            clusterDefinition.clusterAttributes().isCSLModeEnabled()) {
-            // CSL and FSM must be both true or both false, other combinations
-            // are not supported
-            errorDescription
-                << "Cluster ('" << name << "') has incompatible CSL ("
-                << clusterDefinition.clusterAttributes().isCSLModeEnabled()
-                << ") and FSM ("
-                << clusterDefinition.clusterAttributes().isFSMWorkflow()
-                << ") modes, not creating cluster.";
-            return (rc * 10) + rc_FETCH_DEFINITION_FAILED;  // RETURN
-        }
 
         // 2. Create the mqbnet::Cluster
         rc = createNetCluster(errorDescription,

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -884,8 +884,7 @@ void ClusterOrchestrator::processClusterStateFSMMessage(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isCSLModeEnabled() &&
-                     d_clusterConfig.clusterAttributes().isFSMWorkflow());
+    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isFSMWorkflow());
     BSLS_ASSERT(message.choice().isClusterMessageValue());
     BSLS_ASSERT(message.choice()
                     .clusterMessage()
@@ -943,8 +942,7 @@ void ClusterOrchestrator::processPartitionMessage(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isCSLModeEnabled() &&
-                     d_clusterConfig.clusterAttributes().isFSMWorkflow());
+    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isFSMWorkflow());
     BSLS_ASSERT(message.choice().isClusterMessageValue());
     BSLS_ASSERT(
         message.choice().clusterMessage().choice().isPartitionMessageValue());

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -885,7 +885,7 @@ void ClusterQueueHelper::finishReopening(QueueContext*        queueContext,
     pendingClose.swap(sqit->value().d_pendingCloseRequests);
 
     const bool isOpen  = (sqit->value().d_state == SubQueueContext::k_OPEN);
-    bool isValid = true;
+    bool       isValid = true;
 
     for (size_t i = 0; i < pendingClose.size(); ++i) {
         if (isOpen && isValid) {
@@ -1548,7 +1548,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
         return;  // RETURN
     }
 
-    SubQueueContext& subQueueContext = sqit->value();
+    SubQueueContext&          subQueueContext = sqit->value();
     const bsls::Types::Uint64 generationCount = cycle->generationCount();
 
     if (subQueueContext.d_generationCount != generationCount) {
@@ -4018,7 +4018,7 @@ bmqt::GenericResult::Enum ClusterQueueHelper::restoreStateHelper(
 
     QueueLiveState&           queueInfo = queueContext->d_liveQInfo;
     bmqt::GenericResult::Enum rc        = bmqt::GenericResult::e_SUCCESS;
-    const mqbi::Queue* queuePtr = queueInfo.d_queue_sp.get();
+    const mqbi::Queue*        queuePtr  = queueInfo.d_queue_sp.get();
 
     BSLS_ASSERT_SAFE(queuePtr);
 
@@ -6018,17 +6018,6 @@ int ClusterQueueHelper::gcExpiredQueues(bool               immediate,
             keyCopy,
             pid,
             *d_clusterState_p);
-
-        if (!d_cluster_p->isCSLModeEnabled()) {
-            // Broadcast 'QueueUnAssignmentAdvisory' to all followers
-            //
-            // NOTE: We must broadcast this control message before applying to
-            // CSL, because if CSL is running in eventual consistency it will
-            // immediately apply a commit with a higher seqeuence number than
-            // the QueueUnAssignmentAdvisory.  If we ever receive the commit
-            // before the QUA, we will alarm due to out-of-sequence advisory.
-            d_clusterData_p->messageTransmitter().broadcastMessage(controlMsg);
-        }
 
         // Apply 'QueueUnAssignmentAdvisory' to CSL
         d_clusterStateManager_p->unassignQueue(queueAdvisory);

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemonitor.t.cpp
@@ -179,7 +179,6 @@ struct TestHelper {
                 mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
-                                 false,  // isCSLMode
                                  false,  // isFSMWorkflow
                                  false,  // doesFSMwriteQLIST
                                  clusterNodeDefs,

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -159,7 +159,6 @@ struct Tester {
                 mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,  // isClusterMember
                                  d_isLeader,
-                                 true,   // isCSLMode
                                  true,   // isFSMWorkflow
                                  false,  // doesFSMwriteQLIST
                                  clusterNodeDefs,

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -1049,19 +1049,6 @@ bool ClusterUtil::assignQueue(ClusterState*         clusterState,
 
     clusterState->queueKeys().erase(key);
 
-    if (!cluster->isCSLModeEnabled()) {
-        // Broadcast 'queueAssignmentAdvisory' to all followers
-
-        // NOTE: We must broadcast this control message before applying to CSL,
-        // because if CSL is running in eventual consistency it will
-        // immediately apply a commit with a higher seqeuence number than the
-        // QueueAssignmentAdvisory.  If we ever receive the commit before the
-        // QAA, we will alarm due to out-of-sequence advisory.
-        clusterData->messageTransmitter().broadcastMessage(controlMsg);
-
-        BSLS_ASSERT_SAFE(queueAdvisory.queues().size() == 1);
-    }
-
     // Apply 'queueAssignmentAdvisory' to CSL
     BALL_LOG_INFO << clusterData->identity().description()
                   << ": 'QueueAssignmentAdvisory' will be applied to "
@@ -1590,18 +1577,6 @@ void ClusterUtil::sendClusterState(
             &advisory.sequenceNumber());
 
         loadQueuesInfo(&advisory.queues(), clusterState);
-    }
-
-    // Need to send the control message for the old brokers to process
-    // LeaderAdvisory.
-    if (!clusterData->cluster().isCSLModeEnabled()) {
-        if (node) {
-            clusterData->messageTransmitter().sendMessage(controlMessage,
-                                                          node);
-        }
-        else {
-            clusterData->messageTransmitter().broadcastMessage(controlMessage);
-        }
     }
 
     const int rc = ledger->apply(clusterMessage);

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -244,7 +244,6 @@ struct Tester {
                 mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,  // isClusterMember
                                  isLeader,
-                                 true,   // isCSLMode
                                  false,  // isFSMWorkflow
                                  false,  // doesFSMwriteQLIST
                                  clusterNodeDefs,

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -124,8 +124,7 @@ RecoveryManager::RecoveryManager(
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(allocator);
-    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isCSLModeEnabled() &&
-                     d_clusterConfig.clusterAttributes().isFSMWorkflow());
+    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isFSMWorkflow());
 
     d_recoveryContextVec.resize(
         clusterConfig.partitionConfig().numPartitions());

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3662,8 +3662,7 @@ StorageManager::StorageManager(
     BSLS_ASSERT_SAFE(d_cluster_p);
     BSLS_ASSERT_SAFE(d_recoveryStatusCb);
     BSLS_ASSERT_SAFE(d_partitionPrimaryStatusCb);
-    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isCSLModeEnabled() &&
-                     d_clusterConfig.clusterAttributes().isFSMWorkflow());
+    BSLS_ASSERT_SAFE(d_clusterConfig.clusterAttributes().isFSMWorkflow());
 
     const mqbcfg::PartitionConfig& partitionCfg =
         d_clusterConfig.partitionConfig();

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -194,7 +194,6 @@ struct TestHelper {
                 mqbmock::Cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
-                                 true,   // isCSLMode
                                  true,   // isFSMWorkflow
                                  false,  // doesFSMwriteQLIST
                                  clusterNodeDefs,

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -423,9 +423,6 @@ class Cluster : public DispatcherClient {
                                           int           level = 0,
                                           int spacesPerLevel  = 0) const = 0;
 
-    /// Return boolean flag indicating if CSL Mode is enabled.
-    virtual bool isCSLModeEnabled() const;
-
     /// Return boolean flag indicating if CSL FSM workflow is in effect.
     virtual bool isFSMWorkflow() const;
 
@@ -537,11 +534,6 @@ struct ClusterResources {
 // ============================================================================
 //                             INLINE DEFINITIONS
 // ============================================================================
-
-inline bool Cluster::isCSLModeEnabled() const
-{
-    return false;
-}
 
 inline bool Cluster::isFSMWorkflow() const
 {

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -83,7 +83,6 @@ void Cluster::_initializeClusterDefinition(
     const bslstl::StringRef&                location,
     const bslstl::StringRef&                archive,
     const bsl::vector<mqbcfg::ClusterNode>& nodes,
-    bool                                    isCSLMode,
     bool                                    isFSMWorkflow,
     bool                                    doesFSMwriteQLIST)
 {
@@ -91,14 +90,10 @@ void Cluster::_initializeClusterDefinition(
     BSLS_ASSERT_OPT(!d_isStarted &&
                     "_initializeClusterDefinition() must be called before"
                     " start()");
-    if (isFSMWorkflow) {
-        BSLS_ASSERT_SAFE(isCSLMode);
-    }
 
     d_clusterDefinition.name() = name;
 
-    d_clusterDefinition.clusterAttributes().isCSLModeEnabled() = isCSLMode;
-    d_clusterDefinition.clusterAttributes().isFSMWorkflow()    = isFSMWorkflow;
+    d_clusterDefinition.clusterAttributes().isFSMWorkflow() = isFSMWorkflow;
     d_clusterDefinition.clusterAttributes().doesFSMwriteQLIST() =
         doesFSMwriteQLIST;
 
@@ -214,7 +209,6 @@ void Cluster::_initializeNodeSessions()
 Cluster::Cluster(bslma::Allocator*        allocator,
                  bool                     isClusterMember,
                  bool                     isLeader,
-                 bool                     isCSLMode,
                  bool                     isFSMWorkflow,
                  bool                     doesFSMwriteQLIST,
                  const ClusterNodeDefs&   clusterNodeDefs,
@@ -274,7 +268,6 @@ Cluster::Cluster(bslma::Allocator*        allocator,
                                  location,
                                  archive,
                                  clusterNodeDefs,
-                                 isCSLMode,
                                  isFSMWorkflow,
                                  doesFSMwriteQLIST);
     _initializeNetcluster();

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -252,13 +252,12 @@ class Cluster : public mqbi::Cluster {
     // PRIVATE MANIPULATORS
 
     /// Initialize the internal cluster definition with the specified
-    /// `name`, `location`, `archive` location, `nodes`, `isCSLMode`,
-    /// `isFSMWorkflow` and `doesFSMwriteQLIST`.
+    /// `name`, `location`, `archive` location, `nodes`, `isFSMWorkflow` and
+    /// `doesFSMwriteQLIST`.
     void _initializeClusterDefinition(const bslstl::StringRef& name,
                                       const bslstl::StringRef& location,
                                       const bslstl::StringRef& archive,
                                       const ClusterNodeDefs&   nodes,
-                                      bool                     isCSLMode,
                                       bool                     isFSMWorkflow,
                                       bool doesFSMwriteQLIST);
 
@@ -275,17 +274,15 @@ class Cluster : public mqbi::Cluster {
     // CREATORS
 
     /// Create a `mqbmock::Cluster` object having the optionally specified
-    /// `name`, `location`, `archive`, `clusterNodeDefs`, `isCSLMode`,
-    /// `isFSMWorkflow` and `doesFSMwriteQLIST`, and using the specified
-    /// `bufferFactory` and `allocator`.  If the optionally specified
-    /// `isClusterMember` is true, self will be a member of the cluster.  If
-    /// the optionally specified `isLeader` is true, self will become the
-    /// leader of the cluster.  Note that if `isClusterMember` is false,
-    /// `isLeader` cannot be true.
+    /// `name`, `location`, `archive`, `clusterNodeDefs`, `isFSMWorkflow` and
+    /// `doesFSMwriteQLIST`, and using the specified `bufferFactory` and
+    /// `allocator`.  If the optionally specified `isClusterMember` is true,
+    /// self will be a member of the cluster.  If the optionally specified
+    /// `isLeader` is true, self will become the leader of the cluster.  Note
+    /// that if `isClusterMember` is false, `isLeader` cannot be true.
     Cluster(bslma::Allocator*        allocator,
             bool                     isClusterMember   = false,
             bool                     isLeader          = false,
-            bool                     isCSLMode         = false,
             bool                     isFSMWorkflow     = false,
             bool                     doesFSMwriteQLIST = false,
             const ClusterNodeDefs&   clusterNodeDefs   = ClusterNodeDefs(),
@@ -544,9 +541,6 @@ class Cluster : public mqbi::Cluster {
                                   int           spacesPerLevel = 0) const
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Return boolean flag indicating if CSL Mode is enabled.
-    bool isCSLModeEnabled() const BSLS_KEYWORD_OVERRIDE;
-
     /// Return boolean flag indicating if CSL FSM workflow is in effect.
     bool isFSMWorkflow() const BSLS_KEYWORD_OVERRIDE;
 
@@ -675,11 +669,6 @@ inline void Cluster::getPartitionPrimaryNode(int*,
 
 // ACCESSORS
 //   (virtual: mqbi::Cluster)
-inline bool Cluster::isCSLModeEnabled() const
-{
-    return d_clusterDefinition.clusterAttributes().isCSLModeEnabled();
-}
-
 inline bool Cluster::isFSMWorkflow() const
 {
     return d_clusterDefinition.clusterAttributes().isFSMWorkflow();

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -233,7 +233,6 @@ TestContext::TestContext(int nodesCount, bslma::Allocator* allocator)
                    d_allocator_p,
                    true,   // isClusterMember
                    false,  // isLeader
-                   false,  // isCSLMode
                    false,  // isFSMWorkflow
                    false,  // doesFSMwriteQLIST
                    generateNodeDefs(nodesCount, d_allocator_p),
@@ -455,7 +454,6 @@ static void test1_contextTest()
         mqbmock::Cluster    cluster(bmqtst::TestHelperUtil::allocator(),
                                  true,   // isClusterMember
                                  false,  // isLeader
-                                 false,  // isCSLMode
                                  false,  // isFSMWorkflow
                                  false,  // doesFSMwriteQLIST
                                  defs,

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.t.cpp
@@ -542,7 +542,6 @@ static void test5_appIdMetrics()
     // Create a mock cluster/domain
     const bool isClusterMember = true;
     const bool isLeader        = true;
-    const bool isCSL           = false;
     const bool isFSM           = false;
 
     mqbmock::Cluster::ClusterNodeDefs clusterNodeDefs(
@@ -578,7 +577,6 @@ static void test5_appIdMetrics()
     mqbmock::Cluster mockCluster(bmqtst::TestHelperUtil::allocator(),
                                  isClusterMember,
                                  isLeader,
-                                 isCSL,
                                  isFSM,
                                  false,  // doesFSMWriteQLIST
                                  clusterNodeDefs);


### PR DESCRIPTION
The 'isCSLModeEnabled' flag will only exist in `mqbcfg.xsd` and the associated generated files. Will clean them up later to preserve backward compatibility.