### PR TITLE
Misc: Add convenience script for cpp03 files

### DIFF
--- a/bin/skip-cpp03-in-workspace.sh
+++ b/bin/skip-cpp03-in-workspace.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Skip these files in the git workspace since we rarely touch them and the script that
+# generates them will always update a timestamp when we configure the project. If you
+# do need to update them and you've run this script in your local checkout, change the
+# flag to --no-skip-worktree and rerun this script.
+
+declare -a TO_SKIP
+TO_SKIP=(
+        src/groups/bmq/bmqex/bmqex_bindutil.h
+        src/groups/bmq/bmqex/bmqex_bindutil_cpp03.h
+        src/groups/bmq/bmqex/bmqex_bindutil_cpp03.cpp
+        src/groups/bmq/bmqu/bmqu_managedcallback.h
+        src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.cpp
+        src/groups/bmq/bmqu/bmqu_managedcallback_cpp03.h
+        src/groups/bmq/bmqu/bmqu_objectplaceholder.h
+        src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.cpp
+        src/groups/bmq/bmqu/bmqu_objectplaceholder_cpp03.h
+        src/groups/bmq/bmqu/bmqu_operationchain.h
+        src/groups/bmq/bmqu/bmqu_operationchain_cpp03.cpp
+        src/groups/bmq/bmqu/bmqu_operationchain_cpp03.h
+)
+
+git update-index --skip-worktree "${TO_SKIP[@]}"


### PR DESCRIPTION
This script is meant to be run for developers working in a checkout and are getting annoyed by the timestamp being generated by the `sim_cpp11_features.pl` script that gets run during the CMake configure step.