### PR TITLE
Fix[bmqu::SingletonAllocator]: use thread-safe adapter

### DIFF
--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -36,20 +36,24 @@ namespace bmqu {
 
 bslma::Allocator* SingletonAllocator::allocator()
 {
-    static bslma::Allocator* s_alloc_p = 0;
+    typedef bdlma::BufferedSequentialAllocator SeqAllocType;
+    typedef bdlma::ConcurrentAllocatorAdapter  AdapterType;
+
+    static char                             buffer[4096];
+    static bsls::ObjectBuffer<bslmt::Mutex> mutex;
+    static bsls::ObjectBuffer<SeqAllocType> seqAlloc;
+    static bsls::ObjectBuffer<AdapterType>  adapter;
     BSLMT_ONCE_DO
     {
-        static char                               buffer[4096];
-        static bslmt::Mutex                       mutex;
-        static bdlma::BufferedSequentialAllocator seqAlloc(
-            buffer,
-            sizeof(buffer),
-            bslma::Default::globalAllocator());
-        static bdlma::ConcurrentAllocatorAdapter adapter(&mutex, &seqAlloc);
-
-        s_alloc_p = &adapter;
+        new (static_cast<void*>(mutex.buffer())) bslmt::Mutex();
+        new (static_cast<void*>(seqAlloc.buffer()))
+            SeqAllocType(buffer,
+                         sizeof(buffer),
+                         bslma::Default::globalAllocator());
+        new (static_cast<void*>(adapter.buffer()))
+            AdapterType(&mutex.object(), &seqAlloc.object());
     }
-    return s_alloc_p;
+    return &adapter.object();
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -36,22 +36,18 @@ namespace bmqu {
 
 bslma::Allocator* SingletonAllocator::allocator()
 {
-    typedef bdlma::BufferedSequentialAllocator SeqAllocType;
-    typedef bdlma::ConcurrentAllocatorAdapter  AdapterType;
-
-    static char                             buffer[4096];
-    static bsls::ObjectBuffer<bslmt::Mutex> mutex;
-    static bsls::ObjectBuffer<SeqAllocType> seqAlloc;
-    static bsls::ObjectBuffer<AdapterType>  adapter;
+    static bslma::Allocator *s_alloc_p = 0;
     BSLMT_ONCE_DO
     {
-        new (static_cast<void*>(mutex.buffer())) bslmt::Mutex();
-        new (static_cast<void*>(seqAlloc.buffer()))
-            SeqAllocType(buffer,
-                         sizeof(buffer),
-                         bslma::Default::globalAllocator());
-        new (static_cast<void*>(adapter.buffer()))
-            AdapterType(&mutex.object(), &seqAlloc.object());
+        static char                               buffer[4096];
+        static bslmt::Mutex                       mutex;
+        static bdlma::BufferedSequentialAllocator seqAlloc(
+            buffer,
+            sizeof(buffer),
+            bslma::Default::globalAllocator());
+        static bdlma::ConcurrentAllocatorAdapter  adapter(&mutex, &seqAlloc);
+
+        s_alloc_p = &adapter;
     }
     return &adapter.object();
 }

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -36,7 +36,7 @@ namespace bmqu {
 
 bslma::Allocator* SingletonAllocator::allocator()
 {
-    static bslma::Allocator *s_alloc_p = 0;
+    static bslma::Allocator* s_alloc_p = 0;
     BSLMT_ONCE_DO
     {
         static char                               buffer[4096];
@@ -45,7 +45,7 @@ bslma::Allocator* SingletonAllocator::allocator()
             buffer,
             sizeof(buffer),
             bslma::Default::globalAllocator());
-        static bdlma::ConcurrentAllocatorAdapter  adapter(&mutex, &seqAlloc);
+        static bdlma::ConcurrentAllocatorAdapter adapter(&mutex, &seqAlloc);
 
         s_alloc_p = &adapter;
     }

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -49,7 +49,7 @@ bslma::Allocator* SingletonAllocator::allocator()
 
         s_alloc_p = &adapter;
     }
-    return &adapter.object();
+    return s_alloc_p;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
+++ b/src/groups/bmq/bmqu/bmqu_singletonallocator.cpp
@@ -20,8 +20,10 @@
 
 // BDE
 #include <bdlma_bufferedsequentialallocator.h>
+#include <bdlma_concurrentallocatoradapter.h>
 #include <bsl_new.h>
 #include <bslma_default.h>
+#include <bslmt_mutex.h>
 #include <bslmt_once.h>
 #include <bsls_objectbuffer.h>
 
@@ -34,18 +36,24 @@ namespace bmqu {
 
 bslma::Allocator* SingletonAllocator::allocator()
 {
-    typedef bdlma::BufferedSequentialAllocator AllocType;
+    typedef bdlma::BufferedSequentialAllocator SeqAllocType;
+    typedef bdlma::ConcurrentAllocatorAdapter  AdapterType;
 
-    static char                          buffer[4096];
-    static bsls::ObjectBuffer<AllocType> alloc;
+    static char                             buffer[4096];
+    static bsls::ObjectBuffer<bslmt::Mutex> mutex;
+    static bsls::ObjectBuffer<SeqAllocType> seqAlloc;
+    static bsls::ObjectBuffer<AdapterType>  adapter;
     BSLMT_ONCE_DO
     {
-        new (static_cast<void*>(alloc.buffer()))
-            AllocType(buffer,
-                      sizeof(buffer),
-                      bslma::Default::globalAllocator());
+        new (static_cast<void*>(mutex.buffer())) bslmt::Mutex();
+        new (static_cast<void*>(seqAlloc.buffer()))
+            SeqAllocType(buffer,
+                         sizeof(buffer),
+                         bslma::Default::globalAllocator());
+        new (static_cast<void*>(adapter.buffer()))
+            AdapterType(&mutex.object(), &seqAlloc.object());
     }
-    return &alloc.object();
+    return &adapter.object();
 }
 
 }  // close package namespace


### PR DESCRIPTION
`bdlma::BufferedSequentialAllocator` is not thread-safe on its own