### PR TITLE
CI: Run lint workflow when PR is edited

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ on:
       - "synchronize"
       - "labeled"
       - "unlabeled"
+      - "edited"
 
 jobs:
   commits_check_job:


### PR DESCRIPTION
This patch causes the lint workflow to be rerun whenever the PR is edited in the GitHub interface, such as editing its description or title.  In particular, this is meant to fix an issue we see where editing the title of a PR does not fix failing a PR title check. After applying this patch, modifying the title of the PR will kick off another run of the linting workflow, which will succeed if the new PR title matches the correct format.