### PR TITLE
Refactor: Use bmqp::MessageGuidGenerator for mqbu_messageguidutil

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -14,11 +14,12 @@
 // limitations under the License.
 
 // bmqstoragetool
-#include "m_bmqstoragetool_compositesequencenumber.h"
-#include "m_bmqstoragetool_parameters.h"
-#include <m_bmqstoragetool_commandprocessorfactory.h>
-#include <m_bmqstoragetool_filemanagermock.h>
 #include <m_bmqstoragetool_journalfileprocessor.h>
+
+#include <m_bmqstoragetool_commandprocessorfactory.h>
+#include <m_bmqstoragetool_compositesequencenumber.h>
+#include <m_bmqstoragetool_filemanagermock.h>
+#include <m_bmqstoragetool_parameters.h>
 #include <m_bmqstoragetool_printermock.h>
 #include <m_bmqstoragetool_searchresultfactory.h>
 
@@ -36,6 +37,7 @@
 #include <bsl_list.h>
 #include <bsl_utility.h>
 #include <bslma_allocator.h>
+#include <bslma_default.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -2655,5 +2657,5 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.t.cpp
@@ -2604,5 +2604,5 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqio/bmqio_resolveutil.cpp
+++ b/src/groups/bmq/bmqio/bmqio_resolveutil.cpp
@@ -18,12 +18,16 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlma_localsequentialallocator.h>
+#include <bslma_allocator.h>
+#include <bslma_default.h>
 #include <bsls_assert.h>
 
 // NTC
 #include <bsl_memory.h>
+#include <bsls_keyword.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
+#include <ntsa_ipaddressoptions.h>
 #include <ntsf_system.h>
 #include <ntsi_resolver.h>
 
@@ -50,7 +54,11 @@ ntsa::Error ResolveUtil::getHostname(bsl::string* result)
     // PRECONDITIONS
     BSLS_ASSERT(result);
 
-    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver();
+    const BSLS_KEYWORD_CONSTEXPR int                  k_ALLOC_ESTIMATE = 1024;
+    bdlma::LocalSequentialAllocator<k_ALLOC_ESTIMATE> alloc;
+
+    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver(
+        &alloc);
     return resolver->getHostname(result);
 }
 
@@ -60,18 +68,22 @@ ntsa::Error ResolveUtil::getIpAddress(ntsa::Ipv4Address*      result,
     // PRECONDITIONS
     BSLS_ASSERT(result);
 
-    ntsa::IpAddressOptions options;
+    // Avoid dynamic memory allocation
+    const BSLS_KEYWORD_CONSTEXPR int k_ALLOC_ESTIMATE =
+        sizeof(ntsa::IpAddressOptions) + sizeof(ntsa::IpAddress) + 1024;
+    bdlma::LocalSequentialAllocator<k_ALLOC_ESTIMATE> alloc;
+
+    ntsa::IpAddressOptions options(&alloc);
 
     // Limit addresses to V4 only
     options.setIpAddressType(ntsa::IpAddressType::e_V4);
     // Return first address
     options.setIpAddressSelector(0);
 
-    // Avoid dynamic memory allocation
-    bdlma::LocalSequentialAllocator<sizeof(ntsa::IpAddress)> lsa;
-    bsl::vector<ntsa::IpAddress>                             ipAddresses(&lsa);
+    bsl::vector<ntsa::IpAddress> ipAddresses(&alloc);
 
-    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver();
+    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver(
+        &alloc);
     ntsa::Error error = resolver->getIpAddress(&ipAddresses,
                                                domainName,
                                                options);
@@ -89,10 +101,14 @@ ntsa::Error ResolveUtil::getIpAddress(bsl::vector<ntsa::IpAddress>* result,
     // PRECONDITIONS
     BSLS_ASSERT(result);
 
-    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver();
-    ntsa::Error                     error    = resolver->getIpAddress(result,
+    const BSLS_KEYWORD_CONSTEXPR int k_ALLOC_ESTIMATE =
+        1024 + sizeof(ntsa::IpAddressOptions);
+    bdlma::LocalSequentialAllocator<k_ALLOC_ESTIMATE> alloc;
+    bsl::shared_ptr<ntsi::Resolver> resolver = ntsf::System::createResolver(
+        &alloc);
+    ntsa::Error error = resolver->getIpAddress(result,
                                                domainName,
-                                               ntsa::IpAddressOptions());
+                                               ntsa::IpAddressOptions(&alloc));
 
     return error;
 }

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.cpp
@@ -18,6 +18,7 @@
 #include <bmqscm_version.h>
 
 #include <bmqio_resolveutil.h>
+#include <bmqt_messageguid.h>
 #include <bmqu_memoutstream.h>
 
 // BDE
@@ -30,15 +31,19 @@
 #include <bdls_processutil.h>
 #include <bsl_cstring.h>
 #include <bsl_iostream.h>
+#include <bsl_limits.h>
 #include <bsl_string.h>
 #include <bsls_assert.h>
+#include <bsls_keyword.h>
 #include <bsls_systemtime.h>
 #include <bsls_timeutil.h>
 
 // NTC
 #include <bsl_ios.h>
+#include <bsl_optional.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
+#include <ntsa_ipv4address.h>
 
 namespace BloombergLP {
 namespace bmqp {
@@ -64,6 +69,8 @@ const int k_GUID_VERSION_AND_COUNTER_BYTES = 3;
 /// Number of bytes used to encode those various fields.
 const int k_TIMERTICK_BYTES = 7;
 
+const BSLS_KEYWORD_CONSTEXPR int k_HOSTNAME_LEN = 128;
+
 }  // close unnamed namespace
 
 // --------------------------
@@ -72,10 +79,9 @@ const int k_TIMERTICK_BYTES = 7;
 
 // CREATORS
 MessageGUIDGenerator::MessageGUIDGenerator(int sessionId, bool doIpResolving)
-: d_clientId()     // init array with zeros
-, d_clientIdHex()  // init array with zeros
-, d_counter(-1)    // Initialize 'd_counter' to -1, so that pre-incremented
-                   // value starts  from zero.
+: d_clientId()
+, d_clientIdHex()
+, d_counter(0)
 , d_nanoSecondsFromEpoch(
       bsls::SystemTime::nowRealtimeClock().totalNanoseconds())
 , d_timerBaseOffset(bsls::TimeUtil::getTimer())
@@ -84,7 +90,8 @@ MessageGUIDGenerator::MessageGUIDGenerator(int sessionId, bool doIpResolving)
     //       big-endian (network byte order).
 
     // Get hostname
-    bsl::string hostname;
+    bdlma::LocalSequentialAllocator<k_HOSTNAME_LEN> hostnameAlloc;
+    bsl::string                                     hostname(&hostnameAlloc);
     ntsa::Error error = bmqio::ResolveUtil::getHostname(&hostname);
 
     if (error.code() != ntsa::Error::e_OK) {
@@ -113,21 +120,10 @@ MessageGUIDGenerator::MessageGUIDGenerator(int sessionId, bool doIpResolving)
         }
     }
 
-    // Get timestamp (seconds from epoch)
-    const bdlb::BigEndianInt64 secondsBE = bdlb::BigEndianInt64::make(
-        bsls::SystemTime::nowRealtimeClock().totalSeconds());
-
-    // Get PID
-    const bdlb::BigEndianInt32 pidBE = bdlb::BigEndianInt32::make(
-        bdls::ProcessUtil::getProcessId());
-
-    // Get sessionId
-    const bdlb::BigEndianInt32 sessionIdBE = bdlb::BigEndianInt32::make(
-        sessionId);
-
     // Calculate md5(HostId + timestamp + PID + sessionId)
-    bdlde::Md5            md5;
-    bdlde::Md5::Md5Digest md5Buffer;
+    bdlde::Md5 md5;
+
+    // Get IP or hostname
     if (useIP) {
         // 'ntsa::Ipv4Address::value()' returns an unsigned int
         // in network byte order
@@ -135,11 +131,32 @@ MessageGUIDGenerator::MessageGUIDGenerator(int sessionId, bool doIpResolving)
         md5.update(&ipAddressBE, sizeof(ipAddressBE));
     }
     else {
-        md5.update(hostname.c_str(), hostname.size());
+        // We have to do a kind of saturating cast or else there's the
+        // potential for a ridiculously (probably impossibly?) long hostname to
+        // overflow the size parameter, which is a int.
+        int size = static_cast<int>(
+            bsl::min(hostname.size(),
+                     static_cast<bsl::string::size_type>(
+                         bsl::numeric_limits<int>::max())));
+        md5.update(hostname.c_str(), size);
     }
+
+    // Get timestamp (seconds from epoch)
+    const bdlb::BigEndianInt64 secondsBE = bdlb::BigEndianInt64::make(
+        d_nanoSecondsFromEpoch);
     md5.update(&secondsBE, sizeof(secondsBE));
+
+    // Get PID
+    const bdlb::BigEndianInt32 pidBE = bdlb::BigEndianInt32::make(
+        bdls::ProcessUtil::getProcessId());
     md5.update(&pidBE, sizeof(pidBE));
+
+    // Get sessionId
+    const bdlb::BigEndianInt32 sessionIdBE = bdlb::BigEndianInt32::make(
+        sessionId);
     md5.update(&sessionIdBE, sizeof(sessionIdBE));
+
+    bdlde::Md5::Md5Digest md5Buffer;
     md5.loadDigest(&md5Buffer);
 
     // ClientId == first 'k_CLIENT_ID_LEN_BINARY' bytes of the md5 hash
@@ -172,7 +189,7 @@ void MessageGUIDGenerator::generateGUID(bmqt::MessageGUID* guid)
     // Get a snapshot of timer tick and counter values
     const bsls::Types::Int64 timerTickDiff = bsls::TimeUtil::getTimer() -
                                              d_timerBaseOffset;
-    const unsigned int counter = ++d_counter;
+    const unsigned int counter = d_counter++;
 
     // Below, we use our knowledge of internal memory layout of
     // bmqt::MessageGUID to populate its data member.  Alternatives are:

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -298,8 +298,6 @@ int main(int argc, char* argv[])
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);
 
-        mqbu::MessageGUIDUtil::initialize();
-
         switch (_testCase) {
         case 0:
         case 1: test1_watermark(); break;

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -116,9 +116,6 @@ void Application::oneTimeInit()
                                       0xFFFFFFFF);
 
         bsl::srand(seed);
-
-        // Make MessageGUID generation thread-safe by calling initialize
-        mqbu::MessageGUIDUtil::initialize();
     }
 }
 

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -2508,8 +2508,6 @@ int main(int argc, char* argv[])
                 30,
                 bmqtst::TestHelperUtil::allocator());
 
-        mqbu::MessageGUIDUtil::initialize();
-
         switch (_testCase) {
         case 0:
         case 11: test11_initiateShutdown(); break;

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -423,8 +423,6 @@ void QueueEngineTester::oneTimeInit()
     BSLMT_ONCE_DO
     {
         bmqsys::Time::initialize();
-        // Make MessageGUID generation thread-safe by calling initialize
-        mqbu::MessageGUIDUtil::initialize();
     }
 }
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -2160,8 +2160,6 @@ int main(int argc, char* argv[])
 
     bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
 
-    mqbu::MessageGUIDUtil::initialize();
-
     {
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -949,7 +949,6 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     bmqsys::Time::initialize();
-    mqbu::MessageGUIDUtil::initialize();
 
     switch (_testCase) {
     case 0:

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -1469,8 +1469,6 @@ int main(int argc, char* argv[])
 
     bmqsys::Time::initialize(bmqtst::TestHelperUtil::allocator());
 
-    mqbu::MessageGUIDUtil::initialize();
-
     {
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);

--- a/src/groups/mqb/mqbs/mqbs_journalfileiterator.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_journalfileiterator.t.cpp
@@ -1424,8 +1424,6 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    mqbu::MessageGUIDUtil::initialize();
-
     switch (_testCase) {
     case 0:
     case 12: test12_backwardAdvance(); break;

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.cpp
@@ -16,34 +16,12 @@
 #include <mqbu_messageguidutil.h>
 
 #include <mqbscm_version.h>
-/// Implementation Notes
-///====================
-//
-/// MessageGUID layout [16 bytes]
-///-----------------------------
-//..
-//   +---------------+---------------+---------------+---------------+
-//   |0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|0|1|2|3|4|5|6|7|
-//   +---------------+---------------+---------------+---------------+
-//   |GV |        Counter (22 bits)                  | TimerTick MSB |
-//   +---------------+---------------+---------------+---------------+
-//   |                     TimerTick (next 32 bits)                  |
-//   +---------------+---------------+---------------+---------------+
-//   |       TimerTick (lowest 24 bits)              |  BrokerId     |
-//   +---------------+---------------+---------------+---------------+
-//   |                           BrokerId                            |
-//   +---------------+---------------+---------------+---------------+
-//
-//       GV...: Guid Version
-//       MSB..: Most significant byte
-//..
-//
-// BrokerID:
-//   The brokerId is the first 5 bytes of the MD5 of {IP + timestamp + PID}.
 
 // BMQ
 #include <bmqio_resolveutil.h>
+#include <bmqp_messageguidgenerator.h>
 #include <bmqu_memoutstream.h>
+#include <bmqu_singletonallocator.h>
 
 // BDE
 #include <bdlb_bigendian.h>
@@ -56,8 +34,12 @@
 #include <bsl_iostream.h>
 #include <bsl_limits.h>
 #include <bsl_string.h>
+#include <bslma_allocator.h>
+#include <bslma_constructionutil.h>
+#include <bslmt_once.h>
 #include <bsls_assert.h>
 #include <bsls_atomic.h>
+#include <bsls_objectbuffer.h>
 #include <bsls_systemtime.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
@@ -70,33 +52,19 @@ namespace BloombergLP {
 namespace mqbu {
 
 namespace {  // unnamed namespace
-const int k_GUID_VERSION = 0;
 
-// Note that guid version & counter are captured in 3 bytes.  Following
-// constants (*_BITS and *_START_IDX) assume that layout.
-const int k_GUID_VERSION_BITS      = 2;
-const int k_GUID_VERSION_START_IDX = 22;
-const int k_GUID_VERSION_MASK =
-    bdlb::BitMaskUtil::one(k_GUID_VERSION_START_IDX, k_GUID_VERSION_BITS);
-
-const int k_COUNTER_BITS      = 22;
-const int k_COUNTER_START_IDX = 0;
-const int k_COUNTER_MASK      = bdlb::BitMaskUtil::one(k_COUNTER_START_IDX,
-                                                  k_COUNTER_BITS);
-
-const int k_BROKER_ID_LEN_BINARY = 5;
-const int k_BROKER_ID_LEN_HEX    = 2 * k_BROKER_ID_LEN_BINARY;
-
-const int k_GUID_VERSION_AND_COUNTER_LEN = 3;
-
-char g_brokerId[k_BROKER_ID_LEN_BINARY]     = {0};
-char g_brokerIdHex[k_BROKER_ID_LEN_HEX + 1] = {0};
-// NOTE: each character takes two char in hex, and we add a terminating
-//       null character.
-
-/// Initialize `g_counter` to max UINT, so the pre-incremented value starts
-/// from zero.
-bsls::AtomicUint g_counter(bsl::numeric_limits<unsigned int>::max());
+bmqp::MessageGUIDGenerator& guidGenerator()
+{
+    static bmqp::MessageGUIDGenerator* guidGenerator_p;
+    BSLMT_ONCE_DO
+    {
+        bslma::Allocator* alloc = bmqu::SingletonAllocator::allocator();
+        guidGenerator_p =
+            bslma::AllocatorUtil::newObject<bmqp::MessageGUIDGenerator>(alloc,
+                                                                        0);
+    }
+    return *guidGenerator_p;
+}
 
 }  // close unnamed namespace
 
@@ -105,133 +73,14 @@ bsls::AtomicUint g_counter(bsl::numeric_limits<unsigned int>::max());
 // ---------------------
 
 // CLASS LEVEL METHODS
-void MessageGUIDUtil::initialize()
-{
-    // NOTE: 'BE' suffix in variable name implies that variable's value is
-    //       big-endian (network byte order).
-
-    // PRECONDITIONS
-    BSLS_ASSERT_OPT(g_counter == bsl::numeric_limits<unsigned int>::max());
-
-    // Get hostname
-
-    bsl::string hostname;
-    ntsa::Error error = bmqio::ResolveUtil::getHostname(&hostname);
-
-    if (error.code() != ntsa::Error::e_OK) {
-        BALL_LOG_ERROR << "Failed to get local hostname, error: " << error;
-        BSLS_ASSERT_OPT(false && "Failed to get local hostname");
-        return;  // RETURN
-    }
-
-    // Get IP
-    ntsa::Ipv4Address defaultIP;
-    error = bmqio::ResolveUtil::getIpAddress(&defaultIP, hostname);
-    if (error.code() != ntsa::Error::e_OK) {
-        BALL_LOG_ERROR << "Failed to get IP address of the host '" << hostname
-                       << "' error: " << error;
-        BSLS_ASSERT_OPT(false && "Failed to get IP address of the host");
-        return;  // RETURN
-    }
-
-    // 'ntsa::Ipv4Address::value()' returns an unsigned int
-    // in network byte order
-    const bsl::uint32_t ipAddressBE = defaultIP.value();
-
-    // Get timestamp (seconds from epoch)
-    bdlb::BigEndianInt64 secondsBE = bdlb::BigEndianInt64::make(
-        bsls::SystemTime::nowRealtimeClock().totalSeconds());
-
-    // Note that above, we could use totalMilliseconds(), totalMicroseconds()
-    // or totalNanoseconds() instead of totalSeconds() but they may exhibit
-    // undefined behavior in certain conditions (see their contract).
-
-    // Get PID
-    bdlb::BigEndianInt32 pidBE = bdlb::BigEndianInt32::make(
-        bdls::ProcessUtil::getProcessId());
-
-    // Calculate md5(IP + timestamp + PID)
-    bdlde::Md5            md5;
-    bdlde::Md5::Md5Digest md5Buffer;
-    md5.update(&ipAddressBE, sizeof(ipAddressBE));
-    md5.update(&secondsBE, sizeof(secondsBE));
-    md5.update(&pidBE, sizeof(pidBE));
-    md5.loadDigest(&md5Buffer);
-
-    // BrokerId == first 'k_BROKER_ID_LEN_BINARY' bytes of the md5 hash
-    bsl::memcpy(g_brokerId, md5Buffer.buffer(), k_BROKER_ID_LEN_BINARY);
-
-    // NOTE: since we know the size, the `defaultAllocator` will never be
-    //       used here
-    bdlma::LocalSequentialAllocator<k_BROKER_ID_LEN_HEX> localAllocator(0);
-    bmqu::MemOutStream                                   os(&localAllocator);
-    bdlb::Print::singleLineHexDump(os, g_brokerId, k_BROKER_ID_LEN_BINARY);
-    bsl::memcpy(g_brokerIdHex, os.str().data(), os.str().length());
-
-    BALL_LOG_INFO << "GUID generator initialized ["
-                  << "currentTimerTick: " << bsls::TimeUtil::getTimer()
-                  << ", IPAddress: " << defaultIP << ", secondsFromEpoch: "
-                  << static_cast<bsls::Types::Int64>(secondsBE)
-                  << ", pid: " << static_cast<int>(pidBE)
-                  << ", brokerID: " << g_brokerIdHex << "]";
-}
-
 void MessageGUIDUtil::generateGUID(bmqt::MessageGUID* guid)
 {
-    // NOTE: we could keep track of last timer tick value and reset the counter
-    //       to zero if timer's value is different from last value, but during
-    //       testing some collisions were observed using that approach. So we
-    //       just increment the counter and let it wrap over to zero.
-    //
-    // NOTE: 'BE' suffix in variable name implies that variable's value is
-    //       big-endian (network byte order)
-
-    // Get a snapshot of timer tick  and counter values
-    bsls::Types::Int64 timerTick = bsls::TimeUtil::getTimer();
-    unsigned int       counter   = ++g_counter;
-
-    // Below, we use our knowledge of internal memory layout of
-    // bmqt::MessageGUID to populate its data member.  Alternatives are:
-    //   o having setters in bmqt::MessageGUID, which is not ideal given that
-    //     it should be completely opaque to clients.
-    //   o using friendship
-    char* buffer = reinterpret_cast<char*>(guid);
-
-    // Populate GuidVersionAndCounter
-    unsigned int versionAndCounter = (k_GUID_VERSION
-                                      << k_GUID_VERSION_START_IDX) |
-                                     (counter & k_COUNTER_MASK);
-
-    BSLS_ASSERT_SAFE((versionAndCounter & 0xFF000000) == 0);  // MSB is zero
-
-    bdlb::BigEndianUint32 versionAndCounterBE = bdlb::BigEndianUint32::make(
-        versionAndCounter);
-
-    // Copy 3 lower bytes of 'versionAndCounterBE'
-    bsl::memcpy(
-        buffer,
-        (reinterpret_cast<char*>(&versionAndCounterBE) + 1),  // skip MSB
-        k_GUID_VERSION_AND_COUNTER_LEN);
-
-    // Populate TimerTick
-    bdlb::BigEndianInt64 timerTickBE = bdlb::BigEndianInt64::make(timerTick);
-    bsl::memcpy(buffer + k_GUID_VERSION_AND_COUNTER_LEN,
-                &timerTickBE,
-                sizeof(timerTickBE));
-
-    // Populate BrokerId hash
-    bsl::memcpy(buffer + k_GUID_VERSION_AND_COUNTER_LEN + sizeof(timerTickBE),
-                g_brokerId,
-                k_BROKER_ID_LEN_BINARY);
+    guidGenerator().generateGUID(guid);
 }
 
 const char* MessageGUIDUtil::brokerIdHex()
 {
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(g_brokerIdHex[0] != 0 &&
-                     "MessageGUIDUtil has not been Initialized");
-
-    return g_brokerIdHex;
+    return guidGenerator().clientIdHex();
 }
 
 void MessageGUIDUtil::extractFields(int*                     version,
@@ -240,37 +89,7 @@ void MessageGUIDUtil::extractFields(int*                     version,
                                     bsl::string*             brokerId,
                                     const bmqt::MessageGUID& guid)
 {
-    const char* buffer = reinterpret_cast<const char*>(&guid);
-
-    // Version and counter
-    bdlb::BigEndianUint32 versionAndCounterBE = bdlb::BigEndianUint32::make(0);
-    bsl::memcpy(reinterpret_cast<char*>(&versionAndCounterBE) +
-                    1,  // copy 3 LSB
-                buffer,
-                k_GUID_VERSION_AND_COUNTER_LEN);
-
-    unsigned int versionAndCounter = static_cast<unsigned int>(
-        versionAndCounterBE);
-
-    *version = ((versionAndCounter & k_GUID_VERSION_MASK) >>
-                k_GUID_VERSION_START_IDX);
-    *counter = (versionAndCounter & k_COUNTER_MASK);
-
-    // TimerTick
-    bdlb::BigEndianInt64 timerTickBE;
-    bsl::memcpy(&timerTickBE,
-                buffer + k_GUID_VERSION_AND_COUNTER_LEN,
-                sizeof(bdlb::BigEndianInt64));
-    *timerTick = static_cast<bsls::Types::Int64>(timerTickBE);
-
-    // BrokerId
-    bdlma::LocalSequentialAllocator<k_BROKER_ID_LEN_HEX> localAlloc(0);
-    bmqu::MemOutStream                                   os(&localAlloc);
-    bdlb::Print::singleLineHexDump(os,
-                                   buffer + k_GUID_VERSION_AND_COUNTER_LEN +
-                                       sizeof(bdlb::BigEndianInt64),
-                                   k_BROKER_ID_LEN_BINARY);
-    brokerId->assign(os.str());
+    guidGenerator().extractFields(version, counter, timerTick, brokerId, guid);
 }
 
 bsl::ostream& MessageGUIDUtil::print(bsl::ostream&            stream,
@@ -285,10 +104,11 @@ bsl::ostream& MessageGUIDUtil::print(bsl::ostream&            stream,
         return stream;  // RETURN
     }
 
-    int                version;
-    unsigned int       counter;
-    bsls::Types::Int64 timerTick;
-    bsl::string        brokerId;
+    bdlma::LocalSequentialAllocator<16> alloc;
+    int                                 version;
+    unsigned int                        counter;
+    bsls::Types::Int64                  timerTick;
+    bsl::string                         brokerId(&alloc);
 
     extractFields(&version, &counter, &timerTick, &brokerId, guid);
     stream << "[version: " << version << ", "

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.h
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.h
@@ -16,19 +16,17 @@
 #ifndef INCLUDED_MQBU_MESSAGEGUIDUTIL
 #define INCLUDED_MQBU_MESSAGEGUIDUTIL
 
-//@PURPOSE: Provide a utility component for bmqt::MessageGUID.
-//
-//@CLASSES:
-//  mqbu::MessageGUIDUtil : Utility methods for bmqt::MessageGUID
-//
-//@SEE_ALSO:
-// bmqt::MessageGUID
-//
-//@DESCRIPTION: 'mqbu::MessageGUIDUtil' provide a method to generate
-// 'bmqt::MessageGUID'.
-//
-
-// MQB
+///@PURPOSE: Provide a utility component for bmqt::MessageGUID.
+///
+///@CLASSES:
+///  mqbu::MessageGUIDUtil : Utility methods for bmqt::MessageGUID
+///
+///@SEE_ALSO:
+/// bmqt::MessageGUID
+/// bmqp::MessageGUIDGenerator
+///
+///@DESCRIPTION: 'mqbu::MessageGUIDUtil' provide a method to generate
+/// 'bmqt::MessageGUID'.
 
 // BMQ
 #include <bmqt_messageguid.h>
@@ -54,23 +52,14 @@ class MessageGUIDUtil {
   public:
     // CLASS METHODS
 
-    /// Perform a one-time initialization before generating GUIDs.  It is
-    /// undefined behavior to call this method more than once during an
-    /// application's lifetime.  It is undefined behavior to call
-    /// `generateGUID()` unless this method has been called once before.
-    /// Note that this method is not thread-safe.
-    static void initialize();
-
     /// Generate a new MessageGUID. This method can be called simultaneously
-    /// from multiple threads.  Behavior is undefined unless `initialize`
-    /// has been called once before this method's invocation.  Behavior is
-    /// undefined unless specified `guid` is non-null.
+    /// from multiple threads.  Behavior is undefined unless specified `guid`
+    /// is non-null.
     static void generateGUID(bmqt::MessageGUID* guid);
 
     /// Return the hexadecimal representation of the unique id associated to
     /// this broker (refer to the `Implementation notes` section in the
-    /// associated .cpp file for details about how it is computed).  The
-    /// behavior is undefined unless `initialize()` has been called.
+    /// associated .cpp file for details about how it is computed).
     static const char* brokerIdHex();
 
     /// --------------------------

--- a/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
+++ b/src/groups/mqb/mqbu/mqbu_messageguidutil.t.cpp
@@ -277,7 +277,7 @@ static void test3_print()
 
         // Print and compare
         const char k_EXPECTED[] = "[version: 1, counter: 5, timerTick: "
-                                  "297593876864458, brokerId: CE04742D2E]";
+                                  "1162476081501, brokerId: CACE04742D2E]";
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         mqbu::MessageGUIDUtil::print(out, guid);
         BMQTST_ASSERT_EQ(out.str(), k_EXPECTED);
@@ -291,11 +291,11 @@ static void test3_print()
         bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
         mqbu::MessageGUIDUtil::print(out, guid);
 
-        // Extract the BrokerId from the printed string, that is the 10
-        // characters before the last one (an hexadecimal brokerId is 10
+        // Extract the BrokerId from the printed string, that is the 12
+        // characters before the last one (an hexadecimal brokerId is 12
         // characters, and we skip the closing ']').
         bslstl::StringRef printedBrokerId =
-            bslstl::StringRef(&out.str()[out.length() - 11], 10);
+            bslstl::StringRef(&out.str()[out.length() - 13], 12);
         BMQTST_ASSERT_EQ(printedBrokerId,
                          mqbu::MessageGUIDUtil::brokerIdHex());
     }
@@ -1217,7 +1217,6 @@ int main(int argc, char* argv[])
     // here before the TEST_PROLOG because 'MessageGUIDUtil::initialize' prints
     // a BALL_LOG_INFO which allocates using the default allocator.
     bsls::TimeUtil::initialize();
-    mqbu::MessageGUIDUtil::initialize();
 
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
@@ -1289,7 +1288,7 @@ int main(int argc, char* argv[])
     }
 #endif
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
The mqbu_messageguidutil component has had a slightly different implementation from `bmqp::MessageGuidGenerator` for generating message GUIDs for a bit now to no real benefit, so we are consolidating them into the same. This does mean that the format for message GUIDs generated by the broker will change, but there is no known system that relies on this format so we believe it is safe to change.