### PR TITLE
Feat[mqb]: store `AppConfig` value, not a pointer to config

### DIFF
--- a/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.cpp
@@ -16,8 +16,16 @@
 // mqbcfg_brokerconfig.cpp                                            -*-C++-*-
 #include <mqbcfg_brokerconfig.h>
 
+// MQB
+#include <mqbcfg_messages.h>
+
+// BMQ
+#include <bmqu_singletonallocator.h>
+
 // BDE
+#include <bslmt_once.h>
 #include <bsls_assert.h>
+#include <bsls_objectbuffer.h>
 
 namespace BloombergLP {
 namespace mqbcfg {
@@ -25,6 +33,18 @@ namespace mqbcfg {
 namespace {
 
 const AppConfig* s_config_p;
+
+mqbcfg::AppConfig* getImpl()
+{
+    static mqbcfg::AppConfig* s_appConfig_p;
+    BSLMT_ONCE_DO
+    {
+        bslma::Allocator* alloc = bmqu::SingletonAllocator::allocator();
+        s_appConfig_p = bslma::AllocatorUtil::newObject<mqbcfg::AppConfig>(
+            alloc);
+    }
+    return s_appConfig_p;
+}
 
 }  // close unnamed namespace
 
@@ -35,14 +55,15 @@ const AppConfig* s_config_p;
 // MANIPULATORS
 void BrokerConfig::set(const AppConfig& config)
 {
-    BSLS_ASSERT_SAFE(!s_config_p && "config already set");
-    s_config_p = &config;
+    BSLS_ASSERT_OPT(!s_config_p && "config already set");
+    *getImpl() = config;
+    s_config_p = getImpl();
 }
 
 // ACCESSORS
 const AppConfig& BrokerConfig::get()
 {
-    BSLS_ASSERT_SAFE(s_config_p && "config not set");
+    BSLS_ASSERT_OPT(s_config_p && "config not set");
     return *s_config_p;
 }
 

--- a/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.t.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.t.cpp
@@ -47,7 +47,7 @@ BMQTST_TEST(breathing)
 
     // Broker config should be available even when the original config goes
     // out of scope and destructed.
-    BMQTST_ASSERT_NE(&mqbcfg::BrokerConfig::get(), NULL);
+    BMQTST_ASSERT(&mqbcfg::BrokerConfig::get() != NULL);
 }
 
 // ============================================================================

--- a/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.t.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_brokerconfig.t.cpp
@@ -34,11 +34,20 @@ BMQTST_TEST(breathing)
 {
     BMQTST_ASSERT_SAFE_FAIL(mqbcfg::BrokerConfig::get());
 
-    mqbcfg::AppConfig config;
-    mqbcfg::BrokerConfig::set(config);
-    BMQTST_ASSERT_EQ(&mqbcfg::BrokerConfig::get(), &config);
+    {
+        mqbcfg::AppConfig config;
+        mqbcfg::BrokerConfig::set(config);
 
-    BMQTST_ASSERT_SAFE_FAIL(mqbcfg::BrokerConfig::set(config));
+        // The singleton must return another object (copy)
+        BMQTST_ASSERT_NE(&mqbcfg::BrokerConfig::get(), &config);
+
+        // Second attempt to set broker config should fail
+        BMQTST_ASSERT_SAFE_FAIL(mqbcfg::BrokerConfig::set(config));
+    }
+
+    // Broker config should be available even when the original config goes
+    // out of scope and destructed.
+    BMQTST_ASSERT_NE(&mqbcfg::BrokerConfig::get(), NULL);
 }
 
 // ============================================================================

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -295,7 +295,7 @@ class ClusterImp : public Cluster {
                   bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).
+    /// (with the exception of the current node).
     void
     broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -270,7 +270,7 @@ class MockCluster : public Cluster {
                   bmqp::EventType::Enum type) BSLS_KEYWORD_OVERRIDE;
 
     /// Send the specified `blob` to all currently up nodes of this cluster
-    /// (exception of the current node).
+    /// (with the exception of the current node).
     void
     broadcast(const bsl::shared_ptr<bdlbb::Blob>& blob) BSLS_KEYWORD_OVERRIDE;
 


### PR DESCRIPTION
`mqbcfg::BrokerConfig` only stores a pointer to an external configuration object. Due to this, the configuration object must be kept alive in runtime, or the pointer becomes invalid.
It is possible to make a copy of a provided configuration and remove the restriction of keeping configuration object alive.
