### PR TITLE
cleanup: make ClusterCatalog ClusterInfo private

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
@@ -155,19 +155,6 @@ class ClusterCatalog {
         int         d_myNodeId;
     };
 
-    /// Struct containing meta information associated to a created cluster.
-    /// TBD: should be private but AIX compiler bug,  see
-    /// {internal-ticket D39833134}
-    struct ClusterInfo {
-        // PUBLIC DATA
-
-        /// Cluster created, owned by this struct.
-        bsl::shared_ptr<mqbi::Cluster> d_cluster_sp;
-
-        /// Event processor associated to this cluster.
-        mqbnet::SessionEventProcessor* d_eventProcessor_p;
-    };
-
     typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
                                  bmqp_ctrlmsg::ControlMessage>
         RequestManagerType;
@@ -179,6 +166,17 @@ class ClusterCatalog {
 
   private:
     // PRIVATE TYPES
+
+    /// Struct containing meta information associated to a created cluster.
+    struct ClusterInfo {
+        // PUBLIC DATA
+
+        /// Cluster created, owned by this struct.
+        bsl::shared_ptr<mqbi::Cluster> d_cluster_sp;
+
+        /// Event processor associated to this cluster.
+        mqbnet::SessionEventProcessor* d_eventProcessor_p;
+    };
 
     /// Map of `Cluster name` to `ClusterInfo` object.
     typedef bsl::unordered_map<bsl::string, ClusterInfo> ClustersMap;


### PR DESCRIPTION
Move `ClusterCatalog::ClusterInfo` into the private type section now that the old AIX workaround is obsolete. This keeps the struct as an internal implementation detail while preserving existing cluster catalog behavior.

Closes: #548

Verification:
- `cmake --build /tmp/blazingmq-issue-548/build/blazingmq --target libmqbblp.a`
- `cmake --build /tmp/blazingmq-issue-548/build/blazingmq --target mqbblp.t`
- `git clang-format`
- `git diff --check`

Note: `ctest --test-dir /tmp/blazingmq-issue-548/build/blazingmq --output-on-failure -R '^mqbblp_'` was attempted locally. Five tests passed; `mqbblp_relayqueueengine.t` and `mqbblp_rootqueueengine.t` failed because this machine cannot resolve its local hostname (`MacBook-Air-75.local`) during `MessageGUIDUtil::initialize()`. The failure occurs before the affected `ClusterCatalog` logic.