### PR TITLE
feat: add fallible Uri parse API

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_uri.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.cpp
@@ -430,6 +430,13 @@ struct UriParsingContext {
 // class Uri
 // ---------
 
+int Uri::parse(Uri*                     result,
+               const bslstl::StringRef& uriString,
+               bsl::string*             errorDescription)
+{
+    return UriParser::parse(result, errorDescription, uriString);
+}
+
 Uri::Uri(bslma::Allocator* allocator)
 : d_uri(allocator)
 {

--- a/src/groups/bmq/bmqt/bmqt_uri.h
+++ b/src/groups/bmq/bmqt/bmqt_uri.h
@@ -24,8 +24,8 @@
 ///
 /// This component provides a value-semantic type, @bbref{bmqt::Uri}
 /// representing a URI for a BlazingMQ queue.  A @bbref{bmqt::Uri} can be built
-/// by parsing from a string representation, using the @bbref{bmqt::UriParser},
-/// or built using the @bbref{bmqt::UriBuilder}.
+/// by parsing from a string representation using @bbref{bmqt::Uri::parse}, or
+/// built using the @bbref{bmqt::UriBuilder}.
 ///
 /// @see https://tools.ietf.org/html/rfc3986
 ///
@@ -82,12 +82,12 @@
 /// bmqt::Uri   uri(allocator);
 /// bsl::string errorDescription;
 ///
-/// int         rc = bmqt::UriParser::parse(&uri, &errorDescription, input);
+/// int         rc = bmqt::Uri::parse(&uri, input, &errorDescription);
 /// if (rc != 0) {
 ///    BALL_LOG_ERROR << "Invalid URI [error: " << errorDescription << "]";
 /// }
 /// assert(rc == 0);
-/// assert(error == "");
+/// assert(errorDescription == "");
 /// assert(uri.scheme()    == "bmq");
 /// assert(uri.domain()    == "my.domain");
 /// assert(uri.queue()     == "queue");
@@ -97,7 +97,8 @@
 /// ===============
 ///
 /// Instantiate a @bbref{bmqt::Uri} object with a string representation of the
-/// URI and an allocator.
+/// URI and an allocator.  Prefer @bbref{bmqt::Uri::parse} when the caller
+/// needs to handle parse failures explicitly.
 ///
 /// ```
 /// bmqt::Uri uri("bmq://my.domain/queue", allocator);
@@ -119,6 +120,7 @@
 #include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsla_maybeunused.h>
+#include <bsla_nodiscard.h>
 #include <bslh_hash.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -195,6 +197,19 @@ class Uri {
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(Uri, bslma::UsesBslmaAllocator)
+
+    // CLASS METHODS
+
+    /// Parse the specified `uriString` into the specified `result` object if
+    /// `uriString` is a valid URI, otherwise load the specified
+    /// `errorDescription` with a description of the syntax error present in
+    /// `uriString`.  Return 0 on success and non-zero if `uriString` does not
+    /// have a valid syntax.  Note that `errorDescription` may be null if the
+    /// caller does not care about getting error messages.
+    BSLA_NODISCARD
+    static int parse(Uri*                     result,
+                     const bslstl::StringRef& uriString,
+                     bsl::string*             errorDescription);
 
     // CREATORS
 

--- a/src/groups/bmq/bmqt/bmqt_uri.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_uri.t.cpp
@@ -65,7 +65,7 @@ static void test1_breathingTest()
 //
 // Testing:
 //   class Uri
-//   int Uri::parseUri
+//   int Uri::parse
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("BREATHING TEST");
@@ -97,6 +97,50 @@ static void test1_breathingTest()
 
         BMQTST_ASSERT_EQ(obj4.isValid(), true);
         BMQTST_ASSERT_EQ(obj3, obj4);
+    }
+
+    PV("Test explicit parse");
+    {
+        const char  k_URI[] = "bmq://my.domain/queue-foo-bar?id=my.app";
+        bmqt::Uri   obj(bmqtst::TestHelperUtil::allocator());
+        bsl::string parseError(bmqtst::TestHelperUtil::allocator());
+
+        rc = bmqt::Uri::parse(&obj, k_URI, &parseError);
+
+        BMQTST_ASSERT_EQ(rc, 0);
+        BMQTST_ASSERT_EQ(parseError, "");
+        BMQTST_ASSERT_EQ(obj.isValid(), true);
+        BMQTST_ASSERT_EQ(obj.scheme(), "bmq");
+        BMQTST_ASSERT_EQ(obj.domain(), "my.domain");
+        BMQTST_ASSERT_EQ(obj.queue(), "queue-foo-bar");
+        BMQTST_ASSERT_EQ(obj.id(), "my.app");
+        BMQTST_ASSERT_EQ(obj.canonical(), "bmq://my.domain/queue-foo-bar");
+    }
+
+    PV("Test explicit parse failures");
+    {
+        const char k_VALID_URI[] = "bmq://my.domain/queue-foo-bar";
+
+        bmqt::Uri   obj(k_VALID_URI, bmqtst::TestHelperUtil::allocator());
+        bsl::string parseError(bmqtst::TestHelperUtil::allocator());
+
+        BMQTST_ASSERT_EQ(obj.isValid(), true);
+
+        rc = bmqt::Uri::parse(&obj, "foobar", &parseError);
+
+        BMQTST_ASSERT_EQ(rc,
+                         bmqt::UriParser::UriParseResult::e_INVALID_SCHEME);
+        BMQTST_ASSERT_EQ(obj.isValid(), false);
+        BMQTST_ASSERT(!parseError.empty());
+
+        bmqt::Uri objNoError(k_VALID_URI, bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(objNoError.isValid(), true);
+
+        rc = bmqt::Uri::parse(&objNoError, "foobar", 0);
+
+        BMQTST_ASSERT_EQ(rc,
+                         bmqt::UriParser::UriParseResult::e_INVALID_SCHEME);
+        BMQTST_ASSERT_EQ(objNoError.isValid(), false);
     }
 
     PV("Test basic parsing");


### PR DESCRIPTION
Summary:
- Add an explicit fallible bmqt::Uri::parse API that wraps the existing UriParser::parse implementation.
- Keep the existing string constructors in place for compatibility and avoid compiler deprecation attributes in this first pass.
- Update bmqt_uri documentation/examples and add focused coverage for success and failure parsing paths.

Validation:
- cmake --build build/blazingmq --target bmqt_uri.t
- ctest --test-dir build/blazingmq --output-on-failure -R '^bmqt_uri\.t$'
- cmake --build build/blazingmq --target bmqt.t
- ctest --test-dir build/blazingmq --output-on-failure -R '^bmqt_'
- git clang-format
- git diff --check --cached

Closes: #579