### PR TITLE
Fix[bmqio]: guard null Status* in TestChannel read/write

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_testchannel.cpp
+++ b/src/groups/bmq/bmqio/bmqio_testchannel.cpp
@@ -100,7 +100,9 @@ void TestChannel::read(Status*                   status,
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
     d_readCalls.emplace_back(numBytes, readCallback, timeout);
-    *status = d_readStatus;
+    if (status) {
+        *status = d_readStatus;
+    }
 }
 
 void TestChannel::write(Status*            status,
@@ -110,7 +112,9 @@ void TestChannel::write(Status*            status,
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
 
     d_writeCalls.emplace_back(blob, watermark);
-    *status = d_writeStatus;
+    if (status) {
+        *status = d_writeStatus;
+    }
 
     d_condition.signal();
 }


### PR DESCRIPTION
TestChannel::read() and TestChannel::write() unconditionally dereference the Status* output parameter, crashing when callers pass null. The real NtcChannel implementation already guards against this, so tests should match that behavior.

This doesn't matter for any current tests; I encountered this while working on some new greenfield testing of network related components.