### PR TITLE
Feat[bmq]: Free MessageEvent from MessageEventBuilder

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_messageeventbuilder.cpp
+++ b/src/groups/bmq/bmqa/bmqa_messageeventbuilder.cpp
@@ -176,16 +176,11 @@ void MessageEventBuilder::reset()
     msgImplRef.d_event_p    = 0;
     msgImplRef.d_correlationId.makeUnset();
 
-    // Get bmqimp::Event from bmqa::MessageEvent
-    typedef bsl::shared_ptr<bmqimp::Event> EventSP;
-    EventSP& eventSpRef = reinterpret_cast<EventSP&>(d_impl.d_msgEvent);
+    BSLS_ASSERT_OPT(d_impl.d_messageEventFactory);
 
+    d_impl.d_msgEvent              = d_impl.d_messageEventFactory();
     d_impl.d_messageCountFinal     = 0;
     d_impl.d_messageEventSizeFinal = 0;
-
-    eventSpRef->upgradeMessageEventModeToWrite();
-    // underlying PutEventBuilder is reset in
-    // 'upgradeMessageEventModeToWrite'
 }
 
 const MessageEvent& MessageEventBuilder::messageEvent()

--- a/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
+++ b/src/groups/bmq/bmqa/bmqa_messageeventbuilder.h
@@ -285,6 +285,8 @@ namespace bmqa {
 struct MessageEventBuilderImpl {
     // PUBLIC DATA
 
+    typedef bsl::function<MessageEvent()> MessageEventFactory;
+
     /// This is needed so that `getMessageEvent()` can return a const ref.
     MessageEvent d_msgEvent;
 
@@ -309,6 +311,8 @@ struct MessageEventBuilderImpl {
     /// CONTRACT: the stored value is correct every moment when in READ mode,
     /// and the value is not guaranteed to be correct when in WRITE mode.
     int d_messageEventSizeFinal;
+
+    MessageEventFactory d_messageEventFactory;
 };
 
 // =========================

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -877,6 +877,23 @@ void MockSession::processIfPushEvent(const Event& event)
         d_unconfirmedGUIDs.insert(mIter.message().messageGUID());
     }
 }
+MessageEvent MockSession::createMessageEvent()
+{
+    MessageEvent result;
+
+    // MessageEvent::d_impl is private
+    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
+        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(result);
+
+    eventImplSpRef.createInplace(d_allocator_p,
+                                 g_bufferFactory_p,
+                                 d_allocator_p);
+    eventImplSpRef->configureAsMessageEvent(d_blobSpPool_sp.get());
+    eventImplSpRef->setMessageCorrelationIdContainer(
+        d_corrIdContainer_sp.get());
+
+    return result;
+}
 
 void MockSession::assertWrongCall(const Method method) const
 {
@@ -1498,18 +1515,10 @@ void MockSession::loadMessageEventBuilder(MessageEventBuilder* builder)
 
     builderImplRef.d_guidGenerator_sp = g_guidGenerator_sp;
 
-    // Get bmqimp::Event sharedptr from MessageEventBuilderImpl
-    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
-        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(
-            builderImplRef.d_msgEvent);
+    builderImplRef.d_messageEventFactory =
+        bdlf::BindUtil::bind(&MockSession::createMessageEvent, this);
 
-    eventImplSpRef.createInplace(d_allocator_p,
-                                 g_bufferFactory_p,
-                                 d_allocator_p);
-
-    eventImplSpRef->configureAsMessageEvent(d_blobSpPool_sp.get());
-    eventImplSpRef->setMessageCorrelationIdContainer(
-        d_corrIdContainer_sp.get());
+    builder->reset();
 }
 
 void MockSession::loadConfirmEventBuilder(ConfirmEventBuilder* builder)

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -1124,6 +1124,8 @@ class MockSession : public AbstractSession {
     /// a push message event.
     void processIfPushEvent(const Event& event);
 
+    MessageEvent createMessageEvent();
+
     // PRIVATE ACCESSORS
 
     /// Invoke the failure callback because of a wrong call to the specified

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -1351,6 +1351,36 @@ static void test7_postAndAccess()
     bmqa::MessageEvent postedEvent2(builder.messageEvent());
     bmqa::MessageEvent postedEvent3(builder.messageEvent());
 
+    // Test that MessageEvent can survive builder reset
+    builder.reset();
+
+    bmqa::MessageIterator i = postedEvent2.messageIterator();
+    bdlbb::Blob payload(&bufferFactory, bmqtst::TestHelperUtil::allocator());
+    int         rc = 0;
+    BMQTST_ASSERT(i.nextMessage());
+
+    rc = i.message().getData(&payload);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(0, bdlbb::BlobUtil::compare(payload, payload1));
+
+    BMQTST_ASSERT(i.nextMessage());
+    payload.setLength(0);
+    rc = i.message().getData(&payload);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(0, bdlbb::BlobUtil::compare(payload, payload2));
+
+    BMQTST_ASSERT(i.nextMessage());
+    payload.setLength(0);
+    rc = i.message().getData(&payload);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(0, bdlbb::BlobUtil::compare(payload, payload3));
+
+    BMQTST_ASSERT(i.nextMessage());
+    payload.setLength(0);
+    rc = i.message().getData(&payload);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(0, bdlbb::BlobUtil::compare(payload, payload4));
+
     BMQA_EXPECT_CALL(mockSession, post(postedEvent2)).returning(0);
     BMQTST_ASSERT_EQ(mockSession.post(postedEvent2), 0);
 

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -638,6 +638,36 @@ bmqt::CloseQueueResult::Enum SessionUtil::validateAndSetCloseQueueParameters(
     return bmqt::CloseQueueResult::e_SUCCESS;
 }
 
+class MessageEventCreator {
+    bmqp::BlobPoolUtil::BlobSpPool* d_blobSpPool_p;
+    bmqimp::BrokerSession*          d_brokerSession_p;
+
+  public:
+    MessageEventCreator(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool_p,
+                        bmqimp::BrokerSession*          brokerSession_p)
+    : d_blobSpPool_p(blobSpPool_p)
+    , d_brokerSession_p(brokerSession_p)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_OPT(d_blobSpPool_p);
+        BSLS_ASSERT_OPT(d_brokerSession_p);
+    }
+
+    MessageEvent operator()()
+    {
+        MessageEvent result;
+
+        // MessageEvent::d_impl is private
+        bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
+            reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(result);
+
+        eventImplSpRef = d_brokerSession_p->createEvent();
+        eventImplSpRef->configureAsMessageEvent(d_blobSpPool_p);
+
+        return result;
+    }
+};
+
 }  // close unnamed namespace
 
 // -------------------------
@@ -665,19 +695,25 @@ SessionImpl::SessionImpl(const bmqt::SessionOptions&            options,
     // NOTHING
 }
 
-MessageEvent SessionImpl::createMessageEvent()
+void SessionImpl::loadMessageEventBuilder(MessageEventBuilder* builder)
 {
-    MessageEvent result;
+    // PRECONDITIONS
+    BSLS_ASSERT(d_application_mp && "The session was not started");
+    BSLS_ASSERT(builder);
 
-    // MessageEvent::d_impl is private
-    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
-        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(result);
+    MessageEventBuilder& builderRef = *builder;
 
-    eventImplSpRef = d_application_mp->brokerSession().createEvent();
+    // Get MessageEventBuilderImpl from MessageEventBuilder
+    MessageEventBuilderImpl& builderImplRef =
+        reinterpret_cast<MessageEventBuilderImpl&>(builderRef);
 
-    eventImplSpRef->configureAsMessageEvent(d_application_mp->blobSpPool());
+    builderImplRef.d_guidGenerator_sp = d_guidGenerator_sp;
 
-    return result;
+    builderImplRef.d_messageEventFactory = MessageEventCreator(
+        d_application_mp->blobSpPool(),
+        &d_application_mp->brokerSession());
+
+    builder->reset();
 }
 
 // -------------
@@ -790,44 +826,14 @@ MessageEventBuilder Session::createMessageEventBuilder()
 
     MessageEventBuilder builder;
 
-    // Get MessageEventBuilderImpl from MessageEventBuilder
-    MessageEventBuilderImpl& builderRef =
-        reinterpret_cast<MessageEventBuilderImpl&>(builder);
-
-    builderRef.d_guidGenerator_sp = d_impl.d_guidGenerator_sp;
-
-    //    // Get bmqimp::Event sharedptr from MessageEventBuilderImpl
-    //    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
-    //        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(
-    //            builderRef.d_msgEvent);
-    //
-    //    eventImplSpRef =
-    //    d_impl.d_application_mp->brokerSession().createEvent();
-    //
-    //    eventImplSpRef->configureAsMessageEvent(
-    //        d_impl.d_application_mp->blobSpPool());
+    d_impl.loadMessageEventBuilder(&builder);
 
     return builder;
 }
 
 void Session::loadMessageEventBuilder(MessageEventBuilder* builder)
 {
-    // PRECONDITIONS
-    BSLS_ASSERT(d_impl.d_application_mp && "The session was not started");
-    BSLS_ASSERT(builder);
-
-    MessageEventBuilder& builderRef = *builder;
-
-    // Get MessageEventBuilderImpl from MessageEventBuilder
-    MessageEventBuilderImpl& builderImplRef =
-        reinterpret_cast<MessageEventBuilderImpl&>(builderRef);
-
-    builderImplRef.d_guidGenerator_sp = d_impl.d_guidGenerator_sp;
-
-    builderImplRef.d_messageEventFactory =
-        bdlf::BindUtil::bind(&SessionImpl::createMessageEvent, &d_impl);
-
-    builder->reset();
+    d_impl.loadMessageEventBuilder(builder);
 }
 
 void Session::loadConfirmEventBuilder(ConfirmEventBuilder* builder)

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -665,6 +665,21 @@ SessionImpl::SessionImpl(const bmqt::SessionOptions&            options,
     // NOTHING
 }
 
+MessageEvent SessionImpl::createMessageEvent()
+{
+    MessageEvent result;
+
+    // MessageEvent::d_impl is private
+    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
+        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(result);
+
+    eventImplSpRef = d_application_mp->brokerSession().createEvent();
+
+    eventImplSpRef->configureAsMessageEvent(d_application_mp->blobSpPool());
+
+    return result;
+}
+
 // -------------
 // class Session
 // -------------
@@ -781,15 +796,16 @@ MessageEventBuilder Session::createMessageEventBuilder()
 
     builderRef.d_guidGenerator_sp = d_impl.d_guidGenerator_sp;
 
-    // Get bmqimp::Event sharedptr from MessageEventBuilderImpl
-    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
-        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(
-            builderRef.d_msgEvent);
-
-    eventImplSpRef = d_impl.d_application_mp->brokerSession().createEvent();
-
-    eventImplSpRef->configureAsMessageEvent(
-        d_impl.d_application_mp->blobSpPool());
+    //    // Get bmqimp::Event sharedptr from MessageEventBuilderImpl
+    //    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
+    //        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(
+    //            builderRef.d_msgEvent);
+    //
+    //    eventImplSpRef =
+    //    d_impl.d_application_mp->brokerSession().createEvent();
+    //
+    //    eventImplSpRef->configureAsMessageEvent(
+    //        d_impl.d_application_mp->blobSpPool());
 
     return builder;
 }
@@ -808,15 +824,10 @@ void Session::loadMessageEventBuilder(MessageEventBuilder* builder)
 
     builderImplRef.d_guidGenerator_sp = d_impl.d_guidGenerator_sp;
 
-    // Get bmqimp::Event sharedptr from MessageEventBuilderImpl
-    bsl::shared_ptr<bmqimp::Event>& eventImplSpRef =
-        reinterpret_cast<bsl::shared_ptr<bmqimp::Event>&>(
-            builderImplRef.d_msgEvent);
+    builderImplRef.d_messageEventFactory =
+        bdlf::BindUtil::bind(&SessionImpl::createMessageEvent, &d_impl);
 
-    eventImplSpRef = d_impl.d_application_mp->brokerSession().createEvent();
-
-    eventImplSpRef->configureAsMessageEvent(
-        d_impl.d_application_mp->blobSpPool());
+    builder->reset();
 }
 
 void Session::loadConfirmEventBuilder(ConfirmEventBuilder* builder)

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -669,7 +669,7 @@ struct SessionImpl {
                 bslma::ManagedPtr<SessionEventHandler> eventHandler,
                 bslma::Allocator*                      allocator = 0);
 
-    MessageEvent createMessageEvent();
+    void loadMessageEventBuilder(MessageEventBuilder* builder);
 };
 
 // =============

--- a/src/groups/bmq/bmqa/bmqa_session.h
+++ b/src/groups/bmq/bmqa/bmqa_session.h
@@ -668,6 +668,8 @@ struct SessionImpl {
     SessionImpl(const bmqt::SessionOptions&            options,
                 bslma::ManagedPtr<SessionEventHandler> eventHandler,
                 bslma::Allocator*                      allocator = 0);
+
+    MessageEvent createMessageEvent();
 };
 
 // =============

--- a/src/groups/bmq/bmqimp/bmqimp_event.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.cpp
@@ -319,27 +319,6 @@ Event& Event::downgradeMessageEventModeToRead()
     return *this;
 }
 
-Event& Event::upgradeMessageEventModeToWrite()
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(type() == EventType::e_MESSAGE);
-
-    if (MessageEventMode::e_WRITE == d_msgEventMode) {
-        return *this;  // RETURN
-    }
-
-    d_msgEventMode = MessageEventMode::e_WRITE;
-    BSLS_ASSERT_SAFE(d_isPutEventBuilderConstructed);
-    d_putEventBuilderBuffer.object().reset();
-    d_putMsgIter.clear();
-    d_rawEvent.clear();
-    d_queues.clear();
-    d_queuesBySubscriptionId.clear();
-    d_contexts.clear();
-    d_correlationId.makeUnset();
-    return *this;
-}
-
 Event& Event::insertQueue(const bsl::shared_ptr<Queue>& queue)
 {
     // PRECONDITIONS

--- a/src/groups/bmq/bmqimp/bmqimp_event.h
+++ b/src/groups/bmq/bmqimp/bmqimp_event.h
@@ -363,14 +363,6 @@ class Event {
     /// write (builder) to read (iterator).
     Event& downgradeMessageEventModeToRead();
 
-    /// Change the message event mode with which this instance is currently
-    /// configured to MessageEventMode::WRITE, *and* reset the underlying
-    /// blob.  This method has no effect if the mode is already `WRITE`.
-    /// Behavior is undefined unless this instance's `type()` is
-    /// MESSAGEVENT.  Note that this method should logically be thought of
-    /// as resetting this instance as a message event in write mode.
-    Event& upgradeMessageEventModeToWrite();
-
     // ACCESSORS
 
     /// Get a pointer to the correlationId container.

--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -1547,13 +1547,6 @@ static void test12_upgradeDowngradeMessageEvent()
     //   3.  Downgrade to READ mode via 'downgradeMessageEventModeToRead'.
     //   4.  Check event 'MessageEventMode' is READ.
     //   5.  Call 'downgradeMessageEventModeToRead' again.
-    //   6.  Check MessageEventMode' is the same as after last call of
-    //       'upgradeMessageEventModeToWrite'.
-    //   7.  Upgrade to WRITE mode via 'upgradeMessageEventModeToWrite'.
-    //   8.  Check event 'MessageEventMode' is WRITE.
-    //   9.  Call 'upgradeMessageEventModeToWrite' again.
-    //   10. Check MessageEventMode' is the same as after last call of
-    //       'upgradeMessageEventModeToWrite'.
     //
     // Testing manipulators:
     //   - downgradeMessageEventModeToRead
@@ -1590,21 +1583,6 @@ static void test12_upgradeDowngradeMessageEvent()
     // 6. Check MessageEventMode' is the same as after last call of
     //    'upgradeMessageEventModeToWrite'.
     BMQTST_ASSERT_EQ(bmqimp::Event::MessageEventMode::e_READ,
-                     obj.messageEventMode());
-
-    // 7. Upgrade to WRITE mode via 'upgradeMessageEventModeToWrite'.
-    obj.upgradeMessageEventModeToWrite();
-
-    // 8. Check event 'MessageEventMode' is WRITE.
-    BMQTST_ASSERT_EQ(bmqimp::Event::MessageEventMode::e_WRITE,
-                     obj.messageEventMode());
-
-    // 9. Call 'upgradeMessageEventModeToWrite' again.
-    obj.upgradeMessageEventModeToWrite();
-
-    //   10. Check MessageEventMode' is the same as after last call of
-    //       'upgradeMessageEventModeToWrite'.
-    BMQTST_ASSERT_EQ(bmqimp::Event::MessageEventMode::e_WRITE,
                      obj.messageEventMode());
 }
 


### PR DESCRIPTION
The goal is to be able to reset `MessageEventBuilder` while cashing manufactured `MessageEvent`

https://github.com/bloomberg/blazingmq/pull/1099 was not enough
