### PR TITLE
Cleanup[mqbc::ClusterStateTable]: Intermediate REAPPLY transitions

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1038,7 +1038,7 @@ void ClusterStateManager::do_reapplySelectLeader(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(d_clusterData_p->electorInfo().isSelfLeader());
-    BSLS_ASSERT_SAFE(d_clusterFSM.state() == ClusterFSM::State::e_UNKNOWN);
+    BSLS_ASSERT_SAFE(d_clusterFSM.isSelfLeader());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << ": Re-apply transition to leader in the Cluster FSM.";
@@ -1058,7 +1058,7 @@ void ClusterStateManager::do_reapplySelectFollower(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(!d_clusterData_p->electorInfo().isSelfLeader());
-    BSLS_ASSERT_SAFE(d_clusterFSM.state() == ClusterFSM::State::e_UNKNOWN);
+    BSLS_ASSERT_SAFE(d_clusterFSM.isSelfFollower());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << ": Re-apply transition to follower in the Cluster FSM.";

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -374,9 +374,9 @@ class ClusterStateTableActions {
 
     void do_stopPFSMs_cleanupLSNs(const ARGS& args);
 
-    void do_cancelRequests_reapplySelectFollower(const ARGS& args);
+    void do_cancelRequests_reapplyEvent(const ARGS& args);
 
-    void do_cleanupLSNs_cancelRequests_reapplySelectLeader(const ARGS& args);
+    void do_cleanupLSNs_cancelRequests_reapplyEvent(const ARGS& args);
 
     void do_sendFollowerLSNResponse_logErrorLeaderNotHealed(const ARGS& args);
 
@@ -490,6 +490,10 @@ class ClusterStateTable
                 stopWatchDog_cancelRequests_reapplyEvent,
                 UNKNOWN);
         CST_CFG(FOL_HEALING,
+                REAPPLY_FOL,
+                cancelRequests_reapplyEvent,
+                UNKNOWN);
+        CST_CFG(FOL_HEALING,
                 FOL_LSN_RQST,
                 sendFollowerLSNResponse,
                 FOL_HEALING);
@@ -519,10 +523,7 @@ class ClusterStateTable
                 stopWatchDog_cancelRequests,
                 UNKNOWN);
         CST_CFG(FOL_HEALING, RST_PRIMARY, updatePrimaryInPFSMs, FOL_HEALING);
-        CST_CFG(FOL_HEALING,
-                WATCH_DOG,
-                cancelRequests_reapplySelectFollower,
-                UNKNOWN);
+        CST_CFG(FOL_HEALING, WATCH_DOG, reapplySelectFollower, FOL_HEALING);
         CST_CFG(FOL_HEALING,
                 STOP_NODE,
                 stopPFSMs_stopWatchDog_cancelRequests,
@@ -584,9 +585,13 @@ class ClusterStateTable
                 updatePrimaryInPFSMs,
                 LDR_HEALING_STG1);
         CST_CFG(LDR_HEALING_STG1,
-                WATCH_DOG,
-                cleanupLSNs_cancelRequests_reapplySelectLeader,
+                REAPPLY_LDR,
+                cleanupLSNs_cancelRequests_reapplyEvent,
                 UNKNOWN);
+        CST_CFG(LDR_HEALING_STG1,
+                WATCH_DOG,
+                reapplySelectLeader,
+                LDR_HEALING_STG1);
         CST_CFG(LDR_HEALING_STG1,
                 STOP_NODE,
                 stopPFSMs_stopWatchDog_cleanupLSNs_cancelRequests,
@@ -657,9 +662,13 @@ class ClusterStateTable
                 updatePrimaryInPFSMs,
                 LDR_HEALING_STG2);
         CST_CFG(LDR_HEALING_STG2,
-                WATCH_DOG,
-                cleanupLSNs_cancelRequests_reapplySelectLeader,
+                REAPPLY_LDR,
+                cleanupLSNs_cancelRequests_reapplyEvent,
                 UNKNOWN);
+        CST_CFG(LDR_HEALING_STG2,
+                WATCH_DOG,
+                reapplySelectLeader,
+                LDR_HEALING_STG2);
         CST_CFG(LDR_HEALING_STG2,
                 STOP_NODE,
                 stopPFSMs_stopWatchDog_cleanupLSNs_cancelRequests,
@@ -830,20 +839,20 @@ void ClusterStateTableActions<ARGS>::do_stopPFSMs_cleanupLSNs(const ARGS& args)
 }
 
 template <typename ARGS>
-void ClusterStateTableActions<ARGS>::do_cancelRequests_reapplySelectFollower(
+void ClusterStateTableActions<ARGS>::do_cancelRequests_reapplyEvent(
     const ARGS& args)
 {
     do_cancelRequests(args);
-    do_reapplySelectFollower(args);
+    do_reapplyEvent(args);
 }
 
 template <typename ARGS>
 void ClusterStateTableActions<
-    ARGS>::do_cleanupLSNs_cancelRequests_reapplySelectLeader(const ARGS& args)
+    ARGS>::do_cleanupLSNs_cancelRequests_reapplyEvent(const ARGS& args)
 {
     do_cleanupLSNs(args);
     do_cancelRequests(args);
-    do_reapplySelectLeader(args);
+    do_reapplyEvent(args);
 }
 
 template <typename ARGS>

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -486,6 +486,10 @@ class ClusterStateTable
                 stopWatchDog_cancelRequests_reapplyEvent,
                 UNKNOWN);
         CST_CFG(FOL_HEALING,
+                SLCT_FOL,
+                stopWatchDog_cancelRequests_reapplyEvent,
+                UNKNOWN);
+        CST_CFG(FOL_HEALING,
                 FOL_LSN_RQST,
                 sendFollowerLSNResponse,
                 FOL_HEALING);
@@ -661,6 +665,7 @@ class ClusterStateTable
                 stopPFSMs_stopWatchDog_cleanupLSNs_cancelRequests,
                 STOPPED);
         CST_CFG(FOL_HEALED, SLCT_LDR, reapplyEvent, UNKNOWN);
+        CST_CFG(FOL_HEALED, SLCT_FOL, reapplyEvent, UNKNOWN);
         CST_CFG(FOL_HEALED,
                 FOL_LSN_RQST,
                 sendFollowerLSNResponse_logErrorLeaderNotHealed,


### PR DESCRIPTION
## Summary   
                                                                                                                           
  - Introduce intermediate `REAPPLY_LDR` / `REAPPLY_FOL` transition rows in the Cluster FSM table, building on the events  
  declared in #1341. This separates the "trigger a retry" step (WATCH_DOG) from the "clean up and restart" step (REAPPLY), 
  making the FSM flow explicit and readable — the same pattern applied to the Partition FSM in #1342.                      
  - WATCH_DOG events now stay in the current healing state and simply call `do_reapplySelectLeader` /
  `do_reapplySelectFollower`, which enqueue the corresponding REAPPLY event. The REAPPLY event then performs cleanup       
  (without `stopWatchDog`) and transitions through UNKNOWN back into healing.
  - Add missing `SLCT_FOL` transitions for `FOL_HEALING` and `FOL_HEALED` states. When the leader changes but self remains 
  a follower, the FSM must restart healing with the new leader. Previously these events would silently hit the default     
  `do_none` action.
