### PR TITLE
Cleanup[bmqt::AuthnCallback]: immutable interface

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_authncredential.cpp
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.cpp
@@ -95,20 +95,6 @@ AuthnCredential::~AuthnCredential()
     // NOTHING
 }
 
-// MANIPULATORS
-
-AuthnCredential& AuthnCredential::setMechanism(const bsl::string& mechanism)
-{
-    d_mechanism = mechanism;
-    return *this;
-}
-
-AuthnCredential& AuthnCredential::setData(const bsl::vector<char>& data)
-{
-    d_data = data;
-    return *this;
-}
-
 // ACCESSORS
 
 const bsl::string& AuthnCredential::mechanism() const

--- a/src/groups/bmq/bmqt/bmqt_authncredential.cpp
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.cpp
@@ -39,7 +39,7 @@ AuthnCredential::AuthnCredential(bslma::Allocator* allocator)
     // NOTHING
 }
 
-AuthnCredential::AuthnCredential(const bsl::string&       mechanism,
+AuthnCredential::AuthnCredential(bsl::string_view         mechanism,
                                  const bsl::vector<char>& data,
                                  bslma::Allocator*        allocator)
 : d_mechanism(mechanism, allocator)

--- a/src/groups/bmq/bmqt/bmqt_authncredential.h
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.h
@@ -56,7 +56,7 @@ class AuthnCredential {
     /// Create an `AuthnCredential` object with the specified `mechanism`
     /// and `data`, using the specified `allocator` to supply memory.  If
     /// `allocator` is 0, the currently installed default allocator is used.
-    explicit AuthnCredential(const bsl::string&       mechanism,
+    explicit AuthnCredential(bsl::string_view         mechanism,
                              const bsl::vector<char>& data,
                              bslma::Allocator*        allocator = 0);
 

--- a/src/groups/bmq/bmqt/bmqt_authncredential.h
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.h
@@ -66,10 +66,6 @@ class AuthnCredential {
     AuthnCredential& operator=(const AuthnCredential& rhs);
     AuthnCredential& operator=(bslmf::MovableRef<AuthnCredential> rhs);
 
-    // MANIPULATORS
-    AuthnCredential& setMechanism(const bsl::string& mechanism);
-    AuthnCredential& setData(const bsl::vector<char>& data);
-
     // ACCESSORS
     const bsl::string&       mechanism() const;
     const bsl::vector<char>& data() const;

--- a/src/groups/bmq/bmqt/bmqt_authncredential.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_authncredential.t.cpp
@@ -72,19 +72,6 @@ static void test1_breathingTest()
         ASSERT(cred.data() == data);
     }
 
-    PV("Test setMechanism and setData");
-    {
-        bmqt::AuthnCredential cred;
-        bsl::string           mechanism("BMQ");
-        bsl::vector<char>     data(Local::makeAuthnData());
-
-        cred.setMechanism(mechanism);
-        cred.setData(data);
-
-        ASSERT(cred.mechanism() == mechanism);
-        ASSERT(cred.data() == data);
-    }
-
     PV("Test allocator usage");
     {
         bslma::Allocator*     allocator = bmqtst::TestHelperUtil::allocator();


### PR DESCRIPTION
- Remove setters from `bmqt::AuthnCallback`
- Require `bsl::string_view` in `bmqt::AuthnCallback` constructor to avoid constructing an intermediate `bsl::string` when `const char *` is provided, in cases like `bmqt::AuthnCallback("ANONYMOUS", data);`