### PR TITLE
Fix[mqb]: removing erroneous assertion

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -3587,7 +3587,6 @@ bool ClusterQueueHelper::subtractCounters(
     StreamsMap::iterator&                      itSubStream)
 {
     BSLS_ASSERT_SAFE(qinfo);
-    BSLS_ASSERT_SAFE(qinfo->d_queue_sp);
 
     SubQueueContext& subQueueContext = itSubStream.value();
 


### PR DESCRIPTION
`ClusterQueueHelper::subtractCounters` should not assert `qinfo->d_queue_sp`
It can be `0` if queue creation failed and `subtractCounters` is part of rollback
