### PR TITLE
Fix[mqb]: race between recoveredQueuesCb and setActivePrimary

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -1121,11 +1121,12 @@ void QueueHandle::configureDispatched(
         d_queue_sp->configureHandle(this, streamParameters, configuredCb);
     }
     else {
-        BALL_LOG_ERROR
-            << "#CLIENT_IMPROPER_BEHAVIOR "
-            << "Attempting to configure handle without a client. Queue '"
-            << d_queue_sp->uri() << "', stream params: " << streamParameters
-            << ", handlePtr '" << this << "'.";
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+
+        BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR "
+                       << "Attempting to configure handle [" << this
+                       << "] without a client, queue '" << d_queue_sp->uri()
+                       << "', stream params: [" << streamParameters << "].";
 
         bmqp_ctrlmsg::Status status(d_allocator_p);
         status.category() = bmqp_ctrlmsg::StatusCategory::E_UNKNOWN;

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -1110,7 +1110,6 @@ void QueueHandle::configureDispatched(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_queue_sp->inDispatcherThread());
-    BSLS_ASSERT_SAFE(d_haveClient);
 
     BALL_LOG_INFO << "Client [" << d_clientContext_sp->description()
                   << "] requested to configure queue [" << d_queue_sp->uri()
@@ -1118,7 +1117,23 @@ void QueueHandle::configureDispatched(
                   << ", appId: " << streamParameters.appId()
                   << "] with streamParameters: " << streamParameters;
 
-    d_queue_sp->configureHandle(this, streamParameters, configuredCb);
+    if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(d_haveClient)) {
+        d_queue_sp->configureHandle(this, streamParameters, configuredCb);
+    }
+    else {
+        BALL_LOG_ERROR
+            << "#CLIENT_IMPROPER_BEHAVIOR "
+            << "Attempting to configure handle without a client. Queue '"
+            << d_queue_sp->uri() << "', stream params: " << streamParameters
+            << ", handlePtr '" << this << "'.";
+
+        bmqp_ctrlmsg::Status status(d_allocator_p);
+        status.category() = bmqp_ctrlmsg::StatusCategory::E_UNKNOWN;
+        status.code()     = -1;
+        status.message()  = "Attempting to configure handle without a client";
+
+        configuredCb(status, streamParameters);
+    }
 }
 
 void QueueHandle::deconfigureAll(

--- a/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuesessionmanager.cpp
@@ -76,13 +76,6 @@ void handleHolderDummy(BSLA_MAYBE_UNUSED const bsl::shared_ptr<void>& handle)
     // NOTHING
 }
 
-void clearClient(mqbi::QueueHandle* queueHandle)
-{
-    if (queueHandle) {
-        queueHandle->clearClient(false);
-    }
-}
-
 }  // close unnamed namespace
 
 // -------------------------
@@ -235,9 +228,6 @@ void QueueSessionManager::onQueueOpenCb(
     const bmqu::AtomicValidatorSp&             validator)
 {
     // executed by *ANY* thread
-
-    bdlb::ScopeExitAny cleaner(bdlf::BindUtil::bind(clearClient, queueHandle));
-
     bmqu::AtomicValidatorGuard guard(validator.get());
     if (!guard.isValid()) {
         // The session was destroyed before we received the response (see
@@ -261,8 +251,6 @@ void QueueSessionManager::onQueueOpenCb(
                              responseCallback,
                              request),
         d_dispatcherClient_p);
-
-    cleaner.release();
 }
 
 void QueueSessionManager::onQueueOpenCbDispatched(
@@ -278,8 +266,6 @@ void QueueSessionManager::onQueueOpenCbDispatched(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_dispatcherClient_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(request.choice().isOpenQueueValue());
-
-    bdlb::ScopeExitAny cleaner(bdlf::BindUtil::bind(clearClient, queueHandle));
 
     if (d_shutdownInProgress) {
         return;  // RETURN
@@ -342,8 +328,9 @@ void QueueSessionManager::onQueueOpenCbDispatched(
                 cluster,
                 queueFlags);
         }
-
-        cleaner.release();
+    }
+    else if (queueHandle) {
+        queueHandle->clearClient(false);
     }
 
     responseCallback(status, queueHandle, openQueueResponse);

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6435,8 +6435,7 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
     rawEvent.loadStorageMessageIterator(&iter);
     BSLS_ASSERT_SAFE(iter.isValid());
 
-    FileStore::NodeContext* nodeContext           = 0;
-    bool                    hasValidLeaseIdSeqNum = false;
+    bool hasValidLeaseIdSeqNum = false;
 
     if (0 < d_primaryLeaseId) {
         // File store encountered valid PSN in 'open()'.
@@ -6555,14 +6554,6 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
 
         if (bmqp::StorageMessageType::e_DATA == header.messageType()) {
             rc = writeMessageRecord(header, *recHeader, blob, recordPosition);
-
-            if (0 == rc && (header.flags() &
-                            bmqp::StorageHeaderFlags::e_RECEIPT_REQUESTED)) {
-                nodeContext = generateReceipt(nodeContext,
-                                              d_primaryNode_p,
-                                              recHeader->primaryLeaseId(),
-                                              recHeader->sequenceNumber());
-            }
         }
         else if (bmqp::StorageMessageType::e_QLIST == header.messageType()) {
             rc = writeQueueCreationRecord(header,
@@ -6591,8 +6582,6 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
             return 10 * rc + rc_WRITE_FAILURE;  // RETURN
         }
     }
-
-    sendReceipt(d_primaryNode_p, nodeContext);
 
     return rc_SUCCESS;
 }
@@ -6682,6 +6671,28 @@ void FileStore::sendReceipt(mqbnet::ClusterNode* node,
 
         // Ignore the error and keep the blob
     }
+}
+
+void FileStore::sendImplicitReceipt()
+{
+    if (!d_primaryNode_p) {
+        return;  // RETURN
+    }
+
+    if (!d_lastRecoveredStrongConsistency.d_primaryLeaseId) {
+        return;  // RETURN
+    }
+    BALL_LOG_INFO << partitionDesc() << "Issuing Implicit Receipt ["
+                  << "primaryLeaseId = " << d_primaryLeaseId
+                  << ", d_sequenceNum = " << d_sequenceNum << "].";
+
+    FileStore::NodeContext* nodeContext = generateReceipt(
+        0,
+        d_primaryNode_p,
+        d_lastRecoveredStrongConsistency.d_primaryLeaseId,
+        d_lastRecoveredStrongConsistency.d_sequenceNum);
+
+    sendReceipt(d_primaryNode_p, nodeContext);
 }
 
 int FileStore::issueSyncPoint()
@@ -6798,20 +6809,8 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
             mqbstat::PartitionStats::PrimaryStatus::e_REPLICA);
         cancelTimersAndWait();
 
-        if (d_lastRecoveredStrongConsistency.d_primaryLeaseId ==
-            d_primaryLeaseId) {
-            BALL_LOG_INFO << partitionDesc()
-                          << "Issuing Implicit Receipt with PSN: "
-                          << printPSN(d_primaryLeaseId, sequenceNumber())
-                          << ".";
+        sendImplicitReceipt();
 
-            FileStore::NodeContext* nodeContext = generateReceipt(
-                0,
-                primaryNode,
-                d_lastRecoveredStrongConsistency.d_primaryLeaseId,
-                d_lastRecoveredStrongConsistency.d_sequenceNum);
-            sendReceipt(primaryNode, nodeContext);
-        }
         return;  // RETURN
     }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6684,7 +6684,7 @@ void FileStore::sendImplicitReceipt()
     }
     BALL_LOG_INFO << partitionDesc() << "Issuing Implicit Receipt ["
                   << "primaryLeaseId = " << d_primaryLeaseId
-                  << ", d_sequenceNum = " << d_sequenceNum << "].";
+                  << ", d_sequenceNum = " << sequenceNumber() << "].";
 
     FileStore::NodeContext* nodeContext = generateReceipt(
         0,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -655,6 +655,7 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// Send previously generated Replication Receipt to the specified `node`
     /// using the specified `nodeContext`.
     void sendReceipt(mqbnet::ClusterNode* node, NodeContext* nodeContext);
+    void sendImplicitReceipt();
 
     /// Insert the specified `record` value by the specified `key` into the
     /// list of outstanding records, and assign to the specified `handle` an
@@ -1251,6 +1252,8 @@ FileStore::setLastStrongConsistency(unsigned int        primaryLeaseId,
 {
     d_lastRecoveredStrongConsistency.d_primaryLeaseId = primaryLeaseId;
     d_lastRecoveredStrongConsistency.d_sequenceNum    = sequenceNum;
+
+    sendImplicitReceipt();
 }
 
 inline void

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -655,6 +655,9 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// Send previously generated Replication Receipt to the specified `node`
     /// using the specified `nodeContext`.
     void sendReceipt(mqbnet::ClusterNode* node, NodeContext* nodeContext);
+
+    /// Generate and send Replication Receipt for the
+    /// `d_lastRecoveredStrongConsistency`, if any, to the current primary.
     void sendImplicitReceipt();
 
     /// Insert the specified `record` value by the specified `key` into the


### PR DESCRIPTION
`FileStore::setActivePrimary` and `StorageUtil::recoveredQueuesCb` can happen in any order
So, issuing implicit Receipts from both (used to be done in `FileStore::setActivePrimary` only)

And reverting https://github.com/bloomberg/blazingmq/pull/1265 as it is a partial fix.

2.  Unrelated.  `QueueHandle::configureDispatched` can be called _after_ `QueueHandle::clearClientDispatched` and needs to survive that.