### PR TITLE
Fix[mqbblp::Domain]: fix thread-unsafe config write from admin thread

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1048,7 +1048,7 @@ void ClusterQueueHelper::processOpenQueueRequest(
                 &openQueueResp.routingConfiguration());
 
             openQueueResp.deduplicationTimeMs() =
-                context->d_domain_p->config().deduplicationTimeMs();
+                context->d_domain_p->config()->deduplicationTimeMs();
             openQueueResp.originalRequest().handleParameters() =
                 context->d_handleParameters;
             openQueueResp.originalRequest().handleParameters().qId() =
@@ -2087,7 +2087,7 @@ bool ClusterQueueHelper::createQueue(
         match(&added,
               &removed,
               *queueContext->d_stateQInfo_sp,
-              domain->config().mode());
+              domain->config()->mode());
 
         if (!removed.empty() || !added.empty()) {
             // Add to 'd_pending' before calling 'updateAppIds' which is
@@ -3907,7 +3907,7 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                 match(&added,
                       &removed,
                       *queueContext->d_stateQInfo_sp,
-                      domain->config().mode());
+                      domain->config()->mode());
 
                 if (!removed.empty() || !added.empty()) {
                     VoidFunctor park = bdlf::BindUtil::bindS(

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -101,10 +101,10 @@ bool validateSubscriptionExpression(bsl::ostream& errorDescription,
 
 /// Validates a domain configuration. If `previousDefn` is provided, also
 /// checks that the implied reconfiguration is also valid.
-int validateConfig(bsl::ostream& errorDescription,
-                   const bdlb::NullableValue<mqbconfm::Domain>& previousDefn,
-                   const mqbconfm::Domain&                      newConfig,
-                   bslma::Allocator*                            allocator)
+int validateConfig(bsl::ostream&           errorDescription,
+                   const mqbconfm::Domain* previousDefn,
+                   const mqbconfm::Domain& newConfig,
+                   bslma::Allocator*       allocator)
 {
     enum RcEnum {
         // Value for the various RC error categories
@@ -164,13 +164,13 @@ int validateConfig(bsl::ostream& errorDescription,
 
     // 2. Check compatibility between old/new configurations,
     // if old configuration exists
-    if (previousDefn.isNull()) {
+    if (0 == previousDefn) {
         // First time configure, nothing more to validate
         return rc_SUCCESS;  // RETURN
     }
 
     // Validate properties of new configurations relative to old ones.
-    const mqbconfm::Domain& previousCfg = previousDefn.value();
+    const mqbconfm::Domain& previousCfg = *previousDefn;
 
     // Reconfiguring the routing mode is not allowed.
     if (previousCfg.mode().selectionId() != newConfig.mode().selectionId()) {
@@ -262,7 +262,8 @@ Domain::Domain(const bsl::string&                     name,
 : d_allocator_p(allocator)
 , d_state(e_STOPPED)
 , d_name(name, d_allocator_p)
-, d_config(d_allocator_p)
+, d_config_sp()
+, d_configLock()
 , d_cluster_sp(cluster)
 , d_dispatcher_p(dispatcher)
 , d_blobBufferFactory_p(blobBufferFactory)
@@ -294,7 +295,7 @@ Domain::~Domain()
 }
 
 int Domain::configure(bsl::ostream&           errorDescription,
-                      const mqbconfm::Domain& config)
+                      const mqbconfm::Domain& newConfig)
 {
     enum RcEnum {
         // Value for the various RC error categories
@@ -306,11 +307,15 @@ int Domain::configure(bsl::ostream&           errorDescription,
     };
 
     // Store a copy of the old configuration.
-    bdlb::NullableValue<mqbconfm::Domain> oldConfig(d_config);
-    const bool                            isReconfigure(oldConfig.has_value());
+    bsl::shared_ptr<const mqbconfm::Domain> oldConfig;
+    {
+        bslmt::ReadLockGuard<bslmt::ReaderWriterMutex> guard(&d_configLock);
+        oldConfig = d_config_sp;
+    }
+    const bool isReconfigure(oldConfig.get() != 0);
 
     // Certain invalid values might need to be updated in the configuration.
-    mqbconfm::Domain finalConfig(config);
+    mqbconfm::Domain finalConfig(newConfig);
     {
         bmqu::MemOutStream err;
         if (normalizeConfig(&finalConfig, err, *this)) {
@@ -320,7 +325,7 @@ int Domain::configure(bsl::ostream&           errorDescription,
     }
 
     // Return early if there are no changes.
-    if (oldConfig && (finalConfig == oldConfig.value())) {
+    if (oldConfig && (finalConfig == *oldConfig)) {
         return rc_SUCCESS;  // RETURN
     }
 
@@ -332,17 +337,22 @@ int Domain::configure(bsl::ostream&           errorDescription,
 
     // Validate config. Return early if the configuration is not valid.
     if (const int rc = validateConfig(errorDescription,
-                                      d_config,
+                                      oldConfig.get(),
                                       finalConfig,
                                       d_allocator_p)) {
         return (rc * 10 + rc_VALIDATION_FAILED);  // RETURN
     }
 
     // Adopt the updated domain configuration.
-    d_config.makeValue(finalConfig);
+    {
+        bslmt::WriteLockGuard<bslmt::ReaderWriterMutex> guard(&d_configLock);
+        d_config_sp = bsl::allocate_shared<const mqbconfm::Domain>(
+            d_allocator_p,
+            finalConfig);
+    }
 
     // Configure domain limits.
-    const mqbconfm::Limits& limits = d_config.value().storage().domainLimits();
+    const mqbconfm::Limits& limits = finalConfig.storage().domainLimits();
     d_capacityMeter.setLimits(limits.messages(), limits.bytes())
         .setWatermarkThresholds(limits.messagesWatermarkRatio(),
                                 limits.bytesWatermarkRatio());
@@ -352,14 +362,11 @@ int Domain::configure(bsl::ostream&           errorDescription,
         limits.bytes());
 
     if (isReconfigure) {
-        BSLS_ASSERT_OPT(oldConfig.has_value());
-        BSLS_ASSERT_OPT(d_config.has_value());
+        BSLS_ASSERT_OPT(oldConfig);
 
         // Notify the 'cluster' of the updated configuration, so it can write
         // any needed update-advisories to the CSL.
-        d_cluster_sp->onDomainReconfigured(*this,
-                                           oldConfig.value(),
-                                           d_config.value());
+        d_cluster_sp->onDomainReconfigured(*this, *oldConfig, finalConfig);
 
         // Note: Queues must only be reconfigured AFTER ensuring that virtual
         // storage has been created for any new AppIds. This is done by the
@@ -374,9 +381,7 @@ int Domain::configure(bsl::ostream&           errorDescription,
         //  of 'Queue::configure' dispatches to the Queue dispatcher thread, it
         //  will also happen after completion of 'afterAppIdRegistered' above.
         BALL_LOG_INFO << "Reconfiguring " << d_queues.size()
-                      << " queues from "
-                         "domain "
-                      << d_name;
+                      << " queues from domain " << d_name;
 
         QueueMap::iterator it = d_queues.begin();
         for (; it != d_queues.end(); it++) {
@@ -663,7 +668,13 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
 
         domainInfo.name()        = d_name;
         domainInfo.clusterName() = d_cluster_sp->name();
-        if (!d_config.isNull()) {
+        bsl::shared_ptr<const mqbconfm::Domain> cfgSnapshot;
+        {
+            bslmt::ReadLockGuard<bslmt::ReaderWriterMutex> guard(
+                &d_configLock);
+            cfgSnapshot = d_config_sp;
+        }
+        if (cfgSnapshot) {
             baljsn::Encoder                       encoder;
             bdlma::LocalSequentialAllocator<1024> localAllocator(
                 d_allocator_p);
@@ -674,7 +685,7 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
             options.setSpacesPerLevel(2);
 
             BSLA_MAYBE_UNUSED const int rc = encoder.encode(out,
-                                                            d_config.value(),
+                                                            *cfgSnapshot,
                                                             options);
             BSLS_ASSERT_SAFE(rc == 0);
             domainInfo.configJson() = out.str();
@@ -860,14 +871,19 @@ void Domain::loadRoutingConfiguration(
 
     bmqp::RoutingConfigurationUtils::clear(config);
 
-    if (d_config.isNull()) {
+    bsl::shared_ptr<const mqbconfm::Domain> cfgSnapshot;
+    {
+        bslmt::ReadLockGuard<bslmt::ReaderWriterMutex> guard(&d_configLock);
+        cfgSnapshot = d_config_sp;
+    }
+    if (!cfgSnapshot) {
         BALL_LOG_ERROR << "#DOMAIN_INVALID_CONFIG "
                        << "Uninitialized config for domain '" << d_name
                        << "'.";
         return;  // RETURN
     }
 
-    switch (d_config.value().mode().selectionId()) {
+    switch (cfgSnapshot->mode().selectionId()) {
     case mqbconfm::QueueMode::SELECTION_ID_FANOUT: {
         RootQueueEngine::FanoutConfiguration::loadRoutingConfiguration(config);
     } break;
@@ -883,9 +899,8 @@ void Domain::loadRoutingConfiguration(
     default: {
         BSLS_ASSERT_SAFE(false && "Invalid domain routing mode");
         BALL_LOG_ERROR << "#DOMAIN_INVALID_CONFIG "
-                       << "Invalid or undefined mode '"
-                       << d_config.value().mode() << "' for domain '" << d_name
-                       << "'.";
+                       << "Invalid or undefined mode '" << cfgSnapshot->mode()
+                       << "' for domain '" << d_name << "'.";
     }
     }
 }

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -51,7 +51,10 @@
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bslmt_mutex.h>
+#include <bslmt_readerwritermutex.h>
+#include <bslmt_readlockguard.h>
 #include <bslmt_semaphore.h>
+#include <bslmt_writelockguard.h>
 #include <bsls_assert.h>
 #include <bsls_atomic.h>
 #include <bsls_keyword.h>
@@ -128,8 +131,12 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     /// Name of this domain.
     bsl::string d_name;
 
-    /// Configuration for the domain.
-    bdlb::NullableValue<mqbconfm::Domain> d_config;
+    /// Configuration for the domain.  Protected by `d_configLock`.
+    bsl::shared_ptr<const mqbconfm::Domain> d_config_sp;
+
+    /// Read-write lock for `d_config_sp` to allow thread-safe concurrent reads
+    /// from dispatcher threads while the admin thread writes.
+    mutable bslmt::ReaderWriterMutex d_configLock;
 
     /// Cluster to use by this domain.
     bsl::shared_ptr<mqbi::Cluster> d_cluster_sp;
@@ -307,8 +314,9 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     /// Return the name of this domain.
     const bsl::string& name() const BSLS_KEYWORD_OVERRIDE;
 
-    /// Return the configuration of this domain.
-    const mqbconfm::Domain& config() const BSLS_KEYWORD_OVERRIDE;
+    /// Return a thread-safe snapshot of the configuration of this domain.
+    bsl::shared_ptr<const mqbconfm::Domain>
+    config() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the `DomainStats` object associated to this Domain.
     mqbstat::DomainStats* domainStats() BSLS_KEYWORD_OVERRIDE;
@@ -356,12 +364,14 @@ inline const bsl::string& Domain::name() const
     return d_name;
 }
 
-inline const mqbconfm::Domain& Domain::config() const
+inline bsl::shared_ptr<const mqbconfm::Domain> Domain::config() const
 {
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!d_config.isNull());
+    bslmt::ReadLockGuard<bslmt::ReaderWriterMutex> guard(&d_configLock);
 
-    return d_config.value();
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_config_sp);
+
+    return d_config_sp;
 }
 
 inline mqbstat::DomainStats* Domain::domainStats()

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -110,7 +110,8 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
 
     int                     rc        = 0;
     mqbi::Queue*            queue     = d_state_p->queue();
-    const mqbconfm::Domain& domainCfg = d_state_p->domain()->config();
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg =
+        d_state_p->domain()->config();
 
     // Create the associated storage.
     if (!d_state_p->storage()) {
@@ -123,9 +124,9 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
             d_state_p->uri(),
             d_state_p->key(),
             d_state_p->partitionId(),
-            domainCfg.messageTtl(),
-            domainCfg.maxDeliveryAttempts(),
-            domainCfg.storage());
+            domainCfg->messageTtl(),
+            domainCfg->maxDeliveryAttempts(),
+            domainCfg->storage());
         if (rc != 0) {
             return 10 * rc + rc_STORAGE_CREATION_FAILURE;  // RETURN
         }
@@ -146,12 +147,13 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
         d_state_p->setStorage(storageSp);
     }
     else {
-        d_state_p->storage()->setConsistency(domainCfg.consistency());
-        rc = d_state_p->storage()->configure(errorDescription,
-                                             domainCfg.storage().config(),
-                                             domainCfg.storage().queueLimits(),
-                                             domainCfg.messageTtl(),
-                                             domainCfg.maxDeliveryAttempts());
+        d_state_p->storage()->setConsistency(domainCfg->consistency());
+        rc = d_state_p->storage()->configure(
+            errorDescription,
+            domainCfg->storage().config(),
+            domainCfg->storage().queueLimits(),
+            domainCfg->messageTtl(),
+            domainCfg->maxDeliveryAttempts());
         if (rc) {
             return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
         }
@@ -164,7 +166,7 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
     if (!d_queueEngine_mp) {
         RootQueueEngine::create(&d_queueEngine_mp,
                                 d_state_p,
-                                domainCfg,
+                                *domainCfg,
                                 d_allocator_p);
     }
 
@@ -176,7 +178,7 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
         return 10 * rc + rc_QUEUE_ENGINE_CFG_FAILURE;  // RETURN
     }
 
-    d_haveStrongConsistency = domainCfg.consistency().isStrongValue();
+    d_haveStrongConsistency = domainCfg->consistency().isStrongValue();
 
     d_state_p->stats()
         ->onEvent<mqbstat::QueueStatsDomain::EventType::e_CHANGE_ROLE>(
@@ -184,17 +186,17 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
 
     d_state_p->stats()
         ->onEvent<mqbstat::QueueStatsDomain::EventType::e_CFG_MSGS>(
-            domainCfg.storage().queueLimits().messages());
+            domainCfg->storage().queueLimits().messages());
 
     d_state_p->stats()
         ->onEvent<mqbstat::QueueStatsDomain::EventType::e_CFG_BYTES>(
-            domainCfg.storage().queueLimits().bytes());
+            domainCfg->storage().queueLimits().bytes());
 
     if (isReconfigure) {
-        if (domainCfg.mode().isFanoutValue()) {
+        if (domainCfg->mode().isFanoutValue()) {
             d_state_p->stats()->updateDomainAppIds(
-                domainCfg.mode().fanout().publishAppIdMetrics()
-                    ? domainCfg.mode().fanout().appIDs()
+                domainCfg->mode().fanout().publishAppIdMetrics()
+                    ? domainCfg->mode().fanout().appIDs()
                     : bsl::vector<bsl::string>(d_allocator_p));
         }
     }

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -725,8 +725,9 @@ QueueEngineTester::getHandle(const bsl::string& clientText)
     // Consistency
     // NOTE: appId can only be specified in fanout mode, and it must be
     //       associated with a readCount of 1
-    const mqbconfm::Domain& domainConfig = d_queueState_mp->domain()->config();
-    const bool              isFanout     = domainConfig.mode().isFanoutValue();
+    bsl::shared_ptr<const mqbconfm::Domain> domainConfig =
+        d_queueState_mp->domain()->config();
+    const bool   isFanout           = domainConfig->mode().isFanoutValue();
     unsigned int upstreamSubQueueId = bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID;
     // Populate SubQueueIdInfo (if any)
     if (isFanout) {
@@ -898,8 +899,9 @@ int QueueEngineTester::configureHandle(const bsl::string& clientText)
 
     // Consistency
     // NOTE: appId can only be specified in fanout mode
-    const mqbconfm::Domain& domainConfig = d_queueState_mp->domain()->config();
-    const bool              isFanout     = domainConfig.mode().isFanoutValue();
+    bsl::shared_ptr<const mqbconfm::Domain> domainConfig =
+        d_queueState_mp->domain()->config();
+    const bool isFanout = domainConfig->mode().isFanoutValue();
     BSLS_ASSERT_OPT((appId == bmqp::ProtocolUtil::k_DEFAULT_APP_ID) ||
                     isFanout);
 
@@ -1223,8 +1225,9 @@ void QueueEngineTester::purgeQueue(const bslstl::StringRef& appId)
     mqbu::StorageKey          appKey = mqbi::QueueEngine::k_DEFAULT_APP_KEY;
 
     bsl::string appIdInternal = bmqp::ProtocolUtil::k_DEFAULT_APP_ID;
-    const mqbconfm::Domain& domainConfig = d_queueState_mp->domain()->config();
-    const bool              isFanout     = domainConfig.mode().isFanoutValue();
+    bsl::shared_ptr<const mqbconfm::Domain> domainConfig =
+        d_queueState_mp->domain()->config();
+    const bool isFanout = domainConfig->mode().isFanoutValue();
     if (isFanout) {
         appIdInternal = appId;
         appKey        = mqbu::StorageKey::k_NULL_KEY;
@@ -1542,8 +1545,9 @@ bool QueueEngineTester::getUpstreamParameters(
     const bslstl::StringRef&        appId) const
 {
     unsigned int upstreamSubQueueId = bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID;
-    const mqbconfm::Domain& domainConfig = d_queueState_mp->domain()->config();
-    const bool              isFanout     = domainConfig.mode().isFanoutValue();
+    bsl::shared_ptr<const mqbconfm::Domain> domainConfig =
+        d_queueState_mp->domain()->config();
+    const bool isFanout = domainConfig->mode().isFanoutValue();
 
     if (isFanout) {
         SubIdsMap::const_iterator subIdCiter = d_subIds.find(appId);

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
@@ -645,7 +645,7 @@ inline T* QueueEngineTester::createQueueEngine()
     BSLS_ASSERT_OPT(!d_queueEngine_mp && "'createQueueEngine()' was called");
     T* result = new (*d_allocator_p)
         T(d_queueState_mp.get(),
-          d_queueState_mp->queue()->domain()->config(),
+          *d_queueState_mp->queue()->domain()->config(),
           d_allocator_p);
     // Create and configure Queue Engine
     d_queueEngine_mp.load(result, d_allocator_p);

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -179,24 +179,24 @@ bool QueueEngineUtil::consumerAndProducerLimitsAreValid(
     bool              isValid = true;
     mqbi::QueueCounts counts  = queueState->consumerAndProducerCounts(
         handleParameters);
-    const mqbconfm::Domain& domainConfig =
+    bsl::shared_ptr<const mqbconfm::Domain> domainConfig =
         queueState->queue()->domain()->config();
 
-    if (domainConfig.maxProducers() &&
+    if (domainConfig->maxProducers() &&
         ((handleParameters.writeCount() + counts.d_writeCount) >
-         domainConfig.maxProducers())) {
+         domainConfig->maxProducers())) {
         errorDescription << "Client would exceed the limit of "
-                         << domainConfig.maxProducers() << " producer(s)";
+                         << domainConfig->maxProducers() << " producer(s)";
 
         isValid = false;
     }
 
-    if (domainConfig.maxConsumers() &&
+    if (domainConfig->maxConsumers() &&
         ((handleParameters.readCount() + counts.d_readCount) >
-         domainConfig.maxConsumers())) {
+         domainConfig->maxConsumers())) {
         errorDescription << (isValid ? "Client would exceed the limit of "
                                      : " and the limit of ")
-                         << domainConfig.maxConsumers() << " consumer(s)";
+                         << domainConfig->maxConsumers() << " consumer(s)";
 
         isValid = false;
     }
@@ -327,7 +327,7 @@ void QueueEngineUtil::logRejectMessage(
     bdlbb::Blob payload(queueState->blobBufferFactory(), allocator);
     bmqp::MessageProperties properties(allocator);
     int                     attemptedDeliveries =
-        queueState->domain()->config().maxDeliveryAttempts();
+        queueState->domain()->config()->maxDeliveryAttempts();
     bdlbb::Blob msgProperties(queueState->blobBufferFactory(), allocator);
     int         messagePropertiesSize = 0;
     int         rc                    = bmqp::ProtocolUtil::parse(

--- a/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuestate.cpp
@@ -85,7 +85,7 @@ QueueState::QueueState(mqbi::Queue*                 queue,
     // Initialize stats
     // There are neither FileBackedStorage nor domain config on proxies
     if (d_domain_p->cluster()->isRemote() ||
-        !d_domain_p->config().storage().config().isFileBackedValue()) {
+        !d_domain_p->config()->storage().config().isFileBackedValue()) {
         d_stats_sp.createInplace(allocator, allocator);
         d_stats_sp->initialize(d_uri, d_domain_p);
     }

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -202,7 +202,8 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
 
     int                     rc        = 0;
     mqbi::Queue*            queue     = d_state_p->queue();
-    const mqbconfm::Domain& domainCfg = d_state_p->domain()->config();
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg =
+        d_state_p->domain()->config();
 
     if (!isReconfigure) {
         // Only create a storage if this is the initial configure; reconfigure
@@ -217,9 +218,9 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
             d_state_p->uri(),
             d_state_p->key(),
             d_state_p->partitionId(),
-            domainCfg.messageTtl(),
-            domainCfg.maxDeliveryAttempts(),
-            domainCfg.storage());
+            domainCfg->messageTtl(),
+            domainCfg->maxDeliveryAttempts(),
+            domainCfg->storage());
         if (rc != 0) {
             // This most likely means that this queue's partition at this
             // replica is out of sync.
@@ -254,17 +255,17 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
         // Create the queueEngine.
         d_queueEngine_mp.load(
             new (*d_allocator_p)
-                RelayQueueEngine(d_state_p, domainCfg, d_allocator_p),
+                RelayQueueEngine(d_state_p, *domainCfg, d_allocator_p),
             d_allocator_p);
     }
     else {
-        d_state_p->storage()->setConsistency(domainCfg.consistency());
+        d_state_p->storage()->setConsistency(domainCfg->consistency());
         rc = d_state_p->storage()->configure(
             errorDescription,
-            domainCfg.storage().config(),
-            domainCfg.storage().domainLimits(),
-            domainCfg.messageTtl(),
-            domainCfg.maxDeliveryAttempts());
+            domainCfg->storage().config(),
+            domainCfg->storage().domainLimits(),
+            domainCfg->messageTtl(),
+            domainCfg->maxDeliveryAttempts());
         if (rc) {
             return 10 * rc + rc_STORAGE_CONFIGURE_FAILURE;  // RETURN
         }
@@ -548,11 +549,12 @@ int RemoteQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
 
     // Update stats
     if (isReconfigure) {
-        const mqbconfm::Domain& domainCfg = d_state_p->domain()->config();
-        if (domainCfg.mode().isFanoutValue()) {
+        bsl::shared_ptr<const mqbconfm::Domain> domainCfg =
+            d_state_p->domain()->config();
+        if (domainCfg->mode().isFanoutValue()) {
             d_state_p->stats()->updateDomainAppIds(
-                domainCfg.mode().fanout().publishAppIdMetrics()
-                    ? domainCfg.mode().fanout().appIDs()
+                domainCfg->mode().fanout().publishAppIdMetrics()
+                    ? domainCfg->mode().fanout().appIDs()
                     : bsl::vector<bsl::string>(d_allocator_p));
         }
     }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -390,13 +390,15 @@ int RootQueueEngine::configure(bsl::ostream& errorDescription,
     // Populate map of appId to appKey for statically registered consumers
     size_t numApps = 0;
 
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg = config();
+
     const bsl::vector<mqbconfm::Subscription>& subscriptions =
-        config().subscriptions();
+        domainCfg->subscriptions();
     d_hasAppSubscriptions = !subscriptions.empty();
 
     if (d_isFanout) {
         const bsl::vector<bsl::string>& cfgAppIds =
-            config().mode().fanout().appIDs();
+            domainCfg->mode().fanout().appIDs();
         for (numApps = 0; numApps < cfgAppIds.size(); ++numApps) {
             if (initializeAppId(cfgAppIds[numApps],
                                 errorDescription,
@@ -480,7 +482,7 @@ int RootQueueEngine::configure(bsl::ostream& errorDescription,
     }
 
     if (!QueueEngineUtil::isBroadcastMode(d_queueState_p->queue())) {
-        d_consumptionMonitor.setMaxIdleTime(config().maxIdleTime());
+        d_consumptionMonitor.setMaxIdleTime(domainCfg->maxIdleTime());
     }
 
     return rc_SUCCESS;
@@ -1654,7 +1656,7 @@ int RootQueueEngine::onRejectMessage(
         // replica/proxy will free the corresponding handles, and all message
         // iterators will be recreated with the correct 'rdaInfo' received from
         // primary, if a new consumer connects to the replica/proxy.
-        const int      maxDeliveryAttempts = config().maxDeliveryAttempts();
+        const int      maxDeliveryAttempts = config()->maxDeliveryAttempts();
         const bool     domainIsUnlimited   = (maxDeliveryAttempts == 0);
         bmqp::RdaInfo& rda = message->appMessageState(app.ordinal()).d_rdaInfo;
 
@@ -2022,7 +2024,7 @@ void RootQueueEngine::logAlarmCb(
     storage->capacityMeter()->printShortSummary(out);
     out << ", max idle time "
         << bmqu::PrintUtil::prettyTimeInterval(
-               config().maxIdleTime() *
+               config()->maxIdleTime() *
                bdlt::TimeUnitRatio::k_NANOSECONDS_PER_SECOND)
         << " appears to be stuck. It currently has " << numConsumers
         << " consumers." << ss.str() << '\n';
@@ -2324,8 +2326,9 @@ void RootQueueEngine::loadInternals(mqbcmd::QueueEngine* out) const
     mqbcmd::FanoutQueueEngine& fanoutQueueEngine = out->makeFanout();
     // TODO: Implement in a way that makes sense
 
-    fanoutQueueEngine.mode()         = config().mode().selectionName();
-    fanoutQueueEngine.maxConsumers() = config().maxConsumers();
+    bsl::shared_ptr<const mqbconfm::Domain> cfg = config();
+    fanoutQueueEngine.mode()                    = cfg->mode().selectionName();
+    fanoutQueueEngine.maxConsumers()            = cfg->maxConsumers();
     Apps& consumerStatesRef          = const_cast<Apps&>(d_apps);
 
     bsl::vector<mqbcmd::ConsumerState>& consumerStates =

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -464,7 +464,7 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     bsl::ostream& logAppSubscriptionInfo(bsl::ostream&     stream,
                                          const AppStateSp& appState) const;
 
-    const mqbconfm::Domain& config() const;
+    bsl::shared_ptr<const mqbconfm::Domain> config() const;
 };
 
 // ============================================================================
@@ -475,7 +475,7 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
 // struct RootQueueEngine
 // ----------------------
 
-inline const mqbconfm::Domain& RootQueueEngine::config() const
+inline bsl::shared_ptr<const mqbconfm::Domain> RootQueueEngine::config() const
 {
     return d_queueState_p->queue()->domain()->config();
 }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -1389,7 +1389,7 @@ static void test9_priorityCreateAndConfigure()
             mqbblp::RootQueueEngine::create(
                 queueEngine,
                 d_queueState_mp.get(),
-                d_queueState_mp->domain()->config(),
+                *d_queueState_mp->domain()->config(),
                 allocator);
         }
 
@@ -2598,7 +2598,7 @@ static void test22_createAndConfigure()
             mqbblp::RootQueueEngine::create(
                 queueEngine,
                 d_queueState_mp.get(),
-                d_queueState_mp->domain()->config(),
+                *d_queueState_mp->domain()->config(),
                 allocator);
         }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -952,19 +952,19 @@ bool ClusterUtil::assignQueue(ClusterState*         clusterState,
         static void panic(mqbi::Domain* domain)
         {
             BMQTSK_ALARMLOG_PANIC("DOMAIN_QUEUE_LIMIT_FULL")
-                << "domain '" << "bmq://" << domain->name()
+                << "domain 'bmq://" << domain->name()
                 << "' has reached the maximum number of queues (limit: "
-                << domain->config().maxQueues() << ")." << BMQTSK_ALARMLOG_END;
+                << domain->config()->maxQueues() << ")."
+                << BMQTSK_ALARMLOG_END;
         }
 
         static void alarm(mqbi::Domain* domain, int queues)
         {
             BMQTSK_ALARMLOG_ALARM("DOMAIN_QUEUE_LIMIT_HIGH_WATERMARK")
-                << "domain '" << "bmq://" << domain->name()
-                << "' has reached the " << (k_MAX_QUEUES_HIGH_WATERMARK * 100)
-                << "% watermark limit for the number of queues "
-                   "(current: "
-                << queues << ", limit: " << domain->config().maxQueues()
+                << "domain 'bmq://" << domain->name() << "' has reached the "
+                << (k_MAX_QUEUES_HIGH_WATERMARK * 100)
+                << "% watermark limit for the number of queues (current: "
+                << queues << ", limit: " << domain->config()->maxQueues()
                 << ")." << BMQTSK_ALARMLOG_END;
         }
     };
@@ -978,7 +978,7 @@ bool ClusterUtil::assignQueue(ClusterState*         clusterState,
         // num(assigned) + num(assigning) + num(unassigning).
         const int registeredQueues = static_cast<int>(
             domIt->second->queuesInfo().size());
-        const int maxQueues = domIt->second->domain()->config().maxQueues();
+        const int maxQueues = domIt->second->domain()->config()->maxQueues();
         if (maxQueues != 0) {
             const int requestedQueues = registeredQueues + 1;
             if (requestedQueues > maxQueues) {
@@ -1042,7 +1042,7 @@ bool ClusterUtil::assignQueue(ClusterState*         clusterState,
                                     clusterState,
                                     clusterData,
                                     uri,
-                                    domIt->second->domain()->config().mode());
+                                    domIt->second->domain()->config()->mode());
 
     // 'ClusterQueueHelper::onQueueAssigned' (the 'onQueueAssigned' observer
     // callback) will insert the key to 'ClusterState::queueKeys'.

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1809,10 +1809,10 @@ void StorageUtil::recoveredQueuesCb(
                       << "], queueKey [" << queueKey << "].";
 
         // Update 'storageMap'.
-        const mqbconfm::Domain&            domainCfg  = domain->config();
-        const mqbconfm::StorageDefinition& storageDef = domainCfg.storage();
+        bsl::shared_ptr<const mqbconfm::Domain> domainCfg = domain->config();
+        const mqbconfm::StorageDefinition& storageDef = domainCfg->storage();
 
-        if (domainCfg.mode().isUndefinedValue()) {
+        if (domainCfg->mode().isUndefinedValue()) {
             BMQTSK_ALARMLOG_ALARM("RECOVERY")
                 << clusterDescription << ": Partition [" << partitionId
                 << "]: Domain for queue [" << queueUri << "], queueKey ["
@@ -1835,7 +1835,7 @@ void StorageUtil::recoveredQueuesCb(
         if (domain->cluster()->isClusterMember() &&
             !domain->cluster()->isLocal() &&
             (storageDef.config().isInMemoryValue() !=
-             domainCfg.mode().isBroadcastValue())) {
+             domainCfg->mode().isBroadcastValue())) {
             // In-memory storage without broadcast mode, as well as broadcast
             // mode without in-memory storage are incompatible config in a
             // clustered setup.
@@ -1847,7 +1847,7 @@ void StorageUtil::recoveredQueuesCb(
                 << "config. In-memory storage: " << bsl::boolalpha
                 << storageDef.config().isInMemoryValue()
                 << ", broadcast mode: " << bsl::boolalpha
-                << domainCfg.mode().isBroadcastValue() << ". Aboring broker."
+                << domainCfg->mode().isBroadcastValue() << ". Aboring broker."
                 << BMQTSK_ALARMLOG_END;
             mqbu::ExitUtil::terminate(mqbu::ExitCode::e_RECOVERY_FAILURE);
             // EXIT
@@ -1865,7 +1865,7 @@ void StorageUtil::recoveredQueuesCb(
         // Create and add virtual storages, if any.
         bmqu::MemOutStream errorDesc;
         int                rc;
-        if (domain->config().mode().isFanoutValue()) {
+        if (domainCfg->mode().isFanoutValue()) {
             for (mqbs::DataStoreConfigQueueInfo::AppInfos::const_iterator ait =
                      appIdKeyPairs.cbegin();
                  ait != appIdKeyPairs.cend();
@@ -2429,8 +2429,9 @@ void StorageUtil::registerQueueAsPrimary(const mqbi::Cluster*    cluster,
     // If StorageMgr is not aware of the queue, then its a simpler process --
     // simply register it and its associated appIds, if any.
 
-    const mqbconfm::StorageDefinition& storageDef = domain->config().storage();
-    const mqbconfm::QueueMode&         queueMode  = domain->config().mode();
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg  = domain->config();
+    const mqbconfm::StorageDefinition&      storageDef = domainCfg->storage();
+    const mqbconfm::QueueMode&              queueMode  = domainCfg->mode();
 
     bmqu::Printer<AppInfos> printer1(&appIdKeyPairs);
 
@@ -2494,13 +2495,13 @@ void StorageUtil::registerQueueAsPrimary(const mqbi::Cluster*    cluster,
 
             bsl::shared_ptr<mqbevt::DispatcherEvent> event_sp =
                 cluster->getEvent<mqbevt::DispatcherEvent>();
-            (*event_sp).setCallback(
-                bdlf::BindUtil::bind(updateQueuePrimaryDispatched,
-                                     storageSp.get(),
-                                     storagesLock,
-                                     fs,
-                                     appIdKeyPairs,
-                                     domain->config().mode().isFanoutValue()));
+            (*event_sp).setCallback(bdlf::BindUtil::bind(
+                updateQueuePrimaryDispatched,
+                storageSp.get(),
+                storagesLock,
+                fs,
+                appIdKeyPairs,
+                domain->config()->mode().isFanoutValue()));
 
             dispatcher->dispatchEvent(bslmf::MovableRefUtil::move(event_sp),
                                       fs);
@@ -2564,8 +2565,9 @@ void StorageUtil::createQueueStorageAsPrimary(StorageSpMap*    storageMap,
     BSLS_ASSERT_SAFE(!appIdKeyPairs.empty());
     BSLS_ASSERT_SAFE(domain);
 
-    const mqbconfm::StorageDefinition& storageDef = domain->config().storage();
-    const mqbconfm::QueueMode&         queueMode  = domain->config().mode();
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg  = domain->config();
+    const mqbconfm::StorageDefinition&      storageDef = domainCfg->storage();
+    const mqbconfm::QueueMode&              queueMode  = domainCfg->mode();
 
     bmqu::Printer<AppInfos> printer(&appIdKeyPairs);
 
@@ -2858,8 +2860,9 @@ void StorageUtil::createQueueStorageAsReplica(
         }
     }
 
-    if (domain->config().storage().config().isInMemoryValue() !=
-        domain->config().mode().isBroadcastValue()) {
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg = domain->config();
+    if (domainCfg->storage().config().isInMemoryValue() !=
+        domainCfg->mode().isBroadcastValue()) {
         // In-memory storage without broadcast mode, as well as broadcast mode
         // without in-memory storage are incompatible config in a clustered
         // setup.
@@ -2910,11 +2913,11 @@ StorageUtil::createQueueStorageImpl(mqbs::FileStore*        fs,
     BSLS_ASSERT_SAFE(uri.isValid());
     BSLS_ASSERT_SAFE(!queueKey.isNull());
 
-    const mqbconfm::Domain&                  domainCfg  = domain->config();
-    const mqbconfm::StorageDefinition&       storageDef = domainCfg.storage();
+    bsl::shared_ptr<const mqbconfm::Domain>  domainCfg  = domain->config();
+    const mqbconfm::StorageDefinition&       storageDef = domainCfg->storage();
     bsl::shared_ptr<mqbs::ReplicatedStorage> rs_sp;
 
-    if (domainCfg.mode().isUndefinedValue()) {
+    if (domainCfg->mode().isUndefinedValue()) {
         BALL_LOG_ERROR << fs->description()
                        << ": undefined domain mode for the queue '" << uri
                        << "', queueKey: [" << queueKey << "].";
@@ -2933,11 +2936,10 @@ StorageUtil::createQueueStorageImpl(mqbs::FileStore*        fs,
     fs->createStorage(&rs_sp, uri, queueKey, domain);
     BSLS_ASSERT_SAFE(rs_sp);
 
-    if (0 !=
-        addVirtualStoragesInternal(rs_sp.get(),
-                                   appIdKeyPairs,
-                                   fs->description(),
-                                   domain->config().mode().isFanoutValue())) {
+    if (0 != addVirtualStoragesInternal(rs_sp.get(),
+                                        appIdKeyPairs,
+                                        fs->description(),
+                                        domainCfg->mode().isFanoutValue())) {
         // Discard
         rs_sp.reset();
     }
@@ -3099,7 +3101,7 @@ void StorageUtil::updateQueueStorageDispatched(
         storage,
         appIdKeyPairs,
         description,
-        domain->config().mode().isFanoutValue());
+        domain->config()->mode().isFanoutValue());
 
     bmqu::Printer<AppInfos> printer(&appIdKeyPairs);
 

--- a/src/groups/mqb/mqbi/mqbi_domain.h
+++ b/src/groups/mqb/mqbi/mqbi_domain.h
@@ -200,8 +200,8 @@ class Domain {
     /// Return the name of this domain.
     virtual const bsl::string& name() const = 0;
 
-    /// Return the configuration of this domain.
-    virtual const mqbconfm::Domain& config() const = 0;
+    /// Return a thread-safe snapshot of the configuration of this domain.
+    virtual bsl::shared_ptr<const mqbconfm::Domain> config() const = 0;
 
     /// Return the `DomainStats` object associated to this Domain.
     virtual mqbstat::DomainStats* domainStats() = 0;

--- a/src/groups/mqb/mqbmock/mqbmock_domain.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_domain.cpp
@@ -38,7 +38,8 @@ namespace mqbmock {
 
 // CREATORS
 Domain::Domain(mqbi::Cluster* cluster, bslma::Allocator* allocator)
-: d_name("mock-domain", allocator)
+: d_allocator_p(allocator)
+, d_name("mock-domain", allocator)
 , d_cluster_p(cluster)
 , d_domainsStatContext(
       mqbstat::DomainStatsUtil::initializeStatContext(5, allocator))
@@ -46,7 +47,7 @@ Domain::Domain(mqbi::Cluster* cluster, bslma::Allocator* allocator)
       mqbstat::QueueStatsUtil::initializeStatContextDomains(5, allocator))
 // NOTE: Some test drivers require a few snapshot, hence the 'arbitrary' 5
 //       used here
-, d_config(allocator)
+, d_config()
 , d_capacityMeter(bsl::string("domain [", allocator) + d_name + "]",
                   0,
                   allocator)
@@ -73,7 +74,8 @@ Domain::~Domain()
 int Domain::configure(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
                       const mqbconfm::Domain&         config)
 {
-    d_config = config;
+    d_config = bsl::allocate_shared<const mqbconfm::Domain>(d_allocator_p,
+                                                            config);
 
     return 0;
 }
@@ -194,7 +196,7 @@ const bsl::string& Domain::name() const
     return d_name;
 }
 
-const mqbconfm::Domain& Domain::config() const
+bsl::shared_ptr<const mqbconfm::Domain> Domain::config() const
 {
     return d_config;
 }

--- a/src/groups/mqb/mqbmock/mqbmock_domain.h
+++ b/src/groups/mqb/mqbmock/mqbmock_domain.h
@@ -105,6 +105,9 @@ class Domain : public mqbi::Domain {
   private:
     // DATA
 
+    // Allocator to use.
+    bslma::Allocator* d_allocator_p;
+
     // Name of this domain
     bsl::string d_name;
 
@@ -123,7 +126,7 @@ class Domain : public mqbi::Domain {
     bsl::shared_ptr<bmqst::StatContext> d_statContext;
 
     // Configuration for the domain
-    mqbconfm::Domain d_config;
+    bsl::shared_ptr<const mqbconfm::Domain> d_config;
 
     // Domain resource capacity meter
     mqbu::CapacityMeter d_capacityMeter;
@@ -226,8 +229,9 @@ class Domain : public mqbi::Domain {
     /// Return the name of this domain.
     const bsl::string& name() const BSLS_KEYWORD_OVERRIDE;
 
-    /// Return the configuration of this domain.
-    const mqbconfm::Domain& config() const BSLS_KEYWORD_OVERRIDE;
+    /// Return a thread-safe snapshot of the configuration of this domain.
+    bsl::shared_ptr<const mqbconfm::Domain>
+    config() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the `DomainStats` object associated to this Domain.
     mqbstat::DomainStats* domainStats() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -117,7 +117,7 @@ FileBackedStorage::FileBackedStorage(
 , d_virtualStorageCatalog(
       this,
       allocatorStore ? allocatorStore->get("VirtualHandles") : d_allocator_p)
-, d_ttlSeconds(domain->config().messageTtl())
+, d_ttlSeconds(domain->config()->messageTtl())
 , d_capacityMeter(
       bsl::string("queue [", d_allocator_p) + queueUri.asString() + "]",
       domain->capacityMeter(),
@@ -127,12 +127,12 @@ FileBackedStorage::FileBackedStorage(
                             bdlf::PlaceHolders::_1),  // stream
       d_allocator_p)
 , d_handles(bsls::TimeInterval()
-                .addMilliseconds(domain->config().deduplicationTimeMs())
+                .addMilliseconds(domain->config()->deduplicationTimeMs())
                 .totalNanoseconds(),
             allocatorStore ? allocatorStore->get("Handles") : d_allocator_p)
 , d_queueOpRecordHandles(d_allocator_p)
 , d_isEmpty(1)
-, d_hasReceipts(!domain->config().consistency().isStrongValue())
+, d_hasReceipts(!domain->config()->consistency().isStrongValue())
 , d_currentlyAutoConfirming()
 , d_autoConfirmHandles(d_allocator_p)
 , d_autoConfirmApps(d_allocator_p)
@@ -150,7 +150,7 @@ FileBackedStorage::FileBackedStorage(
     // passed to the 'FileBackedStorage' instance.
     d_virtualStorageCatalog.stats()->initialize(queueUri, domain);
     d_virtualStorageCatalog.setDefaultRda(
-        domain->config().maxDeliveryAttempts());
+        domain->config()->maxDeliveryAttempts());
 }
 
 FileBackedStorage::~FileBackedStorage()
@@ -791,7 +791,7 @@ int FileBackedStorage::gcExpiredMessages(const bdlt::Datetime& currentTimeUtc,
     bsls::Types::Int64 deduplicationTimeNs = 0;
     if (queue() && queue()->domain()) {
         deduplicationTimeNs =
-            queue()->domain()->config().deduplicationTimeMs() *
+            queue()->domain()->config()->deduplicationTimeMs() *
             bdlt::TimeUnitRatio::k_NANOSECONDS_PER_MILLISECOND;
     }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5375,8 +5375,9 @@ void FileStore::createStorage(bsl::shared_ptr<ReplicatedStorage>* storageSp,
     BSLS_ASSERT_SAFE(storageSp);
     BSLS_ASSERT_SAFE(domain);
 
-    const mqbconfm::StorageDefinition& storageDef = domain->config().storage();
-    const mqbconfm::Storage&           storageCfg = storageDef.config();
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg  = domain->config();
+    const mqbconfm::StorageDefinition&      storageDef = domainCfg->storage();
+    const mqbconfm::Storage&                storageCfg = storageDef.config();
 
     BSLS_ASSERT_SAFE(!storageCfg.isUndefinedValue());
 
@@ -5388,7 +5389,7 @@ void FileStore::createStorage(bsl::shared_ptr<ReplicatedStorage>* storageSp,
                                              queueKey,
                                              domain,
                                              config().partitionId(),
-                                             domain->config(),
+                                             *domain->config(),
                                              domain->capacityMeter(),
                                              storageAlloc,
                                              &d_storageAllocatorStore),

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -424,14 +424,19 @@ void QueueStatsDomain::initialize(const bmqt::Uri& uri, mqbi::Domain* domain)
 
     datum->adopt(builder.commit());
 
+    if (domain->cluster()->isRemote()) {
+        // Proxy doesn't have domain configuration, nothing else to do
+        return;  // RETURN
+    }
+
     // Create subcontexts for each AppId to store per-AppId metrics, such as
     // `e_CONFIRM_TIME_MAX` or `e_QUEUE_TIME_MAX`, so the metrics can be
     // inspected separately for each application.
-    if (!domain->cluster()->isRemote() &&
-        domain->config().mode().isFanoutValue() &&
-        domain->config().mode().fanout().publishAppIdMetrics()) {
+    bsl::shared_ptr<const mqbconfm::Domain> domainCfg = domain->config();
+    if (domainCfg->mode().isFanoutValue() &&
+        domainCfg->mode().fanout().publishAppIdMetrics()) {
         const bsl::vector<bsl::string>& appIDs =
-            domain->config().mode().fanout().appIDs();
+            domainCfg->mode().fanout().appIDs();
         for (bsl::vector<bsl::string>::const_iterator cit = appIDs.begin();
              cit != appIDs.end();
              ++cit) {


### PR DESCRIPTION
`Domain::config` is read from multiple threads.
Admin thread might reconfigure a domain, updating `d_config` while it is being read.
This might result in the following crash:

```
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f21b9e58ee5 in __GI_abort () at abort.c:79
#2  0x0000000000abdfbf in BloombergLP::bsls::AssertImpUtil::failByAbort ()
    at /groups/bsl/bsls/bsls_assertimputil.cpp:91
#3  0x0000000000b218e3 in bmqAssertHandler (
    comment=0x1d125ec "!d_config.isNull()", 
    file=0x1d12600 
"/blazingmq/src/groups/mqb/mqbblp/mqbblp_domain.h
", line=362)
    at 
/blazingmq/src/applications/bmqbrkr/bmqbrkr.m.cpp:185
#4  0x0000000001614737 in BloombergLP::bsls::Assert::invokeHandler (
    violation=...)
    at /groups/bsl/bsls/bsls_assert.cpp:252
#5  0x0000000000d67cd4 in BloombergLP::mqbblp::Domain::config (
```