### PR TITLE
Feat[bmq]: get by without blob sp pool

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -138,12 +138,12 @@ struct BlobSpCreatorF {
     : d_bufferFactory_p(bufferFactory)
     , d_allocator_p(allocator)
     {
+        BSLS_ASSERT_SAFE(d_bufferFactory_p);
     }
     bsl::shared_ptr<bdlbb::Blob> operator()()
     {
-        return bsl::shared_ptr<bdlbb::Blob>(
-            new (*d_allocator_p) bdlbb::Blob(d_bufferFactory_p, d_allocator_p),
-            d_allocator_p);
+        return bsl::allocate_shared<bdlbb::Blob>(d_allocator_p,
+                                                 d_bufferFactory_p);
     }
 };
 

--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -128,6 +128,133 @@ UriCorrIdToQueueMap& uriCorrIdToQueues(B& buffer)
 {
     return reinterpret_cast<UriCorrIdToQueueMap&>(*(buffer.buffer()));
 }
+
+struct BlobSpCreatorF {
+    bdlbb::BlobBufferFactory* d_bufferFactory_p;
+    bslma::Allocator*         d_allocator_p;
+
+    explicit BlobSpCreatorF(bdlbb::BlobBufferFactory* bufferFactory,
+                            bslma::Allocator*         allocator)
+    : d_bufferFactory_p(bufferFactory)
+    , d_allocator_p(allocator)
+    {
+    }
+    bsl::shared_ptr<bdlbb::Blob> operator()()
+    {
+        return bsl::shared_ptr<bdlbb::Blob>(
+            new (*d_allocator_p) bdlbb::Blob(d_bufferFactory_p, d_allocator_p),
+            d_allocator_p);
+    }
+};
+
+Event createAckEventImpl(bmqp::AckEventBuilder& ackBuilder,
+                         const bsl::vector<MockSessionUtil::AckParams>& acks,
+                         bdlbb::BlobBufferFactory* bufferFactory,
+                         bslma::Allocator*         allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!acks.empty());
+    BSLS_ASSERT_SAFE(bufferFactory);
+
+    /// Event impl shared pointer to access
+    /// the pimpl of `bmqa::Event`.
+    typedef bsl::shared_ptr<bmqimp::Event> EventImplSp;
+
+    /// Queue impl shared pointer to access
+    /// the pimpl of `bmqa::QueueId`.
+    typedef bsl::shared_ptr<bmqimp::Queue> QueueImplSp;
+
+    Event        event;
+    EventImplSp& implPtr = reinterpret_cast<EventImplSp&>(
+        static_cast<Event&>(event));
+    implPtr = EventImplSp(new (*allocator)
+                              bmqimp::Event(bufferFactory, allocator),
+                          allocator);
+
+    for (size_t i = 0; i != acks.size(); ++i) {
+        const MockSessionUtil::AckParams& params = acks[i];
+        const QueueImplSp& impQueue = reinterpret_cast<const QueueImplSp&>(
+            params.d_queueId);
+
+        ackBuilder.appendMessage(
+            bmqp::ProtocolUtil::ackResultToCode(params.d_status),
+            0,  // Don't care about corrId in raw event
+            params.d_guid,
+            impQueue->id());
+        implPtr->insertQueue(impQueue);
+    }
+
+    implPtr->configureAsMessageEvent(
+        bmqp::Event(ackBuilder.blob(), allocator));
+    for (size_t i = 0; i != acks.size(); ++i) {
+        implPtr->addContext(acks[i].d_correlationId);
+    }
+
+    return event;
+}
+
+Event createPushEventImpl(
+    bmqp::PushEventBuilder&                                pushBuilder,
+    const bsl::vector<MockSessionUtil::PushMessageParams>& pushEventParams,
+    bdlbb::BlobBufferFactory*                              bufferFactory,
+    bslma::Allocator*                                      allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!pushEventParams.empty());
+    BSLS_ASSERT_SAFE(bufferFactory);
+
+    /// Event impl shared pointer to access
+    /// the pimpl of `bmqa::Event`.
+    typedef bsl::shared_ptr<bmqimp::Event> EventImplSp;
+
+    /// Queue impl shared pointer to access
+    /// the pimpl of `bmqa::QueueId`.
+    typedef bsl::shared_ptr<bmqimp::Queue> QueueImplSp;
+
+    Event        event;
+    EventImplSp& implPtr = reinterpret_cast<EventImplSp&>(event);
+    implPtr              = EventImplSp(new (*allocator)
+                              bmqimp::Event(bufferFactory, allocator),
+                          allocator);
+
+    for (size_t i = 0; i != pushEventParams.size(); ++i) {
+        const QueueImplSp& queueImplPtr = reinterpret_cast<const QueueImplSp&>(
+            static_cast<const QueueId&>(pushEventParams[i].d_queueId));
+
+        const MockSessionUtil::PushMessageParams& pushMessageParams =
+            pushEventParams[i];
+
+        // By default, no flags are set; i.e. 0.
+
+        bdlbb::Blob                 combinedBlob;
+        bmqp::MessagePropertiesInfo logic;
+
+        if (pushMessageParams.d_properties.numProperties() > 0) {
+            combinedBlob = pushMessageParams.d_properties.streamOut(
+                bufferFactory);
+            logic = bmqp::MessagePropertiesInfo::makeNoSchema();
+            // Use the same old style as the 'streamOut' above.
+        }
+
+        bdlbb::BlobUtil::append(&combinedBlob, pushMessageParams.d_payload);
+
+        pushBuilder.packMessage(combinedBlob,
+                                queueImplPtr->id(),
+                                pushMessageParams.d_guid,
+                                0,
+                                bmqt::CompressionAlgorithmType::e_NONE,
+                                logic);
+        implPtr->insertQueue(bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID,
+                             queueImplPtr);
+        implPtr->addContext(bmqt::CorrelationId());
+    }
+
+    bmqp::Event bmqpEvent(pushBuilder.blob(), allocator);
+    implPtr->configureAsMessageEvent(bmqpEvent);
+
+    return event;
+}
+
 }  // close unnamed namespace
 
 #define BMQA_CHECK_ARG(METHOD, ARGNAME, EXPECTED, ACTUAL, CALL)               \
@@ -274,98 +401,70 @@ Event MockSessionUtil::createQueueSessionEvent(
     return event;
 }
 
-Event MockSessionUtil::createAckEvent(
-    const bsl::vector<AckParams>&   acks,
-    bmqp::BlobPoolUtil::BlobSpPool* blobSpPool,
-    bslma::Allocator*               allocator)
+Event MockSessionUtil::createAckEvent(const bsl::vector<AckParams>& acks,
+                                      bdlbb::BlobBufferFactory* bufferFactory,
+                                      bslma::Allocator*         allocator)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!acks.empty());
-    BSLS_ASSERT_SAFE(blobSpPool);
+    BSLS_ASSERT_SAFE(bufferFactory);
 
     bslma::Allocator* alloc = bslma::Default::allocator(allocator);
+    bmqp::AckEventBuilder ackBuilder(BlobSpCreatorF(bufferFactory, alloc),
+                                     alloc);
 
-    Event        event;
-    EventImplSp& implPtr = reinterpret_cast<EventImplSp&>(
-        static_cast<Event&>(event));
-    implPtr = EventImplSp(new (*alloc) bmqimp::Event(g_bufferFactory_p, alloc),
-                          alloc);
+    return createAckEventImpl(ackBuilder, acks, bufferFactory, allocator);
+}
 
+Event MockSessionUtil::createAckEvent(const bsl::vector<AckParams>& acks,
+                                      BlobSpPool*                   blobSpPool,
+                                      bdlbb::BlobBufferFactory* bufferFactory,
+                                      bslma::Allocator*         allocator)
+{
+    bslma::Allocator*     alloc = bslma::Default::allocator(allocator);
     bmqp::AckEventBuilder ackBuilder(blobSpPool, alloc);
-    for (size_t i = 0; i != acks.size(); ++i) {
-        const AckParams&   params   = acks[i];
-        const QueueImplSp& impQueue = reinterpret_cast<const QueueImplSp&>(
-            params.d_queueId);
 
-        ackBuilder.appendMessage(
-            bmqp::ProtocolUtil::ackResultToCode(params.d_status),
-            0,  // Don't care about corrId in raw event
-            params.d_guid,
-            impQueue->id());
-        implPtr->insertQueue(impQueue);
-    }
-
-    implPtr->configureAsMessageEvent(bmqp::Event(ackBuilder.blob(), alloc));
-    for (size_t i = 0; i != acks.size(); ++i) {
-        implPtr->addContext(acks[i].d_correlationId);
-    }
-
-    return event;
+    return createAckEventImpl(ackBuilder, acks, bufferFactory, alloc);
 }
 
 Event MockSessionUtil::createPushEvent(
     const bsl::vector<PushMessageParams>& pushEventParams,
-    bmqp::BlobPoolUtil::BlobSpPool*       blobSpPool,
     bdlbb::BlobBufferFactory*             bufferFactory,
     bslma::Allocator*                     allocator)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!pushEventParams.empty());
+    BSLS_ASSERT_SAFE(bufferFactory);
 
     bslma::Allocator* alloc = bslma::Default::allocator(allocator);
 
-    Event        event;
-    EventImplSp& implPtr = reinterpret_cast<EventImplSp&>(event);
-    implPtr = EventImplSp(new (*alloc) bmqimp::Event(g_bufferFactory_p, alloc),
-                          alloc);
+    bmqp::PushEventBuilder pushBuilder(BlobSpCreatorF(bufferFactory, alloc),
+                                       alloc);
+
+    return createPushEventImpl(pushBuilder,
+                               pushEventParams,
+                               bufferFactory,
+                               allocator);
+}
+
+Event MockSessionUtil::createPushEvent(
+    const bsl::vector<PushMessageParams>& pushEventParams,
+    BlobSpPool*                           blobSpPool,
+    bdlbb::BlobBufferFactory*             bufferFactory,
+    bslma::Allocator*                     allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(!pushEventParams.empty());
+    BSLS_ASSERT_SAFE(blobSpPool);
+    BSLS_ASSERT_SAFE(bufferFactory);
+
+    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
 
     bmqp::PushEventBuilder pushBuilder(blobSpPool, alloc);
 
-    for (size_t i = 0; i != pushEventParams.size(); ++i) {
-        const QueueImplSp& queueImplPtr = reinterpret_cast<const QueueImplSp&>(
-            static_cast<const QueueId&>(pushEventParams[i].d_queueId));
-
-        const PushMessageParams& pushMessageParams = pushEventParams[i];
-
-        // By default, no flags are set; i.e. 0.
-
-        bdlbb::Blob                 combinedBlob;
-        bmqp::MessagePropertiesInfo logic;
-
-        if (pushMessageParams.d_properties.numProperties() > 0) {
-            combinedBlob = pushMessageParams.d_properties.streamOut(
-                bufferFactory);
-            logic = bmqp::MessagePropertiesInfo::makeNoSchema();
-            // Use the same old style as the 'streamOut' above.
-        }
-
-        bdlbb::BlobUtil::append(&combinedBlob, pushMessageParams.d_payload);
-
-        pushBuilder.packMessage(combinedBlob,
-                                queueImplPtr->id(),
-                                pushMessageParams.d_guid,
-                                0,
-                                bmqt::CompressionAlgorithmType::e_NONE,
-                                logic);
-        implPtr->insertQueue(bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID,
-                             queueImplPtr);
-        implPtr->addContext(bmqt::CorrelationId());
-    }
-
-    bmqp::Event bmqpEvent(pushBuilder.blob(), alloc);
-    implPtr->configureAsMessageEvent(bmqpEvent);
-
-    return event;
+    return createPushEventImpl(pushBuilder,
+                               pushEventParams,
+                               bufferFactory,
+                               alloc);
 }
 
 OpenQueueStatus

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -694,13 +694,21 @@ struct MockSessionUtil {
     /// `e_ACK` with the specified `acks` params using the specified
     /// `bufferFactory` and the specified `allocator` to supply memory.
     static Event createAckEvent(const bsl::vector<AckParams>& acks,
+                                bdlbb::BlobBufferFactory*     bufferFactory,
+                                bslma::Allocator*             allocator);
+    static Event createAckEvent(const bsl::vector<AckParams>& acks,
                                 BlobSpPool*                   blobSpPool,
+                                bdlbb::BlobBufferFactory*     bufferFactory,
                                 bslma::Allocator*             allocator);
 
     /// Create and return an `Event` configured as a message event of type
     /// `e_PUSH` and with the specified `pushEventParams`, using the
     /// specified `bufferFactory` and the specified `allocator` to supply
     /// memory.
+    static Event
+    createPushEvent(const bsl::vector<PushMessageParams>& pushEventParams,
+                    bdlbb::BlobBufferFactory*             bufferFactory,
+                    bslma::Allocator*                     allocator);
     static Event
     createPushEvent(const bsl::vector<PushMessageParams>& pushEventParams,
                     BlobSpPool*                           blobSpPool,

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -696,6 +696,10 @@ struct MockSessionUtil {
     static Event createAckEvent(const bsl::vector<AckParams>& acks,
                                 bdlbb::BlobBufferFactory*     bufferFactory,
                                 bslma::Allocator*             allocator);
+
+    /// Create and return an `Event` configured as a message event of type
+    /// `e_ACK` with the specified `acks` params using the specified
+    /// `blobSpPool`, `bufferFactory`, and `allocator` to supply memory.
     static Event createAckEvent(const bsl::vector<AckParams>& acks,
                                 BlobSpPool*                   blobSpPool,
                                 bdlbb::BlobBufferFactory*     bufferFactory,
@@ -709,6 +713,11 @@ struct MockSessionUtil {
     createPushEvent(const bsl::vector<PushMessageParams>& pushEventParams,
                     bdlbb::BlobBufferFactory*             bufferFactory,
                     bslma::Allocator*                     allocator);
+
+    /// Create and return an `Event` configured as a message event of type
+    /// `e_PUSH` and with the specified `pushEventParams`, using the
+    /// specified `blobSpPool`, `bufferFactory`, and `allocator` to supply
+    /// memory.
     static Event
     createPushEvent(const bsl::vector<PushMessageParams>& pushEventParams,
                     BlobSpPool*                           blobSpPool,

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -298,11 +298,6 @@ static void test1_staticMethods()
             bmqtst::TestHelperUtil::allocator()));
     }
 
-    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
-        bmqp::BlobPoolUtil::createBlobPool(
-            &bufferFactory,
-            bmqtst::TestHelperUtil::allocator()));
-
     {
         PVV("Create Ack Event");
 
@@ -320,7 +315,7 @@ static void test1_staticMethods()
 
         bmqa::Event event = bmqa::MockSessionUtil::createAckEvent(
             acks,
-            blobSpPool.get(),
+            &bufferFactory,
             bmqtst::TestHelperUtil::allocator());
 
         bmqa::MessageEvent ackEvent = event.messageEvent();
@@ -379,7 +374,6 @@ static void test1_staticMethods()
         pushMsgs.emplace_back(payload, queueId, guid, properties);
         bmqa::Event event = bmqa::MockSessionUtil::createPushEvent(
             pushMsgs,
-            blobSpPool.get(),
             &bufferFactory,
             bmqtst::TestHelperUtil::allocator());
 
@@ -860,14 +854,8 @@ static void test5_confirmingMessages()
     pushMsgs.emplace_back(payload, queueId, guid2, properties);
     pushMsgs.emplace_back(payload, queueId, guid3, properties);
 
-    bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
-        bmqp::BlobPoolUtil::createBlobPool(
-            &bufferFactory,
-            bmqtst::TestHelperUtil::allocator()));
-
     mockSession.enqueueEvent(bmqa::MockSessionUtil::createPushEvent(
         pushMsgs,
-        blobSpPool.get(),
         &bufferFactory,
         bmqtst::TestHelperUtil::allocator()));
 
@@ -895,7 +883,6 @@ static void test5_confirmingMessages()
             bmqa::MessageEvent invalidEvent =
                 bmqa::MockSessionUtil ::createPushEvent(
                     invalidMsg,
-                    blobSpPool.get(),
                     &bufferFactory,
                     bmqtst::TestHelperUtil::allocator())
                     .messageEvent();
@@ -1195,16 +1182,9 @@ static void test6_runThrough()
                                 queueId,
                                 messageGUID,
                                 bmqa::MessageProperties());
-
-        bmqp::BlobPoolUtil::BlobSpPoolSp blobSpPool(
-            bmqp::BlobPoolUtil::createBlobPool(
-                &bufferFactory,
-                bmqtst::TestHelperUtil::allocator()));
-
         bmqa::MessageEvent pushMsgEvt =
             bmqa::MockSessionUtil::createPushEvent(
                 pushParams,
-                blobSpPool.get(),
                 &bufferFactory,
                 bmqtst::TestHelperUtil::allocator())
                 .messageEvent();

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
@@ -30,13 +30,30 @@
 namespace BloombergLP {
 namespace bmqp {
 
+namespace {
+
+struct BlobSpCreatorF {
+    bmqp::BlobPoolUtil::BlobSpPool* d_blobSpPool_p;
+
+    explicit BlobSpCreatorF(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool)
+    : d_blobSpPool_p(blobSpPool)
+    {
+    }
+    bsl::shared_ptr<bdlbb::Blob> operator()()
+    {
+        return d_blobSpPool_p->getObject();
+    }
+};
+
+}
+
 // ---------------------
 // class AckEventBuilder
 // ---------------------
 
 AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
                                  bslma::Allocator* allocator)
-: d_blobSpPool_p(blobSpPool_p)
+: d_blobSpCreator(BlobSpCreatorF(blobSpPool_p))
 , d_blob_sp(0, allocator)       // initialized in `reset()`
 , d_emptyBlob_sp(0, allocator)  // initialized later in constructor
 , d_msgCount(0)
@@ -44,7 +61,29 @@ AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blobSpPool_p);
 
-    d_emptyBlob_sp = blobSpPool_p->getObject();
+    d_emptyBlob_sp = d_blobSpCreator();
+
+    // Assume that items built with the given `blobSpPool_p` either all have or
+    // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
+    // We require this since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_emptyBlob_sp->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
+
+    reset();
+}
+
+AckEventBuilder::AckEventBuilder(const BlobSpCreator& blobSpCreator,
+                                 bslma::Allocator*    allocator)
+: d_blobSpCreator(blobSpCreator)
+, d_blob_sp(0, allocator)       // initialized in `reset()`
+, d_emptyBlob_sp(0, allocator)  // initialized later in constructor
+, d_msgCount(0)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(blobSpCreator);
+
+    d_emptyBlob_sp = d_blobSpCreator();
 
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for `d_emptyBlob_sp`.
@@ -58,7 +97,7 @@ AckEventBuilder::AckEventBuilder(BlobSpPool*       blobSpPool_p,
 
 void AckEventBuilder::reset()
 {
-    d_blob_sp = d_blobSpPool_p->getObject();
+    d_blob_sp = d_blobSpCreator();
 
     d_msgCount = 0;
 

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.cpp
@@ -38,6 +38,7 @@ struct BlobSpCreatorF {
     explicit BlobSpCreatorF(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool)
     : d_blobSpPool_p(blobSpPool)
     {
+        BSLS_ASSERT_SAFE(d_blobSpPool_p);
     }
     bsl::shared_ptr<bdlbb::Blob> operator()()
     {

--- a/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_ackeventbuilder.h
@@ -87,11 +87,11 @@ class AckEventBuilder BSLS_CPP11_FINAL {
   public:
     // TYPES
     typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+    typedef bsl::function<bsl::shared_ptr<bdlbb::Blob>(void)> BlobSpCreator;
 
   private:
     // DATA
-    /// Blob pool to use.  Held, not owned.
-    BlobSpPool* d_blobSpPool_p;
+    BlobSpCreator d_blobSpCreator;
 
     /// Blob being built by this object.
     /// `mutable` to skip writing the length until the blob is retrieved.
@@ -122,6 +122,8 @@ class AckEventBuilder BSLS_CPP11_FINAL {
     /// set BlobBufferFactory since we might want to expand the built Blob
     /// dynamically.
     AckEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
+    AckEventBuilder(const BlobSpCreator& blobSpCreator,
+                    bslma::Allocator*    allocator);
 
     // MANIPULATORS
 

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
@@ -47,6 +47,7 @@ struct BlobSpCreatorF {
     explicit BlobSpCreatorF(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool)
     : d_blobSpPool_p(blobSpPool)
     {
+        BSLS_ASSERT_SAFE(d_blobSpPool_p);
     }
     bsl::shared_ptr<bdlbb::Blob> operator()()
     {

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.cpp
@@ -41,6 +41,19 @@ bool isDefaultSubQueueInfo(const Protocol::SubQueueInfosArray& subQueueInfos)
            subQueueInfos[0].id() == Protocol::k_DEFAULT_SUBSCRIPTION_ID;
 }
 
+struct BlobSpCreatorF {
+    bmqp::BlobPoolUtil::BlobSpPool* d_blobSpPool_p;
+
+    explicit BlobSpCreatorF(bmqp::BlobPoolUtil::BlobSpPool* blobSpPool)
+    : d_blobSpPool_p(blobSpPool)
+    {
+    }
+    bsl::shared_ptr<bdlbb::Blob> operator()()
+    {
+        return d_blobSpPool_p->getObject();
+    }
+};
+
 }  // close anonymous namespace
 
 // ----------------------
@@ -149,20 +162,42 @@ void PushEventBuilder::ensurePushHeader()
 PushEventBuilder::PushEventBuilder(BlobSpPool*       blobSpPool_p,
                                    bslma::Allocator* allocator)
 : d_allocator_p(bslma::Default::allocator(allocator))
-, d_blobSpPool_p(blobSpPool_p)
+, d_blobSpCreator(BlobSpCreatorF(blobSpPool_p))
 , d_blob_sp(0, allocator)  // initialized in `reset()`
 , d_msgCount(0)
 , d_options()
 , d_currPushHeader()
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(blobSpPool_p);
+    BSLS_ASSERT_SAFE(d_blobSpCreator);
 
     // Assume that items built with the given `blobSpPool_p` either all have or
     // all don't have buffer factory, and check it once for a sample blob.
     // We require this since we do `Blob::setLength`:
     BSLS_ASSERT_SAFE(
-        NULL != d_blobSpPool_p->getObject()->factory() &&
+        NULL != d_blobSpCreator()->factory() &&
+        "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
+
+    reset();
+}
+
+PushEventBuilder::PushEventBuilder(const BlobSpCreator& blobSpCreator,
+                                   bslma::Allocator*    allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_blobSpCreator(blobSpCreator)
+, d_blob_sp(0, allocator)  // initialized in `reset()`
+, d_msgCount(0)
+, d_options()
+, d_currPushHeader()
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_blobSpCreator);
+
+    // Assume that items built with the given `blobSpPool_p` either all have or
+    // all don't have buffer factory, and check it once for a sample blob.
+    // We require this since we do `Blob::setLength`:
+    BSLS_ASSERT_SAFE(
+        NULL != d_blobSpCreator()->factory() &&
         "Passed BlobSpPool must build Blobs with set BlobBufferFactory");
 
     reset();
@@ -175,7 +210,7 @@ int PushEventBuilder::reset()
     // Flush any buffered changes if necessary, and make this object not
     // refer to any valid blob object.
 
-    d_blob_sp = d_blobSpPool_p->getObject();
+    d_blob_sp = d_blobSpCreator();
 
     d_msgCount = 0;
     d_options.reset();

--- a/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
+++ b/src/groups/bmq/bmqp/bmqp_pusheventbuilder.h
@@ -89,14 +89,14 @@ class PushEventBuilder {
   public:
     // TYPES
     typedef bmqp::BlobPoolUtil::BlobSpPool BlobSpPool;
+    typedef bsl::function<bsl::shared_ptr<bdlbb::Blob>(void)> BlobSpCreator;
 
   private:
     // DATA
     /// Allocator to use.
     bslma::Allocator* d_allocator_p;
 
-    /// Blob pool to use.  Held, not owned.
-    BlobSpPool* d_blobSpPool_p;
+    BlobSpCreator d_blobSpCreator;
 
     /// Blob being built by this object.
     /// `mutable` to skip writing the length until the blob is retrieved.
@@ -163,6 +163,8 @@ class PushEventBuilder {
     /// set BlobBufferFactory since we might want to expand the built Blob
     /// dynamically.
     PushEventBuilder(BlobSpPool* blobSpPool_p, bslma::Allocator* allocator);
+    PushEventBuilder(const BlobSpCreator& blobSpCreator,
+                     bslma::Allocator*    allocator);
 
     // MANIPULATORS
 


### PR DESCRIPTION
Why insist on `BlobSpPool*` for `AckEventBuilder` and `PushEventBuilder`?

`MockSessionUtil` does not and should have it.