### PR TITLE
Fix[test]: ensure_message_at_storage_layer must reissue command while waiting

### DIFF
--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -63,15 +63,14 @@ def ensure_message_at_storage_layer(
     nodes = cluster.nodes(alive=alive)
 
     for node in nodes:
-        node.command(f"CLUSTERS CLUSTER {node.cluster_name} STORAGE SUMMARY")
 
-    def check():
-        return node.outputs_regex(
-            r"\w{10}\s+%s\s+%s\s+\d+\s+B\s+" % (partition_id, expected_count)
-            + re.escape(queue_uri)
-        )
+        def check(node=node):
+            node.command(f"CLUSTERS CLUSTER {node.cluster_name} STORAGE SUMMARY")
+            return node.outputs_regex(
+                r"\w{10}\s+%s\s+%s\s+\d+\s+B\s+" % (partition_id, expected_count)
+                + re.escape(queue_uri)
+            )
 
-    for node in nodes:
         assert wait_until(
             check,
             timeout=3,


### PR DESCRIPTION
⏺ Root cause: ensure_message_at_storage_layer issued the STORAGE SUMMARY command once upfront, then polled the same
  stale output for 3 seconds. In the failing test, east2's Partition [0] took ~23 seconds to recover after the
  legacy mode restart, and the 3rd message's replication data arrived 112ms after the STORAGE SUMMARY was already
  captured — showing 2 messages instead of 3.

  Fix: Re-issue STORAGE SUMMARY inside each wait_until retry so the check sees fresh storage state.