### PR TITLE
Remove: Don’t allow `FileStore` to ignore crc32c

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -16,6 +16,7 @@
 #include <mqbc_storagemanager.h>
 
 // BMQ
+#include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_event.h>
 #include <bmqp_storagemessageiterator.h>
@@ -53,7 +54,6 @@
 #include <bdlmt_fixedthreadpool.h>
 #include <bdlt_currenttime.h>
 #include <bdlt_epochutil.h>
-#include <bsl_limits.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bsl_utility.h>
@@ -832,13 +832,17 @@ struct TestHelper {
         const unsigned int appDataLen = static_cast<unsigned int>(
             rec.d_appData_sp->length());
 
+        const unsigned int crc32c = bmqp::Crc32c::calculate(*rec.d_appData_sp);
+
         rec.d_msgAttributes = mqbi::StorageMessageAttributes(
             bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
             recNum % mqbs::FileStoreProtocol::k_MAX_MSG_REF_COUNT_HARD,
             appDataLen,
             mpsInfo,
             bmqt::CompressionAlgorithmType::e_NONE,
-            bsl::numeric_limits<unsigned int>::max() / recNum);
+            true,  // hasReceipt
+            0,     // queueHandle
+            crc32c);
 
         const int rc = fs->writeMessageRecord(&rec.d_msgAttributes,
                                               &handle,
@@ -2478,7 +2482,6 @@ static void test15_replicaWaitingReceivesReplicaDataRqstPull()
     helper.startStorageManager(&storageManager, primaryNode);
 
     mqbs::FileStore& fs = storageManager.fileStore(k_PARTITION_ID);
-    fs.setIgnoreCrc32c(true);
 
     BSLS_ASSERT_OPT(storageManager.partitionHealthState(k_PARTITION_ID) ==
                     mqbc::PartitionFSM::State::e_REPLICA_WAITING);

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2603,26 +2603,23 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             unsigned int appDataLen = totalLen - headerSize - optionsSize -
                                       lastByte;
 
-            if (!d_ignoreCrc32c) {
-                // Check CRC32C
-                unsigned int checksum = bmqp::Crc32c::calculate(
-                    dataFd->block().base() + appDataOffset,
-                    appDataLen);
+            // Check CRC32C
+            unsigned int checksum = bmqp::Crc32c::calculate(
+                dataFd->block().base() + appDataOffset,
+                appDataLen);
 
-                if (rec.crc32c() != checksum) {
-                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
-                        << partitionDesc()
-                        << "Recovery: CRC mismatch for guid ["
-                        << rec.messageGUID() << "] for queueKey ["
-                        << rec.queueKey() << "] in journal file ["
-                        << activeFileSet->d_journalFileName
-                        << "], offset: " << jit->recordOffset()
-                        << ", index: " << jit->recordIndex()
-                        << ". CRC32-C in JOURNAL record: " << rec.crc32c()
-                        << ". CRC32-C of payload in DATA file: " << checksum
-                        << ". Payload offset in DATA file: " << appDataOffset
-                        << BMQTSK_ALARMLOG_END;
-                }
+            if (rec.crc32c() != checksum) {
+                BMQTSK_ALARMLOG_ALARM("RECOVERY")
+                    << partitionDesc() << "Recovery: CRC mismatch for guid ["
+                    << rec.messageGUID() << "] for queueKey ["
+                    << rec.queueKey() << "] in journal file ["
+                    << activeFileSet->d_journalFileName
+                    << "], offset: " << jit->recordOffset()
+                    << ", index: " << jit->recordIndex()
+                    << ". CRC32-C in JOURNAL record: " << rec.crc32c()
+                    << ". CRC32-C of payload in DATA file: " << checksum
+                    << ". Payload offset in DATA file: " << appDataOffset
+                    << BMQTSK_ALARMLOG_END;
             }
 
             DataStoreRecordKey key(sequenceNum, primaryLeaseId);
@@ -5208,7 +5205,6 @@ FileStore::FileStore(
 , d_storages(allocator)
 , d_isFSMWorkflow(isFSMWorkflow)
 , d_qListAware(!d_isFSMWorkflow || doesFSMwriteQLIST)
-, d_ignoreCrc32c(false)
 , d_storageEventBuilder(FileStoreProtocol::k_VERSION,
                         bmqp::EventType::e_STORAGE,
                         d_blobSpPool_p,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -387,11 +387,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     // Whether the broker still reads and writes to the to-be-deprecated Qlist
     // file.
 
-    bool d_ignoreCrc32c;
-    // Whether to ignore Crc32
-    // calculations.  We should only set
-    // this to true during testing.
-
     bmqp::StorageEventBuilder d_storageEventBuilder;
     // Storage event builder to use.
 
@@ -927,10 +922,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// Set the replication factor for strong consistency to `factor`.
     void setReplicationFactor(int factor);
 
-    /// Set the ignore Crc32c flag to the specified `value`.  We should only
-    /// set this to true during testing.
-    void setIgnoreCrc32c(bool value);
-
     /// This will be used as Implicit Receipt
     void setLastStrongConsistency(unsigned int        primaryLeaseId,
                                   bsls::Types::Uint64 sequenceNum);
@@ -1214,11 +1205,6 @@ inline void FileStore::execute(const mqbi::Dispatcher::VoidFunction& functor)
 }
 
 // MANIPULATORS
-inline void FileStore::setIgnoreCrc32c(bool value)
-{
-    d_ignoreCrc32c = value;
-}
-
 inline void
 FileStore::setLastStrongConsistency(unsigned int        primaryLeaseId,
                                     bsls::Types::Uint64 sequenceNum)


### PR DESCRIPTION
This pull request removes the `d_ignoreCrc32c` state from `mqbs::FileStore`, which is only used in one single test case for `mqbc::StorageManager` to avoid computing a crc32 checksum of a message.