### PR TITLE
Remove: `flushAtShutdown` broker configuration

### DIFF
--- a/docker/cluster/config/clusters.json
+++ b/docker/cluster/config/clusters.json
@@ -50,7 +50,6 @@
             ],
             "partitionConfig": {
                 "name": "local",
-                "flushAtShutdown": true,
                 "location": "/var/local/bmq/storage",
                 "maxArchivedFileSets": 0,
                 "maxDataFileSize": 268435456,

--- a/docker/single-node/config/clusters.json
+++ b/docker/single-node/config/clusters.json
@@ -20,7 +20,6 @@
             ],
             "partitionConfig": {
                 "name": "local",
-                "flushAtShutdown": true,
                 "location": "/var/local/bmq/storage",
                 "maxArchivedFileSets": 0,
                 "maxDataFileSize": 268435456,

--- a/src/applications/bmqbrkr/etc/clusters.json
+++ b/src/applications/bmqbrkr/etc/clusters.json
@@ -19,7 +19,6 @@
                 }
             ],
             "partitionConfig": {
-                "flushAtShutdown": true,
                 "location": "localBMQ/storage/local",
                 "maxArchivedFileSets": 0,
                 "maxDataFileSize": 268435456,

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -446,8 +446,7 @@ void StorageManager::shutdownCb(int partitionId, bslmt::Latch* latch)
     mqbc::StorageUtil::shutdown(partitionId,
                                 latch,
                                 &d_fileStores,
-                                d_clusterData_p->identity().description(),
-                                d_clusterConfig);
+                                d_clusterData_p->identity().description());
 }
 
 void StorageManager::queueCreationCb(int                     partitionId,

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -344,7 +344,7 @@ void StorageManager::onPartitionRecovery(
                         << "] failed to apply buffered storage event, rc: "
                         << rc << ". Closing the partition."
                         << BMQTSK_ALARMLOG_END;
-                    fs->close();
+                    fs->close(false);  // don't flush
                     break;  // BREAK
                 }
             }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -124,8 +124,7 @@ void StorageManager::shutdownCb(int partitionId, bslmt::Latch* latch)
     StorageUtil::shutdown(partitionId,
                           latch,
                           &d_fileStores,
-                          d_clusterData_p->identity().description(),
-                          d_clusterConfig);
+                          d_clusterData_p->identity().description());
 }
 
 void StorageManager::queueCreationCb(int                     partitionId,
@@ -2919,7 +2918,7 @@ void StorageManager::do_processBufferedLiveData(const EventWithData& event)
                 << partitionId << "]: "
                 << "Failed to apply buffered storage event, rc: " << rc
                 << ". Closing the partition." << BMQTSK_ALARMLOG_END;
-            fs->close(d_clusterConfig.partitionConfig().flushAtShutdown());
+            fs->close(true);  // flush
 
             EventData eventDataVecLocal;
             eventDataVecLocal.emplace_back(primary,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -940,7 +940,7 @@ struct TestHelper {
             writeMessageRecord(&fs, queueKey, i);
         }
 
-        fs.close();
+        fs.close(true);
         dynamic_cast<mqbnet::MockCluster&>(d_cluster_mp->netCluster())
             ._setDisableBroadcast(false);
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -2392,11 +2392,10 @@ void StorageUtil::stop(FileStores*        fileStores,
         << " (" << (shutdownEndTime - shutdownStartTime) << " nanoseconds)";
 }
 
-void StorageUtil::shutdown(int                              partitionId,
-                           bslmt::Latch*                    latch,
-                           FileStores*                      fileStores,
-                           const bsl::string&               clusterDescription,
-                           const mqbcfg::ClusterDefinition& clusterConfig)
+void StorageUtil::shutdown(int                partitionId,
+                           bslmt::Latch*      latch,
+                           FileStores*        fileStores,
+                           const bsl::string& clusterDescription)
 {
     // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
 
@@ -2416,7 +2415,7 @@ void StorageUtil::shutdown(int                              partitionId,
         BALL_LOG_INFO << clusterDescription << ": Closing Partition ["
                       << partitionId << "].";
 
-        fs->close(clusterConfig.partitionConfig().flushAtShutdown());
+        fs->close(true);  // flush
 
         BALL_LOG_INFO << clusterDescription << ": Partition [" << partitionId
                       << "] closed.";

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -629,16 +629,15 @@ struct StorageUtil {
 
     /// Shutdown the underlying partition associated with the specified
     /// `partitionId` from the specified `fileStores` by using the specified
-    /// `latch`, and the specified `clusterConfig`. The cluster information
-    /// is printed using the specified `clusterDescription`.
+    /// `latch`. The cluster information is printed using the specified
+    /// `clusterDescription`.
     ///
     /// THREAD: Executed by *QUEUE_DISPATCHER* thread with the specified
     ///         `partitionId`.
-    static void shutdown(int                              partitionId,
-                         bslmt::Latch*                    latch,
-                         FileStores*                      fileStores,
-                         const bsl::string&               clusterDescription,
-                         const mqbcfg::ClusterDefinition& clusterConfig);
+    static void shutdown(int                partitionId,
+                         bslmt::Latch*      latch,
+                         FileStores*        fileStores,
+                         const bsl::string& clusterDescription);
 
     /// Lookup queue storage for the specified `uri` in the specified
     /// `storageMap` under specified `storagesLock`.  If the storage is

--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -646,8 +646,6 @@
                                partition to keep
         prefaultPages........: flag to indicate whether to populate (prefault)
                                page tables for a mapping.
-        flushAtShutdown......: flag to indicate whether broker should flush
-                               storage files to disk at shutdown
         syncConfig...........: configuration for storage synchronization and
                                recovery
       </documentation>
@@ -663,7 +661,6 @@
       <element name='preallocate'         type='boolean' default='false'/>
       <element name='maxArchivedFileSets' type='int'/>
       <element name='prefaultPages'       type='boolean' default='false'/>
-      <element name='flushAtShutdown'     type='boolean' default='true'/>
       <element name='syncConfig'          type='tns:StorageSyncConfig'/>
     </sequence>
   </complexType>

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
@@ -4450,8 +4450,6 @@ const bool PartitionConfig::DEFAULT_INITIALIZER_PREALLOCATE = false;
 
 const bool PartitionConfig::DEFAULT_INITIALIZER_PREFAULT_PAGES = false;
 
-const bool PartitionConfig::DEFAULT_INITIALIZER_FLUSH_AT_SHUTDOWN = true;
-
 const bdlat_AttributeInfo PartitionConfig::ATTRIBUTE_INFO_ARRAY[] = {
     {ATTRIBUTE_ID_NUM_PARTITIONS,
      "numPartitions",
@@ -4503,11 +4501,6 @@ const bdlat_AttributeInfo PartitionConfig::ATTRIBUTE_INFO_ARRAY[] = {
      sizeof("prefaultPages") - 1,
      "",
      bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
-    {ATTRIBUTE_ID_FLUSH_AT_SHUTDOWN,
-     "flushAtShutdown",
-     sizeof("flushAtShutdown") - 1,
-     "",
-     bdlat_FormattingMode::e_TEXT | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_SYNC_CONFIG,
      "syncConfig",
      sizeof("syncConfig") - 1,
@@ -4519,7 +4512,7 @@ const bdlat_AttributeInfo PartitionConfig::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 PartitionConfig::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 12; ++i) {
+    for (int i = 0; i < 11; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             PartitionConfig::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -4555,8 +4548,6 @@ const bdlat_AttributeInfo* PartitionConfig::lookupAttributeInfo(int id)
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_ARCHIVED_FILE_SETS];
     case ATTRIBUTE_ID_PREFAULT_PAGES:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PREFAULT_PAGES];
-    case ATTRIBUTE_ID_FLUSH_AT_SHUTDOWN:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN];
     case ATTRIBUTE_ID_SYNC_CONFIG:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SYNC_CONFIG];
     default: return 0;
@@ -4577,7 +4568,6 @@ PartitionConfig::PartitionConfig(bslma::Allocator* basicAllocator)
 , d_maxArchivedFileSets()
 , d_preallocate(DEFAULT_INITIALIZER_PREALLOCATE)
 , d_prefaultPages(DEFAULT_INITIALIZER_PREFAULT_PAGES)
-, d_flushAtShutdown(DEFAULT_INITIALIZER_FLUSH_AT_SHUTDOWN)
 {
 }
 
@@ -4594,7 +4584,6 @@ PartitionConfig::PartitionConfig(const PartitionConfig& original,
 , d_maxArchivedFileSets(original.d_maxArchivedFileSets)
 , d_preallocate(original.d_preallocate)
 , d_prefaultPages(original.d_prefaultPages)
-, d_flushAtShutdown(original.d_flushAtShutdown)
 {
 }
 
@@ -4611,8 +4600,7 @@ PartitionConfig::PartitionConfig(PartitionConfig&& original) noexcept
   d_numPartitions(bsl::move(original.d_numPartitions)),
   d_maxArchivedFileSets(bsl::move(original.d_maxArchivedFileSets)),
   d_preallocate(bsl::move(original.d_preallocate)),
-  d_prefaultPages(bsl::move(original.d_prefaultPages)),
-  d_flushAtShutdown(bsl::move(original.d_flushAtShutdown))
+  d_prefaultPages(bsl::move(original.d_prefaultPages))
 {
 }
 
@@ -4629,7 +4617,6 @@ PartitionConfig::PartitionConfig(PartitionConfig&& original,
 , d_maxArchivedFileSets(bsl::move(original.d_maxArchivedFileSets))
 , d_preallocate(bsl::move(original.d_preallocate))
 , d_prefaultPages(bsl::move(original.d_prefaultPages))
-, d_flushAtShutdown(bsl::move(original.d_flushAtShutdown))
 {
 }
 #endif
@@ -4653,7 +4640,6 @@ PartitionConfig& PartitionConfig::operator=(const PartitionConfig& rhs)
         d_preallocate         = rhs.d_preallocate;
         d_maxArchivedFileSets = rhs.d_maxArchivedFileSets;
         d_prefaultPages       = rhs.d_prefaultPages;
-        d_flushAtShutdown     = rhs.d_flushAtShutdown;
         d_syncConfig          = rhs.d_syncConfig;
     }
 
@@ -4675,7 +4661,6 @@ PartitionConfig& PartitionConfig::operator=(PartitionConfig&& rhs)
         d_preallocate         = bsl::move(rhs.d_preallocate);
         d_maxArchivedFileSets = bsl::move(rhs.d_maxArchivedFileSets);
         d_prefaultPages       = bsl::move(rhs.d_prefaultPages);
-        d_flushAtShutdown     = bsl::move(rhs.d_flushAtShutdown);
         d_syncConfig          = bsl::move(rhs.d_syncConfig);
     }
 
@@ -4694,8 +4679,7 @@ void PartitionConfig::reset()
     d_maxCSLFileSize = DEFAULT_INITIALIZER_MAX_C_S_L_FILE_SIZE;
     d_preallocate    = DEFAULT_INITIALIZER_PREALLOCATE;
     bdlat_ValueTypeFunctions::reset(&d_maxArchivedFileSets);
-    d_prefaultPages   = DEFAULT_INITIALIZER_PREFAULT_PAGES;
-    d_flushAtShutdown = DEFAULT_INITIALIZER_FLUSH_AT_SHUTDOWN;
+    d_prefaultPages = DEFAULT_INITIALIZER_PREFAULT_PAGES;
     bdlat_ValueTypeFunctions::reset(&d_syncConfig);
 }
 
@@ -4717,7 +4701,6 @@ bsl::ostream& PartitionConfig::print(bsl::ostream& stream,
     printer.printAttribute("preallocate", this->preallocate());
     printer.printAttribute("maxArchivedFileSets", this->maxArchivedFileSets());
     printer.printAttribute("prefaultPages", this->prefaultPages());
-    printer.printAttribute("flushAtShutdown", this->flushAtShutdown());
     printer.printAttribute("syncConfig", this->syncConfig());
     printer.end();
     return stream;
@@ -7956,6 +7939,6 @@ Configuration::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.05.07
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.h
@@ -6694,9 +6694,8 @@ class PartitionConfig {
     // preallocated on disk maxArchivedFileSets..: maximum number of archived
     // file sets per partition to keep prefaultPages........: flag to indicate
     // whether to populate (prefault) page tables for a mapping.
-    // flushAtShutdown......: flag to indicate whether broker should flush
-    // storage files to disk at shutdown syncConfig...........: configuration
-    // for storage synchronization and recovery
+    // syncConfig...........: configuration for storage synchronization and
+    // recovery
 
     // INSTANCE DATA
     bsls::Types::Uint64 d_maxDataFileSize;
@@ -6710,7 +6709,6 @@ class PartitionConfig {
     int                 d_maxArchivedFileSets;
     bool                d_preallocate;
     bool                d_prefaultPages;
-    bool                d_flushAtShutdown;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
@@ -6731,11 +6729,10 @@ class PartitionConfig {
         ATTRIBUTE_ID_PREALLOCATE            = 7,
         ATTRIBUTE_ID_MAX_ARCHIVED_FILE_SETS = 8,
         ATTRIBUTE_ID_PREFAULT_PAGES         = 9,
-        ATTRIBUTE_ID_FLUSH_AT_SHUTDOWN      = 10,
-        ATTRIBUTE_ID_SYNC_CONFIG            = 11
+        ATTRIBUTE_ID_SYNC_CONFIG            = 10
     };
 
-    enum { NUM_ATTRIBUTES = 12 };
+    enum { NUM_ATTRIBUTES = 11 };
 
     enum {
         ATTRIBUTE_INDEX_NUM_PARTITIONS         = 0,
@@ -6748,8 +6745,7 @@ class PartitionConfig {
         ATTRIBUTE_INDEX_PREALLOCATE            = 7,
         ATTRIBUTE_INDEX_MAX_ARCHIVED_FILE_SETS = 8,
         ATTRIBUTE_INDEX_PREFAULT_PAGES         = 9,
-        ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN      = 10,
-        ATTRIBUTE_INDEX_SYNC_CONFIG            = 11
+        ATTRIBUTE_INDEX_SYNC_CONFIG            = 10
     };
 
     // CONSTANTS
@@ -6760,8 +6756,6 @@ class PartitionConfig {
     static const bool DEFAULT_INITIALIZER_PREALLOCATE;
 
     static const bool DEFAULT_INITIALIZER_PREFAULT_PAGES;
-
-    static const bool DEFAULT_INITIALIZER_FLUSH_AT_SHUTDOWN;
 
     static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
 
@@ -6896,10 +6890,6 @@ class PartitionConfig {
     // Return a reference to the modifiable "PrefaultPages" attribute of
     // this object.
 
-    bool& flushAtShutdown();
-    // Return a reference to the modifiable "FlushAtShutdown" attribute of
-    // this object.
-
     StorageSyncConfig& syncConfig();
     // Return a reference to the modifiable "SyncConfig" attribute of this
     // object.
@@ -6980,9 +6970,6 @@ class PartitionConfig {
 
     bool prefaultPages() const;
     // Return the value of the "PrefaultPages" attribute of this object.
-
-    bool flushAtShutdown() const;
-    // Return the value of the "FlushAtShutdown" attribute of this object.
 
     const StorageSyncConfig& syncConfig() const;
     // Return a reference offering non-modifiable access to the
@@ -17510,7 +17497,6 @@ void PartitionConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
     hashAppend(hashAlgorithm, this->preallocate());
     hashAppend(hashAlgorithm, this->maxArchivedFileSets());
     hashAppend(hashAlgorithm, this->prefaultPages());
-    hashAppend(hashAlgorithm, this->flushAtShutdown());
     hashAppend(hashAlgorithm, this->syncConfig());
 }
 
@@ -17526,7 +17512,6 @@ inline bool PartitionConfig::isEqualTo(const PartitionConfig& rhs) const
            this->preallocate() == rhs.preallocate() &&
            this->maxArchivedFileSets() == rhs.maxArchivedFileSets() &&
            this->prefaultPages() == rhs.prefaultPages() &&
-           this->flushAtShutdown() == rhs.flushAtShutdown() &&
            this->syncConfig() == rhs.syncConfig();
 }
 
@@ -17602,12 +17587,6 @@ int PartitionConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
-    ret = manipulator(&d_flushAtShutdown,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN]);
-    if (ret) {
-        return ret;
-    }
-
     ret = manipulator(&d_syncConfig,
                       ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SYNC_CONFIG]);
     if (ret) {
@@ -17670,11 +17649,6 @@ int PartitionConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
         return manipulator(
             &d_prefaultPages,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PREFAULT_PAGES]);
-    }
-    case ATTRIBUTE_ID_FLUSH_AT_SHUTDOWN: {
-        return manipulator(
-            &d_flushAtShutdown,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN]);
     }
     case ATTRIBUTE_ID_SYNC_CONFIG: {
         return manipulator(&d_syncConfig,
@@ -17750,11 +17724,6 @@ inline bool& PartitionConfig::prefaultPages()
     return d_prefaultPages;
 }
 
-inline bool& PartitionConfig::flushAtShutdown()
-{
-    return d_flushAtShutdown;
-}
-
 inline StorageSyncConfig& PartitionConfig::syncConfig()
 {
     return d_syncConfig;
@@ -17827,12 +17796,6 @@ int PartitionConfig::accessAttributes(t_ACCESSOR& accessor) const
         return ret;
     }
 
-    ret = accessor(d_flushAtShutdown,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN]);
-    if (ret) {
-        return ret;
-    }
-
     ret = accessor(d_syncConfig,
                    ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SYNC_CONFIG]);
     if (ret) {
@@ -17893,11 +17856,6 @@ int PartitionConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PREFAULT_PAGES: {
         return accessor(d_prefaultPages,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PREFAULT_PAGES]);
-    }
-    case ATTRIBUTE_ID_FLUSH_AT_SHUTDOWN: {
-        return accessor(
-            d_flushAtShutdown,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FLUSH_AT_SHUTDOWN]);
     }
     case ATTRIBUTE_ID_SYNC_CONFIG: {
         return accessor(d_syncConfig,
@@ -17971,11 +17929,6 @@ inline int PartitionConfig::maxArchivedFileSets() const
 inline bool PartitionConfig::prefaultPages() const
 {
     return d_prefaultPages;
-}
-
-inline bool PartitionConfig::flushAtShutdown() const
-{
-    return d_flushAtShutdown;
 }
 
 inline const StorageSyncConfig& PartitionConfig::syncConfig() const
@@ -22551,6 +22504,6 @@ inline const AppConfig& Configuration::appConfig() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.05.07
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -593,11 +593,11 @@ class DataStore : public mqbi::DispatcherClient {
     /// Return zero on success, non-zero value otherwise.
     virtual int open(QueueKeyInfoMap* queueKeyInfoMap) = 0;
 
-    /// Close this instance.  If the optional `flush` flag is true, flush
+    /// Close this instance.  If the specified `flush` flag is true, flush
     /// the data store to the backup storage (e.g., disk) if applicable.
-    /// If the optional `archive` flag is true, archive the data store.  Return
-    /// zero on success, non-zero value otherwise.
-    virtual int close(bool flush = false, bool archive = false) = 0;
+    /// If the optional `archive` flag is true, archive the data store.
+    /// Return zero on success, non-zero value otherwise.
+    virtual int close(bool flush, bool archive = false) = 0;
 
     /// Create and load into the specified `storageSp` an instance of
     /// ReplicatedStorage for the queue having the specified `queueUri` and

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -796,11 +796,11 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// Return zero on success, non-zero value otherwise.
     int open(QueueKeyInfoMap* queueKeyInfoMap) BSLS_KEYWORD_OVERRIDE;
 
-    /// Close this instance.  If the optional `flush` flag is true, flush
+    /// Close this instance.  If the specified `flush` flag is true, flush
     /// the data store to disk.  If the optional `archive` flag is true,
     /// archive the data store.  Return zero on success, non-zero value
     /// otherwise.
-    int close(bool flush = false, bool archive = false) BSLS_KEYWORD_OVERRIDE;
+    int close(bool flush, bool archive = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Create and load into the specified `storageSp` an instance of
     /// ReplicatedStorage for the queue having the specified `queueUri` and

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -894,7 +894,7 @@ static void test1_breathingTest()
 
     BMQTST_ASSERT_EQ(true, success);
     if (!success) {
-        fs.close();
+        fs.close(true);
         return;  // RETURN
     }
 
@@ -915,7 +915,7 @@ static void test1_breathingTest()
         // TBD: verify
     }
 
-    fs.close();
+    fs.close(true);
 
     BMQTST_ASSERT_EQ(false, fs.isOpen());
 
@@ -1016,7 +1016,7 @@ static void test2_printTest()
     stream << fsIt;
     BMQTST_ASSERT_EQ(stream.str(), "INVALID");
 
-    fs.close();
+    fs.close(true);
 }
 
 static void test3_partitionFullAlarm()

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -443,7 +443,6 @@ class Proto:
                 preallocate=False,
                 max_archived_file_sets=0,
                 prefault_pages=False,
-                flush_at_shutdown=True,
                 sync_config=mqbcfg.StorageSyncConfig(
                     startup_recovery_max_duration_ms=20000,
                     max_attempts_storage_sync=2,
@@ -472,7 +471,6 @@ class Proto:
                 preallocate=False,
                 max_archived_file_sets=0,
                 prefault_pages=False,
-                flush_at_shutdown=True,
                 sync_config=mqbcfg.StorageSyncConfig(
                     startup_recovery_max_duration_ms=0,
                     max_attempts_storage_sync=0,

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -1373,11 +1373,6 @@ class TweakFactory:
 
             prefault_pages = PrefaultPages()
 
-            class FlushAtShutdown(metaclass=TweakMetaclass):
-                def __call__(self, value: bool) -> Callable: ...
-
-            flush_at_shutdown = FlushAtShutdown()
-
             class SyncConfig(metaclass=TweakMetaclass):
                 class StartupRecoveryMaxDurationMs(metaclass=TweakMetaclass):
                     def __call__(self, value: int) -> Callable: ...

--- a/src/python/blazingmq/schemas/mqbcfg.py
+++ b/src/python/blazingmq/schemas/mqbcfg.py
@@ -1425,8 +1425,6 @@ class PartitionConfig:
     partition to keep
     prefaultPages........: flag to indicate whether to populate (prefault)
     page tables for a mapping.
-    flushAtShutdown......: flag to indicate whether broker should flush
-    storage files to disk at shutdown
     syncConfig...........: configuration for storage synchronization and
     recovery
     """
@@ -1514,15 +1512,6 @@ class PartitionConfig:
         default=False,
         metadata={
             "name": "prefaultPages",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    flush_at_shutdown: bool = field(
-        default=True,
-        metadata={
-            "name": "flushAtShutdown",
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,


### PR DESCRIPTION
This pull request removes the `flushAtShutdown` broker configuration flag.  It is safe to do this because we never BER encode our broker configuration, just JSON-encode it, and we ignore configuration flags we don't know about.