### PR TITLE
Fix[mqbs::FileStore]: Archive before erasing file set

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3340,8 +3340,7 @@ void StorageManager::do_replicaRemoveStorage(const EventWithData& event)
     BSLS_ASSERT_SAFE(fs);
 
     if (fs->isOpen()) {
-        fs->close(false);  // flush
-        fs->deprecateFileSet();
+        fs->close(false, true);  // flush, archive
     }
     else {
         d_recoveryManager_mp->deprecateFileSet(partitionId);

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -586,7 +586,8 @@ class DataStore : public mqbi::DispatcherClient {
 
     /// Close this instance.  If the optional `flush` flag is true, flush
     /// the data store to the backup storage (e.g., disk) if applicable.
-    virtual void close(bool flush = false) = 0;
+    /// If the optional `archive` flag is true, archive the data store.
+    virtual void close(bool flush = false, bool archive = false) = 0;
 
     /// Create and load into the specified `storageSp` an instance of
     /// ReplicatedStorage for the queue having the specified `queueUri` and

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -393,7 +393,7 @@ class MockDataStore : public mqbs::DataStore {
 
     int open(QueueKeyInfoMap*) BSLS_KEYWORD_OVERRIDE { return 0; }
 
-    void close(bool) BSLS_KEYWORD_OVERRIDE {}
+    void close(bool, bool) BSLS_KEYWORD_OVERRIDE {}
 
     void createStorage(bsl::shared_ptr<mqbs::ReplicatedStorage>*,
                        const bmqt::Uri&,

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3553,7 +3553,6 @@ void FileStore::gcWorkerDispatched(const bsl::shared_ptr<FileSet>& fileSet)
     }
 
     bsls::Types::Int64 startTime = bmqsys::Time::highResolutionTimer();
-
     close(*fileSet, false);
     bsls::Types::Int64 closeTime = bmqsys::Time::highResolutionTimer();
     BALL_LOG_INFO << partitionDesc() << "File set closed. Time taken: "
@@ -5312,7 +5311,7 @@ int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap)
     return rc_SUCCESS;
 }
 
-void FileStore::close(bool flush)
+void FileStore::close(bool flush, bool archive)
 {
     // The FileStore might be not opened by the time we call `close()`
     cancelTimersAndWait();
@@ -5344,7 +5343,9 @@ void FileStore::close(bool flush)
     if (0 == --activeFileSet->d_aliasedBlobBufferCount) {
         BALL_LOG_INFO_BLOCK
         {
-            BALL_LOG_OUTPUT_STREAM << partitionDesc() << "Closing file set ["
+            BALL_LOG_OUTPUT_STREAM << partitionDesc() << "Closing "
+                                   << (archive ? "and archiving " : "")
+                                   << "file set ["
                                    << activeFileSet->d_dataFileName << "], ["
                                    << activeFileSet->d_journalFileName << "]";
             if (d_qListAware) {
@@ -5354,7 +5355,25 @@ void FileStore::close(bool flush)
             BALL_LOG_OUTPUT_STREAM << ".";
         }
 
+        bsls::Types::Int64 startTime = bmqsys::Time::highResolutionTimer();
         close(*activeFileSet, flush);
+        bsls::Types::Int64 closeTime = bmqsys::Time::highResolutionTimer();
+        BALL_LOG_INFO << partitionDesc() << "File set closed. Time taken: "
+                      << bmqu::PrintUtil::prettyTimeInterval(closeTime -
+                                                             startTime);
+
+        if (archive) {
+            bsls::Types::Int64 archiveStartTime =
+                bmqsys::Time::highResolutionTimer();
+            FileStore::archive(activeFileSet);
+            bsls::Types::Int64 archiveEndTime =
+                bmqsys::Time::highResolutionTimer();
+            BALL_LOG_INFO << partitionDesc()
+                          << "File set archived. Time taken: "
+                          << bmqu::PrintUtil::prettyTimeInterval(
+                                 archiveEndTime - archiveStartTime);
+        }
+
         d_fileSets.erase(d_fileSets.begin());
     }
     else {
@@ -5366,6 +5385,7 @@ void FileStore::close(bool flush)
         if (d_qListAware) {
             BSLS_ASSERT_SAFE(activeFileSet->d_qlistFile.isValid());
         }
+        BSLS_ASSERT_SAFE(!archive);
     }
 }
 
@@ -7090,19 +7110,6 @@ void FileStore::applyForEachQueue(const QueueFunctor& functor) const
             functor(it->second->queue());
         }
     }
-}
-
-void FileStore::deprecateFileSet()
-{
-    if (d_isOpen) {
-        BALL_LOG_ERROR << partitionDesc()
-                       << "Cannot deprecate the active file set as this "
-                       << "FileStore is still open.";
-
-        return;  // RETURN
-    }
-
-    archive(d_fileSets[0].get());
 }
 
 void FileStore::registerStorage(ReplicatedStorage* storage)

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -764,8 +764,9 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     int open(QueueKeyInfoMap* queueKeyInfoMap) BSLS_KEYWORD_OVERRIDE;
 
     /// Close this instance.  If the optional `flush` flag is true, flush
-    /// the data store to disk.
-    void close(bool flush = false) BSLS_KEYWORD_OVERRIDE;
+    /// the data store to disk.  If the optional `archive` flag is true,
+    /// archive the data store.
+    void close(bool flush = false, bool archive = false) BSLS_KEYWORD_OVERRIDE;
 
     /// Create and load into the specified `storageSp` an instance of
     /// ReplicatedStorage for the queue having the specified `queueUri` and
@@ -906,13 +907,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     void applyForEachQueue(const QueueFunctor& functor) const;
 
     /// mqbs::FileStore specific MANIPULATORS
-
-    /// Deprecate the active file set.  Behavior is undefined unless this
-    /// instance is closed.
-    ///
-    /// NOTE: This routine is dangerous and archives storage files. Must be
-    /// used with caution.
-    void deprecateFileSet();
 
     /// Perform complete rollover of this partition and issue necessary sync
     /// points.


### PR DESCRIPTION
Fix for Internal Ticket 184009356

The old code calls
```
        fs->close(false);  // flush
        fs->deprecateFileSet();
```
which is bugged, because we will try to call `archive(d_fileSets[0].get());` after that entry in `d_fileSets` has been erased.
