### PR TITLE
Fix[mqb]: disable reconnecting on shutdown

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
@@ -184,6 +184,10 @@ ReconnectingChannelFactory_ConnectHandle::properties() const
 void ReconnectingChannelFactory::scheduleConnect(
     const ConnectHandlePtr& handle)
 {
+    if (!d_isReconnectEnabled) {
+        return;  // RETURN
+    }
+
     if (!handle->d_endpoints.empty()) {
         // If we haven't yet exhausted all endpoints, retry immediately without
         // waiting.
@@ -458,6 +462,7 @@ ReconnectingChannelFactory::ReconnectingChannelFactory(
     const Config&     config,
     bslma::Allocator* basicAllocator)
 : d_validator(false)
+, d_isReconnectEnabled(true)
 , d_config(config, basicAllocator)
 , d_handles(basicAllocator)
 , d_mutex()
@@ -500,6 +505,11 @@ void ReconnectingChannelFactory::stop()
     }
 
     d_config.d_base_p->stop();
+}
+
+void ReconnectingChannelFactory::disableReconnect()
+{
+    d_isReconnectEnabled = false;
 }
 
 void ReconnectingChannelFactory::listen(Status*                      status,

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
@@ -257,6 +257,7 @@ class ReconnectingChannelFactory : public ChannelFactory {
 
     // DATA
     bmqu::AtomicValidator d_validator;
+    bsls::AtomicBool      d_isReconnectEnabled;
     Config                d_config;
     ConnectHandleMap      d_handles;
     bslmt::Mutex          d_mutex;
@@ -318,6 +319,10 @@ class ReconnectingChannelFactory : public ChannelFactory {
     /// the thread calling this function is the same thread that called
     /// `start()` and is not one of the I/O threads used by this object.
     void stop() BSLS_KEYWORD_OVERRIDE;
+
+    /// Disable automatic reconnection.  After this call, channels that go
+    /// down will not trigger a reconnect attempt.
+    void disableReconnect();
 
     // ChannelFactory
 

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -1309,6 +1309,10 @@ void TCPSessionFactory::stopListening()
     d_isListening = false;
 
     cancelListeners();
+
+    if (d_reconnectingChannelFactory_mp) {
+        d_reconnectingChannelFactory_mp->disableReconnect();
+    }
 }
 
 void TCPSessionFactory::closeClients()


### PR DESCRIPTION
`TCPSessionFactory::stopListening()` prevents new incoming connections.
Outgoing connections should be disabled as well.
