### PR TITLE
Fix[bmqstoragetool]: Pass allocator to `ManagedPtr.load()`

### DIFF
--- a/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
+++ b/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
@@ -244,7 +244,8 @@ int main(int argc, const char* argv[])
                                              arguments.d_dataFile,
                                              arguments.d_cslFile,
                                              arguments.d_cslFromBegin,
-                                             allocator));
+                                             allocator),
+                         allocator);
         if (!arguments.d_cslFile.empty()) {
             fileManager->fillQueueMapFromCslFile(&parameters.d_queueMap);
             parameters.validateQueueNames();


### PR DESCRIPTION
Without passing the allocator we used to construct the object a `ManagedPtr` takes ownership of, it cannot know how to delete it.  This PR supplies the same `allocator` to `ManagedPtr.load()`.