### PR TITLE
Fix[mqb]: prevent queue deletion when there is anything in flight

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -251,10 +251,12 @@ void ClusterQueueHelper::finishAllOpening(const QueueContextSp& queueContext,
 {
     BSLS_ASSERT_SAFE(queueContext);
 
-    for (bsl::vector<OpenQueueContextSp>::const_iterator
-             cIt   = queueContext->d_liveQInfo.d_pending.begin(),
-             cLast = queueContext->d_liveQInfo.d_pending.end();
-         cIt != cLast;
+    bsl::vector<OpenQueueContextSp> contexts(d_allocator_p);
+    contexts.swap(queueContext->d_liveQInfo.d_pending);
+
+    for (bsl::vector<OpenQueueContextSp>::const_iterator cIt =
+             contexts.begin();
+         cIt != contexts.end();
          ++cIt) {
         finishOpening(*cIt,
                       status,
@@ -5295,6 +5297,11 @@ void ClusterQueueHelper::processShutdownEvent()
     // This works for both cluster members and proxies: 'deleteQueue' skips
     // storage reset when 'isRemote()' and 'unregisterQueue' is proxy-safe.
 
+    bmqp_ctrlmsg::Status cancelStatus;
+    cancelStatus.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+    cancelStatus.code()     = mqbi::ClusterErrorCode::e_STOPPING;
+    cancelStatus.message()  = "Node is stopping";
+
     for (QueueContextMapIter it = d_queues.begin(); it != d_queues.end();
          ++it) {
         QueueContextSp& queueContextSp = it->second;
@@ -5304,6 +5311,8 @@ void ClusterQueueHelper::processShutdownEvent()
         if (!queue) {
             continue;  // CONTINUE
         }
+
+        finishAllOpening(queueContextSp, cancelStatus);
 
         if (!qinfo.isIdle()) {
             // Queue has non-zero handles.  Since self is stopping, self will

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -3313,8 +3313,7 @@ void ClusterQueueHelper::onQueueHandleCreatedDispatched(mqbi::Queue*     queue,
                          << "], queue ptr [" << queue << "]: "
                          << queueContextSp->d_liveQInfo.d_numQueueHandles;
 
-    if (0 == queueContextSp->d_liveQInfo.d_numHandleCreationsInProgress &&
-        0 == queueContextSp->d_liveQInfo.d_numQueueHandles) {
+    if (queueContextSp->d_liveQInfo.isIdle()) {
         // Both counters are zero.  This could occur if queue was created but
         // failed to create its first handle.
 
@@ -3380,12 +3379,14 @@ void ClusterQueueHelper::onQueueHandleDestroyedDispatched(mqbi::Queue* queue,
 
     BSLS_ASSERT_SAFE(0 == numHandles);
 
-    if (0 != queueContextSp->d_liveQInfo.d_numHandleCreationsInProgress) {
+    if (!queueContextSp->d_liveQInfo.isIdle()) {
         BMQ_LOGTHROTTLE_INFO
             << d_cluster_p->description() << ": num handle count for queue ["
             << uri << "] has gone to zero but there are ["
             << queueContextSp->d_liveQInfo.d_numHandleCreationsInProgress
-            << "] handle-creation events in progress.";
+            << "] handle-creation events in progress and/or ["
+            << queueContextSp->d_liveQInfo.d_inFlight
+            << "] in flight requests.";
         return;  // RETURN
     }
 
@@ -5304,7 +5305,7 @@ void ClusterQueueHelper::processShutdownEvent()
             continue;  // CONTINUE
         }
 
-        if (0 != qinfo.d_numQueueHandles) {
+        if (!qinfo.isIdle()) {
             // Queue has non-zero handles.  Since self is stopping, self will
             // receive/send close-queue requests for this queue, and eventually
             // num handles will go to zero, and queue will be removed.
@@ -5866,10 +5867,7 @@ int ClusterQueueHelper::gcExpiredQueues(bool               immediate,
         // Queue has no outstanding messages.
 
         bool nothingOutstanding =
-            queueContextSp->d_liveQInfo.d_pending.empty() &&
-            0 == queueContextSp->d_liveQInfo.d_inFlight &&
-            0 == qinfo.d_numHandleCreationsInProgress &&
-            0 == qinfo.d_numQueueHandles;
+            queueContextSp->d_liveQInfo.d_pending.empty() && qinfo.isIdle();
 
         if (!nothingOutstanding) {
             // Something is outstanding on the queue, can't mark it for gc.
@@ -6023,10 +6021,7 @@ bool ClusterQueueHelper::hasActiveQueue(const bsl::string& domainName)
             continue;
         }
 
-        if (queueContextCIt->second->d_liveQInfo.d_inFlight != 0 ||
-            queueContextCIt->second->d_liveQInfo
-                    .d_numHandleCreationsInProgress != 0 ||
-            queueContextCIt->second->d_liveQInfo.d_numQueueHandles != 0) {
+        if (!queueContextCIt->second->d_liveQInfo.isIdle()) {
             return true;  // RETURN
         }
     }

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -297,6 +297,10 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         /// object.  Note that `uri` is left untouched because it is an
         /// invariant member of a given instance of such a QueueInfo object.
         void resetButKeepPending();
+
+        // ACCESSORS
+        /// Return `false` if there is a handle or handle creation in progress.
+        bool isIdle() const;
     };
 
     typedef bsl::unordered_map<const mqbnet::ClusterNode*,
@@ -1144,6 +1148,16 @@ inline ClusterQueueHelper::StopContext::StopContext(
 , d_callback(callback)
 , d_previous_sp()
 {
+}
+
+// -----------------------------------------
+// struct ClusterQueueHelper::QueueLiveState
+// -----------------------------------------
+
+inline bool ClusterQueueHelper::QueueLiveState::isIdle() const
+{
+    return d_numQueueHandles == 0 && d_numHandleCreationsInProgress == 0 &&
+           d_inFlight == 0;
 }
 
 // ---------------------------------------


### PR DESCRIPTION
If queue is deleted (on shutdown) while there is open in progress, 
` mqbblp_domain.cpp:245 Assertion failed: lookupQueue(0, queuehandle->queue()->uri()) == 0, `
