### PR TITLE
Fix[mqbc::ClusterStateMgr]: Only cancel requests initiated by Cluster FSM 

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -4597,7 +4597,7 @@ void BrokerSession::cancel(int                                 groupId,
     bmqp_ctrlmsg::ControlMessage controlMessage(d_allocator_p);
     bmqp::ControlMessageUtil::makeStatus(&controlMessage, status, -1, reason);
     if (groupId >= 0) {
-        d_requestManager.cancelAllRequests(controlMessage, groupId);
+        d_requestManager.cancelGroupRequests(controlMessage, groupId);
     }
     else {
         d_requestManager.cancelAllRequests(controlMessage);

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -861,15 +861,15 @@ class RequestManager {
     /// behavior is undefined if `groupId` is `NO_GROUP_ID`.  The
     /// corresponding response callbacks will be invoked in the order in
     /// which requests were sent.
-    void cancelAllRequests(const RESPONSE& reason, int groupId);
+    void cancelGroupRequests(const RESPONSE& reason, int groupId);
 
     /// Cancel all outstanding requests tagged with the specified
     /// `componentId`, with the specified `reason` response description.
     /// The behavior is undefined if `componentId` is `e_NO_COMPONENT_ID`.
     /// The corresponding response callbacks will be invoked in the order
     /// in which requests were sent.
-    void cancelAllRequests(const RESPONSE&                 reason,
-                           RequestManagerComponentId::Enum componentId);
+    void cancelComponentRequests(const RESPONSE&                 reason,
+                                 RequestManagerComponentId::Enum componentId);
 };
 
 // ============================================================================
@@ -1525,7 +1525,7 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
 }
 
 template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
+void RequestManager<REQUEST, RESPONSE>::cancelGroupRequests(
     const RESPONSE& reason,
     int             groupId)
 {
@@ -1538,7 +1538,7 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
 }
 
 template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
+void RequestManager<REQUEST, RESPONSE>::cancelComponentRequests(
     const RESPONSE&                 reason,
     RequestManagerComponentId::Enum componentId)
 {
@@ -1608,10 +1608,10 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
                       << " items) with " << reason << ".";
     }
     else {
-        BALL_LOG_INFO << "Canceling requests belonging to group '" << groupId
-                      << "' and component '" << componentId << "' ("
-                      << requestsCopy.size() << " items) with " << reason
-                      << ".";
+        BALL_LOG_INFO
+            << "Canceling requests simultaneously belonging to group '"
+            << groupId << "' and component '" << componentId << "' ("
+            << requestsCopy.size() << " items) with " << reason << ".";
     }
 
     if (requestsCopy.empty()) {

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -83,10 +83,15 @@
 // 'cancelAllRequests' is invoked, response callback of request 'A' will be
 // invoked first, followed by response callback of request 'B'.  This guarantee
 // is provided because application may rely on the assumption that response
-// callbacks are invoked in the order of sending requests.  There are two
-// versions of 'cancelAllRequests': the one that does take 'groupId' and the
-// one that does not.  Without 'groupId', all requests get cancelled, otherwise
-// only those requests which were associated with the same id by 'setGroupId'.
+// callbacks are invoked in the order of sending requests.  There are three
+// versions of 'cancelAllRequests': the one that takes no filter argument, the
+// one that takes 'groupId', and the one that takes 'componentId'.  Without
+// any filter all requests get cancelled.  With 'groupId', only those requests
+// which were associated with the same id by 'setGroupId' get cancelled.  With
+// 'componentId', only those requests tagged with the same component identifier
+// via 'setComponentId' get cancelled.  The two filtered versions operate on
+// orthogonal axes and can therefore coexist on the same 'RequestManager'
+// instance without interference.
 //
 /// Distributed Trace Integration
 ///-----------------------------
@@ -378,6 +383,26 @@ namespace bmqp {
 template <class REQUEST, class RESPONSE>
 class RequestManager;
 
+// ================================
+// struct RequestManagerComponentId
+// ================================
+
+/// Enumeration of component identifiers used to tag requests sent via a
+/// `RequestManager` for the purpose of component-scoped cancellation.
+struct RequestManagerComponentId {
+    // TYPES
+    enum Enum {
+        /// Default; no component association.
+        e_NO_COMPONENT_ID = 0,
+
+        /// Cluster State Manager FSM.
+        e_CLUSTER_FSM = 1,
+
+        /// Storage Manager Partition FSM.
+        e_PARTITION_FSM = 2
+    };
+};
+
 // ===========================
 // class RequestManagerRequest
 // ===========================
@@ -459,6 +484,11 @@ class RequestManagerRequest {
     // requests, allowing to cancel all
     // requests sharing the same group.
 
+    RequestManagerComponentId::Enum d_componentId;
+    // The 'componentId' associated with this
+    // request.  Used to cancel all requests
+    // belonging to a specific component.
+
     bsl::shared_ptr<bmqpi::DTSpan> d_dtSpan_sp;
     // Distributed Trace span representing
     // this request.
@@ -534,13 +564,20 @@ class RequestManagerRequest {
     /// reference offering modifiable access to this object.
     RequestManagerRequest& setAsyncNotifierCb(const AsyncNotifierCb& value);
 
-    /// Set group identifier to the specified value to assist canceling
+    /// Set group identifier to the specified `value` to assist canceling
     /// requests belonging to one group only.  By default, the identifier is
     /// `k_NO_GROUP_ID` meaning the request does not belong to any group in
     /// which case it gets cancelled by `cancelAllRequests` without
     /// `groupId`.  Return a reference offering modifiable access to this
     /// object.
     RequestManagerRequest& setGroupId(int value);
+
+    /// Set component identifier to the specified `value` to assist canceling
+    /// requests belonging to one component only.  By default, the identifier
+    /// is `RequestManagerComponentId::e_NO_COMPONENT_ID`.  Return a
+    /// reference offering modifiable access to this object.
+    RequestManagerRequest&
+    setComponentId(RequestManagerComponentId::Enum value);
 
     /// Take shared ownership of the specified `span` and ensure that it
     /// lives at least as long as this object. The `span` is intended to
@@ -583,6 +620,10 @@ class RequestManagerRequest {
 
     /// Return the associated group id (`NO_GROUP_ID` by default).
     int groupId() const;
+
+    /// Return the associated component identifier
+    /// (`e_NO_COMPONENT_ID` by default).
+    RequestManagerComponentId::Enum componentId() const;
 
     /// Return the associated user data.
     const bdld::Datum& userData() const;
@@ -714,12 +755,16 @@ class RequestManager {
     /// Apply the specified `response` to the specified `request`.
     void applyResponse(const RequestSp& request, const RESPONSE& response);
 
-    /// Cancel all outstanding requests belonging to the specified
-    /// `groupId`, with the specified `reason` response description.  If the
-    /// `groupId` is `NO_GROUP_ID`, cancel all requests.  The corresponding
-    /// response callbacks will be invoked in the order in which requests
-    /// were sent.
-    void cancelAllRequestsImpl(const RESPONSE& reason, int groupId);
+    /// Cancel all outstanding requests matching the specified `groupId` and
+    /// `componentId` filters, with the specified `reason` response
+    /// description.  A value of `NO_GROUP_ID` for `groupId` disables
+    /// group filtering; a value of `e_NO_COMPONENT_ID` for `componentId`
+    /// disables component filtering.  Both filters are applied with AND
+    /// semantics.  The corresponding response callbacks will be invoked in
+    /// the order in which requests were sent.
+    void cancelAllRequestsImpl(const RESPONSE&                 reason,
+                               int                             groupId,
+                               RequestManagerComponentId::Enum componentId);
 
   private:
     // NOT IMPLEMENTED
@@ -817,6 +862,14 @@ class RequestManager {
     /// corresponding response callbacks will be invoked in the order in
     /// which requests were sent.
     void cancelAllRequests(const RESPONSE& reason, int groupId);
+
+    /// Cancel all outstanding requests tagged with the specified
+    /// `componentId`, with the specified `reason` response description.
+    /// The behavior is undefined if `componentId` is `e_NO_COMPONENT_ID`.
+    /// The corresponding response callbacks will be invoked in the order
+    /// in which requests were sent.
+    void cancelAllRequests(const RESPONSE&                 reason,
+                           RequestManagerComponentId::Enum componentId);
 };
 
 // ============================================================================
@@ -841,6 +894,7 @@ RequestManagerRequest<REQUEST, RESPONSE>::RequestManagerRequest(
 , d_haveTimeout(false)
 , d_haveResponse(false)
 , d_groupId(k_NO_GROUP_ID)
+, d_componentId(RequestManagerComponentId::e_NO_COMPONENT_ID)
 , d_dtSpan_sp(NULL)
 , d_dtContext_p(NULL)
 , d_userData(allocator)
@@ -872,6 +926,8 @@ void RequestManagerRequest<REQUEST, RESPONSE>::clear()
     d_asyncNotifierCb = bsl::nullptr_t();
     d_sendTime        = 0;
     d_nodeDescription.clear();
+    d_groupId     = k_NO_GROUP_ID;
+    d_componentId = RequestManagerComponentId::e_NO_COMPONENT_ID;
     d_dtSpan_sp.reset();
     d_dtContext_p = NULL;
 }
@@ -933,6 +989,15 @@ RequestManagerRequest<REQUEST, RESPONSE>&
 RequestManagerRequest<REQUEST, RESPONSE>::setGroupId(int value)
 {
     d_groupId = value;
+    return *this;
+}
+
+template <class REQUEST, class RESPONSE>
+RequestManagerRequest<REQUEST, RESPONSE>&
+RequestManagerRequest<REQUEST, RESPONSE>::setComponentId(
+    RequestManagerComponentId::Enum value)
+{
+    d_componentId = value;
     return *this;
 }
 
@@ -1033,6 +1098,13 @@ template <class REQUEST, class RESPONSE>
 int RequestManagerRequest<REQUEST, RESPONSE>::groupId() const
 {
     return d_groupId;
+}
+
+template <class REQUEST, class RESPONSE>
+RequestManagerComponentId::Enum
+RequestManagerRequest<REQUEST, RESPONSE>::componentId() const
+{
+    return d_componentId;
 }
 
 template <class REQUEST, class RESPONSE>
@@ -1447,7 +1519,9 @@ template <class REQUEST, class RESPONSE>
 void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
     const RESPONSE& reason)
 {
-    cancelAllRequestsImpl(reason, RequestType::k_NO_GROUP_ID);
+    cancelAllRequestsImpl(reason,
+                          RequestType::k_NO_GROUP_ID,
+                          RequestManagerComponentId::e_NO_COMPONENT_ID);
 }
 
 template <class REQUEST, class RESPONSE>
@@ -1455,15 +1529,31 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
     const RESPONSE& reason,
     int             groupId)
 {
+    // PRECONDITIONS
     BSLS_ASSERT_SAFE(groupId != RequestType::k_NO_GROUP_ID);
 
-    cancelAllRequestsImpl(reason, groupId);
+    cancelAllRequestsImpl(reason,
+                          groupId,
+                          RequestManagerComponentId::e_NO_COMPONENT_ID);
+}
+
+template <class REQUEST, class RESPONSE>
+void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
+    const RESPONSE&                 reason,
+    RequestManagerComponentId::Enum componentId)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(componentId !=
+                     RequestManagerComponentId::e_NO_COMPONENT_ID);
+
+    cancelAllRequestsImpl(reason, RequestType::k_NO_GROUP_ID, componentId);
 }
 
 template <class REQUEST, class RESPONSE>
 void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
-    const RESPONSE& reason,
-    int             groupId)
+    const RESPONSE&                 reason,
+    int                             groupId,
+    RequestManagerComponentId::Enum componentId)
 {
     // Note that requests must be cancelled in the same order in which they
     // were sent.
@@ -1475,12 +1565,16 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // MUTEX LOCKED
 
-        // Iterate over each requests, moving the ones matching
-        // 'nodeDescription' from the 'd_requests' map to 'requests'.
         RequestMapIter it = d_requests.begin();
         while (it != d_requests.end()) {
-            if (groupId == RequestType::k_NO_GROUP_ID  // i.e., cancel all
-                || groupId == it->second->groupId()) {
+            const bool matchGroup = (groupId == RequestType::k_NO_GROUP_ID) ||
+                                    (groupId == it->second->groupId());
+            const bool matchComponent =
+                (componentId ==
+                 RequestManagerComponentId::e_NO_COMPONENT_ID) ||
+                (componentId == it->second->componentId());
+
+            if (matchGroup && matchComponent) {
                 // Do not notify about timed out requests.
                 if (!it->second->d_haveTimeout) {
                     BSLA_MAYBE_UNUSED bsl::pair<RequestMapIter, bool>
@@ -1496,14 +1590,28 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
         }
     }
 
-    if (groupId == RequestType::k_NO_GROUP_ID) {
+    const bool hasGroup     = (groupId != RequestType::k_NO_GROUP_ID);
+    const bool hasComponent = (componentId !=
+                               RequestManagerComponentId::e_NO_COMPONENT_ID);
+    if (!hasGroup && !hasComponent) {
         BALL_LOG_INFO << "Canceling all requests (" << requestsCopy.size()
                       << " items) with " << reason << ".";
     }
-    else {
-        BALL_LOG_INFO << "Canceling requests belonging to '" << groupId
-                      << "' group (" << requestsCopy.size() << " items) with "
+    else if (hasGroup && !hasComponent) {
+        BALL_LOG_INFO << "Canceling requests belonging to group '" << groupId
+                      << "' (" << requestsCopy.size() << " items) with "
                       << reason << ".";
+    }
+    else if (!hasGroup && hasComponent) {
+        BALL_LOG_INFO << "Canceling requests belonging to component '"
+                      << componentId << "' (" << requestsCopy.size()
+                      << " items) with " << reason << ".";
+    }
+    else {
+        BALL_LOG_INFO << "Canceling requests belonging to group '" << groupId
+                      << "' and component '" << componentId << "' ("
+                      << requestsCopy.size() << " items) with " << reason
+                      << ".";
     }
 
     if (requestsCopy.empty()) {

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -53,7 +53,7 @@ using namespace bsl;
 // - createRequestTest
 // - sendRequestTest
 // - processResponseTest
-// - cancelAllRequestsTest
+// - cancelAllRequestsTest (by groupId and by componentId)
 //-----------------------------------------------------------------------------
 // ============================================================================
 //                            TEST HELPERS UTILITY
@@ -928,6 +928,51 @@ static void test6_cancelAllRequestsTest()
             }
         }
     }
+
+    {
+        // Cancel by componentId: only requests tagged with the specified
+        // component should be cancelled; requests tagged with a different
+        // component or untagged (e_NO_COMPONENT_ID) must remain outstanding.
+        TestContext       context(false, bmqtst::TestHelperUtil::allocator());
+        const bsl::size_t numRequests = 6;
+        ReqVec            requests(bmqtst::TestHelperUtil::allocator());
+        requests.reserve(numRequests);
+        for (bsl::size_t i = 0; i < numRequests; ++i) {
+            ReqSp request = context.createRequest();
+            context.populateRequest(request);
+            if (i < 2) {
+                request->setComponentId(
+                    bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            }
+            else if (i < 4) {
+                request->setComponentId(
+                    bmqp::RequestManagerComponentId::e_PARTITION_FSM);
+            }
+            // i >= 4: leave as e_NO_COMPONENT_ID (default)
+            context.sendChannelRequest(request);
+            requests.emplace_back(request);
+        }
+
+        Mes reason = context.createResponseCancel();
+        context.manager().cancelAllRequests(
+            reason,
+            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+
+        for (bsl::size_t i = 0; i < numRequests; ++i) {
+            ReqSp request = requests[i];
+            if (request->componentId() ==
+                bmqp::RequestManagerComponentId::e_CLUSTER_FSM) {
+                BMQTST_ASSERT_EQ(request->result(),
+                                 bmqt::GenericResult::e_CANCELED);
+                BMQTST_ASSERT_EQ(request->response().choice().status(),
+                                 reason.choice().status());
+            }
+            else {
+                BMQTST_ASSERT_EQ(request->result(),
+                                 bmqt::GenericResult::e_SUCCESS);
+            }
+        }
+    }
 }
 
 static void test7_requestBreathingTest()
@@ -958,6 +1003,8 @@ static void test7_requestBreathingTest()
         BMQTST_ASSERT_EQ(request->result(), bmqt::GenericResult::e_SUCCESS);
         BMQTST_ASSERT(request->nodeDescription().empty());
         BMQTST_ASSERT_EQ(request->groupId(), -1);  // Req::k_NO_GROUP_ID
+        BMQTST_ASSERT_EQ(request->componentId(),
+                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
         BMQTST_ASSERT(request->userData().isNull());
     }
 
@@ -1001,6 +1048,19 @@ static void test7_requestBreathingTest()
         int expected = 666;
         request->setGroupId(expected);
         BMQTST_ASSERT_EQ(request->groupId(), expected);
+    }
+
+    {
+        // set componentId and check it
+        ReqSp request;
+        request.createInplace(bmqtst::TestHelperUtil::allocator(),
+                              bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(request->componentId(),
+                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+        request->setComponentId(
+            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+        BMQTST_ASSERT_EQ(request->componentId(),
+                         bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
     }
 
     {

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -912,7 +912,7 @@ static void test6_cancelAllRequestsTest()
         }
 
         Mes reason = context.createResponseCancel();
-        context.manager().cancelAllRequests(reason, 1);
+        context.manager().cancelGroupRequests(reason, 1);
 
         for (bsl::size_t i = 0; i < numRequests; ++i) {
             ReqSp request = requests[i];
@@ -954,7 +954,7 @@ static void test6_cancelAllRequestsTest()
         }
 
         Mes reason = context.createResponseCancel();
-        context.manager().cancelAllRequests(
+        context.manager().cancelComponentRequests(
             reason,
             bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -1012,7 +1012,7 @@ void ClusterOrchestrator::processNodeStoppingNotification(
     failure.code()     = mqbi::ClusterErrorCode::e_STOPPING;
     failure.message()  = "Peer node is stopping";
 
-    d_clusterData_p->requestManager().cancelAllRequests(
+    d_clusterData_p->requestManager().cancelGroupRequests(
         response,
         ns->clusterNode()->nodeId());
 
@@ -1273,8 +1273,8 @@ void ClusterOrchestrator::processNodeStateChangeEvent(
     failure.code()     = mqbi::ClusterErrorCode::e_NODE_DOWN;
     failure.message()  = "Lost connection with peer node";
 
-    d_clusterData_p->requestManager().cancelAllRequests(response,
-                                                        node->nodeId());
+    d_clusterData_p->requestManager().cancelGroupRequests(response,
+                                                          node->nodeId());
 
     // Note that if the 'node' went down gracefully, 'onNodeUnavailable' would
     // have also been called in

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -361,8 +361,8 @@ void ClusterProxy::onActiveNodeDown(const mqbnet::ClusterNode* node)
         failure.code()     = mqbi::ClusterErrorCode::e_STOPPING;
         failure.message()  = "Lost connection with active node while stopping";
 
-        d_clusterData.requestManager().cancelAllRequests(response,
-                                                         node->nodeId());
+        d_clusterData.requestManager().cancelGroupRequests(response,
+                                                           node->nodeId());
 
         return;  // RETURN
     }
@@ -387,7 +387,8 @@ void ClusterProxy::onActiveNodeDown(const mqbnet::ClusterNode* node)
     failure.code()     = mqbi::ClusterErrorCode::e_ACTIVE_LOST;
     failure.message()  = "Lost connection with active node";
 
-    d_clusterData.requestManager().cancelAllRequests(response, node->nodeId());
+    d_clusterData.requestManager().cancelGroupRequests(response,
+                                                       node->nodeId());
 }
 
 // PRIVATE MANIPULATORS
@@ -1411,8 +1412,8 @@ void ClusterProxy::onNodeDownDispatched(mqbnet::ClusterNode* node)
         failure.code()     = mqbi::ClusterErrorCode::e_NODE_DOWN;
         failure.message()  = "Lost connection with node";
 
-        d_clusterData.requestManager().cancelAllRequests(response,
-                                                         node->nodeId());
+        d_clusterData.requestManager().cancelGroupRequests(response,
+                                                           node->nodeId());
     }
 
     processActiveNodeManagerResult(result, node);

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1100,7 +1100,7 @@ void ClusterStateManager::do_cancelRequests(
     failure.code()     = mqbi::ClusterErrorCode::e_UNKNOWN;
     failure.message()  = "Cancellation by Cluster FSM";
 
-    d_clusterData_p->requestManager().cancelAllRequests(
+    d_clusterData_p->requestManager().cancelComponentRequests(
         response,
         bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
 }

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -388,6 +388,7 @@ void ClusterStateManager::do_sendFollowerLSNRequests(
         .makeFollowerLSNRequest();
 
     contextSp->setDestinationNodes(followers);
+    contextSp->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
     contextSp->setResponseCb(
         bdlf::BindUtil::bind(&ClusterStateManager::onFollowerLSNResponse,
                              this,
@@ -513,6 +514,7 @@ void ClusterStateManager::do_sendFollowerClusterStateRequest(
 
     RequestContextSp request =
         d_clusterData_p->requestManager().createRequest();
+    request->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
     request->request()
         .choice()
         .makeClusterMessage()
@@ -740,6 +742,7 @@ void ClusterStateManager::do_sendRegistrationRequest(
 
     RequestContextSp request =
         d_clusterData_p->requestManager().createRequest();
+    request->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
 
     bmqp_ctrlmsg::RegistrationRequest& registrationRequest =
         request->request()
@@ -1097,7 +1100,9 @@ void ClusterStateManager::do_cancelRequests(
     failure.code()     = mqbi::ClusterErrorCode::e_UNKNOWN;
     failure.message()  = "Cancellation by Cluster FSM";
 
-    d_clusterData_p->requestManager().cancelAllRequests(response);
+    d_clusterData_p->requestManager().cancelAllRequests(
+        response,
+        bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
 }
 
 // PRIVATE MANIPULATORS

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -19,7 +19,7 @@
 //@PURPOSE: Provide a mechanism to manage multiple requests.
 //
 //@CLASSES:
-//  mqbnet::MultiRequestManager     : Mechanism to manage multiple requests
+//  mqbnet::MultiRequestManager: Mechanism to manage multiple requests
 //
 //@DESCRIPTION: 'mqbnet::MultiRequestManager' is a mechanism to manage multiple
 // requests sent to peer nodes in a cluster.
@@ -113,6 +113,8 @@ class MultiRequestManagerRequestContext {
 
     ResponseCb d_responseCb;
 
+    bmqp::RequestManagerComponentId::Enum d_componentId;
+
   private:
     // NOT IMPLEMENTED
     MultiRequestManagerRequestContext(
@@ -146,8 +148,16 @@ class MultiRequestManagerRequestContext {
     /// Set the response call to the specified `value`.
     void setResponseCb(const ResponseCb& value);
 
+    /// Set the component id to the specified `value`.  This value is
+    /// propagated to each sub-request created by the `MultiRequestManager`
+    /// when sending.
+    void setComponentId(bmqp::RequestManagerComponentId::Enum value);
+
     // ACCESSORS
     const REQUEST& request() const;
+
+    /// Return the component id.
+    bmqp::RequestManagerComponentId::Enum componentId() const;
 
     /// Return a reference offering non-modifiable access to the
     /// corresponding member of this object.
@@ -274,6 +284,7 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
 , d_nodeResponsePairs(allocator)
 , d_numOutstandingRequests(0)
 , d_responseCb(bsl::allocator_arg, allocator)
+, d_componentId(bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID)
 {
     // NOTHING
 }
@@ -286,6 +297,7 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::clear()
     d_nodeResponsePairs.clear();
     d_numOutstandingRequests = 0;
     d_responseCb             = bsl::nullptr_t();
+    d_componentId = bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID;
 }
 
 template <class REQUEST, class RESPONSE, class TARGET>
@@ -314,12 +326,27 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
     d_responseCb = value;
 }
 
+template <class REQUEST, class RESPONSE, class TARGET>
+void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
+    setComponentId(bmqp::RequestManagerComponentId::Enum value)
+{
+    d_componentId = value;
+}
+
 // ACCESSORS
 template <class REQUEST, class RESPONSE, class TARGET>
 const REQUEST&
 MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::request() const
 {
     return d_request;
+}
+
+template <class REQUEST, class RESPONSE, class TARGET>
+bmqp::RequestManagerComponentId::Enum
+MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::componentId()
+    const
+{
+    return d_componentId;
 }
 
 template <class REQUEST, class RESPONSE, class TARGET>
@@ -455,6 +482,7 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
                                  context,
                                  it->first));
         setGroupId(singleRequestCtx, it->first);
+        singleRequestCtx->setComponentId(context->componentId());
 
         bsl::string               errorDescription;
         bmqt::GenericResult::Enum sendRc = d_requestManager_p->sendRequest(

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -762,7 +762,7 @@ static void test5_cancelByComponentIdTest()
 
         // Cancel only CLUSTER_FSM requests
         Mes reason = context.createResponseCancel();
-        context.manager()->cancelAllRequests(
+        context.manager()->cancelComponentRequests(
             reason,
             bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
 

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -167,6 +167,9 @@ class TestContext {
     /// Return shared pointer to the RequestManager object
     ReqManagerTypeSp manager();
 
+    /// Return shared pointer to the MultiRequestManager object
+    MultiReqManagerTypeSp multiManager();
+
     /// Return cluster nodes.
     Nodes& nodes();
 
@@ -293,6 +296,11 @@ ReqContextSp& TestContext::context()
 ReqManagerTypeSp TestContext::manager()
 {
     return d_requestManager;
+}
+
+MultiReqManagerTypeSp TestContext::multiManager()
+{
+    return d_multiRequestManager;
 }
 
 Nodes& TestContext::nodes()
@@ -441,6 +449,14 @@ static void test1_contextTest()
         BMQTST_ASSERT_PASS(reqContext = bsl::make_shared<ReqContextType>(
                                bmqtst::TestHelperUtil::allocator()));
 
+        BMQTST_ASSERT_EQ(reqContext->componentId(),
+                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+
+        reqContext->setComponentId(
+            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+        BMQTST_ASSERT_EQ(reqContext->componentId(),
+                         bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+
         ReqSp request = bsl::make_shared<Req>(
             bmqtst::TestHelperUtil::allocator());
         TestContext::populateRequest(request);
@@ -477,6 +493,8 @@ static void test1_contextTest()
         BMQTST_ASSERT_EQ(reqContext->request(),
                          Mes(bmqtst::TestHelperUtil::allocator()));
         BMQTST_ASSERT(reqContext->response().empty());
+        BMQTST_ASSERT_EQ(reqContext->componentId(),
+                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
     }
 }
 
@@ -676,6 +694,94 @@ static void test4_handleResponseTest()
     }
 }
 
+static void test5_cancelByComponentIdTest()
+// ------------------------------------------------------------------------
+// Testing:
+//    cancelAllRequests with componentId only cancels matching sub-requests
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CANCEL BY COMPONENT ID TEST");
+
+    {
+        // Declare booleans before TestContext so they outlive it (the
+        // destructor cancels remaining requests, invoking callbacks).
+        bool clusterCalled   = false;
+        bool partitionCalled = false;
+        bool untaggedCalled  = false;
+
+        TestContext context(2, bmqtst::TestHelperUtil::allocator());
+
+        // Create 3 multi-request contexts with different componentIds
+        ReqContextSp clusterCtx =
+            context.multiManager()->createRequestContext();
+        ReqContextSp partitionCtx =
+            context.multiManager()->createRequestContext();
+        ReqContextSp untaggedCtx =
+            context.multiManager()->createRequestContext();
+
+        clusterCtx->setDestinationNodes(context.nodes());
+        partitionCtx->setDestinationNodes(context.nodes());
+        untaggedCtx->setDestinationNodes(context.nodes());
+
+        clusterCtx->setComponentId(
+            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+        partitionCtx->setComponentId(
+            bmqp::RequestManagerComponentId::e_PARTITION_FSM);
+        // untaggedCtx: default e_NO_COMPONENT_ID
+
+        clusterCtx->setResponseCb(
+            bdlf::BindUtil::bind(&Caller::callback,
+                                 &clusterCalled,
+                                 bdlf::PlaceHolders::_1));
+        partitionCtx->setResponseCb(
+            bdlf::BindUtil::bind(&Caller::callback,
+                                 &partitionCalled,
+                                 bdlf::PlaceHolders::_1));
+        untaggedCtx->setResponseCb(
+            bdlf::BindUtil::bind(&Caller::callback,
+                                 &untaggedCalled,
+                                 bdlf::PlaceHolders::_1));
+
+        // Populate and send all 3 multi-requests
+        ReqSp req = context.createRequest();
+        context.populateRequest(req);
+
+        clusterCtx->request()   = req->request();
+        partitionCtx->request() = req->request();
+        untaggedCtx->request()  = req->request();
+
+        context.multiManager()->sendRequest(clusterCtx, SEND_REQUEST_TIMEOUT);
+        context.multiManager()->sendRequest(partitionCtx,
+                                            SEND_REQUEST_TIMEOUT);
+        context.multiManager()->sendRequest(untaggedCtx, SEND_REQUEST_TIMEOUT);
+
+        // All 3 multi-requests are outstanding, no callbacks yet
+        BMQTST_ASSERT(!clusterCalled);
+        BMQTST_ASSERT(!partitionCalled);
+        BMQTST_ASSERT(!untaggedCalled);
+
+        // Cancel only CLUSTER_FSM requests
+        Mes reason = context.createResponseCancel();
+        context.manager()->cancelAllRequests(
+            reason,
+            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+
+        // Only the CLUSTER_FSM multi-request callback should have fired
+        BMQTST_ASSERT(clusterCalled);
+        BMQTST_ASSERT(!partitionCalled);
+        BMQTST_ASSERT(!untaggedCalled);
+
+        // Verify the CLUSTER_FSM responses have cancel status
+        const NodeResponses& clusterResponses = clusterCtx->response();
+        for (NodeResponsesIt rIt = clusterResponses.begin();
+             rIt != clusterResponses.end();
+             ++rIt) {
+            BMQTST_ASSERT_EQ(rIt->second.choice().status().category(),
+                             bmqp_ctrlmsg::StatusCategory::E_CANCELED);
+        }
+    }
+}
+
 // ============================================================================
 //                                MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -688,6 +794,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 5: test5_cancelByComponentIdTest(); break;
     case 4: test4_handleResponseTest(); break;
     case 3: test3_sendRequestTest(); break;
     case 2: test2_creatorsTest(); break;


### PR DESCRIPTION
## Summary
  - `ClusterStateManager::do_cancelRequests` currently calls `cancelAllRequests()` with no filter on the shared `ClusterData::requestManager`, which cancels  **all** outstanding requests — including those from other components sharing the same `RequestManager` instance. This is too broad and can interfere with unrelated in-flight operations.
  - This PR adds a `componentId` dimension to `bmqp::RequestManager` so that each component can tag its requests and cancel only its own. The Cluster FSM now tags its requests with `e_CLUSTER_FSM` and `do_cancelRequests` only cancels those.
  - The existing `groupId`-based cancellation (used for per-node cancellation when a node goes down) is unchanged and orthogonal to the new `componentId` axis.