### PR TITLE
Refactor[mqbi::Storage::configure]: simplify interface

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -103,8 +103,7 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
         rc_STORAGE_CREATION_FAILURE = -1,
         rc_INCOMPATIBLE_STORAGE     = -2,
         rc_UNKNOWN_DOMAIN_CONFIG    = -3,
-        rc_QUEUE_ENGINE_CFG_FAILURE = -4,
-        rc_STORAGE_CFG_FAILURE      = -5
+        rc_QUEUE_ENGINE_CFG_FAILURE = -4
     };
 
     int                     rc        = 0;
@@ -147,15 +146,10 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
     }
     else {
         d_state_p->storage()->setConsistency(domainCfg->consistency());
-        rc = d_state_p->storage()->configure(
-            errorDescription,
-            domainCfg->storage().config(),
-            domainCfg->storage().queueLimits(),
-            domainCfg->messageTtl(),
-            domainCfg->maxDeliveryAttempts());
-        if (rc) {
-            return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
-        }
+        d_state_p->storage()->configure(domainCfg->storage().config(),
+                                        domainCfg->storage().queueLimits(),
+                                        domainCfg->messageTtl(),
+                                        domainCfg->maxDeliveryAttempts());
     }
 
     // Create the associated queue-engine. This can either be on first

--- a/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_pushstream.t.cpp
@@ -16,16 +16,13 @@
 #include <mqbblp_pushstream.h>
 
 // MQB
+#include <mqbcfg_messages.h>
 #include <mqbmock_cluster.h>
 #include <mqbmock_domain.h>
+#include <mqbs_inmemorystorage.h>
 
 // BMQ
 #include <bmqp_messageguidgenerator.h>
-
-#include <mqbcfg_messages.h>
-#include <mqbs_inmemorystorage.h>
-
-#include <bmqu_memoutstream.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -142,9 +139,7 @@ static void test2_iterations()
     limits.messages() = bsl::numeric_limits<bsls::Types::Int64>::max();
     limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
 
-    bmqu::MemOutStream errorDescription(bmqtst::TestHelperUtil::allocator());
-    dummyStorage.configure(errorDescription,
-                           config,
+    dummyStorage.configure(config,
                            limits,
                            bsl::numeric_limits<bsls::Types::Int64>::max(),
                            0);

--- a/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueconsumptionmonitor.t.cpp
@@ -293,8 +293,6 @@ Test::Test()
     d_queue._setDispatcher(&d_dispatcher);
     d_queue.setThreadId(bslmt::ThreadUtil::selfId());
 
-    bmqu::MemOutStream errorDescription(d_allocator_p);
-
     bslma::ManagedPtr<mqbi::Queue> queueMp(&d_queue,
                                            0,
                                            bslma::ManagedPtrUtil::noOpDeleter);
@@ -308,8 +306,7 @@ Test::Test()
     limits.messages() = bsl::numeric_limits<bsls::Types::Int64>::max();
     limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
 
-    d_storage.configure(errorDescription,
-                        config,
+    d_storage.configure(config,
                         limits,
                         bsl::numeric_limits<bsls::Types::Int64>::max(),
                         0);

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -566,12 +566,10 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig,
     limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
 
     storage_p->setConsistency(domainConfig.consistency());
-    rc = storage_p->configure(errorDescription,
-                              config,
-                              limits,
-                              domainConfig.messageTtl(),
-                              domainConfig.maxDeliveryAttempts());
-    BSLS_ASSERT_OPT(rc == 0 && "storage configure fail");
+    storage_p->configure(config,
+                         limits,
+                         domainConfig.messageTtl(),
+                         domainConfig.maxDeliveryAttempts());
 
     // Add virtual storages
     const bool isFanoutMode = domainConfig.mode().isFanoutValue();

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.cpp
@@ -96,10 +96,9 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     enum RcEnum {
         // Value for the various RC error categories
         rc_SUCCESS                  = 0,
-        rc_STORAGE_CFG_FAILURE      = -1,
-        rc_INCOMPATIBLE_STORAGE     = -2,
-        rc_UNKNOWN_DOMAIN_CONFIG    = -3,
-        rc_QUEUE_ENGINE_CFG_FAILURE = -4
+        rc_INCOMPATIBLE_STORAGE     = -1,
+        rc_UNKNOWN_DOMAIN_CONFIG    = -2,
+        rc_QUEUE_ENGINE_CFG_FAILURE = -3
     };
 
     if (isReconfigure) {
@@ -134,14 +133,10 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
 
     storageSp->setConsistency(domainCfg.consistency());
-    int rc = storageSp->configure(errorDescription,
-                                  config,
-                                  limits,
-                                  domainCfg.messageTtl(),
-                                  domainCfg.maxDeliveryAttempts());
-    if (0 != rc) {
-        return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
-    }
+    storageSp->configure(config,
+                         limits,
+                         domainCfg.messageTtl(),
+                         domainCfg.maxDeliveryAttempts());
 
     storageSp->capacityMeter()->disable();
     // In a remote queue, we don't care about monitoring, so disable it for
@@ -162,7 +157,8 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
             RelayQueueEngine(d_state_p, mqbconfm::Domain(), d_allocator_p),
         d_allocator_p);
 
-    rc = d_queueEngine_mp->configure(errorDescription, isReconfigure);
+    const int rc = d_queueEngine_mp->configure(errorDescription,
+                                               isReconfigure);
     if (rc != 0) {
         return 10 * rc + rc_QUEUE_ENGINE_CFG_FAILURE;  // RETURN
     }
@@ -185,18 +181,16 @@ int RemoteQueue::configureAsProxy(bsl::ostream& errorDescription,
     return rc_SUCCESS;
 }
 
-int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
-                                          bool          isReconfigure)
+int RemoteQueue::configureAsClusterMember(bool isReconfigure)
 {
     // executed by the *QUEUE DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_state_p->queue()->inDispatcherThread());
     enum {
-        rc_SUCCESS                   = 0,
-        rc_QUEUE_CONFIGURE_FAILURE   = -1,
-        rc_ENGINE_CONFIGURE_FAILURE  = -2,
-        rc_STORAGE_CONFIGURE_FAILURE = -3
+        rc_SUCCESS                  = 0,
+        rc_QUEUE_CONFIGURE_FAILURE  = -1,
+        rc_ENGINE_CONFIGURE_FAILURE = -2
     };
 
     int                     rc        = 0;
@@ -259,15 +253,10 @@ int RemoteQueue::configureAsClusterMember(bsl::ostream& errorDescription,
     }
     else {
         d_state_p->storage()->setConsistency(domainCfg->consistency());
-        rc = d_state_p->storage()->configure(
-            errorDescription,
-            domainCfg->storage().config(),
-            domainCfg->storage().domainLimits(),
-            domainCfg->messageTtl(),
-            domainCfg->maxDeliveryAttempts());
-        if (rc) {
-            return 10 * rc + rc_STORAGE_CONFIGURE_FAILURE;  // RETURN
-        }
+        d_state_p->storage()->configure(domainCfg->storage().config(),
+                                        domainCfg->storage().domainLimits(),
+                                        domainCfg->messageTtl(),
+                                        domainCfg->maxDeliveryAttempts());
     }
 
     bdlma::LocalSequentialAllocator<1024> localAllocator(d_allocator_p);
@@ -562,8 +551,8 @@ int RemoteQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
         return configureAsProxy(errorDescription, isReconfigure);  // RETURN
     }
     else {
-        return configureAsClusterMember(errorDescription, isReconfigure);
-        // RETURN
+        // Will print an ALARM on failure
+        return configureAsClusterMember(isReconfigure);  // RETURN
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_remotequeue.h
@@ -250,8 +250,7 @@ class RemoteQueue {
     // PRIVATE MANIPULATORS
     int configureAsProxy(bsl::ostream& errorDescription, bool isReconfigure);
 
-    int configureAsClusterMember(bsl::ostream& errorDescription,
-                                 bool          isReconfigure);
+    int configureAsClusterMember(bool isReconfigure);
 
     /// Load into the specified `subQueueInfos` all subQueueIds which are
     /// present in the `SubQueueIdsOption` of the specified `options` of the

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3151,9 +3151,8 @@ int StorageUtil::configureStorage(
 
     enum {
         // Value for the various RC error categories
-        rc_SUCCESS             = 0,
-        rc_STORAGE_CFG_FAILURE = -1,
-        rc_UNKNOWN_QUEUE       = -2
+        rc_SUCCESS       = 0,
+        rc_UNKNOWN_QUEUE = -1
     };
 
     bslmt::LockGuard<bslmt::Mutex> guard(storagesLock);  // LOCK
@@ -3183,16 +3182,10 @@ int StorageUtil::configureStorage(
 
     // Do not change consistency level of `storageSp`, use the one provided on
     // construction instead.
-    const int rc = storageSp->configure(errorDescription,
-                                        storageDef.config(),
-                                        storageDef.queueLimits(),
-                                        messageTtl,
-                                        maxDeliveryAttempts);
-
-    if (0 != rc) {
-        return 10 * rc + rc_STORAGE_CFG_FAILURE;  // RETURN
-    }
-
+    storageSp->configure(storageDef.config(),
+                         storageDef.queueLimits(),
+                         messageTtl,
+                         maxDeliveryAttempts);
     *out = storageSp;
 
     static_cast<void>(queueKey);

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -451,16 +451,12 @@ class Storage {
     // MANIPULATORS
 
     /// Configure this storage using the specified `config` and `limits`.
-    /// Return 0 on success, or a non-zero return code and fill in a
-    /// description of the error in the specified `errorDescription`
-    /// otherwise.  Note that calling `configure` on an already configured
-    /// storage should atomically reconfigure that storage with the new
-    /// configuration (or fail and leave the storage untouched).
-    virtual int configure(bsl::ostream&            errorDescription,
-                          const mqbconfm::Storage& config,
-                          const mqbconfm::Limits&  limits,
-                          const bsls::Types::Int64 messageTtl,
-                          const int                maxDeliveryAttempts) = 0;
+    /// Note that calling `configure` on an already configured storage should
+    /// atomically reconfigure that storage with the new configuration.
+    virtual void configure(const mqbconfm::Storage& config,
+                           const mqbconfm::Limits&  limits,
+                           bsls::Types::Int64       messageTtl,
+                           int                      maxDeliveryAttempts) = 0;
 
     /// Set the consistency level associated to this storage to the specified
     /// `value`.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -233,7 +233,7 @@ bool FileBackedStorage::hasReceipt(const bmqt::MessageGUID& msgGUID) const
 
 void FileBackedStorage::configure(const mqbconfm::Storage& config,
                                   const mqbconfm::Limits&  limits,
-                                  const bsls::Types::Int64 messageTtl,
+                                  bsls::Types::Int64       messageTtl,
                                   int                      maxDeliveryAttempts)
 {
     d_config = config;

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -231,12 +231,10 @@ bool FileBackedStorage::hasReceipt(const bmqt::MessageGUID& msgGUID) const
     return d_store_p->hasReceipt(handles[0]);
 }
 
-int FileBackedStorage::configure(
-    BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
-    const mqbconfm::Storage&        config,
-    const mqbconfm::Limits&         limits,
-    const bsls::Types::Int64        messageTtl,
-    int                             maxDeliveryAttempts)
+void FileBackedStorage::configure(const mqbconfm::Storage& config,
+                                  const mqbconfm::Limits&  limits,
+                                  const bsls::Types::Int64 messageTtl,
+                                  int                      maxDeliveryAttempts)
 {
     d_config = config;
     d_capacityMeter.setLimits(limits.messages(), limits.bytes())
@@ -245,8 +243,6 @@ int FileBackedStorage::configure(
     d_ttlSeconds = messageTtl;
 
     d_virtualStorageCatalog.setDefaultRda(maxDeliveryAttempts);
-
-    return 0;
 }
 
 void FileBackedStorage::setConsistency(const mqbconfm::Consistency& value)

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.h
@@ -383,16 +383,12 @@ class FileBackedStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     // MANIPULATORS
 
     /// Configure this storage using the specified `config` and `limits`.
-    /// Return 0 on success, or an non-zero return code and fill in a
-    /// description of the error in the specified `errorDescription`
-    /// otherwise.  Note that calling `configure` on an already configured
-    /// storage should atomically reconfigure that storage with the new
-    /// configuration (or fail and leave the storage untouched).
-    int configure(bsl::ostream&            errorDescription,
-                  const mqbconfm::Storage& config,
-                  const mqbconfm::Limits&  limits,
-                  const bsls::Types::Int64 messageTtl,
-                  int maxDeliveryAttempts) BSLS_KEYWORD_OVERRIDE;
+    /// Note that calling `configure` on an already configured storage should
+    /// atomically reconfigure that storage with the new configuration.
+    void configure(const mqbconfm::Storage& config,
+                   const mqbconfm::Limits&  limits,
+                   bsls::Types::Int64       messageTtl,
+                   int maxDeliveryAttempts) BSLS_KEYWORD_OVERRIDE;
 
     /// Set the consistency level associated to this storage to the specified
     /// `value`.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -597,11 +597,11 @@ struct Tester {
     }
 
     // MANIPULATORS
-    int configure(bsls::Types::Int64 msgCapacity       = k_DEFAULT_MSG,
-                  bsls::Types::Int64 byteCapacity      = k_DEFAULT_BYTES,
-                  double             msgWatermarkRatio = k_MSG_WATERMARK_RATIO,
-                  double byteWatermarkRatio     = k_BYTE_WATERMARK_RATIO,
-                  bsls::Types::Int64 messageTtl = k_INT64_MAX)
+    void configure(bsls::Types::Int64 msgCapacity  = k_DEFAULT_MSG,
+                   bsls::Types::Int64 byteCapacity = k_DEFAULT_BYTES,
+                   double msgWatermarkRatio        = k_MSG_WATERMARK_RATIO,
+                   double byteWatermarkRatio       = k_BYTE_WATERMARK_RATIO,
+                   bsls::Types::Int64 messageTtl   = k_INT64_MAX)
     {
         // PRECONDITIONS
         BSLS_ASSERT_OPT(d_replicatedStorage_mp && "Storage was not created");
@@ -616,12 +616,10 @@ struct Tester {
         limits.bytes()                  = byteCapacity;
         limits.bytesWatermarkRatio()    = byteWatermarkRatio;
 
-        bmqu::MemOutStream errDescription(bmqtst::TestHelperUtil::allocator());
-        return d_replicatedStorage_mp->configure(errDescription,
-                                                 config,
-                                                 limits,
-                                                 messageTtl,
-                                                 0);  // maxDeliveryAttempts
+        d_replicatedStorage_mp->configure(config,
+                                          limits,
+                                          messageTtl,
+                                          0);  // maxDeliveryAttempts
     }
 
     mqbs::ReplicatedStorage& storage()
@@ -817,14 +815,14 @@ BMQTST_TEST(configure)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES) == 0);
+    tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
     BMQTST_ASSERT_EQ(storage.capacityMeter()->byteCapacity(), k_DEFAULT_BYTES);
     BMQTST_ASSERT_EQ(storage.config(), fileBackedStorageConfig());
 
-    BMQTST_ASSERT_EQ(tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES + 5), 0);
+    tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES + 5);
     BMQTST_ASSERT_EQ(storage.capacityMeter()->byteCapacity(),
                      k_DEFAULT_BYTES + 5);
     BMQTST_ASSERT_EQ(storage.config(), fileBackedStorageConfig());
@@ -1225,7 +1223,7 @@ BMQTST_TEST(put_withVirtualStorages)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1294,7 +1292,7 @@ BMQTST_TEST(removeAllMessages_appKeyNotFound)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1344,7 +1342,7 @@ BMQTST_TEST(removeAllMessages)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1409,7 +1407,7 @@ BMQTST_TEST(get_withVirtualStorages)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1468,7 +1466,7 @@ BMQTST_TEST(confirm)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1622,7 +1620,7 @@ BMQTST_TEST(getIterator_withVirtualStorages)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1767,7 +1765,7 @@ BMQTST_TEST(capacityMeter_limitBytes)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     bsl::vector<bmqt::MessageGUID> guids(bmqtst::TestHelperUtil::allocator());
 
@@ -1811,11 +1809,11 @@ BMQTST_TEST(garbageCollect)
 
     Tester tester(bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_DEFAULT_MSG,
-                                     k_DEFAULT_BYTES,
-                                     k_MSG_WATERMARK_RATIO,
-                                     k_BYTE_WATERMARK_RATIO,
-                                     k_TTL) == 0);
+    tester.configure(k_DEFAULT_MSG,
+                     k_DEFAULT_BYTES,
+                     k_MSG_WATERMARK_RATIO,
+                     k_BYTE_WATERMARK_RATIO,
+                     k_TTL);
 
     bsl::vector<bmqt::MessageGUID> guids(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.cpp
@@ -100,12 +100,10 @@ InMemoryStorage::~InMemoryStorage()
 
 // MANIPULATORS
 //   (virtual mqbi::Storage)
-int InMemoryStorage::configure(
-    BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
-    const mqbconfm::Storage&        config,
-    const mqbconfm::Limits&         limits,
-    const bsls::Types::Int64        messageTtl,
-    const int                       maxDeliveryAttempts)
+void InMemoryStorage::configure(const mqbconfm::Storage& config,
+                                const mqbconfm::Limits&  limits,
+                                bsls::Types::Int64       messageTtl,
+                                int                      maxDeliveryAttempts)
 {
     d_config = config;
     d_capacityMeter.setLimits(limits.messages(), limits.bytes())
@@ -114,8 +112,6 @@ int InMemoryStorage::configure(
     d_ttlSeconds = messageTtl;
 
     d_virtualStorageCatalog.setDefaultRda(maxDeliveryAttempts);
-
-    return 0;
 }
 
 void InMemoryStorage::setConsistency(const mqbconfm::Consistency& value)

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.h
@@ -267,15 +267,12 @@ class InMemoryStorage BSLS_KEYWORD_FINAL : public ReplicatedStorage {
     //   (virtual mqbi::Storage)
 
     /// Configure this storage using the specified `config` and `limits`.
-    /// Return 0 on success, or an non-zero return code and fill in a
-    /// description of the error in the specified `errorDescription`
-    /// otherwise.  Note that calling `configure` on an already configured
-    /// storage should fail and leave the storage untouched.
-    int configure(bsl::ostream&            errorDescription,
-                  const mqbconfm::Storage& config,
-                  const mqbconfm::Limits&  limits,
-                  const bsls::Types::Int64 messageTtl,
-                  const int maxDeliveryAttempts) BSLS_KEYWORD_OVERRIDE;
+    /// Note that calling `configure` on an already configured storage should
+    /// atomically reconfigure that storage with the new configuration.
+    void configure(const mqbconfm::Storage& config,
+                   const mqbconfm::Limits&  limits,
+                   bsls::Types::Int64       messageTtl,
+                   int maxDeliveryAttempts) BSLS_KEYWORD_OVERRIDE;
 
     /// Set the consistency level associated to this storage to the specified
     /// `value`.

--- a/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_inmemorystorage.t.cpp
@@ -214,11 +214,11 @@ struct Tester {
     }
 
     // MANIPULATORS
-    int configure(bsls::Types::Int64 msgCapacity       = k_DEFAULT_MSG,
-                  bsls::Types::Int64 byteCapacity      = k_DEFAULT_BYTES,
-                  double             msgWatermarkRatio = k_MSG_WATERMARK_RATIO,
-                  double byteWatermarkRatio     = k_BYTE_WATERMARK_RATIO,
-                  bsls::Types::Int64 messageTtl = k_INT64_MAX)
+    void configure(bsls::Types::Int64 msgCapacity  = k_DEFAULT_MSG,
+                   bsls::Types::Int64 byteCapacity = k_DEFAULT_BYTES,
+                   double msgWatermarkRatio        = k_MSG_WATERMARK_RATIO,
+                   double byteWatermarkRatio       = k_BYTE_WATERMARK_RATIO,
+                   bsls::Types::Int64 messageTtl   = k_INT64_MAX)
     {
         // PRECONDITIONS
         BSLS_ASSERT_OPT(d_replicatedStorage_mp && "Storage was not created");
@@ -233,12 +233,10 @@ struct Tester {
         limits.bytes()                  = byteCapacity;
         limits.bytesWatermarkRatio()    = byteWatermarkRatio;
 
-        bmqu::MemOutStream errDescription(bmqtst::TestHelperUtil::allocator());
-        return d_replicatedStorage_mp->configure(errDescription,
-                                                 config,
-                                                 limits,
-                                                 messageTtl,
-                                                 0);  // maxDeliveryAttempts
+        d_replicatedStorage_mp->configure(config,
+                                          limits,
+                                          messageTtl,
+                                          0);  // maxDeliveryAttempts
     }
 
     mqbs::ReplicatedStorage& storage()
@@ -426,14 +424,14 @@ BMQTST_TEST(configure)
 
     Tester tester(k_PROXY_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES) == 0);
+    tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
     BMQTST_ASSERT_EQ(storage.capacityMeter()->byteCapacity(), k_DEFAULT_BYTES);
     BMQTST_ASSERT_EQ(storage.config(), inMemoryStorageConfig());
 
-    BMQTST_ASSERT_EQ(tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES + 5), 0);
+    tester.configure(k_DEFAULT_MSG, k_DEFAULT_BYTES + 5);
     BMQTST_ASSERT_EQ(storage.capacityMeter()->byteCapacity(),
                      k_DEFAULT_BYTES + 5);
     BMQTST_ASSERT_EQ(storage.config(), inMemoryStorageConfig());
@@ -806,7 +804,7 @@ BMQTST_TEST(put_withVirtualStorages)
 
     Tester tester(k_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -875,7 +873,7 @@ BMQTST_TEST(removeAllMessages_appKeyNotFound)
 
     Tester tester(k_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -925,7 +923,7 @@ BMQTST_TEST(removeAllMessages)
 
     Tester tester(k_PROXY_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -990,7 +988,7 @@ BMQTST_TEST(get_withVirtualStorages)
 
     Tester tester(k_PROXY_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1052,7 +1050,7 @@ BMQTST_TEST(confirm)
 
     Tester tester(k_PROXY_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1201,7 +1199,7 @@ BMQTST_TEST(getIterator_withVirtualStorages)
 
     Tester tester(k_PROXY_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     mqbs::ReplicatedStorage& storage = tester.storage();
 
@@ -1346,7 +1344,7 @@ BMQTST_TEST(capacityMeter_limitBytes)
 
     Tester tester(k_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT) == 0);
+    tester.configure(k_MSG_LIMIT, k_BYTES_LIMIT);
 
     bsl::vector<bmqt::MessageGUID> guids(bmqtst::TestHelperUtil::allocator());
 
@@ -1390,11 +1388,11 @@ BMQTST_TEST(garbageCollect)
 
     Tester tester(k_PARTITION_ID, bmqtst::TestHelperUtil::allocator());
 
-    BSLS_ASSERT_OPT(tester.configure(k_DEFAULT_MSG,
-                                     k_DEFAULT_BYTES,
-                                     k_MSG_WATERMARK_RATIO,
-                                     k_BYTE_WATERMARK_RATIO,
-                                     k_TTL) == 0);
+    tester.configure(k_DEFAULT_MSG,
+                     k_DEFAULT_BYTES,
+                     k_MSG_WATERMARK_RATIO,
+                     k_BYTE_WATERMARK_RATIO,
+                     k_TTL);
 
     bsl::vector<bmqt::MessageGUID> guids(bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_storageprintutil.t.cpp
@@ -173,8 +173,7 @@ struct Tester {
         limits.bytes()                  = k_INT64_MAX;
         limits.bytesWatermarkRatio()    = 0.8;
 
-        d_storage_mp->configure(errorDescription,
-                                config,
+        d_storage_mp->configure(config,
                                 limits,
                                 domainCfg.messageTtl(),
                                 domainCfg.maxDeliveryAttempts());


### PR DESCRIPTION
Remove int return code and output error stream.
We always verify parameters before passing it to any storage.