### PR TITLE
Style: Remove anonymous namespace from header

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -92,18 +92,19 @@ class ClusterNode;
 
 namespace mqbc {
 
-namespace {
-/// Constant used to represent an invalid partition id.
-const unsigned int k_INVALID_PARTITION_ID =
-    bsl::numeric_limits<unsigned int>::max();
-}  // close unnamed namespace
-
 // ==================
 // struct StorageUtil
 // ==================
 
 /// Generic utilities for storage related operations.
 struct StorageUtil {
+  public:
+    // PUBLIC CONSTANTS
+
+    /// Constant used to represent an invalid partition id.
+    static const unsigned int k_INVALID_PARTITION_ID =
+        static_cast<unsigned int>(mqbi::Storage::k_INVALID_PARTITION_ID);
+
   private:
     // CLASS SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBC.STORAGEUTIL");

--- a/src/groups/mqb/mqbi/mqbi_storage.h
+++ b/src/groups/mqb/mqbi/mqbi_storage.h
@@ -422,6 +422,10 @@ class StorageIterator {
 class Storage {
   public:
     // PUBLIC CONSTANTS
+    /// Note that this has the same bit pattern as
+    /// `mqbc::StorageUtil::k_INVALID_PARTITION_ID` (`UINT_MAX`), which is
+    /// the unsigned counterpart used when working with wire-protocol
+    /// partition IDs.
     static const int k_INVALID_PARTITION_ID = -1;
 
     /// A constant representing any (but not invalid) partitionId.  This is


### PR DESCRIPTION
This patch removes the anonymous namespace containing `k_INVALID_PARTITION_ID` from mqbc_storageutil’s header, moving it instead to the utility struct contained within that file.

This patch also documents why there are two `k_INVALID_PARTITION_ID` constants in different components that seemingly have different values.