### PR TITLE
Fix[bmqbrkr, bmq]: init allocation limits early

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -393,7 +393,8 @@ static int initializeTask(bsl::ostream&    errorDescription,
     // Create the Task
     new (taskEnv->d_task.buffer())
         m_bmqbrkr::Task(taskEnv->d_bmqPrefix,
-                        taskEnv->d_config.taskConfig().allocatorType());
+                        taskEnv->d_config.taskConfig().allocatorType(),
+                        taskEnv->d_config.taskConfig().allocationLimit());
 
     bmqu::MemOutStream localError;
     const int          rc = taskEnv->d_task.object().initialize(

--- a/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
@@ -94,8 +94,11 @@ void onAllocationLimit(bsls::Types::Uint64 limit)
 // class Task_AllocatorManager
 // ---------------------------
 
-Task_AllocatorManager::Task_AllocatorManager(mqbcfg::AllocatorType::Value type)
+Task_AllocatorManager::Task_AllocatorManager(
+    mqbcfg::AllocatorType::Value type,
+    bsls::Types::Uint64          allocationLimit)
 : d_type(type)
+, d_allocationLimit(allocationLimit)
 , d_store()
 , d_stackTraceTestAllocator(bslma::Default::allocator(0))
 , d_store_p(0)
@@ -137,8 +140,10 @@ Task_AllocatorManager::Task_AllocatorManager(mqbcfg::AllocatorType::Value type)
     } break;
     case mqbcfg::AllocatorType::COUNTING: {
         bmqma::CountingAllocatorUtil::initGlobalAllocators(
-            bmqst::StatContextConfiguration("task"),
-            "allocators");
+            "task",
+            "allocators",
+            allocationLimit,
+            bdlf::BindUtil::bind(&onAllocationLimit, allocationLimit));
 
         d_statContext_p = bmqma::CountingAllocatorUtil::globalStatContext();
         d_store_p       = &bmqma::CountingAllocatorUtil::topAllocatorStore();
@@ -229,8 +234,9 @@ void Task::onLogCommand(const bsl::string& prefix, bsl::istream& input)
 }
 
 Task::Task(const bsl::string&           bmqPrefix,
-           mqbcfg::AllocatorType::Value allocatorType)
-: d_allocatorManager(allocatorType)
+           mqbcfg::AllocatorType::Value allocatorType,
+           bsls::Types::Uint64          allocationLimit)
+: d_allocatorManager(allocatorType, allocationLimit)
 , d_isInitialized(false)
 , d_bmqPrefix(bmqPrefix, d_allocatorManager.store().get("Task"))
 , d_scheduler(bsls::SystemClockType::e_MONOTONIC,
@@ -305,27 +311,15 @@ int Task::initialize(bsl::ostream&             errorDescription,
 
     // ----------------
     // Allocation limit
-    // Set allocation limit if enabled and using counting allocator
-    if (d_allocatorManager.type() == mqbcfg::AllocatorType::COUNTING) {
-        if (config.allocationLimit() == 0) {
-            BALL_LOG_INFO << "No memory allocation limit set!";
-        }
-        else {
-            BALL_LOG_INFO << "Memory allocation limit set to "
-                          << bmqu::PrintUtil::prettyBytes(
-                                 config.allocationLimit());
-
-            bmqma::CountingAllocator* topAllocator =
-                dynamic_cast<bmqma::CountingAllocator*>(
-                    bmqma::CountingAllocatorUtil::topAllocatorStore()
-                        .baseAllocator());
-
-            BSLS_ASSERT_OPT(topAllocator);
-            topAllocator->setAllocationLimit(
-                config.allocationLimit(),
-                bdlf::BindUtil::bind(&onAllocationLimit,
-                                     config.allocationLimit()));
-        }
+    // Just log the configured limit
+    const bsls::Types::Uint64 allocationLimit =
+        d_allocatorManager.allocationLimit();
+    if (allocationLimit == 0) {
+        BALL_LOG_INFO << "No memory allocation limit set!";
+    }
+    else {
+        BALL_LOG_INFO << "Memory allocation limit set to "
+                      << bmqu::PrintUtil::prettyBytes(allocationLimit);
     }
 
     // ---------------

--- a/src/applications/bmqbrkr/m_bmqbrkr_task.h
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.h
@@ -105,6 +105,10 @@ class Task_AllocatorManager {
     mqbcfg::AllocatorType::Value d_type;
     // Type of allocator in use.
 
+    bsls::Types::Uint64 d_allocationLimit;
+    // Allocation limit in bytes, or 0 if
+    // no limit is set.
+
     bsls::ObjectBuffer<bmqma::CountingAllocatorStore> d_store;
     // Allocator store, to dispence allocators
     // based on the configured type; used if
@@ -135,11 +139,17 @@ class Task_AllocatorManager {
   public:
     // CREATORS
 
-    /// Create a new object, configured to use the specified `type`
-    /// allocator'.  Note that when using the `COUNTING` allocator, the
-    /// `default` and `global` allocators are changed to be counting
-    /// allocators too.
-    explicit Task_AllocatorManager(mqbcfg::AllocatorType::Value type);
+    /// @brief Create a new object managing process-wide allocators.
+    ///
+    /// @param type           Allocator type to use.
+    /// @param allocationLimit  Maximum bytes before the limit callback fires
+    ///                         (0 means no limit).
+    ///
+    /// Note that when using the `COUNTING` allocator, the `default` and
+    /// `global` allocators are changed to be counting allocators too, and
+    /// the allocation limit is set during initialization.
+    explicit Task_AllocatorManager(mqbcfg::AllocatorType::Value type,
+                                   bsls::Types::Uint64 allocationLimit);
 
     /// Destroy this object.  If the allocator is of type `STACKTRACETEST`,
     /// any detected memory leak will be reported to stdout.
@@ -158,8 +168,9 @@ class Task_AllocatorManager {
 
     // ACCESSORS
 
-    /// Return the type of allocator used.
-    mqbcfg::AllocatorType::Value type() const;
+    /// Return the allocation limit if set and counting allocator is used.
+    /// Return 0 otherwise.
+    bsls::Types::Uint64 allocationLimit() const;
 };
 
 //===========
@@ -233,11 +244,15 @@ class Task {
   public:
     // CREATORS
 
-    /// Create a new task, creating the pipe control channel in the
-    /// specified `bmqPrefix` directory.  Use the specified `allocatorType`
-    /// for memory allocations.
-    Task(const bsl::string&           bmqPrefix,
-         mqbcfg::AllocatorType::Value allocatorType);
+    /// @brief Create a new task.
+    ///
+    /// @param bmqPrefix        Directory for the pipe control channel.
+    /// @param allocatorType    Allocator type for memory allocations.
+    /// @param allocationLimit  Maximum bytes before the limit callback fires
+    ///                         (0 means no limit).
+    explicit Task(const bsl::string&           bmqPrefix,
+                  mqbcfg::AllocatorType::Value allocatorType,
+                  bsls::Types::Uint64          allocationLimit);
 
     /// Destroy this object.  If the task was successfully initialized,
     /// `shutdown()` must be called prior to destruction of this object.
@@ -319,9 +334,9 @@ inline bmqma::CountingAllocatorStore& Task_AllocatorManager::store()
     return *d_store_p;
 }
 
-inline mqbcfg::AllocatorType::Value Task_AllocatorManager::type() const
+inline bsls::Types::Uint64 Task_AllocatorManager::allocationLimit() const
 {
-    return d_type;
+    return (d_type == mqbcfg::AllocatorType::COUNTING) ? d_allocationLimit : 0;
 }
 
 // ----------

--- a/src/groups/bmq/bmqma/bmqma_countingallocatorutil.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocatorutil.cpp
@@ -64,8 +64,10 @@ bsls::AtomicBool g_initialized(false);
 
 // CLASS METHODS
 void CountingAllocatorUtil::initGlobalAllocators(
-    const bmqst::StatContextConfiguration& globalStatContextConfiguration,
-    const bslstl::StringRef&               topAllocatorName)
+    bsl::string_view             globalStatContextName,
+    bsl::string_view             topAllocatorName,
+    bsls::Types::Uint64          allocationLimit,
+    const bsl::function<void()>& allocationLimitCb)
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(g_initialized.testAndSwap(false, true) != true);
@@ -75,8 +77,9 @@ void CountingAllocatorUtil::initGlobalAllocators(
     bslma::Allocator* alloc = &bslma::NewDeleteAllocator::singleton();
 
     // Here we create the main CountingAllocator and its StatContext.
-    new (g_statContext.buffer())
-        bmqst::StatContext(globalStatContextConfiguration, alloc);
+    new (g_statContext.buffer()) bmqst::StatContext(
+        bmqst::StatContextConfiguration(globalStatContextName),
+        alloc);
     bmqst::StatContext& stats = g_statContext.object();
 
     new (g_topAllocator.buffer())
@@ -84,21 +87,16 @@ void CountingAllocatorUtil::initGlobalAllocators(
 
     // Create the topAllocatorStore and the default and global allocators
     bmqma::CountingAllocator& topAllocator = g_topAllocator.object();
+    if (allocationLimit > 0) {
+        topAllocator.setAllocationLimit(allocationLimit, allocationLimitCb);
+    }
+
     new (g_topAllocatorStore.buffer())
         bmqma::CountingAllocatorStore(&topAllocator);
 
     bmqma::CountingAllocatorStore& topStore = g_topAllocatorStore.object();
     bslma::Default::setGlobalAllocator(topStore.get("Global Allocator"));
     bslma::Default::setDefaultAllocatorRaw(topStore.get("Default Allocator"));
-}
-
-void CountingAllocatorUtil::initGlobalAllocators(
-    const bslstl::StringRef& globalStatContextName,
-    const bslstl::StringRef& topAllocatorName)
-{
-    initGlobalAllocators(
-        bmqst::StatContextConfiguration(globalStatContextName),
-        topAllocatorName);
 }
 
 bmqst::StatContext* CountingAllocatorUtil::globalStatContext()

--- a/src/groups/bmq/bmqma/bmqma_countingallocatorutil.h
+++ b/src/groups/bmq/bmqma/bmqma_countingallocatorutil.h
@@ -32,8 +32,9 @@
 // in 'bmqma_countingallocatorstore'.
 
 // BDE
+#include <bsl_functional.h>
 #include <bsl_iosfwd.h>
-#include <bsl_string.h>
+#include <bsl_string_view.h>
 
 namespace BloombergLP {
 
@@ -59,21 +60,25 @@ class CountingAllocatorStore;
 struct CountingAllocatorUtil {
     // CLASS METHODS
 
-    /// Set the global and default allocators to counting allocators with
-    /// stats reported to a sub-context having the specified
-    /// `topAllocatorName` under a top-level stat context with the specified
-    /// `globalStatContextConfiguration` or with the specified
-    /// `globalStatContextName` and default configuration.  The default
-    /// allocator will have name "Default Allocator", and the global
-    /// allocator will have name "Global Allocator".  This function should
-    /// be called once in `main`.  The behavior is undefined if this
+    /// @brief Set the global and default allocators to counting allocators.
+    ///
+    /// @param globalStatContextName  Name for the top-level stat context.
+    /// @param topAllocatorName       Name for the top-level allocator
+    ///                               sub-context.
+    /// @param allocationLimit        Maximum bytes before the limit callback
+    ///                               fires (0 means no limit).
+    /// @param allocationLimitCb      Callback invoked when the allocation
+    ///                               limit is exceeded.
+    ///
+    /// The default allocator will have name "Default Allocator", and the
+    /// global allocator will have name "Global Allocator".  This function
+    /// should be called once in `main`.  The behavior is undefined if this
     /// function is called more than once.
-    static void initGlobalAllocators(
-        const bmqst::StatContextConfiguration& globalStatContextConfiguration,
-        const bslstl::StringRef&               topAllocatorName);
     static void
-    initGlobalAllocators(const bslstl::StringRef& globalStatContextName,
-                         const bslstl::StringRef& topAllocatorName);
+    initGlobalAllocators(bsl::string_view             globalStatContextName,
+                         bsl::string_view             topAllocatorName,
+                         bsls::Types::Uint64          allocationLimit,
+                         const bsl::function<void()>& allocationLimitCb);
 
     /// Return the stat context created by `initGlobalAllocators`.  The
     /// behavior is undefined unless `initGlobalAllocators` has been called.

--- a/src/groups/bmq/bmqma/bmqma_countingallocatorutil.t.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocatorutil.t.cpp
@@ -39,6 +39,19 @@ using namespace bsl;
 //                            TEST HELPERS UTILITY
 // ----------------------------------------------------------------------------
 namespace {
+
+struct AllocationLimitCb {
+    int* d_triggered_p;
+
+    AllocationLimitCb(int* triggered)
+    : d_triggered_p(triggered)
+    {
+        BSLS_ASSERT_OPT(d_triggered_p);
+    }
+
+    void operator()() { ++(*d_triggered_p); }
+};
+
 }  // close unnamed namespace
 
 //=============================================================================
@@ -63,12 +76,17 @@ static void test1_breathingTest()
     BMQTST_ASSERT_SAFE_FAIL(bmqma::CountingAllocatorUtil::globalStatContext());
     BMQTST_ASSERT_SAFE_FAIL(bmqma::CountingAllocatorUtil::topAllocatorStore());
 
-    bmqma::CountingAllocatorUtil::initGlobalAllocators("testStatContext",
-                                                       "testAllocatorName");
+    bmqma::CountingAllocatorUtil::initGlobalAllocators(
+        "testStatContext",
+        "testAllocatorName",
+        0,
+        bsl::function<void()>());
 
     BMQTST_ASSERT_SAFE_FAIL(bmqma::CountingAllocatorUtil::initGlobalAllocators(
         "testStatContext",
-        "testAllocatorName"));
+        "testAllocatorName",
+        0,
+        bsl::function<void()>()));
     BMQTST_ASSERT(bmqma::CountingAllocatorUtil::globalStatContext() != 0);
     BMQTST_ASSERT_EQ(bmqma::CountingAllocatorUtil::globalStatContext()->name(),
                      "testStatContext");
@@ -97,8 +115,11 @@ static void test2_initGlobalAllocators()
 
     // 1. Ensure that 'initGlobalAllocators' creates a top-level allocator,
     //    top-level statContext, and top-level 'bmqma::CountingAllocatorStore'.
-    bmqma::CountingAllocatorUtil::initGlobalAllocators("testStatContext",
-                                                       "testAllocatorName");
+    bmqma::CountingAllocatorUtil::initGlobalAllocators(
+        "testStatContext",
+        "testAllocatorName",
+        0,
+        bsl::function<void()>());
 
     BMQTST_ASSERT(bmqma::CountingAllocatorUtil::globalStatContext() != 0);
     BMQTST_ASSERT_EQ(bmqma::CountingAllocatorUtil::globalStatContext()->name(),
@@ -140,6 +161,86 @@ static void test2_initGlobalAllocators()
         dynamic_cast<bmqma::CountingAllocator*>(globalAlloc)->context());
 }
 
+static void test3_allocationLimitCb()
+// ------------------------------------------------------------------------
+// ALLOCATION LIMIT CALLBACK
+//
+// Concerns:
+//   1. The allocation limit callback is not invoked when the total bytes
+//      allocated across all counting allocators in the hierarchy remains
+//      below the specified limit.
+//   2. The allocation limit callback is invoked exactly once when the
+//      total bytes allocated exceeds the specified limit.
+//   3. Deallocated memory does not count toward the limit.
+//   4. Allocations through any nested allocator (global, default, or
+//      custom) contribute to the shared limit.
+//
+// Note:
+//   The counting allocator tracks more bytes per allocation than the
+//   requested size (alignment rounding and a per-block header), and
+//   'initGlobalAllocators' itself performs internal allocations that
+//   count toward the limit.  This test uses a large limit and large
+//   allocation sizes so that this overhead is negligible.
+//
+// Testing:
+//   AllocationLimitChecker
+//   setAllocationLimit
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("ALLOCATION LIMIT CALLBACK");
+
+    int alarmTriggeredCount = 0;
+
+    bmqma::CountingAllocatorUtil::initGlobalAllocators(
+        "testStatContext",
+        "testAllocatorName",
+        4096,
+        AllocationLimitCb(&alarmTriggeredCount));
+
+    // Expect no alarm
+    //  [........] ~0/4096 bytes
+    BMQTST_ASSERT_EQ(alarmTriggeredCount, 0);
+
+    {
+        // Expect no alarm: allocated less than the limit
+        BSLA_MAYBE_UNUSED bsl::vector<char> globalVec(
+            2048,
+            bslma::Default::globalAllocator());
+        //  [====....] ~2048/4096 bytes
+        BMQTST_ASSERT_EQ(alarmTriggeredCount, 0);
+
+        // Free the memory and make sure it doesn't contribute in triggering
+        // the alarm early.
+    }
+    //  [........] ~0/4096 bytes
+
+    // Expect no alarm: allocated less than the limit
+    BSLA_MAYBE_UNUSED bsl::vector<char> globalVec(
+        2048,
+        bslma::Default::globalAllocator());
+    //  [====....] ~2048/4096 bytes
+    BMQTST_ASSERT_EQ(alarmTriggeredCount, 0);
+
+    // Expect no alarm: allocated less than the limit
+    BSLA_MAYBE_UNUSED bsl::vector<char> defaultVec(
+        1024,
+        bslma::Default::defaultAllocator());
+    //  [======..] ~3072/4096 bytes
+    BMQTST_ASSERT_EQ(alarmTriggeredCount, 0);
+
+    // Expect 1 alarm: allocated more than the limit
+    bslma::Allocator* customAllocator =
+        bmqma::CountingAllocatorUtil::topAllocatorStore().get("custom");
+    BSLA_MAYBE_UNUSED bsl::vector<char> customVec(2048, customAllocator);
+    //  [========]== ~5120/4096 bytes ALARM
+    BMQTST_ASSERT_EQ(alarmTriggeredCount, 1);
+
+    // Expect 1 alarm: alarm was already triggered once, no more alarms
+    BSLA_MAYBE_UNUSED bsl::vector<char> customVec2(2048, customAllocator);
+    //  [========]======= ~7168/4096 bytes
+    BMQTST_ASSERT_EQ(alarmTriggeredCount, 1);
+}
+
 //=============================================================================
 //                              MAIN PROGRAM
 //-----------------------------------------------------------------------------
@@ -150,6 +251,7 @@ int main(int argc, char** argv)
 
     switch (_testCase) {
     case 0:
+    case 3: test3_allocationLimitCb(); break;
     case 2: test2_initGlobalAllocators(); break;
     case 1: test1_breathingTest(); break;
     default: {


### PR DESCRIPTION
The existing broker code broke the contract of bmqma::CountingAllocator by configuring allocation limits after some allocations were done. Also, allocation limits are set after the log controller is started, resulting in a race condition.

Address this by setting the limits early.