### PR TITLE
Feat[mqb] Add CredentialProvider interface & broker config

### DIFF
--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -333,6 +333,11 @@
             Minimum number of threads in the authentication thread pool.
         maxThreads..............:
             Maximum number of threads in the authentication thread pool.
+        credentialProvider...:
+            Optional credential provider. When specified, the broker uses credentials
+            provided by the credential provider to authenticate with other brokers.
+            If not specified, the broker will attempt to directly negotiate sessions
+            with other brokers without explicitly authenticating.
       </documentation>
     </annotation>
     <sequence>
@@ -340,6 +345,7 @@
       <element name='anonymousCredential' type='tns:AnonymousCredential' minOccurs='0'/>
       <element name='minThreads' type='int' default='1'/>
       <element name='maxThreads' type='int' default='8'/>
+      <element name='credentialProvider' type='tns:CredentialProviderConfig' minOccurs='0'/>
      </sequence>
   </complexType>
 
@@ -408,6 +414,23 @@
       <element name='settings' type='tns:PluginSettingKeyValue' minOccurs='0' maxOccurs='unbounded'/>
     </sequence>
   </complexType>
+
+  <complexType name='CredentialProviderConfig'>
+    <annotation>
+      <documentation>
+        The configuration for the broker's credential provider.
+
+        name.....:
+            The name of the credential provider.
+        settings.:
+            Plugin-specific settings.
+      </documentation>
+    </annotation>
+    <sequence>
+      <element name='name'     type='string'/>
+      <element name='settings' type='tns:PluginSettingKeyValue' minOccurs='0' maxOccurs='unbounded'/>
+    </sequence>
+ </complexType>
 
   <complexType name="PluginSettingKeyValue">
     <annotation>
@@ -809,25 +832,25 @@
       <documentation>
         Type representing the attributes specific to a cluster.
 
-        isCSLModeEnabled...............: 
+        isCSLModeEnabled...............:
             indicates if CSL is enabled for this cluster
-        isFSMWorkflow..................: 
+        isFSMWorkflow..................:
             indicates if CSL FSM workflow is enabled for this cluster.  This
             flag *must* be false if 'isCSLModeEnabled' is false.
-        doesFSMwriteQLIST..............: 
+        doesFSMwriteQLIST..............:
             indicates whether the broker still writes to the to-be-deprecated
             QLIST file when FSM workflow is enabled.  If above 'isFSMWorkflow'
             flag is false, this flag is ignored.
-        clusterFsmWatchdogTimeoutSec...: 
+        clusterFsmWatchdogTimeoutSec...:
             timeout duration in seconds for Cluster FSM watchdog. Only applies
             when 'isFSMWorkflow' is true.
-        clusterFsmWatchdogNumRetries...: 
-            number of retries for Cluster FSM watchdog before we give up and 
+        clusterFsmWatchdogNumRetries...:
+            number of retries for Cluster FSM watchdog before we give up and
             terminate the broker.  Only applies when 'isFSMWorkflow' is true.
-        partitionFsmWatchdogTimeoutSec.: 
+        partitionFsmWatchdogTimeoutSec.:
             timeout duration in seconds for Partition FSM watchdog. Only
             applies when 'isFSMWorkflow' is true.
-        partitionFsmWatchdogNumRetries.: 
+        partitionFsmWatchdogNumRetries.:
             number of retries for Partition FSM watchdog before we give up and
             terminate the broker.  Only applies when 'isFSMWorkflow' is true.
       </documentation>

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,9 +48,9 @@ namespace mqbcfg {
 const char AllocatorType::CLASS_NAME[] = "AllocatorType";
 
 const bdlat_EnumeratorInfo AllocatorType::ENUMERATOR_INFO_ARRAY[] = {
-    {AllocatorType::NEWDELETE, "NEWDELETE", sizeof("NEWDELETE") - 1, ""},
-    {AllocatorType::COUNTING, "COUNTING", sizeof("COUNTING") - 1, ""},
-    {AllocatorType::STACKTRACETEST,
+    {AllocatorType::e_NEWDELETE, "NEWDELETE", sizeof("NEWDELETE") - 1, ""},
+    {AllocatorType::e_COUNTING, "COUNTING", sizeof("COUNTING") - 1, ""},
+    {AllocatorType::e_STACKTRACETEST,
      "STACKTRACETEST",
      sizeof("STACKTRACETEST") - 1,
      ""}};
@@ -60,9 +60,9 @@ const bdlat_EnumeratorInfo AllocatorType::ENUMERATOR_INFO_ARRAY[] = {
 int AllocatorType::fromInt(AllocatorType::Value* result, int number)
 {
     switch (number) {
-    case AllocatorType::NEWDELETE:
-    case AllocatorType::COUNTING:
-    case AllocatorType::STACKTRACETEST:
+    case AllocatorType::e_NEWDELETE:
+    case AllocatorType::e_COUNTING:
+    case AllocatorType::e_STACKTRACETEST:
         *result = static_cast<AllocatorType::Value>(number);
         return 0;
     default: return -1;
@@ -91,13 +91,13 @@ int AllocatorType::fromString(AllocatorType::Value* result,
 const char* AllocatorType::toString(AllocatorType::Value value)
 {
     switch (value) {
-    case NEWDELETE: {
+    case e_NEWDELETE: {
         return "NEWDELETE";
     }
-    case COUNTING: {
+    case e_COUNTING: {
         return "COUNTING";
     }
-    case STACKTRACETEST: {
+    case e_STACKTRACETEST: {
         return "STACKTRACETEST";
     }
     }
@@ -951,16 +951,16 @@ ElectorConfig::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 const char ExportMode::CLASS_NAME[] = "ExportMode";
 
 const bdlat_EnumeratorInfo ExportMode::ENUMERATOR_INFO_ARRAY[] = {
-    {ExportMode::E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
-    {ExportMode::E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""}};
+    {ExportMode::e_E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
+    {ExportMode::e_E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""}};
 
 // CLASS METHODS
 
 int ExportMode::fromInt(ExportMode::Value* result, int number)
 {
     switch (number) {
-    case ExportMode::E_PUSH:
-    case ExportMode::E_PULL:
+    case ExportMode::e_E_PUSH:
+    case ExportMode::e_E_PULL:
         *result = static_cast<ExportMode::Value>(number);
         return 0;
     default: return -1;
@@ -988,10 +988,10 @@ int ExportMode::fromString(ExportMode::Value* result,
 const char* ExportMode::toString(ExportMode::Value value)
 {
     switch (value) {
-    case E_PUSH: {
+    case e_E_PUSH: {
         return "E_PUSH";
     }
-    case E_PULL: {
+    case e_E_PULL: {
         return "E_PULL";
     }
     }
@@ -1265,11 +1265,11 @@ const char MasterAssignmentAlgorithm::CLASS_NAME[] =
     "MasterAssignmentAlgorithm";
 
 const bdlat_EnumeratorInfo MasterAssignmentAlgorithm::ENUMERATOR_INFO_ARRAY[] =
-    {{MasterAssignmentAlgorithm::E_LEADER_IS_MASTER_ALL,
+    {{MasterAssignmentAlgorithm::e_E_LEADER_IS_MASTER_ALL,
       "E_LEADER_IS_MASTER_ALL",
       sizeof("E_LEADER_IS_MASTER_ALL") - 1,
       ""},
-     {MasterAssignmentAlgorithm::E_LEAST_ASSIGNED,
+     {MasterAssignmentAlgorithm::e_E_LEAST_ASSIGNED,
       "E_LEAST_ASSIGNED",
       sizeof("E_LEAST_ASSIGNED") - 1,
       ""}};
@@ -1281,8 +1281,8 @@ int MasterAssignmentAlgorithm::fromInt(
     int                               number)
 {
     switch (number) {
-    case MasterAssignmentAlgorithm::E_LEADER_IS_MASTER_ALL:
-    case MasterAssignmentAlgorithm::E_LEAST_ASSIGNED:
+    case MasterAssignmentAlgorithm::e_E_LEADER_IS_MASTER_ALL:
+    case MasterAssignmentAlgorithm::e_E_LEAST_ASSIGNED:
         *result = static_cast<MasterAssignmentAlgorithm::Value>(number);
         return 0;
     default: return -1;
@@ -1313,10 +1313,10 @@ const char*
 MasterAssignmentAlgorithm::toString(MasterAssignmentAlgorithm::Value value)
 {
     switch (value) {
-    case E_LEADER_IS_MASTER_ALL: {
+    case e_E_LEADER_IS_MASTER_ALL: {
         return "E_LEADER_IS_MASTER_ALL";
     }
-    case E_LEAST_ASSIGNED: {
+    case e_E_LEAST_ASSIGNED: {
         return "E_LEAST_ASSIGNED";
     }
     }
@@ -5658,6 +5658,141 @@ ClusterNode::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     return stream;
 }
 
+// ------------------------------
+// class CredentialProviderConfig
+// ------------------------------
+
+// CONSTANTS
+
+const char CredentialProviderConfig::CLASS_NAME[] = "CredentialProviderConfig";
+
+const bdlat_AttributeInfo CredentialProviderConfig::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_NAME,
+     "name",
+     sizeof("name") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_SETTINGS,
+     "settings",
+     sizeof("settings") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo*
+CredentialProviderConfig::lookupAttributeInfo(const char* name, int nameLength)
+{
+    for (int i = 0; i < 2; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            CredentialProviderConfig::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo*
+CredentialProviderConfig::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME];
+    case ATTRIBUTE_ID_SETTINGS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SETTINGS];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+CredentialProviderConfig::CredentialProviderConfig(
+    bslma::Allocator* basicAllocator)
+: d_settings(basicAllocator)
+, d_name(basicAllocator)
+{
+}
+
+CredentialProviderConfig::CredentialProviderConfig(
+    const CredentialProviderConfig& original,
+    bslma::Allocator*               basicAllocator)
+: d_settings(original.d_settings, basicAllocator)
+, d_name(original.d_name, basicAllocator)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+CredentialProviderConfig::CredentialProviderConfig(
+    CredentialProviderConfig&& original) noexcept
+: d_settings(bsl::move(original.d_settings)),
+  d_name(bsl::move(original.d_name))
+{
+}
+
+CredentialProviderConfig::CredentialProviderConfig(
+    CredentialProviderConfig&& original,
+    bslma::Allocator*          basicAllocator)
+: d_settings(bsl::move(original.d_settings), basicAllocator)
+, d_name(bsl::move(original.d_name), basicAllocator)
+{
+}
+#endif
+
+CredentialProviderConfig::~CredentialProviderConfig()
+{
+}
+
+// MANIPULATORS
+
+CredentialProviderConfig&
+CredentialProviderConfig::operator=(const CredentialProviderConfig& rhs)
+{
+    if (this != &rhs) {
+        d_name     = rhs.d_name;
+        d_settings = rhs.d_settings;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+CredentialProviderConfig&
+CredentialProviderConfig::operator=(CredentialProviderConfig&& rhs)
+{
+    if (this != &rhs) {
+        d_name     = bsl::move(rhs.d_name);
+        d_settings = bsl::move(rhs.d_settings);
+    }
+
+    return *this;
+}
+#endif
+
+void CredentialProviderConfig::reset()
+{
+    bdlat_ValueTypeFunctions::reset(&d_name);
+    bdlat_ValueTypeFunctions::reset(&d_settings);
+}
+
+// ACCESSORS
+
+bsl::ostream& CredentialProviderConfig::print(bsl::ostream& stream,
+                                              int           level,
+                                              int spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("name", this->name());
+    printer.printAttribute("settings", this->settings());
+    printer.end();
+    return stream;
+}
+
 // ----------------------
 // class DispatcherConfig
 // ----------------------
@@ -6317,19 +6452,24 @@ const bdlat_AttributeInfo AuthenticatorConfig::ATTRIBUTE_INFO_ARRAY[] = {
      "minThreads",
      sizeof("minThreads") - 1,
      "",
-     bdlat_FormattingMode::e_DEC},
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
     {ATTRIBUTE_ID_MAX_THREADS,
      "maxThreads",
      sizeof("maxThreads") - 1,
      "",
-     bdlat_FormattingMode::e_DEC}};
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_CREDENTIAL_PROVIDER,
+     "credentialProvider",
+     sizeof("credentialProvider") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT}};
 
 // CLASS METHODS
 
 const bdlat_AttributeInfo*
 AuthenticatorConfig::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 5; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             AuthenticatorConfig::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -6353,6 +6493,8 @@ const bdlat_AttributeInfo* AuthenticatorConfig::lookupAttributeInfo(int id)
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MIN_THREADS];
     case ATTRIBUTE_ID_MAX_THREADS:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_THREADS];
+    case ATTRIBUTE_ID_CREDENTIAL_PROVIDER:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER];
     default: return 0;
     }
 }
@@ -6361,6 +6503,7 @@ const bdlat_AttributeInfo* AuthenticatorConfig::lookupAttributeInfo(int id)
 
 AuthenticatorConfig::AuthenticatorConfig(bslma::Allocator* basicAllocator)
 : d_authenticators(basicAllocator)
+, d_credentialProvider(basicAllocator)
 , d_anonymousCredential(basicAllocator)
 , d_minThreads(DEFAULT_INITIALIZER_MIN_THREADS)
 , d_maxThreads(DEFAULT_INITIALIZER_MAX_THREADS)
@@ -6370,6 +6513,7 @@ AuthenticatorConfig::AuthenticatorConfig(bslma::Allocator* basicAllocator)
 AuthenticatorConfig::AuthenticatorConfig(const AuthenticatorConfig& original,
                                          bslma::Allocator* basicAllocator)
 : d_authenticators(original.d_authenticators, basicAllocator)
+, d_credentialProvider(original.d_credentialProvider, basicAllocator)
 , d_anonymousCredential(original.d_anonymousCredential, basicAllocator)
 , d_minThreads(original.d_minThreads)
 , d_maxThreads(original.d_maxThreads)
@@ -6381,6 +6525,7 @@ AuthenticatorConfig::AuthenticatorConfig(const AuthenticatorConfig& original,
 AuthenticatorConfig::AuthenticatorConfig(
     AuthenticatorConfig&& original) noexcept
 : d_authenticators(bsl::move(original.d_authenticators)),
+  d_credentialProvider(bsl::move(original.d_credentialProvider)),
   d_anonymousCredential(bsl::move(original.d_anonymousCredential)),
   d_minThreads(bsl::move(original.d_minThreads)),
   d_maxThreads(bsl::move(original.d_maxThreads))
@@ -6390,6 +6535,8 @@ AuthenticatorConfig::AuthenticatorConfig(
 AuthenticatorConfig::AuthenticatorConfig(AuthenticatorConfig&& original,
                                          bslma::Allocator*     basicAllocator)
 : d_authenticators(bsl::move(original.d_authenticators), basicAllocator)
+, d_credentialProvider(bsl::move(original.d_credentialProvider),
+                       basicAllocator)
 , d_anonymousCredential(bsl::move(original.d_anonymousCredential),
                         basicAllocator)
 , d_minThreads(bsl::move(original.d_minThreads))
@@ -6412,6 +6559,7 @@ AuthenticatorConfig::operator=(const AuthenticatorConfig& rhs)
         d_anonymousCredential = rhs.d_anonymousCredential;
         d_minThreads          = rhs.d_minThreads;
         d_maxThreads          = rhs.d_maxThreads;
+        d_credentialProvider  = rhs.d_credentialProvider;
     }
 
     return *this;
@@ -6426,6 +6574,7 @@ AuthenticatorConfig& AuthenticatorConfig::operator=(AuthenticatorConfig&& rhs)
         d_anonymousCredential = bsl::move(rhs.d_anonymousCredential);
         d_minThreads          = bsl::move(rhs.d_minThreads);
         d_maxThreads          = bsl::move(rhs.d_maxThreads);
+        d_credentialProvider  = bsl::move(rhs.d_credentialProvider);
     }
 
     return *this;
@@ -6438,6 +6587,7 @@ void AuthenticatorConfig::reset()
     bdlat_ValueTypeFunctions::reset(&d_anonymousCredential);
     d_minThreads = DEFAULT_INITIALIZER_MIN_THREADS;
     d_maxThreads = DEFAULT_INITIALIZER_MAX_THREADS;
+    bdlat_ValueTypeFunctions::reset(&d_credentialProvider);
 }
 
 // ACCESSORS
@@ -6452,6 +6602,7 @@ bsl::ostream& AuthenticatorConfig::print(bsl::ostream& stream,
     printer.printAttribute("anonymousCredential", this->anonymousCredential());
     printer.printAttribute("minThreads", this->minThreads());
     printer.printAttribute("maxThreads", this->maxThreads());
+    printer.printAttribute("credentialProvider", this->credentialProvider());
     printer.end();
     return stream;
 }
@@ -7705,6 +7856,6 @@ Configuration::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.02.26
+// GENERATED BY BLP_BAS_CODEGEN_2026.04.30
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2025-2026 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -154,6 +154,9 @@ namespace mqbcfg {
 class ClusterNode;
 }
 namespace mqbcfg {
+class CredentialProviderConfig;
+}
+namespace mqbcfg {
 class DispatcherConfig;
 }
 namespace mqbcfg {
@@ -195,9 +198,17 @@ namespace mqbcfg {
 struct AllocatorType {
   public:
     // TYPES
-    enum Value { NEWDELETE = 0, COUNTING = 1, STACKTRACETEST = 2 };
+    enum Value {
+        e_NEWDELETE      = 0,
+        e_COUNTING       = 1,
+        e_STACKTRACETEST = 2,
 
-    enum { NUM_ENUMERATORS = 3 };
+        NEWDELETE      = e_NEWDELETE,
+        COUNTING       = e_COUNTING,
+        STACKTRACETEST = e_STACKTRACETEST
+    };
+
+    enum { k_NUM_ENUMERATORS = 3, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -245,7 +256,7 @@ struct AllocatorType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::AllocatorType)
+BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::AllocatorType);
 
 namespace mqbcfg {
 
@@ -410,7 +421,7 @@ class BmqconfConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::BmqconfConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::BmqconfConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::BmqconfConfig> : bsl::true_type {};
 
@@ -422,22 +433,21 @@ namespace mqbcfg {
 
 class ClusterAttributes {
     // Type representing the attributes specific to a cluster.
-    // isCSLModeEnabled...............:  indicates if CSL is enabled for this
-    // cluster isFSMWorkflow..................:  indicates if CSL FSM workflow
+    // isCSLModeEnabled...............: indicates if CSL is enabled for this
+    // cluster isFSMWorkflow..................: indicates if CSL FSM workflow
     // is enabled for this cluster.  This flag *must* be false if
-    // 'isCSLModeEnabled' is false.  doesFSMwriteQLIST..............:
-    // indicates whether the broker still writes to the to-be-deprecated QLIST
-    // file when FSM workflow is enabled.  If above 'isFSMWorkflow' flag is
-    // false, this flag is ignored.  clusterFsmWatchdogTimeoutSec...:  timeout
-    // duration in seconds for Cluster FSM watchdog.  Only applies when
-    // 'isFSMWorkflow' is true.  clusterFsmWatchdogNumRetries...:  number of
-    // retries for Cluster FSM watchdog before we give up and  terminate the
+    // 'isCSLModeEnabled' is false.  doesFSMwriteQLIST..............: indicates
+    // whether the broker still writes to the to-be-deprecated QLIST file when
+    // FSM workflow is enabled.  If above 'isFSMWorkflow' flag is false, this
+    // flag is ignored.  clusterFsmWatchdogTimeoutSec...: timeout duration in
+    // seconds for Cluster FSM watchdog.  Only applies when 'isFSMWorkflow' is
+    // true.  clusterFsmWatchdogNumRetries...: number of retries for Cluster
+    // FSM watchdog before we give up and terminate the broker.  Only applies
+    // when 'isFSMWorkflow' is true.  partitionFsmWatchdogTimeoutSec.: timeout
+    // duration in seconds for Partition FSM watchdog.  Only applies when
+    // 'isFSMWorkflow' is true.  partitionFsmWatchdogNumRetries.: number of
+    // retries for Partition FSM watchdog before we give up and terminate the
     // broker.  Only applies when 'isFSMWorkflow' is true.
-    // partitionFsmWatchdogTimeoutSec.:  timeout duration in seconds for
-    // Partition FSM watchdog.  Only applies when 'isFSMWorkflow' is true.
-    // partitionFsmWatchdogNumRetries.:  number of retries for Partition FSM
-    // watchdog before we give up and terminate the broker.  Only applies when
-    // 'isFSMWorkflow' is true.
 
     // INSTANCE DATA
     int  d_clusterFsmWatchdogTimeoutSec;
@@ -686,7 +696,7 @@ class ClusterAttributes {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterAttributes)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterAttributes);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClusterAttributes> : bsl::true_type {
 };
@@ -975,7 +985,7 @@ class ClusterMonitorConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterMonitorConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterMonitorConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClusterMonitorConfig>
 : bsl::true_type {};
@@ -1198,7 +1208,7 @@ class Credential {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::Credential)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::Credential);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::Credential> : bsl::true_type {};
 
@@ -1349,7 +1359,7 @@ class Disallow {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::Disallow)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::Disallow);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::Disallow> : bsl::true_type {};
 
@@ -1551,7 +1561,7 @@ class DispatcherProcessorParameters {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::DispatcherProcessorParameters)
+    mqbcfg::DispatcherProcessorParameters);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::DispatcherProcessorParameters>
 : bsl::true_type {};
@@ -1861,7 +1871,7 @@ class ElectorConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ElectorConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::ElectorConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ElectorConfig> : bsl::true_type {};
 
@@ -1874,9 +1884,15 @@ namespace mqbcfg {
 struct ExportMode {
   public:
     // TYPES
-    enum Value { E_PUSH = 0, E_PULL = 1 };
+    enum Value {
+        e_E_PUSH = 0,
+        e_E_PULL = 1,
 
-    enum { NUM_ENUMERATORS = 2 };
+        E_PUSH = e_E_PUSH,
+        E_PULL = e_E_PULL
+    };
+
+    enum { k_NUM_ENUMERATORS = 2, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -1924,7 +1940,7 @@ struct ExportMode {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::ExportMode)
+BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::ExportMode);
 
 namespace mqbcfg {
 
@@ -2147,7 +2163,7 @@ class Heartbeat {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::Heartbeat)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::Heartbeat);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::Heartbeat> : bsl::true_type {};
 
@@ -2392,7 +2408,7 @@ class LogDumpConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::LogDumpConfig)
+    mqbcfg::LogDumpConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::LogDumpConfig> : bsl::true_type {};
 
@@ -2410,9 +2426,15 @@ struct MasterAssignmentAlgorithm {
 
   public:
     // TYPES
-    enum Value { E_LEADER_IS_MASTER_ALL = 0, E_LEAST_ASSIGNED = 1 };
+    enum Value {
+        e_E_LEADER_IS_MASTER_ALL = 0,
+        e_E_LEAST_ASSIGNED       = 1,
 
-    enum { NUM_ENUMERATORS = 2 };
+        E_LEADER_IS_MASTER_ALL = e_E_LEADER_IS_MASTER_ALL,
+        E_LEAST_ASSIGNED       = e_E_LEAST_ASSIGNED
+    };
+
+    enum { k_NUM_ENUMERATORS = 2, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2460,7 +2482,7 @@ struct MasterAssignmentAlgorithm {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::MasterAssignmentAlgorithm)
+BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::MasterAssignmentAlgorithm);
 
 namespace mqbcfg {
 
@@ -2671,7 +2693,7 @@ class MessagePropertiesV2 {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::MessagePropertiesV2)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::MessagePropertiesV2);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::MessagePropertiesV2>
 : bsl::true_type {};
@@ -2899,7 +2921,7 @@ class MessageThrottleConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::MessageThrottleConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::MessageThrottleConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::MessageThrottleConfig>
 : bsl::true_type {};
@@ -3218,7 +3240,7 @@ class PluginSettingValue {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::PluginSettingValue)
+    mqbcfg::PluginSettingValue);
 
 namespace mqbcfg {
 
@@ -3431,7 +3453,7 @@ class Plugins {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::Plugins)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::Plugins);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::Plugins> : bsl::true_type {};
 
@@ -3792,7 +3814,7 @@ class QueueOperationsConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::QueueOperationsConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::QueueOperationsConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::QueueOperationsConfig>
 : bsl::true_type {};
@@ -4024,7 +4046,7 @@ class ResolvedDomain {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::ResolvedDomain)
+    mqbcfg::ResolvedDomain);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ResolvedDomain> : bsl::true_type {};
 
@@ -4291,7 +4313,7 @@ class StatsPrinterConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::StatsPrinterConfig)
+    mqbcfg::StatsPrinterConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StatsPrinterConfig>
 : bsl::true_type {};
@@ -4627,7 +4649,7 @@ class StorageSyncConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::StorageSyncConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::StorageSyncConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StorageSyncConfig> : bsl::true_type {
 };
@@ -4879,7 +4901,8 @@ class SyslogConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::SyslogConfig)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    mqbcfg::SyslogConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::SyslogConfig> : bsl::true_type {};
 
@@ -5095,7 +5118,7 @@ class TcpClusterNodeConnection {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::TcpClusterNodeConnection)
+    mqbcfg::TcpClusterNodeConnection);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::TcpClusterNodeConnection>
 : bsl::true_type {};
@@ -5110,7 +5133,7 @@ class TcpInterfaceListener {
     // This type describes the information needed for the broker to open a TCP
     // listener.
     // name.................: A name to associate this listener to.
-    // address..............: The IP address this listener will accept
+    // address..............: The IPv4 address this listener will accept
     // connections on.  port.................: The port this listener will
     // accept connections on.  tls..................: Use TLS on this
     // interface.
@@ -5359,7 +5382,7 @@ class TcpInterfaceListener {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::TcpInterfaceListener)
+    mqbcfg::TcpInterfaceListener);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::TcpInterfaceListener>
 : bsl::true_type {};
@@ -5843,7 +5866,7 @@ class VirtualClusterInformation {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::VirtualClusterInformation)
+    mqbcfg::VirtualClusterInformation);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::VirtualClusterInformation>
 : bsl::true_type {};
@@ -6101,7 +6124,7 @@ class AnonymousCredential {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::AnonymousCredential)
+    mqbcfg::AnonymousCredential);
 
 namespace mqbcfg {
 
@@ -6324,7 +6347,7 @@ class ClusterNodeConnection {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::ClusterNodeConnection)
+    mqbcfg::ClusterNodeConnection);
 
 namespace mqbcfg {
 
@@ -6510,7 +6533,7 @@ class DispatcherProcessorConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::DispatcherProcessorConfig)
+    mqbcfg::DispatcherProcessorConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::DispatcherProcessorConfig>
 : bsl::true_type {};
@@ -6839,7 +6862,7 @@ class LogController {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::LogController)
+    mqbcfg::LogController);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::LogController> : bsl::true_type {};
 
@@ -7199,7 +7222,7 @@ class PartitionConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::PartitionConfig)
+    mqbcfg::PartitionConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::PartitionConfig> : bsl::true_type {};
 
@@ -7423,7 +7446,7 @@ class PluginSettingKeyValue {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::PluginSettingKeyValue)
+    mqbcfg::PluginSettingKeyValue);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::PluginSettingKeyValue>
 : bsl::true_type {};
@@ -7672,7 +7695,7 @@ class StatPluginConfigPrometheus {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::StatPluginConfigPrometheus)
+    mqbcfg::StatPluginConfigPrometheus);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StatPluginConfigPrometheus>
 : bsl::true_type {};
@@ -8007,7 +8030,7 @@ class TcpInterfaceConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::TcpInterfaceConfig)
+    mqbcfg::TcpInterfaceConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::TcpInterfaceConfig>
 : bsl::true_type {};
@@ -8235,7 +8258,7 @@ class AuthenticatorPluginConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::AuthenticatorPluginConfig)
+    mqbcfg::AuthenticatorPluginConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::AuthenticatorPluginConfig>
 : bsl::true_type {};
@@ -8489,9 +8512,237 @@ class ClusterNode {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterNode)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::ClusterNode);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClusterNode> : bsl::true_type {};
+
+namespace mqbcfg {
+
+// ==============================
+// class CredentialProviderConfig
+// ==============================
+
+class CredentialProviderConfig {
+    // The configuration for the broker's credential provider.
+    // name.....: The name of the credential provider.  settings.:
+    // Plugin-specific settings.
+
+    // INSTANCE DATA
+    bsl::vector<PluginSettingKeyValue> d_settings;
+    bsl::string                        d_name;
+
+  public:
+    // TYPES
+    enum { ATTRIBUTE_ID_NAME = 0, ATTRIBUTE_ID_SETTINGS = 1 };
+
+    enum { NUM_ATTRIBUTES = 2 };
+
+    enum { ATTRIBUTE_INDEX_NAME = 0, ATTRIBUTE_INDEX_SETTINGS = 1 };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit CredentialProviderConfig(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'CredentialProviderConfig' having the
+    // default value.  Use the optionally specified 'basicAllocator' to
+    // supply memory.  If 'basicAllocator' is 0, the currently installed
+    // default allocator is used.
+
+    CredentialProviderConfig(const CredentialProviderConfig& original,
+                             bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'CredentialProviderConfig' having the value
+    // of the specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    CredentialProviderConfig(CredentialProviderConfig&& original) noexcept;
+    // Create an object of type 'CredentialProviderConfig' having the value
+    // of the specified 'original' object.  After performing this action,
+    // the 'original' object will be left in a valid, but unspecified
+    // state.
+
+    CredentialProviderConfig(CredentialProviderConfig&& original,
+                             bslma::Allocator*          basicAllocator);
+    // Create an object of type 'CredentialProviderConfig' having the value
+    // of the specified 'original' object.  After performing this action,
+    // the 'original' object will be left in a valid, but unspecified
+    // state.  Use the optionally specified 'basicAllocator' to supply
+    // memory.  If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+#endif
+
+    ~CredentialProviderConfig();
+    // Destroy this object.
+
+    // MANIPULATORS
+    CredentialProviderConfig& operator=(const CredentialProviderConfig& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    CredentialProviderConfig& operator=(CredentialProviderConfig&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    bsl::string& name();
+    // Return a reference to the modifiable "Name" attribute of this
+    // object.
+
+    bsl::vector<PluginSettingKeyValue>& settings();
+    // Return a reference to the modifiable "Settings" attribute of this
+    // object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    const bsl::string& name() const;
+    // Return a reference offering non-modifiable access to the "Name"
+    // attribute of this object.
+
+    const bsl::vector<PluginSettingKeyValue>& settings() const;
+    // Return a reference offering non-modifiable access to the "Settings"
+    // attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const CredentialProviderConfig& lhs,
+                           const CredentialProviderConfig& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.name() == rhs.name() && lhs.settings() == rhs.settings();
+    }
+
+    friend bool operator!=(const CredentialProviderConfig& lhs,
+                           const CredentialProviderConfig& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream&                   stream,
+                                    const CredentialProviderConfig& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM&               hashAlg,
+                           const CredentialProviderConfig& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for
+    // 'CredentialProviderConfig'.
+    {
+        using bslh::hashAppend;
+        hashAppend(hashAlg, object.name());
+        hashAppend(hashAlg, object.settings());
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    mqbcfg::CredentialProviderConfig);
+template <>
+struct bdlat_UsesDefaultValueFlag<mqbcfg::CredentialProviderConfig>
+: bsl::true_type {};
 
 namespace mqbcfg {
 
@@ -8715,7 +8966,7 @@ class DispatcherConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::DispatcherConfig)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(mqbcfg::DispatcherConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::DispatcherConfig> : bsl::true_type {
 };
@@ -8939,7 +9190,7 @@ class NetworkInterfaces {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::NetworkInterfaces)
+    mqbcfg::NetworkInterfaces);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::NetworkInterfaces> : bsl::true_type {
 };
@@ -9262,7 +9513,7 @@ class StatPluginConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::StatPluginConfig)
+    mqbcfg::StatPluginConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StatPluginConfig> : bsl::true_type {
 };
@@ -9498,7 +9749,7 @@ class TaskConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::TaskConfig)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::TaskConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::TaskConfig> : bsl::true_type {};
 
@@ -9520,12 +9771,18 @@ class AuthenticatorConfig {
     // authentication.  minThreads..............: Minimum number of threads in
     // the authentication thread pool.  maxThreads..............: Maximum
     // number of threads in the authentication thread pool.
+    // credentialProvider...: Optional credential provider.  When specified,
+    // the broker uses credentials provided by the credential provider to
+    // authenticate with other brokers.  If not specified, the broker will
+    // attempt to directly negotiate sessions with other brokers without
+    // explicitly authenticating.
 
     // INSTANCE DATA
-    bsl::vector<AuthenticatorPluginConfig>   d_authenticators;
-    bdlb::NullableValue<AnonymousCredential> d_anonymousCredential;
-    int                                      d_minThreads;
-    int                                      d_maxThreads;
+    bsl::vector<AuthenticatorPluginConfig>        d_authenticators;
+    bdlb::NullableValue<CredentialProviderConfig> d_credentialProvider;
+    bdlb::NullableValue<AnonymousCredential>      d_anonymousCredential;
+    int                                           d_minThreads;
+    int                                           d_maxThreads;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
@@ -9539,16 +9796,18 @@ class AuthenticatorConfig {
         ATTRIBUTE_ID_AUTHENTICATORS       = 0,
         ATTRIBUTE_ID_ANONYMOUS_CREDENTIAL = 1,
         ATTRIBUTE_ID_MIN_THREADS          = 2,
-        ATTRIBUTE_ID_MAX_THREADS          = 3
+        ATTRIBUTE_ID_MAX_THREADS          = 3,
+        ATTRIBUTE_ID_CREDENTIAL_PROVIDER  = 4
     };
 
-    enum { NUM_ATTRIBUTES = 4 };
+    enum { NUM_ATTRIBUTES = 5 };
 
     enum {
         ATTRIBUTE_INDEX_AUTHENTICATORS       = 0,
         ATTRIBUTE_INDEX_ANONYMOUS_CREDENTIAL = 1,
         ATTRIBUTE_INDEX_MIN_THREADS          = 2,
-        ATTRIBUTE_INDEX_MAX_THREADS          = 3
+        ATTRIBUTE_INDEX_MAX_THREADS          = 3,
+        ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER  = 4
     };
 
     // CONSTANTS
@@ -9667,6 +9926,10 @@ class AuthenticatorConfig {
     // Return a reference to the modifiable "MaxThreads" attribute of this
     // object.
 
+    bdlb::NullableValue<CredentialProviderConfig>& credentialProvider();
+    // Return a reference to the modifiable "CredentialProvider" attribute
+    // of this object.
+
     // ACCESSORS
     bsl::ostream&
     print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
@@ -9725,6 +9988,11 @@ class AuthenticatorConfig {
     int maxThreads() const;
     // Return the value of the "MaxThreads" attribute of this object.
 
+    const bdlb::NullableValue<CredentialProviderConfig>&
+    credentialProvider() const;
+    // Return a reference offering non-modifiable access to the
+    // "CredentialProvider" attribute of this object.
+
     // HIDDEN FRIENDS
     friend bool operator==(const AuthenticatorConfig& lhs,
                            const AuthenticatorConfig& rhs)
@@ -9767,7 +10035,7 @@ class AuthenticatorConfig {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::AuthenticatorConfig)
+    mqbcfg::AuthenticatorConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::AuthenticatorConfig>
 : bsl::true_type {};
@@ -10087,7 +10355,7 @@ class ClusterDefinition {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::ClusterDefinition)
+    mqbcfg::ClusterDefinition);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClusterDefinition> : bsl::true_type {
 };
@@ -10361,7 +10629,7 @@ class ClusterProxyDefinition {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::ClusterProxyDefinition)
+    mqbcfg::ClusterProxyDefinition);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClusterProxyDefinition>
 : bsl::true_type {};
@@ -10601,7 +10869,7 @@ class StatsConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::StatsConfig)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::StatsConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StatsConfig> : bsl::true_type {};
 
@@ -11050,7 +11318,7 @@ class AppConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::AppConfig)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(mqbcfg::AppConfig);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::AppConfig> : bsl::true_type {};
 
@@ -11300,7 +11568,7 @@ class ClustersDefinition {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::ClustersDefinition)
+    mqbcfg::ClustersDefinition);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::ClustersDefinition>
 : bsl::true_type {};
@@ -11521,7 +11789,7 @@ class Configuration {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::Configuration)
+    mqbcfg::Configuration);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::Configuration> : bsl::true_type {};
 
@@ -18903,6 +19171,140 @@ inline const ClusterNodeConnection& ClusterNode::transport() const
     return d_transport;
 }
 
+// ------------------------------
+// class CredentialProviderConfig
+// ------------------------------
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int CredentialProviderConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(&d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_settings,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SETTINGS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int CredentialProviderConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                                  int            id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: {
+        return manipulator(&d_name,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    }
+    case ATTRIBUTE_ID_SETTINGS: {
+        return manipulator(&d_settings,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SETTINGS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int CredentialProviderConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                                  const char*    name,
+                                                  int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline bsl::string& CredentialProviderConfig::name()
+{
+    return d_name;
+}
+
+inline bsl::vector<PluginSettingKeyValue>& CredentialProviderConfig::settings()
+{
+    return d_settings;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int CredentialProviderConfig::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_settings, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SETTINGS]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int CredentialProviderConfig::accessAttribute(t_ACCESSOR& accessor,
+                                              int         id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_NAME: {
+        return accessor(d_name, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_NAME]);
+    }
+    case ATTRIBUTE_ID_SETTINGS: {
+        return accessor(d_settings,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_SETTINGS]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int CredentialProviderConfig::accessAttribute(t_ACCESSOR& accessor,
+                                              const char* name,
+                                              int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline const bsl::string& CredentialProviderConfig::name() const
+{
+    return d_name;
+}
+
+inline const bsl::vector<PluginSettingKeyValue>&
+CredentialProviderConfig::settings() const
+{
+    return d_settings;
+}
+
 // ----------------------
 // class DispatcherConfig
 // ----------------------
@@ -19863,6 +20265,7 @@ void AuthenticatorConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
     hashAppend(hashAlgorithm, this->anonymousCredential());
     hashAppend(hashAlgorithm, this->minThreads());
     hashAppend(hashAlgorithm, this->maxThreads());
+    hashAppend(hashAlgorithm, this->credentialProvider());
 }
 
 inline bool
@@ -19871,7 +20274,8 @@ AuthenticatorConfig::isEqualTo(const AuthenticatorConfig& rhs) const
     return this->authenticators() == rhs.authenticators() &&
            this->anonymousCredential() == rhs.anonymousCredential() &&
            this->minThreads() == rhs.minThreads() &&
-           this->maxThreads() == rhs.maxThreads();
+           this->maxThreads() == rhs.maxThreads() &&
+           this->credentialProvider() == rhs.credentialProvider();
 }
 
 // CLASS METHODS
@@ -19906,6 +20310,13 @@ int AuthenticatorConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
         return ret;
     }
 
+    ret = manipulator(
+        &d_credentialProvider,
+        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -19933,6 +20344,11 @@ int AuthenticatorConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_MAX_THREADS: {
         return manipulator(&d_maxThreads,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_THREADS]);
+    }
+    case ATTRIBUTE_ID_CREDENTIAL_PROVIDER: {
+        return manipulator(
+            &d_credentialProvider,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER]);
     }
     default: return NOT_FOUND;
     }
@@ -19976,6 +20392,12 @@ inline int& AuthenticatorConfig::maxThreads()
     return d_maxThreads;
 }
 
+inline bdlb::NullableValue<CredentialProviderConfig>&
+AuthenticatorConfig::credentialProvider()
+{
+    return d_credentialProvider;
+}
+
 // ACCESSORS
 template <typename t_ACCESSOR>
 int AuthenticatorConfig::accessAttributes(t_ACCESSOR& accessor) const
@@ -20006,6 +20428,12 @@ int AuthenticatorConfig::accessAttributes(t_ACCESSOR& accessor) const
         return ret;
     }
 
+    ret = accessor(d_credentialProvider,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER]);
+    if (ret) {
+        return ret;
+    }
+
     return 0;
 }
 
@@ -20031,6 +20459,11 @@ int AuthenticatorConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_MAX_THREADS: {
         return accessor(d_maxThreads,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_THREADS]);
+    }
+    case ATTRIBUTE_ID_CREDENTIAL_PROVIDER: {
+        return accessor(
+            d_credentialProvider,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_CREDENTIAL_PROVIDER]);
     }
     default: return NOT_FOUND;
     }
@@ -20072,6 +20505,12 @@ inline int AuthenticatorConfig::minThreads() const
 inline int AuthenticatorConfig::maxThreads() const
 {
     return d_maxThreads;
+}
+
+inline const bdlb::NullableValue<CredentialProviderConfig>&
+AuthenticatorConfig::credentialProvider() const
+{
+    return d_credentialProvider;
 }
 
 // -----------------------
@@ -21972,6 +22411,6 @@ inline const AppConfig& Configuration::appConfig() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.02.26
+// GENERATED BY BLP_BAS_CODEGEN_2026.04.30
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbplug/mqbplug_authncredential.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_authncredential.cpp
@@ -1,0 +1,24 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbplug_authncredential.h>
+
+#include <mqbscm_version.h>
+
+namespace BloombergLP {
+namespace mqbplug {
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbplug/mqbplug_authncredential.h
+++ b/src/groups/mqb/mqbplug/mqbplug_authncredential.h
@@ -1,0 +1,145 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBPLUG_AUTHNCREDENTIAL
+#define INCLUDED_MQBPLUG_AUTHNCREDENTIAL
+
+//@PURPOSE: Provide a value-semantic type for authentication credentials.
+//
+//@CLASSES:
+//  mqbplug::AuthnCredential: authentication mechanism and credential data.
+//
+//@DESCRIPTION: This component provides a value-semantic type,
+// 'mqbplug::AuthnCredential', that holds an authentication mechanism name and
+// binary credential data.  It is used by 'CredentialProvider' plugins to
+// supply credentials for outbound broker-to-broker authentication.
+
+// BDE
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+
+namespace BloombergLP {
+namespace mqbplug {
+
+// ====================
+// class AuthnCredential
+// ====================
+
+/// A value-semantic type holding an authentication mechanism and binary
+/// credential data for outbound authentication.
+class AuthnCredential {
+  private:
+    // DATA
+    bsl::string       d_mechanism;
+    bsl::vector<char> d_data;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(AuthnCredential, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create an `AuthnCredential` object with empty mechanism and data,
+    /// using the optionally specified `allocator` to supply memory.
+    explicit AuthnCredential(bslma::Allocator* allocator = 0);
+
+    /// Create an `AuthnCredential` object with the specified `mechanism`
+    /// and `data`, using the optionally specified `allocator` to supply
+    /// memory.
+    explicit AuthnCredential(const bsl::string&       mechanism,
+                             const bsl::vector<char>& data,
+                             bslma::Allocator*        allocator = 0);
+
+    /// Create an `AuthnCredential` object having the same value as the
+    /// specified `original`, using the optionally specified `allocator` to
+    /// supply memory.
+    AuthnCredential(const AuthnCredential& original,
+                    bslma::Allocator*      allocator = 0);
+
+    // MANIPULATORS
+
+    /// Assign to this object the value of the specified `rhs` and return a
+    /// reference providing modifiable access to this object.
+    AuthnCredential& operator=(const AuthnCredential& rhs);
+
+    // ACCESSORS
+
+    /// Return a reference providing non-modifiable access to the
+    /// authentication mechanism.
+    const bsl::string& mechanism() const;
+
+    /// Return a reference providing non-modifiable access to the credential
+    /// data.
+    const bsl::vector<char>& data() const;
+};
+
+// ============================================================================
+//                             INLINE DEFINITIONS
+// ============================================================================
+
+// --------------------
+// class AuthnCredential
+// --------------------
+
+// CREATORS
+inline AuthnCredential::AuthnCredential(bslma::Allocator* allocator)
+: d_mechanism(allocator)
+, d_data(allocator)
+{
+}
+
+inline AuthnCredential::AuthnCredential(const bsl::string&       mechanism,
+                                        const bsl::vector<char>& data,
+                                        bslma::Allocator*        allocator)
+: d_mechanism(mechanism, allocator)
+, d_data(data, allocator)
+{
+}
+
+inline AuthnCredential::AuthnCredential(const AuthnCredential& original,
+                                        bslma::Allocator*      allocator)
+: d_mechanism(original.d_mechanism, allocator)
+, d_data(original.d_data, allocator)
+{
+}
+
+// MANIPULATORS
+inline AuthnCredential& AuthnCredential::operator=(const AuthnCredential& rhs)
+{
+    if (this != &rhs) {
+        d_mechanism = rhs.d_mechanism;
+        d_data      = rhs.d_data;
+    }
+    return *this;
+}
+
+// ACCESSORS
+inline const bsl::string& AuthnCredential::mechanism() const
+{
+    return d_mechanism;
+}
+
+inline const bsl::vector<char>& AuthnCredential::data() const
+{
+    return d_data;
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbplug/mqbplug_credentialprovider.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_credentialprovider.cpp
@@ -1,0 +1,47 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbplug_credentialprovider.h>
+
+#include <mqbscm_version.h>
+
+namespace BloombergLP {
+namespace mqbplug {
+
+// ------------------------
+// class CredentialProvider
+// ------------------------
+
+CredentialProvider::~CredentialProvider()
+{
+    // NOTHING
+}
+
+// --------------------------------------
+// class CredentialProviderPluginFactory
+// --------------------------------------
+
+CredentialProviderPluginFactory::CredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+CredentialProviderPluginFactory::~CredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbplug/mqbplug_credentialprovider.h
+++ b/src/groups/mqb/mqbplug/mqbplug_credentialprovider.h
@@ -1,0 +1,110 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBPLUG_CREDENTIALPROVIDER
+#define INCLUDED_MQBPLUG_CREDENTIALPROVIDER
+
+//@PURPOSE: Provide base classes for the 'CredentialProvider' plugin.
+//
+//@CLASSES:
+//  mqbplug::CredentialProvider: interface for a plugin of type
+//                               'e_CREDENTIAL_PROVIDER'.
+//  mqbplug::CredentialProviderPluginFactory: base class for the
+//                                           'CredentialProvider'
+//                                           plugin factory.
+//
+//@DESCRIPTION: This component provides definitions for the
+// 'mqbplug::CredentialProvider' interface and
+// 'mqbplug::CredentialProviderPluginFactory' used as base classes for
+// plugins that supply credentials for outbound broker-to-broker
+// authentication.  A 'CredentialProvider' produces a callable that
+// returns an 'AuthnCredential' when invoked.
+
+// MQB
+#include <mqbplug_authncredential.h>
+#include <mqbplug_pluginfactory.h>
+
+// BDE
+#include <bsl_functional.h>
+#include <bsl_iostream.h>
+#include <bsl_optional.h>
+#include <bslma_managedptr.h>
+
+namespace BloombergLP {
+namespace mqbplug {
+
+// ========================
+// class CredentialProvider
+// ========================
+
+/// Interface for a plugin that supplies credentials for outbound
+/// broker-to-broker authentication.
+class CredentialProvider {
+  public:
+    // TYPES
+
+    /// A callable that returns an `AuthnCredential` on success, or
+    /// `nullopt` on failure (with a description written to the `error`
+    /// stream).  The broker invokes this function each time it needs
+    /// credentials for an outbound connection or reauthentication.
+    typedef bsl::function<bsl::optional<AuthnCredential>(bsl::ostream& error)>
+        CredentialFunc;
+
+    // CREATORS
+
+    /// Destroy this object.
+    virtual ~CredentialProvider();
+
+    // MANIPULATORS
+
+    /// Return a credential-providing function.  This method is called once
+    /// at broker startup after `start()` succeeds; the returned function is
+    /// stored and invoked for each outbound connection and
+    /// reauthentication.  The behavior is undefined unless `start()` has
+    /// been called successfully.
+    virtual CredentialFunc load() = 0;
+
+    /// Start the CredentialProvider and return 0 on success, or return
+    /// a non-zero value and populate the specified `errorDescription` with
+    /// the description of any failure encountered.
+    virtual int start(bsl::ostream& errorDescription) = 0;
+
+    /// Stop the CredentialProvider.
+    virtual void stop() = 0;
+};
+
+// ======================================
+// class CredentialProviderPluginFactory
+// ======================================
+
+/// This is the base class for the factory of plugins of type
+/// `CredentialProvider`.  It allows instantiation of a concrete
+/// `CredentialProvider` object.
+class CredentialProviderPluginFactory : public PluginFactory {
+  public:
+    // CREATORS
+    CredentialProviderPluginFactory();
+
+    ~CredentialProviderPluginFactory() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+    virtual bslma::ManagedPtr<CredentialProvider>
+    create(bslma::Allocator* allocator) = 0;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbplug/mqbplug_plugintype.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_plugintype.cpp
@@ -49,6 +49,7 @@ const char* PluginType::toAscii(PluginType::Enum value)
     switch (value) {
         CASE(STATS_CONSUMER)
         CASE(AUTHENTICATOR)
+        CASE(CREDENTIAL_PROVIDER)
     default: return "(* UNKNOWN *)";
     }
 

--- a/src/groups/mqb/mqbplug/mqbplug_plugintype.h
+++ b/src/groups/mqb/mqbplug/mqbplug_plugintype.h
@@ -41,7 +41,11 @@ namespace mqbplug {
 /// authentication, ...)
 struct PluginType {
     // TYPES
-    enum Enum { e_STATS_CONSUMER = 0, e_AUTHENTICATOR = 1 };
+    enum Enum {
+        e_STATS_CONSUMER      = 0,
+        e_AUTHENTICATOR       = 1,
+        e_CREDENTIAL_PROVIDER = 2
+    };
 
     // CLASS METHODS
 

--- a/src/groups/mqb/mqbplug/package/mqbplug.mem
+++ b/src/groups/mqb/mqbplug/package/mqbplug.mem
@@ -1,4 +1,6 @@
 mqbplug_authenticator
+mqbplug_authncredential
+mqbplug_credentialprovider
 mqbplug_pluginfactory
 mqbplug_plugininfo
 mqbplug_pluginlibrary


### PR DESCRIPTION
**Describe your changes**

This PR adds the initial set of plugin interfaces for supplying credentials during broker-to-broker authentication:

- `e_CREDENTIAL_PROVIDER` PluginType enum added
- `mqbplug::AuthnCredential`: value-semantic type for credentials
- `mqbplug::CredentialProvider`: abstract plugin interface
- `mqbplug::CredentialProviderPluginFactory`: factory base class