### PR TITLE
Feat[mqbs]: allow purge on full JOURNAL file

### DIFF
--- a/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp
@@ -44,6 +44,7 @@ Dispatcher::Dispatcher(bslma::Allocator* allocator)
 , d_eventsForClients(allocator)
 , d_mutex()
 , d_queue(allocator)
+, d_enqueueOnly(false)
 , d_customEventSources(allocator)
 , d_customEventSources_mtx()
 {
@@ -120,32 +121,35 @@ void Dispatcher::executeOnAllQueues(
 
 void Dispatcher::_execute(const mqbi::Dispatcher::VoidFunction& functor)
 {
-    bool run = false;
+    bool firstToEnqueue = false;
 
     {
-        bslmt::LockGuard<bslmt::Mutex> lock(&mutex());
-
-        if (d_queue.empty()) {
-            // The thread that pushes the first functor to the queue
-            // will try to process this queue.
-            run = true;
-        }
+        bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
+        firstToEnqueue = d_queue.empty();
         d_queue.push(functor);
     }
 
-    while (run) {
+    if (!d_enqueueOnly && firstToEnqueue) {
+        processQueue();
+    }
+}
+
+void Dispatcher::setEnqueueOnly(bool value)
+{
+    d_enqueueOnly = value;
+}
+
+void Dispatcher::processQueue()
+{
+    while (true) {
         mqbi::Dispatcher::VoidFunction next;
         {
-            bslmt::LockGuard<bslmt::Mutex> lock(&mutex());
-
-            next = d_queue.front();
-
-            d_queue.pop();
+            bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
             if (d_queue.empty()) {
-                // There is nothing more to process, this thread can stop
-                // after calling the last functor.
-                run = false;
+                return;  // RETURN
             }
+            next = d_queue.front();
+            d_queue.pop();
         }
         next();
     }

--- a/src/groups/mqb/mqbmock/mqbmock_dispatcher.h
+++ b/src/groups/mqb/mqbmock/mqbmock_dispatcher.h
@@ -51,6 +51,7 @@
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bslmt_mutex.h>
+#include <bsls_atomic.h>
 #include <bsls_cpp11.h>
 
 namespace BloombergLP {
@@ -85,6 +86,9 @@ class Dispatcher BSLS_KEYWORD_FINAL : public mqbi::Dispatcher {
 
     /// Synchronize `functor`s to `execute`
     bsl::queue<mqbi::Dispatcher::VoidFunction> d_queue;
+
+    /// When true, `_execute` only enqueues without running.
+    bsls::AtomicBool d_enqueueOnly;
 
     /// All the event sources allocated by `createEventSource`.
     /// Cached to ensure their lifetime is at least until destructor is called.
@@ -244,6 +248,15 @@ class Dispatcher BSLS_KEYWORD_FINAL : public mqbi::Dispatcher {
     bslmt::Mutex& mutex();
 
     void _execute(const mqbi::Dispatcher::VoidFunction& functor);
+
+    /// Set whether `execute` should only enqueue functors without running
+    /// them.  When `true`, functors are queued for later execution via
+    /// `processQueue`.  When `false` (default), functors are executed
+    /// inline by the calling thread.
+    void setEnqueueOnly(bool value);
+
+    /// Execute all queued functors in the calling thread.
+    void processQueue();
 };
 
 // ======================

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -675,6 +675,10 @@ class DataStore : public mqbi::DispatcherClient {
     /// data store.
     virtual void removeRecordRaw(const DataStoreRecordHandle& handle) = 0;
 
+    /// Attempt to rollover the journal if needed after a purge has cleared
+    /// outstanding records.
+    virtual void onPurgeComplete() = 0;
+
     /// Process the specified storage event `blob` containing one or more
     /// storage messages.  The behavior is undefined unless each message in
     /// the event belongs to this partition, and has same primary and

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -651,6 +651,7 @@ FileBackedStorage::removeAll(const mqbu::StorageKey& appKey)
 
         if (mqbi::StorageResult::e_SUCCESS == rc) {
             purgeCommon(mqbu::StorageKey::k_NULL_KEY, true);
+            d_store_p->onPurgeComplete();
 
             d_isEmpty.storeRelaxed(1);
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -449,6 +449,11 @@ class MockDataStore : public mqbs::DataStore {
         }
     }
 
+    void onPurgeComplete() BSLS_KEYWORD_OVERRIDE
+    {
+        // NOTHING
+    }
+
     void processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>&,
                              bool,
                              mqbnet::ClusterNode*) BSLS_KEYWORD_OVERRIDE

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -107,12 +107,31 @@ const int k_NAGLE_PACKET_COUNT = 100;
 
 const int k_KEY_LEN = FileStoreProtocol::k_KEY_LENGTH;
 
-const unsigned int k_REQUESTED_JOURNAL_SPACE =
-    3 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
-// Above, 3 == 1 journal record being written +
-//             1 journal sync point if rolling over +
-//             1 journal sync point if self needs to issue another sync point
-//             in 'setActivePrimary' with old values
+/// k_RESERVED1_SYNC_POINT_SIZE is the space in the end of the JOURNAL file
+/// reserved for SYNC POINTS:
+/// 1 journal sync point if rolling over +
+/// 1 journal sync point if self needs to issue another sync point in
+///   'setActivePrimary' with old values
+const bsls::Types::Uint64 k_RESERVED1_SYNC_POINT_SIZE =
+    2 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
+
+/// k_RESERVED2_PURGE_SIZE is the space in the end of the JOURNAL file reserved
+/// for PURGE records if JOURNAL file is not available
+const bsls::Types::Uint64 k_RESERVED2_PURGE_SIZE =
+    k_RESERVED1_SYNC_POINT_SIZE +
+    16 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
+
+/// k_REQUESTED_JOURNAL_SPACE is the minimum required space in JOURNAL to write
+/// a next common record
+const bsls::Types::Uint64 k_REQUESTED_JOURNAL_SPACE =
+    FileStoreProtocol::k_JOURNAL_RECORD_SIZE + k_RESERVED2_PURGE_SIZE;
+
+/// Reserved areas of the JOURNAL file (not in scale):
+/// [start ======================= JOURNAL FILE ========================== end]
+/// k_RESERVED1_SYNC_POINT_SIZE                                            [==]
+/// k_RESERVED2_PURGE_SIZE                                     [==============]
+/// k_REQUESTED_JOURNAL_SPACE                                 [===============]
+/// [========= normal JOURNAL records ========================]
 
 /// Return a rounded (down) percentage value (range [0-100]) representing
 /// the space in use on a file with the specified `capacity`, currently
@@ -926,13 +945,13 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
     // to bump the journal file size.
 
     if (d_config.maxJournalFileSize() <
-        (journalFileOffset + 2 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE)) {
+        (journalFileOffset + k_RESERVED1_SYNC_POINT_SIZE)) {
         BALL_LOG_ERROR << partitionDesc() << "Journal does not have enough "
                        << "space. Journal offset: " << journalFileOffset
                        << ", max journal file size per config: "
                        << d_config.maxJournalFileSize()
                        << ", additional space (in bytes) required in journal: "
-                       << (2 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
+                       << k_RESERVED1_SYNC_POINT_SIZE;
         return rc_PARTITION_FULL;  // RETURN
     }
 
@@ -3034,7 +3053,7 @@ int FileStore::rolloverIfNeeded(FileType::Enum              fileType,
                                 const MappedFileDescriptor& file,
                                 const bsl::string&          fileName,
                                 bsls::Types::Uint64         currentSize,
-                                unsigned int                requestedSpace)
+                                bsls::Types::Uint64         requestedSpace)
 {
     FileSet* activeFileSet = d_fileSets[0].get();
     BSLS_ASSERT_SAFE(activeFileSet);
@@ -3654,7 +3673,43 @@ int FileStore::writeQueueOpRecord(DataStoreRecordHandle*  handle,
     }
 
     if (!activeFileSet->d_journalFileAvailable) {
-        return rc_UNAVAILABLE;  // RETURN
+        if (QueueOpType::e_PURGE != queueOpFlag) {
+            // Nothing else we can do unless it is a PURGE record
+            return rc_UNAVAILABLE;  // RETURN
+        }
+        if (!appKey.isNull()) {
+            // Per-appId purge requires writing message deletion records to
+            // journal, but we don't have space for it. Only full queue purges
+            // are supported on unavailable journal.
+            return rc_UNAVAILABLE;  // RETURN
+        }
+
+        const bool useSyncPointReservedArea =
+            (activeFileSet->d_journalFile.fileSize() <
+             FileStoreProtocol::k_JOURNAL_RECORD_SIZE +
+                 activeFileSet->d_journalFilePosition +
+                 k_RESERVED1_SYNC_POINT_SIZE);
+        if (useSyncPointReservedArea) {
+            // This is a PURGE record, but we cannot write it because this
+            // record will use space reserved for SYNC POINTS in the end of the
+            // JOURNAL file
+            return rc_UNAVAILABLE;  // RETURN
+        }
+
+        BALL_LOG_WARN << partitionDesc()
+                      << "Writing PURGE record for queueKey [" << queueKey
+                      << "] to journal despite partition being"
+                      << " unavailable";
+
+        writeQueueOpRecordImpl(handle,
+                               queueKey,
+                               appKey,
+                               queueOpFlag,
+                               timestamp,
+                               startPrimaryLeaseId,
+                               startSequenceNum);
+
+        return rc_SUCCESS;  // RETURN
     }
 
     // Roll over if needed
@@ -3667,19 +3722,35 @@ int FileStore::writeQueueOpRecord(DataStoreRecordHandle*  handle,
         return 10 * rc + rc_ROLLOVER_FAILURE;  // RETURN
     }
 
-    // Update 'activeFileSet' as it may have rolled over above.
-    activeFileSet = d_fileSets[0].get();
+    writeQueueOpRecordImpl(handle,
+                           queueKey,
+                           appKey,
+                           queueOpFlag,
+                           timestamp,
+                           startPrimaryLeaseId,
+                           startSequenceNum);
 
-    // Local refs for convenience.
+    return rc_SUCCESS;
+}
+
+void FileStore::writeQueueOpRecordImpl(DataStoreRecordHandle*  handle,
+                                       const mqbu::StorageKey& queueKey,
+                                       const mqbu::StorageKey& appKey,
+                                       QueueOpType::Enum       queueOpFlag,
+                                       bsls::Types::Uint64     timestamp,
+                                       unsigned int        startPrimaryLeaseId,
+                                       bsls::Types::Uint64 startSequenceNum)
+{
+    FileSet* activeFileSet = d_fileSets[0].get();
+    BSLS_ASSERT_SAFE(activeFileSet);
+
     MappedFileDescriptor& journal    = activeFileSet->d_journalFile;
     bsls::Types::Uint64&  journalPos = activeFileSet->d_journalFilePosition;
 
-    BSLS_ASSERT_SAFE(journal.fileSize() >=
-                     (journalPos + k_REQUESTED_JOURNAL_SPACE));
-    // JOURNAL has been successfully rolled over, so above assert should
-    // not fire.
+    BSLS_ASSERT_SAFE(journalPos + k_RESERVED1_SYNC_POINT_SIZE +
+                         FileStoreProtocol::k_JOURNAL_RECORD_SIZE <=
+                     journal.fileSize());
 
-    // Append queueOp record to journal.
     bsls::Types::Uint64      recordOffset = journalPos;
     OffsetPtr<QueueOpRecord> qRec(journal.block(), journalPos);
     new (qRec.get()) QueueOpRecord();
@@ -3701,8 +3772,6 @@ int FileStore::writeQueueOpRecord(DataStoreRecordHandle*  handle,
                                       bmqp::StorageMessageType::e_QUEUE_OP,
                                       RecordType::e_QUEUE_OP,
                                       recordOffset);
-
-    return rc_SUCCESS;
 }
 
 void FileStore::writeRolledOverRecord(DataStoreRecord*    record,
@@ -5300,7 +5369,8 @@ int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap)
     enum {
         rc_SUCCESS                   = 0,
         rc_NON_RECOVERY_MODE_FAILURE = -1,
-        rc_RECOVERY_MODE_FAILURE     = -2
+        rc_RECOVERY_MODE_FAILURE     = -2,
+        rc_JOURNAL_FILE_TOO_SMALL    = -3
     };
 
     BALL_LOG_INFO_BLOCK
@@ -5313,6 +5383,17 @@ int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap)
     if (d_isOpen) {
         BALL_LOG_INFO << partitionDesc() << "is already open.";
         return rc_SUCCESS;  // RETURN
+    }
+
+    const bsls::Types::Uint64 minJournalFileSize = sizeof(FileHeader) +
+                                                   sizeof(JournalFileHeader) +
+                                                   k_REQUESTED_JOURNAL_SPACE;
+    if (d_config.maxJournalFileSize() < minJournalFileSize) {
+        BALL_LOG_ERROR << partitionDesc() << "maxJournalFileSize ("
+                       << d_config.maxJournalFileSize()
+                       << ") is too small. Minimum required: "
+                       << minJournalFileSize;
+        return rc_JOURNAL_FILE_TOO_SMALL;  // RETURN
     }
 
     bmqu::MemOutStream errorDescription;
@@ -6232,6 +6313,26 @@ void FileStore::removeRecordRaw(const DataStoreRecordHandle& handle)
     }
 
     d_records.erase(recordIt);
+}
+
+void FileStore::onPurgeComplete()
+{
+    BSLS_ASSERT_SAFE(0 < d_fileSets.size());
+
+    FileSet* activeFileSet = d_fileSets[0].get();
+    BSLS_ASSERT_SAFE(activeFileSet);
+
+    if (activeFileSet->d_journalFileAvailable) {
+        return;  // RETURN
+    }
+
+    activeFileSet->d_journalFileAvailable = true;
+
+    rolloverIfNeeded(FileType::e_JOURNAL,
+                     activeFileSet->d_journalFile,
+                     activeFileSet->d_journalFileName,
+                     activeFileSet->d_journalFilePosition,
+                     k_REQUESTED_JOURNAL_SPACE);
 }
 
 void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -532,7 +532,7 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                          const MappedFileDescriptor& file,
                          const bsl::string&          fileName,
                          bsls::Types::Uint64         currentSize,
-                         unsigned int                requestedSpace);
+                         bsls::Types::Uint64         requestedSpace);
 
     /// Write a QUEUE_OP record to the journal with the specified
     /// `queueKey`, optional `appKey`, `timestamp`, `opValue` and `subValue`
@@ -547,6 +547,18 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                            bsls::Types::Uint64     timestamp,
                            unsigned int            startPrimaryLeaseId,
                            bsls::Types::Uint64     startSequenceNum);
+
+    /// Write a QUEUE_OP record to the journal for the specified `queueKey`,
+    /// optional `appKey`, `queueOpFlag`, `timestamp`,
+    /// `startPrimaryLeaseId`, and `startSequenceNum`.  Performs the actual
+    /// writing after all checks have been done by the caller.
+    void writeQueueOpRecordImpl(DataStoreRecordHandle*  handle,
+                                const mqbu::StorageKey& queueKey,
+                                const mqbu::StorageKey& appKey,
+                                QueueOpType::Enum       queueOpFlag,
+                                bsls::Types::Uint64     timestamp,
+                                unsigned int            startPrimaryLeaseId,
+                                bsls::Types::Uint64     startSequenceNum);
 
     /// Rollover over the specified `record` from `oldFileSet` to the
     /// `newFileSet`, and if it is a message record, update the counter of
@@ -866,6 +878,10 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// record in the data store.
     void
     removeRecordRaw(const DataStoreRecordHandle& handle) BSLS_KEYWORD_OVERRIDE;
+
+    /// Attempt to rollover the journal if needed after a purge has cleared
+    /// outstanding records.
+    void onPurgeComplete() BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified storage event `blob` containing one or more
     /// storage messages.  The behavior is undefined unless each message in

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -19,7 +19,10 @@
 #include <mqbcfg_messages.h>
 #include <mqbi_dispatcher.h>
 #include <mqbi_storage.h>
+#include <mqbmock_cluster.h>
 #include <mqbmock_dispatcher.h>
+#include <mqbmock_domain.h>
+#include <mqbmock_queue.h>
 #include <mqbnet_mockcluster.h>
 #include <mqbs_datastore.h>
 #include <mqbs_filestoreprotocol.h>
@@ -31,6 +34,7 @@
 
 // BMQ
 #include <bmqp_blobpoolutil.h>
+#include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_messageguid.h>
 #include <bmqt_uri.h>
@@ -90,6 +94,61 @@ typedef mqbs::DataStore::AppInfos                      AppInfos;
 typedef mqbs::FileStore::SyncPointOffsetPairs          SyncPointOffsetPairs;
 typedef bsl::pair<mqbs::DataStoreRecordHandle, Record> HandleRecordPair;
 
+// CLASSES
+
+/// Helper to post dummy messages to a `ReplicatedStorage` for testing.
+class StoragePoster {
+    /// Target storage to post messages to.
+    bsl::shared_ptr<mqbs::ReplicatedStorage> d_storage_sp;
+
+    /// Factory for allocating blob buffers for message payloads.
+    bdlbb::PooledBlobBufferFactory d_bufferFactory;
+
+  public:
+    /// Create a `StoragePoster` that posts to the specified `storage`,
+    /// using the specified `allocator` for memory allocation.
+    StoragePoster(const bsl::shared_ptr<mqbs::ReplicatedStorage>& storage,
+                  bslma::Allocator*                               allocator)
+    : d_storage_sp(storage)
+    , d_bufferFactory(1024, allocator)
+    {
+    }
+
+    /// Post a dummy message to the underlying storage. Return the result
+    /// of the put operation.
+    mqbi::StorageResult::Enum postMessage()
+    {
+        bmqt::MessageGUID guid;
+        mqbu::MessageGUIDUtil::generateGUID(&guid);
+
+        bsl::shared_ptr<bdlbb::Blob> appData_sp;
+        appData_sp.createInplace(bmqtst::TestHelperUtil::allocator(),
+                                 &d_bufferFactory,
+                                 bmqtst::TestHelperUtil::allocator());
+        bsl::string payload(10, 'x', bmqtst::TestHelperUtil::allocator());
+        bdlbb::BlobUtil::append(appData_sp.get(),
+                                payload.c_str(),
+                                payload.length());
+
+        bsls::Types::Uint64 timestamp = bdlt::EpochUtil::convertToTimeT64(
+            bdlt::CurrentTime::utc());
+
+        mqbi::StorageMessageAttributes attributes(
+            timestamp,
+            1,  // refCount
+            static_cast<unsigned int>(appData_sp->length()),
+            bmqp::MessagePropertiesInfo(),
+            bmqt::CompressionAlgorithmType::e_NONE,
+            true,  // hasReceipt
+            0,     // queueHandle
+            bmqp::Crc32c::calculate(*appData_sp));
+
+        bsl::shared_ptr<bdlbb::Blob> options_sp;
+
+        return d_storage_sp->put(&attributes, guid, appData_sp, options_sp);
+    }
+};
+
 // FUNCTIONS
 
 void recoveredQueuesCb(
@@ -129,12 +188,13 @@ struct Tester {
 
   public:
     // CREATORS
-    Tester(const char* location)
+    Tester(const char* location, const char* archiveLocation = 0)
     : d_scheduler(bsls::SystemClockType::e_MONOTONIC,
                   bmqtst::TestHelperUtil::allocator())
     , d_bufferFactory(1024, bmqtst::TestHelperUtil::allocator())
     , d_clusterLocation(location, bmqtst::TestHelperUtil::allocator())
-    , d_clusterArchiveLocation(location, bmqtst::TestHelperUtil::allocator())
+    , d_clusterArchiveLocation(archiveLocation ? archiveLocation : location,
+                               bmqtst::TestHelperUtil::allocator())
     , d_blobSpPool_sp(bmqp::BlobPoolUtil::createBlobPool(
           &d_bufferFactory,
           bmqtst::TestHelperUtil::allocator()))
@@ -157,6 +217,15 @@ struct Tester {
         bdls::FilesystemUtil::createDirectories(d_clusterLocation, true);
         bdls::FilesystemUtil::createDirectories(d_clusterArchiveLocation,
                                                 true);
+        {
+            BSLA_MAYBE_UNUSED const int rc = d_scheduler.start();
+            BMQTST_ASSERT_EQ(rc, 0);
+        }
+
+        {
+            BSLA_MAYBE_UNUSED const int rc = d_miscWorkThreadPool.start();
+            BMQTST_ASSERT_EQ(rc, 0);
+        }
 
         d_partitionCfg.maxDataFileSize()     = 100 * 1024 * 1024;
         d_partitionCfg.maxQlistFileSize()    = 1 * 1024 * 1024;
@@ -233,6 +302,9 @@ struct Tester {
 
     ~Tester()
     {
+        d_scheduler.stop();
+        d_miscWorkThreadPool.stop();
+
         bdls::FilesystemUtil::remove(d_clusterLocation, true);
         bdls::FilesystemUtil::remove(d_clusterArchiveLocation, true);
     }
@@ -706,6 +778,15 @@ struct Tester {
     mqbs::FileStore& fileStore() const { return *(d_fs_mp); }
 
     mqbnet::ClusterNode* node() const { return d_node_p; }
+
+    bdlmt::FixedThreadPool& miscWorkThreadPool()
+    {
+        return d_miscWorkThreadPool;
+    }
+
+    mqbmock::Dispatcher& dispatcher() { return d_dispatcher; }
+
+    bdlmt::EventScheduler& scheduler() { return d_scheduler; }
 };
 
 // ============================================================================
@@ -938,6 +1019,152 @@ static void test2_printTest()
     fs.close();
 }
 
+static void test3_partitionFullAlarm()
+// ------------------------------------------------------------------------
+// PARTITION FULL ALARM
+//
+// Concerns:
+//   Verify that writing records to the journal until it is full triggers
+//   a partition-full alarm (rollover failure), and that purging records
+//   afterwards decreases the outstanding byte count.
+//
+// Testing:
+//   writeQueueCreationRecord, writeMessageRecord, removeRecordRaw
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-3";
+
+    Tester           tester(k_FILE_STORE_LOCATION);
+    mqbs::FileStore& fs = tester.fileStore();
+
+    // Disable in-place callback execution in mock dispatcher to prevent
+    // thread races between the main thread (that modifies FileStore) and
+    // scheduler thread (that performs gc on FileStore).
+    tester.dispatcher().setEnqueueOnly(true);
+
+    int rc = fs.open(0);
+    BMQTST_ASSERT_EQ(0, rc);
+    if (rc) {
+        cout << "Failed to open partition, rc: " << rc << endl;
+        return;  // RETURN
+    }
+
+    // Set primary.
+    unsigned int primaryLeaseId = 1;
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
+
+    // Create a storage and register it with the FileStore.
+    bmqt::Uri        queueUri("bmq://si.amw.bmq.stats/testQueue",
+                       bmqtst::TestHelperUtil::allocator());
+    mqbu::StorageKey queueKey(mqbu::StorageKey::BinaryRepresentation(),
+                              "ABCDE");
+
+    mqbmock::Cluster mockCluster(bmqtst::TestHelperUtil::allocator());
+    mqbmock::Domain  mockDomain(&mockCluster,
+                               bmqtst::TestHelperUtil::allocator());
+    mqbconfm::Domain domainCfg(bmqtst::TestHelperUtil::allocator());
+    domainCfg.messageTtl() = bsl::numeric_limits<bsls::Types::Int64>::max();
+    domainCfg.storage().config().makeFileBacked();
+    bmqu::MemOutStream errDesc(bmqtst::TestHelperUtil::allocator());
+    mockDomain.configure(errDesc, domainCfg);
+
+    bsl::shared_ptr<mqbs::ReplicatedStorage> storage_sp;
+    fs.createStorage(&storage_sp, queueUri, queueKey, &mockDomain);
+
+    mqbconfm::Limits limits;
+    limits.messages() = bsl::numeric_limits<bsls::Types::Int64>::max();
+    limits.bytes()    = bsl::numeric_limits<bsls::Types::Int64>::max();
+    limits.messagesWatermarkRatio() = 0.8;
+    limits.bytesWatermarkRatio()    = 0.8;
+    storage_sp->configure(domainCfg.storage().config(),
+                          limits,
+                          domainCfg.messageTtl(),
+                          0);  // maxDeliveryAttempts
+
+    fs.registerStorage(storage_sp.get());
+
+    mqbmock::Queue mockQueue(&mockDomain, bmqtst::TestHelperUtil::allocator());
+    storage_sp->setQueue(&mockQueue);
+
+    // 1. Create a queue.
+    mqbs::DataStoreRecordHandle queueHandle;
+    bsls::Types::Uint64         timestamp = bdlt::EpochUtil::convertToTimeT64(
+        bdlt::CurrentTime::utc());
+
+    rc = fs.writeQueueCreationRecord(&queueHandle,
+                                     queueUri,
+                                     queueKey,
+                                     AppInfos(),
+                                     timestamp,
+                                     true);  // isNewQueue
+    BMQTST_ASSERT_EQ(0, rc);
+
+    // 2. Write message records until the journal is full.
+    StoragePoster poster(storage_sp, bmqtst::TestHelperUtil::allocator());
+
+    const size_t k_MAX_ITERATIONS = 20000;
+    size_t       numWritten       = 0;
+    int          failedRc         = 0;
+
+    for (size_t i = 0; i < k_MAX_ITERATIONS; ++i) {
+        mqbi::StorageResult::Enum putRc = poster.postMessage();
+        if (putRc != mqbi::StorageResult::e_SUCCESS) {
+            failedRc = static_cast<int>(putRc);
+            break;
+        }
+
+        ++numWritten;
+    }
+
+    BMQTST_ASSERT_D("journal should have filled up", failedRc != 0);
+    BMQTST_ASSERT_D("should have written some records before failure",
+                    numWritten > 0);
+
+    const bsls::Types::Uint64 numRecordsBeforePurge = fs.numRecords();
+    BMQTST_ASSERT_D("records should exist before purge",
+                    numRecordsBeforePurge > 0);
+
+    // 3. Verify subsequent writes also fail (journal unavailable).
+    BMQTST_ASSERT_D("write after full should fail",
+                    poster.postMessage() != mqbi::StorageResult::e_SUCCESS);
+
+    // 4. Purge the queue via storage.
+    storage_sp->removeAll(mqbu::StorageKey());
+    tester.dispatcher().processQueue();
+
+    // 5. Verify the number of records is small after purge + rollover.
+    BMQTST_ASSERT_D("records after purge should be < 1% of pre-purge",
+                    fs.numRecords() < numRecordsBeforePurge / 100);
+
+    // 6. Verify writes succeed after purge.
+    BMQTST_ASSERT_D("write after purge should succeed",
+                    poster.postMessage() == mqbi::StorageResult::e_SUCCESS);
+
+    // 7. Close and reopen the partition.  Wait for background work from
+    //    the rollover (gcWorkerDispatched, deleteArchiveFilesCb) to finish.
+    tester.miscWorkThreadPool().drain();
+    tester.scheduler().cancelAllEventsAndWait();
+    tester.dispatcher().processQueue();
+    fs.unregisterStorage(storage_sp.get());
+    fs.close();
+    BMQTST_ASSERT_EQ(false, fs.isOpen());
+
+    rc = fs.open(0);
+    BMQTST_ASSERT_EQ(0, rc);
+    BMQTST_ASSERT_EQ(true, fs.isOpen());
+
+    // 8. Verify writes succeed after reopen.
+    fs.registerStorage(storage_sp.get());
+    fs.setActivePrimary(tester.node(), ++primaryLeaseId);
+    BMQTST_ASSERT_D("write after reopen should succeed",
+                    poster.postMessage() == mqbi::StorageResult::e_SUCCESS);
+
+    fs.unregisterStorage(storage_sp.get());
+    fs.close();
+}
+
 }  // close unnamed namespace
 
 // ============================================================================
@@ -952,6 +1179,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 3: test3_partitionFullAlarm(); break;
     case 2: test2_printTest(); break;
     case 1: test1_breathingTest(); break;
     default: {

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -389,6 +389,8 @@ QueueStatsDomain::QueueStatsDomain(bslma::Allocator* allocator)
 void QueueStatsDomain::initialize(const bmqt::Uri& uri, mqbi::Domain* domain)
 {
     BSLS_ASSERT_SAFE(!d_statContext_mp && "initialize was already called");
+    BSLS_ASSERT_SAFE(domain);
+    BSLS_ASSERT_SAFE(domain->cluster());
 
     // Create subContext
     bdlma::LocalSequentialAllocator<2048> localAllocator(d_allocator_p);

--- a/src/integration-tests/test_fsm_partition_sync.py
+++ b/src/integration-tests/test_fsm_partition_sync.py
@@ -30,7 +30,7 @@ from blazingmq.dev.it.cluster_util import (
 
 
 # Set max journal file size to a small value to force rollover during the test
-MAX_JOURNAL_FILE_SIZE = 884
+MAX_JOURNAL_FILE_SIZE = 1844
 
 
 @tweak.cluster.partition_config.max_journal_file_size(MAX_JOURNAL_FILE_SIZE)

--- a/src/integration-tests/test_journal_full_recovery.py
+++ b/src/integration-tests/test_journal_full_recovery.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Testing recovery from journal-full (PARTITION_READONLY) state via PURGE.
+"""
+
+import blazingmq.dev.it.testconstants as tc
+from blazingmq.dev.it.process.client import Client
+from blazingmq.dev.it.fixtures import (
+    Cluster,
+    tweak,
+)
+
+
+# Journal file size chosen so that outstanding bytes exceed 80% of the file
+# when it fills up, causing rollover to fail with PARTITION_READONLY.
+#
+# Without confirms each message = 1 journal record (60 bytes) that is
+# outstanding.  For rollover to fail: outstanding > 0.8 * fileSize.
+# With fileSize = 8192: ~110 message records fit, outstanding ~6600 bytes =
+# ~81% of 8192.
+MAX_JOURNAL_FILE_SIZE = 8192
+
+
+@tweak.cluster.partition_config.num_partitions(1)
+@tweak.cluster.partition_config.max_journal_file_size(MAX_JOURNAL_FILE_SIZE)
+def test_journal_full_purge_recovery(
+    cluster: Cluster,
+    domain_urls: tc.DomainUrls,
+) -> None:
+    """
+    Test that a partition which becomes READONLY due to a full journal can
+    recover after a full queue purge, but not after a per-appId purge.
+
+    A priority queue fills ~50% of the journal, then a fanout queue fills the
+    rest.  Only the fanout queue is purged — the priority queue's messages
+    remain outstanding.  The partition should still recover because
+    outstanding bytes drop below the 80% rollover threshold.
+
+    Then:
+    1. Fill ~50% of journal with priority queue messages.
+    2. Fill the rest with fanout queue messages until PARTITION_READONLY.
+    3. Verify posts fail.
+    4. Purge appId "baz" only — should NOT recover (per-appId purge is
+       rejected on unavailable journal).
+    5. Purge the entire fanout queue — should recover the journal.
+    6. Verify posts succeed again on both queues.
+    7. Restart leader and verify the partition remains healthy.
+    """
+    du = domain_urls
+
+    leader = cluster.last_known_leader
+    proxy = next(cluster.proxy_cycle())
+
+    # Open priority queue producer and consumer.  Consumer never confirms,
+    # keeping all messages outstanding.
+    pri_producer = proxy.create_client("pri_producer")
+    pri_producer.open(du.uri_priority, flags=["write,ack"], succeed=True)
+
+    pri_consumer = proxy.create_client("pri_consumer")
+    pri_consumer.open(du.uri_priority, flags=["read"], succeed=True)
+
+    # 1. Post ~50 messages to the priority queue to fill ~50% of the journal.
+    num_priority_msgs = 50
+    for i in range(num_priority_msgs):
+        rc = pri_producer.post(
+            du.uri_priority, [f"pri{i}"], wait_ack=True, no_except=True
+        )
+        assert rc == Client.e_SUCCESS, (
+            f"Priority post {i} failed unexpectedly (journal should not be full yet)"
+        )
+
+    # Open fanout producer.
+    producer = proxy.create_client("producer")
+    producer.open(du.uri_fanout, flags=["write,ack"], succeed=True)
+
+    # Open consumers for all appIds so messages are routed, but never confirm
+    # from any of them.  This keeps every message outstanding in storage.
+    consumer_foo = proxy.create_client("consumer_foo")
+    consumer_foo.open(du.uri_fanout_foo, flags=["read"], succeed=True)
+
+    consumer_bar = proxy.create_client("consumer_bar")
+    consumer_bar.open(du.uri_fanout_bar, flags=["read"], succeed=True)
+
+    consumer_baz = proxy.create_client("consumer_baz")
+    consumer_baz.open(du.uri_fanout_baz, flags=["read"], succeed=True)
+
+    # 2. Post to fanout without confirming until journal is full.
+    max_iterations = 500
+    num_posted = 0
+    for i in range(max_iterations):
+        rc = producer.post(du.uri_fanout, [f"msg{i}"], wait_ack=True, no_except=True)
+        if rc != Client.e_SUCCESS:
+            break
+        num_posted += 1
+    else:
+        assert False, f"Journal did not fill up after {max_iterations} posts"
+
+    assert num_posted > 0, "Should have posted at least one message before full"
+    assert leader.outputs_substr("PANIC [PARTITION_READONLY]", timeout=5), (
+        "Expected PARTITION_READONLY panic"
+    )
+
+    # 3. Verify further posts fail on both queues.
+    rc = producer.post(du.uri_fanout, ["should_fail"], wait_ack=True, no_except=True)
+    assert rc != Client.e_SUCCESS, "Fanout post should fail when journal is full"
+
+    rc = pri_producer.post(
+        du.uri_priority, ["should_fail"], wait_ack=True, no_except=True
+    )
+    assert rc != Client.e_SUCCESS, "Priority post should fail when journal is full"
+
+    # 4. Purge appId "baz" only — per-appId purge should NOT recover.
+    leader.purge(du.domain_fanout, tc.TEST_QUEUE, appid="baz")
+
+    rc = producer.post(
+        du.uri_fanout, ["after_baz_purge"], wait_ack=True, no_except=True
+    )
+    assert rc != Client.e_SUCCESS, (
+        "Post should still fail after per-appId purge (journal still unavailable)"
+    )
+
+    # 5. Purge the entire fanout queue — this should recover.
+    #    Priority queue is NOT purged; its messages remain outstanding.
+    leader.purge(du.domain_fanout, tc.TEST_QUEUE)
+
+    assert leader.outputs_substr("Writing PURGE record", timeout=5), (
+        "Expected leader to log PURGE record write on unavailable journal"
+    )
+
+    # 6. Verify posts succeed after full purge on both queues.
+    rc = producer.post(du.uri_fanout, ["after_purge"], wait_ack=True, no_except=True)
+    assert rc == Client.e_SUCCESS, (
+        "Fanout post should succeed after full purge recovered the journal"
+    )
+
+    rc = pri_producer.post(
+        du.uri_priority, ["pri_after_purge"], wait_ack=True, no_except=True
+    )
+    assert rc == Client.e_SUCCESS, "Priority post should succeed after journal recovery"
+
+    # 7. Verify end-to-end: consume the post-recovery fanout message.
+    consumer_foo.wait_push_event()
+    consumer_foo.confirm(du.uri_fanout_foo, "*", succeed=True)
+
+    # 8. Verify end-to-end: consume the post-recovery priority message.
+    pri_consumer.wait_push_event()
+    pri_consumer.confirm(du.uri_priority, "*", succeed=True)
+
+    # 9. Restart leader and verify the partition recovers cleanly.
+    leader.stop()
+    cluster.make_sure_node_stopped(leader)
+    leader.drain()
+    leader.start()
+    leader.wait_until_started()
+
+    producer2 = proxy.create_client("producer2")
+    producer2.open(du.uri_fanout, flags=["write,ack"], succeed=True)
+    rc = producer2.post(du.uri_fanout, ["after_restart"], wait_ack=True, no_except=True)
+    assert rc == Client.e_SUCCESS, "Post should succeed after leader restart"


### PR DESCRIPTION
- Allow writing PURGE records to a JOURNAL file that became unavailable, if there is enough space in the end of the file.
- Reserve space for 16 PURGE records in the end of JOURNAL file.
- Implement a UT in `mqbs_filestore.t.cpp` that checks partition unavailable alarm on full JOURNAL and recovery with PURGE.
- Add precondition checks to `void QueueStatsDomain::initialize` to avoid unhandled segfaults caused by NULL cluster.