### PR TITLE
Refactor[bmqp::RequestMgr]: componentId enum -> int for per-partition scoping

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -387,20 +387,35 @@ class RequestManager;
 // struct RequestManagerComponentId
 // ================================
 
-/// Enumeration of component identifiers used to tag requests sent via a
-/// `RequestManager` for the purpose of component-scoped cancellation.
+/// Integer constants used to tag requests sent via a `RequestManager` for the
+/// purpose of component-scoped cancellation.
 struct RequestManagerComponentId {
-    // TYPES
-    enum Enum {
+    // CONSTANTS
+    enum {
         /// Default; no component association.
-        e_NO_COMPONENT_ID = 0,
+        k_NO_COMPONENT_ID = 0,
 
-        /// Cluster State Manager FSM.
-        e_CLUSTER_FSM = 1,
+        /// Cluster FSM component id.
+        k_CLUSTER_FSM = 1,
 
-        /// Storage Manager Partition FSM.
-        e_PARTITION_FSM = 2
+        /// Base value for Partition FSM component ids.  Each partition
+        /// gets a unique componentId computed as
+        /// `k_PARTITION_FSM_PREFIX + partitionId`.  Use the
+        /// `partitionFSM()` class method to obtain the componentId for a
+        /// given partition.
+        k_PARTITION_FSM_PREFIX = 900
     };
+
+    // CLASS METHODS
+
+    /// Return the componentId for the partition with the specified
+    /// `partitionId`.  The behavior is undefined unless
+    /// `0 <= partitionId < 100`.
+    static int partitionFSM(int partitionId);
+
+    /// Return true if the specified `componentId` is valid, including
+    /// `k_NO_COMPONENT_ID`.
+    static bool isValid(int componentId);
 };
 
 // ===========================
@@ -484,7 +499,7 @@ class RequestManagerRequest {
     // requests, allowing to cancel all
     // requests sharing the same group.
 
-    RequestManagerComponentId::Enum d_componentId;
+    int d_componentId;
     // The 'componentId' associated with this
     // request.  Used to cancel all requests
     // belonging to a specific component.
@@ -574,10 +589,10 @@ class RequestManagerRequest {
 
     /// Set component identifier to the specified `value` to assist canceling
     /// requests belonging to one component only.  By default, the identifier
-    /// is `RequestManagerComponentId::e_NO_COMPONENT_ID`.  Return a
-    /// reference offering modifiable access to this object.
-    RequestManagerRequest&
-    setComponentId(RequestManagerComponentId::Enum value);
+    /// is `RequestManagerComponentId::k_NO_COMPONENT_ID`.  Return a
+    /// reference offering modifiable access to this object.  The behavior is
+    /// undefined unless `value` is valid and is not `k_NO_COMPONENT_ID`.
+    RequestManagerRequest& setComponentId(int value);
 
     /// Take shared ownership of the specified `span` and ensure that it
     /// lives at least as long as this object. The `span` is intended to
@@ -621,9 +636,8 @@ class RequestManagerRequest {
     /// Return the associated group id (`NO_GROUP_ID` by default).
     int groupId() const;
 
-    /// Return the associated component identifier
-    /// (`e_NO_COMPONENT_ID` by default).
-    RequestManagerComponentId::Enum componentId() const;
+    /// Return the associated component id (`k_NO_COMPONENT_ID` by default).
+    int componentId() const;
 
     /// Return the associated user data.
     const bdld::Datum& userData() const;
@@ -758,13 +772,13 @@ class RequestManager {
     /// Cancel all outstanding requests matching the specified `groupId` and
     /// `componentId` filters, with the specified `reason` response
     /// description.  A value of `NO_GROUP_ID` for `groupId` disables
-    /// group filtering; a value of `e_NO_COMPONENT_ID` for `componentId`
+    /// group filtering; a value of `k_NO_COMPONENT_ID` for `componentId`
     /// disables component filtering.  Both filters are applied with AND
     /// semantics.  The corresponding response callbacks will be invoked in
     /// the order in which requests were sent.
-    void cancelAllRequestsImpl(const RESPONSE&                 reason,
-                               int                             groupId,
-                               RequestManagerComponentId::Enum componentId);
+    void cancelAllRequestsImpl(const RESPONSE& reason,
+                               int             groupId,
+                               int             componentId);
 
   private:
     // NOT IMPLEMENTED
@@ -865,16 +879,35 @@ class RequestManager {
 
     /// Cancel all outstanding requests tagged with the specified
     /// `componentId`, with the specified `reason` response description.
-    /// The behavior is undefined if `componentId` is `e_NO_COMPONENT_ID`.
-    /// The corresponding response callbacks will be invoked in the order
-    /// in which requests were sent.
-    void cancelComponentRequests(const RESPONSE&                 reason,
-                                 RequestManagerComponentId::Enum componentId);
+    /// The behavior is undefined if `componentId` is
+    /// `k_NO_COMPONENT_ID`.  The corresponding response callbacks will be
+    /// invoked in the order in which requests were sent.
+    void cancelComponentRequests(const RESPONSE& reason, int componentId);
 };
 
 // ============================================================================
 //                             INLINE DEFINITIONS
 // ============================================================================
+
+// --------------------------------
+// struct RequestManagerComponentId
+// --------------------------------
+
+inline int RequestManagerComponentId::partitionFSM(int partitionId)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(partitionId >= 0);
+    BSLS_ASSERT_SAFE(partitionId < 100);
+
+    return k_PARTITION_FSM_PREFIX + partitionId;
+}
+
+inline bool RequestManagerComponentId::isValid(int componentId)
+{
+    return componentId == k_NO_COMPONENT_ID || componentId == k_CLUSTER_FSM ||
+           (componentId >= k_PARTITION_FSM_PREFIX &&
+            componentId < k_PARTITION_FSM_PREFIX + 100);
+}
 
 // ---------------------------
 // class RequestManagerRequest
@@ -894,7 +927,7 @@ RequestManagerRequest<REQUEST, RESPONSE>::RequestManagerRequest(
 , d_haveTimeout(false)
 , d_haveResponse(false)
 , d_groupId(k_NO_GROUP_ID)
-, d_componentId(RequestManagerComponentId::e_NO_COMPONENT_ID)
+, d_componentId(RequestManagerComponentId::k_NO_COMPONENT_ID)
 , d_dtSpan_sp(NULL)
 , d_dtContext_p(NULL)
 , d_userData(allocator)
@@ -927,7 +960,7 @@ void RequestManagerRequest<REQUEST, RESPONSE>::clear()
     d_sendTime        = 0;
     d_nodeDescription.clear();
     d_groupId     = k_NO_GROUP_ID;
-    d_componentId = RequestManagerComponentId::e_NO_COMPONENT_ID;
+    d_componentId = RequestManagerComponentId::k_NO_COMPONENT_ID;
     d_dtSpan_sp.reset();
     d_dtContext_p = NULL;
 }
@@ -994,9 +1027,12 @@ RequestManagerRequest<REQUEST, RESPONSE>::setGroupId(int value)
 
 template <class REQUEST, class RESPONSE>
 RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setComponentId(
-    RequestManagerComponentId::Enum value)
+RequestManagerRequest<REQUEST, RESPONSE>::setComponentId(int value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(RequestManagerComponentId::isValid(value));
+    BSLS_ASSERT_SAFE(value != RequestManagerComponentId::k_NO_COMPONENT_ID);
+
     d_componentId = value;
     return *this;
 }
@@ -1101,8 +1137,7 @@ int RequestManagerRequest<REQUEST, RESPONSE>::groupId() const
 }
 
 template <class REQUEST, class RESPONSE>
-RequestManagerComponentId::Enum
-RequestManagerRequest<REQUEST, RESPONSE>::componentId() const
+int RequestManagerRequest<REQUEST, RESPONSE>::componentId() const
 {
     return d_componentId;
 }
@@ -1521,7 +1556,7 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
 {
     cancelAllRequestsImpl(reason,
                           RequestType::k_NO_GROUP_ID,
-                          RequestManagerComponentId::e_NO_COMPONENT_ID);
+                          RequestManagerComponentId::k_NO_COMPONENT_ID);
 }
 
 template <class REQUEST, class RESPONSE>
@@ -1534,26 +1569,26 @@ void RequestManager<REQUEST, RESPONSE>::cancelGroupRequests(
 
     cancelAllRequestsImpl(reason,
                           groupId,
-                          RequestManagerComponentId::e_NO_COMPONENT_ID);
+                          RequestManagerComponentId::k_NO_COMPONENT_ID);
 }
 
 template <class REQUEST, class RESPONSE>
 void RequestManager<REQUEST, RESPONSE>::cancelComponentRequests(
-    const RESPONSE&                 reason,
-    RequestManagerComponentId::Enum componentId)
+    const RESPONSE& reason,
+    int             componentId)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(componentId !=
-                     RequestManagerComponentId::e_NO_COMPONENT_ID);
+                     RequestManagerComponentId::k_NO_COMPONENT_ID);
 
     cancelAllRequestsImpl(reason, RequestType::k_NO_GROUP_ID, componentId);
 }
 
 template <class REQUEST, class RESPONSE>
 void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
-    const RESPONSE&                 reason,
-    int                             groupId,
-    RequestManagerComponentId::Enum componentId)
+    const RESPONSE& reason,
+    int             groupId,
+    int             componentId)
 {
     // Note that requests must be cancelled in the same order in which they
     // were sent.
@@ -1571,7 +1606,7 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
                                     (groupId == it->second->groupId());
             const bool matchComponent =
                 (componentId ==
-                 RequestManagerComponentId::e_NO_COMPONENT_ID) ||
+                 RequestManagerComponentId::k_NO_COMPONENT_ID) ||
                 (componentId == it->second->componentId());
 
             if (matchGroup && matchComponent) {
@@ -1592,7 +1627,7 @@ void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
 
     const bool hasGroup     = (groupId != RequestType::k_NO_GROUP_ID);
     const bool hasComponent = (componentId !=
-                               RequestManagerComponentId::e_NO_COMPONENT_ID);
+                               RequestManagerComponentId::k_NO_COMPONENT_ID);
     if (!hasGroup && !hasComponent) {
         BALL_LOG_INFO << "Canceling all requests (" << requestsCopy.size()
                       << " items) with " << reason << ".";

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -932,7 +932,7 @@ static void test6_cancelAllRequestsTest()
     {
         // Cancel by componentId: only requests tagged with the specified
         // component should be cancelled; requests tagged with a different
-        // component or untagged (e_NO_COMPONENT_ID) must remain outstanding.
+        // component or untagged (k_NO_COMPONENT_ID) must remain outstanding.
         TestContext       context(false, bmqtst::TestHelperUtil::allocator());
         const bsl::size_t numRequests = 6;
         ReqVec            requests(bmqtst::TestHelperUtil::allocator());
@@ -942,13 +942,13 @@ static void test6_cancelAllRequestsTest()
             context.populateRequest(request);
             if (i < 2) {
                 request->setComponentId(
-                    bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+                    bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
             }
             else if (i < 4) {
                 request->setComponentId(
-                    bmqp::RequestManagerComponentId::e_PARTITION_FSM);
+                    bmqp::RequestManagerComponentId::partitionFSM(0));
             }
-            // i >= 4: leave as e_NO_COMPONENT_ID (default)
+            // i >= 4: leave as k_NO_COMPONENT_ID (default)
             context.sendChannelRequest(request);
             requests.emplace_back(request);
         }
@@ -956,12 +956,12 @@ static void test6_cancelAllRequestsTest()
         Mes reason = context.createResponseCancel();
         context.manager().cancelComponentRequests(
             reason,
-            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
 
         for (bsl::size_t i = 0; i < numRequests; ++i) {
             ReqSp request = requests[i];
             if (request->componentId() ==
-                bmqp::RequestManagerComponentId::e_CLUSTER_FSM) {
+                bmqp::RequestManagerComponentId::k_CLUSTER_FSM) {
                 BMQTST_ASSERT_EQ(request->result(),
                                  bmqt::GenericResult::e_CANCELED);
                 BMQTST_ASSERT_EQ(request->response().choice().status(),
@@ -1004,7 +1004,7 @@ static void test7_requestBreathingTest()
         BMQTST_ASSERT(request->nodeDescription().empty());
         BMQTST_ASSERT_EQ(request->groupId(), -1);  // Req::k_NO_GROUP_ID
         BMQTST_ASSERT_EQ(request->componentId(),
-                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+                         bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID);
         BMQTST_ASSERT(request->userData().isNull());
     }
 
@@ -1056,11 +1056,11 @@ static void test7_requestBreathingTest()
         request.createInplace(bmqtst::TestHelperUtil::allocator(),
                               bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(request->componentId(),
-                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+                         bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID);
         request->setComponentId(
-            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
         BMQTST_ASSERT_EQ(request->componentId(),
-                         bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+                         bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
     }
 
     {

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -388,7 +388,7 @@ void ClusterStateManager::do_sendFollowerLSNRequests(
         .makeFollowerLSNRequest();
 
     contextSp->setDestinationNodes(followers);
-    contextSp->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+    contextSp->setComponentId(bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
     contextSp->setResponseCb(
         bdlf::BindUtil::bind(&ClusterStateManager::onFollowerLSNResponse,
                              this,
@@ -514,7 +514,7 @@ void ClusterStateManager::do_sendFollowerClusterStateRequest(
 
     RequestContextSp request =
         d_clusterData_p->requestManager().createRequest();
-    request->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+    request->setComponentId(bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
     request->request()
         .choice()
         .makeClusterMessage()
@@ -742,7 +742,7 @@ void ClusterStateManager::do_sendRegistrationRequest(
 
     RequestContextSp request =
         d_clusterData_p->requestManager().createRequest();
-    request->setComponentId(bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+    request->setComponentId(bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
 
     bmqp_ctrlmsg::RegistrationRequest& registrationRequest =
         request->request()
@@ -1102,7 +1102,7 @@ void ClusterStateManager::do_cancelRequests(
 
     d_clusterData_p->requestManager().cancelComponentRequests(
         response,
-        bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+        bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
 }
 
 // PRIVATE MANIPULATORS

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -113,7 +113,7 @@ class MultiRequestManagerRequestContext {
 
     ResponseCb d_responseCb;
 
-    bmqp::RequestManagerComponentId::Enum d_componentId;
+    int d_componentId;
 
   private:
     // NOT IMPLEMENTED
@@ -150,14 +150,15 @@ class MultiRequestManagerRequestContext {
 
     /// Set the component id to the specified `value`.  This value is
     /// propagated to each sub-request created by the `MultiRequestManager`
-    /// when sending.
-    void setComponentId(bmqp::RequestManagerComponentId::Enum value);
+    /// when sending.  The behavior is undefined unless `value` is valid
+    /// and is not `k_NO_COMPONENT_ID`.
+    void setComponentId(int value);
 
     // ACCESSORS
     const REQUEST& request() const;
 
     /// Return the component id.
-    bmqp::RequestManagerComponentId::Enum componentId() const;
+    int componentId() const;
 
     /// Return a reference offering non-modifiable access to the
     /// corresponding member of this object.
@@ -284,7 +285,7 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
 , d_nodeResponsePairs(allocator)
 , d_numOutstandingRequests(0)
 , d_responseCb(bsl::allocator_arg, allocator)
-, d_componentId(bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID)
+, d_componentId(bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID)
 {
     // NOTHING
 }
@@ -297,7 +298,7 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::clear()
     d_nodeResponsePairs.clear();
     d_numOutstandingRequests = 0;
     d_responseCb             = bsl::nullptr_t();
-    d_componentId = bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID;
+    d_componentId = bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID;
 }
 
 template <class REQUEST, class RESPONSE, class TARGET>
@@ -328,8 +329,13 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
 
 template <class REQUEST, class RESPONSE, class TARGET>
 void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
-    setComponentId(bmqp::RequestManagerComponentId::Enum value)
+    setComponentId(int value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(bmqp::RequestManagerComponentId::isValid(value));
+    BSLS_ASSERT_SAFE(value !=
+                     bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID);
+
     d_componentId = value;
 }
 
@@ -342,8 +348,7 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::request() const
 }
 
 template <class REQUEST, class RESPONSE, class TARGET>
-bmqp::RequestManagerComponentId::Enum
-MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::componentId()
+int MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::componentId()
     const
 {
     return d_componentId;
@@ -482,7 +487,10 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
                                  context,
                                  it->first));
         setGroupId(singleRequestCtx, it->first);
-        singleRequestCtx->setComponentId(context->componentId());
+        if (context->componentId() !=
+            bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID) {
+            singleRequestCtx->setComponentId(context->componentId());
+        }
 
         bsl::string               errorDescription;
         bmqt::GenericResult::Enum sendRc = d_requestManager_p->sendRequest(

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -450,12 +450,12 @@ static void test1_contextTest()
                                bmqtst::TestHelperUtil::allocator()));
 
         BMQTST_ASSERT_EQ(reqContext->componentId(),
-                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+                         bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID);
 
         reqContext->setComponentId(
-            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
         BMQTST_ASSERT_EQ(reqContext->componentId(),
-                         bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+                         bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
 
         ReqSp request = bsl::make_shared<Req>(
             bmqtst::TestHelperUtil::allocator());
@@ -494,7 +494,7 @@ static void test1_contextTest()
                          Mes(bmqtst::TestHelperUtil::allocator()));
         BMQTST_ASSERT(reqContext->response().empty());
         BMQTST_ASSERT_EQ(reqContext->componentId(),
-                         bmqp::RequestManagerComponentId::e_NO_COMPONENT_ID);
+                         bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID);
     }
 }
 
@@ -724,10 +724,10 @@ static void test5_cancelByComponentIdTest()
         untaggedCtx->setDestinationNodes(context.nodes());
 
         clusterCtx->setComponentId(
-            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
         partitionCtx->setComponentId(
-            bmqp::RequestManagerComponentId::e_PARTITION_FSM);
-        // untaggedCtx: default e_NO_COMPONENT_ID
+            bmqp::RequestManagerComponentId::partitionFSM(0));
+        // untaggedCtx: default k_NO_COMPONENT_ID
 
         clusterCtx->setResponseCb(
             bdlf::BindUtil::bind(&Caller::callback,
@@ -764,7 +764,7 @@ static void test5_cancelByComponentIdTest()
         Mes reason = context.createResponseCancel();
         context.manager()->cancelComponentRequests(
             reason,
-            bmqp::RequestManagerComponentId::e_CLUSTER_FSM);
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM);
 
         // Only the CLUSTER_FSM multi-request callback should have fired
         BMQTST_ASSERT(clusterCalled);


### PR DESCRIPTION
## Summary                                               
  - Refactors `RequestManagerComponentId` from a fixed enum to an int-based scheme                                                           
    to support per-partition scoped request cancellation in the Partition FSM.                                                               
  - Each partition gets a unique componentId via `k_PARTITION_FSM_PREFIX + partitionId`                                                      
    (range `[900, 999]`), enabling cancellation of one partition's requests without                                                          
    disrupting other partitions' healing sessions.                                                                                           
  - Adds `isValid()` and `partitionFSM()` class methods with precondition assertions                                                         
    to guard against invalid componentId values.                                                                                             
  - Prerequisite for the follow-up PR that wires `do_cancelRequests` into the                                                                
    Partition FSM table and tags StorageManager send sites.  