### PR TITLE
Fix: Use `bsl::allocator_arg_t` overload in `AllocationLimitChecker`

### DIFF
--- a/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
@@ -381,10 +381,9 @@ void CountingAllocator::AllocationLimitChecker::setLimit(
     BSLS_ASSERT_SAFE(callback);
 
     d_allocationLimit = limit;
-    AllocationLimitCallback cb(
-        bsl::allocator_arg,
-        d_allocationLimitCb.get_allocator(),
-        callback);
+    AllocationLimitCallback cb(bsl::allocator_arg,
+                               d_allocationLimitCb.get_allocator(),
+                               callback);
     d_allocationLimitCb.swap(cb);
 }
 

--- a/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
@@ -380,8 +380,12 @@ void CountingAllocator::AllocationLimitChecker::setLimit(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(callback);
 
-    d_allocationLimit   = limit;
-    d_allocationLimitCb = callback;
+    d_allocationLimit = limit;
+    AllocationLimitCallback cb(
+        bsl::allocator_arg,
+        d_allocationLimitCb.get_allocator(),
+        callback);
+    d_allocationLimitCb.swap(cb);
 }
 
 }  // close package namespace


### PR DESCRIPTION
The `d_allocationLimitCb` `bsl::function` *copy-constructor* allocates using the global allocator on Solaris, causing
bmqma_countingallocatorutil.t.cpp CASE 3 to fail with `'_defAlloc.numBlocksTotal()' (1) == '0' (0)`.  This patch passes an allocator down into that copy-constructed function to fix this.