### PR TITLE
Fix[mqbc::StorageManager]: Cancel stale PFSM requests

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -814,6 +814,37 @@ class PartitionStateTable
 // class PartitionStateTableActions
 // --------------------------------
 
+// MACROS
+
+/// Generate a composite action implementation that calls exactly the 4
+/// sub-actions named by the arguments, in order.  The function name is
+/// `do_<a1>_<a2>_<a3>_<a4>`, derived from the same arguments, so the name
+/// and body cannot diverge.
+#define PST_COMPOSITE_4(a1, a2, a3, a4)                                       \
+    template <typename ARGS>                                                  \
+    void PartitionStateTableActions<ARGS>::do_##a1##_##a2##_##a3##_##a4(      \
+        const ARGS& args)                                                     \
+    {                                                                         \
+        do_##a1(args);                                                        \
+        do_##a2(args);                                                        \
+        do_##a3(args);                                                        \
+        do_##a4(args);                                                        \
+    }
+
+/// Generate a composite action implementation that calls exactly the 5
+/// sub-actions named by the arguments, in order.
+#define PST_COMPOSITE_5(a1, a2, a3, a4, a5)                                   \
+    template <typename ARGS>                                                  \
+    void PartitionStateTableActions<                                          \
+        ARGS>::do_##a1##_##a2##_##a3##_##a4##_##a5(const ARGS& args)          \
+    {                                                                         \
+        do_##a1(args);                                                        \
+        do_##a2(args);                                                        \
+        do_##a3(args);                                                        \
+        do_##a4(args);                                                        \
+        do_##a5(args);                                                        \
+    }
+
 // CREATORS
 template <typename ARGS>
 PartitionStateTableActions<ARGS>::~PartitionStateTableActions()
@@ -919,39 +950,21 @@ void PartitionStateTableActions<ARGS>::
     do_reapplyEvent(args);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests(
-        const ARGS& args)
-{
-    do_cleanupMetadata(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
-    do_cancelRequests(args);
-}
+PST_COMPOSITE_4(cleanupMetadata,
+                closeRecoveryFileSet,
+                stopWatchdog,
+                cancelRequests)
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent(
-        const ARGS& args)
-{
-    do_cleanupMetadata(args);
-    do_closeRecoveryFileSet(args);
-    do_cancelRequests(args);
-    do_reapplyEvent(args);
-}
+PST_COMPOSITE_4(cleanupMetadata,
+                closeRecoveryFileSet,
+                cancelRequests,
+                reapplyEvent)
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
-        const ARGS& args)
-{
-    do_cleanupMetadata(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
-    do_cancelRequests(args);
-    do_reapplyEvent(args);
-}
+PST_COMPOSITE_5(cleanupMetadata,
+                closeRecoveryFileSet,
+                stopWatchdog,
+                cancelRequests,
+                reapplyEvent)
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::do_cleanupMetadata_reapplyEvent(

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -318,6 +318,8 @@ class PartitionStateTableActions {
 
     virtual void do_cleanupMetadata(const ARGS& args) = 0;
 
+    virtual void do_cancelRequests(const ARGS& args) = 0;
+
     virtual void do_setExpectedDataChunkRange(const ARGS& args) = 0;
 
     virtual void do_resetReceiveDataCtx(const ARGS& args) = 0;
@@ -376,6 +378,16 @@ class PartitionStateTableActions {
 
     void
     do_cleanupMetadata_closeRecoveryFileSet_reapplyEvent(const ARGS& args);
+
+    void do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests(
+        const ARGS& args);
+
+    void do_cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent(
+        const ARGS& args);
+
+    void
+    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
+        const ARGS& args);
 
     void do_cleanupMetadata_reapplyEvent(const ARGS& args);
 
@@ -530,18 +542,21 @@ class PartitionStateTable
             REPLICA_HIGHEST_SEQ,
             primaryRemoveStorageIfNeeded_setExpectedDataChunkRange_replicaDataRequestPull,
             PRIMARY_HEALING_STG2);
-        PST_CFG(PRIMARY_HEALING_STG1,
-                RST_UNKNOWN,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                UNKNOWN);
-        PST_CFG(PRIMARY_HEALING_STG1,
-                STOP_NODE,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                STOPPED);
-        PST_CFG(PRIMARY_HEALING_STG1,
-                REAPPLY_SELF_PRIMARY,
-                cleanupMetadata_closeRecoveryFileSet_reapplyEvent,
-                UNKNOWN);
+        PST_CFG(
+            PRIMARY_HEALING_STG1,
+            RST_UNKNOWN,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            UNKNOWN);
+        PST_CFG(
+            PRIMARY_HEALING_STG1,
+            STOP_NODE,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            STOPPED);
+        PST_CFG(
+            PRIMARY_HEALING_STG1,
+            REAPPLY_SELF_PRIMARY,
+            cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent,
+            UNKNOWN);
         PST_CFG(PRIMARY_HEALING_STG1,
                 WATCHDOG,
                 reapplyDetectSelfPrimary,
@@ -574,10 +589,11 @@ class PartitionStateTable
                 RECOVERY_DATA,
                 updateStorage,
                 PRIMARY_HEALING_STG2);
-        PST_CFG(PRIMARY_HEALING_STG2,
-                REAPPLY_SELF_PRIMARY,
-                cleanupMetadata_closeRecoveryFileSet_reapplyEvent,
-                UNKNOWN);
+        PST_CFG(
+            PRIMARY_HEALING_STG2,
+            REAPPLY_SELF_PRIMARY,
+            cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent,
+            UNKNOWN);
         PST_CFG(PRIMARY_HEALING_STG2,
                 ERROR_RECEIVING_DATA_CHUNKS,
                 reapplyDetectSelfPrimary,
@@ -595,30 +611,35 @@ class PartitionStateTable
                 QUORUM_REPLICA_DATA_RSPN,
                 stopWatchdog_transitionToActivePrimary,
                 PRIMARY_HEALED);
-        PST_CFG(PRIMARY_HEALING_STG2,
-                RST_UNKNOWN,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                UNKNOWN);
+        PST_CFG(
+            PRIMARY_HEALING_STG2,
+            RST_UNKNOWN,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            UNKNOWN);
         PST_CFG(PRIMARY_HEALING_STG2,
                 WATCHDOG,
                 reapplyDetectSelfPrimary,
                 PRIMARY_HEALING_STG2);
-        PST_CFG(PRIMARY_HEALING_STG2,
-                STOP_NODE,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                STOPPED);
-        PST_CFG(REPLICA_WAITING,
-                DETECT_SELF_PRIMARY,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent,
-                UNKNOWN);
-        PST_CFG(REPLICA_WAITING,
-                DETECT_SELF_REPLICA,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent,
-                UNKNOWN);
-        PST_CFG(REPLICA_WAITING,
-                REAPPLY_SELF_REPLICA,
-                cleanupMetadata_closeRecoveryFileSet_reapplyEvent,
-                UNKNOWN);
+        PST_CFG(
+            PRIMARY_HEALING_STG2,
+            STOP_NODE,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            STOPPED);
+        PST_CFG(
+            REPLICA_WAITING,
+            DETECT_SELF_PRIMARY,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            UNKNOWN);
+        PST_CFG(
+            REPLICA_WAITING,
+            DETECT_SELF_REPLICA,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            UNKNOWN);
+        PST_CFG(
+            REPLICA_WAITING,
+            REAPPLY_SELF_REPLICA,
+            cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent,
+            UNKNOWN);
         PST_CFG(REPLICA_WAITING,
                 REPLICA_STATE_RQST,
                 failureReplicaStateResponse,
@@ -635,30 +656,35 @@ class PartitionStateTable
                 FAIL_PRIMARY_STATE_RSPN,
                 logFailurePrimaryStateResponse,
                 REPLICA_HEALING);
-        PST_CFG(REPLICA_WAITING,
-                RST_UNKNOWN,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                UNKNOWN);
+        PST_CFG(
+            REPLICA_WAITING,
+            RST_UNKNOWN,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            UNKNOWN);
         PST_CFG(REPLICA_WAITING,
                 WATCHDOG,
                 reapplyDetectSelfReplica,
                 REPLICA_WAITING);
-        PST_CFG(REPLICA_WAITING,
-                STOP_NODE,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                STOPPED);
-        PST_CFG(REPLICA_HEALING,
-                DETECT_SELF_PRIMARY,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent,
-                UNKNOWN);
-        PST_CFG(REPLICA_HEALING,
-                DETECT_SELF_REPLICA,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent,
-                UNKNOWN);
-        PST_CFG(REPLICA_HEALING,
-                REAPPLY_SELF_REPLICA,
-                cleanupMetadata_closeRecoveryFileSet_reapplyEvent,
-                UNKNOWN);
+        PST_CFG(
+            REPLICA_WAITING,
+            STOP_NODE,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            STOPPED);
+        PST_CFG(
+            REPLICA_HEALING,
+            DETECT_SELF_PRIMARY,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            UNKNOWN);
+        PST_CFG(
+            REPLICA_HEALING,
+            DETECT_SELF_REPLICA,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            UNKNOWN);
+        PST_CFG(
+            REPLICA_HEALING,
+            REAPPLY_SELF_REPLICA,
+            cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent,
+            UNKNOWN);
         PST_CFG(REPLICA_HEALING,
                 REPLICA_STATE_RQST,
                 storePrimarySeq_replicaStateResponse,
@@ -711,18 +737,20 @@ class PartitionStateTable
                 failureReplicaDataResponsePush_reapplyDetectSelfReplica,
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING, LIVE_DATA, bufferLiveData, REPLICA_HEALING);
-        PST_CFG(REPLICA_HEALING,
-                RST_UNKNOWN,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                UNKNOWN);
+        PST_CFG(
+            REPLICA_HEALING,
+            RST_UNKNOWN,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            UNKNOWN);
         PST_CFG(REPLICA_HEALING,
                 WATCHDOG,
                 reapplyDetectSelfReplica,
                 REPLICA_HEALING);
-        PST_CFG(REPLICA_HEALING,
-                STOP_NODE,
-                cleanupMetadata_closeRecoveryFileSet_stopWatchdog,
-                STOPPED);
+        PST_CFG(
+            REPLICA_HEALING,
+            STOP_NODE,
+            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            STOPPED);
         PST_CFG(REPLICA_HEALED,
                 DETECT_SELF_PRIMARY,
                 cleanupMetadata_reapplyEvent,
@@ -888,6 +916,40 @@ void PartitionStateTableActions<ARGS>::
 {
     do_cleanupMetadata(args);
     do_closeRecoveryFileSet(args);
+    do_reapplyEvent(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
+    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests(
+        const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_closeRecoveryFileSet(args);
+    do_stopWatchdog(args);
+    do_cancelRequests(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
+    do_cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent(
+        const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_closeRecoveryFileSet(args);
+    do_cancelRequests(args);
+    do_reapplyEvent(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
+    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
+        const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_closeRecoveryFileSet(args);
+    do_stopWatchdog(args);
+    do_cancelRequests(args);
     do_reapplyEvent(args);
 }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -805,6 +805,8 @@ void StorageManager::sendReplicaDataRequestPush(
 
         RequestManagerType::RequestSp request =
             d_clusterData_p->requestManager().createRequest();
+        request->setComponentId(
+            bmqp::RequestManagerComponentId::partitionFSM(partitionId));
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRqst =
             request->request()
                 .choice()
@@ -877,6 +879,8 @@ void StorageManager::sendReplicaDataRequestDrop(
 
         RequestManagerType::RequestSp request =
             d_clusterData_p->requestManager().createRequest();
+        request->setComponentId(
+            bmqp::RequestManagerComponentId::partitionFSM(partitionId));
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRqst =
             request->request()
                 .choice()
@@ -2051,6 +2055,8 @@ void StorageManager::do_replicaStateRequest(const EventWithData& event)
         getSelfFirstSyncPointAfterRolloverPSN(partitionId);
 
     contextSp->setDestinationNodes(replicas);
+    contextSp->setComponentId(
+        bmqp::RequestManagerComponentId::partitionFSM(partitionId));
     contextSp->setResponseCb(
         bdlf::BindUtil::bind(&StorageManager::processReplicaStateResponse,
                              this,
@@ -2284,6 +2290,8 @@ void StorageManager::do_primaryStateRequest(const EventWithData& event)
 
     RequestManagerType::RequestSp request =
         d_clusterData_p->requestManager().createRequest();
+    request->setComponentId(
+        bmqp::RequestManagerComponentId::partitionFSM(partitionId));
 
     bmqp_ctrlmsg::PrimaryStateRequest& primaryStateRequest =
         request->request()
@@ -2486,6 +2494,8 @@ void StorageManager::do_replicaDataRequestPull(const EventWithData& event)
 
     RequestManagerType::RequestSp request =
         d_clusterData_p->requestManager().createRequest();
+    request->setComponentId(
+        bmqp::RequestManagerComponentId::partitionFSM(partitionId));
 
     bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
         request->request()
@@ -3005,6 +3015,29 @@ void StorageManager::do_cleanupMetadata(const EventWithData& event)
     d_nodeToPSNCtxMapVec[partitionId].clear();
     d_numReplicaDataResponsesReceivedVec[partitionId] = 0;
     d_recoveryManager_mp->resetReceiveDataCtx(partitionId);
+}
+
+void StorageManager::do_cancelRequests(const EventWithData& event)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with the
+    // paritionId contained in 'event'
+
+    const EventData& eventDataVec = event.second;
+    BSLS_ASSERT_SAFE(eventDataVec.size() == 1);
+
+    const int partitionId = eventDataVec[0].partitionId();
+    BSLS_ASSERT_SAFE(0 <= partitionId &&
+                     partitionId < static_cast<int>(d_fileStores.size()));
+
+    bmqp_ctrlmsg::ControlMessage response;
+    bmqp_ctrlmsg::Status&        failure = response.choice().makeStatus();
+    failure.category() = bmqp_ctrlmsg::StatusCategory::E_CANCELED;
+    failure.code()     = mqbi::ClusterErrorCode::e_UNKNOWN;
+    failure.message()  = "Cancellation by Partition FSM";
+
+    d_clusterData_p->requestManager().cancelComponentRequests(
+        response,
+        bmqp::RequestManagerComponentId::partitionFSM(partitionId));
 }
 
 void StorageManager::do_setExpectedDataChunkRange(const EventWithData& event)

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -696,6 +696,8 @@ class StorageManager BSLS_KEYWORD_FINAL
 
     void do_cleanupMetadata(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
 
+    void do_cancelRequests(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+
     void do_setExpectedDataChunkRange(const EventWithData& event)
         BSLS_KEYWORD_OVERRIDE;
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -3276,6 +3276,109 @@ static void test21_watchdogMultipleRetries()
     helper.d_cluster_mp->stop();
 }
 
+static void test22_rstUnknownCancelsInFlightRequests()
+// ------------------------------------------------------------------------
+// RST_UNKNOWN CANCELS IN-FLIGHT REQUESTS
+//
+// Concerns:
+//   When a partition receives RST_UNKNOWN while in a healing state,
+//   in-flight requests for that partition are cancelled so that stale
+//   responses are not processed by a subsequent healing session.
+//
+// Plan:
+//  1) Start as primary -> PRIMARY_HEALING_STG1 (sends ReplicaStateRequests)
+//  2) Collect the request IDs of those in-flight requests
+//  3) Trigger RST_UNKNOWN via detectPrimaryLossInPFSM
+//  4) Verify processResponse returns non-zero for the old request IDs
+//     (proving they were removed from the RequestManager)
+//
+// Testing:
+//   do_cancelRequests via RST_UNKNOWN transition
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "RST_UNKNOWN CANCELS IN-FLIGHT REQUESTS");
+
+    TestHelper helper;
+
+    mqbc::StorageManager storageManager(
+        helper.d_cluster_mp->_clusterDefinition(),
+        helper.d_cluster_mp.get(),
+        helper.d_cluster_mp->_clusterData(),
+        helper.d_cluster_mp->_state(),
+        helper.d_cluster_mp->_clusterData()->domainFactory(),
+        helper.d_cluster_mp->dispatcher(),
+        k_WATCHDOG_TIMEOUT_DURATION,
+        k_WATCHDOG_NUM_RETRIES,
+        mockOnRecoveryStatus,
+        mockOnPartitionPrimaryStatus,
+        bmqtst::TestHelperUtil::allocator());
+
+    static const int k_PARTITION_ID = 0;
+    const int        selfNodeId     = helper.d_cluster_mp->_clusterData()
+                               ->membership()
+                               .netCluster()
+                               ->selfNodeId();
+    mqbnet::ClusterNode* selfNode = helper.d_cluster_mp->_clusterData()
+                                        ->membership()
+                                        .netCluster()
+                                        ->lookupNode(selfNodeId);
+
+    helper.startStorageManager(&storageManager, selfNode);
+    helper.relaxFileStoreThreadChecks(&storageManager);
+
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_PRIMARY_HEALING_STG1);
+
+    // Collect request IDs from the ReplicaStateRequests sent to peers
+    bsl::vector<int> requestIds;
+    for (TestChannelMapCIter cit = helper.d_cluster_mp->_channels().cbegin();
+         cit != helper.d_cluster_mp->_channels().cend();
+         ++cit) {
+        if (cit->first->nodeId() != selfNodeId) {
+            bmqio::TestChannel::WriteCall writeCall;
+            BMQTST_ASSERT(cit->second->getWriteCall(&writeCall, 0));
+
+            bmqp_ctrlmsg::ControlMessage message;
+            mqbc::ClusterUtil::extractMessage(
+                &message,
+                writeCall.d_blob,
+                bmqtst::TestHelperUtil::allocator());
+            BMQTST_ASSERT(message.rId().has_value());
+            requestIds.push_back(message.rId().value());
+        }
+    }
+    helper.clearChannels();
+
+    // Trigger RST_UNKNOWN -> calls do_cancelRequests
+    storageManager.detectPrimaryLossInPFSM(k_PARTITION_ID);
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_UNKNOWN);
+
+    // Verify that the old requests were cancelled: processResponse should
+    // return non-zero for each request ID (meaning the request is no longer
+    // in the RequestManager's map).
+    for (size_t i = 0; i < requestIds.size(); ++i) {
+        bmqp_ctrlmsg::ControlMessage fakeResponse;
+        fakeResponse.rId() = requestIds[i];
+        fakeResponse.choice()
+            .makeClusterMessage()
+            .choice()
+            .makePartitionMessage()
+            .choice()
+            .makeReplicaStateResponse();
+
+        const int rc = helper.d_cluster_mp->requestManager().processResponse(
+            fakeResponse);
+        BMQTST_ASSERT_NE_D("requestId " << requestIds[i], rc, 0);
+    }
+
+    // Cleanup
+    storageManager.stopPFSMs();
+    storageManager.stop();
+    helper.d_cluster_mp->stop();
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -3293,6 +3396,7 @@ int main(int argc, char* argv[])
         //      - test21_replicaHealingReceivesReplicaDataRqstDrop();
         //      - test20_replicaHealingReceivesReplicaDataRqstPush();
         //      - test19_primaryHealedSendsDataChunks();
+    case 22: test22_rstUnknownCancelsInFlightRequests(); break;
     case 21: test21_watchdogMultipleRetries(); break;
     case 20: test20_watchdogStopResetsState(); break;
     case 19: test19_replicaWaitingWatchdogRetry(); break;


### PR DESCRIPTION
## Summary                     
  - The Partition FSM had no request cancellation — when a healing session was abandoned (role change, reset, stop), in-flight requests remained outstanding and stale responses could be processed by a new session.                                                                                 
  - Adds `do_cancelRequests` to the Partition FSM, mirroring the pattern established for the Cluster FSM in PR #1365.                                                                                             
  - Tags all 5 StorageManager request send sites with a partition-specific `componentId` (`partitionFSM(partitionId)`) so cancellation is scoped to the affected partition only, without disrupting other partitions' healing.                                                               
  - Depends on the `componentId` enum-to-int refactor from PR #1378. 