### PR TITLE
Cleanup[mqbc, mqbblp]: Normalize LSN terminology in logs and comments

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -671,19 +671,18 @@ int ClusterOrchestrator::start(bsl::ostream& errorDescription)
         return rc * 10 + rc_CLUSTER_STATE_MANAGER_FAILURE;  // RETURN
     }
 
-    // Fetch latest leader sequence number from the ledger and supply it to the
-    // elector.
+    // Fetch latest LSN from the ledger and supply it to the elector.
     bmqp_ctrlmsg::LeaderMessageSequence ledgerLSN;
     rc = d_stateManager_mp->latestLedgerLSN(&ledgerLSN);
     if (rc == 0) {
         BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << ": Latest leader sequence number fetched from the "
-                      << "cluster state ledger: " << ledgerLSN;
+                      << ": Latest LSN fetched from the cluster state ledger: "
+                      << ledgerLSN;
     }
     else {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << ": Failed to fetch latest leader sequence number from"
-                      << " the cluster state ledger, rc: " << rc
+                      << ": Failed to fetch latest LSN from the cluster state"
+                      << " ledger, rc: " << rc
                       << ". Using default value: " << ledgerLSN;
     }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterstatemanager.cpp
@@ -207,8 +207,7 @@ void ClusterStateManager::onLeaderSyncStateQueryResponse(
                      d_clusterData_p->membership().selfNodeStatus());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": processing leader sync query response. Self's leader "
-                  << "message sequence: "
+                  << ": processing leader sync query response. Self's LSN: "
                   << d_clusterData_p->electorInfo().leaderMessageSequence();
 
     mqbnet::ClusterNode* maxSeqNode = d_clusterData_p->membership().selfNode();
@@ -269,7 +268,7 @@ void ClusterStateManager::onLeaderSyncStateQueryResponse(
     if (maxSeqNode == d_clusterData_p->membership().selfNode()) {
         BALL_LOG_INFO << d_clusterData_p->identity().description()
                       << ": leader has latest view during leader sync step. "
-                      << "Leader message sequence: " << maxSeq;
+                      << "LSN: " << maxSeq;
 
         onSelfActiveLeader();
 
@@ -281,9 +280,8 @@ void ClusterStateManager::onLeaderSyncStateQueryResponse(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << ": follower node " << maxSeqNode->nodeDescription()
-                  << " has latest view during leader sync step.  Leader "
-                  << "message sequence of that node: " << maxSeq
-                  << ". Self's leader message sequence: "
+                  << " has latest view during leader sync step.  LSN of that"
+                  << " node: " << maxSeq << ". Self's LSN: "
                   << d_clusterData_p->electorInfo().leaderMessageSequence()
                   << ".";
 
@@ -404,8 +402,8 @@ void ClusterStateManager::onLeaderSyncDataQueryResponse(
     BSLS_ASSERT_SAFE(bmqp_ctrlmsg::NodeStatus::E_AVAILABLE ==
                      d_clusterData_p->membership().selfNodeStatus());
 
-    // Self's leader message sequence must be smaller than the one contained in
-    // the response from follower.
+    // Self's LSN must be smaller than the one contained in the response from
+    // follower.
 
     if (!(d_clusterData_p->electorInfo().leaderMessageSequence() <
           leaderSyncData.sequenceNumber())) {
@@ -413,11 +411,11 @@ void ClusterStateManager::onLeaderSyncDataQueryResponse(
 
         BMQTSK_ALARMLOG_ALARM("CLUSTER")
             << d_clusterData_p->identity().description()
-            << ": Received a smaller or equal leader-msg-sequence number in "
-            << "leader-sync data query response from  follower node "
+            << ": Received a smaller or equal LSN in "
+            << "leader-sync data query response from follower node "
             << responder->nodeDescription()
-            << ". Received sequence: " << leaderSyncData.sequenceNumber()
-            << ", self sequence:"
+            << ". Received LSN: " << leaderSyncData.sequenceNumber()
+            << ", self LSN: "
             << d_clusterData_p->electorInfo().leaderMessageSequence()
             << ". Attempting to send leader-sync state query to AVAILABLE "
             << "followers again." << BMQTSK_ALARMLOG_END;
@@ -428,10 +426,9 @@ void ClusterStateManager::onLeaderSyncDataQueryResponse(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << ": processing leader-sync data response from "
-                  << responder->nodeDescription()
-                  << ". Self's leader message sequence: "
+                  << responder->nodeDescription() << ". Self's LSN: "
                   << d_clusterData_p->electorInfo().leaderMessageSequence()
-                  << ", received sequence: " << leaderSyncData.sequenceNumber()
+                  << ", received LSN: " << leaderSyncData.sequenceNumber()
                   << ". Leader sync data: " << leaderSyncData << ".";
 
     // Converge the partitions.  First step is to update self's partition info
@@ -989,7 +986,7 @@ void ClusterStateManager::initiateLeaderSync(bool wait)
     }
 
     // Node is AVAILABLE.  Perform leader sync with all AVAILABLE nodes.  Do
-    // not update self's leader message sequence yet.
+    // not update self's LSN yet.
 
     bsl::vector<mqbnet::ClusterNode*> availableFollowers;
     for (ClusterNodeSessionMapIter nit =
@@ -1089,12 +1086,12 @@ void ClusterStateManager::processLeaderSyncStateQuery(
                          .isLeaderSyncStateQueryValue());
 
     // This query is sent by a passive leader ('source') to all AVAILABLE
-    // followers to find out the latest leader state (leader message sequence
-    // to be specific).  We don't check to see if 'source' is really perceived
-    // as the leader by this node, because it really doesn't matter.  If
-    // 'source' is not the leader anymore, it will simply not process this
-    // response.  We do however check self status, and if self is not
-    // AVAILABLE, we do not respond so as not to send any incomplete info.
+    // followers to find out the latest leader state (LSN to be specific).  We
+    // don't check to see if 'source' is really perceived as the leader by this
+    // node, because it really doesn't matter.  If 'source' is not the leader
+    // anymore, it will simply not process this response.  We do however check
+    // self status, and if self is not AVAILABLE, we do not respond so as not
+    // to send any incomplete info.
 
     bmqp_ctrlmsg::ControlMessage controlMsg;
     controlMsg.rId() = message.rId();

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -95,12 +95,11 @@ bsl::ostream& printRecoveryBanner(bsl::ostream&      out,
     return out;
 }
 
-/// Return true if the leader message sequence number in the specified `lms`
-/// is zero, false otherwise.
-bool isZero(const bmqp_ctrlmsg::LeaderMessageSequence& lms)
+/// Return true if the LSN in the specified `lsn` is zero, false otherwise.
+bool isZero(const bmqp_ctrlmsg::LeaderMessageSequence& lsn)
 {
-    return lms.electorTerm() == mqbnet::Elector::k_INVALID_TERM &&
-           lms.sequenceNumber() == 0;
+    return lsn.electorTerm() == mqbnet::Elector::k_INVALID_TERM &&
+           lsn.sequenceNumber() == 0;
 }
 
 }  // close unnamed namespace

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
@@ -301,8 +301,8 @@ int ClusterStateLedgerUtil::validateLog(mqbsi::Log::Offset* offset,
         crc32cComputed = bmqp::Crc32c::calculate(blob);
         if (crc32cComputed != crc32cExpected) {
             BMQTSK_ALARMLOG_ALARM("CLUSTER")
-                << "CSL Recovery: CRC mismatch for record with sequenceNumber "
-                << "[" << recHeader->sequenceNumber() << "] in file '"
+                << "CSL Recovery: CRC mismatch for record with LSN " << "["
+                << recHeader->sequenceNumber() << "] in file '"
                 << log->logConfig().location() << "' with fileKey ["
                 << fileHeader->fileKey() << "] at offset " << currOffset << "."
                 << " CRC32-C Expected: " << crc32cExpected << "."
@@ -313,7 +313,7 @@ int ClusterStateLedgerUtil::validateLog(mqbsi::Log::Offset* offset,
                 << ", leaderAdvisoryWords: "
                 << recHeader->leaderAdvisoryWords()
                 << ", electorTerm: " << recHeader->electorTerm()
-                << ", sequenceNumber: " << recHeader->sequenceNumber()
+                << ", LSN: " << recHeader->sequenceNumber()
                 << ", timestamp: " << recHeader->timestamp() << "]"
                 << BMQTSK_ALARMLOG_END;
             return ClusterStateLedgerUtilRc::e_INVALID_CHECKSUM;  // RETURN

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -852,7 +852,7 @@ void ClusterStateManager::do_logUnexpectedCSLCommit(
     BALL_LOG_ERROR << d_clusterData_p->identity().description()
                    << ": Cluster FSM is in " << d_clusterFSM.state()
                    << " state while receiving unexpected CSL commit. Current "
-                      "leader sequence number is "
+                      "LSN is "
                    << d_clusterData_p->electorInfo().leaderMessageSequence()
                    << ".";
 }

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -158,7 +158,7 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     mqbc::ClusterFSM d_clusterFSM;
 
     /// Map from a cluster node (including self) to its view of the latest
-    /// ledger leader sequence number.
+    /// ledger LSN.
     NodeToLSNMap d_nodeToLedgerLSNMap;
 
     /// Underlying cluster state ledger.

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -55,8 +55,8 @@ struct ClusterStateTableState {
         /// Self is follower, healing its CSL.
         e_FOL_HEALING = 1,
 
-        /// Self is leader, exchanging leader sequence numbers (LSNs) with
-        /// followers to determine who has the most up-to-date CSL.
+        /// Self is leader, exchanging LSNs with followers to determine who
+        /// has the most up-to-date CSL.
         e_LDR_HEALING_STG1 = 2,
 
         /// Self is leader, healing its CSL and the followers' CSLs.  It will

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -2160,8 +2160,8 @@ int ClusterUtil::latestLedgerLSN(bmqp_ctrlmsg::LeaderMessageSequence* out,
 
     if (!ledger.isOpen()) {
         BALL_LOG_ERROR << clusterData.identity().description()
-                       << ": Leader sequence number cannot be found using "
-                       << "ledger at this time as it is not yet opened.";
+                       << ": LSN cannot be found using ledger at this time as"
+                       << " it is not yet opened.";
 
         return rc_LEDGER_NOT_OPENED;  // RETURN
     }
@@ -2187,8 +2187,7 @@ int ClusterUtil::latestLedgerLSN(bmqp_ctrlmsg::LeaderMessageSequence* out,
     out->sequenceNumber() = header->sequenceNumber();
 
     BALL_LOG_INFO << clusterData.identity().description()
-                  << ": Retrieved latest leader sequence number from ledger to"
-                  << " be " << *out;
+                  << ": Retrieved latest LSN from ledger to be " << *out;
 
     return rc_SUCCESS;
 }

--- a/src/groups/mqb/mqbc/mqbc_electorinfo.h
+++ b/src/groups/mqb/mqbc/mqbc_electorinfo.h
@@ -255,8 +255,7 @@ class ElectorInfo : public ClusterFSMObserver {
                                 mqbnet::ClusterNode*          node,
                                 ElectorInfoLeaderStatus::Enum status);
 
-    /// Bump up the leader sequence number and populate to the optionally
-    /// specified `sequence`.
+    /// Bump up the LSN and populate to the optionally specified `sequence`.
     void nextLeaderMessageSequence(
         bmqp_ctrlmsg::LeaderMessageSequence* sequence = 0);
 
@@ -316,8 +315,7 @@ inline ElectorInfo::ElectorInfo(mqbi::Cluster* cluster)
     d_leaderMessageSequence.electorTerm()    = mqbnet::Elector::k_INVALID_TERM;
     d_leaderMessageSequence.sequenceNumber() = 0;
 
-    BALL_LOG_INFO << "Setting elector's leader sequence number to "
-                  << d_leaderMessageSequence;
+    BALL_LOG_INFO << "Setting elector's LSN to " << d_leaderMessageSequence;
 }
 
 // MANIPULATORS
@@ -326,8 +324,7 @@ inline ElectorInfo& ElectorInfo::setElectorTerm(bsls::Types::Uint64 value)
     d_leaderMessageSequence.electorTerm()    = value;
     d_leaderMessageSequence.sequenceNumber() = 0;
 
-    BALL_LOG_INFO << "Setting elector's leader sequence number to "
-                  << d_leaderMessageSequence;
+    BALL_LOG_INFO << "Setting elector's LSN to " << d_leaderMessageSequence;
     return *this;
 }
 
@@ -344,8 +341,7 @@ inline ElectorInfo& ElectorInfo::setLeaderMessageSequence(
 {
     d_leaderMessageSequence = value;
 
-    BALL_LOG_INFO << "Setting elector's leader sequence number to "
-                  << d_leaderMessageSequence;
+    BALL_LOG_INFO << "Setting elector's LSN to " << d_leaderMessageSequence;
     return *this;
 }
 
@@ -357,8 +353,7 @@ inline void ElectorInfo::nextLeaderMessageSequence(
         *sequence = d_leaderMessageSequence;
     }
 
-    BALL_LOG_INFO << "Bumping up elector's leader sequence number to "
-                  << d_leaderMessageSequence;
+    BALL_LOG_INFO << "Bumping up elector's LSN to " << d_leaderMessageSequence;
 }
 
 inline ElectorInfo::SchedulerEventHandle* ElectorInfo::leaderSyncEventHandle()

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -278,7 +278,7 @@ int IncoreClusterStateLedger::onLogRolloverCb(const mqbu::StorageKey& oldLogId,
     bmqp_ctrlmsg::LeaderAdvisory leaderAdvisory;
 
     // The snapshot will have the same sequence number as the record which
-    // caused rollover.  We do not want to bump up leader sequence number
+    // caused rollover.  We do not want to bump up LSN
     // because the snapshot will not be broadcasted,  Note that since we write
     // the snapshot before the uncommitted records, the records won't be in
     // monotonically increasing order.
@@ -408,8 +408,8 @@ int IncoreClusterStateLedger::applyAdvisoryInternal(
         d_clusterData_p->electorInfo().leaderMessageSequence()) {
         BALL_LOG_WARN << description()
                       << ": Failed to apply advisory: " << clusterMessage
-                      << ". Reason: advisory is stale (sequenceNumber: "
-                      << sequenceNumber << ", leaderMessageSeq: "
+                      << ". Reason: advisory is stale (LSN: " << sequenceNumber
+                      << ", self LSN: "
                       << d_clusterData_p->electorInfo().leaderMessageSequence()
                       << ").";
         return rc_ADVISORY_STALE;  // RETURN
@@ -796,8 +796,7 @@ int IncoreClusterStateLedger::applyCommit(
                      commitAdvisory.sequenceNumberCommitted());
 
     BALL_LOG_INFO << description() << " Quorum of " << ackQuorum
-                  << " acks is achieved for advisory of seqNum "
-                  << sequenceNumber
+                  << " acks is achieved for advisory of LSN " << sequenceNumber
                   << ", creating and applying commit advisory: "
                   << commitMessage << ".";
 
@@ -837,7 +836,7 @@ void IncoreClusterStateLedger::cancelUncommittedAdvisories()
         BALL_LOG_INFO << description() << "Canceling "
                       << d_uncommittedAdvisories.size()
                       << " uncommitted advisories in the incore CSL starting "
-                         "at seqNum = "
+                         "at LSN = "
                       << seqNum;
     }
 
@@ -1013,7 +1012,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         if (recordHeader->recordType() != ClusterStateRecordType::e_ACK) {
             BALL_LOG_ERROR
                 << description()
-                << ": Ignoring cluster state record event with seqNum = "
+                << ": Ignoring cluster state record event with LSN = "
                 << seqNum << " from '" << source->nodeDescription()
                 << "'. Reason: Leader should only receive Acks, "
                    "but we received record of type: "
@@ -1026,11 +1025,10 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
 
         if (d_uncommittedAdvisories.find(seqNum) ==
             d_uncommittedAdvisories.end()) {
-            BALL_LOG_INFO
-                << description()
-                << ": Ignoring cluster state record ack with seqNum = "
-                << seqNum << " from '" << source->nodeDescription()
-                << "', as quorum of acks has already been reached.";
+            BALL_LOG_INFO << description()
+                          << ": Ignoring cluster state record ack with LSN = "
+                          << seqNum << " from '" << source->nodeDescription()
+                          << "', as quorum of acks has already been reached.";
             return rc_SUCCESS;  // RETURN
         }
     }
@@ -1041,7 +1039,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
             recordHeader->recordType() != ClusterStateRecordType::e_COMMIT) {
             BALL_LOG_ERROR
                 << description()
-                << ": Ignoring cluster state record event with seqNum = "
+                << ": Ignoring cluster state record event with LSN = "
                 << seqNum << " from '" << source->nodeDescription()
                 << "'. Reason: Follower should only receive advisories and "
                    "commits, but we received record of type: "
@@ -1052,8 +1050,8 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         if (d_uncommittedAdvisories.find(seqNum) !=
             d_uncommittedAdvisories.end()) {
             BALL_LOG_ERROR << description()
-                           << ": Failed to apply record with seqNum = "
-                           << seqNum << " from '" << source->nodeDescription()
+                           << ": Failed to apply record with LSN = " << seqNum
+                           << " from '" << source->nodeDescription()
                            << "'. Reason: record was already applied. ";
             return rc_RECORD_ALREADY_APPLIED;  // RETURN
         }
@@ -1061,9 +1059,9 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         if (seqNum < d_clusterData_p->electorInfo().leaderMessageSequence()) {
             BALL_LOG_ERROR
                 << description()
-                << ": Failed to apply record with seqNum = " << seqNum
+                << ": Failed to apply record with LSN = " << seqNum
                 << " from '" << source->nodeDescription()
-                << "'. Reason: record is stale; self leaderMessageSeq = "
+                << "'. Reason: record is stale; self LSN = "
                 << d_clusterData_p->electorInfo().leaderMessageSequence()
                 << "].";
             return rc_RECORD_STALE;  // RETURN
@@ -1089,7 +1087,7 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                      message.choice().isLeaderAdvisoryCommitValue());
 
     BALL_LOG_INFO << description() << ": Applying cluster message with type = "
-                  << recordHeader->recordType() << " and seqNum = " << seqNum
+                  << recordHeader->recordType() << " and LSN = " << seqNum
                   << " from '" << source->nodeDescription()
                   << "': " << message;
 
@@ -1224,9 +1222,8 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                                  recordHeader->recordType());
     if (rc != 0) {
         BALL_LOG_WARN << description() << ": Failed to apply record from '"
-                      << source->nodeDescription()
-                      << "' [sequenceNumber: " << seqNum
-                      << ", leaderMessageSeq: "
+                      << source->nodeDescription() << "' [LSN: " << seqNum
+                      << ", self LSN: "
                       << d_clusterData_p->electorInfo().leaderMessageSequence()
                       << "]. rc: " << rc;
         return rc * 10 + rc_APPLY_RECORD_FAILURE;  // RETURN

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -193,7 +193,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     bslma::ManagedPtr<mqbsi::Ledger> d_ledger_mp;
 
     /// Map of uncommitted (but not canceled) advisories and associated record
-    /// id from leader message sequence number.
+    /// id from LSN.
     AdvisoriesMap d_uncommittedAdvisories;
 
   private:

--- a/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
@@ -1163,7 +1163,7 @@ void printElectorInfo(bsl::ostream&      os,
        << bmqu::PrintUtil::newlineAndIndent(level, spacesPerLevel)
        << "Leader Node           : " << electorInfo.leaderNode()
        << bmqu::PrintUtil::newlineAndIndent(level, spacesPerLevel)
-       << "Leader Sequence Number: [ electorTerm = "
+       << "LSN: [ electorTerm = "
        << electorInfo.leaderMessageSequence().electorTerm()
        << " sequenceNumber = "
        << electorInfo.leaderMessageSequence().sequenceNumber() << " ]"


### PR DESCRIPTION
  ## Summary                                                                                                                                 
  - Normalize all log messages and comments referring to Leader Sequence Number to consistently use the abbreviation **"LSN"** instead of the
   6+ variants previously scattered across the codebase (`seqNum`, `sequenceNumber`, `leaderMessageSeq`, `leader message sequence`,          
  `leader-msg-sequence number`, `leader sequence number`).  
  - Inconsistent terminology makes grepping production logs during incidents unreliable — a single canonical term eliminates that problem.   
  - This is the first of two PRs; a follow-up will normalize Partition Sequence Number (PSN) terminology. 