### PR TITLE
Fix[bmqio]: Bump attempt interval for ASAN in unit test

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
@@ -102,13 +102,14 @@ static const int k_ATTEMPT_INTERVAL_MS = 300;
 #elif defined(                                                                \
     __has_feature)  // Clang-supported method for checking sanitizers.
 static const int k_ATTEMPT_INTERVAL_MS =
-    (__has_feature(memory_sanitizer) || __has_feature(thread_sanitizer) ||
+    (__has_feature(address_sanitizer) || __has_feature(memory_sanitizer) ||
+     __has_feature(thread_sanitizer) ||
      __has_feature(undefined_behavior_sanitizer))
         ? 400
         : 1;
-#elif defined(__SANITIZE_MEMORY__) || defined(__SANITIZE_THREAD__) ||         \
-    defined(__SANITIZE_UNDEFINED__)
-// GCC-supported macros for checking MSAN, TSAN and UBSAN.
+#elif defined(__SANITIZE_ADDRESS__) || defined(__SANITIZE_MEMORY__) ||        \
+    defined(__SANITIZE_THREAD__) || defined(__SANITIZE_UNDEFINED__)
+// GCC-supported macros for checking ASAN, MSAN, TSAN and UBSAN.
 static const int k_ATTEMPT_INTERVAL_MS = 400;
 #else
 static const int k_ATTEMPT_INTERVAL_MS = 1;


### PR DESCRIPTION
The `NtcChannelFactory` unit test bumps up the attempt interval time for MSAN, TSAN, and UBSAN, but not ASAN.  ASAN seems to affect this test less, but on slower machines it can still trip.  This patch adds ASAN to the list of conditions to use a higher attempt interval time, which does not substantively change the tested behavior.