### PR TITLE
Fix: Remove attempts to test out of range enums

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_event.t.cpp
@@ -1070,16 +1070,6 @@ static void test7_printing()
         out.clear();
         out.reset();
     }
-
-    {
-        PV("Bad enum value test");
-        bmqimp::Event obj(&bufferFactory, bmqtst::TestHelperUtil::allocator());
-        obj.setType(static_cast<bmqimp::Event::EventType::Enum>(
-            bsl::numeric_limits<int>::min()));
-
-        BMQTST_ASSERT_OPT_FAIL(out << obj);
-        out.reset();
-    }
 }
 static void test8_putEventBuilder()
 {

--- a/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagedumper.t.cpp
@@ -190,11 +190,6 @@ struct Tester BSLS_CPP11_FINAL {
     // is undefined unless 'command' is a valid dump command (as indicated
     // by the return code of 'MessageDumper::parseCommand').
 
-    int processDumpCommand(const bmqp_ctrlmsg::DumpMessages& command);
-    // Process the specified dump 'command'.  Update the state of the
-    // MessageDumper under test and return 0 if successful, otherwise do
-    // nothing and return non-zero error code.
-
     void reset();
     // Reset the state of the MessageDumper under test to its default
     // state, thus nullifying all previously processed dump commands.
@@ -368,11 +363,6 @@ int Tester::processDumpCommand(const bslstl::StringRef& command)
     static_cast<void>(rc);  // suppress 'unused variable' warning
 
     return d_messageDumper.processDumpCommand(dumpMessagesCommand);
-}
-
-int Tester::processDumpCommand(const bmqp_ctrlmsg::DumpMessages& command)
-{
-    return d_messageDumper.processDumpCommand(command);
 }
 
 void Tester::reset()
@@ -1230,30 +1220,6 @@ static void test4_processDumpCommand_invalidDumpMessage()
 
         BMQTST_ASSERT_EQ(tester.processDumpCommand(test.d_command), 0);
 
-        BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_PUSH),
-                         test.d_isPushEnabled);
-        BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_ACK),
-                         test.d_isAckEnabled);
-        BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_PUT),
-                         test.d_isPutEnabled);
-        BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_CONFIRM),
-                         test.d_isConfirmEnabled);
-
-        // b. Attempt to process further an *invalid* dump command and verify
-        //    that it does not impact the state of the MessageDumper object as
-        //    well as that a non-zero error code is returned.
-
-        bmqp_ctrlmsg::DumpMessages invalidDumpMessagesCommand;
-        invalidDumpMessagesCommand.msgTypeToDump() =
-            static_cast<bmqp_ctrlmsg::DumpMsgType::Value>(-1);
-
-        PVV(test.d_line << ": Attempting to process an invalid dump command");
-
-        // Non-zero error code is returned
-        BMQTST_ASSERT_NE(tester.processDumpCommand(invalidDumpMessagesCommand),
-                         0);
-
-        // No impact on the state of the MessageDumper object
         BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_PUSH),
                          test.d_isPushEnabled);
         BMQTST_ASSERT_EQ(tester.isEventDumpEnabled(bmqp::EventType::e_ACK),

--- a/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_queue.t.cpp
@@ -215,9 +215,7 @@ static void test3_printQueueStateTest()
                   {bmqimp::QueueState::e_CLOSING_CFG, "CLOSING_CFG"},
                   {bmqimp::QueueState::e_CLOSING_CLS, "CLOSING_CLS"},
                   {bmqimp::QueueState::e_CLOSED, "CLOSED"},
-                  {bmqimp::QueueState::e_PENDING, "PENDING"},
-                  {static_cast<bmqimp::QueueState::Enum>(-1),
-                   "(* UNKNOWN *)"}};
+                  {bmqimp::QueueState::e_PENDING, "PENDING"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 

--- a/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_optionsview.t.cpp
@@ -998,70 +998,6 @@ void test4_invalidOptionsArea()
     }
     {
         // [4]
-        PV("OPTION HEADER WITH UNSUPPORTED TYPES");
-
-        // #1: An OptionHeader with an unsupported type
-        bdlbb::Blob              optionsBlob(&bufferFactory,
-                                bmqtst::TestHelperUtil::allocator());
-        const bmqu::BlobPosition optionsAreaPosition;  // start of blob
-        const int                numSubQueueInfos = 2;
-
-        const int optionPayloadSize = numSubQueueInfos *
-                                      sizeof(bmqp::SubQueueInfo);
-        const int optionsAreaSize = sizeof(bmqp::OptionHeader) +
-                                    optionPayloadSize;
-
-        bmqp::OptionHeader     oh;
-        bmqp::OptionType::Enum optionType =
-            static_cast<bmqp::OptionType::Enum>(
-                bmqp::OptionType::k_LOWEST_SUPPORTED_TYPE - 1);
-        oh.setType(optionType);
-        oh.setWords(optionsAreaSize / bmqp::Protocol::k_WORD_SIZE);
-
-        // Write OptionHeader
-        bdlbb::BlobUtil::append(&optionsBlob,
-                                reinterpret_cast<const char*>(&oh),
-                                sizeof(bmqp::OptionHeader));
-
-        // Write option payload
-        bsl::vector<bmqp::SubQueueInfo> subQueueInfos(
-            bmqtst::TestHelperUtil::allocator());
-        generateSubQueueInfos(&subQueueInfos, numSubQueueInfos);
-
-        bdlbb::BlobUtil::append(
-            &optionsBlob,
-            reinterpret_cast<const char*>(subQueueInfos.data()),
-            optionPayloadSize);
-
-        // Construct invalid view with an invalid type in an OptionHeader
-        bmqp::OptionsView view1(&optionsBlob,
-                                optionsAreaPosition,
-                                optionsAreaSize,
-                                bmqtst::TestHelperUtil::allocator());
-
-        BMQTST_ASSERT_EQ(false, view1.isValid());
-
-        // #2: An OptionHeader with an unsupported type
-        optionType = static_cast<bmqp::OptionType::Enum>(
-            bmqp::OptionType::k_HIGHEST_SUPPORTED_TYPE + 1);
-        oh.setType(optionType);
-
-        // Overwrite OptionHeader
-        bmqu::BlobUtil::writeBytes(&optionsBlob,
-                                   optionsAreaPosition,
-                                   reinterpret_cast<const char*>(&oh),
-                                   sizeof(bmqp::OptionHeader));
-
-        // Construct invalid view with an invalid type in an OptionHeader
-        bmqp::OptionsView view2(&optionsBlob,
-                                optionsAreaPosition,
-                                optionsAreaSize,
-                                bmqtst::TestHelperUtil::allocator());
-
-        BMQTST_ASSERT_EQ(false, view2.isValid());
-    }
-    {
-        // [5]
         PV("MULTIPLE OPTION HEADERS OF THE SAME TYPE (DUPLICATE)");
 
         // Multiple OptionHeader of the same type (duplicate)
@@ -1128,7 +1064,7 @@ void test4_invalidOptionsArea()
         BMQTST_ASSERT_EQ(false, view.isValid());
     }
     {
-        // [6]
+        // [5]
         PV("EMPTY BLOB");
 
         bdlbb::Blob              optionsBlob(&bufferFactory,
@@ -1148,7 +1084,7 @@ void test4_invalidOptionsArea()
         BMQTST_ASSERT_EQ(false, view.isValid());
     }
     {
-        // [7]
+        // [6]
         PV("WRONG AREA SIZE FOR OPTION VIEW");
 
         bdlbb::Blob              optionsBlob(&bufferFactory,

--- a/src/groups/bmq/bmqt/bmqt_hosthealthstate.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_hosthealthstate.t.cpp
@@ -76,9 +76,7 @@ static void test2_printTest()
         const char*                 d_expected;
     } k_DATA[] = {{bmqt::HostHealthState::e_UNKNOWN, "UNKNOWN"},
                   {bmqt::HostHealthState::e_HEALTHY, "HEALTHY"},
-                  {bmqt::HostHealthState::e_UNHEALTHY, "UNHEALTHY"},
-                  {static_cast<bmqt::HostHealthState::Enum>(-1234),
-                   "(* UNKNOWN *)"}};
+                  {bmqt::HostHealthState::e_UNHEALTHY, "UNHEALTHY"}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 


### PR DESCRIPTION
There are more test cases where we attempt to cast to an enum from an out of range value and test that messages are still process correctly. This is undefined behavior, and likely need to approach handling parsing differently if we want to test our system handles garbage values correctly. Most of our APIs do not have a reasonable expectation to work if the underlying data is invalid.
