### PR TITLE
Fix: Avoid default allocator usage in `test3_allocationLimitCb`

### DIFF
--- a/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocator.cpp
@@ -380,11 +380,8 @@ void CountingAllocator::AllocationLimitChecker::setLimit(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(callback);
 
-    d_allocationLimit = limit;
-    AllocationLimitCallback cb(bsl::allocator_arg,
-                               d_allocationLimitCb.get_allocator(),
-                               callback);
-    d_allocationLimitCb.swap(cb);
+    d_allocationLimit   = limit;
+    d_allocationLimitCb = callback;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqma/bmqma_countingallocatorutil.t.cpp
+++ b/src/groups/bmq/bmqma/bmqma_countingallocatorutil.t.cpp
@@ -25,6 +25,7 @@
 
 // BDE
 #include <bslma_default.h>
+#include <bslmf_isbitwisemoveable.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
 
@@ -41,14 +42,20 @@ using namespace bsl;
 namespace {
 
 struct AllocationLimitCb {
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(AllocationLimitCb, bslmf::IsBitwiseMoveable)
+
+    // DATA
     int* d_triggered_p;
 
+    // CREATORS
     AllocationLimitCb(int* triggered)
     : d_triggered_p(triggered)
     {
         BSLS_ASSERT_OPT(d_triggered_p);
     }
 
+    // MANIPULATORS
     void operator()() { ++(*d_triggered_p); }
 };
 
@@ -195,7 +202,9 @@ static void test3_allocationLimitCb()
         "testStatContext",
         "testAllocatorName",
         4096,
-        AllocationLimitCb(&alarmTriggeredCount));
+        bsl::function<void()>(bsl::allocator_arg,
+                              bmqtst::TestHelperUtil::allocator(),
+                              AllocationLimitCb(&alarmTriggeredCount)));
 
     // Expect no alarm
     //  [........] ~0/4096 bytes


### PR DESCRIPTION
Two previous commits (3537c0d, 33e6199) have attempted to remove default allocator usage in the bmqma_countingallocator unit test, with only partial success.  After applying these two patches, on some systems we are still left with a single allocated block in the default allocator.

The root cause of this appears to be that `bsl::function` can use a small object optimization to copy small functor objects to its internal memory rather than incur an allocation, but this behavior is strongly dependent on the build configuration.  So, on Linux x64 C++17, *the only place we build and run unit tests in CI*, `bsl::function` always uses the small object optimization, our tests thus always see that no allocations have been made with the default allocator, and our tests pass.  On other systems, though, `bsl::function` does not use the small object optimization, and when we do not pass an allocator to the `bsl::function`, it will incur an allocation from the default allocator.  On these platforms, bmqma_countingallocator’s test fails.

The previous two attempts to fix this looked inside the `bmqma::CountingAllocator` implementation itself, and indeed found one use of the default allocator in `bmqma::CountingAllocator`, which was fixed.  However, the test still fails to pass.  Instead, this patch fixes the issue in two separate ways, both of which we should do for correctness’s sake:

  1. First, ensure that `bsl::function` will always use the small object optimization for `AllocationLimitCb`.  `bsl::function` relies on the functor type being bitwise moveable using the `bslmf::IsBitwiseMovable` trait to use the small string optimization.  Because our functor type, `AllocationLimitCb`, contains just a single `int*`, with no enforced invariants, it is safe to `memmove`.  This patch declares that `AllocationLimitCb` satisfies the `bslmf::IsBitwiseMoveable` trait.

  2. Second, the single remaining allocated block that the test reports seems to be due to a temporary `bsl::function` being constructed without passing an allocator to it.  Unlike the fix that commit 33e6199 incorrectly pursued, this temporary was not in the implementation of bmqma_countingallocator, but rather in the failing test itself.  So, this patch reverts the change from commit 33e6199, which did not fix the underlying issue, and instead constructs the temporary `bsl::function` in the unit test with an explicit allocator argument.

While either one of these changes would ameliorate the test failure, both are necessary for correctness.  The first change declares explicitly that `AllocationLimitCb` is eligible for the small object optimization, normalizing that behavior across platforms.  However, if BDE changes the conditions under which they perform the small object operation, just this change leaves us vulnerable.  The second change passes an allocator as we always should have, but paves over the small object optimization differences.  For that reason, we want both.