### PR TITLE
Fix: Ignore `-Wunneeded-member-function`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,9 @@ if( "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang" )
           "-Wno-float-equal"            # operator== in generated classes
           "-Wno-documentation-unknown-command"
                                         # Don't warn about @bbref{}
+          "-Wno-unneeded-member-function"
+                                        # BSLMF_NESTED_TRAIT_DECLARATION in
+                                        # anonymous namespaces
   )
 
 


### PR DESCRIPTION
This warning fires on `BSLMF_NESTED_TRAIT_DECLARATION` in anonymous namespaces when building with clang with modern C++ versions, but it is necessary specifically for C++03 versions.  In this case, the warning is too aggressive, so this patch turns off the warning, rather than changing the source code to do one thing in C++03 and another in later C++ versions.