### PR TITLE
Cleanup[mqbc, mqbblp]: Normalize PSN terminology in logs and comments

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -298,15 +298,15 @@ bsls::Types::Uint64 recordOffset(const RECORD_TYPE& record)
                                mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
 }
 
-/// Helper matcher to check the offset of the record. Return 'true' if the
-/// specified 'expectedOffset' is equal to the offset of the RecordDetails
+/// Helper matcher to check the PSN of the record. Return 'true' if the
+/// specified 'expectedPSN' is equal to the PSN of the RecordDetails
 /// 'arg'.
-MATCHER_P(SequenceNumberMatcher, expectedSequenceNumber, "")
+MATCHER_P(SequenceNumberMatcher, expectedPSN, "")
 {
-    CompositeSequenceNumber seq(arg.d_record.header().primaryLeaseId(),
+    CompositeSequenceNumber psn(arg.d_record.header().primaryLeaseId(),
                                 arg.d_record.header().sequenceNumber());
-    *result_listener << "SequenceNumber : " << seq;
-    return seq == expectedSequenceNumber;
+    *result_listener << "PSN : " << psn;
+    return psn == expectedPSN;
 }
 
 }  // close unnamed namespace

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -15,6 +15,7 @@
 
 #include <bsls_assert.h>
 #include <mqbblp_recoverymanager.h>
+#include <mqbs_filestoreprintutil.h>
 
 #include <mqbscm_version.h>
 // MQB
@@ -1731,7 +1732,8 @@ int RecoveryManager::replayPartition(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << pid << "]: " << "replaying from "
-                  << fromSequenceNum << " to " << toSequenceNum
+                  << mqbs::printPSN(fromSequenceNum) << " to "
+                  << mqbs::printPSN(toSequenceNum)
                   << " to node: " << destination->nodeDescription() << ".";
 
     mqbs::JournalFileIterator journalIt;
@@ -1769,7 +1771,7 @@ int RecoveryManager::replayPartition(
         return rc_INVALID_JOURNALOP_RECORD;  // RETURN
     }
 
-    // Retrieve sequence number from the RecordHeader in the SyncPt, not from
+    // Retrieve PSN from the RecordHeader in the SyncPt, not from
     // the SyncPt itself.
 
     bmqp_ctrlmsg::PartitionSequenceNumber currentSeqNum;
@@ -1787,7 +1789,7 @@ int RecoveryManager::replayPartition(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << pid << "]: " << "replay starts from "
-                  << currentSeqNum << ".";
+                  << mqbs::printPSN(currentSeqNum) << ".";
 
     // 'bootstrapCurrentSeqNum' has positioned 'currentSeqNum' and 'journalIt'
     // precisely to the record after 'fromSequenceNum'.
@@ -1896,9 +1898,11 @@ int RecoveryManager::replayPartition(
     if (!isDone) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
                       << " Partition [" << pid
-                      << "]: incomplete replay of partition. Sequence number "
-                      << "of last record sent: " << currentSeqNum
-                      << ", was supposed to send up to: " << toSequenceNum
+                      << "]: incomplete replay of partition. PSN "
+                      << "of last record sent: "
+                      << mqbs::printPSN(currentSeqNum)
+                      << ", was supposed to send up to: "
+                      << mqbs::printPSN(toSequenceNum)
                       << ". Peer: " << destination->nodeDescription() << ".";
         return rc_INCOMPLETE_REPLAY;  // RETURN
     }
@@ -1969,9 +1973,8 @@ void RecoveryManager::syncPeerPartitions(PrimarySyncContext* primarySyncCtx)
             BALL_LOG_INFO << d_clusterData_p->identity().description()
                           << " Partition [" << pid
                           << "]: skipping partition-sync with peer: "
-                          << pps.peer()->nodeDescription()
-                          << ". Peer's partition sequence num: "
-                          << pps.partitionSequenceNum();
+                          << pps.peer()->nodeDescription() << ". Peer's PSN: "
+                          << mqbs::printPSN(pps.partitionSequenceNum());
             continue;  // CONTINUE
         }
 
@@ -2030,9 +2033,9 @@ int RecoveryManager::syncPeerPartition(PrimarySyncContext* primarySyncCtx,
         // TBD: assert?
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
                        << " Partition [" << pid
-                       << "]: new primary (self) has smaller sequence number: "
-                       << selfSequenceNum << ", than "
-                       << ppState.partitionSequenceNum()
+                       << "]: new primary (self) has smaller PSN: "
+                       << mqbs::printPSN(selfSequenceNum) << ", than "
+                       << mqbs::printPSN(ppState.partitionSequenceNum())
                        << ", of peer: " << ppState.peer()->nodeDescription();
         return rc_NEW_PRIMARY_BEHIND;  // RETURN
     }
@@ -2040,13 +2043,13 @@ int RecoveryManager::syncPeerPartition(PrimarySyncContext* primarySyncCtx,
     if (primarySyncCtx->syncPeer() == ppState.peer()) {
         if (selfSequenceNum != ppState.partitionSequenceNum()) {
             // New primary (self) synced the partition with this peer, so their
-            // sequence numbers *must* match.  TBD: assert?
+            // PSNs *must* match.  TBD: assert?
 
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
                            << " Partition [" << pid
-                           << "]: new primary (self) has different sequence "
-                           << "number: " << selfSequenceNum << ", than "
-                           << ppState.partitionSequenceNum()
+                           << "]: new primary (self) has different PSN" << ": "
+                           << mqbs::printPSN(selfSequenceNum) << ", than "
+                           << mqbs::printPSN(ppState.partitionSequenceNum())
                            << ", of syncing peer: "
                            << ppState.peer()->nodeDescription();
             return rc_SEQ_NUM_MISMATCH_WITH_SYNC_PEER;  // RETURN
@@ -2058,9 +2061,9 @@ int RecoveryManager::syncPeerPartition(PrimarySyncContext* primarySyncCtx,
     if (selfSequenceNum == ppState.partitionSequenceNum()) {
         BALL_LOG_INFO << d_clusterData_p->identity().description()
                       << " Partition [" << pid
-                      << "]: new primary (self) has same sequence "
-                      << "number: " << selfSequenceNum
-                      << ", as: " << ppState.partitionSequenceNum()
+                      << "]: new primary (self) has same PSN" << ": "
+                      << mqbs::printPSN(selfSequenceNum) << ", as: "
+                      << mqbs::printPSN(ppState.partitionSequenceNum())
                       << ", of peer: " << ppState.peer()->nodeDescription()
                       << ". No sync is needed.";
         return rc_SUCCESS;  // RETURN
@@ -2284,16 +2287,17 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
 
         if (0 == syncPointRecHeader->primaryLeaseId() ||
             0 == syncPointRecHeader->sequenceNumber()) {
-            // Peer sent a SyncPt containing invalid seqnum.
+            // Peer sent a SyncPt containing invalid PSN.
 
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
                            << ": For Partition [" << partitionId << "]"
-                           << ", received a sync point with invalid sequence "
-                              "number in the "
-                           << "RecordHeader: ("
-                           << syncPointRecHeader->primaryLeaseId() << ", "
-                           << syncPointRecHeader->sequenceNumber()
-                           << "), from " << source->nodeDescription()
+                           << ", received a sync point with invalid PSN"
+                              " in the "
+                           << "RecordHeader: "
+                           << mqbs::printPSN(
+                                  syncPointRecHeader->primaryLeaseId(),
+                                  syncPointRecHeader->sequenceNumber())
+                           << ", from " << source->nodeDescription()
                            << ". Ignoring this message.";
             continue;  // CONTINUE
         }
@@ -2308,10 +2312,11 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                 << ", received a JOURNAL_OP record of type "
                 << journalOpRec->type()
                 << " (expected type SYNCPOINT) in storage message with "
-                << "sequence number (" << syncPointRecHeader->primaryLeaseId()
-                << ", " << syncPointRecHeader->sequenceNumber() << "), from "
-                << source->nodeDescription() << ". Ignoring this message."
-                << BMQTSK_ALARMLOG_END;
+                << "PSN: "
+                << mqbs::printPSN(syncPointRecHeader->primaryLeaseId(),
+                                  syncPointRecHeader->sequenceNumber())
+                << ", from " << source->nodeDescription()
+                << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
             continue;  // CONTINUE
         }
 
@@ -2321,22 +2326,22 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                 << d_clusterData_p->identity().description()
                 << ": For Partition [" << partitionId << "]"
                 << ", received a syncPoint record of UNDEFINED type (expected "
-                << "type REGULAR/ROLLOVER), in storage message with sequence "
-                << "number (" << syncPointRecHeader->primaryLeaseId() << ", "
-                << syncPointRecHeader->sequenceNumber() << "), from "
-                << source->nodeDescription() << ". Ignoring this message."
-                << BMQTSK_ALARMLOG_END;
+                << "type REGULAR/ROLLOVER), in storage message with PSN: "
+                << mqbs::printPSN(syncPointRecHeader->primaryLeaseId(),
+                                  syncPointRecHeader->sequenceNumber())
+                << ", from " << source->nodeDescription()
+                << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
             continue;  // CONTINUE
         }
 
         // Note that 'journalOpRec.primaryLeaseId()' may be smaller than what
         // appears in its RecordHeader if a new primary was chosen for this
         // partition *while* self node was waiting for a sync point, *and* as
-        // its first job, the new primary issues a sync point with old leaseId
-        // & sequenceNum.  Also note that in this case, sequence number in the
-        // RecordHeader will be different from 'journalOpRec->sequenceNumber()'
-        // (see 'FileStore::writeJournalRecord' for same comment -- for the
-        // same reason).
+        // its first job, the new primary issues a sync point with old PSN.
+        // Also note that in this case, PSN in the RecordHeader will be
+        // different from 'journalOpRec->sequenceNumber()' (see
+        // 'FileStore::writeJournalRecord' for same comment -- for the same
+        // reason).
 
         if (syncPointRecHeader->primaryLeaseId() <
             journalOpRec->primaryLeaseId()) {
@@ -2346,13 +2351,14 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                            << ": For Partition [" << partitionId << "]"
                            << ", received a sync point JOURNAL_OP record "
                            << "with invalid primaryLeaseId in RecordHeader."
-                           << " Sequence number in RecordHeader ("
-                           << syncPointRecHeader->primaryLeaseId() << ", "
-                           << syncPointRecHeader->sequenceNumber()
-                           << "). Sequence number in sync point("
-                           << journalOpRec->primaryLeaseId() << ", "
-                           << journalOpRec->sequenceNum()
-                           << "). Source: " << source->nodeDescription()
+                           << " PSN in RecordHeader: "
+                           << mqbs::printPSN(
+                                  syncPointRecHeader->primaryLeaseId(),
+                                  syncPointRecHeader->sequenceNumber())
+                           << ". PSN in sync point: "
+                           << mqbs::printPSN(journalOpRec->primaryLeaseId(),
+                                             journalOpRec->sequenceNum())
+                           << ". Source: " << source->nodeDescription()
                            << ". Ignoring this message.";
             continue;  // CONTINUE
         }
@@ -2369,13 +2375,13 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                     << d_clusterData_p->identity().description()
                     << " Partition [" << partitionId
                     << "]: " << "received a sync point record with mismatched "
-                    << "sequence numbers. Sequence number in RecordHeader ("
-                    << syncPointRecHeader->primaryLeaseId() << ", "
-                    << syncPointRecHeader->sequenceNumber()
-                    << "). Sequence number in sync point ("
-                    << journalOpRec->primaryLeaseId() << ", "
-                    << journalOpRec->sequenceNum()
-                    << "). Source: " << source->nodeDescription()
+                    << "PSNs. PSN in RecordHeader: "
+                    << mqbs::printPSN(syncPointRecHeader->primaryLeaseId(),
+                                      syncPointRecHeader->sequenceNumber())
+                    << ". PSN in sync point: "
+                    << mqbs::printPSN(journalOpRec->primaryLeaseId(),
+                                      journalOpRec->sequenceNum())
+                    << ". Source: " << source->nodeDescription()
                     << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
                 continue;  // CONTINUE
             }
@@ -2399,13 +2405,13 @@ bool RecoveryManager::hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                 << d_clusterData_p->identity().description() << " Partition ["
                 << partitionId << "] :"
                 << "received a rolled-over sync point, but skipping it. "
-                << "Sequence number in RecordHeader ("
-                << syncPointRecHeader->primaryLeaseId() << ", "
-                << syncPointRecHeader->sequenceNumber()
-                << "). Sequence number in sync point ("
-                << journalOpRec->primaryLeaseId() << ", "
-                << journalOpRec->sequenceNum()
-                << "). Source: " << source->nodeDescription();
+                << "PSN in RecordHeader: "
+                << mqbs::printPSN(syncPointRecHeader->primaryLeaseId(),
+                                  syncPointRecHeader->sequenceNumber())
+                << ". PSN in sync point: "
+                << mqbs::printPSN(journalOpRec->primaryLeaseId(),
+                                  journalOpRec->sequenceNum())
+                << ". Source: " << source->nodeDescription();
 
             bmqp_ctrlmsg::SyncPoint dummySyncPt;
             RecoveryContext& recoveryCtx = d_recoveryContexts[partitionId];
@@ -2602,7 +2608,7 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
         BALL_LOG_INFO << d_clusterData_p->identity().description()
                       << " Partition [" << partitionId
                       << "]: Self node has latest view of partition during "
-                      << "primary sync, with sequence number " << maxSeq
+                      << "primary sync, with PSN " << mqbs::printPSN(maxSeq)
                       << ". Self node will now attempt to sync replica peers.";
 
         syncPeerPartitions(&primarySyncCtx);
@@ -2649,7 +2655,7 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
                   << " Partition [" << partitionId << "]: Peer "
                   << maxSeqNode->nodeDescription()
                   << " has most advanced view of the partition during primary "
-                  << "sync " << maxSeq
+                  << "sync " << mqbs::printPSN(maxSeq)
                   << ", last sync-point: " << maxSeqNodeSyncPt
                   << ".  Will send primary sync data query to it.";
 
@@ -2860,11 +2866,10 @@ void RecoveryManager::onPartitionSyncDataQueryResponseDispatched(
         BMQTSK_ALARMLOG_ALARM("RECOVERY")
             << d_clusterData_p->identity().description() << " Partition ["
             << partitionId
-            << "]: " << "invalid partition sequenceNum specified in response: "
-            << response << " from node: " << responder->nodeDescription()
-            << " for partition sync data request: " << req
-            << ". Self partition seqNum: "
-            << primarySyncCtx.selfPartitionSequenceNum()
+            << "]: " << "invalid PSN specified in response: " << response
+            << " from node: " << responder->nodeDescription()
+            << " for partition sync data request: " << req << ". Self PSN: "
+            << mqbs::printPSN(primarySyncCtx.selfPartitionSequenceNum())
             << "No retry attempt will be made." << BMQTSK_ALARMLOG_END;
         onPartitionPrimarySyncStatus(partitionId, -1 /* status */);
 
@@ -3261,9 +3266,10 @@ void RecoveryManager::startRecovery(
                   << bmqu::PrintUtil::prettyNumber(
                          static_cast<bsls::Types::Int64>(lastSyncPointOffset))
                   << ". sync point details: " << syncPoint
-                  << ". Sequence number is sync point's RecordHeader ("
-                  << journalOpRec.header().primaryLeaseId() << ", "
-                  << journalOpRec.header().sequenceNumber() << ").";
+                  << ". PSN in sync point's RecordHeader: "
+                  << mqbs::printPSN(journalOpRec.header().primaryLeaseId(),
+                                    journalOpRec.header().sequenceNumber())
+                  << ".";
 }
 
 void RecoveryManager::processStorageEvent(
@@ -3344,9 +3350,10 @@ void RecoveryManager::processStorageEvent(
                   << "], received sync point " << syncPoint << " from node "
                   << source->nodeDescription()
                   << ". Primary's journal offset: " << primaryJournalOffset
-                  << ". Sequence number in sync point's RecordHeader: ("
-                  << syncPointRecHeader.primaryLeaseId() << ", "
-                  << syncPointRecHeader.sequenceNumber() << ").";
+                  << ". PSN in sync point's RecordHeader: "
+                  << mqbs::printPSN(syncPointRecHeader.primaryLeaseId(),
+                                    syncPointRecHeader.sequenceNumber())
+                  << ".";
 
     bmqp::Event                  event(blob.get(), d_allocator_p);
     bmqp::StorageMessageIterator iter;
@@ -4573,45 +4580,45 @@ void RecoveryManager::processPartitionSyncDataRequest(
         ChunkDeleter(&requestCtx));
     fti.incrementAliasedChunksCount();
 
-    bmqp_ctrlmsg::PartitionSequenceNumber requesterLastSeqNum;
-    requesterLastSeqNum.primaryLeaseId() = req.lastPrimaryLeaseId();
-    requesterLastSeqNum.sequenceNumber() = req.lastSequenceNum();
+    bmqp_ctrlmsg::PartitionSequenceNumber requesterPSN;
+    requesterPSN.primaryLeaseId() = req.lastPrimaryLeaseId();
+    requesterPSN.sequenceNumber() = req.lastSequenceNum();
 
-    bmqp_ctrlmsg::PartitionSequenceNumber requesterUptoSeqNum;
-    requesterUptoSeqNum.primaryLeaseId() = req.uptoPrimaryLeaseId();
-    requesterUptoSeqNum.sequenceNumber() = req.uptoSequenceNum();
+    bmqp_ctrlmsg::PartitionSequenceNumber requesterUptoPSN;
+    requesterUptoPSN.primaryLeaseId() = req.uptoPrimaryLeaseId();
+    requesterUptoPSN.sequenceNumber() = req.uptoSequenceNum();
 
-    bmqp_ctrlmsg::PartitionSequenceNumber selfSeqNum;
-    selfSeqNum.primaryLeaseId() = fs->primaryLeaseId();
-    selfSeqNum.sequenceNumber() = fs->sequenceNumber();
+    bmqp_ctrlmsg::PartitionSequenceNumber selfPSN;
+    selfPSN.primaryLeaseId() = fs->primaryLeaseId();
+    selfPSN.sequenceNumber() = fs->sequenceNumber();
 
-    if (requesterUptoSeqNum <= requesterLastSeqNum) {
+    if (requesterUptoPSN <= requesterPSN) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
                       << ": For Partition [" << req.partitionId()
                       << "], received partition sync data request from "
                       << source->nodeDescription() << ", with invalid "
-                      << " 'last/upto' sequence numbers: "
-                      << requesterLastSeqNum << ", " << requesterUptoSeqNum;
+                      << " 'last/upto' PSNs: " << mqbs::printPSN(requesterPSN)
+                      << ", " << mqbs::printPSN(requesterUptoPSN);
 
         bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
         status.category() = bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT;
         status.code()     = -1;
-        status.message()  = "Invalid sequence number range..";
+        status.message()  = "Invalid PSN range.";
 
         d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg,
                                                               source);
         return;  // RETURN
     }
 
-    if (selfSeqNum <= requesterLastSeqNum) {
+    if (selfPSN <= requesterPSN) {
         // Request should not have been sent to this node.
 
         BALL_LOG_WARN << d_clusterData_p->identity().description()
                       << ": For Partition [" << req.partitionId()
                       << "], received partition sync data request from "
                       << source->nodeDescription() << ", with equal or greater"
-                      << " last sequence number " << requesterLastSeqNum
-                      << ", self sequence number " << selfSeqNum;
+                      << " last PSN " << mqbs::printPSN(requesterPSN)
+                      << ", self PSN " << mqbs::printPSN(selfPSN);
 
         bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
         status.category() = bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT;
@@ -4623,15 +4630,15 @@ void RecoveryManager::processPartitionSyncDataRequest(
         return;  // RETURN
     }
 
-    if (selfSeqNum < requesterUptoSeqNum) {
+    if (selfPSN < requesterUptoPSN) {
         // Request should not have been sent to this node.
 
         BALL_LOG_WARN << d_clusterData_p->identity().description()
                       << ": For Partition [" << req.partitionId()
                       << "], received partition sync data request from "
                       << source->nodeDescription() << ", with greater 'upto' "
-                      << "sequence number " << requesterUptoSeqNum
-                      << ", self sequence number " << selfSeqNum;
+                      << "PSN " << mqbs::printPSN(requesterUptoPSN)
+                      << ", self PSN " << mqbs::printPSN(selfPSN);
 
         bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
         status.category() = bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT;
@@ -4643,13 +4650,13 @@ void RecoveryManager::processPartitionSyncDataRequest(
         return;  // RETURN
     }
 
-    // If self's partitionSequenceNumber is greater than 'requesterLastSeqNum',
+    // If self's PSN is greater than 'requesterPSN',
     // it means self's leaseId must be greater than zero, because zero is the
     // smallest possible value for leaseId.  This also implies that self's
     // partition must have at least one sync point which captures that non-zero
     // leaseId value.
 
-    BSLS_ASSERT_SAFE(0 != selfSeqNum.primaryLeaseId());
+    BSLS_ASSERT_SAFE(0 != selfPSN.primaryLeaseId());
     BSLS_ASSERT_SAFE(!fs->syncPoints().empty());
 
     const bmqp_ctrlmsg::SyncPointOffsetPair& lastSpoPair =
@@ -4862,8 +4869,8 @@ void RecoveryManager::processPartitionSyncDataRequest(
         clusterMsg.choice().makePartitionSyncDataQueryResponse();
 
     response.partitionId()       = req.partitionId();
-    response.endPrimaryLeaseId() = selfSeqNum.primaryLeaseId();
-    response.endSequenceNum()    = selfSeqNum.sequenceNumber();
+    response.endPrimaryLeaseId() = selfPSN.primaryLeaseId();
+    response.endSequenceNum()    = selfPSN.sequenceNumber();
 
     d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg, source);
 
@@ -4873,8 +4880,9 @@ void RecoveryManager::processPartitionSyncDataRequest(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << req.partitionId()
-                  << "]: replaying partition from: " << requesterLastSeqNum
-                  << " (exclusive) to: " << requesterUptoSeqNum
+                  << "]: replaying partition from: "
+                  << mqbs::printPSN(requesterPSN)
+                  << " (exclusive) to: " << mqbs::printPSN(requesterUptoPSN)
                   << " (inclusive) with preceding sync-point JOURNAL offset "
                   << "of " << journalSpOffset << ", while serving "
                   << "partition-sync data request: " << req
@@ -4883,8 +4891,8 @@ void RecoveryManager::processPartitionSyncDataRequest(
     rc = replayPartition(&requestCtx,
                          0,  // PrimarySyncContext
                          requestCtx.requesterNode(),
-                         requesterLastSeqNum,
-                         requesterUptoSeqNum,
+                         requesterPSN,
+                         requesterUptoPSN,
                          journalSpOffset);
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("CLUSTER")

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -266,7 +266,7 @@ void StorageManager::onPartitionRecovery(
                 }
             }
 
-            // Get the latest leaseId and sequence number for this partition.
+            // Get the latest PSN for this partition.
             if (fs->isOpen()) {
                 d_recoveredPrimaryLeaseIds[partitionId] = fs->primaryLeaseId();
 
@@ -274,12 +274,13 @@ void StorageManager::onPartitionRecovery(
                     << d_clusterData_p->identity().description()
                     << ": Partition [" << partitionId
                     << "] after applying buffered storage events, "
-                    << "(recoveryPeerNode, primaryLeaseId, "
-                    << "sequenceNumber): ("
+                    << "(recoveryPeerNode, PSN): ("
                     << (recoveryPeer ? recoveryPeer->nodeDescription()
                                      : "**none**")
-                    << ", " << fs->primaryLeaseId() << ", "
-                    << fs->sequenceNumber() << ")";
+                    << ", "
+                    << mqbs::printPSN(fs->primaryLeaseId(),
+                                      fs->sequenceNumber())
+                    << ")";
             }
         }
     }

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -17,6 +17,7 @@
 #include <bsls_assert.h>
 #include <mqbc_partitionfsm.h>
 #include <mqbc_recoverymanager.h>
+#include <mqbs_filestoreprintutil.h>
 #include <mqbs_qlistfileiterator.h>
 
 #include <mqbscm_version.h>
@@ -98,9 +99,9 @@ void RecoveryManager::ReceiveDataContext::reset()
     d_recoveryDataSource_p = 0;
     d_expectChunks         = false;
     d_recoveryRequestId    = -1;
-    d_beginSeqNum.reset();
-    d_endSeqNum.reset();
-    d_currSeqNum.reset();
+    d_beginPSN.reset();
+    d_endPSN.reset();
+    d_currPSN.reset();
 }
 
 // ---------------------
@@ -435,22 +436,22 @@ void RecoveryManager::setExpectedDataChunkRange(
             << "]: " << " Got notification to expect chunks when self is "
             << "already expecting chunks.  Self's view: "
             << "recovery requestId = " << receiveDataCtx.d_recoveryRequestId
-            << "; beginSeqNum = " << receiveDataCtx.d_beginSeqNum
-            << "; endSeqNum = " << receiveDataCtx.d_endSeqNum
-            << "; currSeqNum = " << receiveDataCtx.d_currSeqNum
+            << "; beginSeqNum = " << mqbs::printPSN(receiveDataCtx.d_beginPSN)
+            << "; endSeqNum = " << mqbs::printPSN(receiveDataCtx.d_endPSN)
+            << "; currSeqNum = " << mqbs::printPSN(receiveDataCtx.d_currPSN)
             << ".  Please review Partition FSM logic." << BMQTSK_ALARMLOG_END;
     }
 
     receiveDataCtx.d_recoveryDataSource_p = source;
     receiveDataCtx.d_expectChunks         = true;
     receiveDataCtx.d_recoveryRequestId    = requestId;
-    receiveDataCtx.d_beginSeqNum          = beginSeqNum;
-    receiveDataCtx.d_endSeqNum            = endSeqNum;
-    receiveDataCtx.d_currSeqNum           = beginSeqNum;
+    receiveDataCtx.d_beginPSN             = beginSeqNum;
+    receiveDataCtx.d_endPSN               = endSeqNum;
+    receiveDataCtx.d_currPSN              = beginSeqNum;
     if (fs.isOpen()) {
-        BSLS_ASSERT_SAFE(receiveDataCtx.d_currSeqNum.primaryLeaseId() ==
+        BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.primaryLeaseId() ==
                          fs.primaryLeaseId());
-        BSLS_ASSERT_SAFE(receiveDataCtx.d_currSeqNum.sequenceNumber() ==
+        BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.sequenceNumber() ==
                          fs.sequenceNumber());
     }
     else {
@@ -467,7 +468,8 @@ void RecoveryManager::setExpectedDataChunkRange(
             << d_clusterData.identity().description() << " Partition ["
             << partitionId
             << "]: " << "Got notification to expect data chunks "
-            << "of range " << beginSeqNum << " to " << endSeqNum << " from "
+            << "of range " << mqbs::printPSN(beginSeqNum) << " to "
+            << mqbs::printPSN(endSeqNum) << " from "
             << source->nodeDescription() << ".";
         if (requestId != -1) {
             BALL_LOG_OUTPUT_STREAM << " Recovery requestId is " << requestId
@@ -515,7 +517,8 @@ int RecoveryManager::processSendDataChunks(
 
     BALL_LOG_INFO << d_clusterData.identity().description() << " Partition ["
                   << partitionId << "]: sending data chunks from "
-                  << beginSeqNum << " to " << endSeqNum
+                  << mqbs::printPSN(beginSeqNum) << " to "
+                  << mqbs::printPSN(endSeqNum)
                   << ". Peer: " << destination->nodeDescription() << ".";
 
     mqbs::FileStoreSet fileSet;
@@ -610,7 +613,7 @@ int RecoveryManager::processSendDataChunks(
             << d_clusterData.identity().description() << " Partition ["
             << partitionId << "]: "
             << "While sending data chunks, failed to bootstrap the first "
-            << "sequence number to send, rc : " << rc
+            << "PSN to send, rc : " << rc
             << ".  There is likely data gap between self and "
             << destination->nodeDescription() << "." << BMQTSK_ALARMLOG_END;
 
@@ -619,7 +622,7 @@ int RecoveryManager::processSendDataChunks(
 
     BALL_LOG_INFO << d_clusterData.identity().description() << " Partition ["
                   << partitionId << "]: starting data chunks from "
-                  << currentSeqNum << ".";
+                  << mqbs::printPSN(currentSeqNum) << ".";
 
     bmqp::StorageEventBuilder builder(mqbs::FileStoreProtocol::k_VERSION,
                                       bmqp::EventType::e_PARTITION_SYNC,
@@ -743,12 +746,12 @@ int RecoveryManager::processSendDataChunks(
                     << d_clusterData.identity().description() << " Partition ["
                     << partitionId << "]: "
                     << "While sending data chunks, failed to increment "
-                       "sequence number, rc: "
+                       "PSN, rc: "
                     << rc << "." << BMQTSK_ALARMLOG_END;
 
                 // Failure to access our own storage files is non-transient,
-                // will terminate.  If we are able to find a valid sequence
-                // number in our journal, we must be able to call increment.
+                // will terminate.  If we are able to find a valid PSN
+                // in our journal, we must be able to call increment.
                 mqbu::ExitUtil::terminate(
                     mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
             }
@@ -761,9 +764,9 @@ int RecoveryManager::processSendDataChunks(
             << d_clusterData.identity().description() << " Partition ["
             << partitionId << "]: "
             << "While sending data chunks, incomplete replay of "
-               "partition. Sequence number "
-            << "of last record sent: " << currentSeqNum
-            << ", was supposed to send up to: " << endSeqNum
+               "partition. PSN "
+            << "of last record sent: " << mqbs::printPSN(currentSeqNum)
+            << ", was supposed to send up to: " << mqbs::printPSN(endSeqNum)
             << ". Peer: " << destination->nodeDescription()
             << ".  Please review Partition FSM logic." << BMQTSK_ALARMLOG_END;
         return rc_INCOMPLETE_REPLAY;  // RETURN
@@ -789,7 +792,8 @@ int RecoveryManager::processSendDataChunks(
 
     BALL_LOG_INFO << d_clusterData.identity().description() << " Partition ["
                   << partitionId << "]: " << "Sent data chunks from "
-                  << beginSeqNum << " to " << endSeqNum
+                  << mqbs::printPSN(beginSeqNum) << " to "
+                  << mqbs::printPSN(endSeqNum)
                   << " to node: " << destination->nodeDescription() << ".";
 
     return rc_SUCCESS;
@@ -851,30 +855,30 @@ int RecoveryManager::processReceiveDataChunks(
     }
 
     if (fs->isOpen()) {
-        BSLS_ASSERT_SAFE(receiveDataCtx.d_currSeqNum.primaryLeaseId() ==
+        BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.primaryLeaseId() ==
                          fs->primaryLeaseId());
-        BSLS_ASSERT_SAFE(receiveDataCtx.d_currSeqNum.sequenceNumber() ==
+        BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.sequenceNumber() ==
                          fs->sequenceNumber());
 
         fs->processStorageEvent(blob, true /* isPartitionSyncEvent */, source);
 
-        receiveDataCtx.d_currSeqNum.primaryLeaseId() = fs->primaryLeaseId();
-        receiveDataCtx.d_currSeqNum.sequenceNumber() = fs->sequenceNumber();
+        receiveDataCtx.d_currPSN.primaryLeaseId() = fs->primaryLeaseId();
+        receiveDataCtx.d_currPSN.sequenceNumber() = fs->sequenceNumber();
 
-        if (receiveDataCtx.d_currSeqNum == receiveDataCtx.d_endSeqNum) {
+        if (receiveDataCtx.d_currPSN == receiveDataCtx.d_endPSN) {
             receiveDataCtx.d_expectChunks = false;
             return rc_LAST_DATA_CHUNK;  // RETURN
         }
-        else if (receiveDataCtx.d_currSeqNum > receiveDataCtx.d_endSeqNum) {
+        else if (receiveDataCtx.d_currPSN > receiveDataCtx.d_endPSN) {
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << d_clusterData.identity().description() << " Partition ["
                 << partitionId << "]: "
                 << "The last partition sync msg inside a storage event "
-                << "processed by FileStore has sequenceNumber "
-                << receiveDataCtx.d_currSeqNum
-                << ", larger than self's expected ending sequence number of "
-                << "data chunks: " << receiveDataCtx.d_endSeqNum << "."
-                << BMQTSK_ALARMLOG_END;
+                << "processed by FileStore has PSN "
+                << mqbs::printPSN(receiveDataCtx.d_currPSN)
+                << ", larger than self's expected ending PSN of "
+                << "data chunks: " << mqbs::printPSN(receiveDataCtx.d_endPSN)
+                << "." << BMQTSK_ALARMLOG_END;
             return rc_INVALID_RECORD_SEQ_NUM;  // RETURN
         }
 
@@ -907,37 +911,33 @@ int RecoveryManager::processReceiveDataChunks(
             return rc * 10 + rc_INVALID_STORAGE_HDR;  // RETURN
         }
 
-        // Check sequence number (only if leaseId is same).  Received leaseId
-        // cannot be smaller.
-
-        bmqp_ctrlmsg::PartitionSequenceNumber recordSeqNum;
-        recordSeqNum.primaryLeaseId() = recHeader->primaryLeaseId();
-        recordSeqNum.sequenceNumber() = recHeader->sequenceNumber();
-
-        if (recordSeqNum <= receiveDataCtx.d_currSeqNum) {
+        bmqp_ctrlmsg::PartitionSequenceNumber recordPSN;
+        recordPSN.primaryLeaseId() = recHeader->primaryLeaseId();
+        recordPSN.sequenceNumber() = recHeader->sequenceNumber();
+        if (recordPSN <= receiveDataCtx.d_currPSN) {
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << d_clusterData.identity().description() << " Partition ["
                 << partitionId
                 << "]: " << "Received partition sync msg of type "
-                << header.messageType() << " with sequenceNumber "
-                << recordSeqNum
-                << ", smaller than or equal to self current sequence number: "
-                << receiveDataCtx.d_endSeqNum
+                << header.messageType() << " with PSN "
+                << mqbs::printPSN(recordPSN)
+                << ", smaller than or equal to self current PSN: "
+                << mqbs::printPSN(receiveDataCtx.d_endPSN)
                 << ". Record's journal offset (in words): "
                 << header.journalOffsetWords() << ". Ignoring entire event."
                 << BMQTSK_ALARMLOG_END;
             return rc_INVALID_RECORD_SEQ_NUM;  // RETURN
         }
 
-        if (recordSeqNum > receiveDataCtx.d_endSeqNum) {
+        if (recordPSN > receiveDataCtx.d_endPSN) {
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << d_clusterData.identity().description() << " Partition ["
                 << partitionId
                 << "]: " << "Received partition sync msg of type "
-                << header.messageType() << " with sequenceNumber "
-                << recordSeqNum
-                << ", larger than self's expected ending sequence number of "
-                << "data chunks: " << receiveDataCtx.d_endSeqNum
+                << header.messageType() << " with PSN "
+                << mqbs::printPSN(recordPSN)
+                << ", larger than self's expected ending PSN of "
+                << "data chunks: " << mqbs::printPSN(receiveDataCtx.d_endPSN)
                 << ". Record's journal offset (in words): "
                 << header.journalOffsetWords() << ". Ignoring entire event."
                 << BMQTSK_ALARMLOG_END;
@@ -966,10 +966,10 @@ int RecoveryManager::processReceiveDataChunks(
                 << "] with journal offset mismatch from "
                 << source->nodeDescription()
                 << ". Source's journal offset: " << sourceJournalOffset
-                << ", self journal offset: " << journalPos
-                << ", msg sequence number (" << recHeader->primaryLeaseId()
-                << ", " << recHeader->sequenceNumber()
-                << "). Ignoring this message." << BMQTSK_ALARMLOG_END;
+                << ", self journal offset: " << journalPos << ", PSN: "
+                << mqbs::printPSN(recHeader->primaryLeaseId(),
+                                  recHeader->sequenceNumber())
+                << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
             return rc_JOURNAL_OUT_OF_SYNC;  // RETURN
         }
 
@@ -1032,7 +1032,7 @@ int RecoveryManager::processReceiveDataChunks(
             // offset
             if (header.messageType() ==
                     bmqp::StorageMessageType::e_JOURNAL_OP &&
-                firstSyncPointAfterRolloverSeqNum == recordSeqNum) {
+                firstSyncPointAfterRolloverSeqNum == recordPSN) {
                 mqbs::OffsetPtr<const mqbs::FileHeader>  fhJ(journal.block(),
                                                             0);
                 mqbs::OffsetPtr<mqbs::JournalFileHeader> jfh(
@@ -1071,8 +1071,8 @@ int RecoveryManager::processReceiveDataChunks(
             }
         };
 
-        receiveDataCtx.d_currSeqNum = recordSeqNum;
-        if (receiveDataCtx.d_currSeqNum == receiveDataCtx.d_endSeqNum) {
+        receiveDataCtx.d_currPSN = recordPSN;
+        if (receiveDataCtx.d_currPSN == receiveDataCtx.d_endPSN) {
             receiveDataCtx.d_expectChunks = false;
             return rc_LAST_DATA_CHUNK;  // RETURN
         }
@@ -1256,15 +1256,15 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
         return 10 * rc + rc_FILE_ITERATOR_FAILURE;  // RETURN
     }
 
-    // Get first syncpoint after rollover sequence number.
+    // Get first syncpoint after rollover PSN.
     if (jit.firstSyncPointAfterRolloverPosition() > 0) {
         const mqbs::RecordHeader& recHeader =
             jit.firstSyncPointAfterRolloverHeader();
 
         BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId << "]: "
-                      << "Get first sync point after rollover sequence number "
-                      << recHeader.partitionSequenceNumber()
+                      << " Partition [" << partitionId
+                      << "]: " << "Get first sync point after rollover PSN "
+                      << mqbs::printPSN(recHeader.partitionSequenceNumber())
                       << " from journal file ["
                       << recoveryCtx.d_recoveryFileSet.journalFile() << "].";
 
@@ -1374,10 +1374,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << recoveryCtx.d_mappedQlistFd.fileSize()
                     << "] during backward journal iteration. Record "
                     << "offset: " << jit.recordOffset()
-                    << ", record index: " << jit.recordIndex()
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << ", record index: " << jit.recordIndex() << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
 
                 return rc_INVALID_QLIST_OFFSET;  // RETURN
             }
@@ -1398,9 +1397,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << "Journal record offset: " << jit.recordOffset()
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
 
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
@@ -1420,10 +1419,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
                     << ". QLIST file size: "
-                    << recoveryCtx.d_mappedQlistFd.fileSize()
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << recoveryCtx.d_mappedQlistFd.fileSize() << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
 
@@ -1437,9 +1435,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << "header. Journal record offset: " << jit.recordOffset()
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
 
@@ -1458,10 +1456,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
                     << ". QLIST file size: "
-                    << recoveryCtx.d_mappedQlistFd.fileSize()
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << recoveryCtx.d_mappedQlistFd.fileSize() << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
 
@@ -1478,9 +1475,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << "header. Journal record offset: " << jit.recordOffset()
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
 
@@ -1496,10 +1493,9 @@ int RecoveryManager::openRecoveryFileSet(bsl::ostream& errorDescription,
                     << ", journal record index: " << jit.recordIndex()
                     << ". QLIST record offset: " << queueUriRecOffset
                     << ". QLIST file size: "
-                    << recoveryCtx.d_mappedQlistFd.fileSize()
-                    << ", record sequence number: ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber() << ")";
+                    << recoveryCtx.d_mappedQlistFd.fileSize() << ", PSN: "
+                    << mqbs::printPSN(recHeader.primaryLeaseId(),
+                                      recHeader.sequenceNumber());
                 return rc_INVALID_QLIST_RECORD;  // RETURN
             }
 
@@ -1693,15 +1689,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
     return rc_SUCCESS;
 }
 
-int RecoveryManager::recoverSeqNum(
-    bmqp_ctrlmsg::PartitionSequenceNumber* seqNum,
-    int                                    partitionId,
-    bool                                   firstSyncPointAfterRolllover)
+int RecoveryManager::recoverPSN(bmqp_ctrlmsg::PartitionSequenceNumber* psn,
+                                int  partitionId,
+                                bool firstSyncPointAfterRolllover)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with 'partitionId'
 
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(seqNum);
+    BSLS_ASSERT_SAFE(psn);
     validatePartitionId(partitionId);
     enum {
         rc_SUCCESS               = 0,
@@ -1715,9 +1710,9 @@ int RecoveryManager::recoverSeqNum(
     RecoveryContext&   recoveryCtx = d_recoveryContextVec[partitionId];
     int                rc          = rc_UNKNOWN;
 
-    // Retrieve first sync point after rolllover sequence number.
+    // Retrieve first sync point after rolllover PSN.
     if (firstSyncPointAfterRolllover) {
-        *seqNum = recoveryCtx.d_firstSyncPointAfterRolloverSeqNum;
+        *psn = recoveryCtx.d_firstSyncPointAfterRolloverSeqNum;
         return rc_SUCCESS;  // RETURN
     }
 
@@ -1736,26 +1731,27 @@ int RecoveryManager::recoverSeqNum(
         return 10 * rc + rc_FILE_ITERATOR_FAILURE;  // RETURN
     }
 
-    // Retrieve last record sequence number.
+    // Retrieve last record PSN.
     if (jit.hasRecordSizeRemaining()) {
         const mqbs::RecordHeader& lastRecordHeader = jit.lastRecordHeader();
 
         BALL_LOG_INFO << d_clusterData.identity().description()
                       << " Partition [" << partitionId
-                      << "]: " << "Recovered Sequence Number "
-                      << lastRecordHeader.partitionSequenceNumber()
+                      << "]: " << "Recovered PSN "
+                      << mqbs::printPSN(
+                             lastRecordHeader.partitionSequenceNumber())
                       << " from journal file ["
                       << recoveryCtx.d_recoveryFileSet.journalFile() << "].";
 
-        *seqNum = lastRecordHeader.partitionSequenceNumber();
+        *psn = lastRecordHeader.partitionSequenceNumber();
     }
     else {
         BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId << "]: "
-                      << "Journal file has no record. Storing (0, 0) as self "
-                      << "sequence number.";
+                      << " Partition [" << partitionId
+                      << "]: " << "Journal file has no record. Storing "
+                      << mqbs::printPSN(0, 0) << " as self PSN.";
 
-        seqNum->reset();
+        psn->reset();
     }
 
     return rc_SUCCESS;
@@ -1906,8 +1902,8 @@ void RecoveryManager::loadReplicaDataResponsePush(
 
     response.replicaDataType()     = bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
     response.partitionId()         = partitionId;
-    response.beginSequenceNumber() = receiveDataCtx.d_beginSeqNum;
-    response.endSequenceNumber()   = receiveDataCtx.d_endSeqNum;
+    response.beginSequenceNumber() = receiveDataCtx.d_beginPSN;
+    response.endSequenceNumber()   = receiveDataCtx.d_endPSN;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -126,17 +126,17 @@ class RecoveryManager {
         /// replica receiving data from the primary.
         int d_recoveryRequestId;
 
-        /// Beginning sequence number of recovery data chunks.  Note that self
-        /// already contains message with this sequence number.  The first
-        /// recovery data chunk is expected to have sequence number
-        /// `d_beginSeqNum + 1`.
-        bmqp_ctrlmsg::PartitionSequenceNumber d_beginSeqNum;
+        /// Beginning PSN of recovery data chunks.  Note that self
+        /// already contains message with this PSN.  The first
+        /// recovery data chunk is expected to have PSN of
+        /// `d_beginPSN + 1`.
+        bmqp_ctrlmsg::PartitionSequenceNumber d_beginPSN;
 
-        /// Expected ending sequence number of recovery data chunks.
-        bmqp_ctrlmsg::PartitionSequenceNumber d_endSeqNum;
+        /// Expected ending PSN of recovery data chunks.
+        bmqp_ctrlmsg::PartitionSequenceNumber d_endPSN;
 
-        /// Self's current sequence number.
-        bmqp_ctrlmsg::PartitionSequenceNumber d_currSeqNum;
+        /// Self's current PSN.
+        bmqp_ctrlmsg::PartitionSequenceNumber d_currPSN;
 
       public:
         // CREATORS
@@ -381,17 +381,17 @@ class RecoveryManager {
     /// specified `partitionId`.
     int closeRecoveryFileSet(int partitionId);
 
-    /// Recover latest sequence number from storage for the specified
-    /// `partitionId` and populate the output in the specified `seqNum`.
+    /// Recover latest PSN from storage for the specified
+    /// `partitionId` and populate the output in the specified `psn`.
     /// If `firstSyncPointAfterRolllover` is true, recover the first sync point
-    /// after rollover sequence number instead of the latest sequence number.
+    /// after rollover PSN instead of the latest PSN.
     /// Return 0 on success and non-zero otherwise.
     ///
     /// THREAD: Executed in the dispatcher thread associated with the
     /// specified `partitionId`.
-    int recoverSeqNum(bmqp_ctrlmsg::PartitionSequenceNumber* seqNum,
-                      int                                    partitionId,
-                      bool firstSyncPointAfterRolllover = false);
+    int recoverPSN(bmqp_ctrlmsg::PartitionSequenceNumber* psn,
+                   int                                    partitionId,
+                   bool firstSyncPointAfterRolllover = false);
 
     /// Set the live data source of the specified 'partitionId' to the
     /// specified 'source', and clear any existing buffered storage events.
@@ -480,9 +480,9 @@ inline RecoveryManager::ReceiveDataContext::ReceiveDataContext()
 : d_recoveryDataSource_p(0)
 , d_expectChunks(false)
 , d_recoveryRequestId(-1)
-, d_beginSeqNum()
-, d_endSeqNum()
-, d_currSeqNum()
+, d_beginPSN()
+, d_endPSN()
+, d_currPSN()
 {
     // NOTHING
 }
@@ -492,9 +492,9 @@ inline RecoveryManager::ReceiveDataContext::ReceiveDataContext(
 : d_recoveryDataSource_p(other.d_recoveryDataSource_p)
 , d_expectChunks(other.d_expectChunks)
 , d_recoveryRequestId(other.d_recoveryRequestId)
-, d_beginSeqNum(other.d_beginSeqNum)
-, d_endSeqNum(other.d_endSeqNum)
-, d_currSeqNum(other.d_currSeqNum)
+, d_beginPSN(other.d_beginPSN)
+, d_endPSN(other.d_endPSN)
+, d_currPSN(other.d_currPSN)
 {
     // NOTHING
 }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -26,6 +26,7 @@
 #include <mqbevt_storageevent.h>
 #include <mqbi_storage.h>
 #include <mqbnet_cluster.h>
+#include <mqbs_filestoreprintutil.h>
 #include <mqbs_storageprintutil.h>
 #include <mqbu_exit.h>
 
@@ -719,10 +720,10 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
                 << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription()
-                << " has partition sequence number " << nodeSeqNum
-                << ", while the highest sequence number for the same primary "
-                << "lease ID is " << highestSeqNum
+                << cit->first->nodeDescription() << " has PSN "
+                << mqbs::printPSN(nodeSeqNum)
+                << ", while the highest PSN for the same primary "
+                << "lease ID is " << mqbs::printPSN(highestSeqNum)
                 << ", implying that it has extra irreconcilable records.  We "
                 << "need to send ReplicaDataRequestDrop to this replica.";
 
@@ -735,12 +736,11 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
                 << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription()
-                << " has partition sequence number " << nodeSeqNum
-                << ", whose primary lease id is lower than self's partition "
-                   "sequence number "
-                << selfSeqNum
-                << ", and there is no known highest sequence number for the "
+                << cit->first->nodeDescription() << " has PSN "
+                << mqbs::printPSN(nodeSeqNum)
+                << ", whose primary lease id is lower than self's PSN "
+                << mqbs::printPSN(selfSeqNum)
+                << ", and there is no known highest PSN for the "
                 << "same primary lease id.  This implies that this replica "
                    "has "
                 << "extra irreconcilable records, and we need to send "
@@ -758,10 +758,10 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             BALL_LOG_INFO
                 << d_clusterData_p->identity().description() << " Partition ["
                 << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription()
-                << " has partition sequence number " << nodeSeqNum
-                << ", which is lower than or equal to self's partition "
-                << "sequence number " << selfSeqNum
+                << cit->first->nodeDescription() << " has PSN "
+                << mqbs::printPSN(nodeSeqNum)
+                << ", which is lower than or equal to self's PSN "
+                << mqbs::printPSN(selfSeqNum)
                 << ".  We need to send ReplicaDataRequestPush to this "
                 << "replica.";
 
@@ -771,10 +771,10 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
                 << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription()
-                << " has partition sequence number " << nodeSeqNum
-                << ", which is higher than self's partition sequence number "
-                << selfSeqNum
+                << cit->first->nodeDescription() << " has PSN "
+                << mqbs::printPSN(nodeSeqNum)
+                << ", which is higher than self's PSN "
+                << mqbs::printPSN(selfSeqNum)
                 << ".  We need to send ReplicaDataRequestDrop to this "
                 << "replica.";
 
@@ -934,8 +934,8 @@ void StorageManager::startSendDataChunksAsPrimary(
     // executed by the *QUEUE DISPATCHER* thread associated with the
     // paritionId contained in 'event'
 
-    // End Sequence number is primary's latest sequence number.
-    const bmqp_ctrlmsg::PartitionSequenceNumber& endSeqNum =
+    // End PSN is primary's latest PSN.
+    const bmqp_ctrlmsg::PartitionSequenceNumber& endPSN =
         d_nodeToSeqNumCtxMapVec.at(partitionId)
             .at(d_clusterData_p->membership().selfNode())
             .d_seqNum;
@@ -948,20 +948,20 @@ void StorageManager::startSendDataChunksAsPrimary(
          cit != destinationReplicas.end();
          ++cit) {
         mqbnet::ClusterNode*                         destNode = (*cit)->first;
-        const bmqp_ctrlmsg::PartitionSequenceNumber& beginSeqNum =
+        const bmqp_ctrlmsg::PartitionSequenceNumber& beginPSN =
             (*cit)->second.d_seqNum;
-        if (beginSeqNum == endSeqNum) {
+        if (beginPSN == endPSN) {
             // Replica in-sync with primary: no need to send data chunks
             continue;  // CONTINUE
         }
-        BSLS_ASSERT_SAFE(beginSeqNum < endSeqNum);
+        BSLS_ASSERT_SAFE(beginPSN < endPSN);
 
-        PartitionSeqNumDataRange dataRange(beginSeqNum, endSeqNum);
+        PartitionSeqNumDataRange dataRange(beginPSN, endPSN);
         int status = d_recoveryManager_mp->processSendDataChunks(
             partitionId,
             destNode,
-            beginSeqNum,
-            endSeqNum,
+            beginPSN,
+            endPSN,
             fileStore(partitionId));
 
         EventData sendEventDataVec;
@@ -975,8 +975,8 @@ void StorageManager::startSendDataChunksAsPrimary(
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
                            << " Partition [" << partitionId
                            << "]: " << "Failure while sending data chunks "
-                           << ", beginSeqNum = " << beginSeqNum
-                           << ", endSeqNum = " << endSeqNum
+                           << ", beginPSN = " << mqbs::printPSN(beginPSN)
+                           << ", endPSN = " << mqbs::printPSN(endPSN)
                            << ", rc = " << status;
 
             enqueuePartitionFSMEvent(
@@ -987,8 +987,8 @@ void StorageManager::startSendDataChunksAsPrimary(
             BALL_LOG_INFO << d_clusterData_p->identity().description()
                           << " Partition [" << partitionId
                           << "]: " << "Finished sending data chunks "
-                          << ", beginSeqNum = " << beginSeqNum
-                          << ", endSeqNum = " << endSeqNum
+                          << ", beginPSN = " << mqbs::printPSN(beginPSN)
+                          << ", endPSN = " << mqbs::printPSN(endPSN)
                           << ", rc = " << status;
 
             enqueuePartitionFSMEvent(
@@ -1058,28 +1058,29 @@ void StorageManager::processReplicaDataRequestPull(
 
     mqbnet::ClusterNode* const selfNode =
         d_clusterData_p->membership().selfNode();
-    const bmqp_ctrlmsg::PartitionSequenceNumber selfSeqNum =
+    const bmqp_ctrlmsg::PartitionSequenceNumber selfPSN =
         d_nodeToSeqNumCtxMapVec.at(partitionId).at(selfNode).d_seqNum;
-    if (replicaDataRequest.endSequenceNumber() != selfSeqNum) {
+    if (replicaDataRequest.endSequenceNumber() != selfPSN) {
         bmqp_ctrlmsg::ControlMessage controlMsg;
         controlMsg.rId() = message.rId();
 
         bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
         status.category() = bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT;
         status.code()     = mqbi::ClusterErrorCode::e_STORAGE_FAILURE;
-        status.message()  = "End sequence number mismatch";
+        status.message()  = "End PSN mismatch";
 
         d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg,
                                                               source);
 
-        BALL_LOG_ERROR
-            << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId << "]: " << "Received ReplicaDataRequestPull from "
-            << source->nodeDescription() << " with endSequenceNumber: "
-            << replicaDataRequest.endSequenceNumber()
-            << " that does not match self's current sequence number: "
-            << selfSeqNum << ".  Sent a failure response " << controlMsg
-            << ".";
+        BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                       << " Partition [" << partitionId
+                       << "]: " << "Received ReplicaDataRequestPull from "
+                       << source->nodeDescription() << " with end PSN: "
+                       << mqbs::printPSN(
+                              replicaDataRequest.endSequenceNumber())
+                       << " that does not match self's current PSN: "
+                       << mqbs::printPSN(selfPSN)
+                       << ".  Sent a failure response " << controlMsg << ".";
 
         return;  // RETURN
     }
@@ -1879,14 +1880,14 @@ void StorageManager::do_storeSelfSeq(const EventWithData& event)
         nodeSeqNumCtx.d_seqNum.sequenceNumber() = fs->sequenceNumber();
     }
     else {
-        const int rc = d_recoveryManager_mp->recoverSeqNum(
+        const int rc = d_recoveryManager_mp->recoverPSN(
             &nodeSeqNumCtx.d_seqNum,
             partitionId);
         if (rc != 0) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: "
-                << "Error while recovering sequence number, rc: " << rc
+                << partitionId
+                << "]: " << "Error while recovering PSN, rc: " << rc
                 << BMQTSK_ALARMLOG_END;
 
             mqbu::ExitUtil::terminate(
@@ -1899,10 +1900,11 @@ void StorageManager::do_storeSelfSeq(const EventWithData& event)
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << ": In Partition [" << partitionId << "]'s FSM, "
-                  << "storing self sequence number as "
-                  << nodeSeqNumCtx.d_seqNum
+                  << "storing self PSN as "
+                  << mqbs::printPSN(nodeSeqNumCtx.d_seqNum)
                   << ", first sync point after rollover as "
-                  << nodeSeqNumCtx.d_firstSyncPointAfterRolloverSeqNum;
+                  << mqbs::printPSN(
+                         nodeSeqNumCtx.d_firstSyncPointAfterRolloverSeqNum);
 }
 
 void StorageManager::do_storePrimarySeq(const EventWithData& event)
@@ -1947,13 +1949,14 @@ void StorageManager::do_storePrimarySeq(const EventWithData& event)
     }
 
     if (hasNew) {
-        BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << ": In Partition [" << partitionId << "]'s FSM, "
-                      << "storing the sequence number of "
-                      << eventData.source()->nodeDescription() << " as "
-                      << seqNum
-                      << ", first sync point after rollover sequence number: "
-                      << eventData.firstSyncPointAfterRolloverSequenceNumber();
+        BALL_LOG_INFO
+            << d_clusterData_p->identity().description() << ": In Partition ["
+            << partitionId << "]'s FSM, " << "storing the PSN of "
+            << eventData.source()->nodeDescription() << " as "
+            << mqbs::printPSN(seqNum)
+            << ", first sync point after rollover PSN: "
+            << mqbs::printPSN(
+                   eventData.firstSyncPointAfterRolloverSequenceNumber());
     }
 }
 
@@ -2003,10 +2006,11 @@ void StorageManager::do_storeReplicaSeq(const EventWithData& event)
             BALL_LOG_INFO
                 << d_clusterData_p->identity().description()
                 << ": In Partition [" << partitionId << "]'s FSM, "
-                << "storing the sequence number of "
-                << cit->source()->nodeDescription() << " as " << seqNum
-                << ", first sync point after rollover sequence number: "
-                << cit->firstSyncPointAfterRolloverSequenceNumber();
+                << "storing the PSN of " << cit->source()->nodeDescription()
+                << " as " << mqbs::printPSN(seqNum)
+                << ", first sync point after rollover PSN: "
+                << mqbs::printPSN(
+                       cit->firstSyncPointAfterRolloverSequenceNumber());
         }
     }
 }
@@ -2049,7 +2053,7 @@ void StorageManager::do_replicaStateRequest(const EventWithData& event)
     replicaStateRequest.latestSequenceNumber() =
         d_nodeToSeqNumCtxMapVec[partitionId][selfNode].d_seqNum;
 
-    // Get own first sync point after rollover sequence number
+    // Get own first sync point after rollover PSN
     replicaStateRequest.firstSyncPointAfterRolloverSequenceNumber() =
         getSelfFirstSyncPointAfterRolloverSequenceNumber(partitionId);
 
@@ -2096,7 +2100,7 @@ void StorageManager::do_replicaStateResponse(const EventWithData& event)
                                [d_clusterData_p->membership().selfNode()]
                                    .d_seqNum;
 
-    // Get own first sync point after rollover sequence number
+    // Get own first sync point after rollover PSN
     response.firstSyncPointAfterRolloverSequenceNumber() =
         getSelfFirstSyncPointAfterRolloverSequenceNumber(partitionId);
 
@@ -2303,7 +2307,7 @@ void StorageManager::do_primaryStateRequest(const EventWithData& event)
                                [d_clusterData_p->membership().selfNode()]
                                    .d_seqNum;
 
-    // Get own first sync point after rollover sequence number
+    // Get own first sync point after rollover PSN
     primaryStateRequest.firstSyncPointAfterRolloverSequenceNumber() =
         getSelfFirstSyncPointAfterRolloverSequenceNumber(partitionId);
 
@@ -2361,7 +2365,7 @@ void StorageManager::do_primaryStateResponse(const EventWithData& event)
                                [d_clusterData_p->membership().selfNode()]
                                    .d_seqNum;
 
-    // Get own first sync point after rollover sequence number
+    // Get own first sync point after rollover PSN
     response.firstSyncPointAfterRolloverSequenceNumber() =
         getSelfFirstSyncPointAfterRolloverSequenceNumber(partitionId);
 
@@ -2721,8 +2725,9 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
                        << " Partition [" << partitionId
                        << "]: " << "Failure while sending data chunks "
-                       << ", beginSeqNum = " << beginSeqNum
-                       << ", endSeqNum = " << endSeqNum << ", rc = " << status;
+                       << ", beginPSN = " << mqbs::printPSN(beginSeqNum)
+                       << ", endPSN = " << mqbs::printPSN(endSeqNum)
+                       << ", rc = " << status;
 
         enqueuePartitionFSMEvent(
             PartitionFSM::Event::e_ERROR_SENDING_DATA_CHUNKS,
@@ -2732,8 +2737,9 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
         BALL_LOG_INFO << d_clusterData_p->identity().description()
                       << " Partition [" << partitionId
                       << "]: " << "Finished sending data chunks "
-                      << ", beginSeqNum = " << beginSeqNum
-                      << ", endSeqNum = " << endSeqNum << ", rc = " << status;
+                      << ", beginPSN = " << mqbs::printPSN(beginSeqNum)
+                      << ", endPSN = " << mqbs::printPSN(endSeqNum)
+                      << ", rc = " << status;
 
         enqueuePartitionFSMEvent(
             PartitionFSM::Event::e_DONE_SENDING_DATA_CHUNKS,
@@ -3181,7 +3187,7 @@ void StorageManager::do_updateStorage(const EventWithData& event)
     BSLS_ASSERT_SAFE(d_fileStores.size() >
                      static_cast<unsigned int>(partitionId));
 
-    // Get first sync point after rollover sequence number from source node.
+    // Get first sync point after rollover PSN from source node.
     NodeToSeqNumCtxMapIter it = d_nodeToSeqNumCtxMapVec[partitionId].find(
         source);
     BSLS_ASSERT_SAFE(it != d_nodeToSeqNumCtxMapVec[partitionId].end());
@@ -3257,7 +3263,7 @@ void StorageManager::do_primaryRemoveStorageIfNeeded(
         BALL_LOG_WARN
             << d_clusterData_p->identity().description() << " Partition ["
             << partitionId << "]: "
-            << "self's primary is out of sync with highest seqNum replica"
+            << "self's primary is out of sync with highest PSN replica"
             << highestSeqNumNode->nodeDescription() << " and cannot be "
             << "healed trivially. Removing entire storage and requesting it "
                "from "
@@ -3287,7 +3293,7 @@ void StorageManager::do_primaryRemoveStorageIfNeeded(
             mqbu::ExitUtil::terminate(
                 mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
         }
-        // Reset self seqNum to request whole storage data from
+        // Reset self PSN to request whole storage data from
         // the recovery peer.
         selfNodeContext.d_seqNum = bmqp_ctrlmsg::PartitionSequenceNumber();
     }
@@ -3465,12 +3471,11 @@ void StorageManager::do_checkQuorumSeq(const EventWithData& event)
     BSLS_ASSERT_SAFE(d_partitionFSMVec[partitionId]->isSelfPrimary());
 
     if (d_nodeToSeqNumCtxMapVec[partitionId].size() >= getSeqNumQuorum()) {
-        // If we have a quorum of Replica Sequence numbers (including self
-        // Seq)
+        // If we have a quorum of Replica PSNs (including self PSN)
 
         BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId << "]: "
-                      << "Achieved a quorum of SeqNums with a count of "
+                      << " Partition [" << partitionId
+                      << "]: " << "Achieved a quorum of PSNs with a count of "
                       << d_nodeToSeqNumCtxMapVec[partitionId].size();
 
         enqueuePartitionFSMEvent(PartitionFSM::Event::e_QUORUM_REPLICA_SEQ,
@@ -3498,24 +3503,23 @@ void StorageManager::do_findHighestSeq(const EventWithData& event)
     const NodeToSeqNumCtxMap& nodeToSeqNumCtxMap = d_nodeToSeqNumCtxMapVec.at(
         partitionId);
 
-    // Initialize highest sequence number with self/primary sequence
-    // number.
-    mqbnet::ClusterNode* highestSeqNumNode =
+    // Initialize highest PSN with self/primary PSN.
+    mqbnet::ClusterNode* highestPSNNode =
         d_clusterData_p->membership().selfNode();
-    bmqp_ctrlmsg::PartitionSequenceNumber highestPartitionSeqNum(
-        nodeToSeqNumCtxMap.at(highestSeqNumNode).d_seqNum);
+    bmqp_ctrlmsg::PartitionSequenceNumber highestPSN(
+        nodeToSeqNumCtxMap.at(highestPSNNode).d_seqNum);
     bmqp_ctrlmsg::PartitionSequenceNumber
         highestPartitionFirstSyncPointAfterRolloverSeqNum(
-            nodeToSeqNumCtxMap.at(highestSeqNumNode)
+            nodeToSeqNumCtxMap.at(highestPSNNode)
                 .d_firstSyncPointAfterRolloverSeqNum);
 
-    // Find out highest sequence number and number of up-to-date nodes.
+    // Find out highest PSN and number of up-to-date nodes.
     for (NodeToSeqNumCtxMapCIter cit = nodeToSeqNumCtxMap.cbegin();
          cit != nodeToSeqNumCtxMap.cend();
          cit++) {
-        if (cit->second.d_seqNum > highestPartitionSeqNum) {
-            highestSeqNumNode      = cit->first;
-            highestPartitionSeqNum = cit->second.d_seqNum;
+        if (cit->second.d_seqNum > highestPSN) {
+            highestPSNNode = cit->first;
+            highestPSN     = cit->second.d_seqNum;
             highestPartitionFirstSyncPointAfterRolloverSeqNum =
                 cit->second.d_firstSyncPointAfterRolloverSeqNum;
         }
@@ -3523,7 +3527,7 @@ void StorageManager::do_findHighestSeq(const EventWithData& event)
 
     const unsigned int primaryLeaseId =
         d_partitionInfoVec[partitionId].primaryLeaseId();
-    const bool selfHighestSeq = highestSeqNumNode ==
+    const bool selfHighestPSN = highestPSNNode ==
                                 d_clusterData_p->membership().selfNode();
 
     EventData newEventDataVec;
@@ -3534,11 +3538,11 @@ void StorageManager::do_findHighestSeq(const EventWithData& event)
         1,  // incrementCount
         d_clusterData_p->membership().selfNode(),
         primaryLeaseId,
-        highestPartitionSeqNum,
+        highestPSN,
         highestPartitionFirstSyncPointAfterRolloverSeqNum,
-        highestSeqNumNode);
+        highestPSNNode);
 
-    if (selfHighestSeq) {
+    if (selfHighestPSN) {
         enqueuePartitionFSMEvent(PartitionFSM::Event::e_SELF_HIGHEST_SEQ,
                                  newEventDataVec);
     }
@@ -4840,7 +4844,7 @@ StorageManager::getSelfFirstSyncPointAfterRolloverSequenceNumber(
     mqbs::FileStore* fs = d_fileStores[static_cast<size_t>(partitionId)].get();
     BSLS_ASSERT_SAFE(fs);
 
-    // Get own first sync point after rolllover sequence number
+    // Get own first sync point after rollover PSN
     bmqp_ctrlmsg::PartitionSequenceNumber
         selfFirstSyncPointAfterRollloverSeqNum;
     if (fs->isOpen()) {
@@ -4848,7 +4852,7 @@ StorageManager::getSelfFirstSyncPointAfterRolloverSequenceNumber(
             fs->firstSyncPointAfterRolloverSeqNum();
     }
     else {
-        const int rc = d_recoveryManager_mp->recoverSeqNum(
+        const int rc = d_recoveryManager_mp->recoverPSN(
             &selfFirstSyncPointAfterRollloverSeqNum,
             partitionId,
             true);
@@ -4856,8 +4860,7 @@ StorageManager::getSelfFirstSyncPointAfterRolloverSequenceNumber(
             BALL_LOG_WARN << d_clusterData_p->identity().description()
                           << " Partition [" << partitionId << "]: "
                           << "Failed to recover first sync point after "
-                             "rolllover sequence "
-                             "number for partition "
+                             "rollover PSN for partition "
                           << partitionId << ". rc=" << rc;
             selfFirstSyncPointAfterRollloverSeqNum.reset();
         }

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -23,6 +23,7 @@
 #include <mqbi_queueengine.h>
 #include <mqbnet_cluster.h>
 #include <mqbs_datastore.h>
+#include <mqbs_filestoreprintutil.h>
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_filestoreutil.h>
 #include <mqbs_filesystemutil.h>
@@ -3839,21 +3840,22 @@ void StorageUtil::forceIssueAdvisoryAndSyncPt(mqbc::ClusterData*   clusterData,
     else {
         fs->broadcastMessage(controlMsg);
     }
-    const int                             rc = fs->issueSyncPoint();
-    bmqp_ctrlmsg::PartitionSequenceNumber psn;
-    psn.primaryLeaseId() = fs->primaryLeaseId();
-    psn.sequenceNumber() = fs->sequenceNumber();
+    const int rc = fs->issueSyncPoint();
     if (0 == rc) {
         BALL_LOG_INFO << clusterData->identity().description() << "Partition ["
                       << fs->config().partitionId()
-                      << "]: successfully issued a forced SyncPt: " << psn
+                      << "]: successfully issued a forced SyncPt: "
+                      << mqbs::printPSN(fs->primaryLeaseId(),
+                                        fs->sequenceNumber())
                       << ".";
     }
     else {
         BALL_LOG_ERROR << clusterData->identity().description()
                        << "Partition [" << fs->config().partitionId()
                        << "]: failed to force-issue SyncPt, rc: " << rc
-                       << ", current PSN: " << psn;
+                       << ", current PSN: "
+                       << mqbs::printPSN(fs->primaryLeaseId(),
+                                         fs->sequenceNumber());
     }
 }
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3853,7 +3853,7 @@ void StorageUtil::forceIssueAdvisoryAndSyncPt(mqbc::ClusterData*   clusterData,
         BALL_LOG_ERROR << clusterData->identity().description()
                        << "Partition [" << fs->config().partitionId()
                        << "]: failed to force-issue SyncPt, rc: " << rc
-                       << ", current partition sequence number: " << psn;
+                       << ", current PSN: " << psn;
     }
 }
 

--- a/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
@@ -392,8 +392,8 @@ void printFileStoreSummary(bsl::ostream&           os,
        << "]:" << newlineAndIndent(level, spacesPerLevel) << "----------------"
        << newlineAndIndent(level + 1, spacesPerLevel)
        << "Primary Node: " << summary.primaryNodeDescription()
-       << ", Sequence Number: (" << summary.primaryLeaseId() << ", "
-       << summary.sequenceNum() << ")"
+       << ", PSN: [ primaryLeaseId = " << summary.primaryLeaseId()
+       << " sequenceNumber = " << summary.sequenceNum() << "]"
        << newlineAndIndent(level + 1, spacesPerLevel)
        << "IsAvailable: " << bsl::boolalpha << summary.isAvailable()
        << newlineAndIndent(level + 1, spacesPerLevel)

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -455,7 +455,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             recHeader.sequenceNumber();
 
         BALL_LOG_INFO << partitionDesc()
-                      << "First sync point after rollover sequence number: "
+                      << "First sync point after rollover PSN: "
                       << d_firstSyncPointAfterRolloverSeqNum
                       << ", Timestamp (epoch): " << recHeader.timestamp();
     }
@@ -470,12 +470,11 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         out << partitionDesc() << " Last sync point details: "
             << "SyncPoint sub-type: " << lsp.syncPointType()
             << ", PrimaryNodeId: " << lsp.primaryNodeId()
-            << ", PrimaryLeaseId (in SyncPt): " << lsp.primaryLeaseId()
-            << ", SequenceNumber (in SyncPt): " << lsp.sequenceNum()
-            << ", PrimaryLeaseId (in RecordHeader): "
-            << lsp.header().primaryLeaseId()
-            << ", SequenceNumber (in RecordHeader): "
-            << lsp.header().sequenceNumber()
+            << ", PSN (in SyncPt): "
+            << printPSN(lsp.primaryLeaseId(), lsp.sequenceNum())
+            << ", PSN (in RecordHeader): "
+            << printPSN(lsp.header().primaryLeaseId(),
+                        lsp.header().sequenceNumber())
             << ", SyncPoint offset in journal: " << jit.lastSyncPointPosition()
             << ", DataFileOffset: "
             << (static_cast<bsls::Types::Uint64>(lsp.dataFileOffsetDwords()) *
@@ -537,8 +536,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             // There are 3 scenarios as far as last SyncPt in the JOURNAL is
             // concerned in a multi-node cluster:
             // 1) Last SyncPt *is* the last record in the JOURNAL.  All good in
-            //    this case; simply retrieve primaryLeaseId and sequenceNum
-            //    from the SyncPt.
+            //    this case; simply retrieve  PSN from the SyncPt.
             // 2) Last SyncPt is not the last record.  Truncate the JOURNAL to
             //    the last SyncPt, and also truncate the QLIST and DATA files
             //    to the offsets which appear in the last SyncPt.
@@ -552,9 +550,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             // this partition at this node will eventually get synced up.
 
             // Lastly, we truncate the files in (2) and (3) to the last SyncPt
-            // so that its easy to initialize primaryLeaseId and seqNum from
-            // the last SyncPt.  If we don't do that, we'd have to calculate
-            // their values.
+            // so that its easy to initialize PSN from the last SyncPt.  If we
+            // don't do that, we'd have to calculate their values.
 
             bool                needTruncation = false;
             bsls::Types::Uint64 journalOffset  = 0;
@@ -596,11 +593,11 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
 
                 const JournalOpRecord& lsp = jit.lastSyncPoint();
 
-                // (LeaseId, SeqNum) must be extracted from last SyncPt's
-                // record header, not from the SyncPt itself.  The two sequence
-                // numbers can differ in case last SyncPt was issued by new
+                // PSN must be extracted from last SyncPt's
+                // record header, not from the SyncPt itself.  The two PSNs
+                // can differ in case last SyncPt was issued by new
                 // primary on behalf of the old one, and we always use the
-                // (leaseId, seqNum) present in the RecordHeader.
+                // PSN present in the RecordHeader.
                 d_primaryLeaseId   = lsp.header().primaryLeaseId();
                 currentSeqNumRef() = lsp.header().sequenceNumber();
 
@@ -626,8 +623,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
                     << ".";
             }
             else {
-                // Scenario (1) from above.  Initialize primary leaseId and
-                // sequence numbers from last SyncPt's record header.
+                // Scenario (1) from above.  Initialize PSN from last SyncPt's
+                // record header.
 
                 needTruncation             = false;
                 const JournalOpRecord& lsp = jit.lastSyncPoint();
@@ -751,8 +748,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
                 d_primaryLeaseId = 0;
             }
             else if (jit.lastRecordPosition() == jit.lastSyncPointPosition()) {
-                // Last record is a sync point.  Extract leaseId and seqNum
-                // from it's header.
+                // Last record is a sync point.  Extract PSN from it's header.
 
                 const JournalOpRecord& lsp = jit.lastSyncPoint();
                 d_primaryLeaseId           = lsp.header().primaryLeaseId();
@@ -761,7 +757,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             else {
                 // Last record is not a sync point.  This is ok for a single
                 // node cluster; we will explicitly append a SyncPt.  Extract
-                // leaseId and seqNum from last record's header.
+                // PSN from last record's header.
 
                 BSLS_ASSERT_SAFE(0 != jit.lastRecordPosition());
 
@@ -773,9 +769,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         }
     }
 
-    BALL_LOG_INFO << partitionDesc() << "Retrieved primaryLeaseId and sequence"
-                  << " number: (" << d_primaryLeaseId << ", "
-                  << sequenceNumber() << ").";
+    BALL_LOG_INFO << partitionDesc() << "Retrieved PSN: "
+                  << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
 
     // Create file set.
     FileSetSp fileSetSp;
@@ -873,9 +868,10 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         // In a multi-node cluster, retrieved primaryLeaseId is valid.
 
         if (0 == sequenceNumber()) {
-            BALL_LOG_ERROR << partitionDesc() << "Invalid sequence number ["
-                           << sequenceNumber() << "] while primary leaseId is "
-                           << "valid [" << d_primaryLeaseId << "].";
+            BALL_LOG_ERROR << partitionDesc() << "Invalid PSN: "
+                           << printPSN(d_primaryLeaseId, sequenceNumber())
+                           << " while primary leaseId is " << "valid ("
+                           << d_primaryLeaseId << ").";
             return rc_INVALID_SYNC_PT;  // RETURN
         }
 
@@ -883,9 +879,9 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             if (d_syncPoints.empty()) {
                 BALL_LOG_ERROR << partitionDesc()
                                << "Internal list of SyncPts is empty, while "
-                               << "retrieved (leaseId, seqNum) are valid: ("
-                               << d_primaryLeaseId << ", " << sequenceNumber()
-                               << ").";
+                               << "retrieved PSN is valid: "
+                               << printPSN(d_primaryLeaseId, sequenceNumber())
+                               << ".";
                 return rc_INVALID_SYNC_PT;  // RETURN
             }
 
@@ -894,19 +890,17 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
             if (lastSp.primaryLeaseId() > d_primaryLeaseId) {
                 BALL_LOG_ERROR
                     << partitionDesc() << "Invalid leaseId in the last "
-                    << "in-memory SyncPt: " << lastSp
-                    << ". Retrieved (leaseId, seqNum): (" << d_primaryLeaseId
-                    << ", " << sequenceNumber() << ").";
+                    << "in-memory SyncPt: " << lastSp << ". Retrieved PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
                 return rc_INVALID_SYNC_PT;  // RETURN
             }
 
             if (lastSp.primaryLeaseId() == d_primaryLeaseId &&
                 lastSp.sequenceNum() != sequenceNumber()) {
                 BALL_LOG_ERROR
-                    << partitionDesc() << "Invalid seqNum in the last "
-                    << "in-memory SyncPt: " << lastSp
-                    << ". Retrieved (leaseId, seqNum): (" << d_primaryLeaseId
-                    << ", " << sequenceNumber() << ").";
+                    << partitionDesc() << "Invalid PSN in the last "
+                    << "in-memory SyncPt: " << lastSp << ". Retrieved PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
                 return rc_INVALID_SYNC_PT;  // RETURN
             }
         }
@@ -1002,9 +996,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
 
         BALL_LOG_INFO
             << partitionDesc() << "Appending a sync point with "
-            << "(primaryLeaseId, sequenceNum): (" << d_primaryLeaseId << ", "
-            << (sequenceNumber() + 1)
-            << ") since journal does not end with a sync point for this "
+            << "PSN: " << printPSN(d_primaryLeaseId, sequenceNumber() + 1)
+            << " since journal does not end with a sync point for this "
             << "partition belonging to a 1-node cluster.";
 
         BSLS_ASSERT_SAFE(0 == fileSetSp->d_dataFilePosition %
@@ -1062,15 +1055,14 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         if (primaryLeaseIdCurr > d_primaryLeaseId ||
             (primaryLeaseIdCurr == d_primaryLeaseId &&
              sequenceNumcurr > sequenceNumber())) {
-            BALL_LOG_INFO << partitionDesc() << "Current partitionSeqeNum: ("
-                          << primaryLeaseIdCurr << ", " << sequenceNumcurr
-                          << ") is higher than storage-retrieved "
-                          << "partitionSeqeNum: (" << d_primaryLeaseId << ", "
-                          << sequenceNumber()
-                          << ").  This is possible if self "
+            BALL_LOG_INFO << partitionDesc() << "Current PSN: "
+                          << printPSN(primaryLeaseIdCurr, sequenceNumcurr)
+                          << " is higher than storage-retrieved " << "PSN: "
+                          << printPSN(d_primaryLeaseId, sequenceNumber())
+                          << ".  This is possible if self "
                           << "replica has received primary status advisory "
                           << "before opening FileStore.  Thus, we keep current"
-                          << " partitionSeqeNum.";
+                          << " PSN.";
 
             d_primaryLeaseId   = primaryLeaseIdCurr;
             currentSeqNumRef() = sequenceNumcurr;
@@ -1181,11 +1173,11 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
 
         if (recHeader.primaryLeaseId() == 0 ||
             recHeader.sequenceNumber() == 0) {
-            BALL_LOG_ERROR << partitionDesc() << "Encountered invalid leaseId/"
-                           << "sequenceNumber while reverse-iterating JOURNAL "
-                           << "during recovery. LeaseId: "
-                           << recHeader.primaryLeaseId()
-                           << ", sequence num: " << recHeader.sequenceNumber()
+            BALL_LOG_ERROR << partitionDesc() << "Encountered invalid "
+                           << "PSN while reverse-iterating JOURNAL "
+                           << "during recovery: "
+                           << printPSN(recHeader.primaryLeaseId(),
+                                       recHeader.sequenceNumber())
                            << ". Record offset: " << journalIt.recordOffset()
                            << ", record index: " << journalIt.recordIndex();
             return rc_INVALID_JOURNAL_RECORD;  // RETURN
@@ -1524,7 +1516,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
         BSLS_ASSERT_SAFE(0 != recHeader.primaryLeaseId());
         BSLS_ASSERT_SAFE(0 != recHeader.sequenceNumber());
 
-        // Validate (leaseId, seqNum) in the RecordHeader. Note that leaseId in
+        // Validate PSN in the RecordHeader. Note that leaseId in
         // the RecordHeader can be smaller than 'primaryLeaseId'.
 
         if (recHeader.primaryLeaseId() > primaryLeaseId) {
@@ -1550,7 +1542,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 }
             }
             else {
-                // Sequence numbers of rolled over records may not increment by
+                // PSNs of rolled over records may not increment by
                 // 1, but they should still be monotonically increasing.
 
                 if (recHeader.sequenceNumber() > (sequenceNum - 1)) {
@@ -1562,8 +1554,9 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 BALL_LOG_ERROR
                     << partitionDesc()
                     << "Encountered a record during backward journal iteration"
-                    << " with invalid seqnum: " << recHeader.sequenceNumber()
-                    << ". Expected seqNum: " << (sequenceNum - 1)
+                    << " with invalid sequence number in PSN: "
+                    << recHeader.sequenceNumber()
+                    << ". Expected sequence number: " << (sequenceNum - 1)
                     << " (or smaller). PrimaryLeaseId: "
                     << recHeader.primaryLeaseId()
                     << ". Record offset: " << jit->recordOffset()
@@ -1691,7 +1684,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     << partitionDesc()
                     << "Encountered a sync point during backward journal "
                        "iteration"
-                    << " with zero sequenceNum, current sequenceNum: "
+                    << " with zero sequence number, current sequence number: "
                     << sequenceNum
                     << ". Record offset: " << jit->recordOffset()
                     << ", record index: " << jit->recordIndex();
@@ -1699,7 +1692,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 return rc_INVALID_SEQ_NUMBER;  // RETURN
             }
 
-            // Ensure that leaseId/seqNum in the SyncPt are within expected
+            // Ensure that PSN in the SyncPt is within expected
             // bound.  Note that leaseId appearing in the SyncPt can be smaller
             // than the one appearing in its RecordHeader.  This can occur if
             // that SyncPt was issued by new primary on behalf of the old one
@@ -1893,8 +1886,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << "] during backward journal iteration. Record "
                             << "offset: " << jit->recordOffset()
                             << ", record index: " << jit->recordIndex()
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
 
                         return rc_INVALID_QLIST_OFFSET;  // RETURN
                     }
@@ -1914,8 +1907,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << "Journal record offset: " << jit->recordOffset()
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
 
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
@@ -1935,8 +1928,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
                             << ". QLIST file size: " << qlistFd->fileSize()
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
@@ -1950,8 +1943,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << jit->recordOffset()
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
@@ -1970,8 +1963,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
                             << ". QLIST file size: " << qlistFd->fileSize()
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
@@ -1988,8 +1981,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << jit->recordOffset()
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
@@ -2004,8 +1997,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
                             << ". QLIST file size: " << qlistFd->fileSize()
-                            << ", record sequence number: (" << primaryLeaseId
-                            << ", " << sequenceNum << ")";
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
@@ -2834,13 +2827,13 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
     }
 
     // Write the first SyncPt in the new JOURNAL.  This SyncPt will contain
-    // updated DATA and QLIST file offsets, but same (leaseId, seqNum) as the
+    // updated DATA and QLIST file offsets, but same PSN as the
     // last SyncPt in the old JOURNAL.  Also note that the RecordHeader of this
-    // first SyncPt will contain the *same* (leaseId, seqNum) as those
+    // first SyncPt will contain the *same* PSN as those
     // appearing in the RecordHeader of the last SyncPt in the old JOURNAL.
 
     // Also note that we cannot use 'd_primaryLeaseId' and 'sequenceNumber()'
-    // to populate (leaseId, seqnum) fields of the RecordHeader of the first
+    // to populate PSN field of the RecordHeader of the first
     // SyncPt in the new JOURNAL, because in case of replicas, those 2
     // variables are updated at the end of processing the storage event, but
     // this routine is invoked *while* processing the storage event.
@@ -2877,7 +2870,7 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
     jfh->setFirstSyncPointAfterRolloverOffsetWords(
         spoPair.offset() / bmqp::Protocol::k_WORD_SIZE);
 
-    // Initialize first sync point after rollover sequence number.
+    // Initialize first sync point after rollover PSN.
     d_firstSyncPointAfterRolloverSeqNum.primaryLeaseId() =
         syncPoint.primaryLeaseId();
     d_firstSyncPointAfterRolloverSeqNum.sequenceNumber() =
@@ -4289,10 +4282,9 @@ int FileStore::writeMessageRecord(const bmqp::StorageHeader& header,
             << partitionDesc()
             << "Received DATA record with journal offset mismatch.  "
             << "Primary's journal offset: " << primaryJournalOffset
-            << ", self journal offset: " << journalPos
-            << ", msg sequence number (" << recHeader.primaryLeaseId() << ", "
-            << recHeader.sequenceNumber() << "). Ignoring this message."
-            << BMQTSK_ALARMLOG_END;
+            << ", self journal offset: " << journalPos << ", PSN "
+            << printPSN(recHeader.primaryLeaseId(), recHeader.sequenceNumber())
+            << "). Ignoring this message." << BMQTSK_ALARMLOG_END;
         return rc_JOURNAL_OUT_OF_SYNC;  // RETURN
     }
 
@@ -4419,10 +4411,9 @@ int FileStore::writeQueueCreationRecord(
             << partitionDesc()
             << "Received QLIST record with journal offset mismatch.  "
             << "Primary's journal offset: " << primaryJournalOffset
-            << ", self journal offset: " << journalPos
-            << ", msg sequence number (" << recHeader.primaryLeaseId() << ", "
-            << recHeader.sequenceNumber() << "). Ignoring this message."
-            << BMQTSK_ALARMLOG_END;
+            << ", self journal offset: " << journalPos << ", PSN "
+            << printPSN(recHeader.primaryLeaseId(), recHeader.sequenceNumber())
+            << "). Ignoring this message." << BMQTSK_ALARMLOG_END;
         return rc_JOURNAL_OUT_OF_SYNC;  // RETURN
     }
 
@@ -4550,8 +4541,9 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
             << messageType
             << "] with journal offset mismatch. Primary's journal offset: "
             << primaryJournalOffset << ", self journal offset: " << journalPos
-            << ", msg sequence number (" << recHeader.primaryLeaseId() << ", "
-            << recHeader.sequenceNumber() << "). Ignoring this message.\n"
+            << ", PSN: "
+            << printPSN(recHeader.primaryLeaseId(), recHeader.sequenceNumber())
+            << ". Ignoring this message.\n"
             << os.str() << BMQTSK_ALARMLOG_END;
 
         return rc_JOURNAL_OUT_OF_SYNC;  // RETURN
@@ -4696,10 +4688,10 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << partitionDesc()
                 << "Received JournalOp msg with invalid type: "
-                << journalOpType << ", sequence number ("
-                << recHeader.primaryLeaseId() << ", "
-                << recHeader.sequenceNumber() << "). Ignoring this message."
-                << BMQTSK_ALARMLOG_END;
+                << journalOpType << ", PSN: "
+                << printPSN(recHeader.primaryLeaseId(),
+                            recHeader.sequenceNumber())
+                << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
             return rc_INVALID_CONTENT;  // RETURN
         }
 
@@ -4711,17 +4703,17 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
                 BMQTSK_ALARMLOG_ALARM("REPLICATION")
                     << partitionDesc()
                     << "Received sync point record with invalid type: "
-                    << jOpRec->syncPointType() << ", sequence number ("
-                    << recHeader.primaryLeaseId() << ", "
-                    << recHeader.sequenceNumber()
-                    << "). Ignoring this message." << BMQTSK_ALARMLOG_END;
+                    << jOpRec->syncPointType() << ", PSN: "
+                    << printPSN(recHeader.primaryLeaseId(),
+                                recHeader.sequenceNumber())
+                    << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
                 return rc_INVALID_CONTENT;  // RETURN
             }
 
             // Note that 'jOpRec->primaryLeaseId()' may be smaller than
             // 'recHeader.primaryLeaseId()' if a new primary was chosen, and as
-            // its first job, it issues a sync point with old leaseId &
-            // sequenceNum.  Also note that in this case,
+            // its first job, it issues a sync point with old
+            // PSN.  Also note that in this case,
             // 'recHeader.sequenceNumber()' will be different from
             // 'jOpRec->sequenceNum()'.
 
@@ -4822,8 +4814,8 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
                     << "Received last sync point from the primary while "
                        "shutting "
                     << "down. No further storage events will be processed by "
-                    << "self. Current seqNum: (" << d_primaryLeaseId << ", "
-                    << sequenceNumber() << ").";
+                    << "self. Current PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
             }
         }
     }
@@ -4842,10 +4834,10 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << partitionDesc()
                 << "Received QueueOp message with invalid type: "
-                << queueOpType << ", sequence number ("
-                << recHeader.primaryLeaseId() << ", "
-                << recHeader.sequenceNumber() << "). Ignoring this message."
-                << BMQTSK_ALARMLOG_END;
+                << queueOpType << ", PSN: "
+                << printPSN(recHeader.primaryLeaseId(),
+                            recHeader.sequenceNumber())
+                << ". Ignoring this message." << BMQTSK_ALARMLOG_END;
             return rc_INVALID_CONTENT;  // RETURN
         }
 
@@ -4981,8 +4973,8 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
             << "Failed to pack storage record of type: " << type
             << ", of length " << FileStoreProtocol::k_JOURNAL_RECORD_SIZE
             << ", at JOURNAL offset: " << journalOffset << ", rc: " << buildRc
-            << ". Sequence number was: (" << d_primaryLeaseId << ", "
-            << sequenceNumber() << "). Current storage "
+            << ". PSN was: " << printPSN(d_primaryLeaseId, sequenceNumber())
+            << ". Current storage "
             << "event builder size: " << d_storageEventBuilder.eventSize()
             << ", message count: " << d_storageEventBuilder.messageCount()
             << "." << BMQTSK_ALARMLOG_END;
@@ -5091,12 +5083,8 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
             << ", at JOURNAL offset: "
             << bmqu::PrintUtil::prettyNumber(
                    static_cast<bsls::Types::Int64>(journalOffset))
-            << ", rc: " << buildRc << ". Sequence number was: ("
-            << bmqu::PrintUtil::prettyNumber(
-                   static_cast<bsls::Types::Int64>(d_primaryLeaseId))
-            << ", "
-            << bmqu::PrintUtil::prettyNumber(
-                   static_cast<bsls::Types::Int64>(sequenceNumber()))
+            << ", rc: " << buildRc
+            << ". PSN was: " << printPSN(d_primaryLeaseId, sequenceNumber())
             << "). Current storage event builder size: "
             << bmqu::PrintUtil::prettyNumber(d_storageEventBuilder.eventSize())
             << ", message count: "
@@ -6301,21 +6289,22 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
             return;  // RETURN
         }
 
-        // Check sequence number (only if leaseId is same).  Received leaseId
-        // cannot be smaller; it can, however, be larger if self node just
-        // recovered and is applying buffered storage events after being
-        // opened, or received this storage event as part of 'partition sync'
-        // step from the new (passive) primary.
+        // For the PSN, check sequence number (only if leaseId is same).
+        // Received leaseId cannot be smaller; it can, however, be larger if
+        // self node just recovered and is applying buffered storage events
+        // after being opened, or received this storage event as part of
+        // 'partition sync' step from the new (passive) primary.
 
         if (d_primaryLeaseId > recHeader->primaryLeaseId()) {
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << partitionDesc() << "Received storage msg "
                 << header.messageType()
-                << " with smaller leaseId in RecordHeader: "
-                << recHeader->primaryLeaseId()
-                << ", self leaseId: " << d_primaryLeaseId
-                << ". SeqNum in RecordHeader: " << recHeader->sequenceNumber()
-                << ", self seqNum: " << sequenceNumber()
+                << " with smaller leaseId in RecordHeader. RecordHeader's "
+                   "PSN: "
+                << printPSN(recHeader->primaryLeaseId(),
+                            recHeader->sequenceNumber())
+                << ", self PSN: "
+                << printPSN(d_primaryLeaseId, sequenceNumber())
                 << " Record's journal offset (in words): "
                 << header.journalOffsetWords() << ". Ignoring entire event."
                 << BMQTSK_ALARMLOG_END;
@@ -6327,10 +6316,11 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                 BMQTSK_ALARMLOG_ALARM("REPLICATION")
                     << partitionDesc() << "Received storage msg "
                     << header.messageType()
-                    << " with missing sequence num. Expected: "
-                    << (sequenceNumber() + 1)
-                    << ", received: " << recHeader->sequenceNumber()
-                    << ". PrimaryLeaseId: " << recHeader->primaryLeaseId()
+                    << " with missing sequence number. Expected PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber() + 1)
+                    << ", received PSN: "
+                    << printPSN(recHeader->primaryLeaseId(),
+                                recHeader->sequenceNumber())
                     << " Record's journal offset (in words): "
                     << header.journalOffsetWords() << ". Aborting broker."
                     << BMQTSK_ALARMLOG_END;
@@ -6367,7 +6357,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                                     header.messageType());
         }
 
-        // Bump up the current sequence number if record was written
+        // Bump up the current PSN if record was written
         // successfully, raise alarm otherwise.
 
         if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(0 == rc)) {
@@ -6386,17 +6376,17 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                     << partitionDesc()
                     << "Bumped up primaryLeaseId to: " << d_primaryLeaseId
                     << " while processing a "
-                    << "partition-sync storage message. "
-                    << "SequenceNum: " << sequenceNumber();
+                    << "partition-sync storage message. " << "New PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber()) << ")";
             }
         }
         else {
             BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
             BMQTSK_ALARMLOG_ALARM("REPLICATION")
                 << partitionDesc() << "Failed to write storage msg "
-                << header.messageType() << " with sequence number ("
-                << recHeader->primaryLeaseId() << ", "
-                << recHeader->sequenceNumber()
+                << header.messageType() << " with PSN ("
+                << printPSN(recHeader->primaryLeaseId(),
+                            recHeader->sequenceNumber())
                 << "), journal offset words: " << header.journalOffsetWords()
                 << ", rc: " << rc << ". Ignoring this message."
                 << BMQTSK_ALARMLOG_END;
@@ -6433,8 +6423,7 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
     bool                    hasValidLeaseIdSeqNum = false;
 
     if (0 < d_primaryLeaseId) {
-        // File store encountered valid primaryLeaseId and sequence number in
-        // 'open()'.
+        // File store encountered valid PSN in 'open()'.
 
         if (!d_isFSMWorkflow) {
             BSLS_ASSERT_SAFE(0 < sequenceNumber());
@@ -6488,17 +6477,18 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
             currentSeqNumRef()    = recHeader->sequenceNumber();
         }
         else {
-            // Validate leaseId, sequence number, etc.
+            // Validate PSN
 
             if (d_primaryLeaseId > recHeader->primaryLeaseId()) {
                 BMQTSK_ALARMLOG_ALARM("RECOVERY")
                     << partitionDesc()
-                    << "Encountered smaller primaryLeaseId ["
-                    << recHeader->primaryLeaseId() << "] "
-                    << "in buffered storage message of type: "
-                    << header.messageType()
-                    << ", sequence number: " << recHeader->sequenceNumber()
-                    << ", self primary leaseId: " << d_primaryLeaseId
+                    << "Encountered smaller primaryLeaseId in buffered "
+                       "storage message of type : "
+                    << header.messageType() << ", encountered PSN: "
+                    << printPSN(recHeader->primaryLeaseId(),
+                                recHeader->sequenceNumber())
+                    << ", self PSN: "
+                    << printPSN(d_primaryLeaseId, sequenceNumber())
                     << ", with journal offset (words): "
                     << header.journalOffsetWords() << "."
                     << BMQTSK_ALARMLOG_END;
@@ -6517,10 +6507,11 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
                         << "Skipping a buffered storage message of type "
                         << header.messageType()
                         << " as it has same or smaller sequence number. "
-                        << "Sequence number in buffered message: "
-                        << recHeader->sequenceNumber()
-                        << ", self sequence number: " << sequenceNumber()
-                        << ".";
+                        << "PSN in buffered message: "
+                        << printPSN(recHeader->primaryLeaseId(),
+                                    recHeader->sequenceNumber())
+                        << ", self PSN: "
+                        << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
                     return rc_SUCCESS;  // RETURN
                 }
                 else if (recHeader->sequenceNumber() !=
@@ -6528,10 +6519,12 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
                     BMQTSK_ALARMLOG_ALARM("REPLICATION")
                         << partitionDesc() << "Encountered buffered storage "
                         << "message " << header.messageType()
-                        << " with missing sequence num. "
-                        << "Expected: " << (sequenceNumber() + 1)
-                        << ", received: " << recHeader->sequenceNumber()
-                        << ". PrimaryLeaseId: " << recHeader->primaryLeaseId()
+                        << " with missing sequence number. "
+                        << "Expected PSN: "
+                        << printPSN(d_primaryLeaseId, sequenceNumber() + 1)
+                        << ", received PSN: "
+                        << printPSN(recHeader->primaryLeaseId(),
+                                    recHeader->sequenceNumber())
                         << ". Journal offset (words): "
                         << header.journalOffsetWords() << "."
                         << BMQTSK_ALARMLOG_END;
@@ -6573,9 +6566,10 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
             BMQTSK_ALARMLOG_ALARM("RECOVERY")
                 << partitionDesc()
                 << "Failed to write buffered storage message "
-                << header.messageType() << " with sequence number ("
-                << recHeader->primaryLeaseId() << ", "
-                << recHeader->sequenceNumber() << "), with journal "
+                << header.messageType() << " with PSN "
+                << printPSN(recHeader->primaryLeaseId(),
+                            recHeader->sequenceNumber())
+                << ", with journal "
                 << "offset (words): " << header.journalOffsetWords()
                 << ", rc: " << rc << BMQTSK_ALARMLOG_END;
             return 10 * rc + rc_WRITE_FAILURE;  // RETURN
@@ -6623,7 +6617,7 @@ FileStore::generateReceipt(NodeContext*         nodeContext,
             reinterpret_cast<bmqp::ReplicationReceipt*>(
                 buffer + sizeof(bmqp::EventHeader));
 
-        // Overwrite Receipt sequence number
+        // Overwrite Receipt PSN
         (*receipt)
             .setPrimaryLeaseId(primaryLeaseId)
             .setSequenceNum(sequenceNumber);
@@ -6665,11 +6659,10 @@ void FileStore::sendReceipt(mqbnet::ClusterNode* node,
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
             rc != bmqt::GenericResult::e_SUCCESS)) {
-        BALL_LOG_INFO << partitionDesc() << "Failed to send Receipt for "
-                      << "[ primaryLeaseId: "
-                      << nodeContext->d_key.d_primaryLeaseId
-                      << ", sequence number: "
-                      << nodeContext->d_key.d_sequenceNum << ".";
+        BALL_LOG_INFO << partitionDesc() << "Failed to send Receipt for PSN: "
+                      << printPSN(nodeContext->d_key.d_primaryLeaseId,
+                                  nodeContext->d_key.d_sequenceNum)
+                      << ").";
 
         // Ignore the error and keep the blob
     }
@@ -6768,9 +6761,8 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
     // Idempotent
     if (d_primaryLeaseId == primaryLeaseId && d_primaryNode_p == primaryNode) {
         BALL_LOG_INFO << partitionDesc() << " already has primary as "
-                      << primaryNode->nodeDescription()
-                      << " with primaryLeaseId: " << d_primaryLeaseId
-                      << ", and sequence number: " << sequenceNumber() << ".";
+                      << primaryNode->nodeDescription() << " with PSN: "
+                      << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
         return;  // RETURN
     }
 
@@ -6781,9 +6773,8 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
     d_primaryNode_p  = primaryNode;
 
     BALL_LOG_INFO << partitionDesc() << "Primary node is now "
-                  << primaryNode->nodeDescription()
-                  << " with primaryLeaseId: " << d_primaryLeaseId
-                  << ", and sequence number: " << sequenceNumber() << ".";
+                  << primaryNode->nodeDescription() << " with PSN: "
+                  << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
 
     if (primaryNode->nodeId() != d_config.nodeId()) {
         d_isPrimary = false;
@@ -6793,9 +6784,10 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
 
         if (d_lastRecoveredStrongConsistency.d_primaryLeaseId ==
             d_primaryLeaseId) {
-            BALL_LOG_INFO << partitionDesc() << "Issuing Implicit Receipt ["
-                          << "primaryLeaseId = " << d_primaryLeaseId
-                          << ", sequenceNum = " << sequenceNumber() << "].";
+            BALL_LOG_INFO << partitionDesc()
+                          << "Issuing Implicit Receipt with PSN: "
+                          << printPSN(d_primaryLeaseId, sequenceNumber())
+                          << ".";
 
             FileStore::NodeContext* nodeContext = generateReceipt(
                 0,
@@ -6838,12 +6830,12 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
     // primary disappeared w/o issuing a sync point (crash, etc).  It is
     // necessary that JOURNAL record at the primary-switch boundary is always a
     // sync point with old leaseId, because when we recover messages from the
-    // JOURNAL, we iterate in reverse direction, and update 'local' leaseId and
-    // sequenceNum upon encountering a sync point.
+    // JOURNAL, we iterate in reverse direction, and update 'local'
+    // PSN upon encountering a sync point.
 
     // Read the last JOURNAL record to see if its a SyncPt or not.  Note that
-    // we cannot rely on 'd_records' to retrieve last record's sequenceNum &
-    // leaseId, because 'd_records' could be empty or may not contain the
+    // we cannot rely on 'd_records' to retrieve last record's PSN,
+    // because 'd_records' could be empty or may not contain the
     // newest record as it may have been removed from it.
     FileSet* fs = d_fileSets[0].get();
     BSLS_ASSERT_SAFE(fs);
@@ -6902,9 +6894,9 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
 
     if (issueOldSyncPt) {
         BALL_LOG_INFO << partitionDesc() << "New primary (self) will "
-                      << "issue a sync point with old (leaseId, seqNum): ("
-                      << lastRecordLeaseId << ", " << (lastRecordSeqNum + 1)
-                      << "), because last JOURNAL record, at offset: "
+                      << "issue a sync point with old PSN: "
+                      << printPSN(lastRecordLeaseId, lastRecordSeqNum + 1)
+                      << ", because last JOURNAL record, at offset: "
                       << lastRecordOffset << ", is of type [" << lastRecordType
                       << "], which is not a SyncPt.";
 
@@ -6941,8 +6933,7 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
             return;  // RETURN
         }
 
-        // Explicitly create a SyncPt with (leaseId, seqNum) of previous
-        // primary.
+        // Explicitly create a SyncPt with PSN of previous primary.
 
         BSLS_ASSERT_SAFE(0 == fs->d_dataFilePosition %
                                   bmqp::Protocol::k_DWORD_SIZE);
@@ -6960,7 +6951,7 @@ void FileStore::setActivePrimary(mqbnet::ClusterNode* primaryNode,
                 ? fs->d_qlistFilePosition / bmqp::Protocol::k_WORD_SIZE
                 : 0;
 
-        // Explicitly update the sequence number, since we are passing the
+        // Explicitly update the PSN, since we are passing the
         // SyncPt ourselves, and 'issueSyncPointInternal' won't increment
         // the sequence number in that case.
 
@@ -7014,14 +7005,13 @@ void FileStore::clearPrimary()
     }
 
     BALL_LOG_INFO << partitionDesc() << "Clearing current primary: "
-                  << d_primaryNode_p->nodeDescription()
-                  << ". Current (leaseId, seqnum): (" << d_primaryLeaseId
-                  << ", " << sequenceNumber() << ").";
+                  << d_primaryNode_p->nodeDescription() << ". Current PSN: "
+                  << printPSN(d_primaryLeaseId, sequenceNumber()) << ".";
     d_primaryNode_p = 0;
 
-    // If self has a valid leaseId and zero seqnum (ie, previous primary went
-    // away after issuing active primary stats advisory, but before issuing a
-    // SyncPt), update self's (leaseId, seqnum) from last record in the
+    // If self has a valid leaseId and zero sequence number (ie, previous
+    // primary went away after issuing active primary stats advisory, but
+    // before issuing a SyncPt), update self's PSN from last record in the
     // journal.
 
     if (0 == d_primaryLeaseId) {
@@ -7055,8 +7045,8 @@ void FileStore::clearPrimary()
         BSLS_ASSERT_SAFE(0 != d_primaryLeaseId);
         BSLS_ASSERT_SAFE(0 != sequenceNumber());
 
-        BALL_LOG_INFO << partitionDesc() << "Rolled back (leaseId, seqnum) to "
-                      << "(" << d_primaryLeaseId << ", " << sequenceNumber()
+        BALL_LOG_INFO << partitionDesc() << "Rolled back PSN to " << "("
+                      << d_primaryLeaseId << ", " << sequenceNumber()
                       << ") upon processing 'clear-primary' event, as previous"
                       << " primary went away without issuing a SyncPt.";
     }

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1671,8 +1671,10 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     << partitionDesc()
                     << "Encountered a sync point during backward journal "
                        "iteration"
-                    << " with zero primaryLeaseId, current primaryLeaseId: "
-                    << primaryLeaseId
+                    << " with zero primaryLeaseId, record's PSN: "
+                    << mqbs::printPSN(rec.primaryLeaseId(), rec.sequenceNum())
+                    << ", current PSN: "
+                    << mqbs::printPSN(primaryLeaseId, sequenceNum)
                     << ". Record offset: " << jit->recordOffset()
                     << ", record index: " << jit->recordIndex();
 
@@ -1684,8 +1686,10 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     << partitionDesc()
                     << "Encountered a sync point during backward journal "
                        "iteration"
-                    << " with zero sequence number, current sequence number: "
-                    << sequenceNum
+                    << " with zero sequence number, record's PSN: "
+                    << mqbs::printPSN(rec.primaryLeaseId(), rec.sequenceNum())
+                    << ", current PSN: "
+                    << mqbs::printPSN(primaryLeaseId, sequenceNum)
                     << ". Record offset: " << jit->recordOffset()
                     << ", record index: " << jit->recordIndex();
 
@@ -1702,9 +1706,10 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 BMQTSK_ALARMLOG_ALARM("RECOVERY")
                     << partitionDesc()
                     << "Encountered a sync point during backward journal "
-                    << "iteration with higher primaryLeaseId: "
-                    << rec.primaryLeaseId()
-                    << ", current primaryLeaseId: " << primaryLeaseId
+                    << "iteration with higher primaryLeaseId, record's PSN: "
+                    << mqbs::printPSN(rec.primaryLeaseId(), rec.sequenceNum())
+                    << ", current PSN: "
+                    << mqbs::printPSN(primaryLeaseId, sequenceNum)
                     << ". Record offset: " << jit->recordOffset()
                     << ", record index: " << jit->recordIndex()
                     << BMQTSK_ALARMLOG_END;
@@ -1717,9 +1722,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
                         << "Encountered a sync point during backward journal "
-                        << "iteration with incorrect sequence number: "
-                        << rec.sequenceNum()
-                        << ", expected sequence number: " << sequenceNum
+                        << "iteration with incorrect sequence number, "
+                           "record's PSN: "
+                        << mqbs::printPSN(rec.primaryLeaseId(),
+                                          rec.sequenceNum())
+                        << ", expected PSN: "
+                        << mqbs::printPSN(primaryLeaseId, sequenceNum)
                         << ". Record offset: " << jit->recordOffset()
                         << ", record index: " << jit->recordIndex()
                         << BMQTSK_ALARMLOG_END;

--- a/src/groups/mqb/mqbs/mqbs_filestoreprintutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprintutil.h
@@ -32,8 +32,12 @@
 #include <mqbs_replicatedstorage.h>
 #include <mqbs_storagecollectionutil.h>
 
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+
 // BDE
 #include <bsl_memory.h>
+#include <bsl_ostream.h>
 #include <bsl_vector.h>
 #include <bsls_types.h>
 
@@ -98,6 +102,40 @@ struct FileStorePrintUtil {
                                  mqbcmd::StorageContent* storageContent,
                                  unsigned int maxNumQueues = INT_MAX);
 };
+
+// ===============
+// struct PrintPSN
+// ===============
+
+/// Streamable value type for printing a PSN as
+/// `[ primaryLeaseId = X sequenceNumber = Y ]`.
+struct PrintPSN {
+    unsigned int        d_primaryLeaseId;
+    bsls::Types::Uint64 d_sequenceNumber;
+};
+
+/// Return a `PrintPSN` constructed from the specified `primaryLeaseId` and
+/// `sequenceNumber`, suitable for streaming to an `bsl::ostream`.
+inline PrintPSN printPSN(unsigned int        primaryLeaseId,
+                         bsls::Types::Uint64 sequenceNumber)
+{
+    PrintPSN result = {primaryLeaseId, sequenceNumber};
+    return result;
+}
+
+/// Return a `PrintPSN` constructed from the specified `psn`.
+inline PrintPSN printPSN(const bmqp_ctrlmsg::PartitionSequenceNumber& psn)
+{
+    PrintPSN result = {psn.primaryLeaseId(), psn.sequenceNumber()};
+    return result;
+}
+
+// FREE OPERATORS
+inline bsl::ostream& operator<<(bsl::ostream& stream, const PrintPSN& value)
+{
+    return stream << "[ primaryLeaseId = " << value.d_primaryLeaseId
+                  << " sequenceNumber = " << value.d_sequenceNumber << " ]";
+}
 
 }  // close package namespace
 }  // close enterprise namespace


### PR DESCRIPTION
  ## Summary                                                                                                                                    
  - Normalize all "partition sequence number" / "sequence number" / "seqNum" terminology to the abbreviation **PSN** across broker logs and comments, following the same pattern established for LSN in PRs #1382 and #1387.                                                              
  - Add a `PrintPSN` streamable struct and `printPSN()` factory in `mqbs_filestoreprintutil.h` so all PSN values are printed in a consistent `[ primaryLeaseId = X sequenceNumber = Y ]` format.                                                                                              
  - Rename `ReceiveDataContext` members from `d_beginSeqNum`/`d_endSeqNum`/`d_currSeqNum` to `d_beginPSN`/`d_endPSN`/`d_currPSN`, and rename `recoverSeqNum()` to `recoverPSN()` to match the normalized terminology.