### PR TITLE
Fix[bmq]: LogCleaner must stop the Strand

### DIFF
--- a/src/groups/bmq/bmqtsk/bmqtsk_logcleaner.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_logcleaner.cpp
@@ -179,6 +179,9 @@ void LogCleaner::stop()
         return;  // RETURN
     }
 
+    // no future work
+    d_logsCleaningContext.stop();
+
     // cancel the logs cleaning recurring event and synchronize with the
     // callback
     d_scheduler_p->cancelEventAndWait(&d_logsCleaningEvent);


### PR DESCRIPTION
Unless `LogCleaner::stop()` calls `d_logsCleaningContext.stop();`, there is a possibility of pending job running after  `d_logsCleaningContext.dropPendingJobs();`
