### PR TITLE
Fix[mqbs::FileStore]: Reject rollover if self not primary

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1960,8 +1960,8 @@ void StorageManager::processShutdownEvent()
     }
 }
 
-int StorageManager::processCommand(mqbcmd::StorageResult*        result,
-                                   const mqbcmd::StorageCommand& command)
+void StorageManager::processCommand(mqbcmd::StorageResult*        result,
+                                    const mqbcmd::StorageCommand& command)
 {
     // executed by cluster *DISPATCHER* thread
 
@@ -1972,10 +1972,10 @@ int StorageManager::processCommand(mqbcmd::StorageResult*        result,
         result->makeError();
         result->error().message() = "StorageManager not yet started or is "
                                     "stopping.\n\n";
-        return -1;  // RETURN
+        return;  // RETURN
     }
 
-    return mqbc::StorageUtil::processCommand(
+    mqbc::StorageUtil::processCommand(
         result,
         &d_fileStores,
         &d_storages,

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -619,12 +619,11 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
                       const QueueFunctor& functor) const BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified `command`, and load the result to the
-    /// specified `result`.  Return 0 if the command was successfully
-    /// processed, or a non-zero value otherwise.  This function can be
-    /// invoked from any thread, and will block until the potentially
-    /// asynchronous operation is complete.
-    int processCommand(mqbcmd::StorageResult*        result,
-                       const mqbcmd::StorageCommand& command)
+    /// specified `result`.  This function can be invoked from any thread,
+    /// and will block until the potentially asynchronous operation is
+    /// complete.
+    void processCommand(mqbcmd::StorageResult*        result,
+                        const mqbcmd::StorageCommand& command)
         BSLS_KEYWORD_OVERRIDE;
 
     /// GC the queues from unrecognized domains, if any.

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4738,8 +4738,8 @@ void StorageManager::applyForEachQueue(int                 partitionId,
     fs.applyForEachQueue(functor);
 }
 
-int StorageManager::processCommand(mqbcmd::StorageResult*        result,
-                                   const mqbcmd::StorageCommand& command)
+void StorageManager::processCommand(mqbcmd::StorageResult*        result,
+                                    const mqbcmd::StorageCommand& command)
 {
     // executed by cluster *DISPATCHER* thread
 
@@ -4750,19 +4750,18 @@ int StorageManager::processCommand(mqbcmd::StorageResult*        result,
         result->makeError();
         result->error().message() = "StorageManager not yet started or is "
                                     "stopping.\n\n";
-        return -1;  // RETURN
+        return;  // RETURN
     }
 
-    return StorageUtil::processCommand(
-        result,
-        &d_fileStores,
-        &d_storages,
-        &d_storageLockVec,
-        d_domainFactory_p,
-        &d_replicationFactor,
-        command,
-        d_clusterConfig.partitionConfig().location(),
-        d_allocator_p);
+    StorageUtil::processCommand(result,
+                                &d_fileStores,
+                                &d_storages,
+                                &d_storageLockVec,
+                                d_domainFactory_p,
+                                &d_replicationFactor,
+                                command,
+                                d_clusterConfig.partitionConfig().location(),
+                                d_allocator_p);
 }
 
 void StorageManager::gcUnrecognizedDomainQueues()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -1001,12 +1001,11 @@ class StorageManager BSLS_KEYWORD_FINAL
                       const QueueFunctor& functor) const BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified `command`, and load the result to the
-    /// specified `result`.  Return 0 if the command was successfully
-    /// processed, or a non-zero value otherwise.  This function can be
-    /// invoked from any thread, and will block until the potentially
-    /// asynchronous operation is complete.
-    int processCommand(mqbcmd::StorageResult*        result,
-                       const mqbcmd::StorageCommand& command)
+    /// specified `result`.  This function can be invoked from any thread,
+    /// and will block until the potentially asynchronous operation is
+    /// complete.
+    void processCommand(mqbcmd::StorageResult*        result,
+                        const mqbcmd::StorageCommand& command)
         BSLS_KEYWORD_OVERRIDE;
 
     /// GC the queues from unrecognized domains, if any.

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -582,9 +582,7 @@ void StorageUtil::loadStorages(bsl::vector<mqbcmd::StorageQueueInfo>* storages,
 void StorageUtil::doRollover(mqbcmd::StorageResult* result,
                              FileStores*            fileStores,
                              int                    partitionId,
-                             bslma::Allocator*      allocator
-
-)
+                             bslma::Allocator*      allocator)
 {
     // executed by cluster *DISPATCHER* thread
 
@@ -3577,7 +3575,7 @@ void StorageUtil::purgeQueueDispatched(
     queueDetails.numBytesPurged()    = numBytes;
 }
 
-int StorageUtil::processCommand(
+void StorageUtil::processCommand(
     mqbcmd::StorageResult*                       result,
     FileStores*                                  fileStores,
     StorageSpMapVec*                             storageMapVec,
@@ -3600,7 +3598,7 @@ int StorageUtil::processCommand(
 
     if (command.isSummaryValue()) {
         loadStorageSummary(result, *fileStores, partitionLocation);
-        return 0;  // RETURN
+        return;  // RETURN
     }
     else if (command.isPartitionValue()) {
         const int partitionId = command.partition().partitionId();
@@ -3610,7 +3608,7 @@ int StorageUtil::processCommand(
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Too high partitionId value: '" << partitionId << "'";
             result->makeError().message() = os.str();
-            return -1;  // RETURN
+            return;  // RETURN
         }
 
         if (partitionId < -1) {
@@ -3618,14 +3616,14 @@ int StorageUtil::processCommand(
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Too low partitionId value: '" << partitionId << "'";
             result->makeError().message() = os.str();
-            return -1;  // RETURN
+            return;  // RETURN
         }
 
         // PartitionId = -1 is only allowed for rollover command.
         // In this case rollover is performed on all partitions.
         if (command.partition().command().isRolloverValue()) {
             doRollover(result, fileStores, partitionId, allocator);
-            return 0;  // RETURN
+            return;  // RETURN
         }
 
         if (partitionId < 0) {
@@ -3633,7 +3631,7 @@ int StorageUtil::processCommand(
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Too low partitionId value: '" << partitionId << "'";
             result->makeError().message() = os.str();
-            return -1;  // RETURN
+            return;  // RETURN
         }
 
         if (command.partition().command().isSummaryValue()) {
@@ -3641,7 +3639,7 @@ int StorageUtil::processCommand(
                                         fileStores,
                                         partitionId,
                                         partitionLocation);
-            return 0;  // RETURN
+            return;  // RETURN
         }
 
         const bool isAvailable = command.partition().command().isEnableValue();
@@ -3655,7 +3653,7 @@ int StorageUtil::processCommand(
                                  isAvailable));
         // We don't need to wait for the completion of above command.
         result->makeSuccess();
-        return 0;  // RETURN
+        return;  // RETURN
     }
     else if (command.isDomainValue()) {
         if (!domainFactory->getDomain(command.domain().name())) {
@@ -3663,7 +3661,7 @@ int StorageUtil::processCommand(
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Unknown domain '" << command.domain().name() << "'";
             result->makeError().message() = os.str();
-            return -1;  // RETURN
+            return;  // RETURN
         }
         if (command.domain().command().isQueueStatusValue()) {
             mqbcmd::StorageContent& storageContent =
@@ -3671,7 +3669,7 @@ int StorageUtil::processCommand(
             loadStorages(&storageContent.storages(),
                          command.domain().name(),
                          *fileStores);
-            return 0;  // RETURN
+            return;  // RETURN
         }
         else if (command.domain().command().isPurgeValue()) {
             bsl::vector<bsl::vector<mqbcmd::PurgeQueueResult> >
@@ -3704,7 +3702,7 @@ int StorageUtil::processCommand(
                                              purgedQs.end());
             }
 
-            return 0;  // RETURN
+            return;  // RETURN
         }
     }
     else if (command.isQueueValue()) {
@@ -3730,7 +3728,7 @@ int StorageUtil::processCommand(
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Queue was not found in a storage '" << uri << "'";
             result->makeError().message() = os.str();
-            return -1;  // RETURN
+            return;  // RETURN
         }
 
         // Empty string means all appIds, however, for the command, we require
@@ -3756,28 +3754,27 @@ int StorageUtil::processCommand(
         result->makePurgedQueues();
         result->purgedQueues().queues().push_back(purgedQueueResult);
 
-        return 0;  // RETURN
+        return;  // RETURN
     }
     else if (command.isReplicationValue()) {
         mqbcmd::ReplicationResult replicationResult;
-        const int rc = processReplicationCommand(&replicationResult,
-                                                 replicationFactor,
-                                                 fileStores,
-                                                 command.replication());
+        processReplicationCommand(&replicationResult,
+                                  replicationFactor,
+                                  fileStores,
+                                  command.replication());
         if (replicationResult.isErrorValue()) {
             result->makeError(replicationResult.error());
         }
         else {
             result->makeReplicationResult(replicationResult);
         }
-        return rc;  // RETURN
+        return;  // RETURN
     }
 
     bdlma::LocalSequentialAllocator<256> localAllocator(allocator);
     bmqu::MemOutStream                   os(&localAllocator);
     os << "Unknown command '" << command << "'";
     result->makeError().message() = os.str();
-    return -1;
 }
 
 void StorageUtil::onDomain(const bmqp_ctrlmsg::Status& status,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -775,13 +775,11 @@ struct StorageUtil {
     /// used to find a storage for a specific queue, the specified
     /// `storageLockVec` (per-partition mutexes) are used to access this
     /// container safely.  Use the specified `allocator` for memory
-    /// allocations.  Return 0 if the command was successfully processed, or
-    /// a non-zero value otherwise.  This function can be invoked from any
-    /// thread, and will block until the potentially asynchronous operation is
-    /// complete.
+    /// allocations.  This function can be invoked from any thread, and will
+    /// block until the potentially asynchronous operation is complete.
     //
     /// THREAD: Executed by the cluster-dispatcher thread.
-    static int
+    static void
     processCommand(mqbcmd::StorageResult*                       result,
                    FileStores*                                  fileStores,
                    StorageSpMapVec*                             storageMapVec,

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -392,12 +392,11 @@ class StorageManager {
                                    const QueueFunctor& functor) const = 0;
 
     /// Process the specified `command`, and load the result to the
-    /// specified `result`.  Return 0 if the command was successfully
-    /// processed, or a non-zero value otherwise.  This function can be
-    /// invoked from any thread, and will block until the potentially
-    /// asynchronous operation is complete.
-    virtual int processCommand(mqbcmd::StorageResult*        result,
-                               const mqbcmd::StorageCommand& command) = 0;
+    /// Process the specified storage `command`, and load the outcome in the
+    /// specified `result`.  This function can be invoked from any thread, and
+    /// will block until the potentially asynchronous operation is complete.
+    virtual void processCommand(mqbcmd::StorageResult*        result,
+                                const mqbcmd::StorageCommand& command) = 0;
 
     /// GC the queues from unrecognized domains, if any.
     virtual void gcUnrecognizedDomainQueues() = 0;

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
@@ -245,11 +245,11 @@ void StorageManager::applyForEachQueue(
     // NOTHING
 }
 
-int StorageManager::processCommand(
+void StorageManager::processCommand(
     BSLA_MAYBE_UNUSED mqbcmd::StorageResult* result,
     BSLA_MAYBE_UNUSED const mqbcmd::StorageCommand& command)
 {
-    return 0;
+    return;
 }
 
 void StorageManager::gcUnrecognizedDomainQueues()

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
@@ -254,12 +254,11 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
                       const QueueFunctor& functor) const BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified `command`, and load the result to the
-    /// specified `result`.  Return 0 if the command was successfully
-    /// processed, or a non-zero value otherwise.  This function can be
-    /// invoked from any thread, and will block until the potentially
-    /// asynchronous operation is complete.
-    int processCommand(mqbcmd::StorageResult*        result,
-                       const mqbcmd::StorageCommand& command)
+    /// specified `result`.  This function can be invoked from any thread,
+    /// and will block until the potentially asynchronous operation is
+    /// complete.
+    void processCommand(mqbcmd::StorageResult*        result,
+                        const mqbcmd::StorageCommand& command)
         BSLS_KEYWORD_OVERRIDE;
 
     /// GC the queues from unrecognized domains, if any.

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3266,8 +3266,16 @@ int FileStore::rollover()
         rc_SUCCESS                        = 0,
         rc_SYNC_POINT_FAILURE             = -1,
         rc_ROLLOVER_FAILURE               = -2,
-        rc_SYNC_POINT_FORCE_ISSUE_FAILURE = -3
+        rc_SYNC_POINT_FORCE_ISSUE_FAILURE = -3,
+        rc_NOT_PRIMARY                    = -4
     };
+
+    if (!d_isPrimary) {
+        BALL_LOG_ERROR << partitionDesc()
+                       << "Rollover rejected: node is not primary for this "
+                       << "partition.";
+        return rc_NOT_PRIMARY;  // RETURN
+    }
 
     int rc = rc_SUCCESS;
 

--- a/src/integration-tests/test_app_subscriptions.py
+++ b/src/integration-tests/test_app_subscriptions.py
@@ -459,7 +459,7 @@ class TestAppSubscriptions:
                 node.capture(r"Received QueueOpRecord of type DELETION")
 
         all_partition_id = -1  # use -1 to rollover all partitions
-        self.leader.trigger_rollover(all_partition_id, succeed=None)
+        self.leader.trigger_rollover(all_partition_id)
 
         for node in cluster.nodes():
             node.wait_rollover_complete()

--- a/src/integration-tests/test_fsm_partition_sync.py
+++ b/src/integration-tests/test_fsm_partition_sync.py
@@ -399,14 +399,11 @@ def test_sync_if_leader_missed_rollover(
         producer.post(uri_priority, [f"msg{i}"], succeed=True, wait_ack=True)
 
     # Initiate rollover via admin command
-    res = leader.trigger_rollover(0, succeed=True)
-    assert not res is None
+    leader.trigger_rollover(0)
 
     # Wait until rollover completed for other nodes
-    for node in cluster.nodes(exclude=[leader, next_leader]):
-        assert node.outputs_substr("ROLLOVER COMPLETE", 3), (
-            f"Node {node.name} did not complete rollover"
-        )
+    for node in cluster.nodes(exclude=[next_leader]):
+        node.wait_rollover_complete()
 
     # Stop all running nodes
     for node in cluster.nodes(exclude=next_leader):

--- a/src/integration-tests/test_restart_between_modes.py
+++ b/src/integration-tests/test_restart_between_modes.py
@@ -747,9 +747,7 @@ def with_rollover_admin_cmd(
     leader = cluster.last_known_leader
 
     all_partition_id = -1  # use -1 to rollover all partitions
-    # Do not wait for admin command result because "ROLLOVER COMPLETE" log record appears *before* admin command
-    # result record, and it breaks the regex search. Instead, check for ROLLOVER COMPLETE *after*
-    leader.trigger_rollover(all_partition_id, succeed=None)
+    leader.trigger_rollover(all_partition_id)
 
     for node in cluster.nodes():
         node.wait_rollover_complete()

--- a/src/integration-tests/test_rollover_csl.py
+++ b/src/integration-tests/test_rollover_csl.py
@@ -17,6 +17,9 @@
 Testing rollover of CSL file.
 """
 
+import glob
+from functools import partial
+
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
     Cluster,
@@ -24,14 +27,11 @@ from blazingmq.dev.it.fixtures import (
     tweak,
 )
 from blazingmq.dev.it.cluster_util import (
+    rollover_queues_and_apps_test,
     simulate_csl_rollover,
-    check_if_queue_has_n_messages,
 )
-import glob
 
 pytestmark = order(4)
-
-DEFAULT_APP_IDS = tc.TEST_APPIDS[:]
 
 
 class TestRolloverCSL:
@@ -44,7 +44,6 @@ class TestRolloverCSL:
         leader.drain()
 
         proxy = next(cluster.proxy_cycle())
-        domain_priority = domain_urls.domain_priority
 
         producer = proxy.create_client("producer")
 
@@ -69,82 +68,8 @@ class TestRolloverCSL:
         """
         Test that queue and appId information are preserved across rollover of
         CSL file, even after cluster restart.
-
-        1. PROLOGUE:
-            - both priority and fanout queues
-            - post two messages
-            - confirm one on priority and "foo"
-            - add "quux" to the fanout
-            - post to fanout
-            - remove "bar"
-        2. SWITCH:
-            By opening and GC'ing queues, cause the CSL file to rollover.
-            Then, restart the cluster.
-        3. EPILOGUE:
-            - priority consumer gets the second message
-            - "foo" gets 2 messages
-            - "bar" gets 0 messages
-            - "baz" gets 3 messages
-            - "quux" gets the third message
         """
-        du = domain_urls
-        leader = cluster.last_known_leader
-        leader.drain()
-        proxy = next(cluster.proxy_cycle())
-        producer = proxy.create_client("producer")
 
-        # PROLOGUE
-        priority_queue = f"bmq://{du.domain_priority}/q_in_use"
-        fanout_queue = f"bmq://{du.domain_fanout}/q_in_use"
-        for queue in [priority_queue, fanout_queue]:
-            producer.open(queue, flags=["write,ack"], succeed=True)
-            producer.post(
-                queue,
-                ["msg1", "msg2"],
-                succeed=True,
-                wait_ack=True,
-            )
-
-        consumer = proxy.create_client("consumer")
-        consumer.open(
-            priority_queue,
-            flags=["read"],
-            succeed=True,
+        rollover_queues_and_apps_test(
+            cluster, domain_urls, partial(simulate_csl_rollover, domain_urls)
         )
-        consumer.open(
-            fanout_queue + "?id=foo",
-            flags=["read"],
-            succeed=True,
-        )
-        consumer.confirm(priority_queue, "+1", succeed=True)
-        consumer.confirm(fanout_queue + "?id=foo", "+1", succeed=True)
-        consumer.close(priority_queue, succeed=True)
-        consumer.close(fanout_queue + "?id=foo", succeed=True)
-
-        current_app_ids = DEFAULT_APP_IDS + ["quux"]
-        cluster.set_app_ids(current_app_ids, du)
-        producer.post(
-            fanout_queue,
-            ["msg3"],
-            succeed=True,
-            wait_ack=True,
-        )
-
-        current_app_ids.remove("bar")
-        cluster.set_app_ids(current_app_ids, du)
-
-        # SWITCH
-        simulate_csl_rollover(du, leader, producer)
-
-        cluster.restart_nodes()
-        # For a standard cluster, states have already been restored as part of
-        # leader re-election.
-        if cluster.is_single_node:
-            producer.wait_state_restored()
-
-        # EPILOGUE
-        check_if_queue_has_n_messages(consumer, priority_queue, 1)
-        check_if_queue_has_n_messages(consumer, fanout_queue + "?id=foo", 2)
-        check_if_queue_has_n_messages(consumer, fanout_queue + "?id=bar", 0)
-        check_if_queue_has_n_messages(consumer, fanout_queue + "?id=baz", 3)
-        check_if_queue_has_n_messages(consumer, fanout_queue + "?id=quux", 1)

--- a/src/integration-tests/test_rollover_journal.py
+++ b/src/integration-tests/test_rollover_journal.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Testing rollover of journal file.
+"""
+
+import glob
+
+import blazingmq.dev.it.testconstants as tc
+from blazingmq.dev.it.cluster_util import (
+    check_if_queue_has_n_messages,
+    rollover_queues_and_apps_test,
+)
+from blazingmq.dev.it.fixtures import (
+    Cluster,
+    order,
+)
+
+pytestmark = order(4)
+
+
+class TestRolloverJournal:
+    def test_journal_cleanup(self, cluster: Cluster, domain_urls: tc.DomainUrls):
+        """
+        Test that rolling over journal file via admin command cleans up the old
+        file.
+        """
+        NUM_PARTITIONS = cluster.config.definition.partition_config.num_partitions
+        leader = cluster.last_known_leader
+
+        proxy = next(cluster.proxy_cycle())
+        producer = proxy.create_client("producer")
+
+        producer.open(
+            f"bmq://{domain_urls.domain_priority}/q0",
+            flags=["write,ack"],
+            succeed=True,
+        )
+        producer.close(f"bmq://{domain_urls.domain_priority}/q0", succeed=True)
+
+        journal_files_before_rollover = glob.glob(
+            str(cluster.work_dir.joinpath(leader.name, "storage")) + "/*journal*"
+        )
+        journal_files_before_rollover.sort()
+        assert len(journal_files_before_rollover) == NUM_PARTITIONS, (
+            f"Expected {NUM_PARTITIONS} journal files before rollover, "
+            f"got {len(journal_files_before_rollover)}"
+        )
+
+        all_partitions = -1
+        leader.trigger_rollover(partitionId=all_partitions)
+        leader.wait_rollover_complete()
+
+        journal_files_after_rollover = glob.glob(
+            str(cluster.work_dir.joinpath(leader.name, "storage")) + "/*journal*"
+        )
+        journal_files_after_rollover.sort()
+
+        assert len(journal_files_after_rollover) == NUM_PARTITIONS, (
+            f"Expected {NUM_PARTITIONS} journal files after rollover, "
+            f"got {len(journal_files_after_rollover)}"
+        )
+        assert journal_files_before_rollover[0] != journal_files_after_rollover[0], (
+            f"Journal file for partition 0 did not change after rollover: "
+            f"{journal_files_before_rollover[0]}"
+        )
+
+    def test_rollover_queues_and_apps(
+        self, cluster: Cluster, domain_urls: tc.DomainUrls
+    ):
+        """
+        Test that queue and appId information are preserved across rollover of
+        journal file via admin command, even after cluster restart.
+        """
+
+        def trigger_rollover(leader, producer):  # pylint: disable=unused-argument
+            leader.trigger_rollover(partitionId=-1)
+            leader.wait_rollover_complete()
+
+        rollover_queues_and_apps_test(cluster, domain_urls, trigger_rollover)
+
+    def test_rollover_replica_rejected(
+        self, multi_node: Cluster, domain_urls: tc.DomainUrls
+    ):
+        """
+        Test that the ROLLOVER admin command is rejected on a replica, and that
+        the cluster remains healthy afterwards (replica restart, leader restart,
+        queue still works).
+        """
+        leader = multi_node.last_known_leader
+        replicas = multi_node.nodes(exclude=leader)
+        replica = replicas[0]
+
+        proxy = next(multi_node.proxy_cycle())
+        producer = proxy.create_client("producer")
+        consumer = proxy.create_client("consumer")
+
+        queue = f"bmq://{domain_urls.domain_priority}/rollover_test"
+        producer.open(queue, flags=["write,ack"], succeed=True)
+        producer.post(queue, ["msg1", "msg2"], succeed=True, wait_ack=True)
+
+        # Attempt rollover on replica — should be rejected
+        replica.trigger_rollover(partitionId=0)
+        assert replica.outputs_substr(
+            "Rollover rejected: node is not primary for this partition",
+            timeout=5,
+        ), "Replica should have rejected rollover"
+
+        # Restart the replica, then the leader — cluster should remain healthy
+        replica.stop()
+        replica.start()
+        replica.wait_until_started()
+
+        leader.stop()
+        leader.start()
+        leader.wait_until_started()
+
+        # Verify the queue still works after both restarts
+        check_if_queue_has_n_messages(consumer, queue, 2)

--- a/src/integration-tests/test_storage_commands.py
+++ b/src/integration-tests/test_storage_commands.py
@@ -37,21 +37,21 @@ def test_command_rollover_partitionid(
 
     leader = cluster.last_known_leader
 
-    invalid_partition_id = -2
-    res = leader.trigger_rollover(invalid_partition_id, succeed=False)
-    assert res != 0, (
-        f"Rollover for invalid partition {invalid_partition_id} should fail"
+    rollover_cmd = (
+        f"CLUSTERS CLUSTER {leader.cluster_name} STORAGE PARTITION {{}} ROLLOVER"
     )
 
-    all_partition_id = -1
-    res = leader.trigger_rollover(all_partition_id, succeed=True)
-    assert res == 0, "Rollover for all partitions should succeed"
+    res = leader.command(rollover_cmd.format(-2), succeed=False)
+    assert res != 0, "Rollover for invalid partition -2 should fail"
+
+    leader.trigger_rollover(-1)
+    leader.wait_rollover_complete()
 
     for partition_id in range(num_partitions):
-        res = leader.trigger_rollover(partition_id, succeed=True)
-        assert res == 0, f"Rollover for partition {partition_id} should succeed"
+        leader.trigger_rollover(partition_id)
+        leader.wait_rollover_complete()
 
-    res = leader.trigger_rollover(num_partitions, succeed=False)
+    res = leader.command(rollover_cmd.format(num_partitions), succeed=False)
     assert res != 0, f"Rollover for invalid partition {num_partitions} should fail"
 
 

--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -140,6 +140,84 @@ def check_if_queue_has_n_messages(consumer: Client, queue: str, expected_count: 
     return msgs
 
 
+def rollover_queues_and_apps_test(cluster: Cluster, domain_urls, trigger_rollover_fn):
+    """
+    Test that queue and appId information are preserved across rollover, even
+    after cluster restart.
+
+    The caller supplies `trigger_rollover_fn(leader, producer)` which
+    performs the actual rollover (e.g. admin command or CSL simulation).
+
+    1. PROLOGUE:
+        - both priority and fanout queues
+        - post two messages
+        - confirm one on priority and "foo"
+        - add "quux" to the fanout
+        - post to fanout
+        - remove "bar"
+    2. SWITCH:
+        Trigger rollover via `trigger_rollover_fn`.  Then, restart the cluster.
+    3. EPILOGUE:
+        - priority consumer gets the second message
+        - "foo" gets 2 messages
+        - "bar" gets 0 messages
+        - "baz" gets 3 messages
+        - "quux" gets the third message
+    """
+
+    du = domain_urls
+    leader = cluster.last_known_leader
+    leader.drain()
+    proxy = next(cluster.proxy_cycle())
+    producer = proxy.create_client("producer")
+
+    # PROLOGUE
+    priority_queue = f"bmq://{du.domain_priority}/q_in_use"
+    fanout_queue = f"bmq://{du.domain_fanout}/q_in_use"
+    for queue in [priority_queue, fanout_queue]:
+        producer.open(queue, flags=["write,ack"], succeed=True)
+        producer.post(
+            queue,
+            ["msg1", "msg2"],
+            succeed=True,
+            wait_ack=True,
+        )
+
+    consumer = proxy.create_client("consumer")
+    consumer.open(priority_queue, flags=["read"], succeed=True)
+    consumer.open(fanout_queue + "?id=foo", flags=["read"], succeed=True)
+    consumer.confirm(priority_queue, "+1", succeed=True)
+    consumer.confirm(fanout_queue + "?id=foo", "+1", succeed=True)
+    consumer.close(priority_queue, succeed=True)
+    consumer.close(fanout_queue + "?id=foo", succeed=True)
+
+    current_app_ids = tc.TEST_APPIDS[:] + ["quux"]
+    cluster.set_app_ids(current_app_ids, du)
+    producer.post(
+        fanout_queue,
+        ["msg3"],
+        succeed=True,
+        wait_ack=True,
+    )
+
+    current_app_ids.remove("bar")
+    cluster.set_app_ids(current_app_ids, du)
+
+    # SWITCH
+    trigger_rollover_fn(leader, producer)
+
+    cluster.restart_nodes()
+    if cluster.is_single_node:
+        producer.wait_state_restored()
+
+    # EPILOGUE
+    check_if_queue_has_n_messages(consumer, priority_queue, 1)
+    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=foo", 2)
+    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=bar", 0)
+    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=baz", 3)
+    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=quux", 1)
+
+
 def run_storage_tool(journal_file: Path, mode: str) -> subprocess.CompletedProcess:
     """Run storage tool on `journal_file` in the specified `mode`."""
 

--- a/src/python/blazingmq/dev/it/process/broker.py
+++ b/src/python/blazingmq/dev/it/process/broker.py
@@ -257,19 +257,6 @@ class Broker(blazingmq.dev.it.process.bmqproc.BMQProcess):
             self._logger.error(error)
             raise RuntimeError(error)
 
-    def wait_rollover_complete(self):
-        """
-        Wait until rollover is complete on this broker.
-        """
-
-        self._logger.info(f"Waiting for rollover to complete on broker {self.name}...")
-
-        with internal_use(self):
-            if not self.outputs_substr("ROLLOVER COMPLETE", timeout=BLOCK_TIMEOUT):
-                raise RuntimeError(
-                    f"Rollover did not complete on broker {self.name} within {BLOCK_TIMEOUT}s"
-                )
-
     def dump_queue_internals(self, domain, queue):
         """
         Dump state of the specified 'queue' in the specified 'domain'.
@@ -299,16 +286,29 @@ class Broker(blazingmq.dev.it.process.bmqproc.BMQProcess):
             succeed=succeed,
         )
 
-    def trigger_rollover(self, partitionId: int, succeed=None, timeout=None):
+    def trigger_rollover(self, partitionId: int):
         """
-        Rollover the partition on a cluster specified by 'partitionId'.
+        Rollover the partition on a cluster specified by 'partitionId'.  Call
+        `wait_rollover_complete` to wait until rollover is complete.
         """
 
         return self.command(
-            f"CLUSTERS CLUSTER {self.cluster_name} STORAGE PARTITION {partitionId} ROLLOVER",
-            succeed,
-            timeout=timeout,
+            f"CLUSTERS CLUSTER {self.cluster_name} STORAGE PARTITION {partitionId} ROLLOVER"
         )
+
+    def wait_rollover_complete(self):
+        """
+        Wait until rollover is complete on this broker.  Should be called after
+        `trigger_rollover`.
+        """
+
+        self._logger.info(f"Waiting for rollover to complete on broker {self.name}...")
+
+        with internal_use(self):
+            if not self.outputs_substr("ROLLOVER COMPLETE", timeout=BLOCK_TIMEOUT):
+                raise RuntimeError(
+                    f"Rollover did not complete on broker {self.name} within {BLOCK_TIMEOUT}s"
+                )
 
     def get_storage_partition_summary(
         self, partitionId: int, succeed=None, timeout=None


### PR DESCRIPTION
Fix for Internal Ticket 184187997

  ## Summary
  - **Fix crash**: Reject the ROLLOVER admin command on replicas. Previously, running `STORAGE PARTITION <id> ROLLOVER` on a non-primary node crashed the broker with `BSLS_ASSERT_SAFE(d_isPrimary)` in `FileStore::issueSyncPoint()`, then corrupted storage causing cascading failures on restart.
  - **Refactor**: Change `StorageManager::processCommand` return type from `int` to `void` — callers already use `result->isError()` and never checked the return code.
  - **Integration tests**: Add `test_rollover_journal.py` covering primary rollover success, replica rollover rejection with cluster health verification, and journal file cleanup. Refactor shared PROLOGUE/EPILOGUE logic into `cluster_util.rollover_queues_and_apps_test()`.