### PR TITLE
Refactor[mqbc::RecoveryMgr]: Refactor deprecateFileSet w/ closeRecoveryFileSet 

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -154,77 +154,21 @@ int RecoveryManager::deprecateFileSet(int partitionId)
     // PRECONDITIONS
     validatePartitionId(partitionId);
 
-    enum rcEnum { rc_SUCCESS = 0, rc_FAILURE = 1 };
+    enum rcEnum {
+        rc_SUCCESS              = 0,
+        rc_FD_CLOSE_FAILURE     = -1,
+        rc_JOURNAL_MOVE_FAILURE = -2,
+        rc_DATA_MOVE_FAILURE    = -3,
+        rc_QLIST_MOVE_FAILURE   = -4
+    };
 
-    int rcFinal = rc_SUCCESS;
-
-    RecoveryContext&   recoveryCtx = d_recoveryContextVec[partitionId];
-    bmqu::MemOutStream errorDesc;
-    int                rc = -1;
-    if (recoveryCtx.d_mappedJournalFd.isValid()) {
-        rc = mqbs::FileSystemUtil::truncate(&recoveryCtx.d_mappedJournalFd,
-                                            recoveryCtx.d_journalFilePosition,
-                                            errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to truncate journal file ["
-                << recoveryCtx.d_recoveryFileSet.journalFile()
-                << "], rc: " << rc << ", error: " << errorDesc.str()
-                << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Truncated journal file ["
-                          << recoveryCtx.d_recoveryFileSet.journalFile()
-                          << "] to position ["
-                          << recoveryCtx.d_journalFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::flush(
-            recoveryCtx.d_mappedJournalFd.mapping(),
-            recoveryCtx.d_journalFilePosition,
-            errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to flush journal file ["
-                << recoveryCtx.d_recoveryFileSet.journalFile()
-                << "], rc: " << rc << ", error: " << errorDesc.str()
-                << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Flushed journal file ["
-                          << recoveryCtx.d_recoveryFileSet.journalFile()
-                          << "] up to position ["
-                          << recoveryCtx.d_journalFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedJournalFd);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to close journal file ["
-                << recoveryCtx.d_recoveryFileSet.journalFile()
-                << "], rc: " << rc << BMQTSK_ALARMLOG_END;
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Closed journal file ["
-                          << recoveryCtx.d_recoveryFileSet.journalFile()
-                          << "].";
-        }
+    int rc = closeRecoveryFileSet(partitionId);
+    if (rc != 0) {
+        return rc * 10 + rc_FD_CLOSE_FAILURE;  // RETURN
     }
-    rc = mqbs::FileSystemUtil::move(
+
+    RecoveryContext& recoveryCtx = d_recoveryContextVec[partitionId];
+    rc                           = mqbs::FileSystemUtil::move(
         recoveryCtx.d_recoveryFileSet.journalFile(),
         d_dataStoreConfig.archiveLocation());
     if (0 != rc) {
@@ -234,7 +178,7 @@ int RecoveryManager::deprecateFileSet(int partitionId)
             << recoveryCtx.d_recoveryFileSet.journalFile() << "] "
             << "to location [" << d_dataStoreConfig.archiveLocation()
             << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        rcFinal = rc_FAILURE;
+        return rc * 10 + rc_JOURNAL_MOVE_FAILURE;  // RETURN
     }
     else {
         BALL_LOG_INFO << d_clusterData.identity().description()
@@ -244,67 +188,7 @@ int RecoveryManager::deprecateFileSet(int partitionId)
                       << "] to location ["
                       << d_dataStoreConfig.archiveLocation() << "].";
     }
-    recoveryCtx.d_journalFilePosition = 0;
 
-    if (recoveryCtx.d_mappedDataFd.isValid()) {
-        rc = mqbs::FileSystemUtil::truncate(&recoveryCtx.d_mappedDataFd,
-                                            recoveryCtx.d_dataFilePosition,
-                                            errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to truncate data file ["
-                << recoveryCtx.d_recoveryFileSet.dataFile() << "], rc: " << rc
-                << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Truncated data file ["
-                          << recoveryCtx.d_recoveryFileSet.dataFile()
-                          << "] to position ["
-                          << recoveryCtx.d_dataFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::flush(recoveryCtx.d_mappedDataFd.mapping(),
-                                         recoveryCtx.d_dataFilePosition,
-                                         errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to flush data file ["
-                << recoveryCtx.d_recoveryFileSet.dataFile() << "], rc: " << rc
-                << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Flushed data file ["
-                          << recoveryCtx.d_recoveryFileSet.dataFile()
-                          << "] up to position ["
-                          << recoveryCtx.d_dataFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedDataFd);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to close data file ["
-                << recoveryCtx.d_recoveryFileSet.dataFile() << "], rc: " << rc
-                << BMQTSK_ALARMLOG_END;
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Closed data file ["
-                          << recoveryCtx.d_recoveryFileSet.dataFile() << "].";
-        }
-    }
     rc = mqbs::FileSystemUtil::move(recoveryCtx.d_recoveryFileSet.dataFile(),
                                     d_dataStoreConfig.archiveLocation());
     if (0 != rc) {
@@ -314,7 +198,7 @@ int RecoveryManager::deprecateFileSet(int partitionId)
             << recoveryCtx.d_recoveryFileSet.dataFile() << "] "
             << "to location [" << d_dataStoreConfig.archiveLocation()
             << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        rcFinal = rc_FAILURE;
+        return rc * 10 + rc_DATA_MOVE_FAILURE;  // RETURN
     }
     else {
         BALL_LOG_INFO << d_clusterData.identity().description()
@@ -324,67 +208,7 @@ int RecoveryManager::deprecateFileSet(int partitionId)
                       << "] to location ["
                       << d_dataStoreConfig.archiveLocation() << "].";
     }
-    recoveryCtx.d_dataFilePosition = 0;
 
-    if (recoveryCtx.d_mappedQlistFd.isValid()) {
-        rc = mqbs::FileSystemUtil::truncate(&recoveryCtx.d_mappedQlistFd,
-                                            recoveryCtx.d_qlistFilePosition,
-                                            errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to truncate QList file ["
-                << recoveryCtx.d_recoveryFileSet.qlistFile() << "], rc: " << rc
-                << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Truncated QList file ["
-                          << recoveryCtx.d_recoveryFileSet.qlistFile()
-                          << "] to position ["
-                          << recoveryCtx.d_qlistFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::flush(recoveryCtx.d_mappedQlistFd.mapping(),
-                                         recoveryCtx.d_qlistFilePosition,
-                                         errorDesc);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to flush QList file ["
-                << recoveryCtx.d_recoveryFileSet.qlistFile() << "], rc: " << rc
-                << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
-            errorDesc.reset();
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Flushed QList file ["
-                          << recoveryCtx.d_recoveryFileSet.qlistFile()
-                          << "] up to position ["
-                          << recoveryCtx.d_qlistFilePosition << "].";
-        }
-
-        rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedQlistFd);
-        if (rc != 0) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << d_clusterData.identity().description() << " Partition ["
-                << partitionId << "]: " << "Failed to close QList file ["
-                << recoveryCtx.d_recoveryFileSet.qlistFile() << "], rc: " << rc
-                << BMQTSK_ALARMLOG_END;
-            rcFinal = rc_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << d_clusterData.identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Closed QList file ["
-                          << recoveryCtx.d_recoveryFileSet.qlistFile() << "].";
-        }
-    }
     rc = mqbs::FileSystemUtil::move(recoveryCtx.d_recoveryFileSet.qlistFile(),
                                     d_dataStoreConfig.archiveLocation());
     if (0 != rc) {
@@ -394,7 +218,7 @@ int RecoveryManager::deprecateFileSet(int partitionId)
             << recoveryCtx.d_recoveryFileSet.qlistFile() << "] "
             << "to location [" << d_dataStoreConfig.archiveLocation()
             << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        rcFinal = rc_FAILURE;
+        return rc * 10 + rc_QLIST_MOVE_FAILURE;  // RETURN
     }
     else {
         BALL_LOG_INFO << d_clusterData.identity().description()
@@ -404,11 +228,8 @@ int RecoveryManager::deprecateFileSet(int partitionId)
                       << "] to location ["
                       << d_dataStoreConfig.archiveLocation() << "].";
     }
-    recoveryCtx.d_qlistFilePosition = 0;
 
-    recoveryCtx.d_firstSyncPointAfterRolloverPSN.reset();
-
-    return rcFinal;
+    return rc_SUCCESS;
 }
 
 void RecoveryManager::setExpectedDataChunkRange(
@@ -1565,6 +1386,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
         }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Truncated journal file ["
+                          << recoveryCtx.d_recoveryFileSet.journalFile()
+                          << "] to position ["
+                          << recoveryCtx.d_journalFilePosition << "].";
+        }
 
         rc = mqbs::FileSystemUtil::flush(
             recoveryCtx.d_mappedJournalFd.mapping(),
@@ -1579,6 +1408,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
         }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Flushed journal file ["
+                          << recoveryCtx.d_recoveryFileSet.journalFile()
+                          << "] up to position ["
+                          << recoveryCtx.d_journalFilePosition << "].";
+        }
 
         rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedJournalFd);
         if (rc != 0) {
@@ -1591,8 +1428,8 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
         }
 
         BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Closed journal file in recovery file set; "
+                      << " Partition [" << partitionId << "]: "
+                      << "Closed journal file in recovery file set; "
                       << "journal file position was "
                       << recoveryCtx.d_journalFilePosition;
     }
@@ -1610,6 +1447,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
         }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Truncated data file ["
+                          << recoveryCtx.d_recoveryFileSet.dataFile()
+                          << "] to position ["
+                          << recoveryCtx.d_dataFilePosition << "].";
+        }
 
         rc = mqbs::FileSystemUtil::flush(recoveryCtx.d_mappedDataFd.mapping(),
                                          recoveryCtx.d_dataFilePosition,
@@ -1621,6 +1466,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << recoveryCtx.d_recoveryFileSet.dataFile() << "], rc: " << rc
                 << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
+        }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Flushed data file ["
+                          << recoveryCtx.d_recoveryFileSet.dataFile()
+                          << "] up to position ["
+                          << recoveryCtx.d_dataFilePosition << "].";
         }
 
         rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedDataFd);
@@ -1653,6 +1506,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
         }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Truncated QList file ["
+                          << recoveryCtx.d_recoveryFileSet.qlistFile()
+                          << "] to position ["
+                          << recoveryCtx.d_qlistFilePosition << "].";
+        }
 
         rc = mqbs::FileSystemUtil::flush(recoveryCtx.d_mappedQlistFd.mapping(),
                                          recoveryCtx.d_qlistFilePosition,
@@ -1664,6 +1525,14 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
                 << recoveryCtx.d_recoveryFileSet.qlistFile() << "], rc: " << rc
                 << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
             errorDesc.reset();
+        }
+        else {
+            BALL_LOG_INFO << d_clusterData.identity().description()
+                          << " Partition [" << partitionId
+                          << "]: " << "Flushed QList file ["
+                          << recoveryCtx.d_recoveryFileSet.qlistFile()
+                          << "] up to position ["
+                          << recoveryCtx.d_qlistFilePosition << "].";
         }
 
         rc = mqbs::FileSystemUtil::close(&recoveryCtx.d_mappedQlistFd);

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -1428,8 +1428,8 @@ int RecoveryManager::closeRecoveryFileSet(int partitionId)
         }
 
         BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId << "]: "
-                      << "Closed journal file in recovery file set; "
+                      << " Partition [" << partitionId
+                      << "]: " << "Closed journal file in recovery file set; "
                       << "journal file position was "
                       << recoveryCtx.d_journalFilePosition;
     }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3272,8 +3272,8 @@ void StorageManager::do_primaryRemoveStorageIfNeeded(
         if (rc != 0) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: "
-                << "Error while deprecating file set, rc: " << rc
+                << partitionId
+                << "]: " << "Error while deprecating file set, rc: " << rc
                 << BMQTSK_ALARMLOG_END;
 
             mqbu::ExitUtil::terminate(

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3268,14 +3268,24 @@ void StorageManager::do_primaryRemoveStorageIfNeeded(
         BSLS_ASSERT_SAFE(!fs->isOpen());
 
         // Remove file set.
-        d_recoveryManager_mp->deprecateFileSet(partitionId);
+        int rc = d_recoveryManager_mp->deprecateFileSet(partitionId);
+        if (rc != 0) {
+            BMQTSK_ALARMLOG_ALARM("FILE_IO")
+                << d_clusterData_p->identity().description() << " Partition ["
+                << partitionId << "]: "
+                << "Error while deprecating file set, rc: " << rc
+                << BMQTSK_ALARMLOG_END;
+
+            mqbu::ExitUtil::terminate(
+                mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
+        }
 
         // Creating new file set will populate the file headers.  We need to do
         // this before receiving data chunks from the recovery peer.
         bmqu::MemOutStream errorDesc;
-        int rc = d_recoveryManager_mp->createRecoveryFileSet(errorDesc,
-                                                             fs,
-                                                             partitionId);
+        rc = d_recoveryManager_mp->createRecoveryFileSet(errorDesc,
+                                                         fs,
+                                                         partitionId);
         if (rc != 0) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
                 << d_clusterData_p->identity().description() << " Partition ["


### PR DESCRIPTION
  ## Summary                                                                                                                                 
  - Refactor `deprecateFileSet` to reuse `closeRecoveryFileSet` for truncate/flush/close operations, eliminating ~200 lines of duplicated file I/O code                                                                                                                                                                                                       
  - In `StorageManager::do_primaryRemoveStorageIfNeeded`, abort the broker via `mqbu::ExitUtil::terminate` if `deprecateFileSet` fails, instead of silently continuing with corrupted state  