### PR TITLE
Fix[test]: need to have post timeout longer than 15sec

### DIFF
--- a/src/integration-tests/test_client_timeout.py
+++ b/src/integration-tests/test_client_timeout.py
@@ -123,13 +123,15 @@ def test_client_timeout_reopen(multi_node: Cluster, domain_urls: tc.DomainUrls):
             broker.resume()
     producer_broker.wait_healthy()
 
-    # Post after short timeout should result in successful Ack
+    # Post after short timeout should result in successful Ack.
+    # Use a longer timeout to allow the producer's reconnection backoff
+    # (which grows exponentially during the suspended period) to expire.
     assert (
-        producer.post(uri_priority, ["1"], wait_ack=True, succeed=True)
+        producer.post(uri_priority, ["1"], wait_ack=True, succeed=True, timeout=30)
         == Client.e_SUCCESS
     )
     assert (
-        producer.post(uri_priority2, ["2"], wait_ack=True, succeed=True)
+        producer.post(uri_priority2, ["2"], wait_ack=True, succeed=True, timeout=30)
         == Client.e_SUCCESS
     )
 

--- a/src/integration-tests/test_strong_consistency.py
+++ b/src/integration-tests/test_strong_consistency.py
@@ -133,7 +133,7 @@ class TestStrongConsistency:
                 tc.URI_FANOUT_SC_BAZ,
             ]:
                 assert wait_until(
-                    lambda: len(self.consumer.list(uri, block=True)) == 1, 2
+                    lambda: len(self.consumer.list(uri, block=True)) == 1, 10
                 )
 
     def test_suspend_post_resume(

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -258,6 +258,7 @@ class Client(BMQProcess):
         succeed=None,
         no_except=None,
         wait_ack=None,
+        timeout=None,
         **kw,
     ):
         """
@@ -291,6 +292,7 @@ class Client(BMQProcess):
             succeed,
             no_except,
             extra_patterns=extra_patterns,
+            timeout=timeout,
         )
         error_code = res.error_code
         if wait_ack:


### PR DESCRIPTION
`test_client_timeout_reopen[multi_node-eventual_consistency]` can fail if all actions take longer than 15 secs while the next reconnect timeout is 16secs
