### PR TITLE
Feat[bmqtool]: compress latencies by rounding values

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -53,13 +53,10 @@
 #include <bdlf_bind.h>
 #include <bdlf_memfn.h>
 #include <bdlf_placeholder.h>
-#include <bdlt_timeunitratio.h>
-#include <bsl_algorithm.h>
 #include <bsl_fstream.h>
 #include <bsl_iomanip.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
-#include <bsl_numeric.h>
 #include <bsl_ostream.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
@@ -77,13 +74,6 @@ namespace m_bmqtool {
 namespace {
 
 BALL_LOG_SET_NAMESPACE_CATEGORY("BMQTOOL.APPLICATION");
-
-/// The maximum latencies logged per second
-const int k_MAX_LATENCIES_PER_SECOND = 1000;
-
-/// The average expected time between logged latencies
-const bsls::Types::Int64 k_NS_PER_LATENCY = bdlt::TimeUnitRatio::k_NS_PER_S /
-                                            k_MAX_LATENCIES_PER_SECOND;
 
 /// Stack-built functor to pass to `bmqp::ProtocolUtil::buildEvent`
 struct BuildConfirmFunctor {
@@ -439,124 +429,26 @@ void Application::printFinalStats()
               << "Final stats: " << ss.str() << bsl::endl;
 }
 
-void Application::generateLatencyReport(
-    const bsl::list<bsls::Types::Int64>& latencies,
-    const bslstl::StringRef&             name)
+void Application::generateLatencyReport(const LatencyStorage& latencyStorage)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!latencies.empty());
+    BSLS_ASSERT_SAFE(latencyStorage.totalCount() > 0);
     BSLS_ASSERT_SAFE(!d_parameters.latencyReportPath().empty());
 
     bsl::cout << "====================\n"
-              << "Latency Report (" << name
-              << "): " << d_parameters.latencyReportPath() << "\n"
+              << "Latency Report: " << d_parameters.latencyReportPath() << "\n"
               << "====================\n";
 
-    // 1. Skip the first 30s worth of data, to avoid initial warmup to
-    //    interfere and skew the results.  We estimate this by using throttle
-    //    parameters.
-    const unsigned int k_TO_REMOVE_COUNT = k_MAX_LATENCIES_PER_SECOND * 30;
+    latencyStorage.printSummary(bsl::cout);
+    bsl::cout << bsl::endl;
 
-    bsl::list<bsls::Types::Int64>::const_iterator itStart = latencies.cbegin();
-    if (latencies.size() >= k_TO_REMOVE_COUNT * 2) {
-        bsl::advance(itStart, k_TO_REMOVE_COUNT);
-    }
-    else {
-        bsl::cout << " **/!\\: Too few data points (" << latencies.size()
-                  << "), the resulting statistics may not be representative."
-                  << bsl::endl;
-    }
-
-    // 2. Convert the list to a sorted vector: we use a list while collecting
-    //    data to avoid overhead of resizing the vector; but now convert to a
-    //    sorted vector to make it easier to compute some statistic metrics.
-    bsl::vector<bsls::Types::Int64> dataSet(itStart, latencies.cend());
-    bsl::sort(dataSet.begin(), dataSet.end());
-
-    // 3. Compute some interesting metrics
-    const bsls::Types::Int64 min = *bsl::min_element(dataSet.begin(),
-                                                     dataSet.end());
-    const bsls::Types::Int64 max = *bsl::max_element(dataSet.begin(),
-                                                     dataSet.end());
-
-    const bsls::Types::Int64 sum = bsl::accumulate(dataSet.begin(),
-                                                   dataSet.end(),
-                                                   0LL);
-    const double             avg = static_cast<double>(sum) / dataSet.size();
-
-    const bsls::Types::Int64 median = StatUtil::computePercentile(dataSet,
-                                                                  50.0);
-
-    const bsls::Types::Int64 p99 = StatUtil::computePercentile(dataSet, 99.0);
-    const bsls::Types::Int64 p98 = StatUtil::computePercentile(dataSet, 98.0);
-    const bsls::Types::Int64 p97 = StatUtil::computePercentile(dataSet, 97.0);
-    const bsls::Types::Int64 p96 = StatUtil::computePercentile(dataSet, 96.0);
-    const bsls::Types::Int64 p95 = StatUtil::computePercentile(dataSet, 95.0);
-
-    // 4. Print summary stats to stdout
-    bsl::cout
-        << "  Population size.: " << dataSet.size() << "\n"
-        << "  min.............: " << bmqu::PrintUtil::prettyTimeInterval(min)
-        << "\n"
-        << "  avg.............: " << bmqu::PrintUtil::prettyTimeInterval(avg)
-        << "\n"
-        << "  max.............: " << bmqu::PrintUtil::prettyTimeInterval(max)
-        << "\n"
-        << "  median..........: "
-        << bmqu::PrintUtil::prettyTimeInterval(median) << "\n"
-        << "  95Percentile....: " << bmqu::PrintUtil::prettyTimeInterval(p95)
-        << "\n"
-        << "  96Percentile....: " << bmqu::PrintUtil::prettyTimeInterval(p96)
-        << "\n"
-        << "  97Percentile....: " << bmqu::PrintUtil::prettyTimeInterval(p97)
-        << "\n"
-        << "  98Percentile....: " << bmqu::PrintUtil::prettyTimeInterval(p98)
-        << "\n"
-        << "  99Percentile....: " << bmqu::PrintUtil::prettyTimeInterval(p99)
-        << "\n"
-        << bsl::endl;
-
-    // 5. Generate the JSON report
-    bsl::ofstream output(d_parameters.latencyReportPath().c_str());
-    if (!output) {
-        bsl::cout << "Unable to generate latency report, failed to open '"
-                  << d_parameters.latencyReportPath().c_str() << "'"
+    int rc = latencyStorage.save(d_parameters.latencyReportPath());
+    if (rc != 0) {
+        bsl::cout << "Unable to generate latency report, failed to save '"
+                  << d_parameters.latencyReportPath() << "' (rc: " << rc << ")"
                   << bsl::endl;
         return;  // RETURN
     }
-    output << "{\n"
-           << "  \"origin\": \"" << name << "\",\n"
-           << "  \"min\": " << min << ",\n"
-           << "  \"avg\": " << avg << ",\n"
-           << "  \"max\": " << max << ",\n"
-           << "  \"median\": " << median << ",\n"
-           << "  \"99percentile\": " << p99 << ",\n"
-           << "  \"98percentile\": " << p98 << ",\n"
-           << "  \"97percentile\": " << p97 << ",\n"
-           << "  \"96percentile\": " << p96 << ",\n"
-           << "  \"95percentile\": " << p95 << ",\n"
-           << "  \"dataPoints\": [";
-    // Print the unsorted (i.e. in reporting order) data, so that if needed, we
-    // could see the evolution over time and maybe some pattern (for example
-    // initial latency being higher due to cache warmup, ...).
-    int                                           idx = 0;
-    bsl::list<bsls::Types::Int64>::const_iterator it  = itStart;
-    while (it != latencies.cend()) {
-        if (idx++ > 0) {
-            if (idx % 10 == 0) {
-                output << ",\n    ";
-            }
-            else {
-                output << ", ";
-            }
-        }
-        output << *it;
-        ++it;
-    }
-    output << "\n  ]\n"
-           << "}\n";
-
-    output.close();
 }
 
 int Application::initialize()
@@ -781,9 +673,7 @@ void Application::onMessageEvent(const bmqa::MessageEvent& event)
                     break;  // BREAK
                 }
 
-                if (d_ackLatencyThrottle.requestPermission()) {
-                    d_ackLatencies.push_back(delta);
-                }
+                d_ackLatencyStorage.insert(delta);
 
             } while (false);
 
@@ -858,9 +748,7 @@ void Application::onMessageEvent(const bmqa::MessageEvent& event)
                     break;  // BREAK
                 }
 
-                if (d_confirmLatencyThrottle.requestPermission()) {
-                    d_confirmLatencies.push_back(delta);
-                }
+                d_confirmLatencyStorage.insert(delta);
 
             } while (false);
 
@@ -1008,19 +896,13 @@ Application::Application(const Parameters& parameters,
 , d_fileLogger(d_parameters.logFilePath(), d_allocator_p)
 , d_poster(&d_fileLogger, d_statContext_sp.get(), d_allocator_p)
 , d_interactive(parameters, &d_poster, d_allocator_p)
-, d_confirmLatencyThrottle()
-, d_confirmLatencies(allocator)
-, d_ackLatencyThrottle()
-, d_ackLatencies(allocator)
+, d_confirmLatencyStorage("end2end", 3, d_allocator_p)
+, d_ackLatencyStorage("ack", 3, d_allocator_p)
 , d_autoReadInProgress(false)
 , d_autoReadActivity(false)
 , d_numExpectedAcks(0)
 , d_numAcknowledged(0)
 {
-    d_confirmLatencyThrottle.initialize(k_MAX_LATENCIES_PER_SECOND,
-                                        k_NS_PER_LATENCY);
-    d_ackLatencyThrottle.initialize(k_MAX_LATENCIES_PER_SECOND,
-                                    k_NS_PER_LATENCY);
 }
 
 Application::~Application()
@@ -1135,11 +1017,11 @@ void Application::stop()
     /// So we don't try to generate two report files or merge these 2 latency
     /// types in one file.  Instead, we prioritize end-to-end latency over ack
     /// latency.
-    if (!d_confirmLatencies.empty()) {
-        generateLatencyReport(d_confirmLatencies, "end2end");
+    if (d_confirmLatencyStorage.totalCount() > 0) {
+        generateLatencyReport(d_confirmLatencyStorage);
     }
-    else if (!d_ackLatencies.empty()) {
-        generateLatencyReport(d_ackLatencies, "ack");
+    else if (d_ackLatencyStorage.totalCount() > 0) {
+        generateLatencyReport(d_ackLatencyStorage);
     }
 
     BALL_LOG_INFO << "Goodbye.";

--- a/src/applications/bmqtool/m_bmqtool_application.h
+++ b/src/applications/bmqtool/m_bmqtool_application.h
@@ -27,6 +27,7 @@
 // BMQTOOL
 #include <m_bmqtool_filelogger.h>
 #include <m_bmqtool_interactive.h>
+#include <m_bmqtool_latencystorage.h>
 #include <m_bmqtool_messages.h>
 #include <m_bmqtool_poster.h>
 #include <m_bmqtool_storageinspector.h>
@@ -43,10 +44,7 @@
 // BDE
 #include <ball_multiplexobserver.h>
 #include <bdlbb_blob.h>
-#include <bdlbb_pooledblobbufferfactory.h>
 #include <bdlmt_eventscheduler.h>
-#include <bdlmt_throttle.h>
-#include <bsl_list.h>
 #include <bsl_memory.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
@@ -131,26 +129,16 @@ class Application : public bmqa::SessionEventHandler {
     Interactive d_interactive;
     // CLI handler.
 
-    /// A throttle object used to control confirm latency logging on a consumer
-    bdlmt::Throttle d_confirmLatencyThrottle;
-
-    /// List of all confirm message latencies (in ns).
+    /// Storage for confirm message latencies (rounded and bucketed).
     /// Confirm message latency is the end-to-end time to deliver a message,
     /// starting from producer post and ending on a consumer.
-    /// Only populated when requested to generate a latency report (with
-    /// --latency-report).
-    bsl::list<bsls::Types::Int64> d_confirmLatencies;
+    LatencyStorage d_confirmLatencyStorage;
 
-    /// A throttle object used to control ack latency logging on a consumer
-    bdlmt::Throttle d_ackLatencyThrottle;
-
-    /// List of all ack message latencies (in ns).
+    /// Storage for ack message latencies (rounded and bucketed).
     /// Ack message latency is the time between posting a message and getting
     /// an ACK for it, meaning that the message was at least replicated with
     /// a needed quorum (delivery might not have happened yet).
-    /// Only populated when requested to generate a latency report (with
-    /// --latency-report).
-    bsl::list<bsls::Types::Int64> d_ackLatencies;
+    LatencyStorage d_ackLatencyStorage;
 
     bsls::AtomicBool d_autoReadInProgress;
     // Auto-consume mode only.  True if a
@@ -212,12 +200,8 @@ class Application : public bmqa::SessionEventHandler {
     /// Print the final stats to the standard output, at exit time.
     void printFinalStats();
 
-    /// Generate the latency report from the specified `latencies`.
-    /// The specified `name` represents the origin of the latencies, it is
-    /// either end-to-end latency (producer->consumer) or ack latency
-    /// (producer->cluster->producer-ack).
-    void generateLatencyReport(const bsl::list<bsls::Types::Int64>& latencies,
-                               const bslstl::StringRef&             name);
+    /// Generate the latency report from the specified `latencyStorage`.
+    void generateLatencyReport(const LatencyStorage& latencyStorage);
 
     /// Do any `pre` run initialization, such as connecting to bmqbrkr,
     /// opening a queue, preparing the blob to publish, ...  Return 0 on

--- a/src/applications/bmqtool/m_bmqtool_latencystorage.cpp
+++ b/src/applications/bmqtool/m_bmqtool_latencystorage.cpp
@@ -1,0 +1,184 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// BMQTOOL
+#include <m_bmqtool_latencystorage.h>
+
+// BDE
+#include <bsl_cmath.h>
+#include <bsl_fstream.h>
+#include <bslma_default.h>
+#include <bsls_assert.h>
+#include <bsls_types.h>
+
+// BMQ
+#include <bmqu_printutil.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+LatencyStorage::LatencyStorage(bsl::string_view  origin,
+                               int               latencyDigits,
+                               bslma::Allocator* allocator)
+: d_allocator_p(bslma::Default::allocator(allocator))
+, d_origin(origin, d_allocator_p)
+, d_digitsLimit(1)
+, d_totalCount(0)
+, d_latencies(d_allocator_p)
+{
+    BSLS_ASSERT_SAFE(1 <= latencyDigits && latencyDigits <= 9);
+
+    for (int i = 0; i < latencyDigits; ++i) {
+        d_digitsLimit *= 10;
+    }
+}
+
+void LatencyStorage::insert(bsls::Types::Int64 latency)
+{
+    BSLS_ASSERT_SAFE(0 <= latency);
+
+    bsls::Types::Int64 divisor = 1;
+    while (divisor * d_digitsLimit < latency) {
+        divisor *= 10;
+    }
+
+    bsls::Types::Int64 rounded = (latency / divisor) * divisor;
+
+    ++d_latencies[rounded];
+    ++d_totalCount;
+}
+
+bsls::Types::Int64 LatencyStorage::computePercentile(double percentile) const
+{
+    BSLS_ASSERT_SAFE(0 <= percentile && percentile <= 100.0);
+
+    if (d_totalCount == 0) {
+        return 0;  // RETURN
+    }
+
+    bsls::Types::Int64 targetCount = static_cast<bsls::Types::Int64>(
+        bsl::ceil(percentile * d_totalCount / 100.0));
+
+    bsls::Types::Int64 accumulated = 0;
+    for (LatencyMap::const_iterator it = d_latencies.begin();
+         it != d_latencies.end();
+         ++it) {
+        accumulated += it->second;
+        if (targetCount <= accumulated) {
+            return it->first;  // RETURN
+        }
+    }
+
+    // We should be able to find the required bucket in the loop,
+    // keep this return for safety.
+    return d_latencies.rbegin()->first;  // RETURN
+}
+
+bsls::Types::Int64 LatencyStorage::minLatency() const
+{
+    if (d_latencies.empty()) {
+        return 0;  // RETURN
+    }
+    return d_latencies.begin()->first;
+}
+
+bsls::Types::Int64 LatencyStorage::maxLatency() const
+{
+    if (d_latencies.empty()) {
+        return 0;  // RETURN
+    }
+    return d_latencies.rbegin()->first;
+}
+
+bsls::Types::Int64 LatencyStorage::avgLatency() const
+{
+    if (d_totalCount == 0) {
+        return 0;  // RETURN
+    }
+
+    bsls::Types::Int64 sum = 0;
+    for (LatencyMap::const_iterator it = d_latencies.begin();
+         it != d_latencies.end();
+         ++it) {
+        sum += it->first * it->second;
+    }
+    return sum / d_totalCount;
+}
+
+int LatencyStorage::save(const bsl::string& filename) const
+{
+    bsl::ofstream file(filename.c_str());
+    if (!file) {
+        return -1;  // RETURN
+    }
+
+    file << "{\n";
+    file << "  \"origin\": \"" << d_origin << "\",\n";
+    file << "  \"min\": " << minLatency() << ",\n";
+    file << "  \"max\": " << maxLatency() << ",\n";
+    file << "  \"avg\": " << avgLatency() << ",\n";
+    file << "  \"median\": " << computePercentile(50) << ",\n";
+    file << "  \"95percentile\": " << computePercentile(95) << ",\n";
+    file << "  \"96percentile\": " << computePercentile(96) << ",\n";
+    file << "  \"97percentile\": " << computePercentile(97) << ",\n";
+    file << "  \"98percentile\": " << computePercentile(98) << ",\n";
+    file << "  \"99percentile\": " << computePercentile(99) << ",\n";
+    file << "  \"dataPoints\": {";
+    for (LatencyMap::const_iterator cit = d_latencies.cbegin();
+         cit != d_latencies.cend();
+         ++cit) {
+        if (cit != d_latencies.cbegin()) {
+            // Not the first entry, add a separator
+            file << ",";
+        }
+        file << "\n    \"" << cit->first << "\": " << cit->second;
+    }
+    file << "\n  }\n";
+    file << "}\n";
+
+    if (!file) {
+        return -2;  // RETURN
+    }
+
+    file.close();
+    if (!file) {
+        return -3;  // RETURN
+    }
+
+    return 0;
+}
+
+void LatencyStorage::printSummary(bsl::ostream& stream) const
+{
+#define BMQTOOL_LSTAT(DESC, TIMESTAMP)                                        \
+    stream << "    " << (DESC) << ": "                                        \
+           << bmqu::PrintUtil::prettyTimeInterval(TIMESTAMP) << "\n";
+
+    stream << "    totalCount......: " << d_totalCount << "\n";
+    BMQTOOL_LSTAT("min.............", minLatency());
+    BMQTOOL_LSTAT("avg.............", avgLatency());
+    BMQTOOL_LSTAT("max.............", maxLatency());
+    BMQTOOL_LSTAT("median..........", computePercentile(50));
+    BMQTOOL_LSTAT("95Percentile....", computePercentile(95));
+    BMQTOOL_LSTAT("96Percentile....", computePercentile(96));
+    BMQTOOL_LSTAT("97Percentile....", computePercentile(97));
+    BMQTOOL_LSTAT("98Percentile....", computePercentile(98));
+    BMQTOOL_LSTAT("99Percentile....", computePercentile(99));
+
+#undef BMQTOOL_LSTAT
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/applications/bmqtool/m_bmqtool_latencystorage.h
+++ b/src/applications/bmqtool/m_bmqtool_latencystorage.h
@@ -1,0 +1,113 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_M_BMQTOOL_LATENCYSTORAGE
+#define INCLUDED_M_BMQTOOL_LATENCYSTORAGE
+
+//@PURPOSE: Provide a container for storing and analyzing latencies.
+//
+//@CLASSES:
+//  m_bmqtool::LatencyStorage: Storage and analysis of latency measurements.
+//
+//@DESCRIPTION: 'm_bmqtool::LatencyStorage' stores latency measurements
+// (in nanoseconds) with automatic rounding to a specified precision for
+// bucketing. It provides APIs to compute percentiles, save JSON reports,
+// and print human-readable summaries.
+
+// BDE
+#include <bsl_map.h>
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_string_view.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_types.h>
+
+namespace BloombergLP {
+namespace m_bmqtool {
+
+class LatencyStorage {
+  private:
+    // PRIVATE TYPES
+    typedef bsl::map<bsls::Types::Int64, bsls::Types::Int64>
+        LatencyMap;  // Maps rounded latency to counter
+
+    // DATA
+    bslma::Allocator*  d_allocator_p;
+    bsl::string        d_origin;
+    bsls::Types::Int64 d_digitsLimit;
+    bsls::Types::Int64 d_totalCount;
+    LatencyMap         d_latencies;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(LatencyStorage, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// @brief Create a LatencyStorage with the specified origin and precision.
+    /// @param origin Origin name for JSON reports (e.g., "end2end", "ack")
+    /// @param latencyDigits Number of decimal digits for rounding (1-9)
+    /// @param allocator Optional allocator for memory (uses default if 0)
+    explicit LatencyStorage(bsl::string_view  origin,
+                            int               latencyDigits,
+                            bslma::Allocator* allocator = 0);
+
+    // MANIPULATORS
+
+    /// @brief Insert a latency sample.
+    /// @param latency Latency value in nanoseconds
+    void insert(bsls::Types::Int64 latency);
+
+    /// @brief Save the latency report to a JSON file.
+    /// @param filename Path to output file
+    /// @return 0 on success, non-zero error code on failure
+    int save(const bsl::string& filename) const;
+
+    /// @brief Print a summary of latency statistics.
+    /// @param stream Output stream to write to
+    void printSummary(bsl::ostream& stream) const;
+
+    // ACCESSORS
+
+    /// @brief Return the total number of latencies stored.
+    bsls::Types::Int64 totalCount() const;
+
+    /// @brief Compute a percentile latency value.
+    /// @param percentile Percentile level (0-100)
+    /// @return Latency at the specified percentile, or 0 if empty
+    bsls::Types::Int64 computePercentile(double percentile) const;
+
+    /// @brief Get the minimum latency.
+    bsls::Types::Int64 minLatency() const;
+
+    /// @brief Get the maximum latency.
+    bsls::Types::Int64 maxLatency() const;
+
+    /// @brief Get the average latency.
+    bsls::Types::Int64 avgLatency() const;
+};
+
+// INLINE DEFINITIONS
+inline bsls::Types::Int64 LatencyStorage::totalCount() const
+{
+    return d_totalCount;
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif  // INCLUDED_M_BMQTOOL_LATENCYSTORAGE

--- a/src/applications/bmqtool/m_bmqtool_latencystorage.t.cpp
+++ b/src/applications/bmqtool/m_bmqtool_latencystorage.t.cpp
@@ -1,0 +1,335 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqtool
+#include <m_bmqtool_latencystorage.h>
+
+// BDE
+#include <bmqtst_testhelper.h>
+#include <bmqu_tempfile.h>
+#include <bsl_cstdlib.h>
+#include <bsl_fstream.h>
+#include <bsl_iostream.h>
+#include <bsls_types.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace m_bmqtool;
+using namespace bsl;
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_breathingTest()
+// ------------------------------------------------------------------------
+// BREATHING TEST
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    LatencyStorage storage("test", 2, bmqtst::TestHelperUtil::allocator());
+
+    BMQTST_ASSERT_EQ(storage.totalCount(), 0);
+
+    storage.insert(100);
+    BMQTST_ASSERT_EQ(storage.totalCount(), 1);
+
+    storage.insert(200);
+    BMQTST_ASSERT_EQ(storage.totalCount(), 2);
+}
+
+static void test2_roundingPrecisionTest()
+// ------------------------------------------------------------------------
+// ROUNDING PRECISION TEST
+//
+// Verify that latencies are grouped into correct buckets with different
+// 'latencyDigits' values.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("ROUNDING PRECISION TEST");
+
+    // Test with latencyDigits = 1
+    {
+        LatencyStorage storage("test", 1);
+
+        storage.insert(100);  // 100 rounds to 100
+        storage.insert(105);  // 105 rounds to 100
+        storage.insert(199);  // 199 rounds to 100
+
+        storage.insert(200);  // 200 rounds to 200
+        storage.insert(205);  // 205 rounds to 200
+
+        BMQTST_ASSERT_EQ(storage.totalCount(), 5);
+
+        // Buckets: 100 (3 items), 200 (2 items)
+        bsls::Types::Int64 p50 = storage.computePercentile(50);
+        BMQTST_ASSERT_EQ(p50, 100);
+
+        bsls::Types::Int64 p100 = storage.computePercentile(100);
+        BMQTST_ASSERT_EQ(p100, 200);
+    }
+
+    // Test with latencyDigits = 2
+    {
+        LatencyStorage storage("test", 2, bmqtst::TestHelperUtil::allocator());
+
+        storage.insert(500);   // 500 rounds to 500
+        storage.insert(550);   // 550 rounds to 550
+        storage.insert(1000);  // 1000 rounds to 1000
+        storage.insert(1050);  // 1050 rounds to 1000
+
+        BMQTST_ASSERT_EQ(storage.totalCount(), 4);
+        BMQTST_ASSERT_EQ(storage.minLatency(), 500);
+        BMQTST_ASSERT_EQ(storage.maxLatency(), 1000);
+
+        // Buckets: 500 (1 item), 550 (1 item), 1000 (2 items)
+        bsls::Types::Int64 p50 = storage.computePercentile(50);
+        BMQTST_ASSERT(p50 == 550 || p50 == 1000);
+
+        bsls::Types::Int64 p100 = storage.computePercentile(100);
+        BMQTST_ASSERT_EQ(p100, 1000);
+    }
+}
+
+static void test3_percentileComputationTest()
+// ------------------------------------------------------------------------
+// PERCENTILE COMPUTATION TEST
+//
+// Test 0th, 50th, 95th, and 100th percentile computation.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("PERCENTILE COMPUTATION TEST");
+
+    LatencyStorage storage("test", 1);
+
+    // Insert 10 latencies: 10, 10, 20, 20, 20, 30, 30, 40, 50, 60
+    for (int i = 0; i < 2; ++i) {
+        storage.insert(10);
+    }
+    for (int i = 0; i < 3; ++i) {
+        storage.insert(20);
+    }
+    for (int i = 0; i < 2; ++i) {
+        storage.insert(30);
+    }
+    storage.insert(40);
+    storage.insert(50);
+    storage.insert(60);
+
+    BMQTST_ASSERT_EQ(storage.totalCount(), 10);
+
+    // 0th percentile should return first value
+    bsls::Types::Int64 p0 = storage.computePercentile(0);
+    BMQTST_ASSERT_EQ(p0, 10);
+
+    // 50th percentile (median)
+    bsls::Types::Int64 p50 = storage.computePercentile(50);
+    BMQTST_ASSERT(p50 >= 20 && p50 <= 30);
+
+    // 95th percentile should be high
+    bsls::Types::Int64 p95 = storage.computePercentile(95);
+    BMQTST_ASSERT(p95 >= 50);
+
+    // 100th percentile should be max
+    bsls::Types::Int64 p100 = storage.computePercentile(100);
+    BMQTST_ASSERT_EQ(p100, 60);
+}
+
+static void test4_emptyStorageTest()
+// ------------------------------------------------------------------------
+// EMPTY STORAGE TEST
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("EMPTY STORAGE TEST");
+
+    LatencyStorage storage("test", 2, bmqtst::TestHelperUtil::allocator());
+
+    BMQTST_ASSERT_EQ(storage.totalCount(), 0);
+    BMQTST_ASSERT_EQ(storage.minLatency(), 0);
+    BMQTST_ASSERT_EQ(storage.maxLatency(), 0);
+    BMQTST_ASSERT_EQ(storage.avgLatency(), 0);
+    BMQTST_ASSERT_EQ(storage.computePercentile(50), 0);
+    BMQTST_ASSERT_EQ(storage.computePercentile(100), 0);
+}
+
+static void test5_statisticsTest()
+// ------------------------------------------------------------------------
+// STATISTICS TEST
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("STATISTICS TEST");
+
+    LatencyStorage storage("test", 1);
+
+    // Insert: 10, 10, 20, 30, 30, 30
+    // Min: 10, Max: 30, Avg: (10+10+20+30+30+30)/6 = 130/6 ≈ 21.67
+    storage.insert(10);
+    storage.insert(10);
+    storage.insert(20);
+    storage.insert(30);
+    storage.insert(30);
+    storage.insert(30);
+
+    BMQTST_ASSERT_EQ(storage.minLatency(), 10);
+    BMQTST_ASSERT_EQ(storage.maxLatency(), 30);
+
+    bsls::Types::Int64 avg = storage.avgLatency();
+    BMQTST_ASSERT_EQ(avg, 21);  // 130 / 6 = 21 (integer division)
+}
+
+static void test6_saveAndLoadTest()
+// ------------------------------------------------------------------------
+// SAVE AND LOAD TEST
+//
+// Save to file, read back, and verify JSON structure and field values.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("SAVE AND LOAD TEST");
+
+    bmqu::TempFile tempFile;
+    {
+        LatencyStorage storage("test", 2, bmqtst::TestHelperUtil::allocator());
+
+        storage.insert(100);
+        storage.insert(100);
+        storage.insert(200);
+        storage.insert(300);
+        storage.insert(300);
+        storage.insert(300);
+
+        BMQTST_ASSERT_EQ(storage.minLatency(), 100);
+        BMQTST_ASSERT_EQ(storage.maxLatency(), 300);
+
+        int rc = storage.save(tempFile.path());
+        BMQTST_ASSERT_EQ(rc, 0);
+    }
+
+    // Verify file exists and contains JSON
+    bsl::ifstream file(tempFile.path().c_str());
+    BMQTST_ASSERT(file.good());
+
+    bsl::string line;
+    bsl::string content;
+    while (bsl::getline(file, line)) {
+        content += line + "\n";
+    }
+    file.close();
+
+    // Check that content contains expected JSON fields
+    BMQTST_ASSERT(content.find("\"min\": 100") != bsl::string::npos);
+    BMQTST_ASSERT(content.find("\"max\": 300") != bsl::string::npos);
+    BMQTST_ASSERT(content.find("\"dataPoints\": {") != bsl::string::npos);
+    BMQTST_ASSERT(content.find("\"100\": 2") !=
+                  bsl::string::npos);  // 100 appears 2 times
+    BMQTST_ASSERT(content.find("\"300\": 3") !=
+                  bsl::string::npos);  // 300 appears 3 times
+    BMQTST_ASSERT(content.find("\"median\":") != bsl::string::npos);
+    BMQTST_ASSERT(content.find("\"99percentile\":") != bsl::string::npos);
+}
+
+static void test_N1_manualSaveInspection()
+// ------------------------------------------------------------------------
+// MANUAL SAVE INSPECTION TEST
+//
+// Insert a large number of random latencies, save to file, and print
+// stats and sample output for manual inspection.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("MANUAL SAVE INSPECTION TEST");
+
+    bsl::string filename = "/tmp/latency_storage_dump.json";
+
+    LatencyStorage storage("test", 3, bmqtst::TestHelperUtil::allocator());
+
+    cout << "\nGenerating random latencies..." << endl;
+
+    const bsls::Types::Int64 k_ONE_MILLION = 1000000;
+    const bsls::Types::Int64 k_ONE_BILLION = 1000000000;
+
+    for (bsls::Types::Int64 i = 0; i < k_ONE_MILLION; ++i) {
+        bsls::Types::Int64 randomBase = static_cast<bsls::Types::Int64>(
+                                            bsl::rand()) %
+                                        k_ONE_BILLION;
+        int                divisorExp = static_cast<int>(bsl::rand()) % 9;
+        bsls::Types::Int64 divisor    = 1;
+        for (int j = 0; j < divisorExp; ++j) {
+            divisor *= 10;
+        }
+
+        bsls::Types::Int64 latency = (randomBase / divisor) * divisor;
+        storage.insert(latency);
+
+        // Print progress every 100k
+        if ((i + 1) % 100000 == 0) {
+            cout << "  Inserted " << (i + 1) << " latencies" << endl;
+        }
+    }
+
+    cout << "Saving to file..." << endl;
+    int rc = storage.save(filename);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    cout << filename << endl;
+
+    cout << "\nStatistics:" << endl;
+    storage.printSummary(cout);
+
+    // Get file size
+    bsl::ifstream file(filename.c_str(), bsl::ios_base::ate);
+    if (file) {
+        bsl::streampos size = file.tellg();
+        cout << "\nFile size: " << size << " bytes" << endl;
+        file.close();
+    }
+
+    cout << "\nFirst 50 lines of JSON:" << endl;
+    cout << "-----" << endl;
+    bsl::ifstream infile(filename.c_str());
+    bsl::string   line;
+    int           lineCount = 0;
+    while (bsl::getline(infile, line) && lineCount < 50) {
+        cout << line << endl;
+        ++lineCount;
+    }
+    infile.close();
+    cout << "-----" << endl;
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ============================================================================
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 1: test1_breathingTest(); break;
+    case 2: test2_roundingPrecisionTest(); break;
+    case 3: test3_percentileComputationTest(); break;
+    case 4: test4_emptyStorageTest(); break;
+    case 5: test5_statisticsTest(); break;
+    case 6: test6_saveAndLoadTest(); break;
+    case -1: test_N1_manualSaveInspection(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
+}

--- a/src/applications/bmqtool/m_bmqtool_statutil.cpp
+++ b/src/applications/bmqtool/m_bmqtool_statutil.cpp
@@ -19,10 +19,6 @@
 
 // BDE
 #include <bdlt_currenttime.h>
-#include <bsl_cmath.h>
-#include <bsl_cstdlib.h>
-#include <bsl_limits.h>
-#include <bsl_vector.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
 
@@ -44,29 +40,6 @@ StatUtil::getNowAsNs(ParametersLatency::Value resolutionTimer)
     }
 
     return 0;
-}
-
-bsls::Types::Int64
-StatUtil::computePercentile(const bsl::vector<bsls::Types::Int64>& data,
-                            double                                 k)
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!data.empty());
-
-    // Special case (useless, but just to be complete)
-    if (bsl::abs(k) < bsl::numeric_limits<double>::epsilon()) {
-        return data[0];  // RETURN
-    }
-
-    const int    index     = bsl::floor(k * data.size() / 100.0);
-    const double remainder = bsl::fmod(k * data.size(), 100.0);
-
-    if (bsl::abs(remainder) < bsl::numeric_limits<double>::epsilon()) {
-        return data[index - 1];  // RETURN
-    }
-    else {
-        return (data[index - 1] + data[index]) / 2;  // RETURN
-    }
 }
 
 }  // close package namespace

--- a/src/applications/bmqtool/m_bmqtool_statutil.h
+++ b/src/applications/bmqtool/m_bmqtool_statutil.h
@@ -28,8 +28,7 @@
 // BMQTOOL
 #include <m_bmqtool_parameters.h>
 
-// BDe
-#include <bsl_vector.h>
+// BDE
 #include <bsls_types.h>
 
 namespace BloombergLP {
@@ -55,16 +54,6 @@ struct StatUtil {
     /// 'resolutionTimer'
     static bsls::Types::Int64
     getNowAsNs(ParametersLatency::Value resolutionTimer);
-
-    /// Compute the `k`th percentile value of the specified `data` (data must
-    /// be sorted). Formula:
-    ///  - compute the index (k percent * data size)
-    ///  - if index is not a whole number, round up to nearest whole number and
-    ///    return value at that index
-    ///  - if index it not a whole number, compute the average of the data at
-    ///    index and index + 1
-    static bsls::Types::Int64
-    computePercentile(const bsl::vector<bsls::Types::Int64>& data, double k);
 };
 
 }  // close package namespace

--- a/src/applications/bmqtool/package/bmqtool.mem
+++ b/src/applications/bmqtool/package/bmqtool.mem
@@ -2,6 +2,7 @@ m_bmqtool_application
 m_bmqtool_filelogger
 m_bmqtool_inpututil
 m_bmqtool_interactive
+m_bmqtool_latencystorage
 m_bmqtool_messages
 m_bmqtool_parameters
 m_bmqtool_poster


### PR DESCRIPTION
- Move all latency-related code to its own component.
- Round latencies and save it in a compressed representation to save space.

Legacy format (main) - file size is **2.5MB**:
```
{
  "origin": "end2end",
  "min": 1783014,
  "avg": 2.57822e+06,
  "max": 40191575,
  "median": 2419140,
  "99percentile": 6799943,
  "98percentile": 3996685,
  "97percentile": 3297917,
  "96percentile": 2850821,
  "95percentile": 2716236,
  "dataPoints": [2565488, 2543219, 2411077, 2499163, 2465934, 2485937, 2476348, 2449692, 2426135,
    2543405, 2481748, 2398868, 2425773, 2423548, 2499301, 2506187, 2414244, 2592966, 2368239,
    2423434, 2404524, 2472025, 2455141, 2592302, 2410535, 2396157, 2375015, 2544377, 2441079,
    2503401, 2457742, 2511405, 2526051, 2381654, 2537225, 2476052, 2466654, 2497040, 2442045,
    2615664, 2437458, 2340319, 2483730, 2432926, 2424790, 2415374, 2533489, 2440901, 2649307,
    2501082, 2418575, 2485063, 2371685, 2654395, 2434686, 2429297, 2404320, 2461116, 2408367,
    2423854, 2428411, 2392049, 2476984, 2381912, 2538785, 2484396, 2410685, 2731836, 2598562,
    2408855, 2508549, 2684611, 3601657, 3615413, 2781466, 2335511, 2599616, 2430659, 2339164,
    2479627, 2457783, 2436114, 2396252, 2521965, 2467805, 2491276, 2579784, 2420099, 2441262,
    2629782, 2605129, 2327159, 2377020, 2445046, 2421878, 2581606, 2619409, 2452295, 2526855,
    2427048, 2327015, 2304828, 3128945, 3315509, 2350327, 2402532, 2414689, 2418175, 2471165,
    2461286, 2481708, 2626294, 2357247, 2509620, 2430775, 2403493, 2475402, 2396909, 2484735,
    2471287, 2469208, 2636309, 2516213, 2434753, 2499009, 2477042, 2471513, 2458373, 2368498,
    2403797, 2455729, 2388907, 2421668, 2489149, 2578726, 2469480, 2592813, 2444725, 2471876,
    2616124, 2405412, 2381526, 2474861, 2478455, 2464430, 2526665, 2579006, 2657708, 2506927,
    2793541, 2445346, 2491943, 2523771, 2467794, 2643935, 2477305, 2527691, 2504108, 2664903,
    2528699, 2478915, 2457890, 2495005, 2505339, 2506070, 2482926, 2546186, 2529468, 2618945,
    2534386, 2484508, 2484654, 2555561, 2410602, 2391696, 2378048, 2461841, 2426416, 2488796,
    2546665, 2575308, 2615537, 2723569, 2710767, 2421603, 2382081, 2348044, 2359566, 2506485,
    2466100, 2922743, 2531513, 2404985, 2488066, 2430753, 2388425, 2375681, 2427286, 2413750,
    2420302, 2519287, 2719940, 5240315, 5252570, 5373872, 4468933, 3460460, 3281314, 3417213,
    2481735, 2475913, 2494196, 2691985, 2573842, 2626036, 2697378, 2528471, 2703256, 2601645,
    2480604, 2648281, 2464382, 2431107, 2582574, 2487609, 3741761, 3753024, 3302479, 2698138,
    2742921, 2405443, 2435914, 2661277, 2576798, 2502635, 2555017, 2587764, 2716043, 2632184,
    2911768, 2504827, 2424597, 2485361, 2363514, 2399284, 2414587, 2488070, 2389864, 2416463,
    2460277, 2391543, 2441235, 2389180, 2580493, 2483917, 2408789, 2657419, 2448630, 2497361,
...
```

Compressed form (this PR) - file size is **60KB**:

```
{
  "origin": "test",
  "min": 0,
  "max": 999000000,
  "avg": 464071272,
  "median": 458000000,
  "95percentile": 939000000,
  "96percentile": 950000000,
  "97percentile": 962000000,
  "98percentile": 975000000,
  "99percentile": 987000000,
  "dataPoints": {
    "0": 17407,
    "329": 1,
    "3800": 1,
    "10200": 1,
    "11500": 1,
    "12800": 1,
    "13000": 1,
    "14000": 1,
    "15400": 1,
    "15800": 1,
    "16000": 1,
    "18000": 1,
    "18700": 1,
...
```