### PR TITLE
Fix[mqb]: Skip creating storage when there is no journal record

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -3763,7 +3763,7 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
             BALL_LOG_INFO << d_cluster_p->description() << " Partition ["
                           << partitionId
                           << "]: Not restoring partition state because there "
-                          << "is no primary or primary isn't ACTIVE. Current "
+                          << "is no ACTIVE and AVAIALBLE primary. Current "
                           << "primary: "
                           << (pinfo->primaryNode()
                                   ? pinfo->primaryNode()->nodeDescription()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4066,13 +4066,13 @@ void StorageManager::initializeQueueKeyInfoMap(
             BSLS_ASSERT_SAFE(cit->second);
             const ClusterStateQueueInfo& csQinfo = *(cit->second);
 
-            mqbs::DataStoreConfigQueueInfo qinfo(true);
+            mqbs::DataStoreConfigQueueInfo qinfo;
             qinfo.setCanonicalQueueUri(csQinfo.uri().asString());
             qinfo.setPartitionId(csQinfo.partitionId());
             for (AppInfosCIter appIdCit = csQinfo.appInfos().cbegin();
                  appIdCit != csQinfo.appInfos().cend();
                  ++appIdCit) {
-                qinfo.addAppInfo(appIdCit->first, appIdCit->second);
+                qinfo.addAppInfo(appIdCit->first, appIdCit->second, true);
             }
 
             d_queueKeyInfoMapVec.at(csQinfo.partitionId())

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1854,6 +1854,16 @@ void StorageUtil::recoveredQueuesCb(
             // EXIT
         }
 
+        if (!qit->second.isRecorded()) {
+            BALL_LOG_INFO << clusterDescription << " Partition ["
+                          << partitionId
+                          << "]: did not recover QueueCreationRecord and "
+                             "skips creating storage(s) for queueUri ["
+                          << queueUri << "], queueKey [" << queueKey << "].";
+
+            continue;  // CONTINUE
+        }
+
         StorageSp rs_sp;
         fs->createStorage(&rs_sp, queueUri, queueKey, domain);
         BSLS_ASSERT_SAFE(rs_sp);

--- a/src/groups/mqb/mqbs/mqbs_datastore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.cpp
@@ -36,14 +36,15 @@ BSLMF_ASSERT(sizeof(DataStoreRecordHandle) ==
 // ------------------------------
 
 void DataStoreConfigQueueInfo::addAppInfo(const bsl::string&      appId,
-                                          const mqbu::StorageKey& appKey)
+                                          const mqbu::StorageKey& appKey,
+                                          bool                    withCSL)
 {
     // Comparing ages of Apps and messages relies on chronological order
     // (hence 'OrderedHashMap'.
     // The Legacy mode recreates Apps by reverse iterating Journal (w/ QList)
     // The FSM node recreates Apps in chronological order.
 
-    if (d_isFSM) {
+    if (withCSL) {
         d_appIdKeyPairs.insert(bsl::make_pair(appKey, appId));
     }
     else {

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -290,8 +290,6 @@ class DataStoreConfigQueueInfo {
 
   private:
     // DATA
-    bool d_isFSM;
-
     bsl::string d_canonicalUri;
 
     int d_partitionId;
@@ -305,14 +303,17 @@ class DataStoreConfigQueueInfo {
     /// for ghost Apps.
     mutable PurgeOps d_purgeOps;
 
+    /// This queue has QueueCreationRecord in in the journal.
+    /// As opposed to the case when the queue is in the CSL only.
+    bool d_isRecorded;
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(DataStoreConfigQueueInfo,
                                    bslma::UsesBslmaAllocator)
 
     // CREATORS
-    explicit DataStoreConfigQueueInfo(bool              isFSM,
-                                      bslma::Allocator* basicAllocator = 0);
+    explicit DataStoreConfigQueueInfo(bslma::Allocator* basicAllocator = 0);
 
     DataStoreConfigQueueInfo(const DataStoreConfigQueueInfo& other,
                              bslma::Allocator* basicAllocator = 0);
@@ -322,11 +323,15 @@ class DataStoreConfigQueueInfo {
 
     void setPartitionId(int value);
 
+    void setAsRecorded();
+
     /// Save the specified `appId` and the specified `appKey` as a valid App
     /// for which a Storage will be created.  If the same key was specified in
     /// a previous `addPurgeOp` call, remove the App from the cache of Ghost
     /// Apps.
-    void addAppInfo(const bsl::string& appId, const mqbu::StorageKey& appKey);
+    void addAppInfo(const bsl::string&      appId,
+                    const mqbu::StorageKey& appKey,
+                    bool                    withCSL);
 
     /// Cache the Purge interval from the specified `start` to the specified
     /// `end` for the specified `key` unless the `key` was specified in a
@@ -346,6 +351,8 @@ class DataStoreConfigQueueInfo {
     int partitionId() const;
 
     const AppInfos& appIdKeyPairs() const;
+
+    bool isRecorded() const;
 };
 
 // =====================
@@ -882,26 +889,25 @@ DataStoreRecordKeyLess::operator()(const DataStoreRecordKey& lhs,
 
 // CREATORS
 inline DataStoreConfigQueueInfo::DataStoreConfigQueueInfo(
-    bool              isFSM,
     bslma::Allocator* basicAllocator)
-: d_isFSM(isFSM)
-, d_canonicalUri(basicAllocator)
+: d_canonicalUri(basicAllocator)
 , d_partitionId(mqbi::Storage::k_INVALID_PARTITION_ID)
 , d_appIdKeyPairs(basicAllocator)
 , d_ghosts(basicAllocator)
 , d_purgeOps(basicAllocator)
+, d_isRecorded(false)
 {
 }
 
 inline DataStoreConfigQueueInfo::DataStoreConfigQueueInfo(
     const DataStoreConfigQueueInfo& other,
     bslma::Allocator*               basicAllocator)
-: d_isFSM(other.d_isFSM)
-, d_canonicalUri(other.d_canonicalUri, basicAllocator)
+: d_canonicalUri(other.d_canonicalUri, basicAllocator)
 , d_partitionId(other.d_partitionId)
 , d_appIdKeyPairs(other.d_appIdKeyPairs, basicAllocator)
 , d_ghosts(other.d_ghosts, basicAllocator)
 , d_purgeOps(other.d_purgeOps, basicAllocator)
+, d_isRecorded(other.d_isRecorded)
 {
 }
 
@@ -915,6 +921,11 @@ DataStoreConfigQueueInfo::setCanonicalQueueUri(const bsl::string& value)
 inline void DataStoreConfigQueueInfo::setPartitionId(int value)
 {
     d_partitionId = value;
+}
+
+inline void DataStoreConfigQueueInfo::setAsRecorded()
+{
+    d_isRecorded = true;
 }
 
 // ACCESSORS
@@ -932,6 +943,11 @@ inline const DataStoreConfigQueueInfo::AppInfos&
 DataStoreConfigQueueInfo::appIdKeyPairs() const
 {
     return d_appIdKeyPairs;
+}
+
+inline bool DataStoreConfigQueueInfo::isRecorded() const
+{
+    return d_isRecorded;
 }
 
 // ---------------------

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1440,7 +1440,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 // 'QueueOpType::e_ADDITION' as well).
 
                 QueueKeyInfoMapInsertRc insertRc = queueKeyInfoMap->insert(
-                    bsl::make_pair(queueKey, DataStoreConfigQueueInfo(false)));
+                    bsl::make_pair(queueKey, DataStoreConfigQueueInfo()));
                 insertRc.first->second.setPartitionId(d_config.partitionId());
 
                 if (false == insertRc.second) {
@@ -2069,6 +2069,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     return rc_INVALID_PARTITION_ID;  // RETURN
                 }
 
+                iter->second.setAsRecorded();
+
                 if (d_qListAware) {
                     // Retrieve QueueUri from QueueUriRecord.
 
@@ -2216,7 +2218,9 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                 // done in StorageMgr because we have recovered
                                 // all appId/appKey pairs by that time.
 
-                                qinfo.addAppInfo(cit->first, cit->second);
+                                qinfo.addAppInfo(cit->first,
+                                                 cit->second,
+                                                 withCSL);
                             }
                             BALL_LOG_INFO << partitionDesc()
                                           << "Recovered appId/appKey pair ['"


### PR DESCRIPTION
In the case when new queue makes to CSL but not to the journal, do NOT create storage.  Create storage when queue gets open for real, to make sure QueueCreationRecord gets replicated.