### PR TITLE
Perf[bmqu::Blob]: do not create tmp alias when not needed

### DIFF
--- a/src/groups/bmq/bmqu/bmqu_blob.cpp
+++ b/src/groups/bmq/bmqu/bmqu_blob.cpp
@@ -328,14 +328,22 @@ int BlobUtil::appendToBlob(bdlbb::Blob*       dest,
 
     // Now we just have to append new buffers to 'dest'
     while (localSection.start().buffer() < localSection.end().buffer()) {
-        const BlobPosition&         pos    = localSection.start();
-        const bdlbb::BlobBuffer&    srcBuf = src.buffer(pos.buffer());
-        const bsl::shared_ptr<char> buf(srcBuf.buffer(),
-                                        srcBuf.data() + pos.byte());
-        const bdlbb::BlobBuffer     newBuf(buf,
-                                       bufferSize(src, pos.buffer()) -
-                                           pos.byte());
-        dest->appendDataBuffer(newBuf);
+        const BlobPosition&      pos    = localSection.start();
+        const bdlbb::BlobBuffer& srcBuf = src.buffer(pos.buffer());
+        const int size = bufferSize(src, pos.buffer()) - pos.byte();
+
+        if (pos.byte() == 0) {
+            // Can use the same shared_ptr (start byte is 0)
+            bdlbb::BlobBuffer newBuf(srcBuf.buffer(), size);
+            dest->appendDataBuffer(bslmf::MovableRefUtil::move(newBuf));
+        }
+        else {
+            // Have to chop off the beginning (needs aliasing)
+            bsl::shared_ptr<char> buf(srcBuf.buffer(),
+                                      srcBuf.data() + pos.byte());
+            bdlbb::BlobBuffer newBuf(bslmf::MovableRefUtil::move(buf), size);
+            dest->appendDataBuffer(bslmf::MovableRefUtil::move(newBuf));
+        }
 
         localSection.start().setBuffer(localSection.start().buffer() + 1);
         localSection.start().setByte(0);
@@ -350,16 +358,16 @@ int BlobUtil::appendToBlob(bdlbb::Blob*       dest,
         const int size     = endPos - startPos;
 
         if (startPos == 0) {
-            // Can use the same SharedPtr
-            const bdlbb::BlobBuffer appendBuf(buf.buffer(), size);
-            dest->appendDataBuffer(appendBuf);
+            // Can use the same shared_ptr (start byte is 0)
+            bdlbb::BlobBuffer newBuf(buf.buffer(), size);
+            dest->appendDataBuffer(bslmf::MovableRefUtil::move(newBuf));
         }
         else {
-            // Have to chop off the beginning
-            const bsl::shared_ptr<char> srcBuf(buf.buffer(),
-                                               buf.data() + startPos);
-            const bdlbb::BlobBuffer     appendBuf(srcBuf, size);
-            dest->appendDataBuffer(appendBuf);
+            // Have to chop off the beginning (needs aliasing)
+            bsl::shared_ptr<char> srcBuf(buf.buffer(), buf.data() + startPos);
+            bdlbb::BlobBuffer     newBuf(bslmf::MovableRefUtil::move(srcBuf),
+                                     size);
+            dest->appendDataBuffer(bslmf::MovableRefUtil::move(newBuf));
         }
     }
 


### PR DESCRIPTION
We waste CPU cycles on incrementing/decrementing atomics in temporary shared pointers in `BlobUtil::appendToBlob`. This is avoidable.

This makes `bmqu::BlobUtil::appendToBlob` ~2 times faster.

# Primary

**Before**

<img width="840" height="381" alt="Screenshot 2026-05-15 at 16 04 53" src="https://github.com/user-attachments/assets/4ac45443-4e17-45f7-8ffa-b8521feb3353" />

**After**

<img width="859" height="365" alt="Screenshot 2026-05-15 at 16 43 47" src="https://github.com/user-attachments/assets/3027e158-6404-4b29-b31c-a80bbc38b70c" />

# Proxy

**Before**

<img width="840" height="381" alt="Screenshot 2026-05-15 at 16 02 43" src="https://github.com/user-attachments/assets/8c6b47fc-60ec-4611-b5f3-567300847cd4" />

**After**

<img width="840" height="340" alt="Screenshot 2026-05-15 at 16 43 05" src="https://github.com/user-attachments/assets/92591990-45cd-4d39-89a4-ee7a98cd58c6" />

