### PR TITLE
Fix[mqb]: use validateStorageEvent instead of assertion

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2756,7 +2756,6 @@ void StorageManager::do_bufferLiveData(const EventWithData& event)
     BSLS_ASSERT_SAFE(rawEvent.isStorageEvent());
 
     const PartitionInfo& pinfo = d_partitionInfoVec[partitionId];
-    BSLS_ASSERT_SAFE(pinfo.primary() == source);
 
     bool skipAlarm = partitionHealthState(partitionId) ==
                      PartitionFSM::State::e_UNKNOWN;


### PR DESCRIPTION
LIVE_DATA does not carry lease id, so stale filter does not guarantee us the same primary. 
Removing the assertion and letting `validateStorageEvent` filter events
Supposedly, it is not possible to receive stale LIVE_DATA from the same primary with a new lease.