### PR TITLE
Fix: various blazingmq fixes

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -133,7 +133,7 @@ struct ZLib {
 void* ZLib::zAllocate(void* opaque, unsigned int items, unsigned int size)
 {
     bslma::Allocator* allocator = static_cast<bslma::Allocator*>(opaque);
-    return allocator->allocate(items * size);
+    return allocator->allocate(static_cast<size_t>(items) * size);
 }
 
 void ZLib::zFree(void* opaque, void* address)

--- a/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_pushmessageiterator.cpp
@@ -643,7 +643,7 @@ int PushMessageIterator::next()
     const int  length     = compressedApplicationDataSize();
 
     // Validation: 'length' is an unpadded application data size, with
-    // substracted size of the padding bytes section.
+    // subtracted size of the padding bytes section.
     //: o Negative 'length' is a sign that packet is malformed.
     //: o Zero 'length' is not supported.
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(length <= 0)) {

--- a/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
@@ -614,7 +614,7 @@ int PutMessageIterator::next()
     const int length = compressedApplicationDataSize();
 
     // Validation: 'length' is an unpadded application data size, with
-    // substracted size of the padding bytes section.
+    // subtracted size of the padding bytes section.
     //: o Negative 'length' is a sign that packet is malformed.
     //: o Zero 'length' is not supported.
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(length <= 0)) {

--- a/src/groups/bmq/bmqst/bmqst_tableschema.cpp
+++ b/src/groups/bmq/bmqst/bmqst_tableschema.cpp
@@ -62,40 +62,44 @@ void defaultIdColumn(Value*                 value,
                      int                    level,
                      StatContext::ValueType type)
 {
-    bslstl::StringRef name;
-    if (type == StatContext::e_TOTAL_VALUE) {
-        if (context.hasName()) {
-            name = context.name();
-        }
-    }
-    else if (type == StatContext::e_DIRECT_VALUE) {
-        name = DIRECT_NAME;
-    }
-    else if (type == StatContext::e_EXPIRED_VALUE) {
-        name = EXPIRED_NAME;
-    }
-    else {
-        name = UNKNOWN_NAME;
-    }
-
-    char idBuf[64];
-    if (name.isEmpty()) {
-        // Must be Id
-        sprintf(idBuf, "%lld", context.id());
-        name = idBuf;
-    }
-
     bdlma::LocalSequentialAllocator<128> seqAlloc;
 
     bsl::string storage(&seqAlloc);
+    storage.reserve(2 * level + 32 + 2);
 
+    // 1. Indentation
     storage.assign(2 * level, ' ');
+
+    // 2. Open quote (optional)
     if (context.isDeleted()) {
-        storage.append(1, '(');
+        storage += '(';
     }
-    storage.append(name.begin(), name.end());
+
+    // 3. Context name
+    switch (type) {
+    case StatContext::e_TOTAL_VALUE: BSLA_FALLTHROUGH;
+    case StatContext::e_ACTIVE_CHILDREN_TOTAL_VALUE: {
+        if (context.hasName()) {
+            storage += context.name();
+        }
+        else {
+            storage += bsl::to_string(context.id());
+        }
+    } break;
+    case StatContext::e_DIRECT_VALUE: {
+        storage += DIRECT_NAME;
+    } break;
+    case StatContext::e_EXPIRED_VALUE: {
+        storage += EXPIRED_NAME;
+    } break;
+    default: {
+        storage += UNKNOWN_NAME;
+    } break;
+    }
+
+    // 4. Close quote (optional)
     if (context.isDeleted()) {
-        storage.append(1, ')');
+        storage += ')';
     }
 
     value->set(storage);

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -3377,6 +3377,10 @@ void Cluster::getPartitionPrimaryNode(int*                  rc,
     BSLS_ASSERT_SAFE(isSelfPrimary);
     BSLS_ASSERT_SAFE(inDispatcherThread());
 
+    // Reset if uninitialized
+    *node          = NULL;
+    *isSelfPrimary = false;
+
     enum RcEnum {
         rc_SUCCESS = 0,
         rc_ERROR   = -1,

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
@@ -213,6 +213,12 @@ int ClusterStateLedgerUtil::extractLogId(mqbu::StorageKey*  logId,
     int                    rc      = ClusterStateLedgerUtilRc::e_UNKNOWN;
     do {
         rc = ::read(fd, reinterpret_cast<char*>(&header) + numRead, length);
+        if (rc == 0) {
+            BALL_LOG_ERROR << "'read()' reached EOF before reading the "
+                           << "expected number of bytes for file [path: "
+                           << logPath << ", remaining: " << length << "]";
+            return ClusterStateLedgerUtilRc::e_BYTE_READ_FAILURE;  // RETURN
+        }
         if (rc < 0) {
             BALL_LOG_ERROR << "'read()' failure for file [path: " << logPath
                            << ", errno: " << errno << " ("

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3901,18 +3901,6 @@ int StorageManager::start(bsl::ostream& errorDescription)
         return rc * 10 + rc_NOT_ENOUGH_DISK_SPACE;  // RETURN
     }
 
-    // Schedule a periodic event (every minute) which monitors storage
-    // (disk space, archive clean up, etc).
-    d_clusterData_p->scheduler().scheduleRecurringEvent(
-        &d_storageMonitorEventHandle,
-        bsls::TimeInterval(bdlt::TimeUnitRatio::k_SECONDS_PER_MINUTE),
-        bdlf::BindUtil::bind(&StorageUtil::storageMonitorCb,
-                             &d_lowDiskspaceWarning,
-                             &d_isStarted,
-                             d_minimumRequiredDiskSpace,
-                             d_clusterData_p->identity().description(),
-                             d_clusterConfig.partitionConfig()));
-
     rc = StorageUtil::assignPartitionDispatcherThreads(
         &d_miscWorkThreadPool,
         d_clusterData_p,
@@ -3982,6 +3970,18 @@ int StorageManager::start(bsl::ostream& errorDescription)
                                          this,
                                          static_cast<int>(i)));  // partitionId
     }
+
+    // Schedule a periodic event (every minute) which monitors storage
+    // (disk space, archive clean up, etc).
+    d_clusterData_p->scheduler().scheduleRecurringEvent(
+        &d_storageMonitorEventHandle,
+        bsls::TimeInterval(bdlt::TimeUnitRatio::k_SECONDS_PER_MINUTE),
+        bdlf::BindUtil::bind(&StorageUtil::storageMonitorCb,
+                             &d_lowDiskspaceWarning,
+                             &d_isStarted,
+                             d_minimumRequiredDiskSpace,
+                             d_clusterData_p->identity().description(),
+                             d_clusterConfig.partitionConfig()));
 
     d_isStarted = true;
     return rc_SUCCESS;

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1261,7 +1261,7 @@ bool StorageUtil::validatePartitionSyncEvent(
                 << clusterData.identity().description()
                 << ": Received partition-sync event from node with "
                 << source->nodeDescription()
-                << " with different partitionIds: " << partitionId << "vs "
+                << " with different partitionIds: " << partitionId << " vs "
                 << header.partitionId() << ". Ignoring this entire event."
                 << BMQTSK_ALARMLOG_END;
             return false;  // RETURN

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -794,6 +794,13 @@ int StatController::start(bsl::ostream& errorDescription)
         for (; factoryIt != pluginFactories.cend(); ++factoryIt) {
             mqbplug::StatConsumerPluginFactory* factory =
                 dynamic_cast<mqbplug::StatConsumerPluginFactory*>(*factoryIt);
+            if (!factory) {
+                BMQTSK_ALARMLOG_ALARM("#STATS")
+                    << "Not a StatConsumerPluginFactory [" << (*factoryIt)
+                    << "]" << BMQTSK_ALARMLOG_END;
+                continue;  // CONTINUE
+            }
+
             StatConsumerMp consumer = factory->create(ctxPtrMap,
                                                       d_commandProcessorFn,
                                                       d_bufferFactory_p,


### PR DESCRIPTION
1. **Prevent freeze on truncated CSL file.**                                                         
                                                                                                   
  The existing checks for read return code miss the case with `EOF == 0` value. If CSL file is       
  truncated (leading to `EOF` return codes on read), the read loop will block forever.               
                                                                                                   
  2. **mqbstat::StatController: verify dynamic_cast**                                                  
                                                                                                   
  `mqbstat::StatController` doesn't verify the result of `dynamic_cast` before using it, a bug in      
  plugin implementation might lead to UB or crash.
                                                                                                   
  3. **bmqst_tableschema: get rid of unbounded sprintf**

  Remove the only usage of unbounded `sprintf` in non-test code. Refactor `defaultIdColumn` to build   
  string directly. Reserve string capacity before building. Get rid of slow assign for single
  characters append. Remove intermediate name and buffer.                                          
                  
  4. **mqba::Cluster: reset isSelfPrimary if self is not primary**

  `isSelfPrimary` might be uninitialized when primary is another node, causing command execution on  
  replica node (if value == true).
                                                                                                   
  5. **bmqp_compression: use size_t type for uint expression before allocate**                         
   
  The uint expression in `ZLib::zAllocate` might overflow on just 4GiB. Casting to `size_t` makes this 
  scenario impossible in practice.
                                                                                                   
  6. **mqbc::StorageManager: do not schedule monitor event on failure**                                
   
  It is possible to schedule `StorageUtil::storageMonitorCb` and fail to start `mqbc::StorageManager`. 
  Schedule monitor event only when all other checks passed.