### PR TITLE
Fix[bmqp]: Specialize `getPropertyAsStringOr` for `string_view`

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_messageproperties.h
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.h
@@ -1056,7 +1056,16 @@ inline const bsl::string&
 MessageProperties::getPropertyAsStringOr(bsl::string_view   name,
                                          const bsl::string& value) const
 {
-    return getPropertyOr(name, value);
+    PropertyMapIter it = findProperty(name);
+    if (it == d_properties.end()) {
+        return value;
+    }
+
+    const PropertyVariant& v = getPropertyValueAsString(it->second);
+
+    BSLS_ASSERT(v.is<bsl::string>() && "Property data type mismatch");
+
+    return v.the<bsl::string>();
 }
 
 inline const bsl::vector<char>&

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
@@ -905,6 +905,46 @@ static void test5_streamInTest()
     BMQTST_ASSERT_EQ((p.totalSize() + padding), wireRep.length());
 
     verify(&pmap, p);
+
+    // Verify that string accessors work after 'streamIn' with contiguous blob
+    // data.  A large buffer forces 'streamInPropertyValue' to store strings as
+    // 'bsl::string_view'; the accessors must convert before returning.
+    {
+        PV("Testing 'getPropertyAsString' after 'streamIn' (contiguous)");
+
+        bdlbb::PooledBlobBufferFactory bigFactory(
+            4096,
+            bmqtst::TestHelperUtil::allocator());
+        bmqp::MessageProperties src(bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(0, src.setPropertyAsString("tableName", "mytable"));
+
+        const bdlbb::Blob& wire = src.streamOut(&bigFactory, logic);
+
+        bmqp::MessageProperties dst(bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(0, dst.streamIn(wire, logic.isExtended()));
+
+        BMQTST_ASSERT_EQ(dst.getPropertyAsString("tableName"), "mytable");
+    }
+
+    {
+        PV("Testing 'getPropertyAsStringOr' after 'streamIn' (contiguous)");
+
+        bdlbb::PooledBlobBufferFactory bigFactory(
+            4096,
+            bmqtst::TestHelperUtil::allocator());
+        bmqp::MessageProperties src(bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(0, src.setPropertyAsString("tableName", "mytable"));
+
+        const bdlbb::Blob& wire = src.streamOut(&bigFactory, logic);
+
+        bmqp::MessageProperties dst(bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(0, dst.streamIn(wire, logic.isExtended()));
+
+        BMQTST_ASSERT_EQ(dst.getPropertyAsStringOr("tableName", ""),
+                         "mytable");
+        BMQTST_ASSERT_EQ(dst.getPropertyAsStringOr("noSuchProp", "fallback"),
+                         "fallback");
+    }
 }
 
 static void test6_streamOutTest()


### PR DESCRIPTION
Commit 87ddacbe40 introduced a performance optimization for message properties where string properties may be deserialized as `bsl::string_view` rather than `bsl::string` when the property data is contiguous in memory.  However, this commit only modified `getPropertyAsString()` to use the new helper to convert `string_view` back to `string` when checking the property’s data type.  It did not modify the sister function `getPropertyAsStringOr()`.

This patch performs the same change to `getPropertyAsStringOr()` as we made in `getPropertyAsString()`.  The function bodies now mirror each other.  In addition, we add test cases that can reproduce such a failure in both functions without the fix.’