### PR TITLE
CI: Upload ruff patch on formatting failure

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -130,11 +130,27 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
       - name: ruff style check
+        id: format-check
         run: |
           pip3 install ruff
           ruff format .
-          git diff -q | tee format_diff.txt
-          if [ -s format_diff.txt ]; then exit 1; fi
+          git diff | tee ruff_format.patch
+          if [ -s ruff_format.patch ]; then
+            echo ""
+            echo "ruff format check failed.  A patch file with the required"
+            echo "formatting fixes has been uploaded as a build artifact."
+            echo "Download 'ruff-format-patch' from this workflow run and apply it with:"
+            echo ""
+            echo "  git apply ruff_format.patch"
+            echo ""
+            exit 1
+          fi
+      - name: Upload formatting patch
+        if: failure() && steps.format-check.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ruff-format-patch
+          path: ruff_format.patch
 
   python_linter_check:
     name: Python Linter Check


### PR DESCRIPTION
This patch updates our CI to upload a clang-format patch as a build artifact when the Python formatting lint check with ruff fails. This prevents contributors from manually copying and pasting the patch, which could introduce errors, or from needing exactly the same version of ruff installed locally that we use in CI.

We follow the same form as commit f23b41a.