### PR TITLE
Fix[fsm]: REAPPLY_SELF should not clear primary

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -319,6 +319,8 @@ class PartitionStateTableActions {
     virtual void do_cleanupMetadata(const ARGS& args) = 0;
 
     virtual void do_cancelRequests(const ARGS& args) = 0;
+    
+    virtual void do_clearPrimary(const ARGS& args) = 0;
 
     virtual void do_setExpectedDataChunkRange(const ARGS& args) = 0;
 
@@ -360,7 +362,14 @@ class PartitionStateTableActions {
         const ARGS& args);
 
     void
+    do_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
+        const ARGS& args);
+
+    void
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
+        const ARGS& args);
+
+    void do_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
         const ARGS& args);
 
     void
@@ -373,11 +382,17 @@ class PartitionStateTableActions {
     void
     do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog(const ARGS& args);
 
-    void do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
+    void do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog(
+        const ARGS& args);
+
+    void
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
         const ARGS& args);
 
     void
     do_cleanupMetadata_closeRecoveryFileSet_reapplyEvent(const ARGS& args);
+
+    void do_cleanupMetadata_clearPrimary_reapplyEvent(const ARGS& args);
 
     void do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests(
         const ARGS& args);
@@ -491,7 +506,7 @@ class PartitionStateTable
         PST_CFG(
             UNKNOWN,
             REAPPLY_SELF_PRIMARY,
-            setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq,
+            startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq,
             PRIMARY_HEALING_STG1);
         PST_CFG(
             UNKNOWN,
@@ -501,7 +516,7 @@ class PartitionStateTable
         PST_CFG(
             UNKNOWN,
             REAPPLY_SELF_REPLICA,
-            setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest,
+            startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest,
             REPLICA_WAITING);
         PST_CFG(UNKNOWN,
                 PRIMARY_STATE_RQST,
@@ -550,7 +565,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG1,
             STOP_NODE,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(
             PRIMARY_HEALING_STG1,
@@ -614,7 +629,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG2,
             RST_UNKNOWN,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(PRIMARY_HEALING_STG2,
                 WATCHDOG,
@@ -623,17 +638,17 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG2,
             STOP_NODE,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(
             REPLICA_WAITING,
             DETECT_SELF_PRIMARY,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
             UNKNOWN);
         PST_CFG(
             REPLICA_WAITING,
             DETECT_SELF_REPLICA,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
             UNKNOWN);
         PST_CFG(
             REPLICA_WAITING,
@@ -673,12 +688,12 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_HEALING,
             DETECT_SELF_PRIMARY,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
             UNKNOWN);
         PST_CFG(
             REPLICA_HEALING,
             DETECT_SELF_REPLICA,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent,
             UNKNOWN);
         PST_CFG(
             REPLICA_HEALING,
@@ -740,7 +755,7 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_HEALING,
             RST_UNKNOWN,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(REPLICA_HEALING,
                 WATCHDOG,
@@ -749,15 +764,15 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_HEALING,
             STOP_NODE,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(REPLICA_HEALED,
                 DETECT_SELF_PRIMARY,
-                cleanupMetadata_reapplyEvent,
+                cleanupMetadata_clearPrimary_reapplyEvent,
                 UNKNOWN);
         PST_CFG(REPLICA_HEALED,
                 DETECT_SELF_REPLICA,
-                cleanupMetadata_reapplyEvent,
+                cleanupMetadata_clearPrimary_reapplyEvent,
                 UNKNOWN);
         PST_CFG(REPLICA_HEALED,
                 REAPPLY_SELF_REPLICA,
@@ -874,6 +889,18 @@ void PartitionStateTableActions<ARGS>::
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::
+    do_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
+        const ARGS& args)
+{
+    do_startWatchdog(args);
+    do_openRecoveryFileSet(args);
+    do_storeSelfSeq(args);
+    do_replicaStateRequest(args);
+    do_checkQuorumSeq(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
         const ARGS& args)
 {
@@ -891,6 +918,17 @@ void PartitionStateTableActions<ARGS>::
         const ARGS& args)
 {
     do_setPrimary(args);
+    do_startWatchdog(args);
+    do_openRecoveryFileSet(args);
+    do_storeSelfSeq(args);
+    do_primaryStateRequest(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
+    do_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
+        const ARGS& args)
+{
     do_startWatchdog(args);
     do_openRecoveryFileSet(args);
     do_storeSelfSeq(args);
@@ -933,10 +971,22 @@ void PartitionStateTableActions<ARGS>::
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog(
         const ARGS& args)
 {
     do_cleanupMetadata(args);
+    do_clearPrimary(args);
+    do_closeRecoveryFileSet(args);
+    do_stopWatchdog(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
+        const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_clearPrimary(args);
     do_closeRecoveryFileSet(args);
     do_stopWatchdog(args);
     do_reapplyEvent(args);
@@ -972,6 +1022,15 @@ void PartitionStateTableActions<ARGS>::do_cleanupMetadata_reapplyEvent(
     const ARGS& args)
 {
     do_cleanupMetadata(args);
+    do_reapplyEvent(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<
+    ARGS>::do_cleanupMetadata_clearPrimary_reapplyEvent(const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_clearPrimary(args);
     do_reapplyEvent(args);
 }
 

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -380,9 +380,6 @@ class PartitionStateTableActions {
     void do_storePrimarySeq_replicaStateResponse(const ARGS& args);
 
     void
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog(const ARGS& args);
-
-    void
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
         const ARGS& args);
 
@@ -390,19 +387,9 @@ class PartitionStateTableActions {
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
         const ARGS& args);
 
-    void
-    do_cleanupMetadata_closeRecoveryFileSet_reapplyEvent(const ARGS& args);
-
     void do_cleanupMetadata_clearPrimary_reapplyEvent(const ARGS& args);
 
-    void do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests(
-        const ARGS& args);
-
     void do_cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent(
-        const ARGS& args);
-
-    void
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
         const ARGS& args);
 
     void do_cleanupMetadata_reapplyEvent(const ARGS& args);
@@ -434,9 +421,6 @@ class PartitionStateTableActions {
     void do_stopWatchdog_transitionToActivePrimary(const ARGS& args);
 
     void do_replicaStateResponse_storePrimarySeq(const ARGS& args);
-
-    void
-    do_resetReceiveDataCtx_closeRecoveryFileSet_stopWatchdog(const ARGS& args);
 
     void
     do_replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
@@ -977,15 +961,6 @@ void PartitionStateTableActions<ARGS>::do_storePrimarySeq_replicaStateResponse(
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog(const ARGS& args)
-{
-    do_cleanupMetadata(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
-}
-
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
         const ARGS& args)
 {
@@ -1009,28 +984,8 @@ void PartitionStateTableActions<ARGS>::
     do_reapplyEvent(args);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_closeRecoveryFileSet_reapplyEvent(const ARGS& args)
-{
-    do_cleanupMetadata(args);
-    do_closeRecoveryFileSet(args);
-    do_reapplyEvent(args);
-}
-
 PST_COMPOSITE_4(cleanupMetadata,
                 closeRecoveryFileSet,
-                stopWatchdog,
-                cancelRequests)
-
-PST_COMPOSITE_4(cleanupMetadata,
-                closeRecoveryFileSet,
-                cancelRequests,
-                reapplyEvent)
-
-PST_COMPOSITE_5(cleanupMetadata,
-                closeRecoveryFileSet,
-                stopWatchdog,
                 cancelRequests,
                 reapplyEvent)
 
@@ -1145,15 +1100,6 @@ void PartitionStateTableActions<ARGS>::do_replicaStateResponse_storePrimarySeq(
 {
     do_replicaStateResponse(args);
     do_storePrimarySeq(args);
-}
-
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_resetReceiveDataCtx_closeRecoveryFileSet_stopWatchdog(const ARGS& args)
-{
-    do_resetReceiveDataCtx(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
 }
 
 template <typename ARGS>

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -319,7 +319,7 @@ class PartitionStateTableActions {
     virtual void do_cleanupMetadata(const ARGS& args) = 0;
 
     virtual void do_cancelRequests(const ARGS& args) = 0;
-    
+
     virtual void do_clearPrimary(const ARGS& args) = 0;
 
     virtual void do_setExpectedDataChunkRange(const ARGS& args) = 0;
@@ -382,11 +382,12 @@ class PartitionStateTableActions {
     void
     do_cleanupMetadata_closeRecoveryFileSet_stopWatchdog(const ARGS& args);
 
-    void do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog(
+    void
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
         const ARGS& args);
 
     void
-    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
         const ARGS& args);
 
     void
@@ -405,6 +406,8 @@ class PartitionStateTableActions {
         const ARGS& args);
 
     void do_cleanupMetadata_reapplyEvent(const ARGS& args);
+
+    void do_cleanupMetadata_clearPrimary(const ARGS& args);
 
     void do_resetReceiveDataCtx_flagFailedReplicaSeq_checkQuorumSeq(
         const ARGS& args);
@@ -560,12 +563,12 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG1,
             RST_UNKNOWN,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(
             PRIMARY_HEALING_STG1,
             STOP_NODE,
-                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(
             PRIMARY_HEALING_STG1,
@@ -629,7 +632,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG2,
             RST_UNKNOWN,
-                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(PRIMARY_HEALING_STG2,
                 WATCHDOG,
@@ -638,7 +641,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG2,
             STOP_NODE,
-                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(
             REPLICA_WAITING,
@@ -674,7 +677,7 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_WAITING,
             RST_UNKNOWN,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(REPLICA_WAITING,
                 WATCHDOG,
@@ -683,7 +686,7 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_WAITING,
             STOP_NODE,
-            cleanupMetadata_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(
             REPLICA_HEALING,
@@ -755,7 +758,7 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_HEALING,
             RST_UNKNOWN,
-                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             UNKNOWN);
         PST_CFG(REPLICA_HEALING,
                 WATCHDOG,
@@ -764,7 +767,7 @@ class PartitionStateTable
         PST_CFG(
             REPLICA_HEALING,
             STOP_NODE,
-                cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
+            cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests,
             STOPPED);
         PST_CFG(REPLICA_HEALED,
                 DETECT_SELF_PRIMARY,
@@ -795,8 +798,14 @@ class PartitionStateTable
                 ISSUE_LIVESTREAM,
                 reapplyDetectSelfReplica,
                 REPLICA_HEALED);
-        PST_CFG(REPLICA_HEALED, RST_UNKNOWN, cleanupMetadata, UNKNOWN);
-        PST_CFG(REPLICA_HEALED, STOP_NODE, cleanupMetadata, STOPPED);
+        PST_CFG(REPLICA_HEALED,
+                RST_UNKNOWN,
+                cleanupMetadata_clearPrimary,
+                UNKNOWN);
+        PST_CFG(REPLICA_HEALED,
+                STOP_NODE,
+                cleanupMetadata_clearPrimary,
+                STOPPED);
         PST_CFG(PRIMARY_HEALED,
                 DETECT_SELF_REPLICA,
                 unsupportedPrimaryDowngrade,
@@ -814,8 +823,14 @@ class PartitionStateTable
             PRIMARY_STATE_RQST,
             storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas,
             PRIMARY_HEALED);
-        PST_CFG(PRIMARY_HEALED, RST_UNKNOWN, cleanupMetadata, UNKNOWN);
-        PST_CFG(PRIMARY_HEALED, STOP_NODE, cleanupMetadata, STOPPED);
+        PST_CFG(PRIMARY_HEALED,
+                RST_UNKNOWN,
+                cleanupMetadata_clearPrimary,
+                UNKNOWN);
+        PST_CFG(PRIMARY_HEALED,
+                STOP_NODE,
+                cleanupMetadata_clearPrimary,
+                STOPPED);
 
 #undef PST_CFG
     }
@@ -971,24 +986,26 @@ void PartitionStateTableActions<ARGS>::
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog(
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
         const ARGS& args)
 {
     do_cleanupMetadata(args);
     do_clearPrimary(args);
     do_closeRecoveryFileSet(args);
     do_stopWatchdog(args);
+    do_cancelRequests(args);
 }
 
 template <typename ARGS>
 void PartitionStateTableActions<ARGS>::
-    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_reapplyEvent(
+    do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
         const ARGS& args)
 {
     do_cleanupMetadata(args);
     do_clearPrimary(args);
     do_closeRecoveryFileSet(args);
     do_stopWatchdog(args);
+    do_cancelRequests(args);
     do_reapplyEvent(args);
 }
 
@@ -1023,6 +1040,14 @@ void PartitionStateTableActions<ARGS>::do_cleanupMetadata_reapplyEvent(
 {
     do_cleanupMetadata(args);
     do_reapplyEvent(args);
+}
+
+template <typename ARGS>
+void PartitionStateTableActions<ARGS>::do_cleanupMetadata_clearPrimary(
+    const ARGS& args)
+{
+    do_cleanupMetadata(args);
+    do_clearPrimary(args);
 }
 
 template <typename ARGS>

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3014,15 +3014,32 @@ void StorageManager::do_cleanupMetadata(const EventWithData& event)
                      d_partitionFSMVec[partitionId]->state() ==
                          PartitionFSM::State::e_STOPPED);
 
+    d_nodeToPSNCtxMapVec[partitionId].clear();
+    d_numReplicaDataResponsesReceivedVec[partitionId] = 0;
+    d_recoveryManager_mp->resetReceiveDataCtx(partitionId);
+}
+
+void StorageManager::do_clearPrimary(const EventWithData& event)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with the
+    // paritionId contained in 'event'
+
+    const EventData& eventDataVec = event.second;
+    BSLS_ASSERT_SAFE(eventDataVec.size() == 1);
+
+    const PartitionFSMEventData& eventData   = eventDataVec[0];
+    const int                    partitionId = eventData.partitionId();
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(0 <= partitionId &&
+                     partitionId < static_cast<int>(d_fileStores.size()));
+    BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
+
     StorageUtil::clearPrimaryForPartition(
         d_fileStores[partitionId].get(),
         &d_partitionInfoVec[partitionId],
         d_clusterData_p->identity().description(),
         partitionId);
-
-    d_nodeToPSNCtxMapVec[partitionId].clear();
-    d_numReplicaDataResponsesReceivedVec[partitionId] = 0;
-    d_recoveryManager_mp->resetReceiveDataCtx(partitionId);
 }
 
 void StorageManager::do_cancelRequests(const EventWithData& event)

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -697,6 +697,8 @@ class StorageManager BSLS_KEYWORD_FINAL
     void do_cleanupMetadata(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
 
     void do_cancelRequests(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+    
+    void do_clearPrimary(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
 
     void do_setExpectedDataChunkRange(const EventWithData& event)
         BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -697,7 +697,7 @@ class StorageManager BSLS_KEYWORD_FINAL
     void do_cleanupMetadata(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
 
     void do_cancelRequests(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-    
+
     void do_clearPrimary(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
 
     void do_setExpectedDataChunkRange(const EventWithData& event)


### PR DESCRIPTION
`REAPPLY_SELF_REPLICA` should not clear primary status, because t may never receive new primary status advisory and never reach recovered state. 