### PR TITLE
Refactor: rename `mqbstat::Printer` -> `mqbstat::TablePrinter`

### DIFF
--- a/src/groups/mqb/mqbstat/doc/mqbstat.txt
+++ b/src/groups/mqb/mqbstat/doc/mqbstat.txt
@@ -15,7 +15,7 @@
   3. mqbstat_statcontroller
 
   2. mqbstat_jsonprinter
-     mqbstat_printer
+     mqbstat_tableprinter
      mqbstat_statmonitorsnapshotrecorder
 
   1. mqbstat_brokerstats
@@ -44,9 +44,6 @@
 : 'mqbstat_jsonprinter'
 :       Provide a mechanism to print statistics as a JSON.
 :
-: 'mqbstat_printer'
-:       Provide a mechanism to print statistics to streams.
-:
 : 'mqbstat_queuestats'
 :       Provide mechanism to keep track of Queue statistics.
 :
@@ -58,3 +55,6 @@
 :
 : 'mqbstat_statmonitorsnapshotrecorder'
 :       Provide a mechanism to record snapshot of time, cpu, and ctx switch.
+:
+: 'mqbstat_tableprinter'
+:       Provide a mechanism to print statistics to streams.

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -149,7 +149,7 @@ void StatController::initializeStats()
                                true)));
         d_allocatorsStatContext_p->snapshot();
         // Call snaphost to create the 'subContext', so that the
-        // 'mqbstat::Printer::start' can access it.
+        // 'mqbstat::TablePrinter::start' can access it.
     }
 
     // --------
@@ -267,7 +267,7 @@ void StatController::captureStatsAndSemaphorePost(
     switch (encoding) {
     case mqbcmd::EncodingFormat::TEXT: {
         bmqu::MemOutStream os;
-        d_printer_mp->printStats(os);
+        d_tablePrinter_mp->printStats(os);
         result->makeStats() = os.str();
     } break;  // BREAK
 
@@ -561,13 +561,13 @@ bool StatController::snapshot()
     // through snapshot
     d_systemStatMonitor_mp->snapshot();
 
-    // Printer needs to be notified of every snapshot, but has an internal
+    // TablePrinter needs to be notified of every snapshot, but has an internal
     // action counter to know when it's time to print.  Allocator stat context
     // only has a history size of 2, so we need to snapshot only once, just
     // before printing.
     // TODO: adopt this code for `mqbstat::JsonPrinter` when we report
     //       allocator stats in json
-    const bool willPrint = d_printer_mp->nextSnapshotWillPrint();
+    const bool willPrint = d_tablePrinter_mp->nextSnapshotWillPrint();
     if (d_allocatorsStatContext_p && willPrint) {
         d_allocatorsStatContext_p->snapshot();
     }
@@ -595,15 +595,16 @@ void StatController::snapshotAndNotify()
         }
     }
 
-    const bool willPrint = d_printer_mp->nextSnapshotWillPrint();
-    d_printer_mp->onSnapshot();
+    const bool willPrint = d_tablePrinter_mp->nextSnapshotWillPrint();
+    d_tablePrinter_mp->onSnapshot();
 
     // Finally, perform cleanup of expired stat contexts if we have printed
     // them.
-    // TBD: Currently the code relies on the fact that 'printer' is the one
+    // TBD: Currently the code relies on the fact that 'tablePrinter' is the
+    // one
     //      with the largest 'actionInterval', but normally cleanup should be
     //      done after the less frequent consumer has performed its action.
-    if (!d_printer_mp->isEnabled() || willPrint) {
+    if (!d_tablePrinter_mp->isEnabled() || willPrint) {
         // Cleanup deleted subcontexts now that we printed them, or don't care
         for (StatContextDetailsMap::iterator mit = d_statContextsMap.begin();
              mit != d_statContextsMap.end();
@@ -684,7 +685,7 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
 , d_pluginManager_p(pluginManager)
 , d_bufferFactory_p(bufferFactory)
 , d_commandProcessorFn(bsl::allocator_arg, allocator, commandProcessor)
-, d_printer_mp(0)
+, d_tablePrinter_mp(0)
 , d_jsonPrinter_mp(0)
 , d_statConsumers(allocator)
 , d_statConsumerMaxPublishInterval(0)
@@ -837,20 +838,21 @@ int StatController::start(bsl::ostream& errorDescription)
         }
     }
 
-    // Start the printer
-    d_printer_mp.load(new (*d_allocator_p) Printer(brkrCfg.stats(),
-                                                   d_eventScheduler_p,
-                                                   ctxPtrMap,
-                                                   d_allocator_p),
-                      d_allocator_p);
+    // Start the table printer
+    d_tablePrinter_mp.load(new (*d_allocator_p)
+                               TablePrinter(brkrCfg.stats(),
+                                            d_eventScheduler_p,
+                                            ctxPtrMap,
+                                            d_allocator_p),
+                           d_allocator_p);
 
-    // Give the printer a map of statContext ptrs for its printing. It has been
-    // done this way to break the cyclic dependency of ctxPtrMap,
-    // initializeStats() and creation of d_printer.
-    rc = d_printer_mp->start(errorStream);
+    // Give the table printer a map of statContext ptrs for its printing.  It
+    // has been done this way to break the cyclic dependency of ctxPtrMap,
+    // initializeStats() and creation of d_tablePrinter.
+    rc = d_tablePrinter_mp->start(errorStream);
     if (rc != 0) {
         BMQTSK_ALARMLOG_ALARM("#STATS")
-            << "Failed to start Printer [rc: " << rc << ", error: '"
+            << "Failed to start TablePrinter [rc: " << rc << ", error: '"
             << errorStream.str() << "']" << BMQTSK_ALARMLOG_END;
         rc = 0;
         errorStream.reset();
@@ -903,14 +905,14 @@ void StatController::stop()
         STOP_OBJ((*it), it->name());
     }
 
-    STOP_OBJ(d_printer_mp, "Printer");
+    STOP_OBJ(d_tablePrinter_mp, "TablePrinter");
     STOP_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");
 
     // Destroy everything!!
     for (it = d_statConsumers.begin(); it != d_statConsumers.end(); ++it) {
         DESTROY_OBJ((*it), it->name());
     }
-    DESTROY_OBJ(d_printer_mp, "Printer");
+    DESTROY_OBJ(d_tablePrinter_mp, "TablePrinter");
     DESTROY_OBJ(d_jsonPrinter_mp, "JsonPrinter");
     DESTROY_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");
     DESTROY_OBJ(d_scheduler_mp, "Scheduler");

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -29,8 +29,8 @@
 // MQB
 #include <mqbcmd_messages.h>
 #include <mqbstat_jsonprinter.h>
-#include <mqbstat_printer.h>
 #include <mqbstat_statmonitor.h>
+#include <mqbstat_tableprinter.h>
 
 #include <bmqma_countingallocatorstore.h>
 #include <bmqst_statcontext.h>
@@ -126,7 +126,7 @@ class StatController {
     typedef bslma::ManagedPtr<bmqst::StatContext>         StatContextMp;
     typedef bsl::shared_ptr<bmqst::StatContext>           StatContextSp;
     typedef bslma::ManagedPtr<mqbstat::StatMonitor>       SystemStatMonitorMp;
-    typedef bslma::ManagedPtr<Printer>                    PrinterMp;
+    typedef bslma::ManagedPtr<TablePrinter>               TablePrinterMp;
     typedef bslma::ManagedPtr<JsonPrinter>                JsonPrinterMp;
     typedef bslma::ManagedPtr<mqbplug::StatPublisher>     StatPublisherMp;
     typedef bslma::ManagedPtr<mqbplug::StatConsumer>      StatConsumerMp;
@@ -205,7 +205,7 @@ class StatController {
     CommandProcessorFn d_commandProcessorFn;
 
     /// Console and log file stats printer
-    PrinterMp d_printer_mp;
+    TablePrinterMp d_tablePrinter_mp;
 
     /// JsonPrinter used for admin commands processing
     JsonPrinterMp d_jsonPrinter_mp;

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mqbstat_printer.h>
+#include <mqbstat_tableprinter.h>
 
 #include <mqbscm_version.h>
 // MQB
@@ -23,24 +23,19 @@
 #include <bmqma_countingallocator.h>
 #include <bmqst_statvalue.h>
 #include <bmqst_tableutil.h>
-#include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
 
 // BDE
 #include <ball_context.h>
 #include <ball_log.h>
 #include <ball_logfilecleanerutil.h>
-#include <ball_loggermanager.h>
-#include <ball_multiplexobserver.h>
 #include <ball_recordattributes.h>
 #include <ball_recordstringformatter.h>
 #include <ball_transmission.h>
 #include <bdls_processutil.h>
 #include <bdlt_datetime.h>
 #include <bdlt_epochutil.h>
-#include <bsl_algorithm.h>
 #include <bsl_ctime.h>
-#include <bsl_iostream.h>
 #include <bsl_utility.h>
 #include <bslma_allocator.h>
 #include <bslmt_threadutil.h>
@@ -54,18 +49,18 @@ namespace mqbstat {
 
 namespace {
 
-const char k_LOG_CATEGORY[] = "MQBSTAT.PRINTER";
+const char k_LOG_CATEGORY[] = "MQBSTAT.TABLEPRINTER";
 
 // Subcontext names
 const char k_SUBCONTEXT_ALLOCATORS[] = "allocators";
 
 }  // close unnamed namespace
 
-// -------------
-// class Printer
-// -------------
+// ------------------
+// class TablePrinter
+// ------------------
 
-void Printer::initializeTablesAndTips()
+void TablePrinter::initializeTablesAndTips()
 {
     const int historySize = d_config.printer().printInterval() /
                                 d_config.snapshotInterval() +
@@ -112,10 +107,10 @@ void Printer::initializeTablesAndTips()
         end);
 }
 
-Printer::Printer(const mqbcfg::StatsConfig& config,
-                 bdlmt::EventScheduler*     eventScheduler,
-                 const StatContextsMap&     statContextsMap,
-                 bslma::Allocator*          allocator)
+TablePrinter::TablePrinter(const mqbcfg::StatsConfig& config,
+                           bdlmt::EventScheduler*     eventScheduler,
+                           const StatContextsMap&     statContextsMap,
+                           bslma::Allocator*          allocator)
 : d_config(config)
 , d_statsLogFile(allocator)
 , d_lastStatId(0)
@@ -143,7 +138,7 @@ Printer::Printer(const mqbcfg::StatsConfig& config,
     }
 }
 
-int Printer::start(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription)
+int TablePrinter::start(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription)
 {
     // Setup the print of stats if configured for it
     if (!isEnabled()) {
@@ -191,7 +186,7 @@ int Printer::start(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription)
     return 0;
 }
 
-void Printer::stop()
+void TablePrinter::stop()
 {
     // Dump the final stats (to ensure all events have been accounted for, even
     // if they happen within less than the print interval).  Note that since
@@ -210,7 +205,7 @@ void Printer::stop()
     d_statLogCleaner.stop();
 }
 
-void Printer::printStats(bsl::ostream& stream)
+void TablePrinter::printStats(bsl::ostream& stream)
 {
     // This must execute in the 'snapshot' thread
 
@@ -266,7 +261,7 @@ void Printer::printStats(bsl::ostream& stream)
     bmqst::TableUtil::printTable(stream, context->d_tip);
 }
 
-void Printer::logStats()
+void TablePrinter::logStats()
 {
     ++d_lastStatId;
 
@@ -298,7 +293,7 @@ void Printer::logStats()
         ball::Context(ball::Transmission::e_MANUAL_PUBLISH, 0, 1));
 }
 
-void Printer::onSnapshot()
+void TablePrinter::onSnapshot()
 {
     // Check if we need to print the stats to log
     if (!isEnabled() || --d_actionCounter != 0) {

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
@@ -1,4 +1,4 @@
-// Copyright 2017-2023 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,16 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef INCLUDED_MQBSTAT_PRINTER
-#define INCLUDED_MQBSTAT_PRINTER
+#ifndef INCLUDED_MQBSTAT_TABLEPRINTER
+#define INCLUDED_MQBSTAT_TABLEPRINTER
 
 //@PURPOSE: Provide a mechanism to print statistics to streams
 //
 //@CLASSES:
-//  mqbstat::Printer: bmqbrkr statistics printer
+//  mqbstat::TablePrinter: bmqbrkr statistics printer
 //
-//@DESCRIPTION: 'mqbstat::Printer' handles the printing of all the statistics.
-// It holds the tables and table info providers which can be printed.
+//@DESCRIPTION: 'mqbstat::TablePrinter' handles the printing of all the
+// statistics.  It holds the tables and table info providers which can be
+// printed.
 
 // MQB
 #include <mqbcfg_messages.h>
@@ -40,28 +41,30 @@
 #include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
-#include <bsl_vector.h>
 #include <bslma_allocator.h>
-#include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
-#include <bsls_cpp11.h>
+#include <bsls_keyword.h>
 #include <bsls_types.h>
 
 namespace BloombergLP {
 
 namespace mqbstat {
 
-// =============
-// class Printer
-// =============
+// ==================
+// class TablePrinter
+// ==================
 
-class Printer {
+class TablePrinter {
+  public:
+    // PUBLIC TYPES
+    typedef bsl::unordered_map<bsl::string, bmqst::StatContext*>
+        StatContextsMap;
+
   private:
     // CLASS-SCOPE CATEGORY
-    BALL_LOG_SET_CLASS_CATEGORY("MQBSTAT.PRINTER");
+    BALL_LOG_SET_CLASS_CATEGORY("MQBSTAT.TABLEPRINTER");
 
-  private:
     // PRIVATE TYPES
 
     /// Context including table and tip for printing and statcontext for
@@ -79,10 +82,7 @@ class Printer {
 
     typedef bsl::shared_ptr<Context>                   ContextSp;
     typedef bsl::unordered_map<bsl::string, ContextSp> ContextsMap;
-    typedef bsl::unordered_map<bsl::string, bmqst::StatContext*>
-        StatContextsMap;
 
-  private:
     // DATA
 
     /// Config to use.
@@ -91,18 +91,13 @@ class Printer {
     /// FileObserver for the stats log dump.
     ball::FileObserver2 d_statsLogFile;
 
-    /// Sequence number for stat log
-    /// records, used to synchronize the
-    /// stat log and the normal log.
+    /// Sequence number for stat log records.
     int d_lastStatId;
 
-    /// Counter to know when to periodically
-    /// print the stats to file.
+    /// Counter to know when to periodically print the stats to file.
     int d_actionCounter;
 
-    /// HiRes timer value of the last time
-    /// the Counting Allocators snapshot
-    /// happened on the context.
+    /// HiRes timer value of the last allocator snapshot.
     bsls::Types::Int64 d_lastAllocatorSnapshot;
 
     /// Contexts map
@@ -111,31 +106,32 @@ class Printer {
     /// Mechanism to clean up old stat logs.
     bmqtsk::LogCleaner d_statLogCleaner;
 
-  private:
     // NOT IMPLEMENTED
-    Printer(const Printer& other) BSLS_CPP11_DELETED;
-    Printer& operator=(const Printer& other) BSLS_CPP11_DELETED;
+    TablePrinter(const TablePrinter& other) BSLS_KEYWORD_DELETED;
+    TablePrinter& operator=(const TablePrinter& other) BSLS_KEYWORD_DELETED;
+
+    // PRIVATE MANIPULATORS
 
     /// Initialize table and tips.
     void initializeTablesAndTips();
 
   public:
     // TRAITS
-    BSLMF_NESTED_TRAIT_DECLARATION(Printer, bslma::UsesBslmaAllocator)
+    BSLMF_NESTED_TRAIT_DECLARATION(TablePrinter, bslma::UsesBslmaAllocator)
 
     // CREATORS
 
-    /// Create a new `Printer` object, using the specified `config`,
+    /// Create a new `TablePrinter` object, using the specified `config`,
     /// `eventScheduler`, `statContextsMap` and the specified `allocator`
     /// for memory allocation.
-    explicit Printer(const mqbcfg::StatsConfig& config,
-                     bdlmt::EventScheduler*     eventScheduler,
-                     const StatContextsMap&     statContextsMap,
-                     bslma::Allocator*          allocator);
+    explicit TablePrinter(const mqbcfg::StatsConfig& config,
+                          bdlmt::EventScheduler*     eventScheduler,
+                          const StatContextsMap&     statContextsMap,
+                          bslma::Allocator*          allocator);
 
     // MANIPULATORS
 
-    /// Start the Printer.  Return 0 on success, or a non-zero return
+    /// Start the TablePrinter.  Return 0 on success, or a non-zero return
     /// code on error and fill in the specified `errorDescription` stream
     /// with the description of the error.
     int start(bsl::ostream& errorDescription);
@@ -168,17 +164,17 @@ class Printer {
 //                             INLINE DEFINITIONS
 // ============================================================================
 
-// -------------
-// class Printer
-// -------------
+// ------------------
+// class TablePrinter
+// ------------------
 
-inline bool Printer::isEnabled() const
+inline bool TablePrinter::isEnabled() const
 {
     return (d_config.printer().printInterval() > 0 &&
             d_config.snapshotInterval() > 0);
 }
 
-inline bool Printer::nextSnapshotWillPrint() const
+inline bool TablePrinter::nextSnapshotWillPrint() const
 {
     return d_actionCounter == 1;
 }

--- a/src/groups/mqb/mqbstat/package/mqbstat.mem
+++ b/src/groups/mqb/mqbstat/package/mqbstat.mem
@@ -3,8 +3,8 @@ mqbstat_clusterstats
 mqbstat_dispatcherstats
 mqbstat_domainstats
 mqbstat_jsonprinter
-mqbstat_printer
 mqbstat_queuestats
 mqbstat_statcontroller
 mqbstat_statmonitor
 mqbstat_statmonitorsnapshotrecorder
+mqbstat_tableprinter


### PR DESCRIPTION
- Rename component `mqbstat::Printer` -> `mqbstat::TablePrinter`.
- Remove unused includes.
- Change CPP11 keywords with general ones.
- Make type `StatContextsMap` used in public interface public.

https://github.com/bloomberg/blazingmq/pull/1180