### PR TITLE
Refactor[mqbs]: Deduplicate code via FileStoreUtil::archiveFileSet

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -25,6 +25,7 @@
 #include <mqbs_datafileiterator.h>
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_filestoreprotocolutil.h>
+#include <mqbs_filestoreutil.h>
 #include <mqbs_filesystemutil.h>
 #include <mqbs_journalfileiterator.h>
 #include <mqbs_offsetptr.h>
@@ -122,11 +123,7 @@ void movePartitionFiles(int                      partitionId,
     }
 
     for (unsigned int i = 0; i < fileSets.size(); ++i) {
-        BALL_LOG_INFO << "For Partition [" << partitionId
-                      << "], archiving file set: " << fileSets[i];
-        mqbs::FileSystemUtil::move(fileSets[i].dataFile(), archiveLocation);
-        mqbs::FileSystemUtil::move(fileSets[i].journalFile(), archiveLocation);
-        mqbs::FileSystemUtil::move(fileSets[i].qlistFile(), archiveLocation);
+        mqbs::FileStoreUtil::archiveFileSet(fileSets[i], archiveLocation);
     }
 }
 
@@ -1178,17 +1175,8 @@ void RecoveryManager::onStorageSyncResponseDispatched(
         }
         else {
             for (unsigned int i = 0; i < fileSets.size(); ++i) {
-                BALL_LOG_INFO << d_clusterData_p->identity().description()
-                              << ": For Partition [" << partitionId
-                              << "], archiving file set: " << fileSets[i];
-                mqbs::FileSystemUtil::move(
-                    fileSets[i].dataFile(),
-                    d_dataStoreConfig.archiveLocation());
-                mqbs::FileSystemUtil::move(
-                    fileSets[i].journalFile(),
-                    d_dataStoreConfig.archiveLocation());
-                mqbs::FileSystemUtil::move(
-                    fileSets[i].qlistFile(),
+                mqbs::FileStoreUtil::archiveFileSet(
+                    fileSets[i],
                     d_dataStoreConfig.archiveLocation());
             }
         }

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -155,11 +155,9 @@ int RecoveryManager::deprecateFileSet(int partitionId)
     validatePartitionId(partitionId);
 
     enum rcEnum {
-        rc_SUCCESS              = 0,
-        rc_FD_CLOSE_FAILURE     = -1,
-        rc_JOURNAL_MOVE_FAILURE = -2,
-        rc_DATA_MOVE_FAILURE    = -3,
-        rc_QLIST_MOVE_FAILURE   = -4
+        rc_SUCCESS          = 0,
+        rc_FD_CLOSE_FAILURE = -1,
+        rc_MOVE_FAILURE     = -2
     };
 
     int rc = closeRecoveryFileSet(partitionId);
@@ -168,65 +166,11 @@ int RecoveryManager::deprecateFileSet(int partitionId)
     }
 
     RecoveryContext& recoveryCtx = d_recoveryContextVec[partitionId];
-    rc                           = mqbs::FileSystemUtil::move(
-        recoveryCtx.d_recoveryFileSet.journalFile(),
+    rc                           = mqbs::FileStoreUtil::archiveFileSet(
+        recoveryCtx.d_recoveryFileSet,
         d_dataStoreConfig.archiveLocation());
-    if (0 != rc) {
-        BMQTSK_ALARMLOG_ALARM("FILE_IO")
-            << d_clusterData.identity().description() << " Partition ["
-            << partitionId << "]: " << "Failed to move file ["
-            << recoveryCtx.d_recoveryFileSet.journalFile() << "] "
-            << "to location [" << d_dataStoreConfig.archiveLocation()
-            << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        return rc * 10 + rc_JOURNAL_MOVE_FAILURE;  // RETURN
-    }
-    else {
-        BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Moved journal file ["
-                      << recoveryCtx.d_recoveryFileSet.journalFile()
-                      << "] to location ["
-                      << d_dataStoreConfig.archiveLocation() << "].";
-    }
-
-    rc = mqbs::FileSystemUtil::move(recoveryCtx.d_recoveryFileSet.dataFile(),
-                                    d_dataStoreConfig.archiveLocation());
-    if (0 != rc) {
-        BMQTSK_ALARMLOG_ALARM("FILE_IO")
-            << d_clusterData.identity().description() << " Partition ["
-            << partitionId << "]: " << "Failed to move file ["
-            << recoveryCtx.d_recoveryFileSet.dataFile() << "] "
-            << "to location [" << d_dataStoreConfig.archiveLocation()
-            << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        return rc * 10 + rc_DATA_MOVE_FAILURE;  // RETURN
-    }
-    else {
-        BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Moved data file ["
-                      << recoveryCtx.d_recoveryFileSet.dataFile()
-                      << "] to location ["
-                      << d_dataStoreConfig.archiveLocation() << "].";
-    }
-
-    rc = mqbs::FileSystemUtil::move(recoveryCtx.d_recoveryFileSet.qlistFile(),
-                                    d_dataStoreConfig.archiveLocation());
-    if (0 != rc) {
-        BMQTSK_ALARMLOG_ALARM("FILE_IO")
-            << d_clusterData.identity().description() << " Partition ["
-            << partitionId << "]: " << "Failed to move file ["
-            << recoveryCtx.d_recoveryFileSet.qlistFile() << "] "
-            << "to location [" << d_dataStoreConfig.archiveLocation()
-            << "] rc: " << rc << BMQTSK_ALARMLOG_END;
-        return rc * 10 + rc_QLIST_MOVE_FAILURE;  // RETURN
-    }
-    else {
-        BALL_LOG_INFO << d_clusterData.identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Moved QList file ["
-                      << recoveryCtx.d_recoveryFileSet.qlistFile()
-                      << "] to location ["
-                      << d_dataStoreConfig.archiveLocation() << "].";
+    if (rc != 0) {
+        return rc * 10 + rc_MOVE_FAILURE;  // RETURN
     }
 
     return rc_SUCCESS;

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3468,59 +3468,23 @@ int FileStore::archive(FileSet* fileSet)
 {
     enum rcEnum { rc_SUCCESS = 0, rc_FILE_MOVE_FAILURE = -1 };
 
-    int rcFinal = rc_SUCCESS;
-
-    int rc = FileSystemUtil::move(fileSet->d_dataFileName,
-                                  d_config.archiveLocation());
+    int rc = FileStoreUtil::archiveFileSet(fileSet->d_dataFileName,
+                                           fileSet->d_journalFileName,
+                                           fileSet->d_qlistFileName,
+                                           d_config.archiveLocation(),
+                                           d_qListAware);
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
-            << partitionDesc() << "Failed to move data file ["
-            << fileSet->d_dataFileName << "] " << "to location ["
-            << d_config.archiveLocation() << "] rc: " << rc
+            << partitionDesc() << "Failed to archive file set to location ["
+            << d_config.archiveLocation() << "], rc: " << rc
             << BMQTSK_ALARMLOG_END;
-        rcFinal = rc_FILE_MOVE_FAILURE;
-    }
-    else {
-        BALL_LOG_INFO << partitionDesc() << "Moved data file ["
-                      << fileSet->d_dataFileName << "] to location ["
-                      << d_config.archiveLocation() << "].";
+        return rc_FILE_MOVE_FAILURE;  // RETURN
     }
 
-    rc = FileSystemUtil::move(fileSet->d_journalFileName,
-                              d_config.archiveLocation());
-    if (0 != rc) {
-        BMQTSK_ALARMLOG_ALARM("FILE_IO")
-            << partitionDesc() << "Failed to move journal file ["
-            << fileSet->d_journalFileName << "] " << "to location ["
-            << d_config.archiveLocation() << "] rc: " << rc
-            << BMQTSK_ALARMLOG_END;
-        rcFinal = rc_FILE_MOVE_FAILURE;
-    }
-    else {
-        BALL_LOG_INFO << partitionDesc() << "Moved journal file ["
-                      << fileSet->d_journalFileName << "] to location ["
-                      << d_config.archiveLocation() << "].";
-    }
+    BALL_LOG_INFO << partitionDesc() << "Archived file set to location ["
+                  << d_config.archiveLocation() << "].";
 
-    if (d_qListAware) {
-        rc = FileSystemUtil::move(fileSet->d_qlistFileName,
-                                  d_config.archiveLocation());
-        if (0 != rc) {
-            BMQTSK_ALARMLOG_ALARM("FILE_IO")
-                << partitionDesc() << "Failed to move qlistfile ["
-                << fileSet->d_qlistFileName << "] " << "to location ["
-                << d_config.archiveLocation() << "] rc: " << rc
-                << BMQTSK_ALARMLOG_END;
-            rcFinal = rc_FILE_MOVE_FAILURE;
-        }
-        else {
-            BALL_LOG_INFO << partitionDesc() << "Moved qlist file ["
-                          << fileSet->d_qlistFileName << "] to location ["
-                          << d_config.archiveLocation() << "].";
-        }
-    }
-
-    return rcFinal;
+    return rc_SUCCESS;
 }
 
 void FileStore::gc(FileSet* fileSet)
@@ -3636,8 +3600,12 @@ void FileStore::gcWorkerDispatched(const bsl::shared_ptr<FileSet>& fileSet)
                                                          startTime);
 
     bsls::Types::Int64 archiveStartTime = bmqu::Time::highResolutionTimer();
-    rc                                  = archive(fileSet.get());
-    bsls::Types::Int64 archiveEndTime   = bmqu::Time::highResolutionTimer();
+    rc = FileStoreUtil::archiveFileSet(fileSet->d_dataFileName,
+                                       fileSet->d_journalFileName,
+                                       fileSet->d_qlistFileName,
+                                       d_config.archiveLocation(),
+                                       d_qListAware);
+    bsls::Types::Int64 archiveEndTime = bmqu::Time::highResolutionTimer();
     if (rc != 0) {
         BALL_LOG_ERROR << partitionDesc()
                        << "Failed to archive file set. Time taken: "
@@ -5457,7 +5425,12 @@ int FileStore::close(bool flush, bool archive)
         if (archive) {
             bsls::Types::Int64 archiveStartTime =
                 bmqu::Time::highResolutionTimer();
-            rc = FileStore::archive(activeFileSet);
+            rc = FileStoreUtil::archiveFileSet(
+                activeFileSet->d_dataFileName,
+                activeFileSet->d_journalFileName,
+                activeFileSet->d_qlistFileName,
+                d_config.archiveLocation(),
+                d_qListAware);
             if (rc != 0) {
                 BALL_LOG_ERROR << partitionDesc()
                                << "Failed to archive file set, rc: " << rc;

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <ball_log.h>
 #include <mqbs_filestoreutil.h>
 
 #include <mqbscm_version.h>
@@ -803,6 +804,67 @@ int FileStoreUtil::findFileSets(bsl::vector<FileStoreSet>* fileSets,
     return 0;
 }
 
+int FileStoreUtil::archiveFileSet(const bslstl::StringRef& dataFile,
+                                  const bslstl::StringRef& journalFile,
+                                  const bslstl::StringRef& qlistFile,
+                                  const bslstl::StringRef& archiveLocation,
+                                  bool                     qlistAware)
+{
+    enum RcEnum {
+        rc_SUCCESS              = 0,
+        rc_DATA_MOVE_FAILURE    = -1,
+        rc_JOURNAL_MOVE_FAILURE = -2,
+        rc_QLIST_MOVE_FAILURE   = -3
+    };
+
+    int rc = FileSystemUtil::move(dataFile, archiveLocation);
+    if (0 != rc) {
+        BMQTSK_ALARMLOG_ALARM("FILE_IO")
+            << "Failed to archive data file [" << dataFile << "] to location ["
+            << archiveLocation << "], rc: " << rc << BMQTSK_ALARMLOG_END;
+        return rc * 10 + rc_DATA_MOVE_FAILURE;  // RETURN
+    }
+    BALL_LOG_INFO << "Archived data file [" << dataFile << "] to location ["
+                  << archiveLocation << "]";
+
+    rc = FileSystemUtil::move(journalFile, archiveLocation);
+    if (0 != rc) {
+        BMQTSK_ALARMLOG_ALARM("FILE_IO")
+            << "Failed to archive journal file [" << journalFile
+            << "] to location [" << archiveLocation << "], rc: " << rc
+            << BMQTSK_ALARMLOG_END;
+        return rc * 10 + rc_JOURNAL_MOVE_FAILURE;  // RETURN
+    }
+    BALL_LOG_INFO << "Archived journal file [" << journalFile
+                  << "] to location [" << archiveLocation << "]";
+
+    if (qlistAware) {
+        rc = FileSystemUtil::move(qlistFile, archiveLocation);
+        if (0 != rc) {
+            BMQTSK_ALARMLOG_ALARM("FILE_IO")
+                << "Failed to archive qlist file [" << qlistFile
+                << "] to location [" << archiveLocation << "], rc: " << rc
+                << BMQTSK_ALARMLOG_END;
+            return rc * 10 + rc_QLIST_MOVE_FAILURE;  // RETURN
+        }
+        BALL_LOG_INFO << "Archived qlist file [" << qlistFile
+                      << "] to location [" << archiveLocation << "]";
+    }
+
+    return rc_SUCCESS;
+}
+
+int FileStoreUtil::archiveFileSet(const FileStoreSet&      fileSet,
+                                  const bslstl::StringRef& archiveLocation,
+                                  bool                     qlistAware)
+{
+    return archiveFileSet(fileSet.dataFile(),
+                          fileSet.journalFile(),
+                          fileSet.qlistFile(),
+                          archiveLocation,
+                          qlistAware);
+}
+
 void FileStoreUtil::deleteArchiveFiles(int                partitionId,
                                        const bsl::string& archiveLocation,
                                        int                maxArchivedFileSets,
@@ -1223,28 +1285,14 @@ int FileStoreUtil::openRecoveryFileSet(bsl::ostream&         errorDescription,
         }
 
         const FileStoreSet& archivingFileSet = fileSets[archivingIndices[i]];
-        rc = FileSystemUtil::move(archivingFileSet.dataFile(),
-                                  config.archiveLocation());
-        if (rc != 0) {
-            BALL_LOG_WARN << "Partition [" << partitionId << "]: Failed to "
-                          << "archive data file ["
-                          << archivingFileSet.dataFile() << "], rc: " << rc;
-        }
-
-        rc = FileSystemUtil::move(archivingFileSet.qlistFile(),
-                                  config.archiveLocation());
+        rc = FileStoreUtil::archiveFileSet(archivingFileSet.dataFile(),
+                                           archivingFileSet.journalFile(),
+                                           archivingFileSet.qlistFile(),
+                                           config.archiveLocation());
         if (0 != rc) {
             BALL_LOG_WARN << "Partition [" << partitionId << "]: Failed to "
-                          << "archive qlist file ["
-                          << archivingFileSet.qlistFile() << "], rc: " << rc;
-        }
-
-        rc = FileSystemUtil::move(archivingFileSet.journalFile(),
-                                  config.archiveLocation());
-        if (0 != rc) {
-            BALL_LOG_WARN << "Partition [" << partitionId << "]: Failed to "
-                          << "archive journal file ["
-                          << archivingFileSet.journalFile() << "], rc: " << rc;
+                          << "archive file set [" << archivingFileSet
+                          << "], rc: " << rc;
         }
     }
 

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -804,11 +804,11 @@ int FileStoreUtil::findFileSets(bsl::vector<FileStoreSet>* fileSets,
     return 0;
 }
 
-int FileStoreUtil::archiveFileSet(const bslstl::StringRef& dataFile,
-                                  const bslstl::StringRef& journalFile,
-                                  const bslstl::StringRef& qlistFile,
-                                  const bslstl::StringRef& archiveLocation,
-                                  bool                     qlistAware)
+int FileStoreUtil::archiveFileSet(bsl::string_view dataFile,
+                                  bsl::string_view journalFile,
+                                  bsl::string_view qlistFile,
+                                  bsl::string_view archiveLocation,
+                                  bool             qlistAware)
 {
     enum RcEnum {
         rc_SUCCESS              = 0,
@@ -854,9 +854,9 @@ int FileStoreUtil::archiveFileSet(const bslstl::StringRef& dataFile,
     return rc_SUCCESS;
 }
 
-int FileStoreUtil::archiveFileSet(const FileStoreSet&      fileSet,
-                                  const bslstl::StringRef& archiveLocation,
-                                  bool                     qlistAware)
+int FileStoreUtil::archiveFileSet(const FileStoreSet& fileSet,
+                                  bsl::string_view    archiveLocation,
+                                  bool                qlistAware)
 {
     return archiveFileSet(fileSet.dataFile(),
                           fileSet.journalFile(),

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.h
@@ -208,18 +208,18 @@ struct FileStoreUtil {
     /// `qlistFile` if the specified `qlistAware` is true) to the specified
     /// `archiveLocation` directory.  Return zero on success, non-zero value
     /// otherwise.
-    static int archiveFileSet(const bslstl::StringRef& dataFile,
-                              const bslstl::StringRef& journalFile,
-                              const bslstl::StringRef& qlistFile,
-                              const bslstl::StringRef& archiveLocation,
-                              bool                     qlistAware = true);
+    static int archiveFileSet(bsl::string_view dataFile,
+                              bsl::string_view journalFile,
+                              bsl::string_view qlistFile,
+                              bsl::string_view archiveLocation,
+                              bool             qlistAware = true);
 
     /// Move the data, journal, and qlist files if `qlistAware` is true, from
     /// the specified `fileSet` to the specified `archiveLocation` directory.
     /// Return zero on success, non-zero value otherwise.
-    static int archiveFileSet(const FileStoreSet&      fileSet,
-                              const bslstl::StringRef& archiveLocation,
-                              bool                     qlistAware = true);
+    static int archiveFileSet(const FileStoreSet& fileSet,
+                              bsl::string_view    archiveLocation,
+                              bool                qlistAware = true);
 
     /// Delete the archived files located at the specified `archiveLocation`
     /// belonging to the specified `partitionId` of the specified `cluster`

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.h
@@ -204,6 +204,23 @@ struct FileStoreUtil {
                             bool                       withSize  = false,
                             bool                       needQList = true);
 
+    /// Move the specified `dataFile` and `journalFile` (and optionally
+    /// `qlistFile` if the specified `qlistAware` is true) to the specified
+    /// `archiveLocation` directory.  Return zero on success, non-zero value
+    /// otherwise.
+    static int archiveFileSet(const bslstl::StringRef& dataFile,
+                              const bslstl::StringRef& journalFile,
+                              const bslstl::StringRef& qlistFile,
+                              const bslstl::StringRef& archiveLocation,
+                              bool                     qlistAware = true);
+
+    /// Move the data, journal, and qlist files if `qlistAware` is true, from
+    /// the specified `fileSet` to the specified `archiveLocation` directory.
+    /// Return zero on success, non-zero value otherwise.
+    static int archiveFileSet(const FileStoreSet&      fileSet,
+                              const bslstl::StringRef& archiveLocation,
+                              bool                     qlistAware = true);
+
     /// Delete the archived files located at the specified `archiveLocation`
     /// belonging to the specified `partitionId` of the specified `cluster`
     /// and keep at most a maximum of the specified `maxArchivedFileSets`.


### PR DESCRIPTION
## Summary                                                                                                                                 
  - Every call site that archives storage files (data, journal, qlist) repeated the same triple-`FileSystemUtil::move` pattern with per-file error handling and logging — 5 call sites across 4 files, totaling ~150 lines of near-identical code.                                      
  - Introduces `FileStoreUtil::archiveFileSet` to centralize this logic: moves all three files to the archive location, with alarm logging on failure and info logging on success.                                                                                                      
  - Two overloads are provided: one accepting three individual file paths (for callers using `FileSet` which has raw string members), and one accepting a `FileStoreSet` object (delegates to the first). Both support a `qlistAware` flag to conditionally skip the qlist file.        