### PR TITLE
Fix[test]: generator exhaustion bug

### DIFF
--- a/src/python/blazingmq/dev/it/cluster.py
+++ b/src/python/blazingmq/dev/it/cluster.py
@@ -323,9 +323,9 @@ class Cluster(contextlib.AbstractContextManager):
         else:
             self._logger.info("stopping all nodes")
 
-        nodes_to_stop = (
+        nodes_to_stop = [
             node for node in self.nodes() if (exclude is None or node not in exclude)
-        )
+        ]
 
         if prevent_leader_bounce:
             if self.last_known_leader is not None and self.last_known_leader.is_alive():


### PR DESCRIPTION
generator exhaustion bug resulting in `process exited with return code 3` because of ` Named pipe './/bmqbrkr.ctl' is already in use by another process`