### PR TITLE
Feat: broker-to-broker authentication

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -1,0 +1,242 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqba_authenticationclient.h>
+
+#include <mqbscm_version.h>
+
+// MQB
+#include <mqbplug_authncredential.h>
+
+// BMQ
+#include <bmqio_channel.h>
+#include <bmqio_status.h>
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_protocol.h>
+#include <bmqp_schemaeventbuilder.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
+
+// BDE
+#include <bdlf_bind.h>
+#include <bsl_optional.h>
+#include <bslmt_lockguard.h>
+#include <bsls_timeinterval.h>
+
+namespace BloombergLP {
+namespace mqba {
+
+// --------------------------
+// class AuthenticationClient
+// --------------------------
+
+// PRIVATE MANIPULATORS
+void AuthenticationClient::onReauthenticate()
+{
+    // executed by the *SCHEDULER* thread
+
+    bmqu::MemOutStream errStream;
+    const int          rc = authenticate(errStream);
+    if (rc != 0) {
+        BALL_LOG_ERROR << "Reauthentication failed: " << errStream.str();
+    }
+}
+
+void AuthenticationClient::scheduleReauthentication(
+    bsls::Types::Int64 lifetimeMs)
+{
+    // executed by the *IO* thread
+
+    // Reauthenticate at 80% of the lifetime to give margin
+    const bsls::Types::Int64 reauthMs = static_cast<bsls::Types::Int64>(
+        static_cast<double>(lifetimeMs) * 0.8);
+
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        if (d_reauthHandle) {
+            d_scheduler_p->cancelEvent(&d_reauthHandle);
+        }
+
+        d_scheduler_p->scheduleEvent(
+            &d_reauthHandle,
+            bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
+                .addMilliseconds(reauthMs),
+            bdlf::BindUtil::bind(&AuthenticationClient::onReauthenticate,
+                                 this));
+    }
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    BALL_LOG_INFO << "Scheduled reauthentication"
+                  << " [peer: " << channel.get() << "]" << " in " << reauthMs
+                  << " ms (lifetimeMs: " << lifetimeMs << ")";
+}
+
+// CREATORS
+AuthenticationClient::AuthenticationClient(
+    const mqbplug::CredentialProvider::CredentialFunc& credentialFunc,
+    const bsl::shared_ptr<bmqio::Channel>&             channel,
+    BlobSpPool*                                        blobSpPool,
+    bdlmt::EventScheduler*                             scheduler,
+    bslma::Allocator*                                  allocator)
+: d_credentialFunc(bsl::allocator_arg, allocator, credentialFunc)
+, d_channel_wp(channel)
+, d_blobSpPool_p(blobSpPool)
+, d_scheduler_p(scheduler)
+, d_mutex()
+, d_reauthHandle()
+, d_allocator_p(allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_credentialFunc);
+    BSLS_ASSERT_SAFE(channel);
+    BSLS_ASSERT_SAFE(d_blobSpPool_p);
+    BSLS_ASSERT_SAFE(d_scheduler_p);
+    BSLS_ASSERT_SAFE(d_allocator_p);
+}
+
+AuthenticationClient::~AuthenticationClient()
+{
+    stop();
+}
+
+// MANIPULATORS
+int AuthenticationClient::authenticate(bsl::ostream& errorDescription)
+{
+    // executed by the *IO* or *SCHEDULER* thread
+
+    enum RcEnum {
+        rc_SUCCESS            = 0,
+        rc_CHANNEL_GONE       = -1,
+        rc_CREDENTIAL_FAILURE = -2,
+        rc_BUILD_FAILURE      = -3,
+        rc_WRITE_FAILURE      = -4
+    };
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    if (!channel) {
+        errorDescription << "Channel is no longer available";
+        return rc_CHANNEL_GONE;  // RETURN
+    }
+
+    // Obtain credentials
+    bmqu::MemOutStream                      credErrStream;
+    bsl::optional<mqbplug::AuthnCredential> credential = d_credentialFunc(
+        credErrStream);
+
+    if (!credential.has_value()) {
+        errorDescription << "Failed to obtain credentials: "
+                         << credErrStream.str();
+        return rc_CREDENTIAL_FAILURE;  // RETURN
+    }
+
+    BALL_LOG_INFO << "Sending AuthenticationRequest"
+                  << " [peer: " << channel.get() << "]" << " with mechanism '"
+                  << credential->mechanism() << "'";
+
+    // Build AuthenticationRequest
+    bmqp_ctrlmsg::AuthenticationMessage  message;
+    bmqp_ctrlmsg::AuthenticationRequest& request =
+        message.makeAuthenticationRequest();
+
+    request.mechanism() = credential->mechanism();
+    if (!credential->data().empty()) {
+        request.data().makeValue(credential->data());
+    }
+
+    // Encode and send
+    bmqp::SchemaEventBuilder builder(d_blobSpPool_p,
+                                     bmqp::EncodingType::e_BER,
+                                     d_allocator_p);
+
+    int rc = builder.setMessage(message, bmqp::EventType::e_AUTHENTICATION);
+    if (rc != 0) {
+        errorDescription << "Failed building AuthenticationMessage "
+                         << "[rc: " << rc << ", message: " << message << "]";
+        return rc_BUILD_FAILURE;  // RETURN
+    }
+
+    bmqio::Status status;
+    channel->write(&status, *builder.blob());
+    if (!status) {
+        errorDescription << "Failed sending AuthenticationMessage "
+                         << "[status: " << status << ", message: " << message
+                         << "]";
+        return rc_WRITE_FAILURE;  // RETURN
+    }
+
+    return rc_SUCCESS;
+}
+
+int AuthenticationClient::handleResponse(
+    bsl::ostream&                              errorDescription,
+    const bmqp_ctrlmsg::AuthenticationMessage& response)
+{
+    // executed by the *IO* thread
+
+    enum RcEnum {
+        rc_SUCCESS                = 0,
+        rc_INVALID_AUTHN_RESPONSE = -1,
+        rc_AUTHENTICATION_FAILURE = -2
+    };
+
+    if (!response.isAuthenticationResponseValue()) {
+        errorDescription << "Expected AuthenticationResponse but received: "
+                         << response;
+        return rc_INVALID_AUTHN_RESPONSE;  // RETURN
+    }
+
+    const bmqp_ctrlmsg::AuthenticationResponse& authnResponse =
+        response.authenticationResponse();
+
+    if (authnResponse.status().category() !=
+        bmqp_ctrlmsg::StatusCategory::E_SUCCESS) {
+        errorDescription << "Authentication failed: "
+                         << authnResponse.status().message()
+                         << " [code: " << authnResponse.status().code() << "]";
+        return rc_AUTHENTICATION_FAILURE;  // RETURN
+    }
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+
+    BALL_LOG_INFO << "Authentication successful" << " [peer: " << channel.get()
+                  << "]" << " [lifetimeMs: "
+                  << (authnResponse.lifetimeMs().isNull()
+                          ? "N/A"
+                          : bsl::to_string(authnResponse.lifetimeMs().value()))
+                  << "]";
+
+    if (authnResponse.lifetimeMs().has_value()) {
+        scheduleReauthentication(authnResponse.lifetimeMs().value());
+    }
+
+    return rc_SUCCESS;
+}
+
+void AuthenticationClient::stop()
+{
+    // executed by *ANY* thread (during channel teardown)
+
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+    if (d_reauthHandle) {
+        d_scheduler_p->cancelEvent(&d_reauthHandle);
+    }
+
+    d_channel_wp.reset();
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqba/mqba_authenticationclient.h
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.h
@@ -1,0 +1,157 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBA_AUTHENTICATIONCLIENT
+#define INCLUDED_MQBA_AUTHENTICATIONCLIENT
+
+/// @file mqba_authenticationclient.h
+///
+/// @brief Provide a client-side authenticator for an outbound connection.
+///
+/// @bbref{mqba::AuthenticationClient} implements the
+/// @bbref{mqbnet::AuthenticationClient} interface to authenticate an
+/// outbound connection to a broker.  It obtains credentials from a
+/// @bbref{mqbplug::CredentialProvider::CredentialFunc} and sends an
+/// @bbref{bmqp_ctrlmsg::AuthenticationRequest} to the remote broker.
+
+// MQB
+#include <mqbnet_authenticationclient.h>
+#include <mqbplug_credentialprovider.h>
+
+// BMQ
+#include <bmqio_channel.h>
+
+// BDE
+#include <ball_log.h>
+#include <bdlbb_blob.h>
+#include <bdlcc_sharedobjectpool.h>
+#include <bdlmt_eventscheduler.h>
+#include <bsl_memory.h>
+#include <bsl_ostream.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bslmt_mutex.h>
+
+namespace BloombergLP {
+namespace mqba {
+
+// ==========================
+// class AuthenticationClient
+// ==========================
+
+/// Client-side authenticator for an outbound broker-to-broker connection.
+class AuthenticationClient : public mqbnet::AuthenticationClient {
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBA.AUTHENTICATIONCLIENT");
+
+  public:
+    // TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
+
+  private:
+    // DATA
+
+    /// Function to obtain credentials for authentication.
+    mqbplug::CredentialProvider::CredentialFunc d_credentialFunc;
+
+    /// Reference to the channel being authenticated.
+    bsl::weak_ptr<bmqio::Channel> d_channel_wp;
+
+    BlobSpPool* d_blobSpPool_p;
+
+    /// Scheduler for reauthentication timers.  Held, not owned.
+    bdlmt::EventScheduler* d_scheduler_p;
+
+    /// Mutex to protect access to EventHandle and channel.
+    mutable bslmt::Mutex d_mutex;
+
+    /// Handle for the scheduled reauthentication event, if any.
+    bdlmt::EventScheduler::EventHandle d_reauthHandle;
+
+    bslma::Allocator* d_allocator_p;
+
+  private:
+    // NOT IMPLEMENTED
+    AuthenticationClient(const AuthenticationClient&) BSLS_KEYWORD_DELETED;
+    AuthenticationClient&
+    operator=(const AuthenticationClient&) BSLS_KEYWORD_DELETED;
+
+  private:
+    // PRIVATE MANIPULATORS
+
+    /// Callback invoked by the scheduler when the reauthentication timer
+    /// fires.  Sends a fresh AuthenticationRequest on the stored channel.
+    void onReauthenticate();
+
+    /// Schedule a reauthentication timer to fire before the specified
+    /// `lifetimeMs` expires.  Cancel any previously scheduled timer.
+    void scheduleReauthentication(bsls::Types::Int64 lifetimeMs);
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(AuthenticationClient,
+                                   bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a new `AuthenticationClient` using the specified
+    /// `credentialFunc` for obtaining credentials, the specified `channel`
+    /// for sending messages, the specified `blobSpPool` for building
+    /// messages, and the specified `scheduler` for reauthentication timers.
+    /// Use the specified `allocator` for all memory allocations.
+    AuthenticationClient(
+        const mqbplug::CredentialProvider::CredentialFunc& credentialFunc,
+        const bsl::shared_ptr<bmqio::Channel>&             channel,
+        BlobSpPool*                                        blobSpPool,
+        bdlmt::EventScheduler*                             scheduler,
+        bslma::Allocator*                                  allocator);
+
+    /// Destructor
+    ~AuthenticationClient() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+    //   (virtual: mqbnet::AuthenticationClient)
+
+    /// Send an AuthenticationRequest using credentials from the configured
+    /// provider.  Return 0 on success, or a non-zero value and populate the
+    /// specified `errorDescription` with the description of any failure
+    /// encountered.
+    int authenticate(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the specified `response` received from the remote broker.
+    /// Return 0 if authentication succeeded, or a non-zero value and
+    /// populate the specified `errorDescription` with the description of
+    /// any failure encountered.
+    int handleResponse(bsl::ostream& errorDescription,
+                       const bmqp_ctrlmsg::AuthenticationMessage& response)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the authentication client, cancelling any pending
+    /// reauthentication timers.
+    void stop() BSLS_KEYWORD_OVERRIDE;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -1,0 +1,741 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqba_authenticationclient.h>
+
+// MQB
+#include <mqbplug_authncredential.h>
+#include <mqbplug_credentialprovider.h>
+
+// BMQ
+#include <bmqio_testchannel.h>
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_event.h>
+#include <bmqtst_scopedlogobserver.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
+
+// BDE
+#include <ball_severity.h>
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlcc_sharedobjectpool.h>
+#include <bdlf_bind.h>
+#include <bdlmt_eventscheduler.h>
+#include <bsl_memory.h>
+#include <bsl_optional.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bsls_systemclocktype.h>
+#include <bsls_timeinterval.h>
+#include <bsls_types.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+namespace {
+
+typedef bdlcc::SharedObjectPool<
+    bdlbb::Blob,
+    bdlcc::ObjectPoolFunctors::DefaultCreator,
+    bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+    BlobSpPool;
+
+struct TestClock {
+    bdlmt::EventScheduler&              d_scheduler;
+    bdlmt::EventSchedulerTestTimeSource d_timeSource;
+
+    TestClock(bdlmt::EventScheduler& scheduler)
+    : d_scheduler(scheduler)
+    , d_timeSource(&scheduler)
+    {
+    }
+
+    bsls::TimeInterval realtimeClock() { return d_timeSource.now(); }
+    bsls::TimeInterval monotonicClock() { return d_timeSource.now(); }
+    bsls::Types::Int64 highResTimer()
+    {
+        return d_timeSource.now().totalNanoseconds();
+    }
+};
+
+void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
+                void*                     arena,
+                bslma::Allocator*         allocator)
+{
+    new (arena) bdlbb::Blob(bufferFactory, allocator);
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+successCredentialFunc(bsl::ostream&      error,
+                      const bsl::string& mechanism,
+                      const bsl::string& payload)
+{
+    (void)error;
+    bsl::vector<char> data(payload.begin(), payload.end());
+    return mqbplug::AuthnCredential(mechanism, data);
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+failingCredentialFunc(bsl::ostream& error)
+{
+    error << "credential provider is broken";
+    return bsl::nullopt;
+}
+
+bmqp_ctrlmsg::AuthenticationMessage
+makeSuccessResponse(const bdlb::NullableValue<bsls::Types::Int64>& lifetimeMs =
+                        bdlb::NullableValue<bsls::Types::Int64>())
+{
+    bmqp_ctrlmsg::AuthenticationMessage   msg;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        msg.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+    resp.status().code()     = 0;
+    resp.status().message()  = "OK";
+    resp.lifetimeMs()        = lifetimeMs;
+    return msg;
+}
+
+bmqp_ctrlmsg::AuthenticationMessage
+makeFailureResponse(const bsl::string& message, int code)
+{
+    bmqp_ctrlmsg::AuthenticationMessage   msg;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        msg.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+    resp.status().code()     = code;
+    resp.status().message()  = message;
+    return msg;
+}
+
+int decodeAuthenticationEvent(bmqp_ctrlmsg::AuthenticationMessage* output,
+                              const bdlbb::Blob&                   blob,
+                              bslma::Allocator*                    allocator)
+{
+    bmqp::Event event(&blob, allocator);
+    if (!event.isAuthenticationEvent()) {
+        return -1;
+    }
+    return event.loadAuthenticationEvent(output);
+}
+
+class TestBench {
+  public:
+    // DATA
+    bdlbb::PooledBlobBufferFactory      d_bufferFactory;
+    BlobSpPool                          d_blobSpPool;
+    bsl::shared_ptr<bmqio::TestChannel> d_channel;
+    bdlmt::EventScheduler               d_scheduler;
+    TestClock                           d_testClock;
+    bslma::Allocator*                   d_allocator_p;
+
+    // CREATORS
+    explicit TestBench(bslma::Allocator* allocator)
+    : d_bufferFactory(256, allocator)
+    , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
+                                        &d_bufferFactory,
+                                        bdlf::PlaceHolders::_1,
+                                        bdlf::PlaceHolders::_2),
+                   1024,
+                   allocator)
+    , d_channel(new bmqio::TestChannel(allocator))
+    , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
+    , d_testClock(d_scheduler)
+    , d_allocator_p(allocator)
+    {
+        bmqu::Time::shutdown();
+        bmqu::Time::initialize(
+            bdlf::BindUtil::bind(&TestClock::realtimeClock, &d_testClock),
+            bdlf::BindUtil::bind(&TestClock::monotonicClock, &d_testClock),
+            bdlf::BindUtil::bind(&TestClock::highResTimer, &d_testClock),
+            d_allocator_p);
+
+        int rc = d_scheduler.start();
+        BMQTST_ASSERT_EQ(rc, 0);
+    }
+
+    ~TestBench()
+    {
+        d_scheduler.cancelAllEventsAndWait();
+        d_scheduler.stop();
+    }
+
+    // MANIPULATORS
+    mqba::AuthenticationClient*
+    createClient(const mqbplug::CredentialProvider::CredentialFunc& credFunc)
+    {
+        return new (*d_allocator_p) mqba::AuthenticationClient(credFunc,
+                                                               d_channel,
+                                                               &d_blobSpPool,
+                                                               &d_scheduler,
+                                                               d_allocator_p);
+    }
+
+    mqbplug::CredentialProvider::CredentialFunc
+    makeSuccessCredentialFunc(const bsl::string& mechanism = "BASIC",
+                              const bsl::string& payload   = "user:pass")
+    {
+        return bdlf::BindUtil::bind(&successCredentialFunc,
+                                    bdlf::PlaceHolders::_1,
+                                    mechanism,
+                                    payload);
+    }
+
+    mqbplug::CredentialProvider::CredentialFunc makeFailingCredentialFunc()
+    {
+        return &failingCredentialFunc;
+    }
+};
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_authenticateSuccess()
+// ------------------------------------------------------------------------
+// AUTHENTICATE SUCCESS
+//
+// Concerns:
+//   - 'authenticate()' returns 0 on success.
+//   - An AuthenticationRequest is written to the channel with the correct
+//     mechanism and credential data.
+//
+// Plan:
+//   1) Construct a client with a valid credential func and live channel.
+//   2) Call 'authenticate()', verify the return code
+//   3) Pop the write call, decode the blob, verify the request contents.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE SUCCESS");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc("BASIC", "user:pass")),
+        alloc);
+
+    // 2)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 1u);
+
+    // 3)
+    bmqio::TestChannel::WriteCall       wc = tb.d_channel->popWriteCall();
+    bmqp_ctrlmsg::AuthenticationMessage decoded;
+    rc = decodeAuthenticationEvent(&decoded, wc.d_blob, alloc);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT(decoded.isAuthenticationRequestValue());
+
+    const bmqp_ctrlmsg::AuthenticationRequest& req =
+        decoded.authenticationRequest();
+    BMQTST_ASSERT_EQ(req.mechanism(), "BASIC");
+    BMQTST_ASSERT(req.data().has_value());
+
+    bsl::string dataStr(req.data().value().begin(),
+                        req.data().value().end(),
+                        alloc);
+    BMQTST_ASSERT_EQ(dataStr, "user:pass");
+
+    client->stop();
+}
+
+static void test2_authenticateChannelGone()
+// ------------------------------------------------------------------------
+// AUTHENTICATE CHANNEL GONE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CHANNEL_GONE when the channel has been
+//     destroyed, effectively handling dead channels gracefully.
+//
+// Plan:
+//   1) Construct a client
+//   2) Destroy the external channel shared_ptr
+//   3) Call 'authenticate()', and verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE CHANNEL GONE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 2)
+    tb.d_channel.reset();
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -1);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Channel is no longer available") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test3_authenticateCredentialFailure()
+// ------------------------------------------------------------------------
+// AUTHENTICATE CREDENTIAL FAILURE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CREDENTIAL_FAILURE when the credential
+//     func returns nullopt.
+//   - No write is attempted on the channel.
+//
+// Plan:
+//   1) Construct a client with a failing credential func
+//   2) Call 'authenticate()' and verify the error code, description,
+//      and that no data was written to the channel.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE CREDENTIAL FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeFailingCredentialFunc()),
+        alloc);
+
+    // 2)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -2);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Failed to obtain credentials") !=
+                  bsl::string::npos);
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 0u);
+
+    client->stop();
+}
+
+static void test4_authenticateWriteFails()
+// ------------------------------------------------------------------------
+// AUTHENTICATE WRITE FAILS
+//
+// Concerns:
+//   - 'authenticate()' returns rc_WRITE_FAILURE when the channel write
+//     fails.
+//
+// Plan:
+//   1) Construct a client
+//   2) Set the test channel's write status to an error
+//   3) Call 'authenticate()', and verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE WRITE FAILS");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 2)
+    tb.d_channel->setWriteStatus(
+        bmqio::Status(bmqio::StatusCategory::e_GENERIC_ERROR));
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -4);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc).find("Failed sending") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test5_handleResponseSuccessNoLifetime()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE SUCCESS NO LIFETIME
+//
+// Concerns:
+//   - 'handleResponse()' returns 0 for a successful response.
+//   - No reauthentication timer is scheduled when lifetimeMs is absent.
+//
+// Plan:
+//   1) Authenticate to establish the connection.
+//   2) Call 'handleResponse()' with a success response (no lifetimeMs).
+//   3) Advance time significantly and verify no additional writes occur.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE SUCCESS NO LIFETIME");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage response = makeSuccessResponse();
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(bsls::TimeInterval(60));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+
+    client->stop();
+}
+
+static void test6_handleResponseSuccessWithLifetime()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE SUCCESS WITH LIFETIME
+//
+// Concerns:
+//   - 'handleResponse()' returns 0 for a successful response with a
+//     lifetimeMs value.
+//   - A reauthentication timer fires at exactly 80% of the lifetime.
+//   - The reauthentication sends a valid AuthenticationRequest.
+//
+// Plan:
+//   1) Authenticate, then call 'handleResponse()' with lifetimeMs=10000.
+//   2) Advance time to 7999ms, verify no reauth fires.
+//   3) Advance 1ms more (to 8000ms = 80%), verify one
+//      AuthenticationRequest is sent.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE SUCCESS WITH LIFETIME");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    const bsls::Types::Int64            lifetimeMs = 10000;  // 10 seconds
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(7999));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(1));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth + 1);
+
+    bmqio::TestChannel::WriteCall       wc = tb.d_channel->popWriteCall();
+    bmqp_ctrlmsg::AuthenticationMessage decoded;
+    rc = decodeAuthenticationEvent(&decoded, wc.d_blob, alloc);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT(decoded.isAuthenticationRequestValue());
+
+    client->stop();
+}
+
+static void test7_handleResponseAuthenticationFailure()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE AUTHENTICATION FAILURE
+//
+// Concerns:
+//   - 'handleResponse()' returns rc_AUTHENTICATION_FAILURE when the
+//     response status is not E_SUCCESS.
+//   - The error description contains the failure reason.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'handleResponse()' with a response whose status category is
+//      E_REFUSED. Verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "HANDLE RESPONSE AUTHENTICATION FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage response =
+        makeFailureResponse("access denied", 403);
+
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(
+        bsl::string(errStream.str(), alloc).find("Authentication failed") !=
+        bsl::string::npos);
+
+    client->stop();
+}
+
+static void test8_handleResponseInvalidMessage()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE INVALID MESSAGE
+//
+// Concerns:
+//   - 'handleResponse()' returns rc_INVALID_AUTHN_RESPONSE when the
+//     message is not an AuthenticationResponse.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'handleResponse()' with an AuthenticationRequest (not a
+//      response). Verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE INVALID MESSAGE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage badMsg;
+    badMsg.makeAuthenticationRequest();
+    badMsg.authenticationRequest().mechanism() = "BASIC";
+
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->handleResponse(errStream, badMsg);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Expected AuthenticationResponse") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test9_stopCancelsReauthTimer()
+// ------------------------------------------------------------------------
+// STOP CANCELS REAUTH TIMER
+//
+// Concerns:
+//   - Calling 'stop()' cancels a pending reauthentication timer.
+//   - No reauthentication write occurs after stop, even when time
+//     advances past the scheduled point.
+//
+// Plan:
+//   1) Authenticate and handle a response with a lifetime to schedule
+//      reauthentication.
+//   2) Call 'stop()'.
+//   3) Advance time past the reauthn lifetime, verify no additional writes.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("STOP CANCELS REAUTH TIMER");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    const bsls::Types::Int64            lifetimeMs = 10000;
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    client->stop();
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(10 * lifetimeMs));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+}
+
+static void test10_stopThenAuthenticate()
+// ------------------------------------------------------------------------
+// STOP THEN AUTHENTICATE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CHANNEL_GONE after 'stop()' has been
+//     called, because 'stop()' resets the weak_ptr to the channel.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'stop()' on the client.
+//   3) Call 'authenticate()' and verify it fails with the channel-gone
+//      error.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("STOP THEN AUTHENTICATE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 2)
+    client->stop();
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Channel is no longer available") !=
+                  bsl::string::npos);
+}
+
+static void test11_reauthChannelGoneAtTimerFire()
+// ------------------------------------------------------------------------
+// REAUTH CHANNEL GONE AT TIMER FIRE
+//
+// Concerns:
+//   - When the channel is destroyed before the reauthentication timer
+//     fires, the callback handles the expired weak_ptr gracefully.
+//   - No crash or undefined behavior occurs.
+//   - The failure is logged.
+//
+// Plan:
+//   1) Authenticate and handle a response with a lifetime to schedule
+//      reauthentication.
+//   2) Destroy all shared_ptrs to the channel.
+//   3) Advance time past the reauth point and verify the expected error
+//      is logged via a ScopedLogObserver.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("REAUTH CHANNEL GONE AT TIMER FIRE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialFunc()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    const bsls::Types::Int64            lifetimeMs = 10000;
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    tb.d_channel.reset();
+
+    // 3)
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR, alloc);
+
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(lifetimeMs));
+
+    BMQTST_ASSERT_EQ(logObserver.records().size(), 1u);
+    BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
+        logObserver.records()[0],
+        ".*Reauthentication failed.*",
+        alloc));
+
+    client->stop();
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    {
+        bmqu::Time::initialize(bmqtst::TestHelperUtil::allocator());
+
+        switch (_testCase) {
+        case 0:
+        case 11: test11_reauthChannelGoneAtTimerFire(); break;
+        case 10: test10_stopThenAuthenticate(); break;
+        case 9: test9_stopCancelsReauthTimer(); break;
+        case 8: test8_handleResponseInvalidMessage(); break;
+        case 7: test7_handleResponseAuthenticationFailure(); break;
+        case 6: test6_handleResponseSuccessWithLifetime(); break;
+        case 5: test5_handleResponseSuccessNoLifetime(); break;
+        case 4: test4_authenticateWriteFails(); break;
+        case 3: test3_authenticateCredentialFailure(); break;
+        case 2: test2_authenticateChannelGone(); break;
+        case 1: test1_authenticateSuccess(); break;
+        default: {
+            cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+            bmqtst::TestHelperUtil::testStatus() = -1;
+        } break;
+        }
+
+        bmqu::Time::shutdown();
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
+}

--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -29,6 +29,7 @@
 /// asynchronously.
 
 // MQB
+#include <mqba_authenticationclient.h>
 #include <mqbcfg_messages.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_initialconnectioncontext.h>
@@ -104,19 +105,6 @@ int Authenticator::onAuthenticationRequest(
         false);
 
     return rc;
-}
-
-int Authenticator::onAuthenticationResponse(
-    BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
-    BSLA_MAYBE_UNUSED mqbnet::InitialConnectionContext* context_p,
-    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::AuthenticationMessage&
-                            authenticationMsg)
-{
-    // executed by one of the *IO* threads
-
-    BALL_LOG_ERROR << "Not Implemented";
-
-    return -1;
 }
 
 int Authenticator::sendAuthenticationResponse(
@@ -485,12 +473,6 @@ int Authenticator::handleAuthentication(
                                      context_p,
                                      authenticationMsg);
     } break;  // BREAK
-    case bmqp_ctrlmsg::AuthenticationMessage::
-        SELECTION_ID_AUTHENTICATION_RESPONSE: {
-        rc = onAuthenticationResponse(errorDescription,
-                                      context_p,
-                                      authenticationMsg);
-    } break;  // BREAK
     default: {
         errorDescription
             << "Invalid authentication message received (unknown type): "
@@ -542,13 +524,22 @@ int Authenticator::handleReauthentication(
     return rc;
 }
 
-int Authenticator::authenticationOutbound(
-    BSLA_MAYBE_UNUSED bsl::ostream&                  errorDescription,
-    BSLA_MAYBE_UNUSED const AuthenticationContextSp& context)
+bool Authenticator::hasOutboundAuthentication() const
 {
-    BALL_LOG_ERROR << "Not Implemented";
+    return d_authnController_p->hasCredentialProvider();
+}
 
-    return -1;
+bsl::shared_ptr<mqbnet::AuthenticationClient>
+Authenticator::createAuthenticationClient(
+    const bsl::shared_ptr<bmqio::Channel>& channel,
+    bslma::Allocator*                      allocator) const
+{
+    return bsl::allocate_shared<AuthenticationClient>(
+        allocator,
+        d_authnController_p->credentialFunc(),
+        channel,
+        d_blobSpPool_p,
+        d_scheduler_p);
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqba/mqba_authenticator.h
+++ b/src/groups/mqb/mqba/mqba_authenticator.h
@@ -135,18 +135,6 @@ class Authenticator : public mqbnet::Authenticator {
         mqbnet::InitialConnectionContext*          context_p,
         const bmqp_ctrlmsg::AuthenticationMessage& authenticationMsg);
 
-    /// Handle an incoming AuthenticationResponse message by authenticating
-    /// using the specified `authenticationMsg` and `context_p`.  On success,
-    /// create an AuthenticationContext and stores it in `context_p`. The
-    /// behavior of this function is undefined unless `authenticationMsg` is an
-    /// `AuthenticationResponse`.  Return 0 on success; otherwise, return a
-    /// non-zero error code and populate `errorDescription` with details of the
-    /// failure.
-    int onAuthenticationResponse(
-        bsl::ostream&                              errorDescription,
-        mqbnet::InitialConnectionContext*          context_p,
-        const bmqp_ctrlmsg::AuthenticationMessage& authenticationMsg);
-
     /// Send an authentication response message with the specified `authnRc`,
     /// `errorMsg`, and `lifetimeMs` via the specified `channel`, using the
     /// specified `authenticationEncodingType`.  Return 0 on success;
@@ -236,15 +224,14 @@ class Authenticator : public mqbnet::Authenticator {
                                const bsl::shared_ptr<bmqio::Channel>& channel)
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Send out an outbound authentication message with the specified
-    /// `context`.  Return 0 on success, or a non-zero error code and populate
-    /// the specified `errorDescription` with a description of the error
-    /// otherwise.
-    int authenticationOutbound(bsl::ostream&                  errorDescription,
-                               const AuthenticationContextSp& context_sp)
-        BSLS_KEYWORD_OVERRIDE;
+    // ACCESSORS
+    //   (virtual: mqbnet::Authenticator)
 
-    /// ACCESSORS
+    bsl::shared_ptr<mqbnet::AuthenticationClient> createAuthenticationClient(
+        const bsl::shared_ptr<bmqio::Channel>& channel,
+        bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE;
+
+    bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the anonymous credential used for authentication.
     /// If no anonymous credential is set, return an empty optional.

--- a/src/groups/mqb/mqba/package/mqba.mem
+++ b/src/groups/mqb/mqba/package/mqba.mem
@@ -1,5 +1,6 @@
 mqba_adminsession
 mqba_application
+mqba_authenticationclient
 mqba_authenticator
 mqba_clientsession
 mqba_commandrouter

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
@@ -26,10 +26,13 @@
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbplug_authenticator.h>
+#include <mqbplug_credentialprovider.h>
 #include <mqbplug_pluginfactory.h>
+#include <mqbplug_plugintype.h>
 
 // BDE
 #include <ball_log.h>
+#include <bdlb_nullablevalue.h>
 #include <bdlb_string.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -37,6 +40,7 @@
 #include <bsl_unordered_map.h>
 #include <bsl_unordered_set.h>
 #include <bsl_vector.h>
+#include <bslmf_movableref.h>
 
 namespace BloombergLP {
 namespace mqbauthn {
@@ -123,7 +127,9 @@ int AuthenticationController::initializeAuthenticators(
 
     // Step 1: Collect all available plugin factories (built-in + external)
     PluginFactories pluginFactories(d_allocator_p);
-    if (int rc = collectAvailablePluginFactories(&pluginFactories)) {
+    if (int rc = collectAvailablePluginFactories(
+            mqbplug::PluginType::e_AUTHENTICATOR,
+            &pluginFactories)) {
         return rc * 10 + rc_COLLECT_FACTORIES_FAILED;  // RETURN
     }
 
@@ -164,17 +170,17 @@ int AuthenticationController::initializeAuthenticators(
 }
 
 int AuthenticationController::collectAvailablePluginFactories(
-    PluginFactories* pluginFactories)
+    mqbplug::PluginType::Enum type,
+    PluginFactories*          pluginFactories)
 {
     // Collect external plugin factories loaded by PluginManager
-    d_pluginManager_p->get(mqbplug::PluginType::e_AUTHENTICATOR,
-                           pluginFactories);
+    d_pluginManager_p->get(type, pluginFactories);
 
     // Add built-in plugin factories
     bsl::vector<mqbplug::PluginInfo>::const_iterator it =
         d_builtInPluginLibrary->plugins().cbegin();
     for (; it != d_builtInPluginLibrary->plugins().cend(); ++it) {
-        if (it->type() == mqbplug::PluginType::e_AUTHENTICATOR) {
+        if (it->type() == type) {
             pluginFactories->insert(it->factory().get());
         }
     }
@@ -381,6 +387,70 @@ int AuthenticationController::ensureDefaultAuthenticator(
     return 0;
 }
 
+int AuthenticationController::initializeCredentialProvider(
+    bsl::ostream& errorDescription)
+{
+    enum RcEnum {
+        rc_SUCCESS          = 0,
+        rc_COLLECT_FAILED   = -1,
+        rc_PLUGIN_NOT_FOUND = -2,
+        rc_START_FAILED     = -3
+    };
+
+    const bdlb::NullableValue<mqbcfg::CredentialProviderConfig>& credProvCfg =
+        mqbcfg::BrokerConfig::get().authentication().credentialProvider();
+
+    if (credProvCfg.isNull()) {
+        return rc_SUCCESS;  // RETURN
+    }
+
+    const bsl::string& providerName = credProvCfg.value().name();
+
+    BALL_LOG_INFO << "Configuring credential provider '" << providerName
+                  << "'";
+
+    PluginFactories factories(d_allocator_p);
+    if (int rc = collectAvailablePluginFactories(
+            mqbplug::PluginType::e_CREDENTIAL_PROVIDER,
+            &factories)) {
+        return rc * 10 + rc_COLLECT_FAILED;  // RETURN
+    }
+
+    for (PluginFactories::const_iterator it = factories.cbegin();
+         it != factories.cend();
+         ++it) {
+        mqbplug::CredentialProviderPluginFactory* candidate =
+            dynamic_cast<mqbplug::CredentialProviderPluginFactory*>(*it);
+        if (!candidate) {
+            continue;
+        }
+        bslma::ManagedPtr<mqbplug::CredentialProvider> provider =
+            candidate->create(d_allocator_p);
+        if (provider) {
+            d_credentialProvider_mp = bslmf::MovableRefUtil::move(provider);
+            break;
+        }
+    }
+
+    if (!d_credentialProvider_mp) {
+        errorDescription << "CredentialProvider plugin '" << providerName
+                         << "' not found";
+        return rc_PLUGIN_NOT_FOUND;  // RETURN
+    }
+
+    int rc = d_credentialProvider_mp->start(errorDescription);
+    if (rc != 0) {
+        return rc * 10 + rc_START_FAILED;  // RETURN
+    }
+
+    d_credentialFunc = d_credentialProvider_mp->load();
+
+    BALL_LOG_INFO << "Credential provider '" << providerName << "' started";
+
+    return rc_SUCCESS;
+}
+
+// CREATORS
 AuthenticationController::AuthenticationController(
     mqbplug::PluginManager* pluginManager,
     bslma::Allocator*       allocator)
@@ -388,6 +458,8 @@ AuthenticationController::AuthenticationController(
       bslma::ManagedPtrUtil::allocateManaged<mqbauthn::PluginLibrary>(
           allocator))
 , d_pluginManager_p(pluginManager)
+, d_credentialProvider_mp()
+, d_credentialFunc()
 , d_isStarted(false)
 , d_allocator_p(allocator)
 {
@@ -397,10 +469,11 @@ int AuthenticationController::start(bsl::ostream& errorDescription)
 {
     enum RcEnum {
         // Enum for the various RC error categories
-        rc_SUCCESS             = 0,
-        rc_ALREADY_STARTED     = -1,
-        rc_INVALID_CONFIG      = -2,
-        rc_INIT_AUTHENTICATORS = -3
+        rc_SUCCESS                  = 0,
+        rc_ALREADY_STARTED          = -1,
+        rc_INVALID_CONFIG           = -2,
+        rc_INIT_AUTHENTICATORS      = -3,
+        rc_INIT_CREDENTIAL_PROVIDER = -4
     };
 
     if (d_isStarted) {
@@ -420,7 +493,10 @@ int AuthenticationController::start(bsl::ostream& errorDescription)
         return rc * 10 + rc_INIT_AUTHENTICATORS;
     }
 
-    // Initialize Authenticators from plugins
+    rc = initializeCredentialProvider(errorDescription);
+    if (rc != 0) {
+        return rc * 10 + rc_INIT_CREDENTIAL_PROVIDER;
+    }
 
     d_isStarted = true;
     return rc_SUCCESS;
@@ -435,6 +511,13 @@ void AuthenticationController::stop()
     BALL_LOG_INFO << "Stopping AuthenticationController";
 
     d_isStarted = false;
+
+    // Stop credential provider
+    if (d_credentialProvider_mp) {
+        d_credentialProvider_mp->stop();
+        d_credentialProvider_mp.reset();
+        d_credentialFunc = mqbplug::CredentialProvider::CredentialFunc();
+    }
 
     // Stop all authenticators
     for (AuthenticatorMap::iterator it = d_authenticators.begin();
@@ -497,6 +580,19 @@ const bsl::optional<mqbcfg::Credential>&
 AuthenticationController::anonymousCredential()
 {
     return d_anonymousCredential;
+}
+
+// ACCESSORS
+bool AuthenticationController::hasCredentialProvider() const
+{
+    return d_credentialProvider_mp.get() != 0;
+}
+
+const mqbplug::CredentialProvider::CredentialFunc&
+AuthenticationController::credentialFunc() const
+{
+    BSLS_ASSERT_SAFE(hasCredentialProvider());
+    return d_credentialFunc;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
@@ -30,6 +30,7 @@
 // MQB
 #include <mqbcfg_messages.h>
 #include <mqbplug_authenticator.h>
+#include <mqbplug_credentialprovider.h>
 #include <mqbplug_pluginmanager.h>
 
 // BDE
@@ -84,6 +85,14 @@ class AuthenticationController {
     /// Held, not owned.
     mqbplug::PluginManager* d_pluginManager_p;
 
+    /// Credential provider for outbound authentication.  Null if not
+    /// configured.
+    bslma::ManagedPtr<mqbplug::CredentialProvider> d_credentialProvider_mp;
+
+    /// Credential function loaded from the provider.  Empty if no provider
+    /// is configured.
+    mqbplug::CredentialProvider::CredentialFunc d_credentialFunc;
+
     /// True if this component is started.
     bool d_isStarted;
 
@@ -105,11 +114,16 @@ class AuthenticationController {
     /// Initialize authenticators from configuration.
     int initializeAuthenticators(bsl::ostream& errorDescription);
 
-    /// Collect all available plugin factories (built-in and external).
-    /// Load them into the specified `pluginFactories` collection.
-    /// Return 0 on success, non-zero on error.
+    /// Collect all available plugin factories of the specified `type`
+    /// (built-in and external).  Load them into the specified
+    /// `pluginFactories` collection.  Return 0 on success, non-zero on
+    /// error.
     int collectAvailablePluginFactories(
+        mqbplug::PluginType::Enum                    type,
         bsl::unordered_set<mqbplug::PluginFactory*>* pluginFactories);
+
+    /// Initialize the credential provider from configuration.
+    int initializeCredentialProvider(bsl::ostream& errorDescription);
 
     /// Create authenticators based on configuration from the specified
     /// `authenticatorConfig` using the specified `pluginFactories`.
@@ -171,6 +185,16 @@ class AuthenticationController {
     /// Return the anonymous credential used for authentication.
     /// If no anonymous credential is set, return an empty optional.
     const bsl::optional<mqbcfg::Credential>& anonymousCredential();
+
+    // ACCESSORS
+
+    /// Return true if a credential provider is configured and started.
+    bool hasCredentialProvider() const;
+
+    /// Return a reference to the credential function loaded from the
+    /// configured provider.  The behavior is undefined unless
+    /// `hasCredentialProvider()` returns true.
+    const mqbplug::CredentialProvider::CredentialFunc& credentialFunc() const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbauthn_basiccredentialprovider.h>
+
+#include <mqbscm_version.h>
+
+// MQB
+#include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
+#include <mqbplug_authncredential.h>
+
+// BDE
+#include <bsl_optional.h>
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bslma_default.h>
+#include <bslma_managedptr.h>
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace mqbauthn {
+
+const char* BasicCredentialProvider::k_NAME      = "BasicCredentialProvider";
+const char* BasicCredentialProvider::k_MECHANISM = "BASIC";
+
+// ------------------------
+// class CredentialFunctor
+// ------------------------
+
+BasicCredentialProvider::CredentialFunctor::CredentialFunctor(
+    const bsl::string& mechanism,
+    const bsl::string& username,
+    const bsl::string& password)
+: d_mechanism(mechanism)
+, d_username(username)
+, d_password(password)
+{
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+BasicCredentialProvider::CredentialFunctor::operator()(
+    bsl::ostream& error) const
+{
+    if (d_username.empty()) {
+        error << "BasicCredentialProvider: username is empty";
+        return bsl::nullopt;  // RETURN
+    }
+
+    bsl::string payload(d_username);
+    payload.append(":");
+    payload.append(d_password);
+
+    bsl::vector<char> data(payload.begin(), payload.end());
+
+    return mqbplug::AuthnCredential(d_mechanism, data);
+}
+
+// -----------------------------
+// class BasicCredentialProvider
+// -----------------------------
+
+// CREATORS
+BasicCredentialProvider::BasicCredentialProvider(bsl::string_view  username,
+                                                 bsl::string_view  password,
+                                                 bslma::Allocator* allocator)
+: d_username(username, allocator)
+, d_password(password, allocator)
+, d_isStarted(false)
+{
+}
+
+BasicCredentialProvider::~BasicCredentialProvider()
+{
+    BSLS_ASSERT_OPT(!d_isStarted &&
+                    "stop() must be called before destroying this object");
+}
+
+// MANIPULATORS
+mqbplug::CredentialProvider::CredentialFunc BasicCredentialProvider::load()
+{
+    return CredentialFunctor(k_MECHANISM, d_username, d_password);
+}
+
+int BasicCredentialProvider::start(bsl::ostream& errorDescription)
+{
+    if (d_isStarted) {
+        errorDescription << "start() can only be called once on this object";
+        return -1;  // RETURN
+    }
+
+    if (d_username.empty()) {
+        errorDescription << "BasicCredentialProvider: username is empty";
+        return -1;  // RETURN
+    }
+
+    d_isStarted = true;
+
+    BALL_LOG_INFO << "BasicCredentialProvider started for user '" << d_username
+                  << "'";
+
+    return 0;
+}
+
+void BasicCredentialProvider::stop()
+{
+    if (!d_isStarted) {
+        return;  // RETURN
+    }
+
+    d_isStarted = false;
+
+    BALL_LOG_INFO << "BasicCredentialProvider stopped";
+}
+
+// ----------------------------------------
+// class BasicCredentialProviderPluginFactory
+// ----------------------------------------
+
+BasicCredentialProviderPluginFactory::BasicCredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+BasicCredentialProviderPluginFactory::~BasicCredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+bslma::ManagedPtr<mqbplug::CredentialProvider>
+BasicCredentialProviderPluginFactory::create(bslma::Allocator* allocator)
+{
+    const bdlb::NullableValue<mqbcfg::CredentialProviderConfig>& providerCfg =
+        mqbcfg::BrokerConfig::get().authentication().credentialProvider();
+
+    if (providerCfg.isNull()) {
+        return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
+    }
+
+    if (providerCfg.value().name() != BasicCredentialProvider::k_NAME) {
+        return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
+    }
+
+    allocator = bslma::Default::allocator(allocator);
+
+    bsl::string username(allocator);
+    bsl::string password(allocator);
+
+    for (bsl::vector<mqbcfg::PluginSettingKeyValue>::const_iterator it =
+             providerCfg.value().settings().cbegin();
+         it != providerCfg.value().settings().cend();
+         ++it) {
+        if (!it->value().isStringValValue()) {
+            continue;  // CONTINUE
+        }
+        if (it->key() == "username") {
+            username = it->value().stringVal();
+        }
+        else if (it->key() == "password") {
+            password = it->value().stringVal();
+        }
+    }
+
+    return bslma::ManagedPtr<mqbplug::CredentialProvider>(
+        new (*allocator)
+            BasicCredentialProvider(username, password, allocator),
+        allocator);
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
@@ -1,0 +1,164 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBAUTHN_BASICCREDENTIALPROVIDER
+#define INCLUDED_MQBAUTHN_BASICCREDENTIALPROVIDER
+
+/// @file mqbauthn_basiccredentialprovider.h
+///
+/// @brief Provide a basic credential provider that supplies username and
+/// password credentials for outbound broker-to-broker authentication.
+///
+/// @bbref{mqbauthn::BasicCredentialProvider} provides a built-in
+/// credential provider plugin that supplies credentials using a configured
+/// username and password.  When its credential function is invoked, it returns
+/// an @bbref{mqbplug::AuthnCredential} with mechanism "BASIC" and data in the
+/// form "username:password".
+///
+/// This provider reads `username` and `password` from its plugin configuration
+/// settings (key-value pairs).
+
+// MQB
+#include <mqbplug_authncredential.h>
+#include <mqbplug_credentialprovider.h>
+
+// BDE
+#include <ball_log.h>
+#include <bsl_optional.h>
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bslma_allocator.h>
+#include <bslma_managedptr.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+
+// FORWARD DECLARATION
+namespace mqbcfg {
+class CredentialProviderPluginConfig;
+}
+
+namespace mqbauthn {
+
+// =============================
+// class BasicCredentialProvider
+// =============================
+
+class BasicCredentialProvider : public mqbplug::CredentialProvider {
+  public:
+    // PUBLIC CLASS DATA
+    static const char* k_NAME;
+    static const char* k_MECHANISM;
+
+    // ========================
+    // class CredentialFunctor
+    // ========================
+
+    /// A self-contained functor that produces an `AuthnCredential` with the
+    /// "BASIC" mechanism and "username:password" data.
+    class CredentialFunctor {
+        // DATA
+        bsl::string d_mechanism;
+        bsl::string d_username;
+        bsl::string d_password;
+
+      public:
+        // CREATORS
+
+        /// Create a `CredentialFunctor` with the specified `mechanism`,
+        /// `username`, and `password`.
+        CredentialFunctor(const bsl::string& mechanism,
+                          const bsl::string& username,
+                          const bsl::string& password);
+
+        // ACCESSORS
+
+        /// Return an `AuthnCredential` containing the configured
+        /// credentials, or `nullopt` on failure (with a description
+        /// written to the specified `error` stream).
+        bsl::optional<mqbplug::AuthnCredential>
+        operator()(bsl::ostream& error) const;
+    };
+
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.BASICCREDENTIALPROVIDER");
+
+    // DATA
+    bsl::string d_username;
+    bsl::string d_password;
+    bool        d_isStarted;
+
+  private:
+    // NOT IMPLEMENTED
+    BasicCredentialProvider(const BasicCredentialProvider&)
+        BSLS_KEYWORD_DELETED;
+    BasicCredentialProvider&
+    operator=(const BasicCredentialProvider&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(BasicCredentialProvider,
+                                   bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a `BasicCredentialProvider` with the specified `username`
+    /// and `password`, using the optionally specified `allocator` to supply
+    /// memory.
+    BasicCredentialProvider(bsl::string_view  username,
+                            bsl::string_view  password,
+                            bslma::Allocator* allocator = 0);
+
+    /// Destructor.
+    ~BasicCredentialProvider() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+
+    /// Return a credential-providing function.  The behavior is undefined
+    /// unless `start()` has been called successfully.
+    CredentialFunc load() BSLS_KEYWORD_OVERRIDE;
+
+    /// Start the provider and return 0 on success, or return a non-zero
+    /// value and populate the specified `errorDescription` with the
+    /// description of any failure encountered.
+    int start(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the provider.
+    void stop() BSLS_KEYWORD_OVERRIDE;
+};
+
+// ========================================
+// class BasicCredentialProviderPluginFactory
+// ========================================
+
+class BasicCredentialProviderPluginFactory
+: public mqbplug::CredentialProviderPluginFactory {
+  public:
+    // CREATORS
+    BasicCredentialProviderPluginFactory();
+    ~BasicCredentialProviderPluginFactory() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+    bslma::ManagedPtr<mqbplug::CredentialProvider>
+    create(bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbauthn/mqbauthn_pluginlibrary.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_pluginlibrary.cpp
@@ -18,6 +18,7 @@
 // MQB
 #include <mqbauthn_anonauthenticator.h>
 #include <mqbauthn_basicauthenticator.h>
+#include <mqbauthn_basiccredentialprovider.h>
 #include <mqbauthn_testauthenticator.h>
 
 namespace BloombergLP {
@@ -54,6 +55,15 @@ PluginLibrary::PluginLibrary(bslma::Allocator* allocator)
     testPluginInfo.setFactory(
         bsl::allocate_shared<TestAuthenticatorPluginFactory>(allocator));
     testPluginInfo.setDescription("Test Authenticator");
+
+    // BasicCredentialProvider
+    mqbplug::PluginInfo& credProviderInfo = d_plugins.emplace_back(
+        mqbplug::PluginType::e_CREDENTIAL_PROVIDER,
+        mqbauthn::BasicCredentialProvider::k_NAME);
+    credProviderInfo.setFactory(
+        bsl::allocate_shared<BasicCredentialProviderPluginFactory>(allocator));
+    credProviderInfo.setDescription(
+        "Built-in Basic Username/Password Credential Provider");
 }
 
 PluginLibrary::~PluginLibrary()

--- a/src/groups/mqb/mqbauthn/package/mqbauthn.mem
+++ b/src/groups/mqb/mqbauthn/package/mqbauthn.mem
@@ -2,5 +2,6 @@
 mqbauthn_anonauthenticator
 mqbauthn_authenticationcontroller
 mqbauthn_basicauthenticator
+mqbauthn_basiccredentialprovider
 mqbauthn_pluginlibrary
 mqbauthn_testauthenticator

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbnet_authenticationclient.h>
+
+#include <mqbscm_version.h>
+
+namespace BloombergLP {
+namespace mqbnet {
+
+// --------------------------
+// class AuthenticationClient
+// --------------------------
+
+AuthenticationClient::~AuthenticationClient()
+{
+    // NOTHING: Pure interface
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
@@ -1,0 +1,76 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBNET_AUTHENTICATIONCLIENT
+#define INCLUDED_MQBNET_AUTHENTICATIONCLIENT
+
+/// @file mqbnet_authenticationclient.h
+///
+/// @brief Provide a protocol for a client-side authenticator.
+///
+/// @bbref{mqbnet::AuthenticationClient} is a protocol for the client side of
+/// broker-to-broker authentication for a single connection.  An
+/// implementation sends an @bbref{bmqp_ctrlmsg::AuthenticationRequest}
+/// on an outbound channel and processes the resulting
+/// @bbref{bmqp_ctrlmsg::AuthenticationResponse}.
+
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+
+// BDE
+#include <bsl_memory.h>
+#include <bsl_ostream.h>
+
+namespace BloombergLP {
+
+namespace mqbnet {
+
+// ==========================
+// class AuthenticationClient
+// ==========================
+
+/// Protocol for the client side of broker-to-broker authentication.
+class AuthenticationClient {
+  public:
+    // CREATORS
+
+    /// Destructor
+    virtual ~AuthenticationClient();
+
+    // MANIPULATORS
+
+    /// Send an AuthenticationRequest using credentials from the configured
+    /// provider.  Return 0 on success, or a non-zero value and populate the
+    /// specified `errorDescription` with the description of any failure
+    /// encountered.
+    virtual int authenticate(bsl::ostream& errorDescription) = 0;
+
+    /// Process the specified `response` received from the remote broker.
+    /// Return 0 if authentication succeeded, or a non-zero value and
+    /// populate the specified `errorDescription` with the description of
+    /// any failure encountered.
+    virtual int
+    handleResponse(bsl::ostream&                              errorDescription,
+                   const bmqp_ctrlmsg::AuthenticationMessage& response) = 0;
+
+    /// Stop the authentication client, cancelling any pending
+    /// reauthentication timers.
+    virtual void stop() = 0;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbnet/mqbnet_authenticator.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticator.h
@@ -28,6 +28,7 @@
 #include <mqbnet_authenticationcontext.h>
 
 // BMQ
+#include <bmqio_channel.h>
 #include <bmqp_ctrlmsg_messages.h>
 
 // BDE
@@ -40,6 +41,7 @@ namespace BloombergLP {
 namespace mqbnet {
 
 // FORWARD DECLARATION
+class AuthenticationClient;
 class InitialConnectionContext;
 
 // ===================
@@ -86,14 +88,15 @@ class Authenticator {
         const bsl::shared_ptr<AuthenticationContext>& context_sp,
         const bsl::shared_ptr<bmqio::Channel>&        channel) = 0;
 
-    /// Produce and send outbound authentication message with the specified
-    /// `context_sp`.  Return 0 on success, or a non-zero error code and
-    /// populate the specified `errorDescription` with a description of the
-    /// error otherwise.
-    /// TODO: Rethink the need for this method in the interface.
-    virtual int authenticationOutbound(
-        bsl::ostream&                                 errorDescription,
-        const bsl::shared_ptr<AuthenticationContext>& context_sp) = 0;
+    /// Return true if outbound authentication is configured for this host.
+    virtual bool hasOutboundAuthentication() const = 0;
+
+    /// Create and return a per-connection AuthenticationClient for the
+    /// specified outbound `channel` using the specified `allocator`.  The
+    /// behavior is undefined unless `hasOutboundAuthentication()` is true.
+    virtual bsl::shared_ptr<AuthenticationClient>
+    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>& channel,
+                               bslma::Allocator* allocator) const = 0;
 
     // ACCESSORS
 

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -19,6 +19,7 @@
 
 // MQB
 #include <mqbcfg_messages.h>
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_negotiationcontext.h>
 
@@ -83,6 +84,7 @@ const char* InitialConnectionState::toAscii(InitialConnectionState::Enum value)
         CASE(ANON_AUTHENTICATING)
         CASE(NEGOTIATING_OUTBOUND)
         CASE(NEGOTIATED)
+        CASE(AUTHENTICATING_OUTBOUND)
         CASE(FAILED)
     default: return "(* UNKNOWN *)";
     }
@@ -108,6 +110,7 @@ bool InitialConnectionState::fromAscii(InitialConnectionState::Enum* out,
     CHECKVALUE(ANON_AUTHENTICATING)
     CHECKVALUE(NEGOTIATING_OUTBOUND)
     CHECKVALUE(NEGOTIATED)
+    CHECKVALUE(AUTHENTICATING_OUTBOUND)
     CHECKVALUE(FAILED)
 
     // Invalid string
@@ -148,9 +151,10 @@ const char* InitialConnectionEvent::toAscii(InitialConnectionEvent::Enum value)
         CASE(NONE)
         CASE(OUTBOUND_NEGOTIATION)
         CASE(INCOMING)
-        CASE(AUTHN_REQUEST)
+        CASE(AUTHN_MESSAGE)
         CASE(NEGOTIATION_MESSAGE)
         CASE(AUTHN_SUCCESS)
+        CASE(OUTBOUND_AUTHENTICATION)
         CASE(ERROR)
     default: return "(* UNKNOWN *)";
     }
@@ -173,9 +177,10 @@ bool InitialConnectionEvent::fromAscii(InitialConnectionEvent::Enum* out,
     CHECKVALUE(NONE)
     CHECKVALUE(OUTBOUND_NEGOTIATION)
     CHECKVALUE(INCOMING)
-    CHECKVALUE(AUTHN_REQUEST)
+    CHECKVALUE(AUTHN_MESSAGE)
     CHECKVALUE(NEGOTIATION_MESSAGE)
     CHECKVALUE(AUTHN_SUCCESS)
+    CHECKVALUE(OUTBOUND_AUTHENTICATION)
     CHECKVALUE(ERROR)
 
     // Invalid string
@@ -206,6 +211,7 @@ InitialConnectionContext::InitialConnectionContext(
 , d_userData_p(userData)
 , d_channelSp(channel)
 , d_authenticationCtxSp()
+, d_authenticationClientSp()
 , d_negotiationCtxSp()
 , d_initialConnectionCompleteCb(initialConnectionCompleteCb)
 , d_authenticationEncodingType(bmqp::EncodingType::e_BER)
@@ -307,7 +313,7 @@ int InitialConnectionContext::processBlob(bsl::ostream&      errorDescription,
     else if (bsl::holds_alternative<bmqp_ctrlmsg::AuthenticationMessage>(
                  message)) {
         handleEvent(bsl::string(),
-                    InitialConnectionEvent::e_AUTHN_REQUEST,
+                    InitialConnectionEvent::e_AUTHN_MESSAGE,
                     message);
     }
     else {
@@ -497,11 +503,16 @@ void InitialConnectionContext::readCallback(const bmqio::Status& status,
 void InitialConnectionContext::handleInitialConnection()
 {
     if (!isIncoming()) {
-        // TODO: When we are ready to move on to the next step, we should
-        // call `authenticationOutbound` here instead before calling
-        // `negotiateOutbound`.
-        handleEvent(bsl::string(),
-                    mqbnet::InitialConnectionEvent::e_OUTBOUND_NEGOTIATION);
+        if (d_authenticator_p->hasOutboundAuthentication()) {
+            handleEvent(
+                bsl::string(),
+                mqbnet::InitialConnectionEvent::e_OUTBOUND_AUTHENTICATION);
+        }
+        else {
+            handleEvent(
+                bsl::string(),
+                mqbnet::InitialConnectionEvent::e_OUTBOUND_NEGOTIATION);
+        }
     }
     else {
         handleEvent(bsl::string(), mqbnet::InitialConnectionEvent::e_INCOMING);
@@ -554,6 +565,29 @@ void InitialConnectionContext::handleEvent(
         }
         break;
     }
+    case InitialConnectionEvent::e_OUTBOUND_AUTHENTICATION: {
+        if (oldState == InitialConnectionState::e_INITIAL) {
+            setState(InitialConnectionState::e_AUTHENTICATING_OUTBOUND, event);
+
+            // Initialize an authentication client for this outbound connection
+            // to a broker.  This will be stored and if needed, reused for the
+            // lifetime of this connection for reauthentication.
+            d_authenticationClientSp =
+                d_authenticator_p->createAuthenticationClient(d_channelSp,
+                                                              d_allocator_p);
+            rc = d_authenticationClientSp->authenticate(errStream);
+            if (rc == rc_SUCCESS) {
+                rc = scheduleRead(errStream);
+            }
+        }
+        else {
+            errStream << "Unexpected event received: " << oldState << " -> "
+                      << event;
+            BALL_LOG_ERROR << "#UNEXPECTED_STATE " << errStream.str()
+                           << " [peer: " << channel().get() << "]";
+        }
+        break;
+    }
     case InitialConnectionEvent::e_INCOMING: {
         if (oldState == InitialConnectionState::e_INITIAL) {
             // For incoming connections, start reading the first message
@@ -567,7 +601,7 @@ void InitialConnectionContext::handleEvent(
         }
         break;
     }
-    case InitialConnectionEvent::e_AUTHN_REQUEST: {
+    case InitialConnectionEvent::e_AUTHN_MESSAGE: {
         BSLS_ASSERT_SAFE(
             bsl::holds_alternative<bmqp_ctrlmsg::AuthenticationMessage>(
                 message));
@@ -583,6 +617,26 @@ void InitialConnectionContext::handleEvent(
             rc = d_authenticator_p->handleAuthentication(errStream,
                                                          this,
                                                          authenticationMsg);
+        }
+        else if (oldState ==
+                 InitialConnectionState::e_AUTHENTICATING_OUTBOUND) {
+            BSLS_ASSERT_SAFE(d_authenticationClientSp);
+            rc = d_authenticationClientSp->handleResponse(errStream,
+                                                          authenticationMsg);
+            if (rc == rc_SUCCESS) {
+                setState(InitialConnectionState::e_NEGOTIATING_OUTBOUND,
+                         event);
+
+                // Send negotiation directly instead of calling 'handleEvent'
+                // with e_OUTBOUND_NEGOTIATION, as 'd_mutex' is currently held
+                // and calling 'handleEvent' would attempt to acquire it again.
+                createNegotiationContext();
+
+                rc = d_negotiator_p->negotiateOutbound(errStream, this);
+                if (rc == rc_SUCCESS) {
+                    rc = scheduleRead(errStream);
+                }
+            }
         }
         else {
             errStream << "Unexpected event received: " << oldState << " -> "
@@ -734,6 +788,12 @@ const bsl::shared_ptr<AuthenticationContext>&
 InitialConnectionContext::authenticationContext() const
 {
     return d_authenticationCtxSp;
+}
+
+const bsl::shared_ptr<AuthenticationClient>&
+InitialConnectionContext::authenticationClient() const
+{
+    return d_authenticationClientSp;
 }
 
 const bsl::shared_ptr<NegotiationContext>&

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -87,9 +87,12 @@ struct InitialConnectionState {
         e_AUTHENTICATING      = 1,  // First message is authentication Request.
         e_AUTHENTICATED       = 2,  // Authentication success.
         e_ANON_AUTHENTICATING = 3,  // First message is Negotiation Request.
-        e_NEGOTIATING_OUTBOUND = 4,  // Outbound negotiation.
-        e_NEGOTIATED           = 5,  // Negotiation success.  Final state.
-        e_FAILED               = 6   // Final state.
+        e_NEGOTIATING_OUTBOUND    = 4,  // Outbound negotiation.
+        e_NEGOTIATED              = 5,  // Negotiation success.  Final state.
+        e_AUTHENTICATING_OUTBOUND = 6,  // Outbound authentication in progress.
+        // Note: 'e_AUTHENTICATED_OUTBOUND' is omitted as outbound authn
+        // directly transitions to e_NEGOTIATING_OUTBOUND or e_FAILED.
+        e_FAILED = 7  // Final state.
     };
 
     // CLASS METHODS
@@ -143,13 +146,20 @@ bsl::ostream& operator<<(bsl::ostream&                stream,
 struct InitialConnectionEvent {
     // TYPES
     enum Enum {
-        e_NONE                 = 0,
+        e_NONE = 0,
+        /// Negotiate session (as a client)
         e_OUTBOUND_NEGOTIATION = 1,
-        e_INCOMING             = 2,
-        e_AUTHN_REQUEST        = 3,
-        e_NEGOTIATION_MESSAGE  = 4,
-        e_AUTHN_SUCCESS        = 5,
-        e_ERROR                = 6
+        /// New connection from a client
+        e_INCOMING = 2,
+        /// Received authentication message from client or server
+        e_AUTHN_MESSAGE = 3,
+        /// Received negotiation message from client or server
+        e_NEGOTIATION_MESSAGE = 4,
+        /// Client authenticated, proceed to negotiation
+        e_AUTHN_SUCCESS = 5,
+        /// Send authentication message as client
+        e_OUTBOUND_AUTHENTICATION = 6,
+        e_ERROR                   = 7
     };
 
     // CLASS METHODS
@@ -223,7 +233,7 @@ class InitialConnectionContext {
     /// Mutex to protect the context state.
     mutable bslmt::Mutex d_mutex;
 
-    /// Authenticator to use for authenticating a connection.
+    /// Authenticator to use for authenticating connections.
     mqbnet::Authenticator* d_authenticator_p;
 
     /// Negotiator to use for converting a Channel to a Session.
@@ -269,6 +279,11 @@ class InitialConnectionContext {
     /// The AuthenticationContext updated upon receiving an
     /// authentication message.
     bsl::shared_ptr<AuthenticationContext> d_authenticationCtxSp;
+
+    /// Per-connection client for outbound authentication and
+    /// reauthentication.  Non-null for outbound connections if broker
+    /// has a credential provider configured.  Null for inbound connections.
+    bsl::shared_ptr<AuthenticationClient> d_authenticationClientSp;
 
     /// The NegotiationContext updated upon receiving a negotiation message.
     bsl::shared_ptr<NegotiationContext> d_negotiationCtxSp;
@@ -415,6 +430,7 @@ class InitialConnectionContext {
     bmqp::EncodingType::Enum               authenticationEncodingType() const;
     const bsl::shared_ptr<AuthenticationContext>&
                                                authenticationContext() const;
+    const bsl::shared_ptr<AuthenticationClient>& authenticationClient() const;
     const bsl::shared_ptr<NegotiationContext>& negotiationContext() const;
     bool                                       isClosed() const;
     InitialConnectionState::Enum               state() const;

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -16,12 +16,14 @@
 #include <mqbnet_initialconnectioncontext.h>
 
 // MQB
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_initialconnectioncontext.h>
 #include <mqbnet_negotiationcontext.h>
 #include <mqbnet_session.h>
 
 // BMQ
 #include <bmqio_testchannel.h>
+#include <bmqp_ctrlmsg_messages.h>
 
 // BDE
 #include <bsl_memory.h>
@@ -55,12 +57,40 @@ void complete(const bsl::shared_ptr<int>&             check,
     (void)channel;
 }
 
+// Mock authentication client
+struct MockAuthenticationClient : public mqbnet::AuthenticationClient {
+    bool d_authenticateCalled;
+    int  d_authenticateRc;
+    bool d_handleResponseCalled;
+    int  d_handleResponseRc;
+    bool d_stopCalled;
+
+    int authenticate(bsl::ostream&) BSLS_KEYWORD_OVERRIDE
+    {
+        d_authenticateCalled = true;
+        return d_authenticateRc;
+    }
+
+    int handleResponse(bsl::ostream&,
+                       const bmqp_ctrlmsg::AuthenticationMessage&)
+        BSLS_KEYWORD_OVERRIDE
+    {
+        d_handleResponseCalled = true;
+        return d_handleResponseRc;
+    }
+
+    void stop() BSLS_KEYWORD_OVERRIDE { d_stopCalled = true; }
+};
+
 // Mock authenticator
 struct MockAuthenticator : public mqbnet::Authenticator {
-  private:
-    bsl::optional<mqbcfg::Credential> d_anonymousCredential;
+    bsl::optional<mqbcfg::Credential>         d_anonymousCredential;
+    bool                                      d_hasOutboundAuthentication;
+    int                                       d_authenticateRc;
+    int                                       d_handleResponseRc;
+    bsl::shared_ptr<MockAuthenticationClient> d_mockClient;
+    bool                                      d_negotiateOutboundCalled;
 
-  public:
     int  start(bsl::ostream&) BSLS_KEYWORD_OVERRIDE { return 0; }
     void stop() BSLS_KEYWORD_OVERRIDE {}
     int  handleAuthentication(bsl::ostream&,
@@ -80,13 +110,21 @@ struct MockAuthenticator : public mqbnet::Authenticator {
 
     bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE
     {
-        return false;
+        return d_hasOutboundAuthentication;
     }
-    bsl::shared_ptr<mqbnet::AuthenticationClient>
-    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>&,
-                               bslma::Allocator*) const BSLS_KEYWORD_OVERRIDE
+
+    bsl::shared_ptr<mqbnet::AuthenticationClient> createAuthenticationClient(
+        const bsl::shared_ptr<bmqio::Channel>&,
+        bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE
     {
-        return bsl::shared_ptr<mqbnet::AuthenticationClient>();
+        // const_cast because the mock needs to store the client for later
+        // inspection by the test, but the interface is const.
+        MockAuthenticator* self = const_cast<MockAuthenticator*>(this);
+        self->d_mockClient = bsl::allocate_shared<MockAuthenticationClient>(
+            allocator);
+        self->d_mockClient->d_authenticateRc   = d_authenticateRc;
+        self->d_mockClient->d_handleResponseRc = d_handleResponseRc;
+        return self->d_mockClient;
     }
 
     const bsl::optional<mqbcfg::Credential>&
@@ -98,6 +136,8 @@ struct MockAuthenticator : public mqbnet::Authenticator {
 
 // Mock negotiator
 struct MockNegotiator : public mqbnet::Negotiator {
+    bool d_negotiateOutboundCalled;
+
     int createSessionOnMsgType(bsl::ostream&,
                                bsl::shared_ptr<mqbnet::Session>*,
                                mqbnet::InitialConnectionContext*)
@@ -108,7 +148,31 @@ struct MockNegotiator : public mqbnet::Negotiator {
     int negotiateOutbound(bsl::ostream&, mqbnet::InitialConnectionContext*)
         BSLS_KEYWORD_OVERRIDE
     {
+        d_negotiateOutboundCalled = true;
         return 0;
+    }
+};
+
+struct TestBench {
+    bsl::shared_ptr<MockAuthenticator>  d_authenticator;
+    bsl::shared_ptr<MockNegotiator>     d_negotiator;
+    bsl::shared_ptr<bmqio::TestChannel> d_channel;
+    bsl::shared_ptr<int>                d_completionStatus;
+
+    mqbnet::InitialConnectionContext::InitialConnectionCompleteCb d_completeCb;
+
+    explicit TestBench(bslma::Allocator* allocator)
+    : d_authenticator(bsl::allocate_shared<MockAuthenticator>(allocator))
+    , d_negotiator(bsl::allocate_shared<MockNegotiator>(allocator))
+    , d_channel(bsl::allocate_shared<bmqio::TestChannel>(allocator))
+    , d_completionStatus(bsl::allocate_shared<int>(allocator, 0))
+    , d_completeCb(bdlf::BindUtil::bind(&complete,
+                                        d_completionStatus,
+                                        bdlf::PlaceHolders::_1,
+                                        bdlf::PlaceHolders::_2,
+                                        bdlf::PlaceHolders::_3,
+                                        bdlf::PlaceHolders::_4))
+    {
     }
 };
 
@@ -121,33 +185,19 @@ struct MockNegotiator : public mqbnet::Negotiator {
 static void test1_initialConnectionContext()
 {
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
-    bsl::shared_ptr<MockAuthenticator> authenticator =
-        bsl::allocate_shared<MockAuthenticator>(alloc);
-    bsl::shared_ptr<MockNegotiator> negotiator =
-        bsl::allocate_shared<MockNegotiator>(alloc);
-    bsl::shared_ptr<bmqio::TestChannel> channel =
-        bsl::allocate_shared<bmqio::TestChannel>(alloc);
-
-    bsl::shared_ptr<int> check = bsl::allocate_shared<int>(alloc, 0);
-    mqbnet::InitialConnectionContext::InitialConnectionCompleteCb completeCb =
-        bdlf::BindUtil::bind(&complete,
-                             check,
-                             bdlf::PlaceHolders::_1,  // status
-                             bdlf::PlaceHolders::_2,  // errorDescription
-                             bdlf::PlaceHolders::_3,  // session
-                             bdlf::PlaceHolders::_4   // channel
-        );
+    TestBench         tb(alloc);
 
     bmqtst::TestHelper::printTestName("test1_basicConstruction");
     {
         PV("Constructor");
         mqbnet::InitialConnectionContext obj1(false,
-                                              authenticator.get(),
-                                              negotiator.get(),
+                                              0,
+                                              0,
                                               static_cast<void*>(0),
                                               static_cast<void*>(0),
-                                              channel,
-                                              completeCb);
+                                              tb.d_channel,
+                                              tb.d_completeCb,
+                                              alloc);
         BMQTST_ASSERT_EQ(obj1.isIncoming(), false);
         BMQTST_ASSERT_EQ(obj1.resultState(), static_cast<void*>(0));
         BMQTST_ASSERT_EQ(obj1.userData(), static_cast<void*>(0));
@@ -157,12 +207,13 @@ static void test1_initialConnectionContext()
         PV("Manipulators/Accessors");
 
         mqbnet::InitialConnectionContext obj(true,
-                                             authenticator.get(),
-                                             negotiator.get(),
+                                             tb.d_authenticator.get(),
+                                             tb.d_negotiator.get(),
                                              static_cast<void*>(0),
                                              static_cast<void*>(0),
-                                             channel,
-                                             completeCb);
+                                             tb.d_channel,
+                                             tb.d_completeCb,
+                                             alloc);
 
         {  // ResultState
             int value = 9;
@@ -191,9 +242,224 @@ static void test1_initialConnectionContext()
                          bsl::string(),
                          bsl::shared_ptr<mqbnet::Session>());
 
-            BMQTST_ASSERT_EQ(*check, rc);
+            BMQTST_ASSERT_EQ(*tb.d_completionStatus, rc);
         }
     }
+}
+
+static void test2_outboundAuthenticate()
+// ------------------------------------------------------------------------
+// OUTBOUND AUTHENTICATE
+//
+// Concerns:
+//   - 'handleInitialConnection()' on an outbound context with
+//     authentication enters 'e_AUTHENTICATING_OUTBOUND'.
+//   - 'authenticate()' is called on the created client.
+//   - After receiving a successful 'e_AUTHN_MESSAGE', the FSM
+//     transitions to 'e_NEGOTIATING_OUTBOUND'.
+//   - 'handleResponse()' is called on the client.
+//   - 'negotiateOutbound()' is called on the negotiator.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_AUTHENTICATING_OUTBOUND and authenticate() was
+//      called.
+//   4) Fire e_AUTHN_MESSAGE event with a success AuthenticationResponse.
+//   5) Verify state is e_NEGOTIATING_OUTBOUND, handleResponse() was
+//      called, and negotiateOutbound() was called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND AUTHENTICATE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(
+        ctx.state(),
+        mqbnet::InitialConnectionState::e_AUTHENTICATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_authenticateCalled);
+
+    // 4)
+    bmqp_ctrlmsg::AuthenticationMessage   response;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        response.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+    resp.status().code()     = 0;
+    resp.status().message()  = "OK";
+
+    ctx.handleEvent(bsl::string(),
+                    mqbnet::InitialConnectionEvent::e_AUTHN_MESSAGE,
+                    response);
+
+    // 5)
+    BMQTST_ASSERT_EQ(ctx.state(),
+                     mqbnet::InitialConnectionState::e_NEGOTIATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_handleResponseCalled);
+    BMQTST_ASSERT(tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test3_outboundAuthenticateFailure()
+// ------------------------------------------------------------------------
+// OUTBOUND AUTHENTICATE FAILURE
+//
+// Concerns:
+//   - When 'authenticate()' fails, the FSM transitions to 'e_FAILED'.
+//   - The completion callback is invoked with a non-zero status.
+//   - 'negotiateOutbound()' is never called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true
+//      and the mock client's authenticateRc = -1.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_FAILED, the completion callback fired with
+//      non-zero status, and negotiateOutbound() was not called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND AUTHENTICATE FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+    tb.d_authenticator->d_authenticateRc            = -1;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(ctx.state(), mqbnet::InitialConnectionState::e_FAILED);
+    BMQTST_ASSERT_NE(*tb.d_completionStatus, 0);
+    BMQTST_ASSERT(!tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test4_outboundHandleResponseFailure()
+// ------------------------------------------------------------------------
+// OUTBOUND HANDLE RESPONSE FAILURE
+//
+// Concerns:
+//   - When 'authenticate()' succeeds but 'handleResponse()' fails, the
+//     FSM transitions to 'e_FAILED'.
+//   - The completion callback is invoked with a non-zero status.
+//   - 'negotiateOutbound()' is never called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true
+//      and the mock client's handleResponseRc = -1.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_AUTHENTICATING_OUTBOUND (authenticate succeeded).
+//   4) Fire e_AUTHN_MESSAGE with an AuthenticationResponse.
+//   5) Verify state is e_FAILED, completion callback fired with non-zero
+//      status, and negotiateOutbound() was not called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND HANDLE RESPONSE FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+    tb.d_authenticator->d_handleResponseRc          = -1;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(
+        ctx.state(),
+        mqbnet::InitialConnectionState::e_AUTHENTICATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_authenticateCalled);
+
+    // 4)
+    bmqp_ctrlmsg::AuthenticationMessage response;
+    response.makeAuthenticationResponse();
+
+    ctx.handleEvent(bsl::string(),
+                    mqbnet::InitialConnectionEvent::e_AUTHN_MESSAGE,
+                    response);
+
+    // 5)
+    BMQTST_ASSERT_EQ(ctx.state(), mqbnet::InitialConnectionState::e_FAILED);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_handleResponseCalled);
+    BMQTST_ASSERT_NE(*tb.d_completionStatus, 0);
+    BMQTST_ASSERT(!tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test5_outboundNoAuthentication()
+// ------------------------------------------------------------------------
+// OUTBOUND NO AUTHENTICATION
+//
+// Concerns:
+//   - When 'hasOutboundAuthentication()' is false,
+//     'handleInitialConnection()' skips authentication and goes directly
+//     to 'e_NEGOTIATING_OUTBOUND'.
+//   - No AuthenticationClient is created.
+//   - 'negotiateOutbound()' is called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = false.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_NEGOTIATING_OUTBOUND, authenticationClient() is
+//      null, and negotiateOutbound() was called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND NO AUTHENTICATION");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1) d_hasOutboundAuthentication defaults to false
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(ctx.state(),
+                     mqbnet::InitialConnectionState::e_NEGOTIATING_OUTBOUND);
+    BMQTST_ASSERT(!ctx.authenticationClient());
+    BMQTST_ASSERT(tb.d_negotiator->d_negotiateOutboundCalled);
 }
 
 // ============================================================================
@@ -206,6 +472,10 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 5: test5_outboundNoAuthentication(); break;
+    case 4: test4_outboundHandleResponseFailure(); break;
+    case 3: test3_outboundAuthenticateFailure(); break;
+    case 2: test2_outboundAuthenticate(); break;
     case 1: test1_initialConnectionContext(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -77,13 +77,18 @@ struct MockAuthenticator : public mqbnet::Authenticator {
     {
         return 0;
     }
-    int authenticationOutbound(
-        bsl::ostream&,
-        const bsl::shared_ptr<mqbnet::AuthenticationContext>&)
-        BSLS_KEYWORD_OVERRIDE
+
+    bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE
     {
-        return 0;
+        return false;
     }
+    bsl::shared_ptr<mqbnet::AuthenticationClient>
+    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>&,
+                               bslma::Allocator*) const BSLS_KEYWORD_OVERRIDE
+    {
+        return bsl::shared_ptr<mqbnet::AuthenticationClient>();
+    }
+
     const bsl::optional<mqbcfg::Credential>&
     anonymousCredential() const BSLS_KEYWORD_OVERRIDE
     {

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -30,6 +30,7 @@
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbcfg_tcpinterfaceconfigvalidator.h>
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_authenticator.h>
 #include <mqbnet_cluster.h>
@@ -89,6 +90,7 @@
 #include <bsl_vector.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
+#include <string_view>
 
 namespace BloombergLP {
 namespace mqbnet {
@@ -492,7 +494,7 @@ void TCPSessionFactory::read(ChannelInfo*       channelInfo,
     if (channelInfo->d_monitor.checkData(channelInfo->d_channel_sp.get(),
                                          event)) {
         if (event.isAuthenticationEvent()) {
-            reauthnOnAuthenticationEvent(event, channelInfo);
+            handleAuthenticationEvent(event, channelInfo);
         }
         else {
             channelInfo->d_eventProcessor_p->processEvent(
@@ -614,12 +616,14 @@ void TCPSessionFactory::initialConnectionComplete(
             d_allocator_p,
             channel,
             initialConnectionContext_sp->authenticationContext(),
+            initialConnectionContext_sp->authenticationClient(),
             monitoredSession,
             initialConnectionContext_sp->negotiationContext()
                 ->eventProcessor(),
             initialConnectionContext_sp->negotiationContext()
                 ->maxMissedHeartbeats(),
-            d_initialMissedHeartbeatCounter);
+            d_initialMissedHeartbeatCounter,
+            initialConnectionContext_sp->isIncoming());
         // See comments in 'calculateInitialMissedHbCounter'.
 
         bsl::pair<bmqio::Channel*, ChannelInfoSp> toInsert(channel.get(),
@@ -990,7 +994,7 @@ int TCPSessionFactory::validateTcpInterfaces() const
     return validator(d_config);
 }
 
-void TCPSessionFactory::reauthnOnAuthenticationEvent(
+void TCPSessionFactory::handleAuthenticationEvent(
     const bmqp::Event& event,
     const ChannelInfo* channelInfo) const
 {
@@ -998,55 +1002,105 @@ void TCPSessionFactory::reauthnOnAuthenticationEvent(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(channelInfo);
-    BSLS_ASSERT_SAFE(channelInfo->d_authenticationCtx_sp);
     BSLS_ASSERT_SAFE(channelInfo->d_session_sp);
 
-    const bsl::shared_ptr<AuthenticationContext>& context =
-        channelInfo->d_authenticationCtx_sp;
     const bsl::string_view description =
         channelInfo->d_session_sp->description();
-    bmqu::MemOutStream errStream(d_allocator_p);
 
     bmqp_ctrlmsg::AuthenticationMessage authenticationMessage;
     int rc = event.loadAuthenticationEvent(&authenticationMessage);
     if (rc != 0) {
         BALL_LOG_ERROR << "#CORRUPTED_EVENT " << description
                        << ": Received invalid authentication message "
-                          "from client [reason: 'failed to decode', rc: "
+                          "[reason: 'failed to decode', rc: "
                        << rc << "]:\n"
                        << bmqu::BlobStartHexDumper(event.blob());
         return;  // RETURN
     }
 
-    BALL_LOG_INFO << description << ": Received an authentication message";
+    if (channelInfo->d_isIncoming) {
+        handleInboundReauthentication(authenticationMessage,
+                                      event.authenticationEventEncodingType(),
+                                      channelInfo);
+    }
+    else {
+        handleOutboundReauthentication(authenticationMessage, channelInfo);
+    }
+}
 
-    context->setAuthenticationMessage(authenticationMessage);
-    context->setAuthenticationEncodingType(
-        event.authenticationEventEncodingType());
+void TCPSessionFactory::handleOutboundReauthentication(
+    const bmqp_ctrlmsg::AuthenticationMessage& message,
+    const ChannelInfo*                         channelInfo) const
+{
+    // executed by the *IO* thread
 
-    // Try to start reauthentication.  If another reauthentication is
-    // in progress, drop this event.
+    BSLS_ASSERT_SAFE(channelInfo->d_authenticationClient_sp);
+
+    const bsl::string_view description =
+        channelInfo->d_session_sp->description();
+
+    BALL_LOG_INFO << description
+                  << ": Received outbound reauthentication response"
+                  << " [peer: " << channelInfo->d_channel_sp.get() << "]";
+
+    bmqu::MemOutStream errorStream(d_allocator_p);
+    int rc = channelInfo->d_authenticationClient_sp->handleResponse(
+        errorStream,
+        message);
+    if (rc != 0) {
+        BALL_LOG_ERROR << "#AUTHENTICATION_FAILED " << description
+                       << ": Outbound reauthentication failed"
+                       << " [peer: " << channelInfo->d_channel_sp.get() << "]"
+                       << " [reason: '" << errorStream.str() << "', rc: " << rc
+                       << "]";
+    }
+}
+
+void TCPSessionFactory::handleInboundReauthentication(
+    const bmqp_ctrlmsg::AuthenticationMessage& message,
+    bmqp::EncodingType::Enum                   encodingType,
+    const ChannelInfo*                         channelInfo) const
+{
+    // executed by the *IO* thread
+
+    BSLS_ASSERT_SAFE(channelInfo->d_authenticationCtx_sp);
+
+    const bsl::shared_ptr<AuthenticationContext>& context =
+        channelInfo->d_authenticationCtx_sp;
+    const bsl::string_view description =
+        channelInfo->d_session_sp->description();
+
+    BALL_LOG_INFO << description
+                  << ": Received inbound reauthentication request"
+                  << " [peer: " << channelInfo->d_channel_sp.get() << "]";
+
+    context->setAuthenticationMessage(message);
+    context->setAuthenticationEncodingType(encodingType);
+
     if (!context->tryStartReauthentication()) {
         BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR " << description
                        << ": Dropping Authentication event since "
-                          "authentication is in progress: "
-                       << event;
+                          "authentication is in progress"
+                       << " [peer: " << channelInfo->d_channel_sp.get() << "]";
         return;  // RETURN
     }
 
-    bmqu::MemOutStream errorStream;
-    rc = d_authenticator_p->handleReauthentication(errorStream,
-                                                   context,
-                                                   channelInfo->d_channel_sp);
+    bmqu::MemOutStream errorStream(d_allocator_p);
+    int                rc = d_authenticator_p->handleReauthentication(
+        errorStream,
+        context,
+        channelInfo->d_channel_sp);
     if (rc != 0) {
+        bmqu::MemOutStream errStream(d_allocator_p);
         errStream << "#AUTHENTICATION_FAILED " << description
-                  << ": Authentication failed [reason: '" << errorStream.str()
-                  << "', rc: " << rc << "]";
+                  << ": Inbound reauthentication failed"
+                  << " [peer: " << channelInfo->d_channel_sp.get() << "]"
+                  << " [reason: '" << errorStream.str() << "', rc: " << rc
+                  << "]";
         context->onReauthenticateErrorOrTimeout(rc,
                                                 "reauthenticationError",
                                                 errStream.str(),
                                                 channelInfo->d_channel_sp);
-        return;  // RETURN
     }
 }
 
@@ -1649,15 +1703,19 @@ bool TCPSessionFactory::isEndpointLoopback(const bslstl::StringRef& uri) const
 TCPSessionFactory::ChannelInfo::ChannelInfo(
     const bsl::shared_ptr<bmqio::Channel>&        channel_sp,
     const bsl::shared_ptr<AuthenticationContext>& authenticationContext,
+    const bsl::shared_ptr<AuthenticationClient>&  authenticationClient,
     const bsl::shared_ptr<Session>&               monitoredSession,
     SessionEventProcessor*                        eventProcessor,
     int                                           maxMissedHeartbeats,
-    int initialMissedHeartbeatCounter)
+    int  initialMissedHeartbeatCounter,
+    bool isIncoming)
 : d_channel_sp(channel_sp)
 , d_authenticationCtx_sp(authenticationContext)
+, d_authenticationClient_sp(authenticationClient)
 , d_session_sp(monitoredSession)
 , d_eventProcessor_p(eventProcessor)
 , d_monitor(maxMissedHeartbeats, initialMissedHeartbeatCounter)
+, d_isIncoming(isIncoming)
 {
     if (!d_eventProcessor_p) {
         // No eventProcessor was provided default to the negotiated session

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -115,6 +115,7 @@ namespace BloombergLP {
 namespace mqbnet {
 
 // FORWARD DECLARATION
+class AuthenticationClient;
 class Cluster;
 class Session;
 class SessionEventProcessor;
@@ -182,8 +183,14 @@ class TCPSessionFactory {
         /// The channel
         bsl::shared_ptr<bmqio::Channel> d_channel_sp;
 
-        // The context of authentication
+        /// The authentication context for an incoming connection.  Null for
+        /// outbound connections.
         bsl::shared_ptr<AuthenticationContext> d_authenticationCtx_sp;
+
+        /// Per-connection client for outbound authentication and
+        /// reauthentication.  Non-null for outbound connections if broker
+        /// has a credential provider.  Null for inbound connections.
+        bsl::shared_ptr<AuthenticationClient> d_authenticationClient_sp;
 
         /// The session tied to the channel
         bsl::shared_ptr<Session> d_session_sp;
@@ -192,6 +199,10 @@ class TCPSessionFactory {
         SessionEventProcessor* d_eventProcessor_p;
 
         bmqp::HeartbeatMonitor d_monitor;
+
+        /// True if this channel is from an incoming (listen) connection;
+        /// false if it is an outbound (connect) connection.
+        bool d_isIncoming;
 
         /// @param channel_sp The channel
         /// @param authenticationContext The authentication context associated
@@ -203,13 +214,18 @@ class TCPSessionFactory {
         /// missed heartbeats on this channel.
         /// @param initialMissedHeartbeatCounter The initial missed heartbeats
         /// for this channel.
-        explicit ChannelInfo(const bsl::shared_ptr<bmqio::Channel>& channel_sp,
-                             const bsl::shared_ptr<AuthenticationContext>&
-                                 authenticationContext,
-                             const bsl::shared_ptr<Session>& session,
-                             SessionEventProcessor*          eventProcessor,
-                             int maxMissedHeartbeats,
-                             int initialMissedHeartbeatCounter);
+        /// @param isIncoming True if the channel is from an incoming
+        /// connection.
+        explicit ChannelInfo(
+            const bsl::shared_ptr<bmqio::Channel>& channel_sp,
+            const bsl::shared_ptr<AuthenticationContext>&
+                                                         authenticationContext,
+            const bsl::shared_ptr<AuthenticationClient>& authenticationClient,
+            const bsl::shared_ptr<Session>&              session,
+            SessionEventProcessor*                       eventProcessor,
+            int                                          maxMissedHeartbeats,
+            int  initialMissedHeartbeatCounter,
+            bool isIncoming);
     };
 
     /// This class provides mechanism to store a map of port stat contexts.
@@ -538,11 +554,25 @@ class TCPSessionFactory {
     /// @returns 0 on success, nonzero on failure.
     int validateTcpInterfaces() const;
 
-    /// Handle an authentication event for the specified `event` by
-    /// performing reauthentication using the authentication context stored
-    /// in the specified `channelInfo`.
-    void reauthnOnAuthenticationEvent(const bmqp::Event& event,
-                                      const ChannelInfo* channelInfo) const;
+    /// Handle an authentication event for the specified `event` on the
+    /// specified `channelInfo`.  Decodes the message and dispatches to the
+    /// appropriate inbound or outbound handler.
+    void handleAuthenticationEvent(const bmqp::Event& event,
+                                   const ChannelInfo* channelInfo) const;
+
+    /// Handle a reauthentication response on an outbound connection using
+    /// the specified decoded `message` and `channelInfo`.
+    void handleOutboundReauthentication(
+        const bmqp_ctrlmsg::AuthenticationMessage& message,
+        const ChannelInfo*                         channelInfo) const;
+
+    /// Handle a reauthentication request on an inbound connection using the
+    /// specified decoded `message`, the specified `encodingType`, and the
+    /// specified `channelInfo`.
+    void handleInboundReauthentication(
+        const bmqp_ctrlmsg::AuthenticationMessage& message,
+        bmqp::EncodingType::Enum                   encodingType,
+        const ChannelInfo*                         channelInfo) const;
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqbnet/package/mqbnet.mem
+++ b/src/groups/mqb/mqbnet/package/mqbnet.mem
@@ -1,3 +1,4 @@
+mqbnet_authenticationclient
 mqbnet_authenticationcontext
 mqbnet_authenticator
 mqbnet_channel


### PR DESCRIPTION
## Summary

Add support for brokers to authenticate with other brokers.

When a credential provider is configured for a broker, the broker authenticates with remote brokers before session negotiation and reauthenticates at 80% of credential lifetime (if a lifetime is returned). This control flow mirrors authentication in the SDK.

The high level changes are:
- `CredentialProvider` supplies a `CredentialFunc` for obtaining credentials
  - `BasicCredentialProvider` is provided as a built-in implementation. Maybe we want to add Anonymous too, by default to match default anonymous authentication?
- `Authenticator::createAuthenticationClient()` is a factory that produces a per-connection `AuthenticationClient` bound to a channel.
  - `AuthenticationClient` handle reauthenticating with the remote broker; lifetime is tied to `ChannelInfo`.
- `InitialConnectionContext` has a new state, `e_AUTHENTICATING_OUTBOUND`, which transitions to `e_NEGOTIATING_OUTBOUND` on success or `e_FAILED` on error.
- `TCPSessionFactory` routes post-negotiation authn messages (i.e. reauthn responses) directly to the `AuthenticationClient` via `ChannelInfo`.

## Test plan

- [x] `mqba_authenticationclient.t` unit tests covering authentication request/response handling
- [x] `mqbnet_initialconnectioncontext.t` unit tests covering outbound connection state machine w/ authn
- [ ] Integration tests
