### PR TITLE
Feat[mqbcfg]: support stats encoding setting

### DIFF
--- a/src/groups/mqb/mqbcfg/mqbcfg.xsd
+++ b/src/groups/mqb/mqbcfg/mqbcfg.xsd
@@ -177,6 +177,24 @@
     </restriction>
   </simpleType>
 
+  <simpleType name='StatsPrinterEncodingFormat'>
+    <annotation>
+      <documentation>
+        Bitmask of stats output encoding formats:
+        - NONE:           no stats output (0)
+        - TABLE:          human-readable table format (1)
+        - JSON:           machine-readable JSON format (2)
+        - TABLE_AND_JSON: both formats (TABLE | JSON = 3)
+      </documentation>
+    </annotation>
+    <restriction base='string' bdem:preserveEnumOrder='1'>
+      <enumeration value='NONE'           bdem:id='0'/>
+      <enumeration value='TABLE'          bdem:id='1'/>
+      <enumeration value='JSON'           bdem:id='2'/>
+      <enumeration value='TABLE_AND_JSON' bdem:id='3'/>
+    </restriction>
+  </simpleType>
+
   <complexType name="StatsPrinterConfig">
     <sequence>
       <element name='printInterval' type='int' default='60'/>  <!-- 0 to disable -->
@@ -184,6 +202,7 @@
       <element name='maxAgeDays'    type='int'/>
       <element name='rotateBytes'   type='int' default='268435456'/> <!-- 256 * 1024 * 1024 -->
       <element name='rotateDays'    type='int' default='1'/>
+      <element name='encoding'      type='tns:StatsPrinterEncodingFormat' default='TABLE_AND_JSON'/>
     </sequence>
   </complexType>
 

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.cpp
@@ -2493,184 +2493,85 @@ bsl::ostream& ResolvedDomain::print(bsl::ostream& stream,
     return stream;
 }
 
-// ------------------------
-// class StatsPrinterConfig
-// ------------------------
+// --------------------------------
+// class StatsPrinterEncodingFormat
+// --------------------------------
 
 // CONSTANTS
 
-const char StatsPrinterConfig::CLASS_NAME[] = "StatsPrinterConfig";
+const char StatsPrinterEncodingFormat::CLASS_NAME[] =
+    "StatsPrinterEncodingFormat";
 
-const int StatsPrinterConfig::DEFAULT_INITIALIZER_PRINT_INTERVAL = 60;
-
-const int StatsPrinterConfig::DEFAULT_INITIALIZER_ROTATE_BYTES = 268435456;
-
-const int StatsPrinterConfig::DEFAULT_INITIALIZER_ROTATE_DAYS = 1;
-
-const bdlat_AttributeInfo StatsPrinterConfig::ATTRIBUTE_INFO_ARRAY[] = {
-    {ATTRIBUTE_ID_PRINT_INTERVAL,
-     "printInterval",
-     sizeof("printInterval") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
-    {ATTRIBUTE_ID_FILE,
-     "file",
-     sizeof("file") - 1,
-     "",
-     bdlat_FormattingMode::e_TEXT},
-    {ATTRIBUTE_ID_MAX_AGE_DAYS,
-     "maxAgeDays",
-     sizeof("maxAgeDays") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC},
-    {ATTRIBUTE_ID_ROTATE_BYTES,
-     "rotateBytes",
-     sizeof("rotateBytes") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
-    {ATTRIBUTE_ID_ROTATE_DAYS,
-     "rotateDays",
-     sizeof("rotateDays") - 1,
-     "",
-     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE}};
+const bdlat_EnumeratorInfo
+    StatsPrinterEncodingFormat::ENUMERATOR_INFO_ARRAY[] = {
+        {StatsPrinterEncodingFormat::e_NONE, "NONE", sizeof("NONE") - 1, ""},
+        {StatsPrinterEncodingFormat::e_TABLE,
+         "TABLE",
+         sizeof("TABLE") - 1,
+         ""},
+        {StatsPrinterEncodingFormat::e_JSON, "JSON", sizeof("JSON") - 1, ""},
+        {StatsPrinterEncodingFormat::e_TABLE_AND_JSON,
+         "TABLE_AND_JSON",
+         sizeof("TABLE_AND_JSON") - 1,
+         ""}};
 
 // CLASS METHODS
 
-const bdlat_AttributeInfo*
-StatsPrinterConfig::lookupAttributeInfo(const char* name, int nameLength)
+int StatsPrinterEncodingFormat::fromInt(
+    StatsPrinterEncodingFormat::Value* result,
+    int                                number)
 {
-    for (int i = 0; i < 5; ++i) {
-        const bdlat_AttributeInfo& attributeInfo =
-            StatsPrinterConfig::ATTRIBUTE_INFO_ARRAY[i];
+    switch (number) {
+    case StatsPrinterEncodingFormat::e_NONE:
+    case StatsPrinterEncodingFormat::e_TABLE:
+    case StatsPrinterEncodingFormat::e_JSON:
+    case StatsPrinterEncodingFormat::e_TABLE_AND_JSON:
+        *result = static_cast<StatsPrinterEncodingFormat::Value>(number);
+        return 0;
+    default: return -1;
+    }
+}
 
-        if (nameLength == attributeInfo.d_nameLength &&
-            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
-            return &attributeInfo;
+int StatsPrinterEncodingFormat::fromString(
+    StatsPrinterEncodingFormat::Value* result,
+    const char*                        string,
+    int                                stringLength)
+{
+    for (int i = 0; i < 4; ++i) {
+        const bdlat_EnumeratorInfo& enumeratorInfo =
+            StatsPrinterEncodingFormat::ENUMERATOR_INFO_ARRAY[i];
+
+        if (stringLength == enumeratorInfo.d_nameLength &&
+            0 == bsl::memcmp(enumeratorInfo.d_name_p, string, stringLength)) {
+            *result = static_cast<StatsPrinterEncodingFormat::Value>(
+                enumeratorInfo.d_value);
+            return 0;
         }
     }
 
+    return -1;
+}
+
+const char*
+StatsPrinterEncodingFormat::toString(StatsPrinterEncodingFormat::Value value)
+{
+    switch (value) {
+    case e_NONE: {
+        return "NONE";
+    }
+    case e_TABLE: {
+        return "TABLE";
+    }
+    case e_JSON: {
+        return "JSON";
+    }
+    case e_TABLE_AND_JSON: {
+        return "TABLE_AND_JSON";
+    }
+    }
+
+    BSLS_ASSERT(!"invalid enumerator");
     return 0;
-}
-
-const bdlat_AttributeInfo* StatsPrinterConfig::lookupAttributeInfo(int id)
-{
-    switch (id) {
-    case ATTRIBUTE_ID_PRINT_INTERVAL:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL];
-    case ATTRIBUTE_ID_FILE: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE];
-    case ATTRIBUTE_ID_MAX_AGE_DAYS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS];
-    case ATTRIBUTE_ID_ROTATE_BYTES:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES];
-    case ATTRIBUTE_ID_ROTATE_DAYS:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS];
-    default: return 0;
-    }
-}
-
-// CREATORS
-
-StatsPrinterConfig::StatsPrinterConfig(bslma::Allocator* basicAllocator)
-: d_file(basicAllocator)
-, d_printInterval(DEFAULT_INITIALIZER_PRINT_INTERVAL)
-, d_maxAgeDays()
-, d_rotateBytes(DEFAULT_INITIALIZER_ROTATE_BYTES)
-, d_rotateDays(DEFAULT_INITIALIZER_ROTATE_DAYS)
-{
-}
-
-StatsPrinterConfig::StatsPrinterConfig(const StatsPrinterConfig& original,
-                                       bslma::Allocator* basicAllocator)
-: d_file(original.d_file, basicAllocator)
-, d_printInterval(original.d_printInterval)
-, d_maxAgeDays(original.d_maxAgeDays)
-, d_rotateBytes(original.d_rotateBytes)
-, d_rotateDays(original.d_rotateDays)
-{
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StatsPrinterConfig::StatsPrinterConfig(StatsPrinterConfig&& original) noexcept
-: d_file(bsl::move(original.d_file)),
-  d_printInterval(bsl::move(original.d_printInterval)),
-  d_maxAgeDays(bsl::move(original.d_maxAgeDays)),
-  d_rotateBytes(bsl::move(original.d_rotateBytes)),
-  d_rotateDays(bsl::move(original.d_rotateDays))
-{
-}
-
-StatsPrinterConfig::StatsPrinterConfig(StatsPrinterConfig&& original,
-                                       bslma::Allocator*    basicAllocator)
-: d_file(bsl::move(original.d_file), basicAllocator)
-, d_printInterval(bsl::move(original.d_printInterval))
-, d_maxAgeDays(bsl::move(original.d_maxAgeDays))
-, d_rotateBytes(bsl::move(original.d_rotateBytes))
-, d_rotateDays(bsl::move(original.d_rotateDays))
-{
-}
-#endif
-
-StatsPrinterConfig::~StatsPrinterConfig()
-{
-}
-
-// MANIPULATORS
-
-StatsPrinterConfig&
-StatsPrinterConfig::operator=(const StatsPrinterConfig& rhs)
-{
-    if (this != &rhs) {
-        d_printInterval = rhs.d_printInterval;
-        d_file          = rhs.d_file;
-        d_maxAgeDays    = rhs.d_maxAgeDays;
-        d_rotateBytes   = rhs.d_rotateBytes;
-        d_rotateDays    = rhs.d_rotateDays;
-    }
-
-    return *this;
-}
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StatsPrinterConfig& StatsPrinterConfig::operator=(StatsPrinterConfig&& rhs)
-{
-    if (this != &rhs) {
-        d_printInterval = bsl::move(rhs.d_printInterval);
-        d_file          = bsl::move(rhs.d_file);
-        d_maxAgeDays    = bsl::move(rhs.d_maxAgeDays);
-        d_rotateBytes   = bsl::move(rhs.d_rotateBytes);
-        d_rotateDays    = bsl::move(rhs.d_rotateDays);
-    }
-
-    return *this;
-}
-#endif
-
-void StatsPrinterConfig::reset()
-{
-    d_printInterval = DEFAULT_INITIALIZER_PRINT_INTERVAL;
-    bdlat_ValueTypeFunctions::reset(&d_file);
-    bdlat_ValueTypeFunctions::reset(&d_maxAgeDays);
-    d_rotateBytes = DEFAULT_INITIALIZER_ROTATE_BYTES;
-    d_rotateDays  = DEFAULT_INITIALIZER_ROTATE_DAYS;
-}
-
-// ACCESSORS
-
-bsl::ostream& StatsPrinterConfig::print(bsl::ostream& stream,
-                                        int           level,
-                                        int           spacesPerLevel) const
-{
-    bslim::Printer printer(&stream, level, spacesPerLevel);
-    printer.start();
-    printer.printAttribute("printInterval", this->printInterval());
-    printer.printAttribute("file", this->file());
-    printer.printAttribute("maxAgeDays", this->maxAgeDays());
-    printer.printAttribute("rotateBytes", this->rotateBytes());
-    printer.printAttribute("rotateDays", this->rotateDays());
-    printer.end();
-    return stream;
 }
 
 // -----------------------
@@ -5107,6 +5008,205 @@ bsl::ostream& StatPluginConfigPrometheus::print(bsl::ostream& stream,
     printer.printAttribute("mode", this->mode());
     printer.printAttribute("host", this->host());
     printer.printAttribute("port", this->port());
+    printer.end();
+    return stream;
+}
+
+// ------------------------
+// class StatsPrinterConfig
+// ------------------------
+
+// CONSTANTS
+
+const char StatsPrinterConfig::CLASS_NAME[] = "StatsPrinterConfig";
+
+const int StatsPrinterConfig::DEFAULT_INITIALIZER_PRINT_INTERVAL = 60;
+
+const int StatsPrinterConfig::DEFAULT_INITIALIZER_ROTATE_BYTES = 268435456;
+
+const int StatsPrinterConfig::DEFAULT_INITIALIZER_ROTATE_DAYS = 1;
+
+const StatsPrinterEncodingFormat::Value
+    StatsPrinterConfig::DEFAULT_INITIALIZER_ENCODING =
+        StatsPrinterEncodingFormat::TABLE_AND_JSON;
+
+const bdlat_AttributeInfo StatsPrinterConfig::ATTRIBUTE_INFO_ARRAY[] = {
+    {ATTRIBUTE_ID_PRINT_INTERVAL,
+     "printInterval",
+     sizeof("printInterval") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_FILE,
+     "file",
+     sizeof("file") - 1,
+     "",
+     bdlat_FormattingMode::e_TEXT},
+    {ATTRIBUTE_ID_MAX_AGE_DAYS,
+     "maxAgeDays",
+     sizeof("maxAgeDays") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_ROTATE_BYTES,
+     "rotateBytes",
+     sizeof("rotateBytes") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_ROTATE_DAYS,
+     "rotateDays",
+     sizeof("rotateDays") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC | bdlat_FormattingMode::e_DEFAULT_VALUE},
+    {ATTRIBUTE_ID_ENCODING,
+     "encoding",
+     sizeof("encoding") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT | bdlat_FormattingMode::e_DEFAULT_VALUE}};
+
+// CLASS METHODS
+
+const bdlat_AttributeInfo*
+StatsPrinterConfig::lookupAttributeInfo(const char* name, int nameLength)
+{
+    for (int i = 0; i < 6; ++i) {
+        const bdlat_AttributeInfo& attributeInfo =
+            StatsPrinterConfig::ATTRIBUTE_INFO_ARRAY[i];
+
+        if (nameLength == attributeInfo.d_nameLength &&
+            0 == bsl::memcmp(attributeInfo.d_name_p, name, nameLength)) {
+            return &attributeInfo;
+        }
+    }
+
+    return 0;
+}
+
+const bdlat_AttributeInfo* StatsPrinterConfig::lookupAttributeInfo(int id)
+{
+    switch (id) {
+    case ATTRIBUTE_ID_PRINT_INTERVAL:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL];
+    case ATTRIBUTE_ID_FILE: return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE];
+    case ATTRIBUTE_ID_MAX_AGE_DAYS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS];
+    case ATTRIBUTE_ID_ROTATE_BYTES:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES];
+    case ATTRIBUTE_ID_ROTATE_DAYS:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS];
+    case ATTRIBUTE_ID_ENCODING:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ENCODING];
+    default: return 0;
+    }
+}
+
+// CREATORS
+
+StatsPrinterConfig::StatsPrinterConfig(bslma::Allocator* basicAllocator)
+: d_file(basicAllocator)
+, d_printInterval(DEFAULT_INITIALIZER_PRINT_INTERVAL)
+, d_maxAgeDays()
+, d_rotateBytes(DEFAULT_INITIALIZER_ROTATE_BYTES)
+, d_rotateDays(DEFAULT_INITIALIZER_ROTATE_DAYS)
+, d_encoding(DEFAULT_INITIALIZER_ENCODING)
+{
+}
+
+StatsPrinterConfig::StatsPrinterConfig(const StatsPrinterConfig& original,
+                                       bslma::Allocator* basicAllocator)
+: d_file(original.d_file, basicAllocator)
+, d_printInterval(original.d_printInterval)
+, d_maxAgeDays(original.d_maxAgeDays)
+, d_rotateBytes(original.d_rotateBytes)
+, d_rotateDays(original.d_rotateDays)
+, d_encoding(original.d_encoding)
+{
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+StatsPrinterConfig::StatsPrinterConfig(StatsPrinterConfig&& original) noexcept
+: d_file(bsl::move(original.d_file)),
+  d_printInterval(bsl::move(original.d_printInterval)),
+  d_maxAgeDays(bsl::move(original.d_maxAgeDays)),
+  d_rotateBytes(bsl::move(original.d_rotateBytes)),
+  d_rotateDays(bsl::move(original.d_rotateDays)),
+  d_encoding(bsl::move(original.d_encoding))
+{
+}
+
+StatsPrinterConfig::StatsPrinterConfig(StatsPrinterConfig&& original,
+                                       bslma::Allocator*    basicAllocator)
+: d_file(bsl::move(original.d_file), basicAllocator)
+, d_printInterval(bsl::move(original.d_printInterval))
+, d_maxAgeDays(bsl::move(original.d_maxAgeDays))
+, d_rotateBytes(bsl::move(original.d_rotateBytes))
+, d_rotateDays(bsl::move(original.d_rotateDays))
+, d_encoding(bsl::move(original.d_encoding))
+{
+}
+#endif
+
+StatsPrinterConfig::~StatsPrinterConfig()
+{
+}
+
+// MANIPULATORS
+
+StatsPrinterConfig&
+StatsPrinterConfig::operator=(const StatsPrinterConfig& rhs)
+{
+    if (this != &rhs) {
+        d_printInterval = rhs.d_printInterval;
+        d_file          = rhs.d_file;
+        d_maxAgeDays    = rhs.d_maxAgeDays;
+        d_rotateBytes   = rhs.d_rotateBytes;
+        d_rotateDays    = rhs.d_rotateDays;
+        d_encoding      = rhs.d_encoding;
+    }
+
+    return *this;
+}
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+StatsPrinterConfig& StatsPrinterConfig::operator=(StatsPrinterConfig&& rhs)
+{
+    if (this != &rhs) {
+        d_printInterval = bsl::move(rhs.d_printInterval);
+        d_file          = bsl::move(rhs.d_file);
+        d_maxAgeDays    = bsl::move(rhs.d_maxAgeDays);
+        d_rotateBytes   = bsl::move(rhs.d_rotateBytes);
+        d_rotateDays    = bsl::move(rhs.d_rotateDays);
+        d_encoding      = bsl::move(rhs.d_encoding);
+    }
+
+    return *this;
+}
+#endif
+
+void StatsPrinterConfig::reset()
+{
+    d_printInterval = DEFAULT_INITIALIZER_PRINT_INTERVAL;
+    bdlat_ValueTypeFunctions::reset(&d_file);
+    bdlat_ValueTypeFunctions::reset(&d_maxAgeDays);
+    d_rotateBytes = DEFAULT_INITIALIZER_ROTATE_BYTES;
+    d_rotateDays  = DEFAULT_INITIALIZER_ROTATE_DAYS;
+    d_encoding    = DEFAULT_INITIALIZER_ENCODING;
+}
+
+// ACCESSORS
+
+bsl::ostream& StatsPrinterConfig::print(bsl::ostream& stream,
+                                        int           level,
+                                        int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printAttribute("printInterval", this->printInterval());
+    printer.printAttribute("file", this->file());
+    printer.printAttribute("maxAgeDays", this->maxAgeDays());
+    printer.printAttribute("rotateBytes", this->rotateBytes());
+    printer.printAttribute("rotateDays", this->rotateDays());
+    printer.printAttribute("encoding", this->encoding());
     printer.end();
     return stream;
 }
@@ -7856,6 +7956,6 @@ Configuration::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.04.30
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.07
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/groups/mqb/mqbcfg/mqbcfg_messages.h
+++ b/src/groups/mqb/mqbcfg/mqbcfg_messages.h
@@ -103,9 +103,6 @@ namespace mqbcfg {
 class ResolvedDomain;
 }
 namespace mqbcfg {
-class StatsPrinterConfig;
-}
-namespace mqbcfg {
 class StorageSyncConfig;
 }
 namespace mqbcfg {
@@ -143,6 +140,9 @@ class PluginSettingKeyValue;
 }
 namespace mqbcfg {
 class StatPluginConfigPrometheus;
+}
+namespace mqbcfg {
+class StatsPrinterConfig;
 }
 namespace mqbcfg {
 class TcpInterfaceConfig;
@@ -4052,259 +4052,71 @@ struct bdlat_UsesDefaultValueFlag<mqbcfg::ResolvedDomain> : bsl::true_type {};
 
 namespace mqbcfg {
 
-// ========================
-// class StatsPrinterConfig
-// ========================
+// ================================
+// class StatsPrinterEncodingFormat
+// ================================
 
-class StatsPrinterConfig {
-    // INSTANCE DATA
-    bsl::string d_file;
-    int         d_printInterval;
-    int         d_maxAgeDays;
-    int         d_rotateBytes;
-    int         d_rotateDays;
-
-    // PRIVATE ACCESSORS
-    template <typename t_HASH_ALGORITHM>
-    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
-
-    bool isEqualTo(const StatsPrinterConfig& rhs) const;
+struct StatsPrinterEncodingFormat {
+    // Bitmask of stats output encoding formats: - NONE:           no stats
+    // output (0) - TABLE:          human-readable table format (1) - JSON:
+    //       machine-readable JSON format (2) - TABLE_AND_JSON: both formats
+    // (TABLE | JSON = 3)
 
   public:
     // TYPES
-    enum {
-        ATTRIBUTE_ID_PRINT_INTERVAL = 0,
-        ATTRIBUTE_ID_FILE           = 1,
-        ATTRIBUTE_ID_MAX_AGE_DAYS   = 2,
-        ATTRIBUTE_ID_ROTATE_BYTES   = 3,
-        ATTRIBUTE_ID_ROTATE_DAYS    = 4
+    enum Value {
+        e_NONE           = 0,
+        e_TABLE          = 1,
+        e_JSON           = 2,
+        e_TABLE_AND_JSON = 3,
+
+        NONE           = e_NONE,
+        TABLE          = e_TABLE,
+        JSON           = e_JSON,
+        TABLE_AND_JSON = e_TABLE_AND_JSON
     };
 
-    enum { NUM_ATTRIBUTES = 5 };
-
-    enum {
-        ATTRIBUTE_INDEX_PRINT_INTERVAL = 0,
-        ATTRIBUTE_INDEX_FILE           = 1,
-        ATTRIBUTE_INDEX_MAX_AGE_DAYS   = 2,
-        ATTRIBUTE_INDEX_ROTATE_BYTES   = 3,
-        ATTRIBUTE_INDEX_ROTATE_DAYS    = 4
-    };
+    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
 
-    static const int DEFAULT_INITIALIZER_PRINT_INTERVAL;
+    static const bdlat_EnumeratorInfo ENUMERATOR_INFO_ARRAY[];
 
-    static const int DEFAULT_INITIALIZER_ROTATE_BYTES;
-
-    static const int DEFAULT_INITIALIZER_ROTATE_DAYS;
-
-    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
-
-  public:
     // CLASS METHODS
-    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
-    // Return attribute information for the attribute indicated by the
-    // specified 'id' if the attribute exists, and 0 otherwise.
+    static const char* toString(Value value);
+    // Return the string representation exactly matching the enumerator
+    // name corresponding to the specified enumeration 'value'.
 
-    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
-                                                          int nameLength);
-    // Return attribute information for the attribute indicated by the
-    // specified 'name' of the specified 'nameLength' if the attribute
-    // exists, and 0 otherwise.
+    static int fromString(Value* result, const char* string, int stringLength);
+    // Load into the specified 'result' the enumerator matching the
+    // specified 'string' of the specified 'stringLength'.  Return 0 on
+    // success, and a non-zero value with no effect on 'result' otherwise
+    // (i.e., 'string' does not match any enumerator).
 
-    // CREATORS
-    explicit StatsPrinterConfig(bslma::Allocator* basicAllocator = 0);
-    // Create an object of type 'StatsPrinterConfig' having the default
-    // value.  Use the optionally specified 'basicAllocator' to supply
-    // memory.  If 'basicAllocator' is 0, the currently installed default
-    // allocator is used.
+    static int fromString(Value* result, const bsl::string& string);
+    // Load into the specified 'result' the enumerator matching the
+    // specified 'string'.  Return 0 on success, and a non-zero value with
+    // no effect on 'result' otherwise (i.e., 'string' does not match any
+    // enumerator).
 
-    StatsPrinterConfig(const StatsPrinterConfig& original,
-                       bslma::Allocator*         basicAllocator = 0);
-    // Create an object of type 'StatsPrinterConfig' having the value of
-    // the specified 'original' object.  Use the optionally specified
-    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
-    // currently installed default allocator is used.
+    static int fromInt(Value* result, int number);
+    // Load into the specified 'result' the enumerator matching the
+    // specified 'number'.  Return 0 on success, and a non-zero value with
+    // no effect on 'result' otherwise (i.e., 'number' does not match any
+    // enumerator).
 
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    StatsPrinterConfig(StatsPrinterConfig&& original) noexcept;
-    // Create an object of type 'StatsPrinterConfig' having the value of
-    // the specified 'original' object.  After performing this action, the
-    // 'original' object will be left in a valid, but unspecified state.
-
-    StatsPrinterConfig(StatsPrinterConfig&& original,
-                       bslma::Allocator*    basicAllocator);
-    // Create an object of type 'StatsPrinterConfig' having the value of
-    // the specified 'original' object.  After performing this action, the
-    // 'original' object will be left in a valid, but unspecified state.
-    // Use the optionally specified 'basicAllocator' to supply memory.  If
-    // 'basicAllocator' is 0, the currently installed default allocator is
-    // used.
-#endif
-
-    ~StatsPrinterConfig();
-    // Destroy this object.
-
-    // MANIPULATORS
-    StatsPrinterConfig& operator=(const StatsPrinterConfig& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-
-#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
-    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-    StatsPrinterConfig& operator=(StatsPrinterConfig&& rhs);
-    // Assign to this object the value of the specified 'rhs' object.
-    // After performing this action, the 'rhs' object will be left in a
-    // valid, but unspecified state.
-#endif
-
-    void reset();
-    // Reset this object to the default value (i.e., its value upon
-    // default construction).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttributes(t_MANIPULATOR& manipulator);
-    // Invoke the specified 'manipulator' sequentially on the address of
-    // each (modifiable) attribute of this object, supplying 'manipulator'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'manipulator' (i.e., the invocation that
-    // terminated the sequence).
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'id',
-    // supplying 'manipulator' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'manipulator' if 'id' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    template <typename t_MANIPULATOR>
-    int manipulateAttribute(t_MANIPULATOR& manipulator,
-                            const char*    name,
-                            int            nameLength);
-    // Invoke the specified 'manipulator' on the address of
-    // the (modifiable) attribute indicated by the specified 'name' of the
-    // specified 'nameLength', supplying 'manipulator' with the
-    // corresponding attribute information structure.  Return the value
-    // returned from the invocation of 'manipulator' if 'name' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    int& printInterval();
-    // Return a reference to the modifiable "PrintInterval" attribute of
-    // this object.
-
-    bsl::string& file();
-    // Return a reference to the modifiable "File" attribute of this
-    // object.
-
-    int& maxAgeDays();
-    // Return a reference to the modifiable "MaxAgeDays" attribute of this
-    // object.
-
-    int& rotateBytes();
-    // Return a reference to the modifiable "RotateBytes" attribute of this
-    // object.
-
-    int& rotateDays();
-    // Return a reference to the modifiable "RotateDays" attribute of this
-    // object.
-
-    // ACCESSORS
-    bsl::ostream&
-    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
-    // Format this object to the specified output 'stream' at the
-    // optionally specified indentation 'level' and return a reference to
-    // the modifiable 'stream'.  If 'level' is specified, optionally
-    // specify 'spacesPerLevel', the number of spaces per indentation level
-    // for this and all of its nested objects.  Each line is indented by
-    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    // negative, suppress indentation of the first line.  If
-    // 'spacesPerLevel' is negative, suppress line breaks and format the
-    // entire output on one line.  If 'stream' is initially invalid, this
-    // operation has no effect.  Note that a trailing newline is provided
-    // in multiline mode only.
-
-    template <typename t_ACCESSOR>
-    int accessAttributes(t_ACCESSOR& accessor) const;
-    // Invoke the specified 'accessor' sequentially on each
-    // (non-modifiable) attribute of this object, supplying 'accessor'
-    // with the corresponding attribute information structure until such
-    // invocation returns a non-zero value.  Return the value from the
-    // last invocation of 'accessor' (i.e., the invocation that terminated
-    // the sequence).
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor, int id) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'id', supplying 'accessor'
-    // with the corresponding attribute information structure.  Return the
-    // value returned from the invocation of 'accessor' if 'id' identifies
-    // an attribute of this class, and -1 otherwise.
-
-    template <typename t_ACCESSOR>
-    int accessAttribute(t_ACCESSOR& accessor,
-                        const char* name,
-                        int         nameLength) const;
-    // Invoke the specified 'accessor' on the (non-modifiable) attribute
-    // of this object indicated by the specified 'name' of the specified
-    // 'nameLength', supplying 'accessor' with the corresponding attribute
-    // information structure.  Return the value returned from the
-    // invocation of 'accessor' if 'name' identifies an attribute of this
-    // class, and -1 otherwise.
-
-    int printInterval() const;
-    // Return the value of the "PrintInterval" attribute of this object.
-
-    const bsl::string& file() const;
-    // Return a reference offering non-modifiable access to the "File"
-    // attribute of this object.
-
-    int maxAgeDays() const;
-    // Return the value of the "MaxAgeDays" attribute of this object.
-
-    int rotateBytes() const;
-    // Return the value of the "RotateBytes" attribute of this object.
-
-    int rotateDays() const;
-    // Return the value of the "RotateDays" attribute of this object.
+    static bsl::ostream& print(bsl::ostream& stream, Value value);
+    // Write to the specified 'stream' the string representation of
+    // the specified enumeration 'value'.  Return a reference to
+    // the modifiable 'stream'.
 
     // HIDDEN FRIENDS
-    friend bool operator==(const StatsPrinterConfig& lhs,
-                           const StatsPrinterConfig& rhs)
-    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
-    // have the same value, and 'false' otherwise.  Two attribute objects
-    // have the same value if each respective attribute has the same value.
-    {
-        return lhs.isEqualTo(rhs);
-    }
-
-    friend bool operator!=(const StatsPrinterConfig& lhs,
-                           const StatsPrinterConfig& rhs)
-    // Returns '!(lhs == rhs)'
-    {
-        return !(lhs == rhs);
-    }
-
-    friend bsl::ostream& operator<<(bsl::ostream&             stream,
-                                    const StatsPrinterConfig& rhs)
+    friend bsl::ostream& operator<<(bsl::ostream& stream, Value rhs)
     // Format the specified 'rhs' to the specified output 'stream' and
     // return a reference to the modifiable 'stream'.
     {
-        return rhs.print(stream, 0, -1);
-    }
-
-    template <typename t_HASH_ALGORITHM>
-    friend void hashAppend(t_HASH_ALGORITHM&         hashAlg,
-                           const StatsPrinterConfig& object)
-    // Pass the specified 'object' to the specified 'hashAlg'.  This
-    // function integrates with the 'bslh' modular hashing system and
-    // effectively provides a 'bsl::hash' specialization for
-    // 'StatsPrinterConfig'.
-    {
-        object.hashAppendImpl(hashAlg);
+        return StatsPrinterEncodingFormat::print(stream, rhs);
     }
 };
 
@@ -4312,11 +4124,7 @@ class StatsPrinterConfig {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    mqbcfg::StatsPrinterConfig);
-template <>
-struct bdlat_UsesDefaultValueFlag<mqbcfg::StatsPrinterConfig>
-: bsl::true_type {};
+BDLAT_DECL_ENUMERATION_TRAITS(mqbcfg::StatsPrinterEncodingFormat);
 
 namespace mqbcfg {
 
@@ -7698,6 +7506,287 @@ BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
     mqbcfg::StatPluginConfigPrometheus);
 template <>
 struct bdlat_UsesDefaultValueFlag<mqbcfg::StatPluginConfigPrometheus>
+: bsl::true_type {};
+
+namespace mqbcfg {
+
+// ========================
+// class StatsPrinterConfig
+// ========================
+
+class StatsPrinterConfig {
+    // INSTANCE DATA
+    bsl::string                       d_file;
+    int                               d_printInterval;
+    int                               d_maxAgeDays;
+    int                               d_rotateBytes;
+    int                               d_rotateDays;
+    StatsPrinterEncodingFormat::Value d_encoding;
+
+    // PRIVATE ACCESSORS
+    template <typename t_HASH_ALGORITHM>
+    void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
+
+    bool isEqualTo(const StatsPrinterConfig& rhs) const;
+
+  public:
+    // TYPES
+    enum {
+        ATTRIBUTE_ID_PRINT_INTERVAL = 0,
+        ATTRIBUTE_ID_FILE           = 1,
+        ATTRIBUTE_ID_MAX_AGE_DAYS   = 2,
+        ATTRIBUTE_ID_ROTATE_BYTES   = 3,
+        ATTRIBUTE_ID_ROTATE_DAYS    = 4,
+        ATTRIBUTE_ID_ENCODING       = 5
+    };
+
+    enum { NUM_ATTRIBUTES = 6 };
+
+    enum {
+        ATTRIBUTE_INDEX_PRINT_INTERVAL = 0,
+        ATTRIBUTE_INDEX_FILE           = 1,
+        ATTRIBUTE_INDEX_MAX_AGE_DAYS   = 2,
+        ATTRIBUTE_INDEX_ROTATE_BYTES   = 3,
+        ATTRIBUTE_INDEX_ROTATE_DAYS    = 4,
+        ATTRIBUTE_INDEX_ENCODING       = 5
+    };
+
+    // CONSTANTS
+    static const char CLASS_NAME[];
+
+    static const int DEFAULT_INITIALIZER_PRINT_INTERVAL;
+
+    static const int DEFAULT_INITIALIZER_ROTATE_BYTES;
+
+    static const int DEFAULT_INITIALIZER_ROTATE_DAYS;
+
+    static const StatsPrinterEncodingFormat::Value
+        DEFAULT_INITIALIZER_ENCODING;
+
+    static const bdlat_AttributeInfo ATTRIBUTE_INFO_ARRAY[];
+
+  public:
+    // CLASS METHODS
+    static const bdlat_AttributeInfo* lookupAttributeInfo(int id);
+    // Return attribute information for the attribute indicated by the
+    // specified 'id' if the attribute exists, and 0 otherwise.
+
+    static const bdlat_AttributeInfo* lookupAttributeInfo(const char* name,
+                                                          int nameLength);
+    // Return attribute information for the attribute indicated by the
+    // specified 'name' of the specified 'nameLength' if the attribute
+    // exists, and 0 otherwise.
+
+    // CREATORS
+    explicit StatsPrinterConfig(bslma::Allocator* basicAllocator = 0);
+    // Create an object of type 'StatsPrinterConfig' having the default
+    // value.  Use the optionally specified 'basicAllocator' to supply
+    // memory.  If 'basicAllocator' is 0, the currently installed default
+    // allocator is used.
+
+    StatsPrinterConfig(const StatsPrinterConfig& original,
+                       bslma::Allocator*         basicAllocator = 0);
+    // Create an object of type 'StatsPrinterConfig' having the value of
+    // the specified 'original' object.  Use the optionally specified
+    // 'basicAllocator' to supply memory.  If 'basicAllocator' is 0, the
+    // currently installed default allocator is used.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    StatsPrinterConfig(StatsPrinterConfig&& original) noexcept;
+    // Create an object of type 'StatsPrinterConfig' having the value of
+    // the specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+
+    StatsPrinterConfig(StatsPrinterConfig&& original,
+                       bslma::Allocator*    basicAllocator);
+    // Create an object of type 'StatsPrinterConfig' having the value of
+    // the specified 'original' object.  After performing this action, the
+    // 'original' object will be left in a valid, but unspecified state.
+    // Use the optionally specified 'basicAllocator' to supply memory.  If
+    // 'basicAllocator' is 0, the currently installed default allocator is
+    // used.
+#endif
+
+    ~StatsPrinterConfig();
+    // Destroy this object.
+
+    // MANIPULATORS
+    StatsPrinterConfig& operator=(const StatsPrinterConfig& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+
+#if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
+    defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
+    StatsPrinterConfig& operator=(StatsPrinterConfig&& rhs);
+    // Assign to this object the value of the specified 'rhs' object.
+    // After performing this action, the 'rhs' object will be left in a
+    // valid, but unspecified state.
+#endif
+
+    void reset();
+    // Reset this object to the default value (i.e., its value upon
+    // default construction).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttributes(t_MANIPULATOR& manipulator);
+    // Invoke the specified 'manipulator' sequentially on the address of
+    // each (modifiable) attribute of this object, supplying 'manipulator'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'manipulator' (i.e., the invocation that
+    // terminated the sequence).
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator, int id);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'id',
+    // supplying 'manipulator' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'manipulator' if 'id' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    template <typename t_MANIPULATOR>
+    int manipulateAttribute(t_MANIPULATOR& manipulator,
+                            const char*    name,
+                            int            nameLength);
+    // Invoke the specified 'manipulator' on the address of
+    // the (modifiable) attribute indicated by the specified 'name' of the
+    // specified 'nameLength', supplying 'manipulator' with the
+    // corresponding attribute information structure.  Return the value
+    // returned from the invocation of 'manipulator' if 'name' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    int& printInterval();
+    // Return a reference to the modifiable "PrintInterval" attribute of
+    // this object.
+
+    bsl::string& file();
+    // Return a reference to the modifiable "File" attribute of this
+    // object.
+
+    int& maxAgeDays();
+    // Return a reference to the modifiable "MaxAgeDays" attribute of this
+    // object.
+
+    int& rotateBytes();
+    // Return a reference to the modifiable "RotateBytes" attribute of this
+    // object.
+
+    int& rotateDays();
+    // Return a reference to the modifiable "RotateDays" attribute of this
+    // object.
+
+    StatsPrinterEncodingFormat::Value& encoding();
+    // Return a reference to the modifiable "Encoding" attribute of this
+    // object.
+
+    // ACCESSORS
+    bsl::ostream&
+    print(bsl::ostream& stream, int level = 0, int spacesPerLevel = 4) const;
+    // Format this object to the specified output 'stream' at the
+    // optionally specified indentation 'level' and return a reference to
+    // the modifiable 'stream'.  If 'level' is specified, optionally
+    // specify 'spacesPerLevel', the number of spaces per indentation level
+    // for this and all of its nested objects.  Each line is indented by
+    // the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    // negative, suppress indentation of the first line.  If
+    // 'spacesPerLevel' is negative, suppress line breaks and format the
+    // entire output on one line.  If 'stream' is initially invalid, this
+    // operation has no effect.  Note that a trailing newline is provided
+    // in multiline mode only.
+
+    template <typename t_ACCESSOR>
+    int accessAttributes(t_ACCESSOR& accessor) const;
+    // Invoke the specified 'accessor' sequentially on each
+    // (non-modifiable) attribute of this object, supplying 'accessor'
+    // with the corresponding attribute information structure until such
+    // invocation returns a non-zero value.  Return the value from the
+    // last invocation of 'accessor' (i.e., the invocation that terminated
+    // the sequence).
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor, int id) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'id', supplying 'accessor'
+    // with the corresponding attribute information structure.  Return the
+    // value returned from the invocation of 'accessor' if 'id' identifies
+    // an attribute of this class, and -1 otherwise.
+
+    template <typename t_ACCESSOR>
+    int accessAttribute(t_ACCESSOR& accessor,
+                        const char* name,
+                        int         nameLength) const;
+    // Invoke the specified 'accessor' on the (non-modifiable) attribute
+    // of this object indicated by the specified 'name' of the specified
+    // 'nameLength', supplying 'accessor' with the corresponding attribute
+    // information structure.  Return the value returned from the
+    // invocation of 'accessor' if 'name' identifies an attribute of this
+    // class, and -1 otherwise.
+
+    int printInterval() const;
+    // Return the value of the "PrintInterval" attribute of this object.
+
+    const bsl::string& file() const;
+    // Return a reference offering non-modifiable access to the "File"
+    // attribute of this object.
+
+    int maxAgeDays() const;
+    // Return the value of the "MaxAgeDays" attribute of this object.
+
+    int rotateBytes() const;
+    // Return the value of the "RotateBytes" attribute of this object.
+
+    int rotateDays() const;
+    // Return the value of the "RotateDays" attribute of this object.
+
+    StatsPrinterEncodingFormat::Value encoding() const;
+    // Return the value of the "Encoding" attribute of this object.
+
+    // HIDDEN FRIENDS
+    friend bool operator==(const StatsPrinterConfig& lhs,
+                           const StatsPrinterConfig& rhs)
+    // Return 'true' if the specified 'lhs' and 'rhs' attribute objects
+    // have the same value, and 'false' otherwise.  Two attribute objects
+    // have the same value if each respective attribute has the same value.
+    {
+        return lhs.isEqualTo(rhs);
+    }
+
+    friend bool operator!=(const StatsPrinterConfig& lhs,
+                           const StatsPrinterConfig& rhs)
+    // Returns '!(lhs == rhs)'
+    {
+        return !(lhs == rhs);
+    }
+
+    friend bsl::ostream& operator<<(bsl::ostream&             stream,
+                                    const StatsPrinterConfig& rhs)
+    // Format the specified 'rhs' to the specified output 'stream' and
+    // return a reference to the modifiable 'stream'.
+    {
+        return rhs.print(stream, 0, -1);
+    }
+
+    template <typename t_HASH_ALGORITHM>
+    friend void hashAppend(t_HASH_ALGORITHM&         hashAlg,
+                           const StatsPrinterConfig& object)
+    // Pass the specified 'object' to the specified 'hashAlg'.  This
+    // function integrates with the 'bslh' modular hashing system and
+    // effectively provides a 'bsl::hash' specialization for
+    // 'StatsPrinterConfig'.
+    {
+        object.hashAppendImpl(hashAlg);
+    }
+};
+
+}  // close package namespace
+
+// TRAITS
+
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    mqbcfg::StatsPrinterConfig);
+template <>
+struct bdlat_UsesDefaultValueFlag<mqbcfg::StatsPrinterConfig>
 : bsl::true_type {};
 
 namespace mqbcfg {
@@ -15265,248 +15354,24 @@ inline const bsl::string& ResolvedDomain::clusterName() const
     return d_clusterName;
 }
 
-// ------------------------
-// class StatsPrinterConfig
-// ------------------------
-
-// PRIVATE ACCESSORS
-template <typename t_HASH_ALGORITHM>
-void StatsPrinterConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
-{
-    using bslh::hashAppend;
-    hashAppend(hashAlgorithm, this->printInterval());
-    hashAppend(hashAlgorithm, this->file());
-    hashAppend(hashAlgorithm, this->maxAgeDays());
-    hashAppend(hashAlgorithm, this->rotateBytes());
-    hashAppend(hashAlgorithm, this->rotateDays());
-}
-
-inline bool StatsPrinterConfig::isEqualTo(const StatsPrinterConfig& rhs) const
-{
-    return this->printInterval() == rhs.printInterval() &&
-           this->file() == rhs.file() &&
-           this->maxAgeDays() == rhs.maxAgeDays() &&
-           this->rotateBytes() == rhs.rotateBytes() &&
-           this->rotateDays() == rhs.rotateDays();
-}
+// --------------------------------
+// class StatsPrinterEncodingFormat
+// --------------------------------
 
 // CLASS METHODS
-// MANIPULATORS
-template <typename t_MANIPULATOR>
-int StatsPrinterConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+inline int StatsPrinterEncodingFormat::fromString(Value*             result,
+                                                  const bsl::string& string)
 {
-    int ret;
-
-    ret = manipulator(&d_printInterval,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_maxAgeDays,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_rotateBytes,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = manipulator(&d_rotateDays,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
+    return fromString(result,
+                      string.c_str(),
+                      static_cast<int>(string.length()));
 }
 
-template <typename t_MANIPULATOR>
-int StatsPrinterConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+inline bsl::ostream&
+StatsPrinterEncodingFormat::print(bsl::ostream&                     stream,
+                                  StatsPrinterEncodingFormat::Value value)
 {
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_PRINT_INTERVAL: {
-        return manipulator(
-            &d_printInterval,
-            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
-    }
-    case ATTRIBUTE_ID_FILE: {
-        return manipulator(&d_file,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
-    }
-    case ATTRIBUTE_ID_MAX_AGE_DAYS: {
-        return manipulator(&d_maxAgeDays,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
-    }
-    case ATTRIBUTE_ID_ROTATE_BYTES: {
-        return manipulator(&d_rotateBytes,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
-    }
-    case ATTRIBUTE_ID_ROTATE_DAYS: {
-        return manipulator(&d_rotateDays,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_MANIPULATOR>
-int StatsPrinterConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
-                                            const char*    name,
-                                            int            nameLength)
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return manipulateAttribute(manipulator, attributeInfo->d_id);
-}
-
-inline int& StatsPrinterConfig::printInterval()
-{
-    return d_printInterval;
-}
-
-inline bsl::string& StatsPrinterConfig::file()
-{
-    return d_file;
-}
-
-inline int& StatsPrinterConfig::maxAgeDays()
-{
-    return d_maxAgeDays;
-}
-
-inline int& StatsPrinterConfig::rotateBytes()
-{
-    return d_rotateBytes;
-}
-
-inline int& StatsPrinterConfig::rotateDays()
-{
-    return d_rotateDays;
-}
-
-// ACCESSORS
-template <typename t_ACCESSOR>
-int StatsPrinterConfig::accessAttributes(t_ACCESSOR& accessor) const
-{
-    int ret;
-
-    ret = accessor(d_printInterval,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_maxAgeDays,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_rotateBytes,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
-    if (ret) {
-        return ret;
-    }
-
-    ret = accessor(d_rotateDays,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
-    if (ret) {
-        return ret;
-    }
-
-    return 0;
-}
-
-template <typename t_ACCESSOR>
-int StatsPrinterConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
-{
-    enum { NOT_FOUND = -1 };
-
-    switch (id) {
-    case ATTRIBUTE_ID_PRINT_INTERVAL: {
-        return accessor(d_printInterval,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
-    }
-    case ATTRIBUTE_ID_FILE: {
-        return accessor(d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
-    }
-    case ATTRIBUTE_ID_MAX_AGE_DAYS: {
-        return accessor(d_maxAgeDays,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
-    }
-    case ATTRIBUTE_ID_ROTATE_BYTES: {
-        return accessor(d_rotateBytes,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
-    }
-    case ATTRIBUTE_ID_ROTATE_DAYS: {
-        return accessor(d_rotateDays,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
-    }
-    default: return NOT_FOUND;
-    }
-}
-
-template <typename t_ACCESSOR>
-int StatsPrinterConfig::accessAttribute(t_ACCESSOR& accessor,
-                                        const char* name,
-                                        int         nameLength) const
-{
-    enum { NOT_FOUND = -1 };
-
-    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
-                                                                   nameLength);
-    if (0 == attributeInfo) {
-        return NOT_FOUND;
-    }
-
-    return accessAttribute(accessor, attributeInfo->d_id);
-}
-
-inline int StatsPrinterConfig::printInterval() const
-{
-    return d_printInterval;
-}
-
-inline const bsl::string& StatsPrinterConfig::file() const
-{
-    return d_file;
-}
-
-inline int StatsPrinterConfig::maxAgeDays() const
-{
-    return d_maxAgeDays;
-}
-
-inline int StatsPrinterConfig::rotateBytes() const
-{
-    return d_rotateBytes;
-}
-
-inline int StatsPrinterConfig::rotateDays() const
-{
-    return d_rotateDays;
+    return stream << toString(value);
 }
 
 // -----------------------
@@ -18415,6 +18280,281 @@ inline const bsl::string& StatPluginConfigPrometheus::host() const
 inline int StatPluginConfigPrometheus::port() const
 {
     return d_port;
+}
+
+// ------------------------
+// class StatsPrinterConfig
+// ------------------------
+
+// PRIVATE ACCESSORS
+template <typename t_HASH_ALGORITHM>
+void StatsPrinterConfig::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
+{
+    using bslh::hashAppend;
+    hashAppend(hashAlgorithm, this->printInterval());
+    hashAppend(hashAlgorithm, this->file());
+    hashAppend(hashAlgorithm, this->maxAgeDays());
+    hashAppend(hashAlgorithm, this->rotateBytes());
+    hashAppend(hashAlgorithm, this->rotateDays());
+    hashAppend(hashAlgorithm, this->encoding());
+}
+
+inline bool StatsPrinterConfig::isEqualTo(const StatsPrinterConfig& rhs) const
+{
+    return this->printInterval() == rhs.printInterval() &&
+           this->file() == rhs.file() &&
+           this->maxAgeDays() == rhs.maxAgeDays() &&
+           this->rotateBytes() == rhs.rotateBytes() &&
+           this->rotateDays() == rhs.rotateDays() &&
+           this->encoding() == rhs.encoding();
+}
+
+// CLASS METHODS
+// MANIPULATORS
+template <typename t_MANIPULATOR>
+int StatsPrinterConfig::manipulateAttributes(t_MANIPULATOR& manipulator)
+{
+    int ret;
+
+    ret = manipulator(&d_printInterval,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_maxAgeDays,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_rotateBytes,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_rotateDays,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_encoding,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ENCODING]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_MANIPULATOR>
+int StatsPrinterConfig::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_PRINT_INTERVAL: {
+        return manipulator(
+            &d_printInterval,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
+    }
+    case ATTRIBUTE_ID_FILE: {
+        return manipulator(&d_file,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
+    }
+    case ATTRIBUTE_ID_MAX_AGE_DAYS: {
+        return manipulator(&d_maxAgeDays,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
+    }
+    case ATTRIBUTE_ID_ROTATE_BYTES: {
+        return manipulator(&d_rotateBytes,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
+    }
+    case ATTRIBUTE_ID_ROTATE_DAYS: {
+        return manipulator(&d_rotateDays,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
+    }
+    case ATTRIBUTE_ID_ENCODING: {
+        return manipulator(&d_encoding,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ENCODING]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_MANIPULATOR>
+int StatsPrinterConfig::manipulateAttribute(t_MANIPULATOR& manipulator,
+                                            const char*    name,
+                                            int            nameLength)
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return manipulateAttribute(manipulator, attributeInfo->d_id);
+}
+
+inline int& StatsPrinterConfig::printInterval()
+{
+    return d_printInterval;
+}
+
+inline bsl::string& StatsPrinterConfig::file()
+{
+    return d_file;
+}
+
+inline int& StatsPrinterConfig::maxAgeDays()
+{
+    return d_maxAgeDays;
+}
+
+inline int& StatsPrinterConfig::rotateBytes()
+{
+    return d_rotateBytes;
+}
+
+inline int& StatsPrinterConfig::rotateDays()
+{
+    return d_rotateDays;
+}
+
+inline StatsPrinterEncodingFormat::Value& StatsPrinterConfig::encoding()
+{
+    return d_encoding;
+}
+
+// ACCESSORS
+template <typename t_ACCESSOR>
+int StatsPrinterConfig::accessAttributes(t_ACCESSOR& accessor) const
+{
+    int ret;
+
+    ret = accessor(d_printInterval,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_maxAgeDays,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_rotateBytes,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_rotateDays,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_encoding, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ENCODING]);
+    if (ret) {
+        return ret;
+    }
+
+    return 0;
+}
+
+template <typename t_ACCESSOR>
+int StatsPrinterConfig::accessAttribute(t_ACCESSOR& accessor, int id) const
+{
+    enum { NOT_FOUND = -1 };
+
+    switch (id) {
+    case ATTRIBUTE_ID_PRINT_INTERVAL: {
+        return accessor(d_printInterval,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRINT_INTERVAL]);
+    }
+    case ATTRIBUTE_ID_FILE: {
+        return accessor(d_file, ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_FILE]);
+    }
+    case ATTRIBUTE_ID_MAX_AGE_DAYS: {
+        return accessor(d_maxAgeDays,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_MAX_AGE_DAYS]);
+    }
+    case ATTRIBUTE_ID_ROTATE_BYTES: {
+        return accessor(d_rotateBytes,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_BYTES]);
+    }
+    case ATTRIBUTE_ID_ROTATE_DAYS: {
+        return accessor(d_rotateDays,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ROTATE_DAYS]);
+    }
+    case ATTRIBUTE_ID_ENCODING: {
+        return accessor(d_encoding,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_ENCODING]);
+    }
+    default: return NOT_FOUND;
+    }
+}
+
+template <typename t_ACCESSOR>
+int StatsPrinterConfig::accessAttribute(t_ACCESSOR& accessor,
+                                        const char* name,
+                                        int         nameLength) const
+{
+    enum { NOT_FOUND = -1 };
+
+    const bdlat_AttributeInfo* attributeInfo = lookupAttributeInfo(name,
+                                                                   nameLength);
+    if (0 == attributeInfo) {
+        return NOT_FOUND;
+    }
+
+    return accessAttribute(accessor, attributeInfo->d_id);
+}
+
+inline int StatsPrinterConfig::printInterval() const
+{
+    return d_printInterval;
+}
+
+inline const bsl::string& StatsPrinterConfig::file() const
+{
+    return d_file;
+}
+
+inline int StatsPrinterConfig::maxAgeDays() const
+{
+    return d_maxAgeDays;
+}
+
+inline int StatsPrinterConfig::rotateBytes() const
+{
+    return d_rotateBytes;
+}
+
+inline int StatsPrinterConfig::rotateDays() const
+{
+    return d_rotateDays;
+}
+
+inline StatsPrinterEncodingFormat::Value StatsPrinterConfig::encoding() const
+{
+    return d_encoding;
 }
 
 // ------------------------
@@ -22411,6 +22551,6 @@ inline const AppConfig& Configuration::appConfig() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.04.30
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.07
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package mqbcfg --msgComponent messages mqbcfg.xsd

--- a/src/python/blazingmq/schemas/mqbcfg.py
+++ b/src/python/blazingmq/schemas/mqbcfg.py
@@ -894,52 +894,17 @@ class ResolvedDomain:
     )
 
 
-@dataclass
-class StatsPrinterConfig:
-    print_interval: int = field(
-        default=60,
-        metadata={
-            "name": "printInterval",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    file: Optional[str] = field(
-        default=None,
-        metadata={
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    max_age_days: Optional[int] = field(
-        default=None,
-        metadata={
-            "name": "maxAgeDays",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    rotate_bytes: int = field(
-        default=268435456,
-        metadata={
-            "name": "rotateBytes",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
-    rotate_days: int = field(
-        default=1,
-        metadata={
-            "name": "rotateDays",
-            "type": "Element",
-            "namespace": "http://bloomberg.com/schemas/mqbcfg",
-            "required": True,
-        },
-    )
+class StatsPrinterEncodingFormat(Enum):
+    """Bitmask of stats output encoding formats:
+    - NONE:           no stats output (0)
+    - TABLE:          human-readable table format (1)
+    - JSON:           machine-readable JSON format (2)
+    - TABLE_AND_JSON: both formats (TABLE | JSON = 3)"""
+
+    NONE = "NONE"
+    TABLE = "TABLE"
+    JSON = "JSON"
+    TABLE_AND_JSON = "TABLE_AND_JSON"
 
 
 @dataclass
@@ -1235,8 +1200,8 @@ class TlsConfig:
             "required": True,
         },
     )
-    versions: Optional[str] = field(
-        default=None,
+    versions: str = field(
+        default="TLSv1.3",
         metadata={
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
@@ -1629,6 +1594,62 @@ class StatPluginConfigPrometheus:
 
 
 @dataclass
+class StatsPrinterConfig:
+    print_interval: int = field(
+        default=60,
+        metadata={
+            "name": "printInterval",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    file: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    max_age_days: Optional[int] = field(
+        default=None,
+        metadata={
+            "name": "maxAgeDays",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    rotate_bytes: int = field(
+        default=268435456,
+        metadata={
+            "name": "rotateBytes",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    rotate_days: int = field(
+        default=1,
+        metadata={
+            "name": "rotateDays",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    encoding: StatsPrinterEncodingFormat = field(
+        default=StatsPrinterEncodingFormat.TABLE_AND_JSON,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+
+
+@dataclass
 class TcpInterfaceConfig:
     """name.................:
 
@@ -1813,6 +1834,33 @@ class ClusterNode:
 
 
 @dataclass
+class CredentialProviderConfig:
+    """The configuration for the broker's credential provider.
+
+    name.....:
+    The name of the credential provider.
+    settings.:
+    Plugin-specific settings.
+    """
+
+    name: Optional[str] = field(
+        default=None,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    settings: List[PluginSettingKeyValue] = field(
+        default_factory=list,
+        metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+        },
+    )
+
+
+@dataclass
 class DispatcherConfig:
     sessions: Optional[DispatcherProcessorConfig] = field(
         default=None,
@@ -1833,6 +1881,24 @@ class DispatcherConfig:
     clusters: Optional[DispatcherProcessorConfig] = field(
         default=None,
         metadata={
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    alarm_timeout_ms: int = field(
+        default=180000,
+        metadata={
+            "name": "alarmTimeoutMs",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
+            "required": True,
+        },
+    )
+    warning_timeout_ms: int = field(
+        default=10000,
+        metadata={
+            "name": "warningTimeoutMs",
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,
@@ -1990,6 +2056,11 @@ class AuthenticatorConfig:
     Minimum number of threads in the authentication thread pool.
     maxThreads..............:
     Maximum number of threads in the authentication thread pool.
+    credentialProvider...:
+    Optional credential provider. When specified, the broker uses credentials
+    provided by the credential provider to authenticate with other brokers.
+    If not specified, the broker will attempt to directly negotiate sessions
+    with other brokers without explicitly authenticating.
     """
 
     authenticators: List[AuthenticatorPluginConfig] = field(
@@ -2023,6 +2094,14 @@ class AuthenticatorConfig:
             "type": "Element",
             "namespace": "http://bloomberg.com/schemas/mqbcfg",
             "required": True,
+        },
+    )
+    credential_provider: Optional[CredentialProviderConfig] = field(
+        default=None,
+        metadata={
+            "name": "credentialProvider",
+            "type": "Element",
+            "namespace": "http://bloomberg.com/schemas/mqbcfg",
         },
     )
 


### PR DESCRIPTION
- `mqbcfg`: add (but do not use yet) settings for extended stats printing.
- default to table print **and** json print.
- regenerate schema sources (c++, python).

https://github.com/bloomberg/blazingmq/pull/1180