### PR TITLE
Feat[mqbauthn]: integrate CredentialProvider with AuthenticationController

### DIFF
--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
@@ -26,10 +26,13 @@
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbplug_authenticator.h>
+#include <mqbplug_credentialprovider.h>
 #include <mqbplug_pluginfactory.h>
+#include <mqbplug_plugintype.h>
 
 // BDE
 #include <ball_log.h>
+#include <bdlb_nullablevalue.h>
 #include <bdlb_string.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -37,6 +40,7 @@
 #include <bsl_unordered_map.h>
 #include <bsl_unordered_set.h>
 #include <bsl_vector.h>
+#include <bslmf_movableref.h>
 
 namespace BloombergLP {
 namespace mqbauthn {
@@ -123,7 +127,9 @@ int AuthenticationController::initializeAuthenticators(
 
     // Step 1: Collect all available plugin factories (built-in + external)
     PluginFactories pluginFactories(d_allocator_p);
-    if (int rc = collectAvailablePluginFactories(&pluginFactories)) {
+    if (int rc = collectAvailablePluginFactories(
+            mqbplug::PluginType::e_AUTHENTICATOR,
+            &pluginFactories)) {
         return rc * 10 + rc_COLLECT_FACTORIES_FAILED;  // RETURN
     }
 
@@ -164,17 +170,17 @@ int AuthenticationController::initializeAuthenticators(
 }
 
 int AuthenticationController::collectAvailablePluginFactories(
-    PluginFactories* pluginFactories)
+    mqbplug::PluginType::Enum type,
+    PluginFactories*          pluginFactories)
 {
     // Collect external plugin factories loaded by PluginManager
-    d_pluginManager_p->get(mqbplug::PluginType::e_AUTHENTICATOR,
-                           pluginFactories);
+    d_pluginManager_p->get(type, pluginFactories);
 
     // Add built-in plugin factories
     bsl::vector<mqbplug::PluginInfo>::const_iterator it =
         d_builtInPluginLibrary->plugins().cbegin();
     for (; it != d_builtInPluginLibrary->plugins().cend(); ++it) {
-        if (it->type() == mqbplug::PluginType::e_AUTHENTICATOR) {
+        if (it->type() == type) {
             pluginFactories->insert(it->factory().get());
         }
     }
@@ -381,6 +387,70 @@ int AuthenticationController::ensureDefaultAuthenticator(
     return 0;
 }
 
+int AuthenticationController::initializeCredentialProvider(
+    bsl::ostream& errorDescription)
+{
+    enum RcEnum {
+        rc_SUCCESS          = 0,
+        rc_COLLECT_FAILED   = -1,
+        rc_PLUGIN_NOT_FOUND = -2,
+        rc_START_FAILED     = -3
+    };
+
+    const bdlb::NullableValue<mqbcfg::CredentialProviderConfig>& credProvCfg =
+        mqbcfg::BrokerConfig::get().authentication().credentialProvider();
+
+    if (credProvCfg.isNull()) {
+        return rc_SUCCESS;  // RETURN
+    }
+
+    const bsl::string& providerName = credProvCfg.value().name();
+
+    BALL_LOG_INFO << "Configuring credential provider '" << providerName
+                  << "'";
+
+    PluginFactories factories(d_allocator_p);
+    if (int rc = collectAvailablePluginFactories(
+            mqbplug::PluginType::e_CREDENTIAL_PROVIDER,
+            &factories)) {
+        return rc * 10 + rc_COLLECT_FAILED;  // RETURN
+    }
+
+    for (PluginFactories::const_iterator it = factories.cbegin();
+         it != factories.cend();
+         ++it) {
+        mqbplug::CredentialProviderPluginFactory* candidate =
+            dynamic_cast<mqbplug::CredentialProviderPluginFactory*>(*it);
+        if (!candidate) {
+            continue;
+        }
+        bslma::ManagedPtr<mqbplug::CredentialProvider> provider =
+            candidate->create(d_allocator_p);
+        if (provider) {
+            d_credentialProvider_mp = bslmf::MovableRefUtil::move(provider);
+            break;
+        }
+    }
+
+    if (!d_credentialProvider_mp) {
+        errorDescription << "CredentialProvider plugin '" << providerName
+                         << "' not found";
+        return rc_PLUGIN_NOT_FOUND;  // RETURN
+    }
+
+    int rc = d_credentialProvider_mp->start(errorDescription);
+    if (rc != 0) {
+        return rc * 10 + rc_START_FAILED;  // RETURN
+    }
+
+    d_credentialFunc = d_credentialProvider_mp->load();
+
+    BALL_LOG_INFO << "Credential provider '" << providerName << "' started";
+
+    return rc_SUCCESS;
+}
+
+// CREATORS
 AuthenticationController::AuthenticationController(
     mqbplug::PluginManager* pluginManager,
     bslma::Allocator*       allocator)
@@ -388,6 +458,8 @@ AuthenticationController::AuthenticationController(
       bslma::ManagedPtrUtil::allocateManaged<mqbauthn::PluginLibrary>(
           allocator))
 , d_pluginManager_p(pluginManager)
+, d_credentialProvider_mp()
+, d_credentialFunc()
 , d_isStarted(false)
 , d_allocator_p(allocator)
 {
@@ -397,10 +469,11 @@ int AuthenticationController::start(bsl::ostream& errorDescription)
 {
     enum RcEnum {
         // Enum for the various RC error categories
-        rc_SUCCESS             = 0,
-        rc_ALREADY_STARTED     = -1,
-        rc_INVALID_CONFIG      = -2,
-        rc_INIT_AUTHENTICATORS = -3
+        rc_SUCCESS                  = 0,
+        rc_ALREADY_STARTED          = -1,
+        rc_INVALID_CONFIG           = -2,
+        rc_INIT_AUTHENTICATORS      = -3,
+        rc_INIT_CREDENTIAL_PROVIDER = -4
     };
 
     if (d_isStarted) {
@@ -420,7 +493,10 @@ int AuthenticationController::start(bsl::ostream& errorDescription)
         return rc * 10 + rc_INIT_AUTHENTICATORS;
     }
 
-    // Initialize Authenticators from plugins
+    rc = initializeCredentialProvider(errorDescription);
+    if (rc != 0) {
+        return rc * 10 + rc_INIT_CREDENTIAL_PROVIDER;
+    }
 
     d_isStarted = true;
     return rc_SUCCESS;
@@ -435,6 +511,13 @@ void AuthenticationController::stop()
     BALL_LOG_INFO << "Stopping AuthenticationController";
 
     d_isStarted = false;
+
+    // Stop credential provider
+    if (d_credentialProvider_mp) {
+        d_credentialProvider_mp->stop();
+        d_credentialProvider_mp.reset();
+        d_credentialFunc = mqbplug::CredentialProvider::CredentialFunc();
+    }
 
     // Stop all authenticators
     for (AuthenticatorMap::iterator it = d_authenticators.begin();
@@ -497,6 +580,19 @@ const bsl::optional<mqbcfg::Credential>&
 AuthenticationController::anonymousCredential()
 {
     return d_anonymousCredential;
+}
+
+// ACCESSORS
+bool AuthenticationController::hasCredentialProvider() const
+{
+    return d_credentialProvider_mp.get() != 0;
+}
+
+const mqbplug::CredentialProvider::CredentialFunc&
+AuthenticationController::credentialFunc() const
+{
+    BSLS_ASSERT_SAFE(hasCredentialProvider());
+    return d_credentialFunc;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
@@ -173,8 +173,11 @@ int AuthenticationController::collectAvailablePluginFactories(
     mqbplug::PluginType::Enum type,
     PluginFactories*          pluginFactories)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(pluginFactories);
+
     // Collect external plugin factories loaded by PluginManager
-    d_pluginManager_p->get(type, pluginFactories);
+    d_pluginManager_p->get(pluginFactories, type);
 
     // Add built-in plugin factories
     bsl::vector<mqbplug::PluginInfo>::const_iterator it =
@@ -421,9 +424,7 @@ int AuthenticationController::initializeCredentialProvider(
          ++it) {
         mqbplug::CredentialProviderPluginFactory* candidate =
             dynamic_cast<mqbplug::CredentialProviderPluginFactory*>(*it);
-        if (!candidate) {
-            continue;
-        }
+        BSLS_ASSERT_SAFE(candidate);
         bslma::ManagedPtr<mqbplug::CredentialProvider> provider =
             candidate->create(d_allocator_p);
         if (provider) {
@@ -443,7 +444,7 @@ int AuthenticationController::initializeCredentialProvider(
         return rc * 10 + rc_START_FAILED;  // RETURN
     }
 
-    d_credentialFunc = d_credentialProvider_mp->load();
+    d_credentialCb = d_credentialProvider_mp->load();
 
     BALL_LOG_INFO << "Credential provider '" << providerName << "' started";
 
@@ -459,7 +460,7 @@ AuthenticationController::AuthenticationController(
           allocator))
 , d_pluginManager_p(pluginManager)
 , d_credentialProvider_mp()
-, d_credentialFunc()
+, d_credentialCb()
 , d_isStarted(false)
 , d_allocator_p(allocator)
 {
@@ -516,7 +517,7 @@ void AuthenticationController::stop()
     if (d_credentialProvider_mp) {
         d_credentialProvider_mp->stop();
         d_credentialProvider_mp.reset();
-        d_credentialFunc = mqbplug::CredentialProvider::CredentialFunc();
+        d_credentialCb = mqbplug::CredentialProvider::CredentialCb();
     }
 
     // Stop all authenticators
@@ -588,11 +589,11 @@ bool AuthenticationController::hasCredentialProvider() const
     return d_credentialProvider_mp.get() != 0;
 }
 
-const mqbplug::CredentialProvider::CredentialFunc&
-AuthenticationController::credentialFunc() const
+const mqbplug::CredentialProvider::CredentialCb&
+AuthenticationController::credentialCb() const
 {
     BSLS_ASSERT_SAFE(hasCredentialProvider());
-    return d_credentialFunc;
+    return d_credentialCb;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.cpp
@@ -445,6 +445,11 @@ int AuthenticationController::initializeCredentialProvider(
     }
 
     d_credentialCb = d_credentialProvider_mp->load();
+    if (!d_credentialCb) {
+        errorDescription << "CredentialProvider '" << providerName
+                         << "' did not return a valid credential callback";
+        return rc_START_FAILED;  // RETURN
+    }
 
     BALL_LOG_INFO << "Credential provider '" << providerName << "' started";
 
@@ -593,6 +598,8 @@ const mqbplug::CredentialProvider::CredentialCb&
 AuthenticationController::credentialCb() const
 {
     BSLS_ASSERT_SAFE(hasCredentialProvider());
+    BSLS_ASSERT_SAFE(d_credentialCb);
+
     return d_credentialCb;
 }
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
@@ -30,6 +30,7 @@
 // MQB
 #include <mqbcfg_messages.h>
 #include <mqbplug_authenticator.h>
+#include <mqbplug_credentialprovider.h>
 #include <mqbplug_pluginmanager.h>
 
 // BDE
@@ -84,6 +85,14 @@ class AuthenticationController {
     /// Held, not owned.
     mqbplug::PluginManager* d_pluginManager_p;
 
+    /// Credential provider for outbound authentication.  Null if not
+    /// configured.
+    bslma::ManagedPtr<mqbplug::CredentialProvider> d_credentialProvider_mp;
+
+    /// Credential function loaded from the provider.  Empty if no provider
+    /// is configured.
+    mqbplug::CredentialProvider::CredentialFunc d_credentialFunc;
+
     /// True if this component is started.
     bool d_isStarted;
 
@@ -105,11 +114,16 @@ class AuthenticationController {
     /// Initialize authenticators from configuration.
     int initializeAuthenticators(bsl::ostream& errorDescription);
 
-    /// Collect all available plugin factories (built-in and external).
-    /// Load them into the specified `pluginFactories` collection.
-    /// Return 0 on success, non-zero on error.
+    /// Collect all available plugin factories of the specified `type`
+    /// (built-in and external).  Load them into the specified
+    /// `pluginFactories` collection.  Return 0 on success, non-zero on
+    /// error.
     int collectAvailablePluginFactories(
+        mqbplug::PluginType::Enum                    type,
         bsl::unordered_set<mqbplug::PluginFactory*>* pluginFactories);
+
+    /// Initialize the credential provider from configuration.
+    int initializeCredentialProvider(bsl::ostream& errorDescription);
 
     /// Create authenticators based on configuration from the specified
     /// `authenticatorConfig` using the specified `pluginFactories`.
@@ -171,6 +185,16 @@ class AuthenticationController {
     /// Return the anonymous credential used for authentication.
     /// If no anonymous credential is set, return an empty optional.
     const bsl::optional<mqbcfg::Credential>& anonymousCredential();
+
+    // ACCESSORS
+
+    /// Return true if a credential provider is configured and started.
+    bool hasCredentialProvider() const;
+
+    /// Return a reference to the credential function loaded from the
+    /// configured provider.  The behavior is undefined unless
+    /// `hasCredentialProvider()` returns true.
+    const mqbplug::CredentialProvider::CredentialFunc& credentialFunc() const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_authenticationcontroller.h
@@ -91,7 +91,7 @@ class AuthenticationController {
 
     /// Credential function loaded from the provider.  Empty if no provider
     /// is configured.
-    mqbplug::CredentialProvider::CredentialFunc d_credentialFunc;
+    mqbplug::CredentialProvider::CredentialCb d_credentialCb;
 
     /// True if this component is started.
     bool d_isStarted;
@@ -191,10 +191,10 @@ class AuthenticationController {
     /// Return true if a credential provider is configured and started.
     bool hasCredentialProvider() const;
 
-    /// Return a reference to the credential function loaded from the
+    /// Return a reference to the credential callback loaded from the
     /// configured provider.  The behavior is undefined unless
     /// `hasCredentialProvider()` returns true.
-    const mqbplug::CredentialProvider::CredentialFunc& credentialFunc() const;
+    const mqbplug::CredentialProvider::CredentialCb& credentialCb() const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
@@ -30,57 +30,86 @@
 #include <bslma_allocator.h>
 #include <bslma_default.h>
 #include <bslma_managedptr.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
 namespace mqbauthn {
 
-const char* BasicCredentialProvider::k_NAME      = "BasicCredentialProvider";
-const char* BasicCredentialProvider::k_MECHANISM = "BASIC";
+const char* BasicCredentialProvider::k_NAME = "BasicCredentialProvider";
 
-// ------------------------
-// class CredentialFunctor
-// ------------------------
+namespace {
 
-BasicCredentialProvider::CredentialFunctor::CredentialFunctor(
-    const bsl::string& mechanism,
-    const bsl::string& username,
-    const bsl::string& password)
-: d_mechanism(mechanism)
-, d_username(username)
-, d_password(password)
-{
-}
+const char k_MECHANISM[] = "BASIC";
 
-bsl::optional<mqbplug::AuthnCredential>
-BasicCredentialProvider::CredentialFunctor::operator()(
-    bsl::ostream& error) const
-{
-    if (d_username.empty()) {
-        error << "BasicCredentialProvider: username is empty";
-        return bsl::nullopt;  // RETURN
+// ============================
+// class BasicCredentialFunctor
+// ============================
+
+class BasicCredentialFunctor {
+    // DATA
+    bsl::string       d_username;
+    bsl::string       d_password;
+    bslma::Allocator* d_allocator_p;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(BasicCredentialFunctor,
+                                   bslma::UsesBslmaAllocator)
+
+    // CREATORS
+    BasicCredentialFunctor(const bsl::string& username,
+                           const bsl::string& password,
+                           bslma::Allocator*  basicAllocator = 0)
+    : d_username(username, basicAllocator)
+    , d_password(password, basicAllocator)
+    , d_allocator_p(basicAllocator)
+    {
     }
 
-    bsl::string payload(d_username);
-    payload.append(":");
-    payload.append(d_password);
+    BasicCredentialFunctor(const BasicCredentialFunctor& original,
+                           bslma::Allocator*             basicAllocator = 0)
+    : d_username(original.d_username, basicAllocator)
+    , d_password(original.d_password, basicAllocator)
+    , d_allocator_p(basicAllocator)
+    {
+    }
 
-    bsl::vector<char> data(payload.begin(), payload.end());
+    // ACCESSORS
+    bsl::optional<mqbplug::AuthnCredential>
+    operator()(bsl::ostream& error) const
+    {
+        if (d_username.empty()) {
+            error << "BasicCredentialProvider: username is empty";
+            return bsl::nullopt;  // RETURN
+        }
 
-    return mqbplug::AuthnCredential(d_mechanism, data);
-}
+        bsl::string payload(d_username, d_allocator_p);
+        payload.append(":");
+        payload.append(d_password);
+
+        bsl::vector<char> data(payload.begin(), payload.end(), d_allocator_p);
+
+        return mqbplug::AuthnCredential(k_MECHANISM, data, d_allocator_p);
+    }
+};
+
+}  // close unnamed namespace
 
 // -----------------------------
 // class BasicCredentialProvider
 // -----------------------------
 
 // CREATORS
-BasicCredentialProvider::BasicCredentialProvider(bsl::string_view  username,
-                                                 bsl::string_view  password,
-                                                 bslma::Allocator* allocator)
-: d_username(username, allocator)
-, d_password(password, allocator)
+BasicCredentialProvider::BasicCredentialProvider(
+    bsl::string_view  username,
+    bsl::string_view  password,
+    bslma::Allocator* basicAllocator)
+: d_username(username, basicAllocator)
+, d_password(password, basicAllocator)
 , d_isStarted(false)
+, d_allocator_p(basicAllocator)
 {
 }
 
@@ -91,9 +120,9 @@ BasicCredentialProvider::~BasicCredentialProvider()
 }
 
 // MANIPULATORS
-mqbplug::CredentialProvider::CredentialFunc BasicCredentialProvider::load()
+mqbplug::CredentialProvider::CredentialCb BasicCredentialProvider::load()
 {
-    return CredentialFunctor(k_MECHANISM, d_username, d_password);
+    return BasicCredentialFunctor(d_username, d_password, d_allocator_p);
 }
 
 int BasicCredentialProvider::start(bsl::ostream& errorDescription)
@@ -127,9 +156,9 @@ void BasicCredentialProvider::stop()
     BALL_LOG_INFO << "BasicCredentialProvider stopped";
 }
 
-// ----------------------------------------
+// ------------------------------------------
 // class BasicCredentialProviderPluginFactory
-// ----------------------------------------
+// ------------------------------------------
 
 BasicCredentialProviderPluginFactory::BasicCredentialProviderPluginFactory()
 {
@@ -151,18 +180,17 @@ BasicCredentialProviderPluginFactory::create(bslma::Allocator* allocator)
         return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
     }
 
-    if (providerCfg.value().name() != BasicCredentialProvider::k_NAME) {
+    const mqbcfg::CredentialProviderConfig& cfg = providerCfg.value();
+    if (cfg.name() != BasicCredentialProvider::k_NAME) {
         return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
     }
-
-    allocator = bslma::Default::allocator(allocator);
 
     bsl::string username(allocator);
     bsl::string password(allocator);
 
     for (bsl::vector<mqbcfg::PluginSettingKeyValue>::const_iterator it =
-             providerCfg.value().settings().cbegin();
-         it != providerCfg.value().settings().cend();
+             cfg.settings().cbegin();
+         it != cfg.settings().cend();
          ++it) {
         if (!it->value().isStringValValue()) {
             continue;  // CONTINUE
@@ -176,9 +204,10 @@ BasicCredentialProviderPluginFactory::create(bslma::Allocator* allocator)
     }
 
     return bslma::ManagedPtr<mqbplug::CredentialProvider>(
-        new (*allocator)
-            BasicCredentialProvider(username, password, allocator),
-        allocator);
+        bslma::ManagedPtrUtil::allocateManaged<BasicCredentialProvider>(
+            allocator,
+            username,
+            password));
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbauthn_basiccredentialprovider.h>
+
+#include <mqbscm_version.h>
+
+// MQB
+#include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
+#include <mqbplug_authncredential.h>
+
+// BDE
+#include <bsl_optional.h>
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bslma_default.h>
+#include <bslma_managedptr.h>
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace mqbauthn {
+
+const char* BasicCredentialProvider::k_NAME      = "BasicCredentialProvider";
+const char* BasicCredentialProvider::k_MECHANISM = "BASIC";
+
+// ------------------------
+// class CredentialFunctor
+// ------------------------
+
+BasicCredentialProvider::CredentialFunctor::CredentialFunctor(
+    const bsl::string& mechanism,
+    const bsl::string& username,
+    const bsl::string& password)
+: d_mechanism(mechanism)
+, d_username(username)
+, d_password(password)
+{
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+BasicCredentialProvider::CredentialFunctor::operator()(
+    bsl::ostream& error) const
+{
+    if (d_username.empty()) {
+        error << "BasicCredentialProvider: username is empty";
+        return bsl::nullopt;  // RETURN
+    }
+
+    bsl::string payload(d_username);
+    payload.append(":");
+    payload.append(d_password);
+
+    bsl::vector<char> data(payload.begin(), payload.end());
+
+    return mqbplug::AuthnCredential(d_mechanism, data);
+}
+
+// -----------------------------
+// class BasicCredentialProvider
+// -----------------------------
+
+// CREATORS
+BasicCredentialProvider::BasicCredentialProvider(bsl::string_view  username,
+                                                 bsl::string_view  password,
+                                                 bslma::Allocator* allocator)
+: d_username(username, allocator)
+, d_password(password, allocator)
+, d_isStarted(false)
+{
+}
+
+BasicCredentialProvider::~BasicCredentialProvider()
+{
+    BSLS_ASSERT_OPT(!d_isStarted &&
+                    "stop() must be called before destroying this object");
+}
+
+// MANIPULATORS
+mqbplug::CredentialProvider::CredentialFunc BasicCredentialProvider::load()
+{
+    return CredentialFunctor(k_MECHANISM, d_username, d_password);
+}
+
+int BasicCredentialProvider::start(bsl::ostream& errorDescription)
+{
+    if (d_isStarted) {
+        errorDescription << "start() can only be called once on this object";
+        return -1;  // RETURN
+    }
+
+    if (d_username.empty()) {
+        errorDescription << "BasicCredentialProvider: username is empty";
+        return -1;  // RETURN
+    }
+
+    d_isStarted = true;
+
+    BALL_LOG_INFO << "BasicCredentialProvider started for user '" << d_username
+                  << "'";
+
+    return 0;
+}
+
+void BasicCredentialProvider::stop()
+{
+    if (!d_isStarted) {
+        return;  // RETURN
+    }
+
+    d_isStarted = false;
+
+    BALL_LOG_INFO << "BasicCredentialProvider stopped";
+}
+
+// ----------------------------------------
+// class BasicCredentialProviderPluginFactory
+// ----------------------------------------
+
+BasicCredentialProviderPluginFactory::BasicCredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+BasicCredentialProviderPluginFactory::~BasicCredentialProviderPluginFactory()
+{
+    // NOTHING
+}
+
+bslma::ManagedPtr<mqbplug::CredentialProvider>
+BasicCredentialProviderPluginFactory::create(bslma::Allocator* allocator)
+{
+    const bdlb::NullableValue<mqbcfg::CredentialProviderConfig>& providerCfg =
+        mqbcfg::BrokerConfig::get().authentication().credentialProvider();
+
+    if (providerCfg.isNull()) {
+        return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
+    }
+
+    if (providerCfg.value().name() != BasicCredentialProvider::k_NAME) {
+        return bslma::ManagedPtr<mqbplug::CredentialProvider>();  // RETURN
+    }
+
+    allocator = bslma::Default::allocator(allocator);
+
+    bsl::string username(allocator);
+    bsl::string password(allocator);
+
+    for (bsl::vector<mqbcfg::PluginSettingKeyValue>::const_iterator it =
+             providerCfg.value().settings().cbegin();
+         it != providerCfg.value().settings().cend();
+         ++it) {
+        if (!it->value().isStringValValue()) {
+            continue;  // CONTINUE
+        }
+        if (it->key() == "username") {
+            username = it->value().stringVal();
+        }
+        else if (it->key() == "password") {
+            password = it->value().stringVal();
+        }
+    }
+
+    return bslma::ManagedPtr<mqbplug::CredentialProvider>(
+        new (*allocator)
+            BasicCredentialProvider(username, password, allocator),
+        allocator);
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.cpp
@@ -49,9 +49,7 @@ const char k_MECHANISM[] = "BASIC";
 
 class BasicCredentialFunctor {
     // DATA
-    bsl::string       d_username;
-    bsl::string       d_password;
-    bslma::Allocator* d_allocator_p;
+    mqbplug::AuthnCredential d_credential;
 
   public:
     // TRAITS
@@ -59,39 +57,32 @@ class BasicCredentialFunctor {
                                    bslma::UsesBslmaAllocator)
 
     // CREATORS
-    BasicCredentialFunctor(const bsl::string& username,
-                           const bsl::string& password,
-                           bslma::Allocator*  basicAllocator = 0)
-    : d_username(username, basicAllocator)
-    , d_password(password, basicAllocator)
-    , d_allocator_p(basicAllocator)
+    BasicCredentialFunctor(bsl::string_view  username,
+                           bsl::string_view  password,
+                           bslma::Allocator* basicAllocator = 0)
+    : d_credential(basicAllocator)
     {
+        bsl::string payload(username, basicAllocator);
+        payload.append(":");
+        payload.append(password);
+
+        bsl::vector<char> data(payload.begin(), payload.end(), basicAllocator);
+
+        d_credential = mqbplug::AuthnCredential(k_MECHANISM,
+                                                data,
+                                                basicAllocator);
     }
 
     BasicCredentialFunctor(const BasicCredentialFunctor& original,
                            bslma::Allocator*             basicAllocator = 0)
-    : d_username(original.d_username, basicAllocator)
-    , d_password(original.d_password, basicAllocator)
-    , d_allocator_p(basicAllocator)
+    : d_credential(original.d_credential, basicAllocator)
     {
     }
 
     // ACCESSORS
-    bsl::optional<mqbplug::AuthnCredential>
-    operator()(bsl::ostream& error) const
+    bsl::optional<mqbplug::AuthnCredential> operator()(bsl::ostream&) const
     {
-        if (d_username.empty()) {
-            error << "BasicCredentialProvider: username is empty";
-            return bsl::nullopt;  // RETURN
-        }
-
-        bsl::string payload(d_username, d_allocator_p);
-        payload.append(":");
-        payload.append(d_password);
-
-        bsl::vector<char> data(payload.begin(), payload.end(), d_allocator_p);
-
-        return mqbplug::AuthnCredential(k_MECHANISM, data, d_allocator_p);
+        return d_credential;
     }
 };
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
@@ -1,0 +1,164 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBAUTHN_BASICCREDENTIALPROVIDER
+#define INCLUDED_MQBAUTHN_BASICCREDENTIALPROVIDER
+
+/// @file mqbauthn_basiccredentialprovider.h
+///
+/// @brief Provide a basic credential provider that supplies username and
+/// password credentials for outbound broker-to-broker authentication.
+///
+/// @bbref{mqbauthn::BasicCredentialProvider} provides a built-in
+/// credential provider plugin that supplies credentials using a configured
+/// username and password.  When its credential function is invoked, it returns
+/// an @bbref{mqbplug::AuthnCredential} with mechanism "BASIC" and data in the
+/// form "username:password".
+///
+/// This provider reads `username` and `password` from its plugin configuration
+/// settings (key-value pairs).
+
+// MQB
+#include <mqbplug_authncredential.h>
+#include <mqbplug_credentialprovider.h>
+
+// BDE
+#include <ball_log.h>
+#include <bsl_optional.h>
+#include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bslma_allocator.h>
+#include <bslma_managedptr.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+
+// FORWARD DECLARATION
+namespace mqbcfg {
+class CredentialProviderPluginConfig;
+}
+
+namespace mqbauthn {
+
+// =============================
+// class BasicCredentialProvider
+// =============================
+
+class BasicCredentialProvider : public mqbplug::CredentialProvider {
+  public:
+    // PUBLIC CLASS DATA
+    static const char* k_NAME;
+    static const char* k_MECHANISM;
+
+    // ========================
+    // class CredentialFunctor
+    // ========================
+
+    /// A self-contained functor that produces an `AuthnCredential` with the
+    /// "BASIC" mechanism and "username:password" data.
+    class CredentialFunctor {
+        // DATA
+        bsl::string d_mechanism;
+        bsl::string d_username;
+        bsl::string d_password;
+
+      public:
+        // CREATORS
+
+        /// Create a `CredentialFunctor` with the specified `mechanism`,
+        /// `username`, and `password`.
+        CredentialFunctor(const bsl::string& mechanism,
+                          const bsl::string& username,
+                          const bsl::string& password);
+
+        // ACCESSORS
+
+        /// Return an `AuthnCredential` containing the configured
+        /// credentials, or `nullopt` on failure (with a description
+        /// written to the specified `error` stream).
+        bsl::optional<mqbplug::AuthnCredential>
+        operator()(bsl::ostream& error) const;
+    };
+
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.BASICCREDENTIALPROVIDER");
+
+    // DATA
+    bsl::string d_username;
+    bsl::string d_password;
+    bool        d_isStarted;
+
+  private:
+    // NOT IMPLEMENTED
+    BasicCredentialProvider(const BasicCredentialProvider&)
+        BSLS_KEYWORD_DELETED;
+    BasicCredentialProvider&
+    operator=(const BasicCredentialProvider&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(BasicCredentialProvider,
+                                   bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a `BasicCredentialProvider` with the specified `username`
+    /// and `password`, using the optionally specified `allocator` to supply
+    /// memory.
+    BasicCredentialProvider(bsl::string_view  username,
+                            bsl::string_view  password,
+                            bslma::Allocator* allocator = 0);
+
+    /// Destructor.
+    ~BasicCredentialProvider() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+
+    /// Return a credential-providing function.  The behavior is undefined
+    /// unless `start()` has been called successfully.
+    CredentialFunc load() BSLS_KEYWORD_OVERRIDE;
+
+    /// Start the provider and return 0 on success, or return a non-zero
+    /// value and populate the specified `errorDescription` with the
+    /// description of any failure encountered.
+    int start(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the provider.
+    void stop() BSLS_KEYWORD_OVERRIDE;
+};
+
+// ========================================
+// class BasicCredentialProviderPluginFactory
+// ========================================
+
+class BasicCredentialProviderPluginFactory
+: public mqbplug::CredentialProviderPluginFactory {
+  public:
+    // CREATORS
+    BasicCredentialProviderPluginFactory();
+    ~BasicCredentialProviderPluginFactory() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+    bslma::ManagedPtr<mqbplug::CredentialProvider>
+    create(bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basiccredentialprovider.h
@@ -62,46 +62,16 @@ class BasicCredentialProvider : public mqbplug::CredentialProvider {
   public:
     // PUBLIC CLASS DATA
     static const char* k_NAME;
-    static const char* k_MECHANISM;
-
-    // ========================
-    // class CredentialFunctor
-    // ========================
-
-    /// A self-contained functor that produces an `AuthnCredential` with the
-    /// "BASIC" mechanism and "username:password" data.
-    class CredentialFunctor {
-        // DATA
-        bsl::string d_mechanism;
-        bsl::string d_username;
-        bsl::string d_password;
-
-      public:
-        // CREATORS
-
-        /// Create a `CredentialFunctor` with the specified `mechanism`,
-        /// `username`, and `password`.
-        CredentialFunctor(const bsl::string& mechanism,
-                          const bsl::string& username,
-                          const bsl::string& password);
-
-        // ACCESSORS
-
-        /// Return an `AuthnCredential` containing the configured
-        /// credentials, or `nullopt` on failure (with a description
-        /// written to the specified `error` stream).
-        bsl::optional<mqbplug::AuthnCredential>
-        operator()(bsl::ostream& error) const;
-    };
 
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.BASICCREDENTIALPROVIDER");
 
     // DATA
-    bsl::string d_username;
-    bsl::string d_password;
-    bool        d_isStarted;
+    bsl::string       d_username;
+    bsl::string       d_password;
+    bool              d_isStarted;
+    bslma::Allocator* d_allocator_p;
 
   private:
     // NOT IMPLEMENTED
@@ -120,9 +90,9 @@ class BasicCredentialProvider : public mqbplug::CredentialProvider {
     /// Create a `BasicCredentialProvider` with the specified `username`
     /// and `password`, using the optionally specified `allocator` to supply
     /// memory.
-    BasicCredentialProvider(bsl::string_view  username,
-                            bsl::string_view  password,
-                            bslma::Allocator* allocator = 0);
+    explicit BasicCredentialProvider(bsl::string_view  username,
+                                     bsl::string_view  password,
+                                     bslma::Allocator* basicAllocator = 0);
 
     /// Destructor.
     ~BasicCredentialProvider() BSLS_KEYWORD_OVERRIDE;
@@ -131,7 +101,7 @@ class BasicCredentialProvider : public mqbplug::CredentialProvider {
 
     /// Return a credential-providing function.  The behavior is undefined
     /// unless `start()` has been called successfully.
-    CredentialFunc load() BSLS_KEYWORD_OVERRIDE;
+    CredentialCb load() BSLS_KEYWORD_OVERRIDE;
 
     /// Start the provider and return 0 on success, or return a non-zero
     /// value and populate the specified `errorDescription` with the

--- a/src/groups/mqb/mqbauthn/mqbauthn_pluginlibrary.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_pluginlibrary.cpp
@@ -18,6 +18,7 @@
 // MQB
 #include <mqbauthn_anonauthenticator.h>
 #include <mqbauthn_basicauthenticator.h>
+#include <mqbauthn_basiccredentialprovider.h>
 #include <mqbauthn_testauthenticator.h>
 
 namespace BloombergLP {
@@ -54,6 +55,15 @@ PluginLibrary::PluginLibrary(bslma::Allocator* allocator)
     testPluginInfo.setFactory(
         bsl::allocate_shared<TestAuthenticatorPluginFactory>(allocator));
     testPluginInfo.setDescription("Test Authenticator");
+
+    // BasicCredentialProvider
+    mqbplug::PluginInfo& credProviderInfo = d_plugins.emplace_back(
+        mqbplug::PluginType::e_CREDENTIAL_PROVIDER,
+        mqbauthn::BasicCredentialProvider::k_NAME);
+    credProviderInfo.setFactory(
+        bsl::allocate_shared<BasicCredentialProviderPluginFactory>(allocator));
+    credProviderInfo.setDescription(
+        "Built-in Basic Username/Password Credential Provider");
 }
 
 PluginLibrary::~PluginLibrary()

--- a/src/groups/mqb/mqbauthn/package/mqbauthn.mem
+++ b/src/groups/mqb/mqbauthn/package/mqbauthn.mem
@@ -2,5 +2,6 @@
 mqbauthn_anonauthenticator
 mqbauthn_authenticationcontroller
 mqbauthn_basicauthenticator
+mqbauthn_basiccredentialprovider
 mqbauthn_pluginlibrary
 mqbauthn_testauthenticator

--- a/src/groups/mqb/mqbplug/mqbplug_credentialprovider.h
+++ b/src/groups/mqb/mqbplug/mqbplug_credentialprovider.h
@@ -60,7 +60,7 @@ class CredentialProvider {
     /// stream).  The broker invokes this function each time it needs
     /// credentials for an outbound connection or reauthentication.
     typedef bsl::function<bsl::optional<AuthnCredential>(bsl::ostream& error)>
-        CredentialFunc;
+        CredentialCb;
 
     // CREATORS
 
@@ -74,7 +74,7 @@ class CredentialProvider {
     /// stored and invoked for each outbound connection and
     /// reauthentication.  The behavior is undefined unless `start()` has
     /// been called successfully.
-    virtual CredentialFunc load() = 0;
+    virtual CredentialCb load() = 0;
 
     /// Start the CredentialProvider and return 0 on success, or return
     /// a non-zero value and populate the specified `errorDescription` with

--- a/src/groups/mqb/mqbplug/mqbplug_pluginmanager.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_pluginmanager.cpp
@@ -422,9 +422,8 @@ void PluginManager::stop()
     d_pluginHandles.clear();
 }
 
-void PluginManager::get(
-    mqbplug::PluginType::Enum                    type,
-    bsl::unordered_set<mqbplug::PluginFactory*>* result) const
+void PluginManager::get(bsl::unordered_set<mqbplug::PluginFactory*>* result,
+                        mqbplug::PluginType::Enum type) const
 {
     bsl::multimap<PluginType::Enum, const PluginInfo*>::const_iterator it =
         d_enabledPlugins.cbegin();

--- a/src/groups/mqb/mqbplug/mqbplug_pluginmanager.h
+++ b/src/groups/mqb/mqbplug/mqbplug_pluginmanager.h
@@ -151,8 +151,9 @@ class PluginManager BSLS_CPP11_FINAL {
     void stop();
 
     // ACCESSORS
-    void get(PluginType::Enum                    type,
-             bsl::unordered_set<PluginFactory*>* result) const;
+
+    void get(bsl::unordered_set<PluginFactory*>* result,
+             PluginType::Enum                    type) const;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -788,8 +788,8 @@ int StatController::start(bsl::ostream& errorDescription)
     // Initialize StatConsumers from plugins.
     {
         PluginFactories pluginFactories(d_allocator_p);
-        d_pluginManager_p->get(mqbplug::PluginType::e_STATS_CONSUMER,
-                               &pluginFactories);
+        d_pluginManager_p->get(&pluginFactories,
+                               mqbplug::PluginType::e_STATS_CONSUMER);
 
         PluginFactories::const_iterator factoryIt = pluginFactories.cbegin();
         for (; factoryIt != pluginFactories.cend(); ++factoryIt) {


### PR DESCRIPTION
This PR contains the first subset of changes in https://github.com/bloomberg/blazingmq/pull/1428 for easier reviewing.

- Move credential provider management into the `AuthenticationController`, which already handles authenticator plugin factory logic.
- Add `BasicCredentialProvider`, corresponding to `BasicAuthenticator`, and register as a built-in credential provider.
