### PR TITLE
Fix: Do not append empty message property

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.cpp
@@ -104,16 +104,20 @@ class PropertyValueStreamOutVisitor {
 
     void operator()(const bsl::string_view& value)
     {
-        bdlbb::BlobUtil::append(d_blob_p,
-                                value.data(),
-                                static_cast<int>(value.length()));
+        if (!value.empty()) {
+            bdlbb::BlobUtil::append(d_blob_p,
+                                    value.data(),
+                                    static_cast<int>(value.length()));
+        }
     }
 
     void operator()(const bsl::vector<char>& value)
     {
-        bdlbb::BlobUtil::append(d_blob_p,
-                                value.data(),
-                                static_cast<int>(value.size()));
+        if (!value.empty()) {
+            bdlbb::BlobUtil::append(d_blob_p,
+                                    value.data(),
+                                    static_cast<int>(value.size()));
+        }
     }
 };
 
@@ -315,6 +319,10 @@ bool MessageProperties::streamInPropertyValue(const Property& p) const
     }
 
     case bmqt::PropertyType::e_STRING: {
+        if (p.d_length == 0) {
+            p.d_value = bsl::string("", d_allocator_p);
+            break;  // BREAK
+        }
         // Try to avoid copying the string.  'd_blop' already keeps a copy.
         bmqu::BlobPosition end;
         const int          ret =
@@ -344,10 +352,12 @@ bool MessageProperties::streamInPropertyValue(const Property& p) const
     }
     case bmqt::PropertyType::e_BINARY: {
         bsl::vector<char> value(p.d_length, d_allocator_p);
-        rc = bmqu::BlobUtil::readNBytes(&value[0],
-                                        *d_blob_p,
-                                        position,
-                                        p.d_length);
+        if (p.d_length > 0) {
+            rc = bmqu::BlobUtil::readNBytes(&value[0],
+                                            *d_blob_p,
+                                            position,
+                                            p.d_length);
+        }
 
         p.d_value = value;
         break;

--- a/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageproperties.t.cpp
@@ -1305,6 +1305,56 @@ static void test11_binaryPropertyRvalueTest()
     BMQTST_ASSERT_EQ('z', out2[0]);
 }
 
+static void test12_emptyPropertyValueStreamOutTest()
+// ------------------------------------------------------------------------
+// EMPTY PROPERTY VALUE STREAM OUT TEST
+//
+// Concerns:
+//   'streamOut' should handle properties with empty string and binary
+//   values without asserting or corrupting the wire format.
+//
+// Plan:
+//   1. Set a string property with an empty value.
+//   2. Set a binary property with an empty value.
+//   3. Call 'streamOut' and verify it does not assert.
+//   4. Round-trip via 'streamIn' and verify the properties are preserved.
+//
+// Testing:
+//   const bdlbb::Blob& streamOut(BlobBufferFactory*, const MPI&) const;
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("EMPTY PROPERTY VALUE STREAM OUT TEST");
+
+    bdlbb::PooledBlobBufferFactory bufferFactory(
+        128,
+        bmqtst::TestHelperUtil::allocator());
+    bmqp::MessageProperties     p(bmqtst::TestHelperUtil::allocator());
+    bmqp::MessagePropertiesInfo logic =
+        bmqp::MessagePropertiesInfo::makeNoSchema();
+
+    // Set an empty string property.
+    BMQTST_ASSERT_EQ(0, p.setPropertyAsString("emptyStr", ""));
+
+    // Set an empty binary property.
+    bsl::vector<char> emptyBin(bmqtst::TestHelperUtil::allocator());
+    BMQTST_ASSERT_EQ(0, p.setPropertyAsBinary("emptyBin", emptyBin));
+
+    BMQTST_ASSERT_EQ(2, p.numProperties());
+
+    // streamOut should not assert.
+    const bdlbb::Blob& wireRep = p.streamOut(&bufferFactory, logic);
+    BMQTST_ASSERT_GT(wireRep.length(), 0);
+
+    // Round-trip: streamIn to a new instance.
+    bmqp::MessageProperties p2(bmqtst::TestHelperUtil::allocator());
+    BMQTST_ASSERT_EQ(0, p2.streamIn(wireRep, logic.isExtended()));
+
+    BMQTST_ASSERT_EQ(2, p2.numProperties());
+    BMQTST_ASSERT_EQ(p2.getPropertyAsString("emptyStr"),
+                     bsl::string("", bmqtst::TestHelperUtil::allocator()));
+    BMQTST_ASSERT_EQ(p2.getPropertyAsBinary("emptyBin"), emptyBin);
+}
+
 #ifdef BMQTST_BENCHMARK_ENABLED
 
 struct MessagePropertiesBenchmark_getPropertyRef {
@@ -1482,6 +1532,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 12: test12_emptyPropertyValueStreamOutTest(); break;
     case 11: test11_binaryPropertyRvalueTest(); break;
     case 10: test10_empty(); break;
     case 9: test9_copyAssignTest(); break;


### PR DESCRIPTION
This appears to be a pre-existing bug that was copied from binary message properties to string message properties.  It is within contract to construct a message with both empty binary message property values and empty string message value (in fact, our Python SDK tests these cases).  Internally when streaming out a message property, we call `BlobUtil::append`.  In the case of `bsl::string`s, the empty string is really a buffer containing the NUL byte, so `str.data()` is a pointer to the NUL byte, and has well-defined behavior, even though the `append` never appends that NUL byte.  For an empty `bsl::vector<char>`, though, `vec.data()` is immediate undefined behavior. When compiled with safe asserts on, as we have recently started doing, this results in a crash.

To make matters worse, the recent change to allow `bsl::string_view` message properties now means we can get this same issue with strings, because a `bsl::string_view` need not point to a NUL-terminated string; it is always illegal to call `data` on an empty `string_view` for the same reason as above.

The same issue in principle applies when streaming an empty message property in, both for binary message properties and now string message properties.  If we stream in an empty binary message property, we construct a vector of length `0` and then dereference it to pass it to `readNBytes`, resulting in undefined behavior (and with safe asserts, a broker crash).

And now, if we stream in an empty string message property, a similar issue can surface now where we attempt to read out past the end of the message property blob buffer.

This patch fixes all four cases: the wire protocol allows length zero message property values (which were already in contract and tested my the Python SDK), but on each end, we only construct in memory representations without invoking undefined behavior.  Additionally, this patch adds a minimal test that only passes when all four of the above changes have been made, showing that each really is necessary.