### PR TITLE
UT[mqbnet_multirequestmanager.t.cpp]: fix channel use-after-free

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -279,6 +279,7 @@ TestContext::~TestContext()
                              &called,
                              bdlf::PlaceHolders::_1));
     cancelRequests();
+    d_cluster_mp->netCluster().closeChannels();
     d_cluster_mp->_scheduler().stop();
 }
 


### PR DESCRIPTION
Call `closeChannels` on UT shutdown.
