### PR TITLE
Refactor[mqbstat]: extract file logging from `mqbstat::TablePrinter`

### DIFF
--- a/src/groups/mqb/mqbstat/doc/mqbstat.txt
+++ b/src/groups/mqb/mqbstat/doc/mqbstat.txt
@@ -9,12 +9,13 @@
 
 /Hierarchical Synopsis
 /---------------------
- The 'mqbstat' package currently has 10 components having 3 levels of physical
+ The 'mqbstat' package currently has 11 components having 3 levels of physical
  dependency.  The list below shows the hierarchical ordering of the components.
 ..
   3. mqbstat_statcontroller
 
   2. mqbstat_jsonprinter
+     mqbstat_statsfilelogger
      mqbstat_tableprinter
      mqbstat_statmonitorsnapshotrecorder
 
@@ -55,6 +56,9 @@
 :
 : 'mqbstat_statmonitorsnapshotrecorder'
 :       Provide a mechanism to record snapshot of time, cpu, and ctx switch.
+:
+: 'mqbstat_statsfilelogger'
+:       Provide a mechanism to log statistics to a file.
 :
 : 'mqbstat_tableprinter'
 :       Provide a mechanism to print statistics to streams.

--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
@@ -32,6 +32,8 @@
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 
 namespace BloombergLP {
 
@@ -57,6 +59,9 @@ class JsonPrinter {
     JsonPrinter& operator=(const JsonPrinter& other) BSLS_CPP11_DELETED;
 
   public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(JsonPrinter, bslma::UsesBslmaAllocator)
+
     // PUBLIC TYPES
     typedef bsl::unordered_map<bsl::string, bmqst::StatContext*>
         StatContextsMap;

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -93,6 +93,57 @@ void optionalSemaphorePost(bslmt::Semaphore* semaphore)
 
 }  // close unnamed namespace
 
+// -------------------------------------
+// class StatController::SnapshotTracker
+// -------------------------------------
+
+StatController::SnapshotTracker::SnapshotTracker()
+: d_actionInterval(0)
+, d_actionCounter(0)
+, d_statId(0)
+{
+    // NOTHING
+}
+
+void StatController::SnapshotTracker::initialize(int printInterval,
+                                                 int snapshotInterval)
+{
+    if (snapshotInterval > 0 && printInterval > 0) {
+        d_actionInterval = printInterval / snapshotInterval;
+        d_actionCounter  = d_actionInterval;
+    }
+}
+
+void StatController::SnapshotTracker::onSnapshot()
+{
+    if (!isEnabled() || --d_actionCounter != 0) {
+        return;  // RETURN
+    }
+
+    d_actionCounter = d_actionInterval;
+    d_statId += 1;
+}
+
+bool StatController::SnapshotTracker::willPrintOnNextSnapshot() const
+{
+    return d_actionCounter == 1;
+}
+
+bool StatController::SnapshotTracker::isEnabled() const
+{
+    return d_actionInterval > 0;
+}
+
+int StatController::SnapshotTracker::statId() const
+{
+    return d_statId;
+}
+
+int StatController::SnapshotTracker::actionInterval() const
+{
+    return d_actionInterval;
+}
+
 // ------------------------
 // class StatContextDetails
 // ------------------------
@@ -130,11 +181,8 @@ void StatController::initializeStats()
 {
     // NOTE: For now, use only one level and with the snapshot interval (10s).
     //       Later, we may need to snapshot every seconds, or keep 5 minutes
-    //       stats with multiple levels..
-    const mqbcfg::AppConfig& brkrCfg = mqbcfg::BrokerConfig::get();
-    int historySize = brkrCfg.stats().printer().printInterval() /
-                          brkrCfg.stats().snapshotInterval() +
-                      1;
+    //       stats with multiple levels.
+    const int historySize = d_snapshotTracker.actionInterval() + 1;
 
     // ----------
     // Allocators
@@ -148,8 +196,8 @@ void StatController::initializeStats()
                                              d_allocator_p),
                                true)));
         d_allocatorsStatContext_p->snapshot();
-        // Call snaphost to create the 'subContext', so that the
-        // 'mqbstat::TablePrinter::start' can access it.
+        // Call snapshot to create the 'subContext', so that the
+        // 'mqbstat::TablePrinter' can access it.
     }
 
     // --------
@@ -561,14 +609,12 @@ bool StatController::snapshot()
     // through snapshot
     d_systemStatMonitor_mp->snapshot();
 
-    // TablePrinter needs to be notified of every snapshot, but has an internal
-    // action counter to know when it's time to print.  Allocator stat context
-    // only has a history size of 2, so we need to snapshot only once, just
-    // before printing.
+    // Allocator stat context only has a history size of 2, so we need to
+    // snapshot only once, just before printing.
     // TODO: adopt this code for `mqbstat::JsonPrinter` when we report
     //       allocator stats in json
-    const bool willPrint = d_tablePrinter_mp->nextSnapshotWillPrint();
-    if (d_allocatorsStatContext_p && willPrint) {
+    if (d_allocatorsStatContext_p &&
+        d_snapshotTracker.willPrintOnNextSnapshot()) {
         d_allocatorsStatContext_p->snapshot();
     }
 
@@ -595,17 +641,21 @@ void StatController::snapshotAndNotify()
         }
     }
 
-    const bool willPrint = d_tablePrinter_mp->nextSnapshotWillPrint();
-    d_tablePrinter_mp->onSnapshot();
+    const bool willPrint = d_snapshotTracker.willPrintOnNextSnapshot();
+    d_snapshotTracker.onSnapshot();
 
-    // Finally, perform cleanup of expired stat contexts if we have printed
-    // them.
-    // TBD: Currently the code relies on the fact that 'tablePrinter' is the
-    // one
-    //      with the largest 'actionInterval', but normally cleanup should be
-    //      done after the less frequent consumer has performed its action.
-    if (!d_tablePrinter_mp->isEnabled() || willPrint) {
-        // Cleanup deleted subcontexts now that we printed them, or don't care
+    if (willPrint && d_statsFileLogger_mp) {
+        d_statsFileLogger_mp->logStats(
+            d_snapshotTracker.statId(),
+            bdlf::BindUtil::bind(&TablePrinter::printStats,
+                                 d_tablePrinter_mp.get(),
+                                 bdlf::PlaceHolders::_1));
+    }
+
+    // Cleanup is required if either:
+    // - We don't log stats (so we don't have an explicit trigger for cleanup)
+    // - We've just logged stats on this snapshot
+    if (!d_snapshotTracker.isEnabled() || willPrint) {
         for (StatContextDetailsMap::iterator mit = d_statContextsMap.begin();
              mit != d_statContextsMap.end();
              ++mit) {
@@ -685,7 +735,9 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
 , d_pluginManager_p(pluginManager)
 , d_bufferFactory_p(bufferFactory)
 , d_commandProcessorFn(bsl::allocator_arg, allocator, commandProcessor)
+, d_snapshotTracker()
 , d_tablePrinter_mp(0)
+, d_statsFileLogger_mp(0)
 , d_jsonPrinter_mp(0)
 , d_statConsumers(allocator)
 , d_statConsumerMaxPublishInterval(0)
@@ -727,10 +779,10 @@ int StatController::start(bsl::ostream& errorDescription)
                                       k_MAX_SNAPSHOTS_PER_INTERVAL);
 
     // Start the scheduler
-    d_scheduler_mp.load(new (*d_allocator_p) bdlmt::TimerEventScheduler(
-                            bsls::SystemClockType::e_MONOTONIC,
-                            d_allocator_p),
-                        d_allocator_p);
+    d_scheduler_mp =
+        bslma::ManagedPtrUtil::allocateManaged<bdlmt::TimerEventScheduler>(
+            d_allocator_p,
+            bsls::SystemClockType::e_MONOTONIC);
     rc = d_scheduler_mp->start();
     if (rc != 0) {
         errorDescription << "Failed to start StatController "
@@ -752,9 +804,10 @@ int StatController::start(bsl::ostream& errorDescription)
     for (; consumerIt != brkrCfg.stats().plugins().end(); ++consumerIt) {
         maxInterval = bsl::max(maxInterval, consumerIt->publishInterval());
     }
-    d_systemStatMonitor_mp.load(
-        new (*d_allocator_p) mqbstat::StatMonitor(maxInterval, d_allocator_p),
-        d_allocator_p);
+    d_systemStatMonitor_mp =
+        bslma::ManagedPtrUtil::allocateManaged<mqbstat::StatMonitor>(
+            d_allocator_p,
+            maxInterval);
 
     // Failing to start some subsystems of StatController should not result in
     // a broker shutdown, but rather be intercepted here and printed as an
@@ -770,6 +823,9 @@ int StatController::start(bsl::ostream& errorDescription)
         rc = 0;
         errorStream.reset();
     }
+
+    d_snapshotTracker.initialize(brkrCfg.stats().printer().printInterval(),
+                                 brkrCfg.stats().snapshotInterval());
 
     // We now need to initialize our stats *AFTER* the system stat monitor has
     // been created to ensure that we have a valid stat contexts in our map.
@@ -845,30 +901,26 @@ int StatController::start(bsl::ostream& errorDescription)
         }
     }
 
-    // Start the table printer
-    d_tablePrinter_mp.load(new (*d_allocator_p)
-                               TablePrinter(brkrCfg.stats(),
-                                            d_eventScheduler_p,
-                                            ctxPtrMap,
-                                            d_allocator_p),
-                           d_allocator_p);
+    // Create the table printer
+    d_tablePrinter_mp = bslma::ManagedPtrUtil::allocateManaged<TablePrinter>(
+        d_allocator_p,
+        ctxPtrMap,
+        d_snapshotTracker.actionInterval() + 1);
 
-    // Give the table printer a map of statContext ptrs for its printing.  It
-    // has been done this way to break the cyclic dependency of ctxPtrMap,
-    // initializeStats() and creation of d_tablePrinter.
-    rc = d_tablePrinter_mp->start(errorStream);
-    if (rc != 0) {
-        BMQTSK_ALARMLOG_ALARM("#STATS")
-            << "Failed to start TablePrinter [rc: " << rc << ", error: '"
-            << errorStream.str() << "']" << BMQTSK_ALARMLOG_END;
-        rc = 0;
-        errorStream.reset();
+    // Start the stats file logger
+    if (d_snapshotTracker.isEnabled()) {
+        d_statsFileLogger_mp =
+            bslma::ManagedPtrUtil::allocateManaged<StatsFileLogger>(
+                d_allocator_p,
+                d_eventScheduler_p);
+
+        d_statsFileLogger_mp->start();
     }
 
     // Create the json printer
-    d_jsonPrinter_mp.load(new (*d_allocator_p)
-                              JsonPrinter(ctxPtrMap, d_allocator_p),
-                          d_allocator_p);
+    d_jsonPrinter_mp = bslma::ManagedPtrUtil::allocateManaged<JsonPrinter>(
+        d_allocator_p,
+        ctxPtrMap);
 
     // Max value for the stat publish interval must be the minimum history size
     // of all stat contexts.
@@ -912,13 +964,24 @@ void StatController::stop()
         STOP_OBJ((*it), it->name());
     }
 
-    STOP_OBJ(d_tablePrinter_mp, "TablePrinter");
+    if (d_snapshotTracker.statId() > 0 && d_statsFileLogger_mp) {
+        // Stats were logged with `statId()` id from scheduler already.
+        // For shutdown, use the next id: `statId() + 1`.
+        d_statsFileLogger_mp->logStats(
+            d_snapshotTracker.statId() + 1,
+            bdlf::BindUtil::bind(&TablePrinter::printStats,
+                                 d_tablePrinter_mp.get(),
+                                 bdlf::PlaceHolders::_1));
+    }
+
+    STOP_OBJ(d_statsFileLogger_mp, "StatsFileLogger");
     STOP_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");
 
     // Destroy everything!!
     for (it = d_statConsumers.begin(); it != d_statConsumers.end(); ++it) {
         DESTROY_OBJ((*it), it->name());
     }
+    DESTROY_OBJ(d_statsFileLogger_mp, "StatsFileLogger");
     DESTROY_OBJ(d_tablePrinter_mp, "TablePrinter");
     DESTROY_OBJ(d_jsonPrinter_mp, "JsonPrinter");
     DESTROY_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -30,6 +30,7 @@
 #include <mqbcmd_messages.h>
 #include <mqbstat_jsonprinter.h>
 #include <mqbstat_statmonitor.h>
+#include <mqbstat_statsfilelogger.h>
 #include <mqbstat_tableprinter.h>
 
 #include <bmqma_countingallocatorstore.h>
@@ -71,9 +72,6 @@ class StatResult;
 }
 namespace mqbplug {
 class PluginManager;
-}
-namespace mqbplug {
-class StatPublisher;
 }
 namespace mqbplug {
 class StatConsumer;
@@ -127,9 +125,34 @@ class StatController {
     typedef bsl::shared_ptr<bmqst::StatContext>           StatContextSp;
     typedef bslma::ManagedPtr<mqbstat::StatMonitor>       SystemStatMonitorMp;
     typedef bslma::ManagedPtr<TablePrinter>               TablePrinterMp;
+    typedef bslma::ManagedPtr<StatsFileLogger>            StatsFileLoggerMp;
     typedef bslma::ManagedPtr<JsonPrinter>                JsonPrinterMp;
-    typedef bslma::ManagedPtr<mqbplug::StatPublisher>     StatPublisherMp;
     typedef bslma::ManagedPtr<mqbplug::StatConsumer>      StatConsumerMp;
+
+    /// Tracks snapshot IDs and the action counter that determines when
+    /// periodic stats output should be produced.
+    class SnapshotTracker {
+        // DATA
+        int d_actionInterval;
+
+        int d_actionCounter;
+        int d_statId;
+
+      public:
+        // CREATORS
+        SnapshotTracker();
+
+        // MANIPULATORS
+        void initialize(int printInterval, int snapshotInterval);
+        void onSnapshot();
+
+        // ACCESSORS
+        bool isEnabled() const;
+        int  actionInterval() const;
+
+        bool willPrintOnNextSnapshot() const;
+        int  statId() const;
+    };
 
     /// Struct containing a statcontext and bool specifying if the
     /// statcontext is managed.
@@ -204,8 +227,14 @@ class StatController {
     /// from a command processor plugin.
     CommandProcessorFn d_commandProcessorFn;
 
-    /// Console and log file stats printer
+    /// Tracks snapshot IDs and print interval countdown.
+    SnapshotTracker d_snapshotTracker;
+
+    /// Stats formatter for console and admin commands
     TablePrinterMp d_tablePrinter_mp;
+
+    /// File logger for periodic stats output
+    StatsFileLoggerMp d_statsFileLogger_mp;
 
     /// JsonPrinter used for admin commands processing
     JsonPrinterMp d_jsonPrinter_mp;

--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbstat_statsfilelogger.h>
+
+#include <mqbscm_version.h>
+// MQB
+#include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
+
+// BDE
+#include <ball_context.h>
+#include <ball_log.h>
+#include <ball_logfilecleanerutil.h>
+#include <ball_recordattributes.h>
+#include <ball_recordstringformatter.h>
+#include <ball_transmission.h>
+#include <bdls_processutil.h>
+#include <bdlt_datetime.h>
+#include <bdlt_epochutil.h>
+#include <bsl_ctime.h>
+#include <bsl_ostream.h>
+#include <bslma_allocator.h>
+#include <bslmt_threadutil.h>
+#include <bsls_assert.h>
+#include <bsls_timeinterval.h>
+
+namespace BloombergLP {
+namespace mqbstat {
+
+namespace {
+
+const char k_LOG_CATEGORY[] = "MQBSTAT.STATSFILELOGGER";
+
+}  // close unnamed namespace
+
+// --------------------
+// class StatsFileLogger
+// --------------------
+
+StatsFileLogger::StatsFileLogger(bdlmt::EventScheduler* eventScheduler,
+                                 bslma::Allocator*      allocator)
+: d_statsLogFile(allocator)
+, d_statLogCleaner(eventScheduler, allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(eventScheduler);
+    BSLS_ASSERT_SAFE(eventScheduler->clockType() ==
+                     bsls::SystemClockType::e_MONOTONIC);
+}
+
+void StatsFileLogger::start()
+{
+    const mqbcfg::StatsPrinterConfig& printer =
+        mqbcfg::BrokerConfig::get().stats().printer();
+
+    // Configure the stats dump log file
+    d_statsLogFile.enableFileLogging(printer.file().c_str());
+    d_statsLogFile.rotateOnSize(printer.rotateBytes() / 1024);
+    d_statsLogFile.rotateOnTimeInterval(
+        bdlt::DatetimeInterval(printer.rotateDays()));
+    d_statsLogFile.setLogFileFunctor(ball::RecordStringFormatter("%m\n"));
+
+    // LogCleanup
+    if (printer.maxAgeDays() <= 0 || printer.file().empty()) {
+        BALL_LOG_INFO << "StatLogCleaning is *disabled* "
+                      << "[reason: either 'maxAgeDays' is set to 0 in config "
+                      << "or file pattern is empty]";
+        return;  // RETURN
+    }
+
+    bsl::string filePattern;
+    ball::LogFileCleanerUtil::logPatternToFilePattern(&filePattern,
+                                                      printer.file());
+    bsls::TimeInterval maxAge(0, 0);
+    maxAge.addDays(printer.maxAgeDays());
+
+    int rc = d_statLogCleaner.start(filePattern, maxAge);
+    if (rc != 0) {
+        BALL_LOG_ERROR << "#STATLOG_CLEANING "
+                       << "Failed to start log cleaning of '" << filePattern
+                       << "' [rc: " << rc << "]";
+    }
+}
+
+void StatsFileLogger::stop()
+{
+    d_statLogCleaner.stop();
+}
+
+void StatsFileLogger::logStats(int statId, const PrinterCb& printerCb)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(printerCb);
+
+    ball::Record            record;
+    ball::RecordAttributes& attributes = record.fixedFields();
+    bdlt::Datetime          now;
+    bdlt::EpochUtil::convertFromTimeT(&now, time(0));
+    attributes.setTimestamp(now);
+    attributes.setProcessID(bdls::ProcessUtil::getProcessId());
+    attributes.setThreadID(bslmt::ThreadUtil::selfIdAsUint64());
+    attributes.setFileName(__FILE__);
+    attributes.setLineNumber(__LINE__);
+    attributes.setCategory(k_LOG_CATEGORY);
+    attributes.setSeverity(ball::Severity::e_INFO);
+
+    attributes.clearMessage();
+    bsl::ostream os(&attributes.messageStreamBuf());
+    os << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n"
+       << "Stats id: " << statId << " @ " << now << "\n"
+       << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n";
+
+    printerCb(os);
+
+    d_statsLogFile.publish(
+        record,
+        ball::Context(ball::Transmission::e_MANUAL_PUBLISH, 0, 1));
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
@@ -1,0 +1,98 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBSTAT_STATSFILELOGGER
+#define INCLUDED_MQBSTAT_STATSFILELOGGER
+
+//@PURPOSE: Provide a mechanism to log statistics to a file.
+//
+//@CLASSES:
+//  mqbstat::StatsFileLogger: statistics file logger
+//
+//@DESCRIPTION: 'mqbstat::StatsFileLogger' handles writing formatted statistics
+// to a log file with support for file rotation and cleanup of old logs.
+
+// MQB
+#include <bmqtsk_logcleaner.h>
+
+// BDE
+#include <ball_fileobserver2.h>
+#include <ball_log.h>
+#include <bdlmt_eventscheduler.h>
+#include <bsl_functional.h>
+#include <bsl_ostream.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+
+namespace mqbstat {
+
+// ====================
+// class StatsFileLogger
+// ====================
+
+class StatsFileLogger {
+  public:
+    // PUBLIC TYPES
+    typedef bsl::function<void(bsl::ostream&)> PrinterCb;
+
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBSTAT.STATSFILELOGGER");
+
+    // DATA
+
+    /// FileObserver for the stats log dump.
+    ball::FileObserver2 d_statsLogFile;
+
+    /// Mechanism to clean up old stat logs.
+    bmqtsk::LogCleaner d_statLogCleaner;
+
+    // NOT IMPLEMENTED
+    StatsFileLogger(const StatsFileLogger& other) BSLS_KEYWORD_DELETED;
+    StatsFileLogger&
+    operator=(const StatsFileLogger& other) BSLS_KEYWORD_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(StatsFileLogger, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a new `StatsFileLogger` object, using the specified
+    /// `eventScheduler` and the specified `allocator` for memory allocation.
+    explicit StatsFileLogger(bdlmt::EventScheduler* eventScheduler,
+                             bslma::Allocator*      allocator);
+
+    // MANIPULATORS
+
+    /// Start the StatsFileLogger.
+    void start();
+
+    /// Stop the logger.
+    void stop();
+
+    /// Dump the stats to the stat log file with the specified `statId`,
+    /// using the specified `printerCb` to format the output.
+    void logStats(int statId, const PrinterCb& printerCb);
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
@@ -26,21 +26,9 @@
 #include <bmqu_printutil.h>
 
 // BDE
-#include <ball_context.h>
-#include <ball_log.h>
-#include <ball_logfilecleanerutil.h>
-#include <ball_recordattributes.h>
-#include <ball_recordstringformatter.h>
-#include <ball_transmission.h>
-#include <bdls_processutil.h>
-#include <bdlt_datetime.h>
-#include <bdlt_epochutil.h>
-#include <bsl_ctime.h>
 #include <bsl_utility.h>
 #include <bslma_allocator.h>
-#include <bslmt_threadutil.h>
 #include <bsls_assert.h>
-#include <bsls_timeinterval.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
 
@@ -48,8 +36,6 @@ namespace BloombergLP {
 namespace mqbstat {
 
 namespace {
-
-const char k_LOG_CATEGORY[] = "MQBSTAT.TABLEPRINTER";
 
 // Subcontext names
 const char k_SUBCONTEXT_ALLOCATORS[] = "allocators";
@@ -60,11 +46,10 @@ const char k_SUBCONTEXT_ALLOCATORS[] = "allocators";
 // class TablePrinter
 // ------------------
 
-void TablePrinter::initializeTablesAndTips()
+void TablePrinter::initializeTablesAndTips(int historySize)
 {
-    const int historySize = d_config.printer().printInterval() /
-                                d_config.snapshotInterval() +
-                            1;
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(historySize > 0);
 
     ContextsMap::iterator it = d_contexts.find("allocators");
     if (it != d_contexts.end()) {
@@ -107,22 +92,12 @@ void TablePrinter::initializeTablesAndTips()
         end);
 }
 
-TablePrinter::TablePrinter(const mqbcfg::StatsConfig& config,
-                           bdlmt::EventScheduler*     eventScheduler,
-                           const StatContextsMap&     statContextsMap,
-                           bslma::Allocator*          allocator)
-: d_config(config)
-, d_statsLogFile(allocator)
-, d_lastStatId(0)
-, d_actionCounter(0)
-, d_lastAllocatorSnapshot(0)
+TablePrinter::TablePrinter(const StatContextsMap& statContextsMap,
+                           int                    historySize,
+                           bslma::Allocator*      allocator)
+: d_lastAllocatorSnapshot(0)
 , d_contexts(allocator)
-, d_statLogCleaner(eventScheduler, allocator)
 {
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(eventScheduler->clockType() ==
-                     bsls::SystemClockType::e_MONOTONIC);
-
     // Insert all the required Contexts
     for (StatContextsMap::const_iterator it = statContextsMap.begin();
          it != statContextsMap.end();
@@ -133,82 +108,15 @@ TablePrinter::TablePrinter(const mqbcfg::StatsConfig& config,
         ContextsMap::iterator cit =
             d_contexts.insert(bsl::make_pair(it->first, contextSp)).first;
         cit->second->d_statContext_p = it->second;
-        // Table and Tip are left default constructed, and will be set
-        // during 'start'.
-    }
-}
-
-int TablePrinter::start(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription)
-{
-    // Setup the print of stats if configured for it
-    if (!isEnabled()) {
-        return 0;  // RETURN
     }
 
-    d_actionCounter = d_config.printer().printInterval() /
-                      d_config.snapshotInterval();
-
-    // Initialize table and tips
-    initializeTablesAndTips();
-
-    // Configure the stats dump log file
-    d_statsLogFile.enableFileLogging(d_config.printer().file().c_str());
-    d_statsLogFile.rotateOnSize(d_config.printer().rotateBytes() / 1024);
-    d_statsLogFile.rotateOnTimeInterval(
-        bdlt::DatetimeInterval(d_config.printer().rotateDays()));
-    d_statsLogFile.setLogFileFunctor(ball::RecordStringFormatter("%m\n"));
-    // Record's time is printed not through the record, but part of the
-    // 'id banner' (see 'onSnapshot').
-
-    // LogCleanup
-    if (d_config.printer().maxAgeDays() <= 0 ||
-        d_config.printer().file().empty()) {
-        BALL_LOG_INFO << "StatLogCleaning is *disabled* "
-                      << "[reason: either 'maxAgeDays' is set to 0 in config "
-                      << "or file pattern is empty]";
-        return 0;  // RETURN
+    if (historySize > 0) {
+        initializeTablesAndTips(historySize);
     }
-
-    bsl::string filePattern;
-    ball::LogFileCleanerUtil::logPatternToFilePattern(
-        &filePattern,
-        d_config.printer().file());
-    bsls::TimeInterval maxAge(0, 0);
-    maxAge.addDays(d_config.printer().maxAgeDays());
-
-    int rc = d_statLogCleaner.start(filePattern, maxAge);
-    if (rc != 0) {
-        BALL_LOG_ERROR << "#STATLOG_CLEANING "
-                       << "Failed to start log cleaning of '" << filePattern
-                       << "' [rc: " << rc << "]";
-    }
-
-    return 0;
-}
-
-void TablePrinter::stop()
-{
-    // Dump the final stats (to ensure all events have been accounted for, even
-    // if they happen within less than the print interval).  Note that since
-    // the scheduler has been stopped, there is no more snapshot happening,
-    // therefore it is fine to print stats from this (arbitrary) thread.
-    if (d_lastStatId != 0) {
-        // Printing needs to access at least 'printInterval' snapshot; in case
-        // the broker starts and stops before that amount of snapshot has been
-        // taken, it is unsafe to print stats.  The above check ensures that at
-        // least one regular stat dump already happened.  This check also takes
-        // care of if the printer was disabled.
-        logStats();
-    }
-
-    // Stop the log cleaner
-    d_statLogCleaner.stop();
 }
 
 void TablePrinter::printStats(bsl::ostream& stream)
 {
-    // This must execute in the 'snapshot' thread
-
     // DOMAINQUEUES
     stream << "\n"
            << ":::::::::: :::::::::: DOMAINQUEUES >>";
@@ -242,12 +150,9 @@ void TablePrinter::printStats(bsl::ostream& stream)
            << ":::::::::: :::::::::: ALLOCATORS >>";
     ContextsMap::iterator it = d_contexts.find("allocators");
     if (it == d_contexts.end()) {
-        // When using test allocator, we don't have a stat context
         stream << " Unavailable\n";
         return;  // RETURN
     }
-    // NOTE: By contract, snapshot needs to be invoked on the statcontexts
-    //       prior to this method.
     if (d_lastAllocatorSnapshot != 0) {
         stream << " Last snapshot was "
                << bmqu::PrintUtil::prettyTimeInterval(
@@ -259,51 +164,6 @@ void TablePrinter::printStats(bsl::ostream& stream)
     context = it->second.get();
     context->d_table.records().update();
     bmqst::TableUtil::printTable(stream, context->d_tip);
-}
-
-void TablePrinter::logStats()
-{
-    ++d_lastStatId;
-
-    // Dump to statslog file
-    // Prepare the log record and associated attributes
-    ball::Record            record;
-    ball::RecordAttributes& attributes = record.fixedFields();
-    bdlt::Datetime          now;
-    bdlt::EpochUtil::convertFromTimeT(&now, time(0));
-    attributes.setTimestamp(now);
-    attributes.setProcessID(bdls::ProcessUtil::getProcessId());
-    attributes.setThreadID(bslmt::ThreadUtil::selfIdAsUint64());
-    attributes.setFileName(__FILE__);
-    attributes.setLineNumber(__LINE__);
-    attributes.setCategory(k_LOG_CATEGORY);
-    attributes.setSeverity(ball::Severity::e_INFO);
-
-    // Dump stats into bmqbrkr.stats.log
-    attributes.clearMessage();
-    bsl::ostream os(&attributes.messageStreamBuf());
-    os << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n"
-       << "Stats id: " << d_lastStatId << " @ " << now << "\n"
-       << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n";
-
-    printStats(os);
-
-    d_statsLogFile.publish(
-        record,
-        ball::Context(ball::Transmission::e_MANUAL_PUBLISH, 0, 1));
-}
-
-void TablePrinter::onSnapshot()
-{
-    // Check if we need to print the stats to log
-    if (!isEnabled() || --d_actionCounter != 0) {
-        return;  // RETURN
-    }
-
-    d_actionCounter = d_config.printer().printInterval() /
-                      d_config.snapshotInterval();
-
-    logStats();
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
@@ -21,22 +21,16 @@
 //@CLASSES:
 //  mqbstat::TablePrinter: bmqbrkr statistics printer
 //
-//@DESCRIPTION: 'mqbstat::TablePrinter' handles the printing of all the
-// statistics.  It holds the tables and table info providers which can be
-// printed.
+//@DESCRIPTION: 'mqbstat::TablePrinter' handles the formatting and printing of
+// all the statistics to a given stream.  It holds the tables and table info
+// providers which can be printed.
 
 // MQB
-#include <mqbcfg_messages.h>
-
 #include <bmqst_basictableinfoprovider.h>
 #include <bmqst_statcontext.h>
 #include <bmqst_table.h>
-#include <bmqtsk_logcleaner.h>
 
 // BDE
-#include <ball_fileobserver2.h>
-#include <ball_log.h>
-#include <bdlmt_eventscheduler.h>
 #include <bsl_memory.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -62,9 +56,6 @@ class TablePrinter {
         StatContextsMap;
 
   private:
-    // CLASS-SCOPE CATEGORY
-    BALL_LOG_SET_CLASS_CATEGORY("MQBSTAT.TABLEPRINTER");
-
     // PRIVATE TYPES
 
     /// Context including table and tip for printing and statcontext for
@@ -85,26 +76,11 @@ class TablePrinter {
 
     // DATA
 
-    /// Config to use.
-    const mqbcfg::StatsConfig& d_config;
-
-    /// FileObserver for the stats log dump.
-    ball::FileObserver2 d_statsLogFile;
-
-    /// Sequence number for stat log records.
-    int d_lastStatId;
-
-    /// Counter to know when to periodically print the stats to file.
-    int d_actionCounter;
-
     /// HiRes timer value of the last allocator snapshot.
     bsls::Types::Int64 d_lastAllocatorSnapshot;
 
     /// Contexts map
     ContextsMap d_contexts;
-
-    /// Mechanism to clean up old stat logs.
-    bmqtsk::LogCleaner d_statLogCleaner;
 
     // NOT IMPLEMENTED
     TablePrinter(const TablePrinter& other) BSLS_KEYWORD_DELETED;
@@ -113,7 +89,7 @@ class TablePrinter {
     // PRIVATE MANIPULATORS
 
     /// Initialize table and tips.
-    void initializeTablesAndTips();
+    void initializeTablesAndTips(int historySize);
 
   public:
     // TRAITS
@@ -121,63 +97,20 @@ class TablePrinter {
 
     // CREATORS
 
-    /// Create a new `TablePrinter` object, using the specified `config`,
-    /// `eventScheduler`, `statContextsMap` and the specified `allocator`
-    /// for memory allocation.
-    explicit TablePrinter(const mqbcfg::StatsConfig& config,
-                          bdlmt::EventScheduler*     eventScheduler,
-                          const StatContextsMap&     statContextsMap,
-                          bslma::Allocator*          allocator);
+    /// Create a new `TablePrinter` object, using the specified
+    /// `statContextsMap`, `historySize` and the specified `allocator` for
+    /// memory allocation.
+    explicit TablePrinter(const StatContextsMap& statContextsMap,
+                          int                    historySize,
+                          bslma::Allocator*      allocator);
 
     // MANIPULATORS
-
-    /// Start the TablePrinter.  Return 0 on success, or a non-zero return
-    /// code on error and fill in the specified `errorDescription` stream
-    /// with the description of the error.
-    int start(bsl::ostream& errorDescription);
-
-    /// Stop the printer.
-    void stop();
 
     /// Print the stats to the specified `stream`.
     ///
     /// THREAD: This method is called in the `snapshot` thread.
     void printStats(bsl::ostream& stream);
-
-    /// Dump the stats to the stat log file.
-    void logStats();
-
-    /// Print the stats to the stats log file at the appropriate time.
-    void onSnapshot();
-
-    // ACCESSORS
-
-    /// Returns true if printing is enabled, false otherwise.
-    bool isEnabled() const;
-
-    /// Returns true if the next call to `onSnapshot` will perform the
-    /// action (i.e., print).
-    bool nextSnapshotWillPrint() const;
 };
-
-// ============================================================================
-//                             INLINE DEFINITIONS
-// ============================================================================
-
-// ------------------
-// class TablePrinter
-// ------------------
-
-inline bool TablePrinter::isEnabled() const
-{
-    return (d_config.printer().printInterval() > 0 &&
-            d_config.snapshotInterval() > 0);
-}
-
-inline bool TablePrinter::nextSnapshotWillPrint() const
-{
-    return d_actionCounter == 1;
-}
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbstat/package/mqbstat.mem
+++ b/src/groups/mqb/mqbstat/package/mqbstat.mem
@@ -7,4 +7,5 @@ mqbstat_queuestats
 mqbstat_statcontroller
 mqbstat_statmonitor
 mqbstat_statmonitorsnapshotrecorder
+mqbstat_statsfilelogger
 mqbstat_tableprinter


### PR DESCRIPTION
`TablePrinter` was doing three jobs: formatting stats into tables, deciding when to print, and managing file I/O (rotation, cleanup). This change splits those responsibilities:

- `SnapshotTracker` (new private class in `StatController`) - owns the countdown logic that determines when periodic stats output should fire. Exposes `willPrintOnNextSnapshot()` so callers can prepare (e.g., snapshot allocator contexts)  before the print triggers.
- `StatsFileLogger` (new component) — owns the `ball::FileObserver2`, file rotation config, and log cleanup. Accepts a `PrinterCb` callback so it doesn't know about `TablePrinter` directly.
- `TablePrinter` (simplified) — pure formatter. Takes a stat contexts map and history size, prints to any `bsl::ostream`. No config, no file I/O, no start/stop lifecycle. 
- `StatController` — orchestrates: initializes the tracker, conditionally creates the file logger, binds `TablePrinter::printStats` as the callback passed to `logStats`. 

This is a preparation PR to extend stats logging with Json. We will be able to reuse `StatsFileLogger` and `SnapshotTracker` and avoid duplicating this logics in `JsonPrinter`.

https://github.com/bloomberg/blazingmq/pull/1180