### PR TITLE
Fix[mqbc::StorageMgr]: --d_numPartitionsRecoveredFully when out of healed

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
@@ -121,6 +121,17 @@ void PartitionFSM::processEvent(const EventWithData& event)
             break;  // BREAK
         }
         }
+
+        if (oldState == State::e_PRIMARY_HEALED ||
+            oldState == State::e_REPLICA_HEALED) {
+            BSLS_ASSERT_SAFE(d_state != State::e_PRIMARY_HEALED &&
+                             d_state != State::e_REPLICA_HEALED);
+            for (ObserversSetIter it = d_observers.begin();
+                 it != d_observers.end();
+                 ++it) {
+                (*it)->onTransitionOutOfHealed(partitionId, oldState);
+            }
+        }
     }
 }
 

--- a/src/groups/mqb/mqbc/mqbc_partitionfsmobserver.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsmobserver.cpp
@@ -52,5 +52,12 @@ void PartitionFSMObserver::onTransitionToUnknown(
     // NOTHING
 }
 
+void PartitionFSMObserver::onTransitionOutOfHealed(
+    BSLA_MAYBE_UNUSED int partitionId,
+    BSLA_MAYBE_UNUSED PartitionStateTableState::Enum oldState)
+{
+    // NOTHING
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbc/mqbc_partitionfsmobserver.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsmobserver.h
@@ -59,6 +59,10 @@ class PartitionFSMObserver {
     virtual void
     onTransitionToUnknown(int                            partitionId,
                           PartitionStateTableState::Enum oldState);
+
+    virtual void
+    onTransitionOutOfHealed(int                            partitionId,
+                            PartitionStateTableState::Enum oldState);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -329,42 +329,35 @@ void StorageManager::onPartitionRecovery(int partitionId)
         d_recoveryStartTimes[partitionId]);
     BALL_LOG_INFO << out.str();
 
-    if (++d_numPartitionsRecoveredFully ==
+    if (++d_numPartitionsRecoveredFully !=
         static_cast<int>(d_fileStores.size())) {
-        BSLMT_ONCE_DO
-        {
-            // First time healing logic
+        BSLS_ASSERT_SAFE(d_numPartitionsRecoveredFully <
+                         static_cast<int>(d_fileStores.size()));
+        return;  // RETURN
+    }
 
-            out.reset();
-            const bool success =
-                mqbs::StoragePrintUtil::printStorageRecoveryCompletion(
-                    out,
-                    d_fileStores,
-                    d_clusterData_p->identity().description());
-            BALL_LOG_INFO << out.str();
+    BSLMT_ONCE_DO
+    {
+        // First time healing logic
 
-            if (success) {
-                // All partitions have opened successfully.  Schedule a
-                // recurring event in StorageMgr, which will in turn enqueue an
-                // event in each partition's dispatcher thread for GC'ing
-                // expired messages as well as cleaning history.
+        out.reset();
+        const bool success =
+            mqbs::StoragePrintUtil::printStorageRecoveryCompletion(
+                out,
+                d_fileStores,
+                d_clusterData_p->identity().description());
+        BALL_LOG_INFO << out.str();
 
-                d_clusterData_p->scheduler().scheduleRecurringEvent(
-                    &d_gcMessagesEventHandle,
-                    bsls::TimeInterval(k_GC_MESSAGES_INTERVAL_SECONDS),
-                    bdlf::BindUtil::bind(&StorageManager::forceFlushFileStores,
-                                         this));
-
-                // Even though Cluster FSM and all Partition FSMs are now
-                // healed, we must check that all partitions have an active
-                // primary before transitioning ourself to E_AVAILABLE.
-                if (allPartitionsAvailable()) {
-                    d_recoveryStatusCb(0);
-                }
+        if (success) {
+            // Even though Cluster FSM and all Partition FSMs are now
+            // healed, we must check that all partitions have an active
+            // primary before transitioning ourself to E_AVAILABLE.
+            if (allPartitionsAvailable()) {
+                d_recoveryStatusCb(0);
             }
-            else {
-                d_recoveryStatusCb(-1);
-            }
+        }
+        else {
+            d_recoveryStatusCb(-1);
         }
     }
 }
@@ -3875,9 +3868,9 @@ void StorageManager::onTransitionOutOfHealed(
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId'
 
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
+    BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId
@@ -4050,6 +4043,14 @@ int StorageManager::start(bsl::ostream& errorDescription)
                              d_minimumRequiredDiskSpace,
                              d_clusterData_p->identity().description(),
                              d_clusterConfig.partitionConfig()));
+
+    // Schedule a periodic event which will in turn enqueue an event in each
+    // partition's dispatcher thread for GC'ing expired messages as well as
+    // cleaning history.
+    d_clusterData_p->scheduler().scheduleRecurringEvent(
+        &d_gcMessagesEventHandle,
+        bsls::TimeInterval(k_GC_MESSAGES_INTERVAL_SECONDS),
+        bdlf::BindUtil::bind(&StorageManager::forceFlushFileStores, this));
 
     d_isStarted = true;
     return rc_SUCCESS;

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -49,6 +49,7 @@
 #include <bsl_algorithm.h>
 #include <bsl_queue.h>
 #include <bsla_annotations.h>
+#include <bslmt_once.h>
 #include <bsls_performancehint.h>
 
 namespace BloombergLP {
@@ -330,37 +331,40 @@ void StorageManager::onPartitionRecovery(int partitionId)
 
     if (++d_numPartitionsRecoveredFully ==
         static_cast<int>(d_fileStores.size())) {
-        // First time healing logic
+        BSLMT_ONCE_DO
+        {
+            // First time healing logic
 
-        out.reset();
-        const bool success =
-            mqbs::StoragePrintUtil::printStorageRecoveryCompletion(
-                out,
-                d_fileStores,
-                d_clusterData_p->identity().description());
-        BALL_LOG_INFO << out.str();
+            out.reset();
+            const bool success =
+                mqbs::StoragePrintUtil::printStorageRecoveryCompletion(
+                    out,
+                    d_fileStores,
+                    d_clusterData_p->identity().description());
+            BALL_LOG_INFO << out.str();
 
-        if (success) {
-            // All partitions have opened successfully.  Schedule a recurring
-            // event in StorageMgr, which will in turn enqueue an event in each
-            // partition's dispatcher thread for GC'ing expired messages as
-            // well as cleaning history.
+            if (success) {
+                // All partitions have opened successfully.  Schedule a
+                // recurring event in StorageMgr, which will in turn enqueue an
+                // event in each partition's dispatcher thread for GC'ing
+                // expired messages as well as cleaning history.
 
-            d_clusterData_p->scheduler().scheduleRecurringEvent(
-                &d_gcMessagesEventHandle,
-                bsls::TimeInterval(k_GC_MESSAGES_INTERVAL_SECONDS),
-                bdlf::BindUtil::bind(&StorageManager::forceFlushFileStores,
-                                     this));
+                d_clusterData_p->scheduler().scheduleRecurringEvent(
+                    &d_gcMessagesEventHandle,
+                    bsls::TimeInterval(k_GC_MESSAGES_INTERVAL_SECONDS),
+                    bdlf::BindUtil::bind(&StorageManager::forceFlushFileStores,
+                                         this));
 
-            // Even though Cluster FSM and all Partition FSMs are now healed,
-            // we must check that all partitions have an active primary before
-            // transitioning ourself to E_AVAILABLE.
-            if (allPartitionsAvailable()) {
-                d_recoveryStatusCb(0);
+                // Even though Cluster FSM and all Partition FSMs are now
+                // healed, we must check that all partitions have an active
+                // primary before transitioning ourself to E_AVAILABLE.
+                if (allPartitionsAvailable()) {
+                    d_recoveryStatusCb(0);
+                }
             }
-        }
-        else {
-            d_recoveryStatusCb(-1);
+            else {
+                d_recoveryStatusCb(-1);
+            }
         }
     }
 }
@@ -3862,6 +3866,26 @@ void StorageManager::onTransitionToReplicaHealed(
                      partitionId < static_cast<int>(d_fileStores.size()));
 
     onPartitionRecovery(partitionId);
+}
+
+void StorageManager::onTransitionOutOfHealed(
+    int               partitionId,
+    BSLA_MAYBE_UNUSED PartitionStateTableState::Enum oldState)
+{
+    // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId'
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_fileStores[partitionId]->inDispatcherThread());
+    BSLS_ASSERT_SAFE(0 <= partitionId &&
+                     partitionId < static_cast<int>(d_fileStores.size()));
+
+    BALL_LOG_INFO << d_clusterData_p->identity().description()
+                  << " Partition [" << partitionId
+                  << "]: Transitioned out of healed state '" << oldState
+                  << "'.";
+
+    --d_numPartitionsRecoveredFully;
+    BSLS_ASSERT_SAFE(d_numPartitionsRecoveredFully >= 0);
 }
 
 // MANIPULATORS

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -800,6 +800,10 @@ class StorageManager BSLS_KEYWORD_FINAL
         int                                  partitionId,
         mqbc::PartitionStateTableState::Enum oldState) BSLS_KEYWORD_OVERRIDE;
 
+    void onTransitionOutOfHealed(int                            partitionId,
+                                 PartitionStateTableState::Enum oldState)
+        BSLS_KEYWORD_OVERRIDE;
+
     // MANIPULATORS
 
     /// Start this storage manager.  Return 0 on success, or a non-zero rc


### PR DESCRIPTION
## Summary
  - Fix `d_numPartitionsRecoveredFully` double-counting bug: if a partition transitions healed → unhealed → healed, the counter was incremented twice for the same partition, causing the "all partitions healed" check to either never trigger or produce incorrect results in `allPartitionsAvailable()`.
  - Add `onTransitionOutOfHealed` observer callback to `PartitionFSMObserver`, which fires when a partition leaves `PRIMARY_HEALED` or `REPLICA_HEALED`. `StorageManager` uses this to decrement the counter.
  - Guard first-time healing logic (`printStorageRecoveryCompletion`, GC event scheduling, `d_recoveryStatusCb`) with `BSLMT_ONCE_DO` to prevent re-execution if the counter re-reaches the target after a heal/unheal/re-heal cycle.
