### PR TITLE
Fix[test]: deploy_domain race with QueueCreationRecord

### DIFF
--- a/src/python/blazingmq/dev/configurator/configurator.py
+++ b/src/python/blazingmq/dev/configurator/configurator.py
@@ -358,11 +358,14 @@ class Configurator:
         ``etc/domains`` directory.
         """
 
-        site.rmdir(str("etc/domains"))
-
+        current_files = set()
         for domain in broker.domains.values():
+            filename = f"{domain.name}.json"
+            current_files.add(filename)
             self._create_json_file(
                 mqbconf.DomainVariant(definition=domain.definition),
                 site,
-                f"etc/domains/{domain.name}.json",
+                f"etc/domains/{filename}",
             )
+
+        site.remove_stale_files("etc/domains", current_files)

--- a/src/python/blazingmq/dev/configurator/localsite.py
+++ b/src/python/blazingmq/dev/configurator/localsite.py
@@ -46,6 +46,16 @@ class LocalSite(Site):
     def create_file(self, path: Union[str, Path], content: str, mode=None) -> None:
         path = self.root_dir / path
         path.parent.mkdir(0o755, exist_ok=True, parents=True)
-        with open(path, "w", encoding="ascii") as out:
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp_path, "w", encoding="ascii") as out:
             out.write(content)
-        path.chmod(mode or 0o644)
+        tmp_path.chmod(mode or 0o644)
+        tmp_path.rename(path)
+
+    def remove_stale_files(self, directory: Union[str, Path], keep: set) -> None:
+        target = self.root_dir / directory
+        if not target.is_dir():
+            return
+        for entry in target.iterdir():
+            if entry.is_file() and entry.name not in keep:
+                entry.unlink()

--- a/src/python/blazingmq/dev/configurator/site.py
+++ b/src/python/blazingmq/dev/configurator/site.py
@@ -31,3 +31,6 @@ class Site(abc.ABC):
 
     @abc.abstractmethod
     def rmdir(self, path: str) -> None: ...
+
+    @abc.abstractmethod
+    def remove_stale_files(self, directory: str, keep: set) -> None: ...


### PR DESCRIPTION
`deploy_domains` removes domain json files.  That can race with late replica receiving QueueCreationRecord and reading domain json.

The fix:  instead of removing old file create new temp file, and then rename (supposedly it is atomic)
