### PR TITLE
Fix[bmqio]: cancel inflight reconnecting on shutdown

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
@@ -489,6 +489,13 @@ void ReconnectingChannelFactory::stop()
 {
     d_validator.invalidate();
 
+    cancelAllHandles();
+
+    d_config.d_base_p->stop();
+}
+
+void ReconnectingChannelFactory::cancelAllHandles()
+{
     // Canceling a handle involves acquiring the factory's lock, so need to
     // call 'cancel' on the handles outside of the lock. This swap enables
     // doing that in a thread-safe manner.
@@ -503,13 +510,13 @@ void ReconnectingChannelFactory::stop()
          ++iter) {
         iter->second->cancel();
     }
-
-    d_config.d_base_p->stop();
 }
 
 void ReconnectingChannelFactory::disableReconnect()
 {
     d_isReconnectEnabled = false;
+
+    cancelAllHandles();
 }
 
 void ReconnectingChannelFactory::listen(Status*                      status,

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.h
@@ -292,6 +292,9 @@ class ReconnectingChannelFactory : public ChannelFactory {
     /// Remove the specified `handle` from `d_handles`.
     void removeConnectHandle(ConnectHandle* handle);
 
+    /// Cancel all handles
+    void cancelAllHandles();
+
     // FRIENDS
     friend struct ReconnectingChannelFactory_ConnectHandle;
 


### PR DESCRIPTION
[https://github.com/bloomberg/blazingmq/pull/1362](https://github.com/bloomberg/blazingmq/pull/1362) was not enough because it allows already scheduled connects.
We need to cancel them at the time of `ReconnectingChannelFactory::disableReconnect()`
