### PR TITLE
Fix[bmqeval]: guard against UB in expression evaluation

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -103,8 +103,9 @@ struct ErrorType {
         e_NAME             = -1,
         e_TYPE             = -2,
         e_BINARY           = -3,
-        e_UNDEFINED        = -4,
-        e_EVALUATION_LAST  = -4
+        e_ARITHMETIC       = -4,
+        e_UNDEFINED        = -5,
+        e_EVALUATION_LAST  = -5
     };
 
     /// Return the non-modifiable string error description corresponding to
@@ -776,6 +777,9 @@ inline const char* ErrorType::toString(ErrorType::Enum value)
     case bmqeval::ErrorType::e_BINARY: {
         return "binary properties are not supported";  // RETURN
     }
+    case bmqeval::ErrorType::e_ARITHMETIC: {
+        return "arithmetic error in expression";  // RETURN
+    }
     case bmqeval::ErrorType::e_UNDEFINED: {
         return "undefined error";  // RETURN
     }
@@ -957,6 +961,13 @@ bdld::Datum SimpleEvaluator::NumBinaryOperation<Op>::evaluate(
     }
     else {
         context.setError(ErrorType::e_TYPE);
+        return bdld::Datum::createNull();  // RETURN
+    }
+
+    if ((bsl::is_same<Op<int>, bsl::divides<int> >::value ||
+         bsl::is_same<Op<int>, bsl::modulus<int> >::value) &&
+        b == 0) {
+        context.setError(ErrorType::e_ARITHMETIC);
         return bdld::Datum::createNull();  // RETURN
     }
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -400,8 +400,6 @@ static void test3_evaluation()
     EvaluationContext    evaluationContext(&reader,
                                         bmqtst::TestHelperUtil::allocator());
 
-    const bool runtimeErrorResult = false;
-
     struct TestParameters {
         const char* expression;
         bool        expected;
@@ -514,15 +512,6 @@ static void test3_evaluation()
         {"!(b_false || b_false)", true},
         {"!(b_false || b_true)", false},
 
-        // type mismatch yields 'runtimeErrorResult' (see above)
-        {"s_foo == 42", runtimeErrorResult},
-        {"s_foo == 42 && b_false", runtimeErrorResult},
-        {"b_false || s_foo == 42", runtimeErrorResult},
-        {"!(s_foo == 42)", runtimeErrorResult},
-
-        // unknown property yields 'runtimeErrorResult' (see above)
-        {"non_existing_property", runtimeErrorResult},
-
         // arithmetic operators
         {"i_1 + 2 == 3", true},
         {"i_1 - 2 == -1", true},
@@ -598,6 +587,60 @@ static void test3_evaluation()
     }
 }
 
+static void test4_evaluationErrors()
+{
+    MockPropertiesReader reader(bmqtst::TestHelperUtil::allocator());
+    EvaluationContext    evaluationContext(&reader,
+                                        bmqtst::TestHelperUtil::allocator());
+
+    struct TestParameters {
+        const char*     expression;
+        ErrorType::Enum expectedError;
+    } testParameters[] = {
+        // type mismatch
+        {"s_foo == 42", ErrorType::e_TYPE},
+        {"s_foo == 42 && b_false", ErrorType::e_TYPE},
+        {"b_false || s_foo == 42", ErrorType::e_TYPE},
+        {"!(s_foo == 42)", ErrorType::e_TYPE},
+
+        // undefined property
+        {"non_existing_property", ErrorType::e_NAME},
+
+        // division by zero
+        {"i_42 / i_0 == 0", ErrorType::e_ARITHMETIC},
+        {"i_42 / i_0 > 1", ErrorType::e_ARITHMETIC},
+        // modulo by zero
+        {"i_42 % i_0 == 0", ErrorType::e_ARITHMETIC},
+        {"i_42 % i_0 > 1", ErrorType::e_ARITHMETIC},
+
+    };
+    const TestParameters* testParametersEnd = testParameters +
+                                              sizeof(testParameters) /
+                                                  sizeof(*testParameters);
+
+    for (const TestParameters* parameters = testParameters;
+         parameters < testParametersEnd;
+         ++parameters) {
+        PV(bsl::string("TESTING ") + parameters->expression);
+
+        CompilationContext compilationContext(
+            bmqtst::TestHelperUtil::allocator());
+        SimpleEvaluator evaluator;
+
+        if (evaluator.compile(parameters->expression, compilationContext)) {
+            PV(bsl::string("UNEXPECTED: ") +
+               compilationContext.lastErrorMessage());
+            BMQTST_ASSERT(false);
+        }
+        else {
+            BMQTST_ASSERT(evaluator.isValid());
+            BMQTST_ASSERT_EQ(evaluator.evaluate(evaluationContext), false);
+            BMQTST_ASSERT_EQ(evaluationContext.lastError(),
+                             parameters->expectedError);
+        }
+    }
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -608,6 +651,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 4: test4_evaluationErrors(); break;
     case 3: test3_evaluation(); break;
     case 2: test2_propertyNames(); break;
     case 1: test1_compilationErrors(); break;


### PR DESCRIPTION
Integer division or modulus by zero in subscription evaluation causes UB, which can result in a SIGFPE on x86. Add check in NumBinaryOperation::evaluate to return a new error code, e_ARITHMETIC, in these cases.

Existing unit tests mixed evaluation failures and errors, indicating the latter by convention. This has been explicitly split into separate test cases that check errors for the correct error code.