### PR TITLE
Feat[mqba,mqbnet]: add AuthenticationClient for outbound broker-to-broker authn

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -74,7 +74,6 @@ AuthenticationClient::AuthenticationClient(
     BSLS_ASSERT_SAFE(channel);
     BSLS_ASSERT_SAFE(d_blobSpPool_p);
     BSLS_ASSERT_SAFE(d_scheduler_p);
-    BSLS_ASSERT_SAFE(d_allocator_p);
 }
 
 AuthenticationClient::~AuthenticationClient()
@@ -196,11 +195,11 @@ int AuthenticationClient::handleResponse(
     }
 
     BALL_LOG_INFO << "Authentication successful [peer: " << channel.get()
-                  << "], [lifetimeMs: "
+                  << "], lifetimeMs: "
                   << (authnResponse.lifetimeMs().isNull()
                           ? "N/A"
-                          : bsl::to_string(authnResponse.lifetimeMs().value()))
-                  << "]";
+                          : bsl::to_string(
+                                authnResponse.lifetimeMs().value()));
 
     // If a lifetime is provided, schedule a reauthentication request to be
     // sent at 80% of the lifetime before the connection expires.

--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -47,7 +47,7 @@ void AuthenticationClient::onReauthenticate()
 {
     // executed by the *SCHEDULER* thread
 
-    bmqu::MemOutStream errStream;
+    bmqu::MemOutStream errStream(d_allocator_p);
     const int          rc = authenticate(errStream);
     if (rc != 0) {
         BALL_LOG_ERROR << "Reauthentication failed: " << errStream.str();
@@ -66,10 +66,7 @@ void AuthenticationClient::scheduleReauthentication(
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
 
-        if (d_reauthHandle) {
-            d_scheduler_p->cancelEvent(&d_reauthHandle);
-        }
-
+        d_scheduler_p->cancelEvent(&d_reauthHandle);
         d_scheduler_p->scheduleEvent(
             &d_reauthHandle,
             bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
@@ -78,6 +75,7 @@ void AuthenticationClient::scheduleReauthentication(
                                  this));
     }
 
+    // Guaranteed to exist, the caller has already checked
     bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
     BALL_LOG_INFO << "Scheduled reauthentication"
                   << " [peer: " << channel.get() << "]" << " in " << reauthMs
@@ -132,7 +130,7 @@ int AuthenticationClient::authenticate(bsl::ostream& errorDescription)
     }
 
     // Obtain credentials
-    bmqu::MemOutStream                      credErrStream;
+    bmqu::MemOutStream                      credErrStream(d_allocator_p);
     bsl::optional<mqbplug::AuthnCredential> credential = d_credentialCb(
         credErrStream);
 
@@ -143,7 +141,7 @@ int AuthenticationClient::authenticate(bsl::ostream& errorDescription)
     }
 
     BALL_LOG_INFO << "Sending AuthenticationRequest"
-                  << " [peer: " << channel.get() << "]" << " with mechanism '"
+                  << " [peer: " << channel.get() << "] with mechanism '"
                   << credential->mechanism() << "'";
 
     // Build AuthenticationRequest
@@ -210,9 +208,15 @@ int AuthenticationClient::handleResponse(
     }
 
     bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    if (!channel) {
+        // This should never happen. The owner of this client should keep
+        // the channel alive while the response is being processed.
+        BALL_LOG_WARN << "Channel is no longer available";
+        return rc_SUCCESS;  // RETURN
+    }
 
-    BALL_LOG_INFO << "Authentication successful" << " [peer: " << channel.get()
-                  << "]" << " [lifetimeMs: "
+    BALL_LOG_INFO << "Authentication successful [peer: " << channel.get()
+                  << "], [lifetimeMs: "
                   << (authnResponse.lifetimeMs().isNull()
                           ? "N/A"
                           : bsl::to_string(authnResponse.lifetimeMs().value()))
@@ -231,10 +235,7 @@ void AuthenticationClient::stop()
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
 
-    if (d_reauthHandle) {
-        d_scheduler_p->cancelEvent(&d_reauthHandle);
-    }
-
+    d_scheduler_p->cancelEvent(&d_reauthHandle);
     d_channel_wp.reset();
 }
 

--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -74,11 +74,17 @@ AuthenticationClient::AuthenticationClient(
     BSLS_ASSERT_SAFE(channel);
     BSLS_ASSERT_SAFE(d_blobSpPool_p);
     BSLS_ASSERT_SAFE(d_scheduler_p);
+
+    d_gateKeeper.open();
 }
 
 AuthenticationClient::~AuthenticationClient()
 {
-    stop();
+    d_gateKeeper.close();
+    d_scheduler_p->cancelEventAndWait(&d_reauthHandle);
+
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    d_channel_wp.reset();
 }
 
 // MANIPULATORS
@@ -165,6 +171,13 @@ int AuthenticationClient::handleResponse(
         rc_AUTHENTICATION_FAILURE = -2
     };
 
+    // Prevent scheduling reauthentication if destructor has been called.
+    // The destructor will wait for this function to return.
+    bmqu::GateKeeper::Status gateStatus(d_gateKeeper);
+    if (!gateStatus.isOpen()) {
+        return rc_SUCCESS;  // RETURN
+    }
+
     if (!response.isAuthenticationResponseValue()) {
         errorDescription << "Expected AuthenticationResponse but received: "
                          << response;
@@ -228,17 +241,6 @@ int AuthenticationClient::handleResponse(
     }
 
     return rc_SUCCESS;
-}
-
-void AuthenticationClient::stop()
-{
-    // executed by *ANY* thread (during channel teardown)
-
-    // Cancel future events, synchronize with any currently executing callback
-    d_scheduler_p->cancelEventAndWait(&d_reauthHandle);
-
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
-    d_channel_wp.reset();
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -54,34 +54,6 @@ void AuthenticationClient::onReauthenticate()
     }
 }
 
-void AuthenticationClient::scheduleReauthentication(
-    bsls::Types::Int64 lifetimeMs)
-{
-    // executed by the *IO* thread
-
-    // Reauthenticate at 80% of the lifetime to give margin
-    const bsls::Types::Int64 reauthMs = static_cast<bsls::Types::Int64>(
-        static_cast<double>(lifetimeMs) * 0.8);
-
-    {
-        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
-
-        d_scheduler_p->cancelEvent(&d_reauthHandle);
-        d_scheduler_p->scheduleEvent(
-            &d_reauthHandle,
-            bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
-                .addMilliseconds(reauthMs),
-            bdlf::BindUtil::bind(&AuthenticationClient::onReauthenticate,
-                                 this));
-    }
-
-    // Guaranteed to exist, the caller has already checked
-    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
-    BALL_LOG_INFO << "Scheduled reauthentication"
-                  << " [peer: " << channel.get() << "]" << " in " << reauthMs
-                  << " ms (lifetimeMs: " << lifetimeMs << ")";
-}
-
 // CREATORS
 AuthenticationClient::AuthenticationClient(
     const mqbplug::CredentialProvider::CredentialCb& credentialCb,
@@ -123,7 +95,11 @@ int AuthenticationClient::authenticate(bsl::ostream& errorDescription)
         rc_WRITE_FAILURE      = -4
     };
 
-    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    bsl::shared_ptr<bmqio::Channel> channel;
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        channel = d_channel_wp.lock();
+    }
     if (!channel) {
         errorDescription << "Channel is no longer available";
         return rc_CHANNEL_GONE;  // RETURN
@@ -207,7 +183,11 @@ int AuthenticationClient::handleResponse(
         return rc_AUTHENTICATION_FAILURE;  // RETURN
     }
 
-    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    bsl::shared_ptr<bmqio::Channel> channel;
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+        channel = d_channel_wp.lock();
+    }
     if (!channel) {
         // This should never happen. The owner of this client should keep
         // the channel alive while the response is being processed.
@@ -222,8 +202,30 @@ int AuthenticationClient::handleResponse(
                           : bsl::to_string(authnResponse.lifetimeMs().value()))
                   << "]";
 
+    // If a lifetime is provided, schedule a reauthentication request to be
+    // sent at 80% of the lifetime before the connection expires.
     if (authnResponse.lifetimeMs().has_value()) {
-        scheduleReauthentication(authnResponse.lifetimeMs().value());
+        const bsls::Types::Int64 lifetimeMs =
+            authnResponse.lifetimeMs().value();
+
+        const bsls::Types::Int64 reauthMs = static_cast<bsls::Types::Int64>(
+            static_cast<double>(lifetimeMs) * 0.8);
+
+        {
+            bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+            d_scheduler_p->cancelEvent(&d_reauthHandle);
+            d_scheduler_p->scheduleEvent(
+                &d_reauthHandle,
+                bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
+                    .addMilliseconds(reauthMs),
+                bdlf::BindUtil::bind(&AuthenticationClient::onReauthenticate,
+                                     this));
+        }
+
+        BALL_LOG_INFO << "Scheduled reauthentication"
+                      << " [peer: " << channel.get() << "] in " << reauthMs
+                      << " ms (lifetimeMs: " << lifetimeMs << ")";
     }
 
     return rc_SUCCESS;
@@ -233,9 +235,10 @@ void AuthenticationClient::stop()
 {
     // executed by *ANY* thread (during channel teardown)
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+    // Cancel future events, synchronize with any currently executing callback
+    d_scheduler_p->cancelEventAndWait(&d_reauthHandle);
 
-    d_scheduler_p->cancelEvent(&d_reauthHandle);
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
     d_channel_wp.reset();
 }
 

--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -1,0 +1,242 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqba_authenticationclient.h>
+
+#include <mqbscm_version.h>
+
+// MQB
+#include <mqbplug_authncredential.h>
+
+// BMQ
+#include <bmqio_channel.h>
+#include <bmqio_status.h>
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_protocol.h>
+#include <bmqp_schemaeventbuilder.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
+
+// BDE
+#include <bdlf_bind.h>
+#include <bsl_optional.h>
+#include <bslmt_lockguard.h>
+#include <bsls_timeinterval.h>
+
+namespace BloombergLP {
+namespace mqba {
+
+// --------------------------
+// class AuthenticationClient
+// --------------------------
+
+// PRIVATE MANIPULATORS
+void AuthenticationClient::onReauthenticate()
+{
+    // executed by the *SCHEDULER* thread
+
+    bmqu::MemOutStream errStream;
+    const int          rc = authenticate(errStream);
+    if (rc != 0) {
+        BALL_LOG_ERROR << "Reauthentication failed: " << errStream.str();
+    }
+}
+
+void AuthenticationClient::scheduleReauthentication(
+    bsls::Types::Int64 lifetimeMs)
+{
+    // executed by the *IO* thread
+
+    // Reauthenticate at 80% of the lifetime to give margin
+    const bsls::Types::Int64 reauthMs = static_cast<bsls::Types::Int64>(
+        static_cast<double>(lifetimeMs) * 0.8);
+
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        if (d_reauthHandle) {
+            d_scheduler_p->cancelEvent(&d_reauthHandle);
+        }
+
+        d_scheduler_p->scheduleEvent(
+            &d_reauthHandle,
+            bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
+                .addMilliseconds(reauthMs),
+            bdlf::BindUtil::bind(&AuthenticationClient::onReauthenticate,
+                                 this));
+    }
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    BALL_LOG_INFO << "Scheduled reauthentication"
+                  << " [peer: " << channel.get() << "]" << " in " << reauthMs
+                  << " ms (lifetimeMs: " << lifetimeMs << ")";
+}
+
+// CREATORS
+AuthenticationClient::AuthenticationClient(
+    const mqbplug::CredentialProvider::CredentialCb& credentialCb,
+    const bsl::shared_ptr<bmqio::Channel>&           channel,
+    BlobSpPool*                                      blobSpPool,
+    bdlmt::EventScheduler*                           scheduler,
+    bslma::Allocator*                                allocator)
+: d_credentialCb(bsl::allocator_arg, allocator, credentialCb)
+, d_channel_wp(channel)
+, d_blobSpPool_p(blobSpPool)
+, d_scheduler_p(scheduler)
+, d_mutex()
+, d_reauthHandle()
+, d_allocator_p(allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_credentialCb);
+    BSLS_ASSERT_SAFE(channel);
+    BSLS_ASSERT_SAFE(d_blobSpPool_p);
+    BSLS_ASSERT_SAFE(d_scheduler_p);
+    BSLS_ASSERT_SAFE(d_allocator_p);
+}
+
+AuthenticationClient::~AuthenticationClient()
+{
+    stop();
+}
+
+// MANIPULATORS
+int AuthenticationClient::authenticate(bsl::ostream& errorDescription)
+{
+    // executed by the *IO* or *SCHEDULER* thread
+
+    enum RcEnum {
+        rc_SUCCESS            = 0,
+        rc_CHANNEL_GONE       = -1,
+        rc_CREDENTIAL_FAILURE = -2,
+        rc_BUILD_FAILURE      = -3,
+        rc_WRITE_FAILURE      = -4
+    };
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+    if (!channel) {
+        errorDescription << "Channel is no longer available";
+        return rc_CHANNEL_GONE;  // RETURN
+    }
+
+    // Obtain credentials
+    bmqu::MemOutStream                      credErrStream;
+    bsl::optional<mqbplug::AuthnCredential> credential = d_credentialCb(
+        credErrStream);
+
+    if (!credential.has_value()) {
+        errorDescription << "Failed to obtain credentials: "
+                         << credErrStream.str();
+        return rc_CREDENTIAL_FAILURE;  // RETURN
+    }
+
+    BALL_LOG_INFO << "Sending AuthenticationRequest"
+                  << " [peer: " << channel.get() << "]" << " with mechanism '"
+                  << credential->mechanism() << "'";
+
+    // Build AuthenticationRequest
+    bmqp_ctrlmsg::AuthenticationMessage  message;
+    bmqp_ctrlmsg::AuthenticationRequest& request =
+        message.makeAuthenticationRequest();
+
+    request.mechanism() = credential->mechanism();
+    if (!credential->data().empty()) {
+        request.data().makeValue(credential->data());
+    }
+
+    // Encode and send
+    bmqp::SchemaEventBuilder builder(d_blobSpPool_p,
+                                     bmqp::EncodingType::e_BER,
+                                     d_allocator_p);
+
+    int rc = builder.setMessage(message, bmqp::EventType::e_AUTHENTICATION);
+    if (rc != 0) {
+        errorDescription << "Failed building AuthenticationMessage "
+                         << "[rc: " << rc << ", message: " << message << "]";
+        return rc_BUILD_FAILURE;  // RETURN
+    }
+
+    bmqio::Status status;
+    channel->write(&status, *builder.blob());
+    if (!status) {
+        errorDescription << "Failed sending AuthenticationMessage "
+                         << "[status: " << status << ", message: " << message
+                         << "]";
+        return rc_WRITE_FAILURE;  // RETURN
+    }
+
+    return rc_SUCCESS;
+}
+
+int AuthenticationClient::handleResponse(
+    bsl::ostream&                              errorDescription,
+    const bmqp_ctrlmsg::AuthenticationMessage& response)
+{
+    // executed by the *IO* thread
+
+    enum RcEnum {
+        rc_SUCCESS                = 0,
+        rc_INVALID_AUTHN_RESPONSE = -1,
+        rc_AUTHENTICATION_FAILURE = -2
+    };
+
+    if (!response.isAuthenticationResponseValue()) {
+        errorDescription << "Expected AuthenticationResponse but received: "
+                         << response;
+        return rc_INVALID_AUTHN_RESPONSE;  // RETURN
+    }
+
+    const bmqp_ctrlmsg::AuthenticationResponse& authnResponse =
+        response.authenticationResponse();
+
+    if (authnResponse.status().category() !=
+        bmqp_ctrlmsg::StatusCategory::E_SUCCESS) {
+        errorDescription << "Authentication failed: "
+                         << authnResponse.status().message()
+                         << " [code: " << authnResponse.status().code() << "]";
+        return rc_AUTHENTICATION_FAILURE;  // RETURN
+    }
+
+    bsl::shared_ptr<bmqio::Channel> channel = d_channel_wp.lock();
+
+    BALL_LOG_INFO << "Authentication successful" << " [peer: " << channel.get()
+                  << "]" << " [lifetimeMs: "
+                  << (authnResponse.lifetimeMs().isNull()
+                          ? "N/A"
+                          : bsl::to_string(authnResponse.lifetimeMs().value()))
+                  << "]";
+
+    if (authnResponse.lifetimeMs().has_value()) {
+        scheduleReauthentication(authnResponse.lifetimeMs().value());
+    }
+
+    return rc_SUCCESS;
+}
+
+void AuthenticationClient::stop()
+{
+    // executed by *ANY* thread (during channel teardown)
+
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+    if (d_reauthHandle) {
+        d_scheduler_p->cancelEvent(&d_reauthHandle);
+    }
+
+    d_channel_wp.reset();
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqba/mqba_authenticationclient.h
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.h
@@ -30,6 +30,9 @@
 #include <mqbnet_authenticationclient.h>
 #include <mqbplug_credentialprovider.h>
 
+// BMQ
+#include <bmqu_atomicgate.h>
+
 // BDE
 #include <ball_log.h>
 #include <bdlbb_blob.h>
@@ -83,6 +86,9 @@ class AuthenticationClient : public mqbnet::AuthenticationClient {
 
     /// Scheduler for reauthentication timers.  Held, not owned.
     bdlmt::EventScheduler* d_scheduler_p;
+
+    /// Gate to drain in-flight handleResponse before destruction.
+    bmqu::GateKeeper d_gateKeeper;
 
     /// Mutex to protect access to EventHandle and channel.
     mutable bslmt::Mutex d_mutex;
@@ -143,10 +149,6 @@ class AuthenticationClient : public mqbnet::AuthenticationClient {
     int handleResponse(bsl::ostream& errorDescription,
                        const bmqp_ctrlmsg::AuthenticationMessage& response)
         BSLS_KEYWORD_OVERRIDE;
-
-    /// Stop the authentication client, cancelling any pending
-    /// reauthentication timers.
-    void stop() BSLS_KEYWORD_OVERRIDE;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqba/mqba_authenticationclient.h
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.h
@@ -30,8 +30,6 @@
 #include <mqbnet_authenticationclient.h>
 #include <mqbplug_credentialprovider.h>
 
-// BMQ
-
 // BDE
 #include <ball_log.h>
 #include <bdlbb_blob.h>
@@ -106,10 +104,6 @@ class AuthenticationClient : public mqbnet::AuthenticationClient {
     /// Callback invoked by the scheduler when the reauthentication timer
     /// fires.  Sends a fresh AuthenticationRequest on the stored channel.
     void onReauthenticate();
-
-    /// Schedule a reauthentication timer to fire before the specified
-    /// `lifetimeMs` expires.  Cancel any previously scheduled timer.
-    void scheduleReauthentication(bsls::Types::Int64 lifetimeMs);
 
   public:
     // TRAITS

--- a/src/groups/mqb/mqba/mqba_authenticationclient.h
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.h
@@ -31,7 +31,6 @@
 #include <mqbplug_credentialprovider.h>
 
 // BMQ
-#include <bmqio_channel.h>
 
 // BDE
 #include <ball_log.h>
@@ -46,6 +45,11 @@
 #include <bslmt_mutex.h>
 
 namespace BloombergLP {
+
+// FORWARD DECLARATION
+namespace bmqio {
+class Channel;
+}
 namespace mqba {
 
 // ==========================

--- a/src/groups/mqb/mqba/mqba_authenticationclient.h
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.h
@@ -1,0 +1,157 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBA_AUTHENTICATIONCLIENT
+#define INCLUDED_MQBA_AUTHENTICATIONCLIENT
+
+/// @file mqba_authenticationclient.h
+///
+/// @brief Provide a client-side authenticator for an outbound connection.
+///
+/// @bbref{mqba::AuthenticationClient} implements the
+/// @bbref{mqbnet::AuthenticationClient} interface to authenticate an
+/// outbound connection to a broker.  It obtains credentials from a
+/// @bbref{mqbplug::CredentialProvider::CredentialFunc} and sends an
+/// @bbref{bmqp_ctrlmsg::AuthenticationRequest} to the remote broker.
+
+// MQB
+#include <mqbnet_authenticationclient.h>
+#include <mqbplug_credentialprovider.h>
+
+// BMQ
+#include <bmqio_channel.h>
+
+// BDE
+#include <ball_log.h>
+#include <bdlbb_blob.h>
+#include <bdlcc_sharedobjectpool.h>
+#include <bdlmt_eventscheduler.h>
+#include <bsl_memory.h>
+#include <bsl_ostream.h>
+#include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bslmt_mutex.h>
+
+namespace BloombergLP {
+namespace mqba {
+
+// ==========================
+// class AuthenticationClient
+// ==========================
+
+/// Client-side authenticator for an outbound broker-to-broker connection.
+class AuthenticationClient : public mqbnet::AuthenticationClient {
+  private:
+    // CLASS-SCOPE CATEGORY
+    BALL_LOG_SET_CLASS_CATEGORY("MQBA.AUTHENTICATIONCLIENT");
+
+  public:
+    // TYPES
+
+    /// Pool of shared pointers to Blobs
+    typedef bdlcc::SharedObjectPool<
+        bdlbb::Blob,
+        bdlcc::ObjectPoolFunctors::DefaultCreator,
+        bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+        BlobSpPool;
+
+  private:
+    // DATA
+
+    /// Function to obtain credentials for authentication.
+    mqbplug::CredentialProvider::CredentialCb d_credentialCb;
+
+    /// Reference to the channel being authenticated.
+    bsl::weak_ptr<bmqio::Channel> d_channel_wp;
+
+    BlobSpPool* d_blobSpPool_p;
+
+    /// Scheduler for reauthentication timers.  Held, not owned.
+    bdlmt::EventScheduler* d_scheduler_p;
+
+    /// Mutex to protect access to EventHandle and channel.
+    mutable bslmt::Mutex d_mutex;
+
+    /// Handle for the scheduled reauthentication event, if any.
+    bdlmt::EventScheduler::EventHandle d_reauthHandle;
+
+    bslma::Allocator* d_allocator_p;
+
+  private:
+    // NOT IMPLEMENTED
+    AuthenticationClient(const AuthenticationClient&) BSLS_KEYWORD_DELETED;
+    AuthenticationClient&
+    operator=(const AuthenticationClient&) BSLS_KEYWORD_DELETED;
+
+  private:
+    // PRIVATE MANIPULATORS
+
+    /// Callback invoked by the scheduler when the reauthentication timer
+    /// fires.  Sends a fresh AuthenticationRequest on the stored channel.
+    void onReauthenticate();
+
+    /// Schedule a reauthentication timer to fire before the specified
+    /// `lifetimeMs` expires.  Cancel any previously scheduled timer.
+    void scheduleReauthentication(bsls::Types::Int64 lifetimeMs);
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(AuthenticationClient,
+                                   bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// Create a new `AuthenticationClient` using the specified
+    /// `credentialFunc` for obtaining credentials, the specified `channel`
+    /// for sending messages, the specified `blobSpPool` for building
+    /// messages, and the specified `scheduler` for reauthentication timers.
+    /// Use the specified `allocator` for all memory allocations.
+    AuthenticationClient(
+        const mqbplug::CredentialProvider::CredentialCb& credentialCb,
+        const bsl::shared_ptr<bmqio::Channel>&           channel,
+        BlobSpPool*                                      blobSpPool,
+        bdlmt::EventScheduler*                           scheduler,
+        bslma::Allocator*                                allocator);
+
+    /// Destructor
+    ~AuthenticationClient() BSLS_KEYWORD_OVERRIDE;
+
+    // MANIPULATORS
+    //   (virtual: mqbnet::AuthenticationClient)
+
+    /// Send an AuthenticationRequest using credentials from the configured
+    /// provider.  Return 0 on success, or a non-zero value and populate the
+    /// specified `errorDescription` with the description of any failure
+    /// encountered.
+    int authenticate(bsl::ostream& errorDescription) BSLS_KEYWORD_OVERRIDE;
+
+    /// Process the specified `response` received from the remote broker.
+    /// Return 0 if authentication succeeded, or a non-zero value and
+    /// populate the specified `errorDescription` with the description of
+    /// any failure encountered.
+    int handleResponse(bsl::ostream& errorDescription,
+                       const bmqp_ctrlmsg::AuthenticationMessage& response)
+        BSLS_KEYWORD_OVERRIDE;
+
+    /// Stop the authentication client, cancelling any pending
+    /// reauthentication timers.
+    void stop() BSLS_KEYWORD_OVERRIDE;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -1,0 +1,741 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqba_authenticationclient.h>
+
+// MQB
+#include <mqbplug_authncredential.h>
+#include <mqbplug_credentialprovider.h>
+
+// BMQ
+#include <bmqio_testchannel.h>
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_event.h>
+#include <bmqtst_scopedlogobserver.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
+
+// BDE
+#include <ball_severity.h>
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlcc_sharedobjectpool.h>
+#include <bdlf_bind.h>
+#include <bdlmt_eventscheduler.h>
+#include <bsl_memory.h>
+#include <bsl_optional.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bslma_allocator.h>
+#include <bsls_systemclocktype.h>
+#include <bsls_timeinterval.h>
+#include <bsls_types.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+namespace {
+
+typedef bdlcc::SharedObjectPool<
+    bdlbb::Blob,
+    bdlcc::ObjectPoolFunctors::DefaultCreator,
+    bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
+    BlobSpPool;
+
+struct TestClock {
+    bdlmt::EventScheduler&              d_scheduler;
+    bdlmt::EventSchedulerTestTimeSource d_timeSource;
+
+    TestClock(bdlmt::EventScheduler& scheduler)
+    : d_scheduler(scheduler)
+    , d_timeSource(&scheduler)
+    {
+    }
+
+    bsls::TimeInterval realtimeClock() { return d_timeSource.now(); }
+    bsls::TimeInterval monotonicClock() { return d_timeSource.now(); }
+    bsls::Types::Int64 highResTimer()
+    {
+        return d_timeSource.now().totalNanoseconds();
+    }
+};
+
+void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
+                void*                     arena,
+                bslma::Allocator*         allocator)
+{
+    new (arena) bdlbb::Blob(bufferFactory, allocator);
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+successCredentialCb(bsl::ostream&      error,
+                    const bsl::string& mechanism,
+                    const bsl::string& payload)
+{
+    (void)error;
+    bsl::vector<char> data(payload.begin(), payload.end());
+    return mqbplug::AuthnCredential(mechanism, data);
+}
+
+bsl::optional<mqbplug::AuthnCredential>
+failingCredentialCb(bsl::ostream& error)
+{
+    error << "credential provider is broken";
+    return bsl::nullopt;
+}
+
+bmqp_ctrlmsg::AuthenticationMessage
+makeSuccessResponse(const bdlb::NullableValue<bsls::Types::Int64>& lifetimeMs =
+                        bdlb::NullableValue<bsls::Types::Int64>())
+{
+    bmqp_ctrlmsg::AuthenticationMessage   msg;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        msg.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+    resp.status().code()     = 0;
+    resp.status().message()  = "OK";
+    resp.lifetimeMs()        = lifetimeMs;
+    return msg;
+}
+
+bmqp_ctrlmsg::AuthenticationMessage
+makeFailureResponse(const bsl::string& message, int code)
+{
+    bmqp_ctrlmsg::AuthenticationMessage   msg;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        msg.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+    resp.status().code()     = code;
+    resp.status().message()  = message;
+    return msg;
+}
+
+int decodeAuthenticationEvent(bmqp_ctrlmsg::AuthenticationMessage* output,
+                              const bdlbb::Blob&                   blob,
+                              bslma::Allocator*                    allocator)
+{
+    bmqp::Event event(&blob, allocator);
+    if (!event.isAuthenticationEvent()) {
+        return -1;
+    }
+    return event.loadAuthenticationEvent(output);
+}
+
+class TestBench {
+  public:
+    // DATA
+    bdlbb::PooledBlobBufferFactory      d_bufferFactory;
+    BlobSpPool                          d_blobSpPool;
+    bsl::shared_ptr<bmqio::TestChannel> d_channel;
+    bdlmt::EventScheduler               d_scheduler;
+    TestClock                           d_testClock;
+    bslma::Allocator*                   d_allocator_p;
+
+    // CREATORS
+    explicit TestBench(bslma::Allocator* allocator)
+    : d_bufferFactory(256, allocator)
+    , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
+                                        &d_bufferFactory,
+                                        bdlf::PlaceHolders::_1,
+                                        bdlf::PlaceHolders::_2),
+                   1024,
+                   allocator)
+    , d_channel(new bmqio::TestChannel(allocator))
+    , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
+    , d_testClock(d_scheduler)
+    , d_allocator_p(allocator)
+    {
+        bmqu::Time::shutdown();
+        bmqu::Time::initialize(
+            bdlf::BindUtil::bind(&TestClock::realtimeClock, &d_testClock),
+            bdlf::BindUtil::bind(&TestClock::monotonicClock, &d_testClock),
+            bdlf::BindUtil::bind(&TestClock::highResTimer, &d_testClock),
+            d_allocator_p);
+
+        int rc = d_scheduler.start();
+        BMQTST_ASSERT_EQ(rc, 0);
+    }
+
+    ~TestBench()
+    {
+        d_scheduler.cancelAllEventsAndWait();
+        d_scheduler.stop();
+    }
+
+    // MANIPULATORS
+    mqba::AuthenticationClient*
+    createClient(const mqbplug::CredentialProvider::CredentialCb& credCb)
+    {
+        return new (*d_allocator_p) mqba::AuthenticationClient(credCb,
+                                                               d_channel,
+                                                               &d_blobSpPool,
+                                                               &d_scheduler,
+                                                               d_allocator_p);
+    }
+
+    mqbplug::CredentialProvider::CredentialCb
+    makeSuccessCredentialCb(const bsl::string& mechanism = "BASIC",
+                            const bsl::string& payload   = "user:pass")
+    {
+        return bdlf::BindUtil::bind(&successCredentialCb,
+                                    bdlf::PlaceHolders::_1,
+                                    mechanism,
+                                    payload);
+    }
+
+    mqbplug::CredentialProvider::CredentialCb makeFailingCredentialCb()
+    {
+        return &failingCredentialCb;
+    }
+};
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_authenticateSuccess()
+// ------------------------------------------------------------------------
+// AUTHENTICATE SUCCESS
+//
+// Concerns:
+//   - 'authenticate()' returns 0 on success.
+//   - An AuthenticationRequest is written to the channel with the correct
+//     mechanism and credential data.
+//
+// Plan:
+//   1) Construct a client with a valid credential func and live channel.
+//   2) Call 'authenticate()', verify the return code
+//   3) Pop the write call, decode the blob, verify the request contents.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE SUCCESS");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb("BASIC", "user:pass")),
+        alloc);
+
+    // 2)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 1u);
+
+    // 3)
+    bmqio::TestChannel::WriteCall       wc = tb.d_channel->popWriteCall();
+    bmqp_ctrlmsg::AuthenticationMessage decoded;
+    rc = decodeAuthenticationEvent(&decoded, wc.d_blob, alloc);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT(decoded.isAuthenticationRequestValue());
+
+    const bmqp_ctrlmsg::AuthenticationRequest& req =
+        decoded.authenticationRequest();
+    BMQTST_ASSERT_EQ(req.mechanism(), "BASIC");
+    BMQTST_ASSERT(req.data().has_value());
+
+    bsl::string dataStr(req.data().value().begin(),
+                        req.data().value().end(),
+                        alloc);
+    BMQTST_ASSERT_EQ(dataStr, "user:pass");
+
+    client->stop();
+}
+
+static void test2_authenticateChannelGone()
+// ------------------------------------------------------------------------
+// AUTHENTICATE CHANNEL GONE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CHANNEL_GONE when the channel has been
+//     destroyed, effectively handling dead channels gracefully.
+//
+// Plan:
+//   1) Construct a client
+//   2) Destroy the external channel shared_ptr
+//   3) Call 'authenticate()', and verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE CHANNEL GONE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 2)
+    tb.d_channel.reset();
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -1);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Channel is no longer available") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test3_authenticateCredentialFailure()
+// ------------------------------------------------------------------------
+// AUTHENTICATE CREDENTIAL FAILURE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CREDENTIAL_FAILURE when the credential
+//     func returns nullopt.
+//   - No write is attempted on the channel.
+//
+// Plan:
+//   1) Construct a client with a failing credential func
+//   2) Call 'authenticate()' and verify the error code, description,
+//      and that no data was written to the channel.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE CREDENTIAL FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeFailingCredentialCb()),
+        alloc);
+
+    // 2)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -2);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Failed to obtain credentials") !=
+                  bsl::string::npos);
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 0u);
+
+    client->stop();
+}
+
+static void test4_authenticateWriteFails()
+// ------------------------------------------------------------------------
+// AUTHENTICATE WRITE FAILS
+//
+// Concerns:
+//   - 'authenticate()' returns rc_WRITE_FAILURE when the channel write
+//     fails.
+//
+// Plan:
+//   1) Construct a client
+//   2) Set the test channel's write status to an error
+//   3) Call 'authenticate()', and verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("AUTHENTICATE WRITE FAILS");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 2)
+    tb.d_channel->setWriteStatus(
+        bmqio::Status(bmqio::StatusCategory::e_GENERIC_ERROR));
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, -4);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc).find("Failed sending") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test5_handleResponseSuccessNoLifetime()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE SUCCESS NO LIFETIME
+//
+// Concerns:
+//   - 'handleResponse()' returns 0 for a successful response.
+//   - No reauthentication timer is scheduled when lifetimeMs is absent.
+//
+// Plan:
+//   1) Authenticate to establish the connection.
+//   2) Call 'handleResponse()' with a success response (no lifetimeMs).
+//   3) Advance time significantly and verify no additional writes occur.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE SUCCESS NO LIFETIME");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage response = makeSuccessResponse();
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(bsls::TimeInterval(60));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+
+    client->stop();
+}
+
+static void test6_handleResponseSuccessWithLifetime()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE SUCCESS WITH LIFETIME
+//
+// Concerns:
+//   - 'handleResponse()' returns 0 for a successful response with a
+//     lifetimeMs value.
+//   - A reauthentication timer fires at exactly 80% of the lifetime.
+//   - The reauthentication sends a valid AuthenticationRequest.
+//
+// Plan:
+//   1) Authenticate, then call 'handleResponse()' with lifetimeMs=10000.
+//   2) Advance time to 7999ms, verify no reauth fires.
+//   3) Advance 1ms more (to 8000ms = 80%), verify one
+//      AuthenticationRequest is sent.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE SUCCESS WITH LIFETIME");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    const bsls::Types::Int64            lifetimeMs = 10000;  // 10 seconds
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(7999));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(1));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth + 1);
+
+    bmqio::TestChannel::WriteCall       wc = tb.d_channel->popWriteCall();
+    bmqp_ctrlmsg::AuthenticationMessage decoded;
+    rc = decodeAuthenticationEvent(&decoded, wc.d_blob, alloc);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT(decoded.isAuthenticationRequestValue());
+
+    client->stop();
+}
+
+static void test7_handleResponseAuthenticationFailure()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE AUTHENTICATION FAILURE
+//
+// Concerns:
+//   - 'handleResponse()' returns rc_AUTHENTICATION_FAILURE when the
+//     response status is not E_SUCCESS.
+//   - The error description contains the failure reason.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'handleResponse()' with a response whose status category is
+//      E_REFUSED. Verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "HANDLE RESPONSE AUTHENTICATION FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage response =
+        makeFailureResponse("access denied", 403);
+
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(
+        bsl::string(errStream.str(), alloc).find("Authentication failed") !=
+        bsl::string::npos);
+
+    client->stop();
+}
+
+static void test8_handleResponseInvalidMessage()
+// ------------------------------------------------------------------------
+// HANDLE RESPONSE INVALID MESSAGE
+//
+// Concerns:
+//   - 'handleResponse()' returns rc_INVALID_AUTHN_RESPONSE when the
+//     message is not an AuthenticationResponse.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'handleResponse()' with an AuthenticationRequest (not a
+//      response). Verify the error code and description.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HANDLE RESPONSE INVALID MESSAGE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 2)
+    bmqp_ctrlmsg::AuthenticationMessage badMsg;
+    badMsg.makeAuthenticationRequest();
+    badMsg.authenticationRequest().mechanism() = "BASIC";
+
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->handleResponse(errStream, badMsg);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Expected AuthenticationResponse") !=
+                  bsl::string::npos);
+
+    client->stop();
+}
+
+static void test9_stopCancelsReauthTimer()
+// ------------------------------------------------------------------------
+// STOP CANCELS REAUTH TIMER
+//
+// Concerns:
+//   - Calling 'stop()' cancels a pending reauthentication timer.
+//   - No reauthentication write occurs after stop, even when time
+//     advances past the scheduled point.
+//
+// Plan:
+//   1) Authenticate and handle a response with a lifetime to schedule
+//      reauthentication.
+//   2) Call 'stop()'.
+//   3) Advance time past the reauthn lifetime, verify no additional writes.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("STOP CANCELS REAUTH TIMER");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+
+    const bsls::Types::Int64            lifetimeMs = 10000;
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    client->stop();
+
+    // 3)
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(10 * lifetimeMs));
+    BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
+}
+
+static void test10_stopThenAuthenticate()
+// ------------------------------------------------------------------------
+// STOP THEN AUTHENTICATE
+//
+// Concerns:
+//   - 'authenticate()' returns rc_CHANNEL_GONE after 'stop()' has been
+//     called, because 'stop()' resets the weak_ptr to the channel.
+//
+// Plan:
+//   1) Construct a client.
+//   2) Call 'stop()' on the client.
+//   3) Call 'authenticate()' and verify it fails with the channel-gone
+//      error.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("STOP THEN AUTHENTICATE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 2)
+    client->stop();
+
+    // 3)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_NE(rc, 0);
+    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
+                      .find("Channel is no longer available") !=
+                  bsl::string::npos);
+}
+
+static void test11_reauthChannelGoneAtTimerFire()
+// ------------------------------------------------------------------------
+// REAUTH CHANNEL GONE AT TIMER FIRE
+//
+// Concerns:
+//   - When the channel is destroyed before the reauthentication timer
+//     fires, the callback handles the expired weak_ptr gracefully.
+//   - No crash or undefined behavior occurs.
+//   - The failure is logged.
+//
+// Plan:
+//   1) Authenticate and handle a response with a lifetime to schedule
+//      reauthentication.
+//   2) Destroy all shared_ptrs to the channel.
+//   3) Advance time past the reauth point and verify the expected error
+//      is logged via a ScopedLogObserver.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("REAUTH CHANNEL GONE AT TIMER FIRE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    bslma::ManagedPtr<mqba::AuthenticationClient> client(
+        tb.createClient(tb.makeSuccessCredentialCb()),
+        alloc);
+
+    // 1)
+    bmqu::MemOutStream errStream(alloc);
+    int                rc = client->authenticate(errStream);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    const bsls::Types::Int64            lifetimeMs = 10000;
+    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+
+    errStream.reset();
+    rc = client->handleResponse(errStream, response);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // 2)
+    tb.d_channel.reset();
+
+    // 3)
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR, alloc);
+
+    tb.d_testClock.d_timeSource.advanceTime(
+        bsls::TimeInterval().addMilliseconds(lifetimeMs));
+
+    BMQTST_ASSERT_EQ(logObserver.records().size(), 1u);
+    BMQTST_ASSERT(bmqtst::ScopedLogObserverUtil::recordMessageMatch(
+        logObserver.records()[0],
+        ".*Reauthentication failed.*",
+        alloc));
+
+    client->stop();
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    {
+        bmqu::Time::initialize(bmqtst::TestHelperUtil::allocator());
+
+        switch (_testCase) {
+        case 0:
+        case 11: test11_reauthChannelGoneAtTimerFire(); break;
+        case 10: test10_stopThenAuthenticate(); break;
+        case 9: test9_stopCancelsReauthTimer(); break;
+        case 8: test8_handleResponseInvalidMessage(); break;
+        case 7: test7_handleResponseAuthenticationFailure(); break;
+        case 6: test6_handleResponseSuccessWithLifetime(); break;
+        case 5: test5_handleResponseSuccessNoLifetime(); break;
+        case 4: test4_authenticateWriteFails(); break;
+        case 3: test3_authenticateCredentialFailure(); break;
+        case 2: test2_authenticateChannelGone(); break;
+        case 1: test1_authenticateSuccess(); break;
+        default: {
+            cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+            bmqtst::TestHelperUtil::testStatus() = -1;
+        } break;
+        }
+
+        bmqu::Time::shutdown();
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
+}

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -75,25 +75,18 @@ struct TestClock {
 };
 
 struct SuccessCredentialCb {
-    const char* d_mechanism;
-    const char* d_payload;
-
-    SuccessCredentialCb(const char* mechanism, const char* payload)
-    : d_mechanism(mechanism)
-    , d_payload(payload)
-    {
-    }
+    static const char* mechanism() { return "BASIC"; }
+    static const char* payload() { return "user:pass"; }
 
     bsl::optional<mqbplug::AuthnCredential> operator()(bsl::ostream&) const
     {
         bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
-        bsl::vector<char> data(d_payload,
-                               d_payload + bsl::strlen(d_payload),
-                               alloc);
+        bslstl::StringRef p(payload());
+        bsl::vector<char> data(p.begin(), p.end(), alloc);
         bsl::optional<mqbplug::AuthnCredential> result(
             bsl::allocator_arg,
             alloc,
-            mqbplug::AuthnCredential(d_mechanism, data, alloc));
+            mqbplug::AuthnCredential(mechanism(), data, alloc));
         return result;
     }
 };
@@ -122,7 +115,7 @@ makeSuccessResponse(const bdlb::NullableValue<bsls::Types::Int64>& lifetimeMs =
 }
 
 bmqp_ctrlmsg::AuthenticationMessage
-makeFailureResponse(const bsl::string& message, int code)
+makeFailureResponse(bslstl::StringRef message, int code)
 {
     bmqp_ctrlmsg::AuthenticationMessage   msg;
     bmqp_ctrlmsg::AuthenticationResponse& resp =
@@ -234,7 +227,7 @@ static void test1_authenticateSuccess()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     bmqu::MemOutStream errStream(alloc);
@@ -283,7 +276,7 @@ static void test2_authenticateChannelGone()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     tb.d_channel.reset();
@@ -292,9 +285,7 @@ static void test2_authenticateChannelGone()
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_EQ(rc, -1);
-    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
-                      .find("Channel is no longer available") !=
-                  bsl::string::npos);
+    BMQTST_ASSERT_EQ(errStream.str(), "Channel is no longer available");
 
     client->stop();
 }
@@ -327,9 +318,9 @@ static void test3_authenticateCredentialFailure()
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_EQ(rc, -2);
-    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
-                      .find("Failed to obtain credentials") !=
-                  bsl::string::npos);
+    BMQTST_ASSERT_EQ(errStream.str(),
+                     "Failed to obtain credentials: "
+                     "credential provider callback failure");
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 0u);
 
     client->stop();
@@ -356,7 +347,7 @@ static void test4_authenticateWriteFails()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     tb.d_channel->setWriteStatus(
@@ -366,8 +357,7 @@ static void test4_authenticateWriteFails()
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_EQ(rc, -4);
-    BMQTST_ASSERT(bsl::string(errStream.str(), alloc).find("Failed sending") !=
-                  bsl::string::npos);
+    BMQTST_ASSERT(errStream.str().starts_with("Failed sending"));
 
     client->stop();
 }
@@ -392,7 +382,7 @@ static void test5_handleResponseSuccessNoLifetime()
     TestBench         tb(alloc);
 
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -438,7 +428,7 @@ static void test6_handleResponseSuccessWithLifetime()
     TestBench         tb(alloc);
 
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -497,7 +487,7 @@ static void test7_handleResponseAuthenticationFailure()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     bmqp_ctrlmsg::AuthenticationMessage response =
@@ -506,9 +496,8 @@ static void test7_handleResponseAuthenticationFailure()
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->handleResponse(errStream, response);
     BMQTST_ASSERT_NE(rc, 0);
-    BMQTST_ASSERT(
-        bsl::string(errStream.str(), alloc).find("Authentication failed") !=
-        bsl::string::npos);
+    BMQTST_ASSERT_EQ(errStream.str(),
+                     "Authentication failed: access denied [code: 403]");
 
     client->stop();
 }
@@ -534,19 +523,18 @@ static void test8_handleResponseInvalidMessage()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     bmqp_ctrlmsg::AuthenticationMessage badMsg;
     badMsg.makeAuthenticationRequest();
-    badMsg.authenticationRequest().mechanism() = "BASIC";
+    badMsg.authenticationRequest().mechanism() = "BAD_INPUT";
 
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->handleResponse(errStream, badMsg);
     BMQTST_ASSERT_NE(rc, 0);
-    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
-                      .find("Expected AuthenticationResponse") !=
-                  bsl::string::npos);
+    BMQTST_ASSERT(
+        errStream.str().starts_with("Expected AuthenticationResponse"));
 
     client->stop();
 }
@@ -573,7 +561,7 @@ static void test9_stopCancelsReauthTimer()
     TestBench         tb(alloc);
 
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -621,7 +609,7 @@ static void test10_stopThenAuthenticate()
 
     // 1)
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 2)
     client->stop();
@@ -630,9 +618,7 @@ static void test10_stopThenAuthenticate()
     bmqu::MemOutStream errStream(alloc);
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_NE(rc, 0);
-    BMQTST_ASSERT(bsl::string(errStream.str(), alloc)
-                      .find("Channel is no longer available") !=
-                  bsl::string::npos);
+    BMQTST_ASSERT_EQ(errStream.str(), "Channel is no longer available");
 }
 
 static void test11_reauthChannelGoneAtTimerFire()
@@ -659,7 +645,7 @@ static void test11_reauthChannelGoneAtTimerFire()
     TestBench         tb(alloc);
 
     bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb("BASIC", "user:pass"));
+        SuccessCredentialCb());
 
     // 1)
     bmqu::MemOutStream errStream(alloc);

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -251,8 +251,6 @@ static void test1_authenticateSuccess()
                         req.data().value().end(),
                         alloc);
     BMQTST_ASSERT_EQ(dataStr, "user:pass");
-
-    client->stop();
 }
 
 static void test2_authenticateChannelGone()
@@ -286,8 +284,6 @@ static void test2_authenticateChannelGone()
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_EQ(rc, -1);
     BMQTST_ASSERT_EQ(errStream.str(), "Channel is no longer available");
-
-    client->stop();
 }
 
 static void test3_authenticateCredentialFailure()
@@ -322,8 +318,6 @@ static void test3_authenticateCredentialFailure()
                      "Failed to obtain credentials: "
                      "credential provider callback failure");
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), 0u);
-
-    client->stop();
 }
 
 static void test4_authenticateWriteFails()
@@ -358,8 +352,6 @@ static void test4_authenticateWriteFails()
     int                rc = client->authenticate(errStream);
     BMQTST_ASSERT_EQ(rc, -4);
     BMQTST_ASSERT(errStream.str().starts_with("Failed sending"));
-
-    client->stop();
 }
 
 static void test5_handleResponseSuccessNoLifetime()
@@ -401,8 +393,6 @@ static void test5_handleResponseSuccessNoLifetime()
     // 3)
     tb.d_testClock.d_timeSource.advanceTime(bsls::TimeInterval(60));
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
-
-    client->stop();
 }
 
 static void test6_handleResponseSuccessWithLifetime()
@@ -460,8 +450,6 @@ static void test6_handleResponseSuccessWithLifetime()
     rc = decodeAuthenticationEvent(&decoded, wc.d_blob, alloc);
     BMQTST_ASSERT_EQ(rc, 0);
     BMQTST_ASSERT(decoded.isAuthenticationRequestValue());
-
-    client->stop();
 }
 
 static void test7_handleResponseAuthenticationFailure()
@@ -498,8 +486,6 @@ static void test7_handleResponseAuthenticationFailure()
     BMQTST_ASSERT_NE(rc, 0);
     BMQTST_ASSERT_EQ(errStream.str(),
                      "Authentication failed: access denied [code: 403]");
-
-    client->stop();
 }
 
 static void test8_handleResponseInvalidMessage()
@@ -535,93 +521,60 @@ static void test8_handleResponseInvalidMessage()
     BMQTST_ASSERT_NE(rc, 0);
     BMQTST_ASSERT(
         errStream.str().starts_with("Expected AuthenticationResponse"));
-
-    client->stop();
 }
 
-static void test9_stopCancelsReauthTimer()
+static void test9_destructorCancelsReauthTimer()
 // ------------------------------------------------------------------------
-// STOP CANCELS REAUTH TIMER
+// DESTRUCTOR CANCELS REAUTH TIMER
 //
 // Concerns:
-//   - Calling 'stop()' cancels a pending reauthentication timer.
-//   - No reauthentication write occurs after stop, even when time
+//   - Destroying the client cancels a pending reauthentication timer.
+//   - No reauthentication write occurs after destruction, even when time
 //     advances past the scheduled point.
 //
 // Plan:
 //   1) Authenticate and handle a response with a lifetime to schedule
 //      reauthentication.
-//   2) Call 'stop()'.
+//   2) Destroy the client.
 //   3) Advance time past the reauthn lifetime, verify no additional writes.
 // ------------------------------------------------------------------------
 {
-    bmqtst::TestHelper::printTestName("STOP CANCELS REAUTH TIMER");
+    bmqtst::TestHelper::printTestName("DESTRUCTOR CANCELS REAUTH TIMER");
 
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
     TestBench         tb(alloc);
 
-    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb());
+    size_t writeCountAfterAuth;
 
-    // 1)
-    bmqu::MemOutStream errStream(alloc);
-    int                rc = client->authenticate(errStream);
-    BMQTST_ASSERT_EQ(rc, 0);
+    {
+        bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+            SuccessCredentialCb());
 
-    size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
+        // 1)
+        bmqu::MemOutStream errStream(alloc);
+        int                rc = client->authenticate(errStream);
+        BMQTST_ASSERT_EQ(rc, 0);
 
-    const bsls::Types::Int64            lifetimeMs = 10000;
-    bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
-        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+        writeCountAfterAuth = tb.d_channel->numWriteCalls();
 
-    errStream.reset();
-    rc = client->handleResponse(errStream, response);
-    BMQTST_ASSERT_EQ(rc, 0);
+        const bsls::Types::Int64            lifetimeMs = 10000;
+        bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
+            bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
 
-    // 2)
-    client->stop();
+        errStream.reset();
+        rc = client->handleResponse(errStream, response);
+        BMQTST_ASSERT_EQ(rc, 0);
+
+        // 2) client destroyed here
+    }
 
     // 3)
     tb.d_testClock.d_timeSource.advanceTime(
-        bsls::TimeInterval().addMilliseconds(10 * lifetimeMs));
+        bsls::TimeInterval().addMilliseconds(100000));
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
 }
 
-static void test10_stopThenAuthenticate()
-// ------------------------------------------------------------------------
-// STOP THEN AUTHENTICATE
-//
-// Concerns:
-//   - 'authenticate()' returns rc_CHANNEL_GONE after 'stop()' has been
-//     called, because 'stop()' resets the weak_ptr to the channel.
-//
-// Plan:
-//   1) Construct a client.
-//   2) Call 'stop()' on the client.
-//   3) Call 'authenticate()' and verify it fails with the channel-gone
-//      error.
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("STOP THEN AUTHENTICATE");
-
-    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
-    TestBench         tb(alloc);
-
-    // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
-        SuccessCredentialCb());
-
-    // 2)
-    client->stop();
-
-    // 3)
-    bmqu::MemOutStream errStream(alloc);
-    int                rc = client->authenticate(errStream);
-    BMQTST_ASSERT_NE(rc, 0);
-    BMQTST_ASSERT_EQ(errStream.str(), "Channel is no longer available");
-}
-
-static void test11_reauthChannelGoneAtTimerFire()
+static void test10_reauthChannelGoneAtTimerFire()
 // ------------------------------------------------------------------------
 // REAUTH CHANNEL GONE AT TIMER FIRE
 //
@@ -674,8 +627,6 @@ static void test11_reauthChannelGoneAtTimerFire()
         logObserver.records()[0],
         ".*Reauthentication failed.*",
         alloc));
-
-    client->stop();
 }
 
 // ============================================================================
@@ -691,9 +642,8 @@ int main(int argc, char* argv[])
 
         switch (_testCase) {
         case 0:
-        case 11: test11_reauthChannelGoneAtTimerFire(); break;
-        case 10: test10_stopThenAuthenticate(); break;
-        case 9: test9_stopCancelsReauthTimer(); break;
+        case 10: test10_reauthChannelGoneAtTimerFire(); break;
+        case 9: test9_destructorCancelsReauthTimer(); break;
         case 8: test8_handleResponseInvalidMessage(); break;
         case 7: test7_handleResponseAuthenticationFailure(); break;
         case 6: test6_handleResponseSuccessWithLifetime(); break;

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bslstl_sharedptr.h>
 #include <mqba_authenticationclient.h>
 
 // MQB
@@ -21,6 +22,7 @@
 
 // BMQ
 #include <bmqio_testchannel.h>
+#include <bmqp_blobpoolutil.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_event.h>
 #include <bmqtst_scopedlogobserver.h>
@@ -30,7 +32,6 @@
 // BDE
 #include <ball_severity.h>
 #include <bdlbb_pooledblobbufferfactory.h>
-#include <bdlcc_sharedobjectpool.h>
 #include <bdlf_bind.h>
 #include <bdlmt_eventscheduler.h>
 #include <bsl_memory.h>
@@ -38,6 +39,7 @@
 #include <bsl_string.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
+#include <bslma_managedptr.h>
 #include <bsls_systemclocktype.h>
 #include <bsls_timeinterval.h>
 #include <bsls_types.h>
@@ -54,19 +56,13 @@ using namespace bsl;
 // ----------------------------------------------------------------------------
 namespace {
 
-typedef bdlcc::SharedObjectPool<
-    bdlbb::Blob,
-    bdlcc::ObjectPoolFunctors::DefaultCreator,
-    bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
-    BlobSpPool;
-
 struct TestClock {
     bdlmt::EventScheduler&              d_scheduler;
     bdlmt::EventSchedulerTestTimeSource d_timeSource;
 
-    TestClock(bdlmt::EventScheduler& scheduler)
+    TestClock(bdlmt::EventScheduler& scheduler, bslma::Allocator* allocator)
     : d_scheduler(scheduler)
-    , d_timeSource(&scheduler)
+    , d_timeSource(&scheduler, allocator)
     {
     }
 
@@ -78,29 +74,38 @@ struct TestClock {
     }
 };
 
-void createBlob(bdlbb::BlobBufferFactory* bufferFactory,
-                void*                     arena,
-                bslma::Allocator*         allocator)
-{
-    new (arena) bdlbb::Blob(bufferFactory, allocator);
-}
+struct SuccessCredentialCb {
+    const char* d_mechanism;
+    const char* d_payload;
 
-bsl::optional<mqbplug::AuthnCredential>
-successCredentialCb(bsl::ostream&      error,
-                    const bsl::string& mechanism,
-                    const bsl::string& payload)
-{
-    (void)error;
-    bsl::vector<char> data(payload.begin(), payload.end());
-    return mqbplug::AuthnCredential(mechanism, data);
-}
+    SuccessCredentialCb(const char* mechanism, const char* payload)
+    : d_mechanism(mechanism)
+    , d_payload(payload)
+    {
+    }
 
-bsl::optional<mqbplug::AuthnCredential>
-failingCredentialCb(bsl::ostream& error)
-{
-    error << "credential provider is broken";
-    return bsl::nullopt;
-}
+    bsl::optional<mqbplug::AuthnCredential> operator()(bsl::ostream&) const
+    {
+        bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+        bsl::vector<char> data(d_payload,
+                               d_payload + bsl::strlen(d_payload),
+                               alloc);
+        bsl::optional<mqbplug::AuthnCredential> result(
+            bsl::allocator_arg,
+            alloc,
+            mqbplug::AuthnCredential(d_mechanism, data, alloc));
+        return result;
+    }
+};
+
+struct FailingCredentialCb {
+    bsl::optional<mqbplug::AuthnCredential>
+    operator()(bsl::ostream& error) const
+    {
+        error << "credential provider callback failure";
+        return bsl::nullopt;
+    }
+};
 
 bmqp_ctrlmsg::AuthenticationMessage
 makeSuccessResponse(const bdlb::NullableValue<bsls::Types::Int64>& lifetimeMs =
@@ -132,6 +137,8 @@ int decodeAuthenticationEvent(bmqp_ctrlmsg::AuthenticationMessage* output,
                               const bdlbb::Blob&                   blob,
                               bslma::Allocator*                    allocator)
 {
+    BSLS_ASSERT(output);
+
     bmqp::Event event(&blob, allocator);
     if (!event.isAuthenticationEvent()) {
         return -1;
@@ -143,7 +150,7 @@ class TestBench {
   public:
     // DATA
     bdlbb::PooledBlobBufferFactory      d_bufferFactory;
-    BlobSpPool                          d_blobSpPool;
+    bmqp::BlobPoolUtil::BlobSpPoolSp    d_blobSpPool_sp;
     bsl::shared_ptr<bmqio::TestChannel> d_channel;
     bdlmt::EventScheduler               d_scheduler;
     TestClock                           d_testClock;
@@ -152,22 +159,24 @@ class TestBench {
     // CREATORS
     explicit TestBench(bslma::Allocator* allocator)
     : d_bufferFactory(256, allocator)
-    , d_blobSpPool(bdlf::BindUtil::bind(&createBlob,
-                                        &d_bufferFactory,
-                                        bdlf::PlaceHolders::_1,
-                                        bdlf::PlaceHolders::_2),
-                   1024,
-                   allocator)
-    , d_channel(new bmqio::TestChannel(allocator))
+    , d_blobSpPool_sp(
+          bmqp::BlobPoolUtil::createBlobPool(&d_bufferFactory, allocator))
+    , d_channel(bsl::allocate_shared<bmqio::TestChannel>(allocator))
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
-    , d_testClock(d_scheduler)
+    , d_testClock(d_scheduler, allocator)
     , d_allocator_p(allocator)
     {
         bmqu::Time::shutdown();
         bmqu::Time::initialize(
-            bdlf::BindUtil::bind(&TestClock::realtimeClock, &d_testClock),
-            bdlf::BindUtil::bind(&TestClock::monotonicClock, &d_testClock),
-            bdlf::BindUtil::bind(&TestClock::highResTimer, &d_testClock),
+            bdlf::BindUtil::bindS(allocator,
+                                  &TestClock::realtimeClock,
+                                  &d_testClock),
+            bdlf::BindUtil::bindS(allocator,
+                                  &TestClock::monotonicClock,
+                                  &d_testClock),
+            bdlf::BindUtil::bindS(allocator,
+                                  &TestClock::highResTimer,
+                                  &d_testClock),
             d_allocator_p);
 
         int rc = d_scheduler.start();
@@ -181,29 +190,19 @@ class TestBench {
     }
 
     // MANIPULATORS
-    mqba::AuthenticationClient*
-    createClient(const mqbplug::CredentialProvider::CredentialCb& credCb)
+    template <class CRED_CB>
+    bslma::ManagedPtr<mqba::AuthenticationClient>
+    createClient(const CRED_CB& credentialCb)
     {
-        return new (*d_allocator_p) mqba::AuthenticationClient(credCb,
-                                                               d_channel,
-                                                               &d_blobSpPool,
-                                                               &d_scheduler,
-                                                               d_allocator_p);
-    }
-
-    mqbplug::CredentialProvider::CredentialCb
-    makeSuccessCredentialCb(const bsl::string& mechanism = "BASIC",
-                            const bsl::string& payload   = "user:pass")
-    {
-        return bdlf::BindUtil::bind(&successCredentialCb,
-                                    bdlf::PlaceHolders::_1,
-                                    mechanism,
-                                    payload);
-    }
-
-    mqbplug::CredentialProvider::CredentialCb makeFailingCredentialCb()
-    {
-        return &failingCredentialCb;
+        mqbplug::CredentialProvider::CredentialCb cb(bsl::allocator_arg,
+                                                     d_allocator_p,
+                                                     credentialCb);
+        return bslma::ManagedPtrUtil::allocateManaged<
+            mqba::AuthenticationClient>(d_allocator_p,
+                                        cb,
+                                        d_channel,
+                                        d_blobSpPool_sp.get(),
+                                        &d_scheduler);
     }
 };
 
@@ -234,9 +233,8 @@ static void test1_authenticateSuccess()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb("BASIC", "user:pass")),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     bmqu::MemOutStream errStream(alloc);
@@ -284,9 +282,8 @@ static void test2_authenticateChannelGone()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     tb.d_channel.reset();
@@ -323,9 +320,8 @@ static void test3_authenticateCredentialFailure()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeFailingCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        FailingCredentialCb());
 
     // 2)
     bmqu::MemOutStream errStream(alloc);
@@ -359,9 +355,8 @@ static void test4_authenticateWriteFails()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     tb.d_channel->setWriteStatus(
@@ -396,9 +391,8 @@ static void test5_handleResponseSuccessNoLifetime()
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
     TestBench         tb(alloc);
 
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -434,7 +428,7 @@ static void test6_handleResponseSuccessWithLifetime()
 // Plan:
 //   1) Authenticate, then call 'handleResponse()' with lifetimeMs=10000.
 //   2) Advance time to 7999ms, verify no reauth fires.
-//   3) Advance 1ms more (to 8000ms = 80%), verify one
+//   3) Advance 1ms more to 8000ms to trigger reauth timer. Verify one
 //      AuthenticationRequest is sent.
 // ------------------------------------------------------------------------
 {
@@ -443,9 +437,8 @@ static void test6_handleResponseSuccessWithLifetime()
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
     TestBench         tb(alloc);
 
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -467,7 +460,7 @@ static void test6_handleResponseSuccessWithLifetime()
         bsls::TimeInterval().addMilliseconds(7999));
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth);
 
-    // 3)
+    // 3) 'advanceTime' triggers events and waits for them to complete
     tb.d_testClock.d_timeSource.advanceTime(
         bsls::TimeInterval().addMilliseconds(1));
     BMQTST_ASSERT_EQ(tb.d_channel->numWriteCalls(), writeCountAfterAuth + 1);
@@ -503,9 +496,8 @@ static void test7_handleResponseAuthenticationFailure()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     bmqp_ctrlmsg::AuthenticationMessage response =
@@ -541,9 +533,8 @@ static void test8_handleResponseInvalidMessage()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     bmqp_ctrlmsg::AuthenticationMessage badMsg;
@@ -581,9 +572,8 @@ static void test9_stopCancelsReauthTimer()
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
     TestBench         tb(alloc);
 
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -630,9 +620,8 @@ static void test10_stopThenAuthenticate()
     TestBench         tb(alloc);
 
     // 1)
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 2)
     client->stop();
@@ -669,9 +658,8 @@ static void test11_reauthChannelGoneAtTimerFire()
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
     TestBench         tb(alloc);
 
-    bslma::ManagedPtr<mqba::AuthenticationClient> client(
-        tb.createClient(tb.makeSuccessCredentialCb()),
-        alloc);
+    bslma::ManagedPtr<mqba::AuthenticationClient> client = tb.createClient(
+        SuccessCredentialCb("BASIC", "user:pass"));
 
     // 1)
     bmqu::MemOutStream errStream(alloc);
@@ -737,5 +725,7 @@ int main(int argc, char* argv[])
         bmqu::Time::shutdown();
     }
 
-    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
+    // NOTE: Can't check default allocation because BER codec internals
+    //       (balber::BerEncoder/BerDecoder) use the default allocator.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/mqb/mqba/package/mqba.mem
+++ b/src/groups/mqb/mqba/package/mqba.mem
@@ -1,5 +1,6 @@
 mqba_adminsession
 mqba_application
+mqba_authenticationclient
 mqba_authenticator
 mqba_clientsession
 mqba_commandrouter

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbnet_authenticationclient.h>
+
+#include <mqbscm_version.h>
+
+namespace BloombergLP {
+namespace mqbnet {
+
+// --------------------------
+// class AuthenticationClient
+// --------------------------
+
+AuthenticationClient::~AuthenticationClient()
+{
+    // NOTHING: Pure interface
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
@@ -63,10 +63,6 @@ class AuthenticationClient {
     virtual int
     handleResponse(bsl::ostream&                              errorDescription,
                    const bmqp_ctrlmsg::AuthenticationMessage& response) = 0;
-
-    /// Stop the authentication client, cancelling any pending
-    /// reauthentication timers.
-    virtual void stop() = 0;
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
@@ -30,7 +30,6 @@
 #include <bmqp_ctrlmsg_messages.h>
 
 // BDE
-#include <bsl_memory.h>
 #include <bsl_ostream.h>
 
 namespace BloombergLP {

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationclient.h
@@ -1,0 +1,76 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_MQBNET_AUTHENTICATIONCLIENT
+#define INCLUDED_MQBNET_AUTHENTICATIONCLIENT
+
+/// @file mqbnet_authenticationclient.h
+///
+/// @brief Provide a protocol for a client-side authenticator.
+///
+/// @bbref{mqbnet::AuthenticationClient} is a protocol for the client side of
+/// broker-to-broker authentication for a single connection.  An
+/// implementation sends an @bbref{bmqp_ctrlmsg::AuthenticationRequest}
+/// on an outbound channel and processes the resulting
+/// @bbref{bmqp_ctrlmsg::AuthenticationResponse}.
+
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+
+// BDE
+#include <bsl_memory.h>
+#include <bsl_ostream.h>
+
+namespace BloombergLP {
+
+namespace mqbnet {
+
+// ==========================
+// class AuthenticationClient
+// ==========================
+
+/// Protocol for the client side of broker-to-broker authentication.
+class AuthenticationClient {
+  public:
+    // CREATORS
+
+    /// Destructor
+    virtual ~AuthenticationClient();
+
+    // MANIPULATORS
+
+    /// Send an AuthenticationRequest using credentials from the configured
+    /// provider.  Return 0 on success, or a non-zero value and populate the
+    /// specified `errorDescription` with the description of any failure
+    /// encountered.
+    virtual int authenticate(bsl::ostream& errorDescription) = 0;
+
+    /// Process the specified `response` received from the remote broker.
+    /// Return 0 if authentication succeeded, or a non-zero value and
+    /// populate the specified `errorDescription` with the description of
+    /// any failure encountered.
+    virtual int
+    handleResponse(bsl::ostream&                              errorDescription,
+                   const bmqp_ctrlmsg::AuthenticationMessage& response) = 0;
+
+    /// Stop the authentication client, cancelling any pending
+    /// reauthentication timers.
+    virtual void stop() = 0;
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/mqb/mqbnet/package/mqbnet.mem
+++ b/src/groups/mqb/mqbnet/package/mqbnet.mem
@@ -1,3 +1,4 @@
+mqbnet_authenticationclient
 mqbnet_authenticationcontext
 mqbnet_authenticator
 mqbnet_channel


### PR DESCRIPTION
This PR contains the second subset of changes in https://github.com/bloomberg/blazingmq/pull/1428 for easier reviewing, follows from https://github.com/bloomberg/blazingmq/pull/1434.

Add `mqbnet::AuthenticationClient` protocol and `mqba::AuthenticationClient`
implementation. The client obtains credentials from a `CredentialProvider`,
sends an AuthenticationRequest, processes the AuthenticationResponse, and
schedules reauthentication at 80% of the credential lifetime.