### PR TITLE
Fix[CI] Add permissions to lint.yaml

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/bloomberg/blazingmq/security/code-scanning/59](https://github.com/bloomberg/blazingmq/security/code-scanning/59)

Add an explicit top-level `permissions` block in `.github/workflows/lint.yaml` so all jobs inherit least-privilege defaults unless overridden. The safest minimal fix that preserves current behavior is:

- `contents: read`

This supports checkout/read operations and satisfies the CodeQL recommendation. Since the shown jobs do not require write operations, this is the best single change with minimal functional impact. Place it near the top of the workflow (after `name` and before `on`, or after `on` and before `jobs`), at root indentation level.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
