### PR TITLE
Fix[mqbc::ClusterStateMgr]: do_sendFollowerLSNResponse error check

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -417,6 +417,35 @@ void ClusterStateManager::do_sendFollowerLSNResponse(
     bmqp_ctrlmsg::ControlMessage controlMsg;
     controlMsg.rId() = inputMessage.requestId();
 
+    if (inputMessage.source()->nodeId() !=
+        d_clusterData_p->electorInfo().leaderNodeId()) {
+        bmqp_ctrlmsg::Status& response = controlMsg.choice().makeStatus();
+        response.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        response.code()     = mqbi::ClusterErrorCode::e_SOURCE_NOT_LEADER;
+        response.message()  = "Source node is not recognized as the leader";
+
+        d_clusterData_p->messageTransmitter().sendMessage(
+            controlMsg,
+            inputMessage.source());
+
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Sent failure response " << controlMsg
+                      << " to follower LSN request from "
+                      << inputMessage.source()->nodeDescription();
+
+        return;  // RETURN
+    }
+
+    if (d_clusterFSM.isSelfHealed()) {
+        BALL_LOG_ERROR
+            << d_clusterData_p->identity().description()
+            << ": Received follower LSN request from "
+            << inputMessage.source()->nodeDescription()
+            << " after self is already healed.  This is not supposed"
+            << " to happen, but will still respond.  Please review "
+            << "Cluster FSM logic.";
+    }
+
     bmqp_ctrlmsg::ClusterMessage& clusterMsg =
         controlMsg.choice().makeClusterMessage();
     bmqp_ctrlmsg::ClusterStateFSMMessage& clusterFSMMessage =

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -429,7 +429,7 @@ void ClusterStateManager::do_sendFollowerLSNResponse(
                                                       inputMessage.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": sent response " << controlMsg
+                  << ": Sent response " << controlMsg
                   << " to follower LSN request from "
                   << inputMessage.source()->nodeDescription();
 }
@@ -459,7 +459,7 @@ void ClusterStateManager::do_sendFailureFollowerLSNResponse(
                                                       inputMessage.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": sent failure response " << controlMsg
+                  << ": Sent failure response " << controlMsg
                   << " to follower LSN request from "
                   << inputMessage.source()->nodeDescription();
 }
@@ -564,6 +564,35 @@ void ClusterStateManager::do_sendFollowerClusterStateResponse(
     bmqp_ctrlmsg::ControlMessage controlMsg;
     controlMsg.rId() = inputMessage.requestId();
 
+    if (inputMessage.source()->nodeId() !=
+        d_clusterData_p->electorInfo().leaderNodeId()) {
+        bmqp_ctrlmsg::Status& response = controlMsg.choice().makeStatus();
+        response.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        response.code()     = mqbi::ClusterErrorCode::e_SOURCE_NOT_LEADER;
+        response.message()  = "Source node is not recognized as the leader";
+
+        d_clusterData_p->messageTransmitter().sendMessage(
+            controlMsg,
+            inputMessage.source());
+
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Sent failure response " << controlMsg
+                      << " to follower cluster state request from "
+                      << inputMessage.source()->nodeDescription();
+
+        return;  // RETURN
+    }
+
+    if (d_clusterFSM.isSelfHealed()) {
+        BALL_LOG_ERROR
+            << d_clusterData_p->identity().description()
+            << ": Received follower cluster state request from "
+            << inputMessage.source()->nodeDescription()
+            << " after self is already healed.  This is not supposed"
+            << " to happen, but will still respond.  Please review "
+            << "Cluster FSM logic.";
+    }
+
     bmqp_ctrlmsg::FollowerClusterStateResponse& response =
         controlMsg.choice()
             .makeClusterMessage()
@@ -587,7 +616,7 @@ void ClusterStateManager::do_sendFollowerClusterStateResponse(
                                                       inputMessage.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": sent response " << controlMsg
+                  << ": Sent response " << controlMsg
                   << " to follower cluster state request from "
                   << inputMessage.source()->nodeDescription();
 }
@@ -617,7 +646,7 @@ void ClusterStateManager::do_sendFailureFollowerClusterStateResponse(
                                                       inputMessage.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": sent failure response " << controlMsg
+                  << ": Sent failure response " << controlMsg
                   << " to follower cluster state request from "
                   << inputMessage.source()->nodeDescription();
 }

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -967,30 +967,6 @@ void ClusterStateManager::do_logStaleFollowerClusterStateResponse(
                   << metadata.clusterStateSnapshot();
 }
 
-void ClusterStateManager::do_logErrorLeaderNotHealed(
-    const EventWithMetadata& event)
-{
-    // executed by the cluster *DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(!d_clusterData_p->cluster().isLocal());
-    BSLS_ASSERT_SAFE(!d_clusterData_p->electorInfo().isSelfLeader());
-    BSLS_ASSERT_SAFE(d_clusterFSM.state() == ClusterFSM::State::e_FOL_HEALING);
-
-    const ClusterFSMEventMetadata& metadata = event.second;
-    BSLS_ASSERT_SAFE(metadata.inputMessages().size() == 1);
-    const InputMessage& inputMessage = metadata.inputMessages().at(0);
-    BSLS_ASSERT_SAFE(inputMessage.source()->nodeId() ==
-                     d_clusterData_p->electorInfo().leaderNodeId());
-
-    BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                   << ": Self detecting leader: "
-                   << inputMessage.source()->nodeDescription()
-                   << " as not healed.  Transitioning self from healed "
-                   << " follower to healing follower.";
-}
-
 void ClusterStateManager::do_logFailFollowerLSNResponses(
     const EventWithMetadata& event)
 {

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -246,9 +246,6 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void do_logStaleFollowerClusterStateResponse(
         const EventWithMetadata& event) BSLS_KEYWORD_OVERRIDE;
 
-    void do_logErrorLeaderNotHealed(const EventWithMetadata& event)
-        BSLS_KEYWORD_OVERRIDE;
-
     void do_logFailFollowerLSNResponses(const EventWithMetadata& event)
         BSLS_KEYWORD_OVERRIDE;
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -334,8 +334,6 @@ class ClusterStateTableActions {
 
     virtual void do_logStaleFollowerClusterStateResponse(const ARGS& args) = 0;
 
-    virtual void do_logErrorLeaderNotHealed(const ARGS& args) = 0;
-
     virtual void do_logFailFollowerLSNResponses(const ARGS& args) = 0;
 
     virtual void do_logFailFollowerClusterStateResponse(const ARGS& args) = 0;

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -386,9 +386,6 @@ class ClusterStateTableActions {
 
     void do_sendFollowerLSNResponse_logErrorLeaderNotHealed(const ARGS& args);
 
-    void do_sendFollowerClusterStateResponse_logErrorLeaderNotHealed(
-        const ARGS& args);
-
     void do_storeFollowerLSNs_checkLSNQuorum(const ARGS& args);
 
     void do_storeFollowerLSNs_checkLSNQuorum_sendRegistrationResponse(
@@ -695,8 +692,8 @@ class ClusterStateTable
                 FOL_HEALED);
         CST_CFG(FOL_HEALED,
                 FOL_CSL_RQST,
-                sendFollowerClusterStateResponse_logErrorLeaderNotHealed,
-                FOL_HEALING);
+                sendFollowerClusterStateResponse,
+                FOL_HEALED);
         CST_CFG(FOL_HEALED, CSL_CMT_SUCCESS, updatePrimaryInPFSMs, FOL_HEALED);
         CST_CFG(FOL_HEALED, RST_UNKNOWN, none, UNKNOWN);
         CST_CFG(FOL_HEALED, RST_PRIMARY, updatePrimaryInPFSMs, FOL_HEALED);
@@ -874,15 +871,6 @@ void ClusterStateTableActions<
     ARGS>::do_sendFollowerLSNResponse_logErrorLeaderNotHealed(const ARGS& args)
 {
     do_sendFollowerLSNResponse(args);
-    do_logErrorLeaderNotHealed(args);
-}
-
-template <typename ARGS>
-void ClusterStateTableActions<ARGS>::
-    do_sendFollowerClusterStateResponse_logErrorLeaderNotHealed(
-        const ARGS& args)
-{
-    do_sendFollowerClusterStateResponse(args);
     do_logErrorLeaderNotHealed(args);
 }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -384,8 +384,6 @@ class ClusterStateTableActions {
 
     void do_cleanupLSNs_cancelRequests_reapplyEvent(const ARGS& args);
 
-    void do_sendFollowerLSNResponse_logErrorLeaderNotHealed(const ARGS& args);
-
     void do_storeFollowerLSNs_checkLSNQuorum(const ARGS& args);
 
     void do_storeFollowerLSNs_checkLSNQuorum_sendRegistrationResponse(
@@ -678,10 +676,7 @@ class ClusterStateTable
                 STOPPED);
         CST_CFG(FOL_HEALED, SLCT_LDR, reapplyEvent, UNKNOWN);
         CST_CFG(FOL_HEALED, SLCT_FOL, reapplyEvent, UNKNOWN);
-        CST_CFG(FOL_HEALED,
-                FOL_LSN_RQST,
-                sendFollowerLSNResponse_logErrorLeaderNotHealed,
-                FOL_HEALING);
+        CST_CFG(FOL_HEALED, FOL_LSN_RQST, sendFollowerLSNResponse, FOL_HEALED);
         CST_CFG(FOL_HEALED,
                 FOL_LSN_RSPN,
                 logStaleFollowerLSNResponse,
@@ -864,14 +859,6 @@ void ClusterStateTableActions<
     do_cleanupLSNs(args);
     do_cancelRequests(args);
     do_reapplyEvent(args);
-}
-
-template <typename ARGS>
-void ClusterStateTableActions<
-    ARGS>::do_sendFollowerLSNResponse_logErrorLeaderNotHealed(const ARGS& args)
-{
-    do_sendFollowerLSNResponse(args);
-    do_logErrorLeaderNotHealed(args);
 }
 
 template <typename ARGS>

--- a/src/groups/mqb/mqbi/mqbi_cluster.cpp
+++ b/src/groups/mqb/mqbi/mqbi_cluster.cpp
@@ -65,6 +65,7 @@ const char* ClusterErrorCode::toAscii(ClusterErrorCode::Enum value)
         CASE(CSL_FAILURE)
         CASE(STORAGE_FAILURE)
         CASE(REPLICA_WAITING)
+        CASE(SOURCE_NOT_LEADER)
     default: return "(* UNKNOWN *)";
     }
 
@@ -93,6 +94,10 @@ bool ClusterErrorCode::fromAscii(ClusterErrorCode::Enum*  out,
     CHECKVALUE(LIMIT)
     CHECKVALUE(NOT_FOLLOWER)
     CHECKVALUE(NOT_REPLICA)
+    CHECKVALUE(CSL_FAILURE)
+    CHECKVALUE(STORAGE_FAILURE)
+    CHECKVALUE(REPLICA_WAITING)
+    CHECKVALUE(SOURCE_NOT_LEADER)
 
     // Invalid string
     return false;

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -126,9 +126,9 @@ struct ClusterErrorCode {
 
         // Cluster specific
         // - - - - - - - -
-        /// The node is not the leader of the cluster
+        /// Self node is not the leader of the cluster
         e_NOT_LEADER = -200,
-        /// The node is not the primary of the partition
+        /// Self node is not the primary of the partition
         e_NOT_PRIMARY = -201,
         /// Unable to find a partition for the queue
         e_NO_PARTITION = -202,
@@ -139,9 +139,9 @@ struct ClusterErrorCode {
         /// A limit has been reached, currently:
         ///   - too many active queues in the domain
         e_LIMIT = -205,
-        /// The node is not a follower in the cluster
+        /// Self node is not a follower in the cluster
         e_NOT_FOLLOWER = -206,
-        /// The node is not a replica of the partition
+        /// Self node is not a replica of the partition
         e_NOT_REPLICA = -207,
         /// Failure to apply to the CSL
         e_CSL_FAILURE = -208,
@@ -150,7 +150,9 @@ struct ClusterErrorCode {
         /// Self is replica waiting for PrimaryStateResponse, and **must**
         /// reject the ReplicaStateRequest to prevent primary from healing us
         /// twice in a row, leading to duplicate work.
-        e_REPLICA_WAITING = -210
+        e_REPLICA_WAITING = -210,
+        /// Source node is not recognized as the leader
+        e_SOURCE_NOT_LEADER = -211
     };
 
     // CLASS METHODS


### PR DESCRIPTION
Fix for Internal Ticket 184373876

  ## Summary
  - **Fixes**: A broker crash (assertion failure in `do_logErrorLeaderNotHealed`) caused by a race condition during leader transition. A newly-elected leader sends Follower LSN requests to peers before those peers have recognized the new leader, triggering an assertion that the source must be the current leader.
  - Replace the fatal assertion with a graceful error-response path: if the source node is not recognized as leader, send a failure response with `e_SOURCE_NOT_LEADER` and return early — no crash, no state transition.
  - The Cluster FSM table no longer transitions `FOL_HEALED → FOL_HEALING` on these requests; it stays in `FOL_HEALED` and lets the response function's runtime check handle the stale-leader case.
  - Remove `do_logErrorLeaderNotHealed` entirely (dead code after the FSM table change).