### PR TITLE
Perf[mqbs::FileStore::aliasMessage]: move shared_ptrs on last use

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -5181,21 +5181,26 @@ void FileStore::aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
             deleter,
             activeFileSet->d_dataFile.block().base() + optionsOffset);
 
-        bdlbb::BlobBuffer optionsBlobBuffer(optionsBufferSp, optionsSize);
+        bdlbb::BlobBuffer optionsBlobBuffer(
+            bslmf::MovableRefUtil::move(optionsBufferSp),
+            optionsSize);
 
         *options = d_blobSpPool_p->getObject();
-        (*options)->appendDataBuffer(optionsBlobBuffer);
+        (*options)->appendDataBuffer(
+            bslmf::MovableRefUtil::move(optionsBlobBuffer));
     }
 
     bsl::shared_ptr<char> appDataBufferSp(
         deleter,
         activeFileSet->d_dataFile.block().base() + appDataOffset);
 
-    bdlbb::BlobBuffer appDataBlobBuffer(appDataBufferSp,
-                                        record.d_appDataUnpaddedLen);
+    bdlbb::BlobBuffer appDataBlobBuffer(
+        bslmf::MovableRefUtil::move(appDataBufferSp),
+        record.d_appDataUnpaddedLen);
 
     *appData = d_blobSpPool_p->getObject();
-    (*appData)->appendDataBuffer(appDataBlobBuffer);
+    (*appData)->appendDataBuffer(
+        bslmf::MovableRefUtil::move(appDataBlobBuffer));
 }
 
 void FileStore::flushIfNeeded(bool immediateFlush)


### PR DESCRIPTION
Avoid unnecessary atomic reference-count increments/decrements in `aliasMessage` by moving `shared_ptr` and `BlobBuffer` objects that are at their last use point. This eliminates up to 5 redundant atomic operations per call on a hot path.

Saves some time on subscriptions evaluation path

<img width="629" height="249" alt="Screenshot 2026-05-27 at 13 53 45" src="https://github.com/user-attachments/assets/c0f2357d-c637-4151-bf28-8cc2eda12da2" />
