### PR TITLE
Feat[mqbstat]: log json stats to files

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
@@ -20,12 +20,11 @@
 // MQB
 #include <mqbstat_queuestats.h>
 
-#include <bmqu_memoutstream.h>
-
 // BDE
 #include <ball_log.h>
 #include <bdljsn_json.h>
 #include <bdljsn_jsonutil.h>
+#include <bslma_managedptr.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
@@ -204,13 +203,19 @@ class JsonPrinter::JsonPrinterImpl {
     /// StatContext-s map
     const StatContextsMap d_contexts;
 
+    /// Allocator
+    bslma::Allocator* d_allocator_p;
+
   private:
     // NOT IMPLEMENTED
-    JsonPrinterImpl(const JsonPrinterImpl& other) BSLS_CPP11_DELETED;
+    JsonPrinterImpl(const JsonPrinterImpl& other) BSLS_KEYWORD_DELETED;
     JsonPrinterImpl&
-    operator=(const JsonPrinterImpl& other) BSLS_CPP11_DELETED;
+    operator=(const JsonPrinterImpl& other) BSLS_KEYWORD_DELETED;
 
   public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(JsonPrinterImpl, bslma::UsesBslmaAllocator)
+
     // CREATORS
 
     /// Create a new `JsonPrinterImpl` object, using the specified
@@ -218,15 +223,14 @@ class JsonPrinter::JsonPrinterImpl {
     explicit JsonPrinterImpl(const StatContextsMap& statContextsMap,
                              bslma::Allocator*      allocator);
 
-    // ACCESSORS
+    // MANIPULATORS
 
-    /// Print the JSON-encoded stats to the specified `out`.
+    /// Print the JSON-encoded stats to the specified `stream`.
     /// If the specified `compact` flag is `true`, the JSON is printed in a
     /// compact form, otherwise the JSON is printed in a pretty form.
-    /// Return `0` on success, and non-zero return code on failure.
     ///
-    /// THREAD: This method is called in the *StatController scheduler* thread.
-    int printStats(bsl::string* out, bool compact) const;
+    /// THREAD: This method is called in the `snapshot` thread.
+    void printStats(bsl::ostream& stream, bool compact);
 };
 
 inline JsonPrinter::JsonPrinterImpl::JsonPrinterImpl(
@@ -241,19 +245,17 @@ inline JsonPrinter::JsonPrinterImpl::JsonPrinterImpl(
                   .setStyle(bdljsn::WriteStyle::e_PRETTY)
                   .setSortMembers(true))
 , d_contexts(statContextsMap, allocator)
+, d_allocator_p(allocator)
 {
     // NOTHING
 }
 
-inline int JsonPrinter::JsonPrinterImpl::printStats(bsl::string* out,
-                                                    bool         compact) const
+inline void JsonPrinter::JsonPrinterImpl::printStats(bsl::ostream& stream,
+                                                     bool          compact)
 {
-    // executed by *StatController scheduler* thread
+    // executed by the `snapshot` thread
 
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(out);
-
-    bdljsn::Json        json;
+    bdljsn::Json        json(d_allocator_p);
     bdljsn::JsonObject& obj = json.makeObject();
 
     {
@@ -266,14 +268,10 @@ inline int JsonPrinter::JsonPrinterImpl::printStats(bsl::string* out,
 
     const bdljsn::WriteOptions& ops = compact ? d_opsCompact : d_opsPretty;
 
-    bmqu::MemOutStream os;
-    const int          rc = bdljsn::JsonUtil::write(os, json, ops);
+    const int rc = bdljsn::JsonUtil::write(stream, json, ops);
     if (0 != rc) {
         BALL_LOG_ERROR << "Failed to encode stats JSON, rc = " << rc;
-        return rc;  // RETURN
     }
-    (*out) = os.str();
-    return 0;
 }
 
 // -----------------
@@ -282,22 +280,18 @@ inline int JsonPrinter::JsonPrinterImpl::printStats(bsl::string* out,
 
 JsonPrinter::JsonPrinter(const StatContextsMap& statContextsMap,
                          bslma::Allocator*      allocator)
+: d_impl_mp(
+      bslma::ManagedPtrUtil::allocateManaged<JsonPrinterImpl>(allocator,
+                                                              statContextsMap))
 {
-    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
-
-    d_impl_mp.load(new (*alloc) JsonPrinterImpl(statContextsMap, alloc),
-                   alloc);
+    // NOTHING
 }
 
-int JsonPrinter::printStats(bsl::string* out, bool compact) const
+void JsonPrinter::printStats(bsl::ostream& stream, bool compact)
 {
-    // executed by *StatController scheduler* thread
+    // executed by the `snapshot` thread
 
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(out);
-    BSLS_ASSERT_SAFE(d_impl_mp);
-
-    return d_impl_mp->printStats(out, compact);
+    d_impl_mp->printStats(stream, compact);
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.h
@@ -29,11 +29,13 @@
 #include <bmqst_statcontext.h>
 
 // BDE
+#include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_keyword.h>
 
 namespace BloombergLP {
 
@@ -55,8 +57,8 @@ class JsonPrinter {
 
   private:
     // NOT IMPLEMENTED
-    JsonPrinter(const JsonPrinter& other) BSLS_CPP11_DELETED;
-    JsonPrinter& operator=(const JsonPrinter& other) BSLS_CPP11_DELETED;
+    JsonPrinter(const JsonPrinter& other) BSLS_KEYWORD_DELETED;
+    JsonPrinter& operator=(const JsonPrinter& other) BSLS_KEYWORD_DELETED;
 
   public:
     // TRAITS
@@ -73,15 +75,14 @@ class JsonPrinter {
     explicit JsonPrinter(const StatContextsMap& statContextsMap,
                          bslma::Allocator*      allocator = 0);
 
-    // ACCESSORS
+    // MANIPULATORS
 
-    /// Print the JSON-encoded stats to the specified `out`.
+    /// Print the JSON-encoded stats to the specified `stream`.
     /// If the specified `compact` flag is `true`, the JSON is printed in
     /// compact form, otherwise the JSON is printed in pretty form.
-    /// Return `0` on success, and non-zero return code on failure.
     ///
-    /// THREAD: This method is called in the *StatController scheduler* thread.
-    int printStats(bsl::string* out, bool compact) const;
+    /// THREAD: This method is called in the `snapshot` thread.
+    void printStats(bsl::ostream& stream, bool compact);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -315,7 +315,7 @@ void StatController::captureStatsAndSemaphorePost(
     switch (encoding) {
     case mqbcmd::EncodingFormat::TEXT: {
         bmqu::MemOutStream os;
-        d_tablePrinter_mp->printStats(os);
+        d_tablePrinter_mp->printStats(os, -1);
         result->makeStats() = os.str();
     } break;  // BREAK
 
@@ -330,11 +330,9 @@ void StatController::captureStatsAndSemaphorePost(
         if (savedNextSnapshot) {
             const bool compact = (encoding ==
                                   mqbcmd::EncodingFormat::JSON_COMPACT);
-            const int  rc = d_jsonPrinter_mp->printStats(&result->makeStats(),
-                                                        compact);
-            if (0 != rc) {
-                result->makeError().message() = "Stats print to json failed";
-            }
+            bmqu::MemOutStream os(d_allocator_p);
+            d_jsonPrinter_mp->printStats(os, compact);
+            result->makeStats() = os.str();
         }
         else {
             result->makeError().message() =
@@ -644,12 +642,24 @@ void StatController::snapshotAndNotify()
     const bool willPrint = d_snapshotTracker.willPrintOnNextSnapshot();
     d_snapshotTracker.onSnapshot();
 
-    if (willPrint && d_statsFileLogger_mp) {
-        d_statsFileLogger_mp->logStats(
-            d_snapshotTracker.statId(),
-            bdlf::BindUtil::bind(&TablePrinter::printStats,
-                                 d_tablePrinter_mp.get(),
-                                 bdlf::PlaceHolders::_1));
+    if (willPrint) {
+        const int statId = d_snapshotTracker.statId();
+
+        if (d_tableStatsFileLogger_mp) {
+            d_tableStatsFileLogger_mp->logStats(
+                bdlf::BindUtil::bind(&TablePrinter::printStats,
+                                     d_tablePrinter_mp.get(),
+                                     bdlf::PlaceHolders::_1,
+                                     statId));
+        }
+
+        if (d_jsonStatsFileLogger_mp) {
+            d_jsonStatsFileLogger_mp->logStats(
+                bdlf::BindUtil::bind(&JsonPrinter::printStats,
+                                     d_jsonPrinter_mp.get(),
+                                     bdlf::PlaceHolders::_1,
+                                     true));
+        }
     }
 
     // Cleanup is required if either:
@@ -737,7 +747,8 @@ StatController::StatController(const CommandProcessorFn& commandProcessor,
 , d_commandProcessorFn(bsl::allocator_arg, allocator, commandProcessor)
 , d_snapshotTracker()
 , d_tablePrinter_mp(0)
-, d_statsFileLogger_mp(0)
+, d_tableStatsFileLogger_mp(0)
+, d_jsonStatsFileLogger_mp(0)
 , d_jsonPrinter_mp(0)
 , d_statConsumers(allocator)
 , d_statConsumerMaxPublishInterval(0)
@@ -907,14 +918,28 @@ int StatController::start(bsl::ostream& errorDescription)
         ctxPtrMap,
         d_snapshotTracker.actionInterval() + 1);
 
-    // Start the stats file logger
+    // Start the stats file loggers
     if (d_snapshotTracker.isEnabled()) {
-        d_statsFileLogger_mp =
-            bslma::ManagedPtrUtil::allocateManaged<StatsFileLogger>(
-                d_allocator_p,
-                d_eventScheduler_p);
+        const bsl::string& file     = brkrCfg.stats().printer().file();
+        const int          encoding = brkrCfg.stats().printer().encoding();
 
-        d_statsFileLogger_mp->start();
+        if (encoding & mqbcfg::StatsPrinterEncodingFormat::e_TABLE) {
+            d_tableStatsFileLogger_mp =
+                bslma::ManagedPtrUtil::allocateManaged<StatsFileLogger>(
+                    d_allocator_p,
+                    file,
+                    d_eventScheduler_p);
+            d_tableStatsFileLogger_mp->start();
+        }
+
+        if (encoding & mqbcfg::StatsPrinterEncodingFormat::e_JSON) {
+            d_jsonStatsFileLogger_mp =
+                bslma::ManagedPtrUtil::allocateManaged<StatsFileLogger>(
+                    d_allocator_p,
+                    file + ".json",
+                    d_eventScheduler_p);
+            d_jsonStatsFileLogger_mp->start();
+        }
     }
 
     // Create the json printer
@@ -964,24 +989,38 @@ void StatController::stop()
         STOP_OBJ((*it), it->name());
     }
 
-    if (d_snapshotTracker.statId() > 0 && d_statsFileLogger_mp) {
+    if (d_snapshotTracker.statId() > 0) {
         // Stats were logged with `statId()` id from scheduler already.
         // For shutdown, use the next id: `statId() + 1`.
-        d_statsFileLogger_mp->logStats(
-            d_snapshotTracker.statId() + 1,
-            bdlf::BindUtil::bind(&TablePrinter::printStats,
-                                 d_tablePrinter_mp.get(),
-                                 bdlf::PlaceHolders::_1));
+        const int lastStatId = d_snapshotTracker.statId() + 1;
+
+        if (d_tableStatsFileLogger_mp) {
+            d_tableStatsFileLogger_mp->logStats(
+                bdlf::BindUtil::bind(&TablePrinter::printStats,
+                                     d_tablePrinter_mp.get(),
+                                     bdlf::PlaceHolders::_1,
+                                     lastStatId));
+        }
+
+        if (d_jsonStatsFileLogger_mp) {
+            d_jsonStatsFileLogger_mp->logStats(
+                bdlf::BindUtil::bind(&JsonPrinter::printStats,
+                                     d_jsonPrinter_mp.get(),
+                                     bdlf::PlaceHolders::_1,
+                                     true /* compact */));
+        }
     }
 
-    STOP_OBJ(d_statsFileLogger_mp, "StatsFileLogger");
+    STOP_OBJ(d_jsonStatsFileLogger_mp, "JsonStatsFileLogger");
+    STOP_OBJ(d_tableStatsFileLogger_mp, "TableStatsFileLogger");
     STOP_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");
 
     // Destroy everything!!
     for (it = d_statConsumers.begin(); it != d_statConsumers.end(); ++it) {
         DESTROY_OBJ((*it), it->name());
     }
-    DESTROY_OBJ(d_statsFileLogger_mp, "StatsFileLogger");
+    DESTROY_OBJ(d_jsonStatsFileLogger_mp, "JsonStatsFileLogger");
+    DESTROY_OBJ(d_tableStatsFileLogger_mp, "TableStatsFileLogger");
     DESTROY_OBJ(d_tablePrinter_mp, "TablePrinter");
     DESTROY_OBJ(d_jsonPrinter_mp, "JsonPrinter");
     DESTROY_OBJ(d_systemStatMonitor_mp, "SystemStatMonitor");

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -52,7 +52,7 @@
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_assert.h>
-#include <bsls_cpp11.h>
+#include <bsls_keyword.h>
 #include <bsls_types.h>
 
 namespace BloombergLP {
@@ -233,8 +233,13 @@ class StatController {
     /// Stats formatter for console and admin commands
     TablePrinterMp d_tablePrinter_mp;
 
-    /// File logger for periodic stats output
-    StatsFileLoggerMp d_statsFileLogger_mp;
+    /// File logger for periodic table stats output.
+    /// Null if TABLE stats logging is disabled.
+    StatsFileLoggerMp d_tableStatsFileLogger_mp;
+
+    /// File logger for periodic JSON stats output.
+    /// Null if JSON stats logging is disabled.
+    StatsFileLoggerMp d_jsonStatsFileLogger_mp;
 
     /// JsonPrinter used for admin commands processing
     JsonPrinterMp d_jsonPrinter_mp;
@@ -307,8 +312,9 @@ class StatController {
 
   private:
     // NOT IMPLEMENTED
-    StatController(const StatController& other) BSLS_CPP11_DELETED;
-    StatController& operator=(const StatController& other) BSLS_CPP11_DELETED;
+    StatController(const StatController& other) BSLS_KEYWORD_DELETED;
+    StatController&
+    operator=(const StatController& other) BSLS_KEYWORD_DELETED;
 
   public:
     // TRAITS

--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
@@ -50,9 +50,11 @@ const char k_LOG_CATEGORY[] = "MQBSTAT.STATSFILELOGGER";
 // class StatsFileLogger
 // --------------------
 
-StatsFileLogger::StatsFileLogger(bdlmt::EventScheduler* eventScheduler,
+StatsFileLogger::StatsFileLogger(bsl::string_view       filePattern,
+                                 bdlmt::EventScheduler* eventScheduler,
                                  bslma::Allocator*      allocator)
-: d_statsLogFile(allocator)
+: d_filePattern(filePattern, allocator)
+, d_statsLogFile(allocator)
 , d_statLogCleaner(eventScheduler, allocator)
 {
     // PRECONDITIONS
@@ -67,30 +69,30 @@ void StatsFileLogger::start()
         mqbcfg::BrokerConfig::get().stats().printer();
 
     // Configure the stats dump log file
-    d_statsLogFile.enableFileLogging(printer.file().c_str());
+    d_statsLogFile.enableFileLogging(d_filePattern.c_str());
     d_statsLogFile.rotateOnSize(printer.rotateBytes() / 1024);
     d_statsLogFile.rotateOnTimeInterval(
         bdlt::DatetimeInterval(printer.rotateDays()));
     d_statsLogFile.setLogFileFunctor(ball::RecordStringFormatter("%m\n"));
 
     // LogCleanup
-    if (printer.maxAgeDays() <= 0 || printer.file().empty()) {
+    if (printer.maxAgeDays() <= 0 || d_filePattern.empty()) {
         BALL_LOG_INFO << "StatLogCleaning is *disabled* "
                       << "[reason: either 'maxAgeDays' is set to 0 in config "
                       << "or file pattern is empty]";
         return;  // RETURN
     }
 
-    bsl::string filePattern;
-    ball::LogFileCleanerUtil::logPatternToFilePattern(&filePattern,
-                                                      printer.file());
+    bsl::string cleanupPattern;
+    ball::LogFileCleanerUtil::logPatternToFilePattern(&cleanupPattern,
+                                                      d_filePattern);
     bsls::TimeInterval maxAge(0, 0);
     maxAge.addDays(printer.maxAgeDays());
 
-    int rc = d_statLogCleaner.start(filePattern, maxAge);
+    int rc = d_statLogCleaner.start(cleanupPattern, maxAge);
     if (rc != 0) {
         BALL_LOG_ERROR << "#STATLOG_CLEANING "
-                       << "Failed to start log cleaning of '" << filePattern
+                       << "Failed to start log cleaning of '" << cleanupPattern
                        << "' [rc: " << rc << "]";
     }
 }
@@ -100,7 +102,7 @@ void StatsFileLogger::stop()
     d_statLogCleaner.stop();
 }
 
-void StatsFileLogger::logStats(int statId, const PrinterCb& printerCb)
+void StatsFileLogger::logStats(const PrinterCb& printerCb)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(printerCb);
@@ -119,9 +121,6 @@ void StatsFileLogger::logStats(int statId, const PrinterCb& printerCb)
 
     attributes.clearMessage();
     bsl::ostream os(&attributes.messageStreamBuf());
-    os << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n"
-       << "Stats id: " << statId << " @ " << now << "\n"
-       << "===== ===== ===== ===== ===== ===== ===== ===== ===== =====\n";
 
     printerCb(os);
 

--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
@@ -33,6 +33,8 @@
 #include <bdlmt_eventscheduler.h>
 #include <bsl_functional.h>
 #include <bsl_ostream.h>
+#include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -57,6 +59,9 @@ class StatsFileLogger {
 
     // DATA
 
+    /// Log file pattern.
+    bsl::string d_filePattern;
+
     /// FileObserver for the stats log dump.
     ball::FileObserver2 d_statsLogFile;
 
@@ -75,8 +80,10 @@ class StatsFileLogger {
     // CREATORS
 
     /// Create a new `StatsFileLogger` object, using the specified
+    /// `filePattern` for the log file path, the specified
     /// `eventScheduler` and the specified `allocator` for memory allocation.
-    explicit StatsFileLogger(bdlmt::EventScheduler* eventScheduler,
+    explicit StatsFileLogger(bsl::string_view       filePattern,
+                             bdlmt::EventScheduler* eventScheduler,
                              bslma::Allocator*      allocator);
 
     // MANIPULATORS
@@ -87,9 +94,9 @@ class StatsFileLogger {
     /// Stop the logger.
     void stop();
 
-    /// Dump the stats to the stat log file with the specified `statId`,
-    /// using the specified `printerCb` to format the output.
-    void logStats(int statId, const PrinterCb& printerCb);
+    /// Dump the stats to the stat log file, using the specified `printerCb`
+    /// to format the output.
+    void logStats(const PrinterCb& printerCb);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.cpp
@@ -26,6 +26,9 @@
 #include <bmqu_printutil.h>
 
 // BDE
+#include <bdlt_datetime.h>
+#include <bdlt_epochutil.h>
+#include <bsl_ctime.h>
 #include <bsl_utility.h>
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
@@ -115,8 +118,18 @@ TablePrinter::TablePrinter(const StatContextsMap& statContextsMap,
     }
 }
 
-void TablePrinter::printStats(bsl::ostream& stream)
+void TablePrinter::printStats(bsl::ostream& stream, int statId)
 {
+    if (statId >= 0) {
+        bdlt::Datetime now;
+        bdlt::EpochUtil::convertFromTimeT(&now, time(0));
+        stream << "===== ===== ===== ===== ===== ===== ===== ===== ====="
+               << " =====\n"
+               << "Stats id: " << statId << " @ " << now << "\n"
+               << "===== ===== ===== ===== ===== ===== ===== ===== ====="
+               << " =====\n";
+    }
+
     // DOMAINQUEUES
     stream << "\n"
            << ":::::::::: :::::::::: DOMAINQUEUES >>";

--- a/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
+++ b/src/groups/mqb/mqbstat/mqbstat_tableprinter.h
@@ -106,10 +106,11 @@ class TablePrinter {
 
     // MANIPULATORS
 
-    /// Print the stats to the specified `stream`.
+    /// Print the stats with the specified `statId` to the specified
+    /// `stream`.  Negative `statId` suppresses the header.
     ///
     /// THREAD: This method is called in the `snapshot` thread.
-    void printStats(bsl::ostream& stream);
+    void printStats(bsl::ostream& stream, int statId);
 };
 
 }  // close package namespace


### PR DESCRIPTION
- Update `JsonPrinter::printStats` to write to `bsl::ostream&` (matching `TablePrinter`'s  
interface) so it can be used with `mqbstat::StatsFileLogger`
- Make `mqbstat::JsonPrinterImpl` allocator-aware
- Add `filePattern` constructor parameter to `mqbstat::StatsFileLogger` (replacing hardcoded
config read), enabling multiple logger instances with different file paths
- Move stats header (Stats id: N @ timestamp) from `mqbstat::StatsFileLogger` into `mqbstat::TablePrinter`; remove `statId` from `mqbstat::StatsFileLogger::logStats` signature
- Add second `mqbstat::StatsFileLogger` instance in `mqbstat::StatController` for JSON output (file pattern: <base>.json)
- Gate table/JSON file logger creation on `StatsPrinterEncodingFormat` bitmask from
config (`e_TABLE`, `e_JSON`, `e_TABLE_AND_JSON`, `e_NONE`)

This PR doesn't extend the metrics logged to JSON, it logs JSON stats one per line to a corresponding file:

<img width="657" height="233" alt="Screenshot 2026-05-27 at 16 34 40" src="https://github.com/user-attachments/assets/1e657982-b9ad-47c5-a1dd-6e0b45d399b3" />


Continues https://github.com/bloomberg/blazingmq/pull/1180
