### PR TITLE
Perf[mqbs]: remove aliased buffer deleters pool

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_fileset.h
+++ b/src/groups/mqb/mqbs/mqbs_fileset.h
@@ -32,6 +32,7 @@
 #include <mqbu_storagekey.h>
 
 // BDE
+#include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
@@ -87,12 +88,18 @@ struct FileSet BSLS_CPP11_FINAL {
 
     bool d_fileSetRolloverPolicyAlarm;
 
-    bsls::AtomicInt64 d_aliasedBlobBufferCount;
-    // Number of payload blob buffers
-    // referencing to the mapped data file
-    // of this file set *PLUS* one.  See
-    // notes in ctor of this component for
-    // more details.
+    /// `true` if this FileSet is garbage-collected on rollover, `false` if
+    /// GC is expected on the last alias destruction.
+    bsls::AtomicBool d_inlineGc;
+
+    /// The shared alias used to keep track of the current number of records
+    /// that still reference this FileSet.  FileSet cannot be safely GCed
+    /// unless all references are gone.
+    bsl::shared_ptr<FileSet> d_aliasedChunk_sp;
+
+    /// A weak_ptr pointing at the aliased chunk.
+    /// Guaranteed to be never reset: safe to get `use_count`.
+    bsl::weak_ptr<FileSet> d_aliasedChunk_wp;
 
     bslma::Allocator* d_allocator_p;
 
@@ -107,6 +114,11 @@ struct FileSet BSLS_CPP11_FINAL {
 
     // CREATORS
     FileSet(FileStore* store, bslma::Allocator* allocator);
+
+    // ACCESSORS
+    /// Return the snapshot of the remaining number of references to this
+    /// FileSet.
+    long numReferences() const { return d_aliasedChunk_wp.use_count(); }
 };
 
 // ============================================================================
@@ -135,20 +147,12 @@ inline FileSet::FileSet(FileStore* store, bslma::Allocator* allocator)
 , d_outstandingBytesQlist(0)
 , d_journalFileAvailable(true)
 , d_fileSetRolloverPolicyAlarm(false)
-, d_aliasedBlobBufferCount(1)  // See note below explaining value of '1'
+, d_inlineGc(false)
+, d_aliasedChunk_sp()
+, d_aliasedChunk_wp()
 , d_allocator_p(allocator)
 {
     BSLS_ASSERT(allocator);
-
-    // The reason 'd_aliasedBlobBufferCount' is initialized with 1 instead of 0
-    // is that we don't want the gc logic to kick in for the active file set
-    // everytime its count goes to zero.  While there is a check in gc logic
-    // which does not gc the file set if its active one, its still expensive to
-    // invoke it (in the dispatcher thread) everytime count goes to 0.  In the
-    // worst case, the count can go to 0 after everytime a message is deleted
-    // from the store.  Here's how: assume that message flow is such that there
-    // is only one outstanding message at any time, which is deleted after
-    // consumer confirms it.
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_fileset.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_fileset.t.cpp
@@ -71,7 +71,7 @@ static void test1_breathingTest()
     BMQTST_ASSERT_EQ(obj.d_outstandingBytesQlist, 0ULL);
     BMQTST_ASSERT_EQ(obj.d_journalFileAvailable, true);
     BMQTST_ASSERT_EQ(obj.d_fileSetRolloverPolicyAlarm, false);
-    BMQTST_ASSERT_EQ(obj.d_aliasedBlobBufferCount, 1LL);
+    BMQTST_ASSERT(!obj.d_aliasedChunk_sp);
 
     BMQTST_ASSERT_EQ(obj.d_allocator_p, bmqtst::TestHelperUtil::allocator());
 }

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -297,39 +297,6 @@ void printNextEventRecord(bsl::ostream&                       stream,
 
 }  // close unnamed namespace
 
-// -------------------------------------
-// struct FileStore_AliasedBufferDeleter
-// -------------------------------------
-
-// CREATORS
-FileStore_AliasedBufferDeleter::FileStore_AliasedBufferDeleter()
-: d_fileSet_p(0)
-{
-    // NOTHING
-}
-
-// MANIPULATORS
-void FileStore_AliasedBufferDeleter::setFileSet(FileSet* fileSet)
-{
-    d_fileSet_p = fileSet;
-    ++d_fileSet_p->d_aliasedBlobBufferCount;
-}
-
-void FileStore_AliasedBufferDeleter::reset()
-{
-    // executed by *ANY* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_fileSet_p);
-    BSLS_ASSERT_SAFE(0 < d_fileSet_p->d_aliasedBlobBufferCount);
-
-    if (0 == --(d_fileSet_p->d_aliasedBlobBufferCount)) {
-        d_fileSet_p->d_store_p->gc(d_fileSet_p);
-    }
-
-    d_fileSet_p = 0;
-}
-
 // ---------------
 // class FileStore
 // ---------------
@@ -794,6 +761,11 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
     // Create file set.
     FileSetSp fileSetSp;
     fileSetSp.createInplace(d_allocator_p, this, d_allocator_p);
+    FileSet* fs = fileSetSp.get();
+    fs->d_aliasedChunk_sp.reset(
+        fs,
+        bdlf::BindUtil::bind(&FileStore::gc, this, fs));
+    fs->d_aliasedChunk_wp = fs->d_aliasedChunk_sp;
     d_fileSets.insert(d_fileSets.begin(), fileSetSp);
 
     fileSetSp->d_dataFile         = dataFd;
@@ -2711,14 +2683,23 @@ int FileStore::create(FileSetSp* fileSetSp)
     BSLS_ASSERT_SAFE(fileSetSp);
 
     bmqu::MemOutStream errorDesc;
-    return FileStoreUtil::create(errorDesc,
-                                 fileSetSp,
-                                 this,
-                                 d_config.partitionId(),
-                                 d_config,
-                                 partitionDesc(),
-                                 d_qListAware,
-                                 d_allocator_p);
+    int                rc = FileStoreUtil::create(errorDesc,
+                                   fileSetSp,
+                                   this,
+                                   d_config.partitionId(),
+                                   d_config,
+                                   partitionDesc(),
+                                   d_qListAware,
+                                   d_allocator_p);
+    if (0 == rc) {
+        FileSet* fs = fileSetSp->get();
+        fs->d_aliasedChunk_sp.reset(
+            fs,
+            bdlf::BindUtil::bind(&FileStore::gc, this, fs));
+        fs->d_aliasedChunk_wp = fs->d_aliasedChunk_sp;
+    }
+
+    return rc;
 }
 
 int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
@@ -2953,12 +2934,6 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
                            "ROLLOVER - STEP 1 (COMPACTION)");
     }
 
-    // Decrement the old file set's aliased blob buffer count by 1 to obtain
-    // the 'real' value.  Note that count was initialized with a value of 1
-    // instead of 0 when file set was created.  If count is 0 (ie, if no
-    // payload blob buffers are referring to the old data file), close it out
-    // too.  Old file set can be archived as well after that.
-
     // Irrespective of the aliased blob buffer counter, file set can be
     // truncated because nothing else will be written to the file.
 
@@ -2969,7 +2944,10 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
                            "ROLLOVER - STEP 2 (TRUNCATE)");
     }
 
-    if (0 == --activeFileSet->d_aliasedBlobBufferCount) {
+    const bool lastReference = (activeFileSet->numReferences() == 1);
+    if (lastReference) {
+        activeFileSet->d_inlineGc = true;
+
         BALL_LOG_INFO_BLOCK
         {
             BALL_LOG_OUTPUT_STREAM << partitionDesc()
@@ -2999,9 +2977,9 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
         BSLS_ASSERT_SAFE(rc == 0);
     }
     else {
+        activeFileSet->d_aliasedChunk_sp.reset();
         BALL_LOG_INFO << partitionDesc() << "Rollover: number of references to"
-                      << " old file set: "
-                      << activeFileSet->d_aliasedBlobBufferCount;
+                      << " old file set: " << activeFileSet->numReferences();
         BSLS_ASSERT_SAFE(activeFileSet->d_dataFile.isValid());
         BSLS_ASSERT_SAFE(activeFileSet->d_journalFile.isValid());
         if (d_qListAware) {
@@ -3017,10 +2995,9 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
         BALL_LOG_OUTPUT_STREAM << partitionDesc()
                                << "All data files and alias counts: \n";
         for (unsigned int index = 0; index < d_fileSets.size(); ++index) {
-            const FileSet*     fs    = d_fileSets[index].get();
-            bsls::Types::Int64 count = fs->d_aliasedBlobBufferCount;
+            long count = d_fileSets[index]->numReferences();
             BALL_LOG_OUTPUT_STREAM
-                << fs->d_dataFileName
+                << d_fileSets[index]->d_dataFileName
                 << " : alias count: " << (0 == index ? (count - 1) : count)
                 << "\n";
         }
@@ -3508,6 +3485,10 @@ int FileStore::archive(FileSet* fileSet)
 void FileStore::gc(FileSet* fileSet)
 {
     // executed by *ANY* thread
+
+    if (fileSet->d_inlineGc) {
+        return;  // RETURN
+    }
 
     // Fast path if we are already in dispatcher thread of this file store.
 
@@ -5001,16 +4982,12 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
     const unsigned int journalOffsetWords = journalOffset /
                                             bmqp::Protocol::k_WORD_SIZE;
 
-    MappedFileDescriptor&  journal = activeFileSet->d_journalFile;
-    AliasedBufferDeleterSp deleterSp =
-        d_aliasedBufferDeleterSpPool.getObject();
+    MappedFileDescriptor& journal = activeFileSet->d_journalFile;
 
-    deleterSp->setFileSet(activeFileSet);
-
-    bsl::shared_ptr<char> journalRecordBufferSp(deleterSp,
-                                                journal.mapping() +
-                                                    journalOffset);
-    bdlbb::BlobBuffer     journalRecordBlobBuffer(
+    bsl::shared_ptr<char> journalRecordBufferSp(
+        activeFileSet->d_aliasedChunk_sp,
+        journal.mapping() + journalOffset);
+    bdlbb::BlobBuffer journalRecordBlobBuffer(
         journalRecordBufferSp,
         FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
 
@@ -5070,15 +5047,12 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
     BSLS_ASSERT_SAFE(activeFileSet);
     BSLS_ASSERT_SAFE(0 != journalOffset);
 
-    MappedFileDescriptor&  journal = activeFileSet->d_journalFile;
-    AliasedBufferDeleterSp deleterSp =
-        d_aliasedBufferDeleterSpPool.getObject();
-    deleterSp->setFileSet(activeFileSet);
+    MappedFileDescriptor& journal = activeFileSet->d_journalFile;
 
-    bsl::shared_ptr<char> journalRecordBufferSp(deleterSp,
-                                                journal.mapping() +
-                                                    journalOffset);
-    bdlbb::BlobBuffer     journalRecordBlobBuffer(
+    bsl::shared_ptr<char> journalRecordBufferSp(
+        activeFileSet->d_aliasedChunk_sp,
+        journal.mapping() + journalOffset);
+    bdlbb::BlobBuffer journalRecordBlobBuffer(
         bslmf::MovableRefUtil::move(journalRecordBufferSp),
         FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
 
@@ -5089,7 +5063,7 @@ void FileStore::replicateRecord(bmqp::StorageMessageType::Enum type,
                                         ? activeFileSet->d_dataFile
                                         : activeFileSet->d_qlistFile;
 
-        bsl::shared_ptr<char> dataBufferSp(deleterSp,  // reuse same deleter
+        bsl::shared_ptr<char> dataBufferSp(activeFileSet->d_aliasedChunk_sp,
                                            mfd.mapping() + dataOffset);
         dataBlobBuffer.reset(bslmf::MovableRefUtil::move(dataBufferSp),
                              totalDataLen);
@@ -5259,12 +5233,9 @@ void FileStore::aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
                                             bmqp::Protocol::k_WORD_SIZE;
     const bsls::Types::Uint64 appDataOffset = record.d_messageOffset +
                                               dataHdrSize + optionsSize;
-    AliasedBufferDeleterSp deleter = d_aliasedBufferDeleterSpPool.getObject();
-    deleter->setFileSet(activeFileSet);
-
     if (0 != optionsSize) {
         bsl::shared_ptr<char> optionsBufferSp(
-            deleter,
+            activeFileSet->d_aliasedChunk_sp,
             activeFileSet->d_dataFile.block().base() + optionsOffset);
 
         bdlbb::BlobBuffer optionsBlobBuffer(
@@ -5277,7 +5248,7 @@ void FileStore::aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
     }
 
     bsl::shared_ptr<char> appDataBufferSp(
-        deleter,
+        activeFileSet->d_aliasedChunk_sp,
         activeFileSet->d_dataFile.block().base() + appDataOffset);
 
     bdlbb::BlobBuffer appDataBlobBuffer(
@@ -5322,7 +5293,6 @@ FileStore::FileStore(
 , d_partitionStats_sp(partitionStats)
 , d_blobSpPool_p(blobSpPool)
 , d_statePool_p(statePool)
-, d_aliasedBufferDeleterSpPool(1024, d_allocators.get("AliasedBufferDeleters"))
 , d_isOpen(false)
 , d_isStopping(false)
 , d_flushWhenClosing(false)
@@ -5483,9 +5453,6 @@ int FileStore::close(bool flush, bool archive)
     BALL_LOG_INFO << partitionDesc() << "Closing partition. ";
 
     // Clear 'd_records' so that gc logic is invoked on all mapped data files.
-    // Note that logic will be invoked in this thread.  Note that data file of
-    // active file set will not be gc'd because its alias blob buffer count
-    // will not go to 0 as its initialized with 1.
     d_unreceipted.clear();
     d_records.clear();
 
@@ -5497,7 +5464,10 @@ int FileStore::close(bool flush, bool archive)
     // Failure to truncate is non-fatal.  No need to check rc.
     truncate(activeFileSet);
 
-    if (0 == --activeFileSet->d_aliasedBlobBufferCount) {
+    const bool lastReference = (activeFileSet->numReferences() == 1);
+    if (lastReference) {
+        activeFileSet->d_inlineGc = true;
+
         BALL_LOG_INFO_BLOCK
         {
             BALL_LOG_OUTPUT_STREAM << partitionDesc() << "Closing "
@@ -5512,7 +5482,6 @@ int FileStore::close(bool flush, bool archive)
             BALL_LOG_OUTPUT_STREAM << ".";
         }
 
-        // TBD Revisit: handle non-zero rc from close()
         bsls::Types::Int64 startTime = bmqu::Time::highResolutionTimer();
         int                rc        = close(*activeFileSet, flush);
         if (rc != 0) {
@@ -5550,14 +5519,9 @@ int FileStore::close(bool flush, bool archive)
         d_fileSets.erase(d_fileSets.begin());
     }
     else {
-        BALL_LOG_INFO << partitionDesc() << "Closing: number of references to"
-                      << " active file set: "
-                      << activeFileSet->d_aliasedBlobBufferCount;
-        BSLS_ASSERT_SAFE(activeFileSet->d_dataFile.isValid());
-        BSLS_ASSERT_SAFE(activeFileSet->d_journalFile.isValid());
-        if (d_qListAware) {
-            BSLS_ASSERT_SAFE(activeFileSet->d_qlistFile.isValid());
-        }
+        activeFileSet->d_aliasedChunk_sp.reset();
+        BALL_LOG_INFO << partitionDesc() << "Closing: number of references to "
+                      << "active file set: " << activeFileSet->numReferences();
         BSLS_ASSERT_SAFE(!archive);
     }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -21,7 +21,6 @@
 //@CLASSES:
 //  mqbs::FileStore:         File-backed BlazingMQ data store.
 //  mqbs::FileStoreIterator: Iterator over records in a 'mqbs::FileStore'
-//  mqbs::FileStore_AliasedBufferDeleter
 //
 //@SEE ALSO: mqbs::FileStoreProtocol
 //
@@ -108,23 +107,6 @@ class JournalFileIterator;
 class QlistFileIterator;
 class ReplicatedStorage;
 
-// =====================================
-// struct FileStore_AliasedBufferDeleter
-// =====================================
-
-struct FileStore_AliasedBufferDeleter {
-    // PUBLIC DATA
-    FileSet* d_fileSet_p;
-
-    // CREATORS
-    FileStore_AliasedBufferDeleter();
-
-    // MANIPULATORS
-    void setFileSet(FileSet* fileSet);
-
-    void reset();
-};
-
 // ===============
 // class FileStore
 // ===============
@@ -138,7 +120,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
     // FRIENDS
     friend class FileStoreIterator;
-    friend struct FileStore_AliasedBufferDeleter;
 
   public:
     // TYPES
@@ -180,16 +161,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
   private:
     // PRIVATE TYPES
-    typedef FileStore_AliasedBufferDeleter        AliasedBufferDeleter;
-    typedef bsl::shared_ptr<AliasedBufferDeleter> AliasedBufferDeleterSp;
-
-    /// Pool of shared pointers to `AliasedBufferDeleter`
-    typedef bdlcc::SharedObjectPool<
-        AliasedBufferDeleter,
-        bdlcc::ObjectPoolFunctors::DefaultCreator,
-        bdlcc::ObjectPoolFunctors::Reset<AliasedBufferDeleter> >
-        AliasedBufferDeleterSpPool;
-
     typedef DataStoreConfig::Records             Records;
     typedef DataStoreConfig::RecordIterator      RecordIterator;
     typedef DataStoreConfig::RecordConstIterator RecordConstIterator;
@@ -301,8 +272,6 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     // use.
 
     StateSpPool* d_statePool_p;
-
-    mutable AliasedBufferDeleterSpPool d_aliasedBufferDeleterSpPool;
 
     bsls::AtomicBool d_isOpen;
     // Flag to indicate open/close status

--- a/src/groups/mqb/mqbs/mqbs_filestoreprintutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprintutil.cpp
@@ -67,7 +67,7 @@ void FileStorePrintUtil::loadSummary(mqbcmd::FileStoreSummary*  summary,
         summary->fileSets()[i].dataFileName() =
             (0 == rc ? leaf : fileSets[i]->d_dataFileName);
         summary->fileSets()[i].aliasedBlobBufferCount() =
-            fileSets[i]->d_aliasedBlobBufferCount;
+            fileSets[i]->numReferences();
         if (0 == i) {
             totalMappedSize += fileSets[i]->d_dataFilePosition;
             totalMappedSize += fileSets[i]->d_qlistFilePosition;


### PR DESCRIPTION
Replace `AliasedBufferDeleterSpPool` with a single `shared_ptr` per `mqbs::FileSet`.
As a result, we don't modify atomics for multiple `shared_ptr`s and do not perform object pool operations. Instead, we mostly modify atomics for 1 `shared_ptr` (associated with the current `FileStore`)

# Changes

- The pool of `AliasedBufferDeleter` objects and its associated struct are removed.
- Instead, each FileSet holds a `d_aliasedChunk_sp` token — a `shared_ptr<FileSet>` with a custom deleter that calls `gc()`.
- All aliased `shared_ptr<char>` instances are created via the aliasing constructor from this token.
- The token's `use_count()` replaces `d_aliasedBlobBufferCount` for tracking outstanding references, and the custom deleter handles deferred `gc` when the last alias dies.
- `d_inlineGc` flag prevents the deleter from firing after inline `gc` has already handled cleanup.

# Benchmarks

**Before**

<img width="736" height="424" alt="Screenshot 2026-05-28 at 14 04 05" src="https://github.com/user-attachments/assets/08159b15-6074-4152-8d3a-2e538b4ab4f0" />

**After**

<img width="736" height="411" alt="Screenshot 2026-05-28 at 14 57 23" src="https://github.com/user-attachments/assets/25ac4ed6-08db-491e-b506-dab2542a43bb" />

This PR saves at least ~1.5% of all CPU frames spent on `SharedObjectPool::getObject` for `AliasedBufferDeleters`, also saves some time on returning elements to this pool.

It removes ~1% of all CPU frames spent on other calls related to `AliasedBufferDeleter` (saving ~2.5% in total).
All this is gone (1.5% on the top is `SharedObjectPool::getObject`):

<img width="967" height="356" alt="Screenshot 2026-05-28 at 15 25 11" src="https://github.com/user-attachments/assets/465abd3b-f513-4b3a-8c1c-711e4bafcd3c" />
