### PR TITLE
Fix[mqbblp]: replace double-throttled LOGTHROTTLE macros with BALL_LOG

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -996,9 +996,8 @@ void QueueHandle::deliverMessage(
             // needed we way have to change this method to return a tri-value
             // (delivered, non-delivered, skipped).
             if (d_throttledDroppedPutMessages.requestPermission()) {
-                BMQ_LOGTHROTTLE_INFO << "Queue '" << d_queue_sp->description()
-                                     << "' skipping duplicate PUSH "
-                                     << iter.guid();
+                BALL_LOG_INFO << "Queue '" << d_queue_sp->description()
+                              << "' skipping duplicate PUSH " << iter.guid();
             }
             continue;  // CONTINUE
         }
@@ -1305,15 +1304,15 @@ void QueueHandle::onAckMessage(const bmqp::AckMessage& ackMessage)
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!d_haveClient)) {
         BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
         if (d_throttledFailedAckMessages.requestPermission()) {
-            BMQ_LOGTHROTTLE_INFO
-                << "#CLIENT_ACK_FAILURE: Received an ACK from "
-                << "upstream for unavailable client "
-                << "[queue: " << d_queue_sp->description()
-                << ", upstream queueId: " << ackMessage.queueId()
-                << ", downstream queueId: " << id()
-                << ", guid: " << ackMessage.messageGUID()
-                << ", status: " << ackMessage.status()
-                << ", correlationId: " << ackMessage.correlationId() << "]";
+            BALL_LOG_INFO << "#CLIENT_ACK_FAILURE: Received an ACK from "
+                          << "upstream for unavailable client "
+                          << "[queue: " << d_queue_sp->description()
+                          << ", upstream queueId: " << ackMessage.queueId()
+                          << ", downstream queueId: " << id()
+                          << ", guid: " << ackMessage.messageGUID()
+                          << ", status: " << ackMessage.status()
+                          << ", correlationId: " << ackMessage.correlationId()
+                          << "]";
         }
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1606,11 +1606,10 @@ int RelayQueueEngine::onRejectMessage(
         result = rda.counter();
 
         if (d_throttledRejectedMessages.requestPermission()) {
-            BMQ_LOGTHROTTLE_INFO
-                << "Queue '" << d_queueState_p->uri()
-                << "' rejecting PUSH [GUID: '" << msgGUID
-                << "', subQueueId: " << app->upstreamSubQueueId()
-                << "] with the counter: [" << rda << "]";
+            BALL_LOG_INFO << "Queue '" << d_queueState_p->uri()
+                          << "' rejecting PUSH [GUID: '" << msgGUID
+                          << "', subQueueId: " << app->upstreamSubQueueId()
+                          << "] with the counter: [" << rda << "]";
         }
 
         if (!rda.isUnlimited()) {
@@ -1636,10 +1635,10 @@ int RelayQueueEngine::onRejectMessage(
         }
     }
     else if (d_throttledRejectedMessages.requestPermission()) {
-        BMQ_LOGTHROTTLE_INFO
-            << "Queue '" << d_queueState_p->uri()
-            << "' got reject for an unknown message [GUID: '" << msgGUID
-            << "', subQueueId: " << app->upstreamSubQueueId() << "]";
+        BALL_LOG_INFO << "Queue '" << d_queueState_p->uri()
+                      << "' got reject for an unknown message [GUID: '"
+                      << msgGUID
+                      << "', subQueueId: " << app->upstreamSubQueueId() << "]";
     }
 
     return result;


### PR DESCRIPTION
Closes #1451

`BMQ_LOGTHROTTLE_INFO` expands to `BALL_LOGTHROTTLE_INFO` which carries its own internal static `bdlmt::Throttle`. When these macros are called inside a `requestPermission()` guard, the message passes through two independent throttle gates in series. The outer gate may grant permission, but the inner one can still suppress the log entry, effectively silencing output that was already meant to be rate-limited by `requestPermission()` alone.

This replaces `BMQ_LOGTHROTTLE_INFO` with `BALL_LOG_INFO` at four sites across `mqbblp_queuehandle.cpp` and `mqbblp_relayqueueengine.cpp` where `requestPermission()` already controls the throttle. The same files use `requestPermission()` with `BALL_LOG_WARN` correctly at other call sites, confirming this was unintentional.

The `mqbstat_statcontroller.cpp` site was intentionally left unchanged. That call uses `!requestPermission()`, which inverts the semantics. It logs when the throttle denies permission, then rate-limits the warning separately. The two throttles serve distinct purposes there and are not redundant.