### PR TITLE
Feat[mqbstat]: put timestamps to Json stats file

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_jsonprinter.cpp
@@ -24,6 +24,10 @@
 #include <ball_log.h>
 #include <bdljsn_json.h>
 #include <bdljsn_jsonutil.h>
+#include <bdlt_datetime.h>
+#include <bdlt_epochutil.h>
+#include <bsl_ctime.h>
+#include <bsl_sstream.h>
 #include <bslma_managedptr.h>
 #include <bsls_assert.h>
 
@@ -257,6 +261,14 @@ inline void JsonPrinter::JsonPrinterImpl::printStats(bsl::ostream& stream,
 
     bdljsn::Json        json(d_allocator_p);
     bdljsn::JsonObject& obj = json.makeObject();
+
+    {
+        bdlt::Datetime now;
+        bdlt::EpochUtil::convertFromTimeT(&now, time(0));
+        bsl::ostringstream ts(d_allocator_p);
+        ts << now;
+        obj["_timestamp"].makeString(ts.str());
+    }
 
     {
         const bmqst::StatContext& ctx =


### PR DESCRIPTION
Example:
```
{"_timestamp":"29MAY2026_19:15:50.881038+0000","domainQueues":{"domains":{"bmq.test.persistent.priority":{"bmq:\/\/bmq.test.persistent.priority\/qqq":{"values":{"queue_ack_msgs":3,"queue_ack_msgs_abs":3,"queue_ack_time_avg":0,"queue_ack_time_max":0,"queue_bytes_current":84,"queue_bytes_utilization_max":0,"queue_cfg_bytes":1048576,"queue_cfg_msgs":1000,"queue_confirm_msgs":0,"queue_confirm_msgs_abs":0,"queue_confirm_time_avg":0,"queue_confirm_time_max":0,"queue_consumers_count":0,"queue_content_bytes":84,"queue_content_msgs":6,"queue_gc_msgs":0,"queue_gc_msgs_abs":0,"queue_history_abs":0,"queue_msgs_current":6,"queue_msgs_utilization_max":0,"queue_nack_msgs":0,"queue_nack_msgs_abs":0,"queue_nack_noquorum_msgs":0,"queue_nack_noquorum_msgs_abs":0,"queue_producers_count":1,"queue_push_bytes":0,"queue_push_bytes_abs":0,"queue_push_msgs":0,"queue_push_msgs_abs":0,"queue_put_bytes":42,"queue_put_bytes_abs":42,"queue_put_msgs":3,"queue_put_msgs_abs":3,"queue_queue_time_avg":0,"queue_queue_time_max":0,"queue_reject_msgs":0,"queue_reject_msgs_abs":0,"queue_role":1}}}}}}
```
