### PR TITLE
Fix[mqb]: Concurrent setChannel and resetChannel

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -259,10 +259,19 @@ Channel::writeBlob(const bsl::shared_ptr<bdlbb::Blob>&       data,
     return enqueue(item);
 }
 
-void Channel::resetChannel()
+void Channel::resetChannel(
+    const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+
+        bsl::shared_ptr<bmqio::Channel> currentSp = d_channel_wp.lock();
+
+        if (currentSp && currentSp != closedChannel) {
+            BALL_LOG_INFO << "Ignoring stale resetChannel for "
+                          << d_description;
+            return;  // RETURN
+        }
 
         BALL_LOG_INFO << "Disconnected " << d_description;
 
@@ -296,7 +305,10 @@ void Channel::setChannel(const bsl::weak_ptr<bmqio::Channel>& value)
 
     bsl::shared_ptr<bmqio::Channel> channelSp = value.lock();
     BSLS_ASSERT(channelSp);
-    BSLS_ASSERT(!isAvailable());
+
+    // 'isAvailable()' can be true in the case when 'setChannel' is called
+    // before 'resetChannel' as the result of a new connection on a different
+    // TCP thread
 
     d_description = d_name + " - " + channelSp->peerUri();
     channelSp->onWatermark(bdlf::BindUtil::bind(&Channel::onWatermark,

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -259,7 +259,7 @@ Channel::writeBlob(const bsl::shared_ptr<bdlbb::Blob>&       data,
     return enqueue(item);
 }
 
-void Channel::resetChannel(
+bool Channel::resetChannel(
     const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
     {
@@ -270,7 +270,7 @@ void Channel::resetChannel(
         if (currentSp && currentSp != closedChannel) {
             BALL_LOG_INFO << "Ignoring stale resetChannel for "
                           << d_description;
-            return;  // RETURN
+            return false;  // RETURN
         }
 
         BALL_LOG_INFO << "Disconnected " << d_description;
@@ -285,6 +285,8 @@ void Channel::resetChannel(
 
     // `threadFn` might be blocked by `popFront`, wake it up
     wakeUp();
+
+    return true;
 }
 
 void Channel::requestToStop()

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -518,10 +518,10 @@ class Channel {
     void setChannel(const bsl::weak_ptr<bmqio::Channel>& value);
 
     /// Reset the channel associated to this node.  The specified
-    /// `closedChannel` identifies the channel being closed; if the node
-    /// already has a different (newer) channel, this reset is stale and
-    /// will be ignored.
-    void resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel);
+    /// `closedChannel` identifies the channel being closed.  Return `false` if
+    /// the node already has a different (newer) channel and ignore the reset.
+    /// Return `true` otherwise.
+    bool resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel);
 
     /// Start draining the channel associated to this node, if any.
     void requestToStop();

--- a/src/groups/mqb/mqbnet/mqbnet_channel.h
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.h
@@ -517,8 +517,11 @@ class Channel {
     /// Set the channel associated to this node to the specified `value`.
     void setChannel(const bsl::weak_ptr<bmqio::Channel>& value);
 
-    /// Reset the channel associated to this node.
-    void resetChannel();
+    /// Reset the channel associated to this node.  The specified
+    /// `closedChannel` identifies the channel being closed; if the node
+    /// already has a different (newer) channel, this reset is stale and
+    /// will be ignored.
+    void resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel);
 
     /// Start draining the channel associated to this node, if any.
     void requestToStop();

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -1214,7 +1214,7 @@ static void test5_reconnect()
     BMQTST_ASSERT_EQ(testChannel->numWriteCalls(), 1U);
 
     // simulate reconnection
-    channel.resetChannel();
+    channel.resetChannel(testChannel);
     channel.setChannel(bsl::weak_ptr<bmqio::TestChannelEx>(testChannel));
 
     testChannel->setWriteStatus(bmqio::StatusCategory::e_SUCCESS);

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -135,8 +135,12 @@ class ClusterNode {
     /// or if it is already reading.
     virtual bool enableRead() = 0;
 
-    /// Reset the channel associated to this node.
-    virtual ClusterNode* resetChannel() = 0;
+    /// Reset the channel associated to this node.  The specified
+    /// `closedChannel` identifies the channel being closed; if the node
+    /// already has a different (newer) channel, this reset is stale and
+    /// will be ignored.
+    virtual ClusterNode*
+    resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel) = 0;
 
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
@@ -68,7 +68,8 @@ struct ClusterNodeTestImp : bsls::ProtocolTestImp<mqbnet::ClusterNode> {
 
     bool enableRead() BSLS_KEYWORD_OVERRIDE { return markDone(); }
 
-    mqbnet::ClusterNode* resetChannel() BSLS_KEYWORD_OVERRIDE
+    mqbnet::ClusterNode*
+    resetChannel(const bsl::shared_ptr<bmqio::Channel>&) BSLS_KEYWORD_OVERRIDE
     {
         return markDone();
     }
@@ -311,7 +312,8 @@ static void test2_ClusterNode()
                                             identity,
                                             bmqio::Channel::ReadCallback()));
         BSLS_PROTOCOLTEST_ASSERT(testObj, enableRead());
-        BSLS_PROTOCOLTEST_ASSERT(testObj, resetChannel());
+        BSLS_PROTOCOLTEST_ASSERT(testObj,
+                                 resetChannel(dummyWeakChannel.lock()));
         BSLS_PROTOCOLTEST_ASSERT(testObj,
                                  write(dummyBlob_sp,
                                        bmqp::EventType::e_CONTROL));

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -123,10 +123,7 @@ bool ClusterNodeImp::enableRead()
 ClusterNode* ClusterNodeImp::resetChannel(
     const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
-    d_channel.resetChannel(closedChannel);
-
-    bsl::shared_ptr<bmqio::Channel> currentSp = d_channel.channel();
-    if (currentSp) {
+    if (!d_channel.resetChannel(closedChannel)) {
         // The channel was not reset (stale close), skip cleanup.
         return this;  // RETURN
     }

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -120,9 +120,17 @@ bool ClusterNodeImp::enableRead()
     return true;
 }
 
-ClusterNode* ClusterNodeImp::resetChannel()
+ClusterNode* ClusterNodeImp::resetChannel(
+    const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
-    d_channel.resetChannel();
+    d_channel.resetChannel(closedChannel);
+
+    bsl::shared_ptr<bmqio::Channel> currentSp = d_channel.channel();
+    if (currentSp) {
+        // The channel was not reset (stale close), skip cleanup.
+        return this;  // RETURN
+    }
+
     d_isReading = false;
     d_identity.reset();
     d_readCb = bmqio::Channel::ReadCallback();

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -139,7 +139,9 @@ class ClusterNodeImp : public ClusterNode {
     bool enableRead() BSLS_KEYWORD_OVERRIDE;
 
     /// Reset the channel associated to this node.
-    ClusterNode* resetChannel() BSLS_KEYWORD_OVERRIDE;
+    ClusterNode*
+    resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
@@ -106,10 +106,7 @@ bool MockClusterNode::enableRead()
 ClusterNode* MockClusterNode::resetChannel(
     const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
-    d_channel.resetChannel(closedChannel);
-
-    bsl::shared_ptr<bmqio::Channel> currentSp = d_channel.channel();
-    if (currentSp) {
+    if (!d_channel.resetChannel(closedChannel)) {
         return this;  // RETURN
     }
 

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.cpp
@@ -103,9 +103,15 @@ bool MockClusterNode::enableRead()
     return true;
 }
 
-ClusterNode* MockClusterNode::resetChannel()
+ClusterNode* MockClusterNode::resetChannel(
+    const bsl::shared_ptr<bmqio::Channel>& closedChannel)
 {
-    d_channel.resetChannel();
+    d_channel.resetChannel(closedChannel);
+
+    bsl::shared_ptr<bmqio::Channel> currentSp = d_channel.channel();
+    if (currentSp) {
+        return this;  // RETURN
+    }
 
     // Notify the cluster of changes to this node
     d_cluster_p->notifyObserversOfNodeStateChange(this, false);

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -124,7 +124,9 @@ class MockClusterNode : public ClusterNode {
     bool enableRead() BSLS_KEYWORD_OVERRIDE;
 
     /// Reset the channel associated to this node.
-    ClusterNode* resetChannel() BSLS_KEYWORD_OVERRIDE;
+    ClusterNode*
+    resetChannel(const bsl::shared_ptr<bmqio::Channel>& closedChannel)
+        BSLS_KEYWORD_OVERRIDE;
 
     /// Enqueue the specified message `blob` of the specified `type`to be
     /// written to the channel associated to this node.  Return 0 on

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -152,13 +152,10 @@ bool TransportManager::processSession(
 
         // Add self as observer of the channel (so that we can monitor when it
         // goes down, and eventually initiate a reconnection).
-        bmqu::MemOutStream channelDescription;
-        channelDescription << session->channel().get();
-
         session->channel()->onClose(
             bdlf::BindUtil::bind(&TransportManager::onClose,
                                  this,
-                                 bsl::string(channelDescription.str()),
+                                 session->channel(),
                                  state));
 
         return true;  // RETURN
@@ -272,8 +269,9 @@ int TransportManager::connectLocked(ConnectionState* state)
         true);  // shouldAutoReconnect
 }
 
-void TransportManager::onClose(const bsl::string& channelDescription,
-                               ConnectionState*   state)
+void TransportManager::onClose(
+    const bsl::shared_ptr<bmqio::Channel>& closedChannel,
+    ConnectionState*                       state)
 {
     // executed by one of the *IO* threads
     // PRECONDITIONS
@@ -284,18 +282,18 @@ void TransportManager::onClose(const bsl::string& channelDescription,
     if (!state->d_node_p) {
         // The cluster was destroyed, we can just remove that ConnectionState
         // entry from the map
-        BALL_LOG_INFO << "Channel onClose [channel: '" << channelDescription
+        BALL_LOG_INFO << "Channel onClose [channel: '" << closedChannel.get()
                       << "']";
         d_connectionsState.erase(state);
         return;  // RETURN
     }
 
-    BALL_LOG_INFO << "Channel onClose [channel: '" << channelDescription
+    BALL_LOG_INFO << "Channel onClose [channel: '" << closedChannel.get()
                   << "', cluster: '" << state->d_node_p->cluster()->name()
                   << "']";
 
     // Notify node of lost of connectivity
-    state->d_node_p->resetChannel();
+    state->d_node_p->resetChannel(closedChannel);
 }
 
 int TransportManager::selfNodeIdLocked(

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
@@ -257,17 +257,11 @@ class TransportManager {
 
     // PRIVATE MANIPULATORS
 
-    /// Method invoked by the channel factory to notify that the channel
-    /// with the specified `channelDescription` went down; and with the
-    /// specified `state` corresponding to the `ConnectionState` associated
-    /// to this channel.  Note that we do not bind the channel but rather
-    /// the `channelDescription` because we have a hierarchy of channel
-    /// (`TCP < Resolving < Stat`); and when the close is invoked, it comes
-    /// from the lower channel (`bmqio::TCPChannel`) while the higher
-    /// channel (which is the one that would have been bindable at the time
-    /// of the `onClose` slot registration) has already been destroyed.
-    virtual void onClose(const bsl::string& channelDescription,
-                         ConnectionState*   state);
+    /// Method invoked by the channel factory to notify that the specified
+    /// `closedChannel` went down; and with the specified `state`
+    /// corresponding to the `ConnectionState` associated to this channel.
+    virtual void onClose(const bsl::shared_ptr<bmqio::Channel>& closedChannel,
+                         ConnectionState*                       state);
 
     // PRIVATE ACCESSORS
 


### PR DESCRIPTION
An existing connection can get disconnected and then connected in a different IO thread.
In this case, new `setChannel` can be called before old `resetChannel` resulting in the old `resetChannel` resetting  the new connection.
Need to detect stale `resetChannel` (by the channel, for example)
