### PR TITLE
Fix[test]: prevent leader change

### DIFF
--- a/src/integration-tests/test_strong_consistency.py
+++ b/src/integration-tests/test_strong_consistency.py
@@ -85,6 +85,11 @@ class TestStrongConsistency:
         leader = cluster.last_known_leader
         active_node = cluster.process(self.replica_proxy.get_active_node())
 
+        # Prevent the leader from losing its election when nodes go down;
+        # otherwise a new leader sends a CSL snapshot with different primaries
+        # and this scenario is currently not supported.
+        leader.set_quorum(1)
+
         # pylint: disable=cell-var-from-loop; passing lambda to 'wait_until' is safe
         with contextlib.ExitStack() as stack:
             # break non-active replica nodes


### PR DESCRIPTION
Currently the scenario when old leader loses leadership does not clear primaries.  Resulting in the old leader `e_UNSUPPORTED_SCENARIO`
_Temporary_ fix is to prevent leader change