### PR TITLE
Fix[mqb]: release event handlers before dtors

### DIFF
--- a/src/groups/mqb/mqba/mqba_domainmanager.cpp
+++ b/src/groups/mqb/mqba/mqba_domainmanager.cpp
@@ -758,7 +758,7 @@ int DomainManager::processCommand(mqbcmd::DomainsResult*        result,
                 clusterResult.storageResult().purgedQueues().queues();
             result->makeDomainResult(domainResult);
 
-            // 3. Mark DOMAIN REMOVED to accecpt the second pass
+            // 3. Mark DOMAIN REMOVED to accept the second pass
             bmqu::SharedResource<DomainManager> self(this);
             bslmt::Latch latch(1, bsls::SystemClockType::e_MONOTONIC);
 

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -265,7 +265,7 @@ Domain::Domain(const bsl::string&                     name,
 , d_teardownCb()
 , d_teardownRemoveCb()
 , d_mutex()
-, d_numQueues(0)
+, d_numQueues(1)
 {
     if (d_cluster_sp->isRemote()) {
         // In a remote domain, we don't care about monitoring, so disable it
@@ -409,8 +409,6 @@ void Domain::teardown(const mqbi::Domain::TeardownCb& teardownCb)
         BALL_LOG_INFO << "Stopping domain '" << d_name << "' having "
                       << d_queues.size() << " registered queues.";
 
-        d_numQueues.add(1);
-
         d_teardownCb = teardownCb;
         d_state      = e_STOPPING;
 
@@ -434,8 +432,6 @@ void Domain::teardownRemove(const TeardownCb& teardownCb)
 
         BALL_LOG_INFO << "Removing domain '" << d_name << "' having "
                       << d_queues.size() << " registered queues.";
-
-        d_numQueues.add(1);
 
         d_teardownRemoveCb = teardownCb;
 

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -55,21 +55,9 @@ namespace BloombergLP {
 namespace mqbblp {
 
 namespace {
-const char k_LOG_CATEGORY[] = "MQBBLP.DOMAIN";
 
 const char k_NODE_IS_STOPPING[]              = "Node is stopping";
 const char k_DOMAIN_IS_REMOVING_OR_REMOVED[] = "Domain is removing or removed";
-
-/// Validates an application subscription.
-/// This method does nothing.. it's just used so that we can control the
-/// destruction of the specified `queue` to happen once we guarantee the
-/// associated Dispatcher's queue has been drained and flushed.
-void queueHolderDummy(const bsl::shared_ptr<mqbi::Queue>& queue)
-{
-    BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
-
-    BALL_LOG_INFO << "Deleted queue '" << queue->uri().canonical() << "'";
-}
 
 bool validateSubscriptionExpression(bsl::ostream& errorDescription,
                                     const mqbconfm::Expression& expression,
@@ -586,7 +574,10 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
     bsl::shared_ptr<mqbi::Queue> queueSp(it->second);
     d_queues.erase(it);
 
-    queueSp->close(bdlf::BindUtil::bind(&queueHolderDummy, queueSp));
+    bslmt::Latch latch(1);
+    queueSp->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
+
+    latch.wait();
 
     BALL_LOG_INFO << "Unregistered queue from domain '" << d_name
                   << "' [canonicalURI: " << queueSp->uri().canonical() << "]. "

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -59,6 +59,7 @@ namespace {
 const char k_NODE_IS_STOPPING[]              = "Node is stopping";
 const char k_DOMAIN_IS_REMOVING_OR_REMOVED[] = "Domain is removing or removed";
 
+/// Validates an application subscription.
 bool validateSubscriptionExpression(bsl::ostream& errorDescription,
                                     const mqbconfm::Expression& expression,
                                     bslma::Allocator*           allocator)
@@ -264,6 +265,7 @@ Domain::Domain(const bsl::string&                     name,
 , d_teardownCb()
 , d_teardownRemoveCb()
 , d_mutex()
+, d_numQueues(0)
 {
     if (d_cluster_sp->isRemote()) {
         // In a remote domain, we don't care about monitoring, so disable it
@@ -400,22 +402,24 @@ void Domain::teardown(const mqbi::Domain::TeardownCb& teardownCb)
     // is atomic.  Otherwise, there is a chance due to race that 'teardownCb'
     // can be executed more than once.
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
+    QueueMap queues(d_allocator_p);
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
 
-    BALL_LOG_INFO << "Stopping domain '" << d_name << "' having "
-                  << d_queues.size() << " registered queues.";
+        BALL_LOG_INFO << "Stopping domain '" << d_name << "' having "
+                      << d_queues.size() << " registered queues.";
 
-    d_teardownCb = teardownCb;
-    d_state      = e_STOPPING;
+        d_numQueues.add(1);
 
-    if (d_queues.empty()) {
-        d_teardownCb(d_name);
-        d_teardownCb = bsl::nullptr_t();
-        d_state      = e_STOPPED;
-        return;  // RETURN
+        d_teardownCb = teardownCb;
+        d_state      = e_STOPPING;
+
+        queues.swap(d_queues);
     }
 
-    closeAllQueues();
+    closeAllQueues(queues);
+
+    subtractQueueCount();
 }
 
 void Domain::teardownRemove(const TeardownCb& teardownCb)
@@ -424,21 +428,23 @@ void Domain::teardownRemove(const TeardownCb& teardownCb)
     BSLS_ASSERT_SAFE(!d_teardownRemoveCb);
     BSLS_ASSERT_SAFE(teardownCb);
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
+    QueueMap queues(d_allocator_p);
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
 
-    BALL_LOG_INFO << "Removing domain '" << d_name << "' having "
-                  << d_queues.size() << " registered queues.";
+        BALL_LOG_INFO << "Removing domain '" << d_name << "' having "
+                      << d_queues.size() << " registered queues.";
 
-    d_teardownRemoveCb = teardownCb;
+        d_numQueues.add(1);
 
-    if (d_queues.empty()) {
-        d_teardownRemoveCb(d_name);
-        d_teardownRemoveCb = bsl::nullptr_t();
-        d_state            = e_STOPPED;
-        return;  // RETURN
+        d_teardownRemoveCb = teardownCb;
+
+        queues.swap(d_queues);
     }
 
-    closeAllQueues();
+    closeAllQueues(queues);
+
+    subtractQueueCount();
 }
 
 void Domain::openQueue(
@@ -537,6 +543,8 @@ int Domain::registerQueue(const bsl::shared_ptr<mqbi::Queue>& queueSp)
         // (assuming Queue.configure() will succeed).
 
         d_queues[queueSp->uri().queue()] = queueSp;
+
+        d_numQueues.add(1);
     }
 
     BALL_LOG_INFO << "Registered queue to domain '" << d_name << "' "
@@ -555,49 +563,38 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_sp->inDispatcherThread());
 
-    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+    bsl::shared_ptr<mqbi::Queue> queueSp;
+    size_t                       count = 0;
 
-    QueueMap::const_iterator it = d_queues.find(queue->uri().queue());
-    BSLS_ASSERT_SAFE(it != d_queues.end() &&
-                     "Queue was not registered with domain");
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
 
-    if (it == d_queues.end()) {
-        BALL_LOG_ERROR << "#DOMAIN_QUEUE_REGISTRATION_FAILURE "
-                       << "Unable to unregister queue '"
-                       << queue->uri().queue() << "' "
-                       << "from domain '" << d_name
-                       << "' [reason: queue was not "
-                       << "registered]";
-        return;  // RETURN
+        QueueMap::const_iterator it = d_queues.find(queue->uri().queue());
+
+        if (it == d_queues.end()) {
+            // Can be a result of concurrent 'tearDown'.
+            BALL_LOG_WARN << "Domain '" << d_name
+                          << "' skips unregistering unknown queue '"
+                          << queue->uri().queue() << "'.";
+            return;  // RETURN
+        }
+
+        queueSp = bslmf::MovableRefUtil::move(it->second);
+        d_queues.erase(it);
+
+        count = d_queues.size();
+        // unlock
     }
 
-    bsl::shared_ptr<mqbi::Queue> queueSp(it->second);
-    d_queues.erase(it);
+    BSLS_ASSERT_SAFE(queueSp);
 
-    bslmt::Latch latch(1);
-    queueSp->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
-
-    latch.wait();
+    queueSp->close(
+        bdlf::BindUtil::bind(&Domain::onQueueClosed, this, queueSp));
 
     BALL_LOG_INFO << "Unregistered queue from domain '" << d_name
                   << "' [canonicalURI: " << queueSp->uri().canonical() << "]. "
                   << "Total number of registered queues in the domain: "
-                  << d_queues.size();
-
-    // Refer to note in 'teardown' routine to see why 'd_state' is updated
-    // while 'd_mutex' is acquired.
-    if (d_queues.empty()) {
-        if (d_teardownCb) {
-            d_teardownCb(d_name);
-            d_teardownCb = bsl::nullptr_t();
-            d_state      = e_STOPPED;
-        }
-        if (d_teardownRemoveCb) {
-            d_teardownRemoveCb(d_name);
-            d_teardownRemoveCb = bsl::nullptr_t();
-            d_state            = e_STOPPED;
-        }
-    }
+                  << count;
 }
 
 int Domain::processCommand(mqbcmd::DomainResult*        result,
@@ -777,15 +774,52 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
     return -1;
 }
 
-void Domain::closeAllQueues()
+void Domain::closeAllQueues(const QueueMap& queues)
 {
-    bslmt::Latch latch(d_queues.size());
-    for (QueueMap::iterator it = d_queues.begin(); it != d_queues.end();
-         ++it) {
-        it->second->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
+    for (QueueMap::const_iterator cit = queues.begin(); cit != queues.end();
+         ++cit) {
+        const bsl::shared_ptr<mqbi::Queue>& queueSp = cit->second;
+        queueSp->close(
+            bdlf::BindUtil::bind(&Domain::onQueueClosed, this, queueSp));
     }
+}
 
-    latch.wait();
+void Domain::onQueueClosed(const bsl::shared_ptr<mqbi::Queue>& closedQueue)
+{
+    BSLS_ASSERT_SAFE(closedQueue);
+
+    BALL_LOG_INFO << "Deleted queue '" << closedQueue->uri().canonical()
+                  << "'";
+
+    subtractQueueCount();
+}
+
+void Domain::subtractQueueCount()
+{
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
+
+    --d_numQueues;
+
+    if (d_numQueues == 0) {
+        // Refer to note in 'teardown' routine to see why 'd_state' is updated
+        // while 'd_mutex' is acquired.
+
+        if (d_teardownCb) {
+            d_teardownCb(d_name);
+            d_teardownCb = bsl::nullptr_t();
+            d_state      = e_STOPPED;
+
+            BALL_LOG_INFO << "Torn down domain '" << d_name << "'.";
+        }
+        if (d_teardownRemoveCb) {
+            d_teardownRemoveCb(d_name);
+            d_teardownRemoveCb = bsl::nullptr_t();
+            d_state            = e_STOPPED;
+
+            BALL_LOG_INFO << "Torn down domain '" << d_name
+                          << "' for removal.";
+        }
+    }
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -55,20 +55,9 @@ namespace BloombergLP {
 namespace mqbblp {
 
 namespace {
-const char k_LOG_CATEGORY[] = "MQBBLP.DOMAIN";
 
 const char k_NODE_IS_STOPPING[]              = "Node is stopping";
 const char k_DOMAIN_IS_REMOVING_OR_REMOVED[] = "Domain is removing or removed";
-
-/// This method does nothing.. it's just used so that we can control the
-/// destruction of the specified `queue` to happen once we guarantee the
-/// associated Dispatcher's queue has been drained and flushed.
-void queueHolderDummy(const bsl::shared_ptr<mqbi::Queue>& queue)
-{
-    BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
-
-    BALL_LOG_INFO << "Deleted queue '" << queue->uri().canonical() << "'";
-}
 
 /// Validates an application subscription.
 bool validateSubscriptionExpression(bsl::ostream& errorDescription,
@@ -427,10 +416,7 @@ void Domain::teardown(const mqbi::Domain::TeardownCb& teardownCb)
         return;  // RETURN
     }
 
-    for (QueueMap::iterator it = d_queues.begin(); it != d_queues.end();
-         ++it) {
-        it->second->close();
-    }
+    closeAllQueues();
 }
 
 void Domain::teardownRemove(const TeardownCb& teardownCb)
@@ -453,10 +439,7 @@ void Domain::teardownRemove(const TeardownCb& teardownCb)
         return;  // RETURN
     }
 
-    for (QueueMap::iterator it = d_queues.begin(); it != d_queues.end();
-         ++it) {
-        it->second->close();
-    }
+    closeAllQueues();
 }
 
 void Domain::openQueue(
@@ -592,21 +575,10 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
     bsl::shared_ptr<mqbi::Queue> queueSp(it->second);
     d_queues.erase(it);
 
-    // Close the queue before we schedule Dummy event so that we can clear
-    // any pending messages before the destruction of the queue
-    queueSp->close();
+    bslmt::Latch latch(1);
+    queueSp->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
 
-    // We need to make sure the 'queue' is not in its associated dispatcher's
-    // thread (flush list or 'expirePendingMessagesDispatched': for that
-    // purpose, enqueue an 'e_DISPATCHER' type event with the shared_ptr to the
-    // queue; once it gets processed, we have guarantees that the dispatcher's
-    // work is done and therefore can then safely delete the queue.
-    //
-    // This code relies on queue being in an 'empty' state meaning it will NOT
-    // schedule any new dispatcher work.
-    d_dispatcher_p->execute(bdlf::BindUtil::bind(&queueHolderDummy, queueSp),
-                            queueSp.get(),
-                            mqbi::DispatcherEventType::e_DISPATCHER);
+    latch.wait();
 
     BALL_LOG_INFO << "Unregistered queue from domain '" << d_name
                   << "' [canonicalURI: " << queueSp->uri().canonical() << "]. "
@@ -804,6 +776,17 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
     os << "Unknown command '" << command << "'";
     result->makeError().message() = os.str();
     return -1;
+}
+
+void Domain::closeAllQueues()
+{
+    bslmt::Latch latch(d_queues.size());
+    for (QueueMap::iterator it = d_queues.begin(); it != d_queues.end();
+         ++it) {
+        it->second->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
+    }
+
+    latch.wait();
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -55,11 +55,22 @@ namespace BloombergLP {
 namespace mqbblp {
 
 namespace {
+const char k_LOG_CATEGORY[] = "MQBBLP.DOMAIN";
 
 const char k_NODE_IS_STOPPING[]              = "Node is stopping";
 const char k_DOMAIN_IS_REMOVING_OR_REMOVED[] = "Domain is removing or removed";
 
 /// Validates an application subscription.
+/// This method does nothing.. it's just used so that we can control the
+/// destruction of the specified `queue` to happen once we guarantee the
+/// associated Dispatcher's queue has been drained and flushed.
+void queueHolderDummy(const bsl::shared_ptr<mqbi::Queue>& queue)
+{
+    BALL_LOG_SET_CATEGORY(k_LOG_CATEGORY);
+
+    BALL_LOG_INFO << "Deleted queue '" << queue->uri().canonical() << "'";
+}
+
 bool validateSubscriptionExpression(bsl::ostream& errorDescription,
                                     const mqbconfm::Expression& expression,
                                     bslma::Allocator*           allocator)
@@ -575,10 +586,7 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
     bsl::shared_ptr<mqbi::Queue> queueSp(it->second);
     d_queues.erase(it);
 
-    bslmt::Latch latch(1);
-    queueSp->close(bdlf::BindUtil::bind(&bslmt::Latch::arrive, &latch));
-
-    latch.wait();
+    queueSp->close(bdlf::BindUtil::bind(&queueHolderDummy, queueSp));
 
     BALL_LOG_INFO << "Unregistered queue from domain '" << d_name
                   << "' [canonicalURI: " << queueSp->uri().canonical() << "]. "

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -179,6 +179,8 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     /// Mutex for protecting the queues map.
     mutable bslmt::Mutex d_mutex;
 
+    bsls::AtomicInt d_numQueues;
+
   private:
     // PRIVATE MANIPULATORS
 
@@ -207,8 +209,17 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     Domain(const Domain&);             // = delete;
     Domain& operator=(const Domain&);  // = delete;
 
-    /// Call close for all queues and wait for all callbacks.
-    void closeAllQueues();
+    /// Call close for all `queues`.
+    void closeAllQueues(const QueueMap& queues);
+
+    /// This method runs when the 'closedQueue' is done closing.  The domain
+    /// can be waiting for 'teardownCb' and/or 'teardownRemoveCb' to complete
+    /// shutdown/removal.
+    void onQueueClosed(const bsl::shared_ptr<mqbi::Queue>& closedQueue);
+
+    /// Decrement `d_numQueues` and call `d_teardownCb`/`d_teardownRemoveCb` if
+    /// it drops to `0`.
+    void subtractQueueCount();
 
   public:
     // TRAITS

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -207,6 +207,9 @@ class Domain BSLS_KEYWORD_FINAL : public mqbi::Domain {
     Domain(const Domain&);             // = delete;
     Domain& operator=(const Domain&);  // = delete;
 
+    /// Call close for all queues and wait for all callbacks.
+    void closeAllQueues();
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(Domain, bslma::UsesBslmaAllocator)

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -334,12 +334,14 @@ void Queue::dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure)
     }
 }
 
-void Queue::closeDispatched()
+void Queue::closeDispatched(const bsl::function<void(void)>& callback)
 {
     // executed by the *QUEUE* dispatcher thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(inDispatcherThread());
+
+    queueEngine()->close();
 
     if (d_localQueue_mp) {
         d_localQueue_mp->close();
@@ -352,6 +354,18 @@ void Queue::closeDispatched()
     }
 
     updateStats();
+
+    // Enqueue the holder AFTER 'engine->close()'.  Any two-hop callbacks
+    // (scheduler -> queue dispatcher) triggered during 'cancelEventAndWait'
+    // are already on the dispatcher queue ahead of this holder, so the
+    // queue stays alive until they complete.
+
+    // We need to make sure the 'queue' is not in the dispatcher's flush list:
+    // for that purpose, enqueue an 'e_DISPATCHER' type event.
+
+    dispatcher()->execute(callback,
+                          this,
+                          mqbi::DispatcherEventType::e_DISPATCHER);
 }
 
 void Queue::convertToLocalDispatched()
@@ -776,12 +790,13 @@ void Queue::dropHandle(mqbi::QueueHandle* handle, bool doDeconfigure)
                           this);
 }
 
-void Queue::close()
+void Queue::close(const bsl::function<void(void)>& callback)
 {
     // executed by *ANY* thread
 
-    dispatcher()->execute(bdlf::BindUtil::bind(&Queue::closeDispatched, this),
-                          this);
+    dispatcher()->execute(
+        bdlf::BindUtil::bind(&Queue::closeDispatched, this, callback),
+        this);
 }
 
 void Queue::onPushMessage(

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -148,7 +148,7 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
 
     void dropHandleDispatched(mqbi::QueueHandle* handle, bool doDeconfigure);
 
-    void closeDispatched();
+    void closeDispatched(const bsl::function<void(void)>& callback);
 
     void convertToLocalDispatched();
 
@@ -251,10 +251,12 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
     void dropHandle(mqbi::QueueHandle* handle,
                     bool doDeconfigure = true) BSLS_KEYWORD_OVERRIDE;
 
-    /// Close this queue.
+    /// Close this queue.  Call the specified `callback` when the queue does
+    /// not have any outstanding events.
     ///
     /// THREAD: this method can be called from any thread.
-    void close() BSLS_KEYWORD_OVERRIDE;
+    void
+    close(const bsl::function<void(void)>& callback) BSLS_KEYWORD_OVERRIDE;
 
     /// Return the resource capacity meter associated to this queue, if
     /// any, or a null pointer otherwise.

--- a/src/groups/mqb/mqbblp/mqbblp_queue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.h
@@ -252,7 +252,7 @@ class Queue BSLS_CPP11_FINAL : public mqbi::Queue {
                     bool doDeconfigure = true) BSLS_KEYWORD_OVERRIDE;
 
     /// Close this queue.  Call the specified `callback` when the queue does
-    /// not have any outstanding events.
+    /// not have any outstanding events and can destruct.
     ///
     /// THREAD: this method can be called from any thread.
     void

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -412,7 +412,14 @@ QueueEngineTester::~QueueEngineTester()
     BSLS_ASSERT_OPT(d_clientContexts.empty());
 
     d_deletedHandles.clear();
-    d_mockDomain_mp->unregisterQueue(d_mockQueue_sp.get());
+
+    // Release the extra reference so that the Domain holds the sole
+    // reference, mimicking the production 'deleteQueue' path where
+    // 'unregisterQueue' is responsible for the queue's lifetime.
+    mqbi::Queue* queue = d_mockQueue_sp.get();
+    d_mockQueue_sp.reset();
+    d_mockDomain_mp->unregisterQueue(queue);
+
     d_mockCluster_mp->stop();
     oneTimeShutdown();
 }

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -1057,6 +1057,11 @@ int RelayQueueEngine::configure(
     return 0;
 }
 
+void RelayQueueEngine::close()
+{
+    // NOTHING
+}
+
 void RelayQueueEngine::resetState(bool isShuttingDown)
 {
     for (AppsMap::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -386,8 +386,7 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     int configure(bsl::ostream& errorDescription,
                   bool          isReconfigure) BSLS_KEYWORD_OVERRIDE;
 
-    /// Prepare this engine for destruction by cancelling any scheduled
-    /// events.
+    /// Prepare this engine for destruction by canceling all scheduled events.
     void close() BSLS_KEYWORD_OVERRIDE;
 
     /// Reset the internal state of this engine.  If the optionally specified

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -386,6 +386,10 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     int configure(bsl::ostream& errorDescription,
                   bool          isReconfigure) BSLS_KEYWORD_OVERRIDE;
 
+    /// Prepare this engine for destruction by cancelling any scheduled
+    /// events.
+    void close() BSLS_KEYWORD_OVERRIDE;
+
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
     /// processing.

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -557,6 +557,15 @@ int RootQueueEngine::initializeAppId(const bsl::string& appId,
     return 0;
 }
 
+void RootQueueEngine::close()
+{
+    if (d_flowControlEventHandle) {
+        d_scheduler_p->cancelEventAndWait(&d_flowControlEventHandle);
+    }
+
+    d_consumptionMonitor.reset();
+}
+
 void RootQueueEngine::resetState(bool isShuttingDown)
 {
     // executed by the *QUEUE DISPATCHER* thread
@@ -564,16 +573,12 @@ void RootQueueEngine::resetState(bool isShuttingDown)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->inDispatcherThread());
 
-    if (d_flowControlEventHandle) {
-        d_scheduler_p->cancelEventAndWait(&d_flowControlEventHandle);
-    }
+    close();
 
     for (Apps::iterator it = d_apps.begin(); it != d_apps.end(); ++it) {
         it->second->undoRouting();
         it->second->routing()->reset();
     }
-
-    d_consumptionMonitor.reset();
 
     if (!isShuttingDown) {
         d_apps.clear();

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -559,9 +559,7 @@ int RootQueueEngine::initializeAppId(const bsl::string& appId,
 
 void RootQueueEngine::close()
 {
-    if (d_flowControlEventHandle) {
-        d_scheduler_p->cancelEventAndWait(&d_flowControlEventHandle);
-    }
+    d_scheduler_p->cancelEventAndWait(&d_flowControlEventHandle);
 
     d_consumptionMonitor.reset();
 }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -263,6 +263,10 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     int configure(bsl::ostream& errorDescription,
                   bool          isReconfigure) BSLS_KEYWORD_OVERRIDE;
 
+    /// Prepare this engine for destruction by cancelling any scheduled
+    /// events.
+    void close() BSLS_KEYWORD_OVERRIDE;
+
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
     /// processing.

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -263,8 +263,7 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     int configure(bsl::ostream& errorDescription,
                   bool          isReconfigure) BSLS_KEYWORD_OVERRIDE;
 
-    /// Prepare this engine for destruction by cancelling any scheduled
-    /// events.
+    /// Prepare this engine for destruction by canceling all scheduled events.
     void close() BSLS_KEYWORD_OVERRIDE;
 
     /// Reset the internal state of this engine.  If the optionally specified

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -5136,6 +5136,51 @@ static void test48_unknownReject()
     BMQTST_ASSERT_EQ(C1->_numMessages("a"), 3);
 }
 
+static void test49_closeWithScheduledAlarm()
+// ------------------------------------------------------------------------
+// CLOSE WITH SCHEDULED ALARM
+//
+// Concerns:
+//   When a queue is destroyed via the non-shutdown path (deleteQueue ->
+//   unregisterQueue -> close), any scheduled consumption monitor alarm
+//   must be cancelled before the engine is destroyed.  Otherwise the
+//   destructor assertion fires and, in production, the scheduler callback
+//   causes a use-after-free.
+//
+// Plan:
+//   1) Configure a priority queue with a large maxIdleTime.
+//   2) Get a consumer handle, post a message.  This triggers
+//      QueueConsumptionMonitor::onMessagePosted which schedules the alarm.
+//   3) Drop handles and let the tester destruct.  The mock Domain's
+//      unregisterQueue calls Queue::close() -> engine->close() which must
+//      cancel the alarm.
+// Testing:
+//   RootQueueEngine::close() cancels the consumption monitor alarm.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CLOSE WITH SCHEDULED ALARM");
+
+    mqbconfm::Domain config = priorityDomainConfig();
+    config.maxIdleTime()    = 1000;
+
+    mqbblp::QueueEngineTester tester(config,
+                                     true,  // startScheduler
+                                     bmqtst::TestHelperUtil::allocator());
+
+    mqbblp::QueueEngineTesterGuard<mqbblp::RootQueueEngine> guard(&tester);
+
+    tester.getHandle("C1 readCount=1");
+    tester.configureHandle("C1 consumerPriority=1 consumerPriorityCount=1");
+
+    tester.post("1");
+    guard.engine()->afterPostMessage();
+    tester.afterNewMessage(1);
+
+    // At this point, d_alarmEventHandle is set in the consumption monitor.
+    // Without the fix, destruction would crash on:
+    //   BSLS_ASSERT_SAFE(!d_alarmEventHandle)
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -5155,6 +5200,7 @@ int main(int argc, char* argv[])
 
         switch (_testCase) {
         case 0:
+        case 49: test49_closeWithScheduledAlarm(); break;
         case 48: test48_unknownReject(); break;
         case 47: test47_handleParametersLimits(); break;
         case 46: test46_throttleRedeliveryNoMoreHandles(); break;

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -869,10 +869,11 @@ class Queue : public DispatcherClient {
     virtual void dropHandle(QueueHandle* handle,
                             bool         doDeconfigure = true) = 0;
 
-    /// Close this queue.
+    /// Close this queue.  Call the specified `callback` when the queue does
+    /// not have any outstanding events.
     ///
     /// THREAD: this method can be called from any thread.
-    virtual void close() = 0;
+    virtual void close(const bsl::function<void(void)>& callback) = 0;
 
     /// Return the resource capacity meter associated to this queue, if
     /// any, or a null pointer otherwise.

--- a/src/groups/mqb/mqbi/mqbi_queue.h
+++ b/src/groups/mqb/mqbi/mqbi_queue.h
@@ -870,7 +870,7 @@ class Queue : public DispatcherClient {
                             bool         doDeconfigure = true) = 0;
 
     /// Close this queue.  Call the specified `callback` when the queue does
-    /// not have any outstanding events.
+    /// not have any outstanding events and can destruct.
     ///
     /// THREAD: this method can be called from any thread.
     virtual void close(const bsl::function<void(void)>& callback) = 0;

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -75,6 +75,10 @@ class QueueEngine {
     virtual int configure(bsl::ostream& errorDescription,
                           bool          isReconfigure) = 0;
 
+    /// Prepare this engine for destruction by cancelling any scheduled
+    /// events.
+    virtual void close() = 0;
+
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'isShuttingDown' is 'true', clear the routing state but keep the Apps
     /// state for CONFIRMs processing.

--- a/src/groups/mqb/mqbi/mqbi_queueengine.h
+++ b/src/groups/mqb/mqbi/mqbi_queueengine.h
@@ -75,8 +75,7 @@ class QueueEngine {
     virtual int configure(bsl::ostream& errorDescription,
                           bool          isReconfigure) = 0;
 
-    /// Prepare this engine for destruction by cancelling any scheduled
-    /// events.
+    /// Prepare this engine for destruction by canceling all scheduled events.
     virtual void close() = 0;
 
     /// Reset the internal state of this engine.  If the optionally specified

--- a/src/groups/mqb/mqbmock/mqbmock_domain.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_domain.cpp
@@ -121,12 +121,14 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
     BSLS_ASSERT_SAFE(lookupQueue(0, queue->uri()) == 0 &&
                      "'queue' was not registered with the domain");
 
-    QueueMap::const_iterator it = d_queues.find(queue->uri().queue());
+    QueueMap::iterator it = d_queues.find(queue->uri().queue());
     if (it == d_queues.end()) {
         return;  // RETURN
     }
 
+    bsl::shared_ptr<mqbi::Queue> queueSp(it->second);
     d_queues.erase(it);
+    queueSp->close(bsl::function<void(void)>());
 }
 
 void Domain::unregisterAppId(BSLA_MAYBE_UNUSED const bsl::string& appId)

--- a/src/groups/mqb/mqbmock/mqbmock_queue.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.cpp
@@ -225,9 +225,15 @@ void Queue::dropHandle(mqbi::QueueHandle* handle, bool doDeconfigure)
     }
 }
 
-void Queue::close()
+void Queue::close(const bsl::function<void(void)>& callback)
 {
-    // NOTHING
+    if (d_queueEngine_p) {
+        d_queueEngine_p->close();
+    }
+
+    if (callback) {
+        callback();
+    }
 }
 
 mqbu::CapacityMeter* Queue::capacityMeter()

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -230,10 +230,12 @@ class Queue : public mqbi::Queue {
     void dropHandle(mqbi::QueueHandle* handle,
                     bool doDeconfigure = true) BSLS_KEYWORD_OVERRIDE;
 
-    /// Close this queue.
+    /// Close this queue.  Call the specified `callback` when the queue does
+    /// not have any outstanding events.
     ///
     /// THREAD: this method can be called from any thread.
-    void close() BSLS_KEYWORD_OVERRIDE;
+    void
+    close(const bsl::function<void(void)>& callback) BSLS_KEYWORD_OVERRIDE;
 
     /// Return the resource capacity meter associated to this queue, if any,
     /// or a null pointer otherwise.

--- a/src/groups/mqb/mqbmock/mqbmock_queue.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queue.h
@@ -231,7 +231,7 @@ class Queue : public mqbi::Queue {
                     bool doDeconfigure = true) BSLS_KEYWORD_OVERRIDE;
 
     /// Close this queue.  Call the specified `callback` when the queue does
-    /// not have any outstanding events.
+    /// not have any outstanding events and can destruct.
     ///
     /// THREAD: this method can be called from any thread.
     void

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.cpp
@@ -45,6 +45,11 @@ int QueueEngine::configure(BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
     return 0;
 }
 
+void QueueEngine::close()
+{
+    // NOTHING
+}
+
 void QueueEngine::resetState(BSLA_MAYBE_UNUSED bool keepConfirming)
 {
     // NOTHING

--- a/src/groups/mqb/mqbmock/mqbmock_queueengine.h
+++ b/src/groups/mqb/mqbmock/mqbmock_queueengine.h
@@ -88,6 +88,10 @@ class QueueEngine : public mqbi::QueueEngine {
     int configure(bsl::ostream& errorDescription,
                   bool          isReconfigure) BSLS_KEYWORD_OVERRIDE;
 
+    /// Prepare this engine for destruction by cancelling any scheduled
+    /// events.
+    void close() BSLS_KEYWORD_OVERRIDE;
+
     /// Reset the internal state of this engine.  If the optionally specified
     /// 'keepConfirming' is 'true', keep the data structures for CONFIRMs
     /// processing.


### PR DESCRIPTION
Need to cancel `QueueConsumptionMonitor::d_alarmEventHandle` before destructing.
Otherwise, if `maxIdleTimeSec` is long enough, `BSLS_ASSERT_SAFE(!d_alarmEventHandle)` fires in dtor.

Similar with `RootQueueEngine::d_flowControlEventHandle` (not used now).

Also, handle the extra hop not covered by `cancelEventAndWait` in a generic way.