### PR TITLE
Fix[mqb]: On restoreState, transition empty streams to k_OPEN

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -912,9 +912,7 @@ void ClusterQueueHelper::finishReopening(QueueContext*        queueContext,
     }
 
     if (0 == --queueContext->d_liveQInfo.d_numReopenQueueRequests) {
-        if (isOpen) {
-            processPendingContexts(queueContext);
-        }
+        processPendingContexts(queueContext);
     }
 }
 
@@ -1008,7 +1006,10 @@ void ClusterQueueHelper::processOpenQueueRequest(
     // At this time, the Queue must have been assigned an id/partition.
 
     if (d_cluster_p->isRemote()) {
-        BSLS_ASSERT_SAFE(d_clusterData_p->electorInfo().hasActiveLeader());
+        if (!d_clusterData_p->electorInfo().hasActiveLeader()) {
+            context->queueContext()->d_liveQInfo.d_pending.push_back(context);
+            return;  // RETURN
+        }
 
         assignUpstreamSubqueueId(context);
 
@@ -1128,6 +1129,20 @@ void ClusterQueueHelper::sendOpenQueueRequest(
 
     SubQueueContext&          subQueueContext = subStreamIt->value();
     bmqt::GenericResult::Enum rc = bmqt::GenericResult::e_NOT_READY;
+
+    if (subQueueContext.d_state == SubQueueContext::k_FAILED) {
+        bmqp_ctrlmsg::Status failure(d_allocator_p);
+        failure.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        failure.code()     = bmqt::GenericResult::e_REFUSED;
+        failure.message().assign("Queue reopen has failed");
+
+        finishOpening(context,
+                      failure,
+                      0,
+                      bmqp_ctrlmsg::OpenQueueResponse(),
+                      mqbi::OpenQueueConfirmationCookieSp());
+        return;  // RETURN
+    }
 
     if (subQueueContext.d_state == SubQueueContext::k_OPEN) {
         RequestManagerType::RequestSp request =
@@ -1276,7 +1291,7 @@ bmqt::GenericResult::Enum ClusterQueueHelper::sendReopenQueueRequest(
             << "ReopenQueue request: " << request->request() << ", rc: " << rc
             << ".";
 
-        setAsClosed(subQueueContext);
+        setStreamState(subQueueContext, SubQueueContext::k_CLOSED);
     }
     return rc;
 }
@@ -1434,8 +1449,7 @@ void ClusterQueueHelper::onOpenQueueResponse(
     bmqp::QueueUtil::subtractHandleParameters(&subQueueContext.d_parameters,
                                               context->d_handleParameters);
 
-    if (!retry || d_cluster_p->isStopping() ||
-        subQueueContext.d_state == SubQueueContext::k_FAILED) {
+    if (!retry || d_cluster_p->isStopping()) {
         finishOpening(context,
                       requestContext->response().choice().status(),
                       0,
@@ -1565,7 +1579,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
 
     if (bmqt::GenericResult::e_SUCCESS != requestContext->result()) {
         // Can now process Close requests instead of caching them
-        setAsClosed(&subQueueContext);
+        setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
 
         if (bmqt::GenericResult::e_CANCELED == requestContext->result()) {
             // Connection to upstream has been lost.  Simply decrement the
@@ -1748,7 +1762,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
         // Decrement all counters.
         // Do not report "state is restored"
 
-        setAsClosed(&subQueueContext);
+        setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
 
         // TBD: Note that invoking 'd_queue_p->streamParameters()' above is not
         // thread safe as queue's parameteres are supposed to be read/written
@@ -3590,7 +3604,7 @@ bool ClusterQueueHelper::subtractCounters(
             << itSubStream->appId() << ", " << itSubStream->subId()
             << "] on close-queue request for queue [" << handleParameters.uri()
             << "].";
-        setAsClosed(&subQueueContext);
+        setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
         qinfo->d_subQueueIds.erase(itSubStream);
 
         return false;
@@ -3965,11 +3979,14 @@ void ClusterQueueHelper::restoreStateCluster(int partitionId)
                     // queue, but the queue has not been deleted by the
                     // primary if another replica still uses it; however
                     // from this replica's perspective, we don't want to
-                    // reopen the queue.
+                    // reopen the queue.  Transition state back to k_OPEN
+                    // so that any pending open requests can proceed.
                     BMQ_LOGTHROTTLE_INFO
                         << d_cluster_p->description()
                         << ": Skipping restore of " << queueContext->uri()
                         << " because it has no active queue handles";
+
+                    setStreamState(queueContext, SubQueueContext::k_OPEN);
                 }
 
                 // We also need to issue requests for any pending contexts:
@@ -4027,12 +4044,14 @@ bmqt::GenericResult::Enum ClusterQueueHelper::restoreStateHelper(
                 << "[parameters: " << parameters
                 << ", reason: 'All read,write,admin counts are <= 0]";
 
-            return bmqt::GenericResult::e_INVALID_ARGUMENT;  // RETURN
+            setStreamState(&subQueueContext, SubQueueContext::k_OPEN);
+            continue;  // CONTINUE
         }
         const SubQueueContext::Enum state = subQueueContext.d_state;
         if (subQueueContext.d_generationCount == generationCount) {
             if (state == SubQueueContext::k_REOPENING ||
-                state == SubQueueContext::k_OPEN) {
+                state == SubQueueContext::k_OPEN ||
+                state == SubQueueContext::k_FAILED) {
                 BMQ_LOGTHROTTLE_INFO
                     << d_cluster_p->description()
                     << ": Not sending ReopenQueue request to "
@@ -4044,7 +4063,7 @@ bmqt::GenericResult::Enum ClusterQueueHelper::restoreStateHelper(
         }
         // else will send new request and drop the pending response
 
-        setAsClosed(&subQueueContext);
+        setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
 
         // All pending Open requests must be cancelled by 'cancelAllRequests'
         // upon node state change or Stop request or active node down.
@@ -4455,7 +4474,7 @@ void ClusterQueueHelper::onQueueUnassigned(
                     -1);
             }
             d_queuesById.erase(qinfo.d_id);
-            setAsClosed(queueContextSp);
+            setStreamState(queueContextSp, SubQueueContext::k_CLOSED);
             qinfo.resetButKeepPending();
             // CQH will recreate 'queueContextSp->d_liveQInfo.d_queue_sp' upon
             // 'onOpenQueueResponse'
@@ -4606,7 +4625,7 @@ void ClusterQueueHelper::onUpstreamNodeChange(mqbnet::ClusterNode* node,
         }
 
         if (node == 0) {
-            setAsClosed(queueContextSp);
+            setStreamState(queueContextSp, SubQueueContext::k_CLOSED);
             // Replica makes all open queues buffer PUTs.
             queue->dispatcher()->execute(
                 bdlf::BindUtil::bindS(d_allocator_p,
@@ -4617,21 +4636,25 @@ void ClusterQueueHelper::onUpstreamNodeChange(mqbnet::ClusterNode* node,
     }
 }
 
-void ClusterQueueHelper::setAsClosed(SubQueueContext* subQueueContext)
+void ClusterQueueHelper::setStreamState(SubQueueContext*      subQueueContext,
+                                        SubQueueContext::Enum state)
 {
-    d_clusterData_p->scheduler().cancelEvent(
-        &subQueueContext->d_reopenRetryHandle);
-    subQueueContext->d_state = SubQueueContext::k_CLOSED;
+    if (state != SubQueueContext::k_REOPENING) {
+        d_clusterData_p->scheduler().cancelEvent(
+            &subQueueContext->d_reopenRetryHandle);
+    }
+    subQueueContext->d_state = state;
 }
 
-void ClusterQueueHelper::setAsClosed(const QueueContextSp& queueContextSp)
+void ClusterQueueHelper::setStreamState(const QueueContextSp& queueContextSp,
+                                        SubQueueContext::Enum state)
 {
     QueueLiveState& queueInfo = queueContextSp->d_liveQInfo;
 
     for (StreamsMap::iterator iter = queueInfo.d_subQueueIds.begin();
          iter != queueInfo.d_subQueueIds.end();
          ++iter) {
-        setAsClosed(&iter->value());
+        setStreamState(&iter->value(), state);
     }
 }
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1277,7 +1277,7 @@ bmqt::GenericResult::Enum ClusterQueueHelper::sendReopenQueueRequest(
         BMQ_LOGTHROTTLE_INFO << "Sent ReopenQueue request "
                              << request->request() << " generationCount "
                              << generationCount;
-        subQueueContext->d_state = SubQueueContext::k_REOPENING;
+        setStreamState(subQueueContext, SubQueueContext::k_REOPENING);
         subQueueContext->d_generationCount = generationCount;
 
         ++queueContext->d_liveQInfo.d_numReopenQueueRequests;
@@ -1612,7 +1612,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
             BSLS_ASSERT_SAFE(sqit != qinfo.d_subQueueIds.end());
             BSLS_ASSERT_SAFE(sqit->appId() == appId);
 
-            subQueueContext.d_state = SubQueueContext::k_FAILED;
+            setStreamState(&subQueueContext, SubQueueContext::k_FAILED);
 
             notifyQueue(queueContext,
                         upstreamSubQueueId,
@@ -1691,7 +1691,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
         return;  // RETURN
     }
 
-    subQueueContext.d_state = SubQueueContext::k_OPEN;
+    setStreamState(&subQueueContext, SubQueueContext::k_OPEN);
 
     BMQ_LOGTHROTTLE_INFO
         << d_cluster_p->description() << ": queue successfully reopened ["

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2014,13 +2014,14 @@ void ClusterQueueHelper::onReopenQueueRetryDispatched(
 
     SubQueueContext& subQueueContext = sqit->value();
 
-    BSLS_ASSERT_SAFE(subQueueContext.d_state == SubQueueContext::k_CLOSED);
-
-    sendReopenQueueRequest(queueContext.get(),
-                           &subQueueContext,
-                           activeNode,
-                           cycle,
-                           numAttempts + 1);
+    if (subQueueContext.d_state == SubQueueContext::k_CLOSED) {
+        sendReopenQueueRequest(queueContext.get(),
+                               &subQueueContext,
+                               activeNode,
+                               cycle,
+                               numAttempts + 1);
+    }
+    // else, this retry must be cancelled
 }
 
 void ClusterQueueHelper::onOpenQueueConfirmationCookieReleased(
@@ -4639,16 +4640,21 @@ void ClusterQueueHelper::onUpstreamNodeChange(mqbnet::ClusterNode* node,
 void ClusterQueueHelper::setStreamState(SubQueueContext*      subQueueContext,
                                         SubQueueContext::Enum state)
 {
-    if (state != SubQueueContext::k_REOPENING) {
-        d_clusterData_p->scheduler().cancelEvent(
-            &subQueueContext->d_reopenRetryHandle);
-    }
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(subQueueContext);
+
+    d_clusterData_p->scheduler().cancelEventAndWait(
+        &subQueueContext->d_reopenRetryHandle);
+
     subQueueContext->d_state = state;
 }
 
 void ClusterQueueHelper::setStreamState(const QueueContextSp& queueContextSp,
                                         SubQueueContext::Enum state)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(queueContextSp);
+
     QueueLiveState& queueInfo = queueContextSp->d_liveQInfo;
 
     for (StreamsMap::iterator iter = queueInfo.d_subQueueIds.begin();

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -911,9 +911,11 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         const bmqp_ctrlmsg::OpenQueueResponse&     openQueueResponse,
         const mqbi::OpenQueueConfirmationCookieSp& confirmationCookie);
 
-    void setAsClosed(const QueueContextSp& queueContextSp);
+    void setStreamState(const QueueContextSp& queueContextSp,
+                        SubQueueContext::Enum state);
 
-    void setAsClosed(SubQueueContext* subQueueContext);
+    void setStreamState(SubQueueContext*      subQueueContext,
+                        SubQueueContext::Enum state);
 
     // PRIVATE MANIPULATORS
     //   (virtual: mqbc::ClusterMembershipObserver)

--- a/src/integration-tests/test_queue_reopen.py
+++ b/src/integration-tests/test_queue_reopen.py
@@ -17,6 +17,8 @@
 Integration tests for queue re-open scenarios.
 """
 
+import re
+
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
     Cluster,
@@ -80,3 +82,80 @@ def test_reopen_substream(multi_node: Cluster, domain_urls: tc.DomainUrls):
 
     consumer2.close(du.uri_fanout_foo, succeed=True)
     consumer2.open(du.uri_fanout_foo, flags=["read"], succeed=True)
+
+
+def test_open_queue_after_close_and_failover(
+    multi_node: Cluster, domain_urls: tc.DomainUrls
+):
+    """
+    If a queue has 0 handles (previous client closed) and a new client sends
+    an open-queue request that gets E_CANCELED due to primary failover, the
+    pending open must still complete after the new primary is elected.
+
+    Reproduces a bug where restoreStateCluster skips reopening queues with 0
+    handles, leaving SubQueueContext::d_state stuck at k_CLOSED, which blocks
+    sendOpenQueueRequest from ever sending the upstream request.
+
+    The bug only triggers when the node stays a REPLICA after failover (not
+    when it becomes the new primary via convertToLocal).
+    """
+    uri_priority = domain_urls.uri_priority
+    proxies = multi_node.proxy_cycle()
+    # pick proxy in datacenter opposite to the primary's (connects to replica)
+    next(proxies)
+    replica_proxy = next(proxies)
+
+    # Step 1: Open queue via proxy -> creates RemoteQueue on the replica
+    producer1 = replica_proxy.create_client("producer1")
+    producer1.open(uri_priority, flags=["write,ack"], succeed=True)
+
+    # Identify the replica (where proxy connects) and the leader
+    active_node = multi_node.process(replica_proxy.get_active_node())
+    leader = multi_node.last_known_leader
+
+    # Step 2: Close the queue -> handle count goes to 0, RemoteQueue persists
+    producer1.close(uri_priority, succeed=True)
+
+    # Pick a different node (not the replica, not the leader) to become new
+    # primary.  The replica must stay a replica to trigger the bug.
+    next_leader = None
+    for node in multi_node.nodes():
+        if node not in (leader, active_node):
+            next_leader = node
+            break
+    assert next_leader is not None
+
+    # Force next_leader to become the new primary; prevent everyone else
+    next_leader.set_quorum(1)
+    for node in multi_node.nodes():
+        if node not in (next_leader, leader):
+            node.set_quorum(99)
+
+    # Step 3: Suspend the primary so it stops processing but stays "alive"
+    leader.suspend()
+
+    # Step 4: Send open-queue request (non-blocking) - replica forwards
+    # upstream to the frozen primary, which will never respond
+    producer2 = replica_proxy.create_client("producer2")
+    producer2.open(uri_priority, flags=["write,ack"], block=False)
+
+    # Step 5: Kill the primary - triggers E_CANCELED for the inflight request
+    leader.check_exit_code = False
+    leader.kill()
+    leader.wait()
+
+    # Step 6: Wait for new leader (a different node, NOT the replica)
+    multi_node.wait_leader()
+    assert multi_node.last_known_leader == next_leader
+
+    # Step 7: The open-queue should complete (with the bug, it times out)
+    assert producer2.capture(
+        r"<--.*openQueue.*uri = " + re.escape(uri_priority) + r".*\(0\)",
+        timeout=15,
+    )
+
+    # Step 8: Verify end-to-end: post should succeed
+    assert (
+        producer2.post(uri_priority, ["msg1"], wait_ack=True, succeed=True)
+        == Client.e_SUCCESS
+    )


### PR DESCRIPTION
⏺ When a replica has a queue with zero active handles (all clients disconnected) but the queue still exists (not yet GC'd by primary), and a primary failover occurs:

  1. A new client sends an open-queue request to the replica during the failover
  2. The request is buffered in `d_pending` (no active primary yet)
  3. The new primary becomes active, triggering restoreStateCluster
  4. restoreStateCluster sees `d_numQueueHandles == 0` — nothing to reopen, skips restoreStateHelper
  5. But the substream state remains `k_CLOSED` (set by `onUpstreamNodeChange(0)` when the old primary was lost)
  6. `onQueueContextAssigned` calls `processPendingContexts`, which calls `sendOpenQueueRequest`
  7. `sendOpenQueueRequest` checks `d_state == k_OPEN` — it's `k_CLOSED` — re-buffers the context
  8. No future event transitions the state or retriggers processing
  9. The client's open request is stuck permanently

  The fix transitions the state to `k_OPEN` when skipping the reopen for zero-handle queues. Since there are no handles to reopen upstream, the substream is effectively idle
  and should accept new open requests. The subsequent onQueueContextAssigned then successfully processes the pending open.


Also, rejecting OpenQueue requests after reopen fails.  Otherwise, cannot handle subsequent Close requests (there is "failed" part of counters)