### PR TITLE
Fix[test]: missing wait_push_event in _stop_proxy

### DIFF
--- a/src/integration-tests/test_poison_messages.py
+++ b/src/integration-tests/test_poison_messages.py
@@ -396,6 +396,7 @@ class TestPoisonMessages:
 
         consumer_0 = proxy.create_client("consumer_0")
         consumer_0.open(f"{uri}", flags=["read"], succeed=True)
+        consumer_0.wait_push_event()
 
         leader = multi_node.last_known_leader
 


### PR DESCRIPTION
 The message gets stored on east1 (the primary), but when consumer_0 opened and listed, the configure-stream round-trip (consumer → westp → west1 → east1 → back) hadn't completed yet. East1 didn't know there was a consumer, so it never pushed the message.
