### PR TITLE
Refactor[bmq]: move `bmqu::TempFile` -> `bmqtst::TempFile`

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_inpututil.t.cpp
+++ b/src/applications/bmqtool/m_bmqtool_inpututil.t.cpp
@@ -20,8 +20,8 @@
 #include <bmqa_messageproperties.h>
 
 // BMQ
+#include <bmqtst_tempfile.h>
 #include <bmqu_memoutstream.h>
-#include <bmqu_tempfile.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -274,7 +274,7 @@ static void test2_loadMessageFromFileTest()
         const Test& test = k_DATA[idx];
 
         // Create temp file and write content
-        bmqu::TempFile    tempFile(bmqtst::TestHelperUtil::allocator());
+        bmqtst::TempFile  tempFile(bmqtst::TestHelperUtil::allocator());
         const bsl::string filePath = tempFile.path();
         {
             bsl::ofstream ofs(filePath.c_str());
@@ -333,5 +333,5 @@ int main(int argc, char* argv[])
 
     // Check for default allocator is explicitly disabled as
     // 'bmqa::MessageProperties' or one of its data members may allocate
-    // temporaries with default allocator. The same for 'bmqu::TempFile'.
+    // temporaries with default allocator. The same for 'bmqtst::TempFile'.
 }

--- a/src/applications/bmqtool/m_bmqtool_latencystorage.t.cpp
+++ b/src/applications/bmqtool/m_bmqtool_latencystorage.t.cpp
@@ -17,8 +17,8 @@
 #include <m_bmqtool_latencystorage.h>
 
 // BDE
+#include <bmqtst_tempfile.h>
 #include <bmqtst_testhelper.h>
-#include <bmqu_tempfile.h>
 #include <bsl_cstdlib.h>
 #include <bsl_fstream.h>
 #include <bsl_iostream.h>
@@ -199,7 +199,7 @@ static void test6_saveAndLoadTest()
 {
     bmqtst::TestHelper::printTestName("SAVE AND LOAD TEST");
 
-    bmqu::TempFile tempFile;
+    bmqtst::TempFile tempFile;
     {
         LatencyStorage storage("test", 2, bmqtst::TestHelperUtil::allocator());
 

--- a/src/groups/bmq/bmqtst/bmqtst_tempfile.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_tempfile.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bmqu_tempfile.h>
+#include <bmqtst_tempfile.h>
 
 #include <bmqscm_version.h>
 
@@ -24,7 +24,7 @@
 #include <bsls_assert.h>
 
 namespace BloombergLP {
-namespace bmqu {
+namespace bmqtst {
 
 // --------------
 // class TempFile

--- a/src/groups/bmq/bmqtst/bmqtst_tempfile.h
+++ b/src/groups/bmq/bmqtst/bmqtst_tempfile.h
@@ -13,23 +13,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef INCLUDED_BMQU_TEMPFILE
-#define INCLUDED_BMQU_TEMPFILE
+#ifndef INCLUDED_BMQTST_TEMPFILE
+#define INCLUDED_BMQTST_TEMPFILE
 
 //@PURPOSE: Provide a guard for creating a temporary file.
 //
 //@CLASSES:
-//  bmqu::TempFile: Guard for a temporary file
+//  bmqtst::TempFile: Guard for a temporary file
 //
 //@SEE_ALSO: bmqu_temputil
 //
-//@DESCRIPTION: This component provides a guard, 'bmqu::TempFile', that creates
-// a file in the effective temporary directory for the current process whose
-// name is randomly assigned to guarantee no collisions with other directories
-// or files in the effective temporary directory. The guarded file is
-// automatically removed when the 'bmqu::TempFile' object is destroyed.  For
-// the definition of the effective temporary directory for the current process,
-// see the bmqu_temputil component documentation.
+//@DESCRIPTION: This component provides a guard, 'bmqtst::TempFile', that
+// creates a file in the effective temporary directory for the current process
+// whose name is randomly assigned to guarantee no collisions with other
+// directories or files in the effective temporary directory. The guarded file
+// is automatically removed when the 'bmqtst::TempFile' object is destroyed.
+// For the definition of the effective temporary directory for the current
+// process, see the bmqu_temputil component documentation.
 //
 /// Thread Safety
 ///-------------
@@ -42,11 +42,11 @@
 /// Usage Example 1: Creating a Temporary File
 ///- - - - - - - - - - - - - - - - - - - - -
 // This example shows how to create a temporary file which is automatically
-// deleted by a 'bmqu::TemporaryFile' guard.
+// deleted by a 'bmqtst::TempFile' guard.
 //..
 //     bsl::string filePath;
 //     {
-//         bmqu::TempFile tempFile;
+//         bmqtst::TempFile tempFile;
 //         filePath = tempFile.path();
 //
 //         bsl::ofstream ofs(filePath.c_str());
@@ -64,7 +64,7 @@
 #include <bslmf_nestedtraitdeclaration.h>
 
 namespace BloombergLP {
-namespace bmqu {
+namespace bmqtst {
 
 // ==============
 // class TempFile

--- a/src/groups/bmq/bmqtst/doc/bmqtst.txt
+++ b/src/groups/bmq/bmqtst/doc/bmqtst.txt
@@ -9,12 +9,13 @@ writing test drivers.
 
 /Hierarchical Synopsis
 /---------------------
- The bmqtst' package currently has 4 components having 1 level of physical
+ The bmqtst' package currently has 5 components having 1 level of physical
  dependency.  The list below shows the hierarchical ordering of the components.
 ..
   1. bmqtst_blobtestutil
      bmqtst_mocktime
      bmqtst_scopedlogobserver
+     bmqtst_tempfile
      bmqtst_testhelper
 ..
 
@@ -26,5 +27,7 @@ writing test drivers.
 :      Provide a mock of the time accessors usable with 'bmqu::Time'.
 : 'bmqtst_scopedlogobserver':
 :      Provide a scoped tester implementation of the log observer protocol.
+: 'bmqtst_tempfile':
+:      Provide a guard for creating a temporary file.
 : 'bmqtst_testhelper':
 :      Provide macros and utilities to assist in writing test drivers.

--- a/src/groups/bmq/bmqtst/package/bmqtst.mem
+++ b/src/groups/bmq/bmqtst/package/bmqtst.mem
@@ -2,4 +2,5 @@ bmqtst_blobtestutil
 bmqtst_mocktime
 bmqtst_scopedlogobserver
 bmqtst_table
+bmqtst_tempfile
 bmqtst_testhelper

--- a/src/groups/bmq/bmqu/doc/bmqu.txt
+++ b/src/groups/bmq/bmqu/doc/bmqu.txt
@@ -9,7 +9,7 @@ reused through various applications.
 
 /Hierarchical Synopsis
 /---------------------
-The 'bmqu' package currently has 21 components having 2 level of physical
+The 'bmqu' package currently has 20 components having 2 level of physical
 dependency.  The list below shows the hierarchal ordering of the components.
 ..
   2. bmqu_blobiterator
@@ -29,7 +29,6 @@ dependency.  The list below shows the hierarchal ordering of the components.
      bmqu_samethreadchecker
      bmqu_singletonallocator
      bmqu_stringutil
-     bmqu_tempfile
      bmqu_temputil
      bmqu_throttledaction
      bmqu_time
@@ -85,9 +84,6 @@ dependency.  The list below shows the hierarchal ordering of the components.
 :
 : 'bmqu_tempdirectory':
 :      Provide a guard for creating a temporary directory.
-:
-: 'bmqu_tempfile':
-:      Provide a guard for creating a temporary file.
 :
 : 'bmqu_temputil':
 :      Provide an utility for resolving the effective temporary directory.

--- a/src/groups/bmq/bmqu/package/bmqu.mem
+++ b/src/groups/bmq/bmqu/package/bmqu.mem
@@ -21,7 +21,6 @@ bmqu_sharedresource
 bmqu_singletonallocator
 bmqu_stringutil
 bmqu_tempdirectory
-bmqu_tempfile
 bmqu_temputil
 bmqu_throttledaction
 bmqu_time


### PR DESCRIPTION
`TempFile` is only used in tests, can move it from `bmqu`