### PR TITLE
Fix[mqbc::StorageMgr]: Send primary lease id in PFSM state rqst/resp

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -702,6 +702,7 @@
         sequence numbers as part of this request.
 
         partitionId:    partition id for corresponding partition.
+        primaryLeaseId: lease id of the current primary
         latestSequenceNumber: Primary's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's first sync point
                                                    after rollover for corresponding partition.
@@ -709,6 +710,7 @@
     </annotation>
     <sequence>
       <element name='partitionId'    type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
       <element name='latestSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='firstSyncPointAfterRolloverSequenceNumber' type='tns:PartitionSequenceNumber'/>
     </sequence>
@@ -721,6 +723,7 @@
         with its sequence numbers.
 
         partitionId:    partition id for corresponding partition.
+        primaryLeaseId: lease id of the current primary
         latestSequenceNumber: Replica's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's first sync point
                                                    after rollover for corresponding partition.
@@ -728,6 +731,7 @@
     </annotation>
     <sequence>
       <element name='partitionId'    type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
       <element name='latestSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='firstSyncPointAfterRolloverSequenceNumber' type='tns:PartitionSequenceNumber'/>
     </sequence>
@@ -741,13 +745,15 @@
         sequence numbers as part of this request.
 
         partitionId:    partition id for corresponding partition.
+        primaryLeaseId: lease id of the current primary
         latestSequenceNumber: Replica's latest sequence number for corresponding partition.
-        firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's first sync point 
+        firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's first sync point
                                                    after rollover for corresponding partition.
       </documentation>
     </annotation>
     <sequence>
       <element name='partitionId'    type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
       <element name='latestSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='firstSyncPointAfterRolloverSequenceNumber' type='tns:PartitionSequenceNumber'/>
     </sequence>
@@ -760,6 +766,7 @@
         with its sequence numbers.
 
         partitionId:    partition id for corresponding partition.
+        primaryLeaseId: lease id of the current primary
         latestSequenceNumber: Primary's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's first sync point
                                                    after rollover for corresponding partition.
@@ -767,6 +774,7 @@
     </annotation>
     <sequence>
       <element name='partitionId'    type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
       <element name='latestSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='firstSyncPointAfterRolloverSequenceNumber' type='tns:PartitionSequenceNumber'/>
     </sequence>

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -702,7 +702,7 @@
         sequence numbers as part of this request.
 
         partitionId:    partition id for corresponding partition.
-        primaryLeaseId: lease id of the current primary
+        primaryLeaseId: lease id of the current primary.
         latestSequenceNumber: Primary's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's first sync point
                                                    after rollover for corresponding partition.
@@ -723,7 +723,7 @@
         with its sequence numbers.
 
         partitionId:    partition id for corresponding partition.
-        primaryLeaseId: lease id of the current primary
+        primaryLeaseId: lease id of the current primary.
         latestSequenceNumber: Replica's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's first sync point
                                                    after rollover for corresponding partition.
@@ -745,7 +745,7 @@
         sequence numbers as part of this request.
 
         partitionId:    partition id for corresponding partition.
-        primaryLeaseId: lease id of the current primary
+        primaryLeaseId: lease id of the current primary.
         latestSequenceNumber: Replica's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's first sync point
                                                    after rollover for corresponding partition.
@@ -766,7 +766,7 @@
         with its sequence numbers.
 
         partitionId:    partition id for corresponding partition.
-        primaryLeaseId: lease id of the current primary
+        primaryLeaseId: lease id of the current primary.
         latestSequenceNumber: Primary's latest sequence number for corresponding partition.
         firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's first sync point
                                                    after rollover for corresponding partition.

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,13 +90,11 @@ AdminCommand::AdminCommand(bslma::Allocator* basicAllocator)
 
 AdminCommand::AdminCommand(const AdminCommand& original,
                            bslma::Allocator*   basicAllocator)
-: d_command(original.d_command, basicAllocator)
-{
-}
+: d_command(original.d_command, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AdminCommand::AdminCommand(AdminCommand&& original) noexcept
+AdminCommand::AdminCommand(AdminCommand && original) noexcept
 : d_command(bsl::move(original.d_command))
 {
 }
@@ -203,14 +201,13 @@ AdminCommandResponse::AdminCommandResponse(bslma::Allocator* basicAllocator)
 AdminCommandResponse::AdminCommandResponse(
     const AdminCommandResponse& original,
     bslma::Allocator*           basicAllocator)
-: d_text(original.d_text, basicAllocator)
-{
-}
+: d_text(original.d_text, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AdminCommandResponse::AdminCommandResponse(AdminCommandResponse&& original)
-    noexcept : d_text(bsl::move(original.d_text))
+AdminCommandResponse::AdminCommandResponse(AdminCommandResponse &&
+                                           original) noexcept
+: d_text(bsl::move(original.d_text))
 {
 }
 
@@ -328,13 +325,11 @@ AppIdInfo::AppIdInfo(bslma::Allocator* basicAllocator)
 AppIdInfo::AppIdInfo(const AppIdInfo&  original,
                      bslma::Allocator* basicAllocator)
 : d_appKey(original.d_appKey, basicAllocator)
-, d_appId(original.d_appId, basicAllocator)
-{
-}
+, d_appId(original.d_appId, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AppIdInfo::AppIdInfo(AppIdInfo&& original) noexcept
+AppIdInfo::AppIdInfo(AppIdInfo && original) noexcept
 : d_appKey(bsl::move(original.d_appKey)),
   d_appId(bsl::move(original.d_appId))
 {
@@ -464,15 +459,14 @@ AuthenticationRequest::AuthenticationRequest(
     const AuthenticationRequest& original,
     bslma::Allocator*            basicAllocator)
 : d_mechanism(original.d_mechanism, basicAllocator)
-, d_data(original.d_data, basicAllocator)
-{
-}
+, d_data(original.d_data, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AuthenticationRequest::AuthenticationRequest(AuthenticationRequest&& original)
-    noexcept : d_mechanism(bsl::move(original.d_mechanism)),
-               d_data(bsl::move(original.d_data))
+AuthenticationRequest::AuthenticationRequest(AuthenticationRequest &&
+                                             original) noexcept
+: d_mechanism(bsl::move(original.d_mechanism)),
+  d_data(bsl::move(original.d_data))
 {
 }
 
@@ -1452,13 +1446,11 @@ GuidInfo::GuidInfo(bslma::Allocator* basicAllocator)
 
 GuidInfo::GuidInfo(const GuidInfo& original, bslma::Allocator* basicAllocator)
 : d_nanoSecondsFromEpoch(original.d_nanoSecondsFromEpoch)
-, d_clientId(original.d_clientId, basicAllocator)
-{
-}
+, d_clientId(original.d_clientId, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-GuidInfo::GuidInfo(GuidInfo&& original) noexcept
+GuidInfo::GuidInfo(GuidInfo && original) noexcept
 : d_nanoSecondsFromEpoch(bsl::move(original.d_nanoSecondsFromEpoch)),
   d_clientId(bsl::move(original.d_clientId))
 {
@@ -2368,14 +2360,12 @@ QueueAssignmentRequest::QueueAssignmentRequest(
 QueueAssignmentRequest::QueueAssignmentRequest(
     const QueueAssignmentRequest& original,
     bslma::Allocator*             basicAllocator)
-: d_queueUri(original.d_queueUri, basicAllocator)
-{
-}
+: d_queueUri(original.d_queueUri, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueAssignmentRequest::QueueAssignmentRequest(
-    QueueAssignmentRequest&& original) noexcept
+QueueAssignmentRequest::QueueAssignmentRequest(QueueAssignmentRequest &&
+                                               original) noexcept
 : d_queueUri(bsl::move(original.d_queueUri))
 {
 }
@@ -2507,14 +2497,12 @@ QueueUnassignmentRequest::QueueUnassignmentRequest(
     bslma::Allocator*               basicAllocator)
 : d_queueKey(original.d_queueKey, basicAllocator)
 , d_queueUri(original.d_queueUri, basicAllocator)
-, d_partitionId(original.d_partitionId)
-{
-}
+, d_partitionId(original.d_partitionId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnassignmentRequest::QueueUnassignmentRequest(
-    QueueUnassignmentRequest&& original) noexcept
+QueueUnassignmentRequest::QueueUnassignmentRequest(QueueUnassignmentRequest &&
+                                                   original) noexcept
 : d_queueKey(bsl::move(original.d_queueKey)),
   d_queueUri(bsl::move(original.d_queueUri)),
   d_partitionId(bsl::move(original.d_partitionId))
@@ -3136,13 +3124,11 @@ StopRequest::StopRequest(bslma::Allocator* basicAllocator)
 StopRequest::StopRequest(const StopRequest& original,
                          bslma::Allocator*  basicAllocator)
 : d_clusterName(original.d_clusterName, basicAllocator)
-, d_version(original.d_version)
-{
-}
+, d_version(original.d_version){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StopRequest::StopRequest(StopRequest&& original) noexcept
+StopRequest::StopRequest(StopRequest && original) noexcept
 : d_clusterName(bsl::move(original.d_clusterName)),
   d_version(bsl::move(original.d_version))
 {
@@ -3255,13 +3241,11 @@ StopResponse::StopResponse(bslma::Allocator* basicAllocator)
 
 StopResponse::StopResponse(const StopResponse& original,
                            bslma::Allocator*   basicAllocator)
-: d_clusterName(original.d_clusterName, basicAllocator)
-{
-}
+: d_clusterName(original.d_clusterName, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StopResponse::StopResponse(StopResponse&& original) noexcept
+StopResponse::StopResponse(StopResponse && original) noexcept
 : d_clusterName(bsl::move(original.d_clusterName))
 {
 }
@@ -3463,13 +3447,11 @@ SubQueueIdInfo::SubQueueIdInfo(bslma::Allocator* basicAllocator)
 SubQueueIdInfo::SubQueueIdInfo(const SubQueueIdInfo& original,
                                bslma::Allocator*     basicAllocator)
 : d_appId(original.d_appId, basicAllocator)
-, d_subId(original.d_subId)
-{
-}
+, d_subId(original.d_subId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-SubQueueIdInfo::SubQueueIdInfo(SubQueueIdInfo&& original) noexcept
+SubQueueIdInfo::SubQueueIdInfo(SubQueueIdInfo && original) noexcept
 : d_appId(bsl::move(original.d_appId)),
   d_subId(bsl::move(original.d_subId))
 {
@@ -3811,13 +3793,11 @@ ClientIdentity::ClientIdentity(const ClientIdentity& original,
 , d_sessionId(original.d_sessionId)
 , d_clusterNodeId(original.d_clusterNodeId)
 , d_clientType(original.d_clientType)
-, d_sdkLanguage(original.d_sdkLanguage)
-{
-}
+, d_sdkLanguage(original.d_sdkLanguage){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClientIdentity::ClientIdentity(ClientIdentity&& original) noexcept
+ClientIdentity::ClientIdentity(ClientIdentity && original) noexcept
 : d_processName(bsl::move(original.d_processName)),
   d_hostName(bsl::move(original.d_hostName)),
   d_features(bsl::move(original.d_features)),
@@ -4897,13 +4877,11 @@ Expression::Expression(bslma::Allocator* basicAllocator)
 Expression::Expression(const Expression& original,
                        bslma::Allocator* basicAllocator)
 : d_text(original.d_text, basicAllocator)
-, d_version(original.d_version)
-{
-}
+, d_version(original.d_version){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Expression::Expression(Expression&& original) noexcept
+Expression::Expression(Expression && original) noexcept
 : d_text(bsl::move(original.d_text)),
   d_version(bsl::move(original.d_version))
 {
@@ -5389,14 +5367,12 @@ PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(
     const PartitionPrimaryAdvisory& original,
     bslma::Allocator*               basicAllocator)
 : d_partitions(original.d_partitions, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber)
-{
-}
+, d_sequenceNumber(original.d_sequenceNumber){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(
-    PartitionPrimaryAdvisory&& original) noexcept
+PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(PartitionPrimaryAdvisory &&
+                                                   original) noexcept
 : d_partitions(bsl::move(original.d_partitions)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
@@ -5476,6 +5452,11 @@ const bdlat_AttributeInfo PrimaryStateRequest::ATTRIBUTE_INFO_ARRAY[] = {
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
     {ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER,
      "latestSequenceNumber",
      sizeof("latestSequenceNumber") - 1,
@@ -5492,7 +5473,7 @@ const bdlat_AttributeInfo PrimaryStateRequest::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 PrimaryStateRequest::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             PrimaryStateRequest::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -5510,6 +5491,8 @@ const bdlat_AttributeInfo* PrimaryStateRequest::lookupAttributeInfo(int id)
     switch (id) {
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER:
@@ -5524,6 +5507,7 @@ const bdlat_AttributeInfo* PrimaryStateRequest::lookupAttributeInfo(int id)
 PrimaryStateRequest::PrimaryStateRequest()
 : d_latestSequenceNumber()
 , d_firstSyncPointAfterRolloverSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 {
 }
@@ -5533,6 +5517,7 @@ PrimaryStateRequest::PrimaryStateRequest()
 void PrimaryStateRequest::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
     bdlat_ValueTypeFunctions::reset(&d_latestSequenceNumber);
     bdlat_ValueTypeFunctions::reset(
         &d_firstSyncPointAfterRolloverSequenceNumber);
@@ -5547,6 +5532,7 @@ bsl::ostream& PrimaryStateRequest::print(bsl::ostream& stream,
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
     printer.printAttribute("latestSequenceNumber",
                            this->latestSequenceNumber());
     printer.printAttribute("firstSyncPointAfterRolloverSequenceNumber",
@@ -5569,6 +5555,11 @@ const bdlat_AttributeInfo PrimaryStateResponse::ATTRIBUTE_INFO_ARRAY[] = {
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
     {ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER,
      "latestSequenceNumber",
      sizeof("latestSequenceNumber") - 1,
@@ -5585,7 +5576,7 @@ const bdlat_AttributeInfo PrimaryStateResponse::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 PrimaryStateResponse::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             PrimaryStateResponse::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -5603,6 +5594,8 @@ const bdlat_AttributeInfo* PrimaryStateResponse::lookupAttributeInfo(int id)
     switch (id) {
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER:
@@ -5617,6 +5610,7 @@ const bdlat_AttributeInfo* PrimaryStateResponse::lookupAttributeInfo(int id)
 PrimaryStateResponse::PrimaryStateResponse()
 : d_latestSequenceNumber()
 , d_firstSyncPointAfterRolloverSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 {
 }
@@ -5626,6 +5620,7 @@ PrimaryStateResponse::PrimaryStateResponse()
 void PrimaryStateResponse::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
     bdlat_ValueTypeFunctions::reset(&d_latestSequenceNumber);
     bdlat_ValueTypeFunctions::reset(
         &d_firstSyncPointAfterRolloverSequenceNumber);
@@ -5640,6 +5635,7 @@ bsl::ostream& PrimaryStateResponse::print(bsl::ostream& stream,
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
     printer.printAttribute("latestSequenceNumber",
                            this->latestSequenceNumber());
     printer.printAttribute("firstSyncPointAfterRolloverSequenceNumber",
@@ -5850,20 +5846,19 @@ QueueHandleParameters::QueueHandleParameters(
 , d_qId(original.d_qId)
 , d_readCount(original.d_readCount)
 , d_writeCount(original.d_writeCount)
-, d_adminCount(original.d_adminCount)
-{
-}
+, d_adminCount(original.d_adminCount){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueHandleParameters::QueueHandleParameters(QueueHandleParameters&& original)
-    noexcept : d_flags(bsl::move(original.d_flags)),
-               d_uri(bsl::move(original.d_uri)),
-               d_subIdInfo(bsl::move(original.d_subIdInfo)),
-               d_qId(bsl::move(original.d_qId)),
-               d_readCount(bsl::move(original.d_readCount)),
-               d_writeCount(bsl::move(original.d_writeCount)),
-               d_adminCount(bsl::move(original.d_adminCount))
+QueueHandleParameters::QueueHandleParameters(QueueHandleParameters &&
+                                             original) noexcept
+: d_flags(bsl::move(original.d_flags)),
+  d_uri(bsl::move(original.d_uri)),
+  d_subIdInfo(bsl::move(original.d_subIdInfo)),
+  d_qId(bsl::move(original.d_qId)),
+  d_readCount(bsl::move(original.d_readCount)),
+  d_writeCount(bsl::move(original.d_writeCount)),
+  d_adminCount(bsl::move(original.d_adminCount))
 {
 }
 
@@ -6027,13 +6022,11 @@ QueueInfo::QueueInfo(const QueueInfo&  original,
 : d_key(original.d_key, basicAllocator)
 , d_appIds(original.d_appIds, basicAllocator)
 , d_uri(original.d_uri, basicAllocator)
-, d_partitionId(original.d_partitionId)
-{
-}
+, d_partitionId(original.d_partitionId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueInfo::QueueInfo(QueueInfo&& original) noexcept
+QueueInfo::QueueInfo(QueueInfo && original) noexcept
 : d_key(bsl::move(original.d_key)),
   d_appIds(bsl::move(original.d_appIds)),
   d_uri(bsl::move(original.d_uri)),
@@ -6209,13 +6202,11 @@ QueueInfoUpdate::QueueInfoUpdate(const QueueInfoUpdate& original,
 , d_removedAppIds(original.d_removedAppIds, basicAllocator)
 , d_uri(original.d_uri, basicAllocator)
 , d_domain(original.d_domain, basicAllocator)
-, d_partitionId(original.d_partitionId)
-{
-}
+, d_partitionId(original.d_partitionId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueInfoUpdate::QueueInfoUpdate(QueueInfoUpdate&& original) noexcept
+QueueInfoUpdate::QueueInfoUpdate(QueueInfoUpdate && original) noexcept
 : d_key(bsl::move(original.d_key)),
   d_addedAppIds(bsl::move(original.d_addedAppIds)),
   d_removedAppIds(bsl::move(original.d_removedAppIds)),
@@ -6411,14 +6402,12 @@ QueueStreamParameters::QueueStreamParameters(
 , d_maxUnconfirmedBytes(original.d_maxUnconfirmedBytes)
 , d_subIdInfo(original.d_subIdInfo, basicAllocator)
 , d_consumerPriority(original.d_consumerPriority)
-, d_consumerPriorityCount(original.d_consumerPriorityCount)
-{
-}
+, d_consumerPriorityCount(original.d_consumerPriorityCount){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueStreamParameters::QueueStreamParameters(
-    QueueStreamParameters&& original) noexcept
+QueueStreamParameters::QueueStreamParameters(QueueStreamParameters &&
+                                             original) noexcept
 : d_maxUnconfirmedMessages(bsl::move(original.d_maxUnconfirmedMessages)),
   d_maxUnconfirmedBytes(bsl::move(original.d_maxUnconfirmedBytes)),
   d_subIdInfo(bsl::move(original.d_subIdInfo)),
@@ -6784,6 +6773,11 @@ const bdlat_AttributeInfo ReplicaStateRequest::ATTRIBUTE_INFO_ARRAY[] = {
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
     {ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER,
      "latestSequenceNumber",
      sizeof("latestSequenceNumber") - 1,
@@ -6800,7 +6794,7 @@ const bdlat_AttributeInfo ReplicaStateRequest::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 ReplicaStateRequest::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             ReplicaStateRequest::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -6818,6 +6812,8 @@ const bdlat_AttributeInfo* ReplicaStateRequest::lookupAttributeInfo(int id)
     switch (id) {
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER:
@@ -6832,6 +6828,7 @@ const bdlat_AttributeInfo* ReplicaStateRequest::lookupAttributeInfo(int id)
 ReplicaStateRequest::ReplicaStateRequest()
 : d_latestSequenceNumber()
 , d_firstSyncPointAfterRolloverSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 {
 }
@@ -6841,6 +6838,7 @@ ReplicaStateRequest::ReplicaStateRequest()
 void ReplicaStateRequest::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
     bdlat_ValueTypeFunctions::reset(&d_latestSequenceNumber);
     bdlat_ValueTypeFunctions::reset(
         &d_firstSyncPointAfterRolloverSequenceNumber);
@@ -6855,6 +6853,7 @@ bsl::ostream& ReplicaStateRequest::print(bsl::ostream& stream,
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
     printer.printAttribute("latestSequenceNumber",
                            this->latestSequenceNumber());
     printer.printAttribute("firstSyncPointAfterRolloverSequenceNumber",
@@ -6877,6 +6876,11 @@ const bdlat_AttributeInfo ReplicaStateResponse::ATTRIBUTE_INFO_ARRAY[] = {
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
     {ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER,
      "latestSequenceNumber",
      sizeof("latestSequenceNumber") - 1,
@@ -6893,7 +6897,7 @@ const bdlat_AttributeInfo ReplicaStateResponse::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 ReplicaStateResponse::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             ReplicaStateResponse::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -6911,6 +6915,8 @@ const bdlat_AttributeInfo* ReplicaStateResponse::lookupAttributeInfo(int id)
     switch (id) {
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER:
@@ -6925,6 +6931,7 @@ const bdlat_AttributeInfo* ReplicaStateResponse::lookupAttributeInfo(int id)
 ReplicaStateResponse::ReplicaStateResponse()
 : d_latestSequenceNumber()
 , d_firstSyncPointAfterRolloverSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 {
 }
@@ -6934,6 +6941,7 @@ ReplicaStateResponse::ReplicaStateResponse()
 void ReplicaStateResponse::reset()
 {
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
     bdlat_ValueTypeFunctions::reset(&d_latestSequenceNumber);
     bdlat_ValueTypeFunctions::reset(
         &d_firstSyncPointAfterRolloverSequenceNumber);
@@ -6948,6 +6956,7 @@ bsl::ostream& ReplicaStateResponse::print(bsl::ostream& stream,
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
     printer.printAttribute("latestSequenceNumber",
                            this->latestSequenceNumber());
     printer.printAttribute("firstSyncPointAfterRolloverSequenceNumber",
@@ -7250,13 +7259,11 @@ Status::Status(bslma::Allocator* basicAllocator)
 Status::Status(const Status& original, bslma::Allocator* basicAllocator)
 : d_message(original.d_message, basicAllocator)
 , d_code(original.d_code)
-, d_category(original.d_category)
-{
-}
+, d_category(original.d_category){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Status::Status(Status&& original) noexcept
+Status::Status(Status && original) noexcept
 : d_message(bsl::move(original.d_message)),
   d_code(bsl::move(original.d_code)),
   d_category(bsl::move(original.d_category))
@@ -7565,14 +7572,12 @@ AuthenticationResponse::AuthenticationResponse(
     const AuthenticationResponse& original,
     bslma::Allocator*             basicAllocator)
 : d_status(original.d_status, basicAllocator)
-, d_lifetimeMs(original.d_lifetimeMs)
-{
-}
+, d_lifetimeMs(original.d_lifetimeMs){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AuthenticationResponse::AuthenticationResponse(
-    AuthenticationResponse&& original) noexcept
+AuthenticationResponse::AuthenticationResponse(AuthenticationResponse &&
+                                               original) noexcept
 : d_status(bsl::move(original.d_status)),
   d_lifetimeMs(bsl::move(original.d_lifetimeMs))
 {
@@ -7749,13 +7754,11 @@ BrokerResponse::BrokerResponse(const BrokerResponse& original,
 , d_brokerVersion(original.d_brokerVersion)
 , d_heartbeatIntervalMs(original.d_heartbeatIntervalMs)
 , d_maxMissedHeartbeats(original.d_maxMissedHeartbeats)
-, d_isDeprecatedSdk(original.d_isDeprecatedSdk)
-{
-}
+, d_isDeprecatedSdk(original.d_isDeprecatedSdk){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-BrokerResponse::BrokerResponse(BrokerResponse&& original) noexcept
+BrokerResponse::BrokerResponse(BrokerResponse && original) noexcept
 : d_result(bsl::move(original.d_result)),
   d_brokerIdentity(bsl::move(original.d_brokerIdentity)),
   d_protocolVersion(bsl::move(original.d_protocolVersion)),
@@ -7910,13 +7913,11 @@ CloseQueue::CloseQueue(bslma::Allocator* basicAllocator)
 CloseQueue::CloseQueue(const CloseQueue& original,
                        bslma::Allocator* basicAllocator)
 : d_handleParameters(original.d_handleParameters, basicAllocator)
-, d_isFinal(original.d_isFinal)
-{
-}
+, d_isFinal(original.d_isFinal){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-CloseQueue::CloseQueue(CloseQueue&& original) noexcept
+CloseQueue::CloseQueue(CloseQueue && original) noexcept
 : d_handleParameters(bsl::move(original.d_handleParameters)),
   d_isFinal(bsl::move(original.d_isFinal))
 {
@@ -8037,15 +8038,14 @@ ConfigureQueueStream::ConfigureQueueStream(
     const ConfigureQueueStream& original,
     bslma::Allocator*           basicAllocator)
 : d_streamParameters(original.d_streamParameters, basicAllocator)
-, d_qId(original.d_qId)
-{
-}
+, d_qId(original.d_qId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureQueueStream::ConfigureQueueStream(ConfigureQueueStream&& original)
-    noexcept : d_streamParameters(bsl::move(original.d_streamParameters)),
-               d_qId(bsl::move(original.d_qId))
+ConfigureQueueStream::ConfigureQueueStream(ConfigureQueueStream &&
+                                           original) noexcept
+: d_streamParameters(bsl::move(original.d_streamParameters)),
+  d_qId(bsl::move(original.d_qId))
 {
 }
 
@@ -8293,13 +8293,11 @@ LeaderAdvisory::LeaderAdvisory(const LeaderAdvisory& original,
                                bslma::Allocator*     basicAllocator)
 : d_queues(original.d_queues, basicAllocator)
 , d_partitions(original.d_partitions, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber)
-{
-}
+, d_sequenceNumber(original.d_sequenceNumber){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-LeaderAdvisory::LeaderAdvisory(LeaderAdvisory&& original) noexcept
+LeaderAdvisory::LeaderAdvisory(LeaderAdvisory && original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_partitions(bsl::move(original.d_partitions)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
@@ -8419,13 +8417,11 @@ OpenQueue::OpenQueue(bslma::Allocator* basicAllocator)
 
 OpenQueue::OpenQueue(const OpenQueue&  original,
                      bslma::Allocator* basicAllocator)
-: d_handleParameters(original.d_handleParameters, basicAllocator)
-{
-}
+: d_handleParameters(original.d_handleParameters, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-OpenQueue::OpenQueue(OpenQueue&& original) noexcept
+OpenQueue::OpenQueue(OpenQueue && original) noexcept
 : d_handleParameters(bsl::move(original.d_handleParameters))
 {
 }
@@ -9311,14 +9307,12 @@ PartitionSyncDataQueryStatus::PartitionSyncDataQueryStatus(
     const PartitionSyncDataQueryStatus& original,
     bslma::Allocator*                   basicAllocator)
 : d_status(original.d_status, basicAllocator)
-, d_partitionId(original.d_partitionId)
-{
-}
+, d_partitionId(original.d_partitionId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 PartitionSyncDataQueryStatus::PartitionSyncDataQueryStatus(
-    PartitionSyncDataQueryStatus&& original) noexcept
+    PartitionSyncDataQueryStatus && original) noexcept
 : d_status(bsl::move(original.d_status)),
   d_partitionId(bsl::move(original.d_partitionId))
 {
@@ -9551,14 +9545,12 @@ QueueAssignmentAdvisory::QueueAssignmentAdvisory(
     const QueueAssignmentAdvisory& original,
     bslma::Allocator*              basicAllocator)
 : d_queues(original.d_queues, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber)
-{
-}
+, d_sequenceNumber(original.d_sequenceNumber){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueAssignmentAdvisory::QueueAssignmentAdvisory(
-    QueueAssignmentAdvisory&& original) noexcept
+QueueAssignmentAdvisory::QueueAssignmentAdvisory(QueueAssignmentAdvisory &&
+                                                 original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
@@ -9716,14 +9708,12 @@ QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
 , d_sequenceNumber(original.d_sequenceNumber)
 , d_primaryLeaseId(original.d_primaryLeaseId)
 , d_partitionId(original.d_partitionId)
-, d_primaryNodeId(original.d_primaryNodeId)
-{
-}
+, d_primaryNodeId(original.d_primaryNodeId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    QueueUnAssignmentAdvisory&& original) noexcept
+    QueueUnAssignmentAdvisory && original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber)),
   d_primaryLeaseId(bsl::move(original.d_primaryLeaseId)),
@@ -9867,15 +9857,14 @@ QueueUpdateAdvisory::QueueUpdateAdvisory(bslma::Allocator* basicAllocator)
 QueueUpdateAdvisory::QueueUpdateAdvisory(const QueueUpdateAdvisory& original,
                                          bslma::Allocator* basicAllocator)
 : d_queueUpdates(original.d_queueUpdates, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber)
-{
-}
+, d_sequenceNumber(original.d_sequenceNumber){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUpdateAdvisory::QueueUpdateAdvisory(QueueUpdateAdvisory&& original)
-    noexcept : d_queueUpdates(bsl::move(original.d_queueUpdates)),
-               d_sequenceNumber(bsl::move(original.d_sequenceNumber))
+QueueUpdateAdvisory::QueueUpdateAdvisory(QueueUpdateAdvisory &&
+                                         original) noexcept
+: d_queueUpdates(bsl::move(original.d_queueUpdates)),
+  d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
 }
 
@@ -10171,13 +10160,11 @@ Subscription::Subscription(const Subscription& original,
                            bslma::Allocator*   basicAllocator)
 : d_consumers(original.d_consumers, basicAllocator)
 , d_expression(original.d_expression, basicAllocator)
-, d_sId(original.d_sId)
-{
-}
+, d_sId(original.d_sId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Subscription::Subscription(Subscription&& original) noexcept
+Subscription::Subscription(Subscription && original) noexcept
 : d_consumers(bsl::move(original.d_consumers)),
   d_expression(bsl::move(original.d_expression)),
   d_sId(bsl::move(original.d_sId))
@@ -10644,14 +10631,12 @@ ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
 ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
     const ConfigureQueueStreamResponse& original,
     bslma::Allocator*                   basicAllocator)
-: d_request(original.d_request, basicAllocator)
-{
-}
+: d_request(original.d_request, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
-    ConfigureQueueStreamResponse&& original) noexcept
+    ConfigureQueueStreamResponse && original) noexcept
 : d_request(bsl::move(original.d_request))
 {
 }
@@ -10768,14 +10753,12 @@ FollowerClusterStateResponse::FollowerClusterStateResponse(
 FollowerClusterStateResponse::FollowerClusterStateResponse(
     const FollowerClusterStateResponse& original,
     bslma::Allocator*                   basicAllocator)
-: d_clusterStateSnapshot(original.d_clusterStateSnapshot, basicAllocator)
-{
-}
+: d_clusterStateSnapshot(original.d_clusterStateSnapshot, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 FollowerClusterStateResponse::FollowerClusterStateResponse(
-    FollowerClusterStateResponse&& original) noexcept
+    FollowerClusterStateResponse && original) noexcept
 : d_clusterStateSnapshot(bsl::move(original.d_clusterStateSnapshot))
 {
 }
@@ -10893,14 +10876,12 @@ LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
 LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
     const LeaderSyncDataQueryResponse& original,
     bslma::Allocator*                  basicAllocator)
-: d_leaderSyncData(original.d_leaderSyncData, basicAllocator)
-{
-}
+: d_leaderSyncData(original.d_leaderSyncData, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
-    LeaderSyncDataQueryResponse&& original) noexcept
+    LeaderSyncDataQueryResponse && original) noexcept
 : d_leaderSyncData(bsl::move(original.d_leaderSyncData))
 {
 }
@@ -11439,13 +11420,11 @@ OpenQueueResponse::OpenQueueResponse(const OpenQueueResponse& original,
                                      bslma::Allocator*        basicAllocator)
 : d_routingConfiguration(original.d_routingConfiguration)
 , d_originalRequest(original.d_originalRequest, basicAllocator)
-, d_deduplicationTimeMs(original.d_deduplicationTimeMs)
-{
-}
+, d_deduplicationTimeMs(original.d_deduplicationTimeMs){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-OpenQueueResponse::OpenQueueResponse(OpenQueueResponse&& original) noexcept
+OpenQueueResponse::OpenQueueResponse(OpenQueueResponse && original) noexcept
 : d_routingConfiguration(bsl::move(original.d_routingConfiguration)),
   d_originalRequest(bsl::move(original.d_originalRequest)),
   d_deduplicationTimeMs(bsl::move(original.d_deduplicationTimeMs))
@@ -11682,13 +11661,11 @@ StreamParameters::StreamParameters(bslma::Allocator* basicAllocator)
 StreamParameters::StreamParameters(const StreamParameters& original,
                                    bslma::Allocator*       basicAllocator)
 : d_subscriptions(original.d_subscriptions, basicAllocator)
-, d_appId(original.d_appId, basicAllocator)
-{
-}
+, d_appId(original.d_appId, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StreamParameters::StreamParameters(StreamParameters&& original) noexcept
+StreamParameters::StreamParameters(StreamParameters && original) noexcept
 : d_subscriptions(bsl::move(original.d_subscriptions)),
   d_appId(bsl::move(original.d_appId))
 {
@@ -12525,13 +12502,11 @@ ConfigureStream::ConfigureStream(bslma::Allocator* basicAllocator)
 ConfigureStream::ConfigureStream(const ConfigureStream& original,
                                  bslma::Allocator*      basicAllocator)
 : d_streamParameters(original.d_streamParameters, basicAllocator)
-, d_qId(original.d_qId)
-{
-}
+, d_qId(original.d_qId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureStream::ConfigureStream(ConfigureStream&& original) noexcept
+ConfigureStream::ConfigureStream(ConfigureStream && original) noexcept
 : d_streamParameters(bsl::move(original.d_streamParameters)),
   d_qId(bsl::move(original.d_qId))
 {
@@ -12683,14 +12658,12 @@ ClusterStateFSMMessage::ClusterStateFSMMessage(
 ClusterStateFSMMessage::ClusterStateFSMMessage(
     const ClusterStateFSMMessage& original,
     bslma::Allocator*             basicAllocator)
-: d_choice(original.d_choice, basicAllocator)
-{
-}
+: d_choice(original.d_choice, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClusterStateFSMMessage::ClusterStateFSMMessage(
-    ClusterStateFSMMessage&& original) noexcept
+ClusterStateFSMMessage::ClusterStateFSMMessage(ClusterStateFSMMessage &&
+                                               original) noexcept
 : d_choice(bsl::move(original.d_choice))
 {
 }
@@ -12803,14 +12776,12 @@ ConfigureStreamResponse::ConfigureStreamResponse(
 ConfigureStreamResponse::ConfigureStreamResponse(
     const ConfigureStreamResponse& original,
     bslma::Allocator*              basicAllocator)
-: d_request(original.d_request, basicAllocator)
-{
-}
+: d_request(original.d_request, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureStreamResponse::ConfigureStreamResponse(
-    ConfigureStreamResponse&& original) noexcept
+ConfigureStreamResponse::ConfigureStreamResponse(ConfigureStreamResponse &&
+                                                 original) noexcept
 : d_request(bsl::move(original.d_request))
 {
 }
@@ -15962,13 +15933,11 @@ ClusterMessage::ClusterMessage(bslma::Allocator* basicAllocator)
 
 ClusterMessage::ClusterMessage(const ClusterMessage& original,
                                bslma::Allocator*     basicAllocator)
-: d_choice(original.d_choice, basicAllocator)
-{
-}
+: d_choice(original.d_choice, basicAllocator){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClusterMessage::ClusterMessage(ClusterMessage&& original) noexcept
+ClusterMessage::ClusterMessage(ClusterMessage && original) noexcept
 : d_choice(bsl::move(original.d_choice))
 {
 }
@@ -17540,13 +17509,11 @@ ControlMessage::ControlMessage(bslma::Allocator* basicAllocator)
 ControlMessage::ControlMessage(const ControlMessage& original,
                                bslma::Allocator*     basicAllocator)
 : d_choice(original.d_choice, basicAllocator)
-, d_rId(original.d_rId)
-{
-}
+, d_rId(original.d_rId){}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ControlMessage::ControlMessage(ControlMessage&& original) noexcept
+ControlMessage::ControlMessage(ControlMessage && original) noexcept
 : d_choice(bsl::move(original.d_choice)),
   d_rId(bsl::move(original.d_rId))
 {
@@ -17612,6 +17579,6 @@ bsl::ostream& ControlMessage::print(bsl::ostream& stream,
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_2025.11.13
+// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -90,11 +90,13 @@ AdminCommand::AdminCommand(bslma::Allocator* basicAllocator)
 
 AdminCommand::AdminCommand(const AdminCommand& original,
                            bslma::Allocator*   basicAllocator)
-: d_command(original.d_command, basicAllocator){}
+: d_command(original.d_command, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AdminCommand::AdminCommand(AdminCommand && original) noexcept
+AdminCommand::AdminCommand(AdminCommand&& original) noexcept
 : d_command(bsl::move(original.d_command))
 {
 }
@@ -201,13 +203,14 @@ AdminCommandResponse::AdminCommandResponse(bslma::Allocator* basicAllocator)
 AdminCommandResponse::AdminCommandResponse(
     const AdminCommandResponse& original,
     bslma::Allocator*           basicAllocator)
-: d_text(original.d_text, basicAllocator){}
+: d_text(original.d_text, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AdminCommandResponse::AdminCommandResponse(AdminCommandResponse &&
-                                           original) noexcept
-: d_text(bsl::move(original.d_text))
+AdminCommandResponse::AdminCommandResponse(AdminCommandResponse&& original)
+    noexcept : d_text(bsl::move(original.d_text))
 {
 }
 
@@ -325,11 +328,13 @@ AppIdInfo::AppIdInfo(bslma::Allocator* basicAllocator)
 AppIdInfo::AppIdInfo(const AppIdInfo&  original,
                      bslma::Allocator* basicAllocator)
 : d_appKey(original.d_appKey, basicAllocator)
-, d_appId(original.d_appId, basicAllocator){}
+, d_appId(original.d_appId, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AppIdInfo::AppIdInfo(AppIdInfo && original) noexcept
+AppIdInfo::AppIdInfo(AppIdInfo&& original) noexcept
 : d_appKey(bsl::move(original.d_appKey)),
   d_appId(bsl::move(original.d_appId))
 {
@@ -459,14 +464,15 @@ AuthenticationRequest::AuthenticationRequest(
     const AuthenticationRequest& original,
     bslma::Allocator*            basicAllocator)
 : d_mechanism(original.d_mechanism, basicAllocator)
-, d_data(original.d_data, basicAllocator){}
+, d_data(original.d_data, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AuthenticationRequest::AuthenticationRequest(AuthenticationRequest &&
-                                             original) noexcept
-: d_mechanism(bsl::move(original.d_mechanism)),
-  d_data(bsl::move(original.d_data))
+AuthenticationRequest::AuthenticationRequest(AuthenticationRequest&& original)
+    noexcept : d_mechanism(bsl::move(original.d_mechanism)),
+               d_data(bsl::move(original.d_data))
 {
 }
 
@@ -1446,11 +1452,13 @@ GuidInfo::GuidInfo(bslma::Allocator* basicAllocator)
 
 GuidInfo::GuidInfo(const GuidInfo& original, bslma::Allocator* basicAllocator)
 : d_nanoSecondsFromEpoch(original.d_nanoSecondsFromEpoch)
-, d_clientId(original.d_clientId, basicAllocator){}
+, d_clientId(original.d_clientId, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-GuidInfo::GuidInfo(GuidInfo && original) noexcept
+GuidInfo::GuidInfo(GuidInfo&& original) noexcept
 : d_nanoSecondsFromEpoch(bsl::move(original.d_nanoSecondsFromEpoch)),
   d_clientId(bsl::move(original.d_clientId))
 {
@@ -2360,12 +2368,14 @@ QueueAssignmentRequest::QueueAssignmentRequest(
 QueueAssignmentRequest::QueueAssignmentRequest(
     const QueueAssignmentRequest& original,
     bslma::Allocator*             basicAllocator)
-: d_queueUri(original.d_queueUri, basicAllocator){}
+: d_queueUri(original.d_queueUri, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueAssignmentRequest::QueueAssignmentRequest(QueueAssignmentRequest &&
-                                               original) noexcept
+QueueAssignmentRequest::QueueAssignmentRequest(
+    QueueAssignmentRequest&& original) noexcept
 : d_queueUri(bsl::move(original.d_queueUri))
 {
 }
@@ -2497,12 +2507,14 @@ QueueUnassignmentRequest::QueueUnassignmentRequest(
     bslma::Allocator*               basicAllocator)
 : d_queueKey(original.d_queueKey, basicAllocator)
 , d_queueUri(original.d_queueUri, basicAllocator)
-, d_partitionId(original.d_partitionId){}
+, d_partitionId(original.d_partitionId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUnassignmentRequest::QueueUnassignmentRequest(QueueUnassignmentRequest &&
-                                                   original) noexcept
+QueueUnassignmentRequest::QueueUnassignmentRequest(
+    QueueUnassignmentRequest&& original) noexcept
 : d_queueKey(bsl::move(original.d_queueKey)),
   d_queueUri(bsl::move(original.d_queueUri)),
   d_partitionId(bsl::move(original.d_partitionId))
@@ -3124,11 +3136,13 @@ StopRequest::StopRequest(bslma::Allocator* basicAllocator)
 StopRequest::StopRequest(const StopRequest& original,
                          bslma::Allocator*  basicAllocator)
 : d_clusterName(original.d_clusterName, basicAllocator)
-, d_version(original.d_version){}
+, d_version(original.d_version)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StopRequest::StopRequest(StopRequest && original) noexcept
+StopRequest::StopRequest(StopRequest&& original) noexcept
 : d_clusterName(bsl::move(original.d_clusterName)),
   d_version(bsl::move(original.d_version))
 {
@@ -3241,11 +3255,13 @@ StopResponse::StopResponse(bslma::Allocator* basicAllocator)
 
 StopResponse::StopResponse(const StopResponse& original,
                            bslma::Allocator*   basicAllocator)
-: d_clusterName(original.d_clusterName, basicAllocator){}
+: d_clusterName(original.d_clusterName, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StopResponse::StopResponse(StopResponse && original) noexcept
+StopResponse::StopResponse(StopResponse&& original) noexcept
 : d_clusterName(bsl::move(original.d_clusterName))
 {
 }
@@ -3447,11 +3463,13 @@ SubQueueIdInfo::SubQueueIdInfo(bslma::Allocator* basicAllocator)
 SubQueueIdInfo::SubQueueIdInfo(const SubQueueIdInfo& original,
                                bslma::Allocator*     basicAllocator)
 : d_appId(original.d_appId, basicAllocator)
-, d_subId(original.d_subId){}
+, d_subId(original.d_subId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-SubQueueIdInfo::SubQueueIdInfo(SubQueueIdInfo && original) noexcept
+SubQueueIdInfo::SubQueueIdInfo(SubQueueIdInfo&& original) noexcept
 : d_appId(bsl::move(original.d_appId)),
   d_subId(bsl::move(original.d_subId))
 {
@@ -3793,11 +3811,13 @@ ClientIdentity::ClientIdentity(const ClientIdentity& original,
 , d_sessionId(original.d_sessionId)
 , d_clusterNodeId(original.d_clusterNodeId)
 , d_clientType(original.d_clientType)
-, d_sdkLanguage(original.d_sdkLanguage){}
+, d_sdkLanguage(original.d_sdkLanguage)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClientIdentity::ClientIdentity(ClientIdentity && original) noexcept
+ClientIdentity::ClientIdentity(ClientIdentity&& original) noexcept
 : d_processName(bsl::move(original.d_processName)),
   d_hostName(bsl::move(original.d_hostName)),
   d_features(bsl::move(original.d_features)),
@@ -4877,11 +4897,13 @@ Expression::Expression(bslma::Allocator* basicAllocator)
 Expression::Expression(const Expression& original,
                        bslma::Allocator* basicAllocator)
 : d_text(original.d_text, basicAllocator)
-, d_version(original.d_version){}
+, d_version(original.d_version)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Expression::Expression(Expression && original) noexcept
+Expression::Expression(Expression&& original) noexcept
 : d_text(bsl::move(original.d_text)),
   d_version(bsl::move(original.d_version))
 {
@@ -5367,12 +5389,14 @@ PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(
     const PartitionPrimaryAdvisory& original,
     bslma::Allocator*               basicAllocator)
 : d_partitions(original.d_partitions, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber){}
+, d_sequenceNumber(original.d_sequenceNumber)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(PartitionPrimaryAdvisory &&
-                                                   original) noexcept
+PartitionPrimaryAdvisory::PartitionPrimaryAdvisory(
+    PartitionPrimaryAdvisory&& original) noexcept
 : d_partitions(bsl::move(original.d_partitions)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
@@ -5846,19 +5870,20 @@ QueueHandleParameters::QueueHandleParameters(
 , d_qId(original.d_qId)
 , d_readCount(original.d_readCount)
 , d_writeCount(original.d_writeCount)
-, d_adminCount(original.d_adminCount){}
+, d_adminCount(original.d_adminCount)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueHandleParameters::QueueHandleParameters(QueueHandleParameters &&
-                                             original) noexcept
-: d_flags(bsl::move(original.d_flags)),
-  d_uri(bsl::move(original.d_uri)),
-  d_subIdInfo(bsl::move(original.d_subIdInfo)),
-  d_qId(bsl::move(original.d_qId)),
-  d_readCount(bsl::move(original.d_readCount)),
-  d_writeCount(bsl::move(original.d_writeCount)),
-  d_adminCount(bsl::move(original.d_adminCount))
+QueueHandleParameters::QueueHandleParameters(QueueHandleParameters&& original)
+    noexcept : d_flags(bsl::move(original.d_flags)),
+               d_uri(bsl::move(original.d_uri)),
+               d_subIdInfo(bsl::move(original.d_subIdInfo)),
+               d_qId(bsl::move(original.d_qId)),
+               d_readCount(bsl::move(original.d_readCount)),
+               d_writeCount(bsl::move(original.d_writeCount)),
+               d_adminCount(bsl::move(original.d_adminCount))
 {
 }
 
@@ -6022,11 +6047,13 @@ QueueInfo::QueueInfo(const QueueInfo&  original,
 : d_key(original.d_key, basicAllocator)
 , d_appIds(original.d_appIds, basicAllocator)
 , d_uri(original.d_uri, basicAllocator)
-, d_partitionId(original.d_partitionId){}
+, d_partitionId(original.d_partitionId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueInfo::QueueInfo(QueueInfo && original) noexcept
+QueueInfo::QueueInfo(QueueInfo&& original) noexcept
 : d_key(bsl::move(original.d_key)),
   d_appIds(bsl::move(original.d_appIds)),
   d_uri(bsl::move(original.d_uri)),
@@ -6202,11 +6229,13 @@ QueueInfoUpdate::QueueInfoUpdate(const QueueInfoUpdate& original,
 , d_removedAppIds(original.d_removedAppIds, basicAllocator)
 , d_uri(original.d_uri, basicAllocator)
 , d_domain(original.d_domain, basicAllocator)
-, d_partitionId(original.d_partitionId){}
+, d_partitionId(original.d_partitionId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueInfoUpdate::QueueInfoUpdate(QueueInfoUpdate && original) noexcept
+QueueInfoUpdate::QueueInfoUpdate(QueueInfoUpdate&& original) noexcept
 : d_key(bsl::move(original.d_key)),
   d_addedAppIds(bsl::move(original.d_addedAppIds)),
   d_removedAppIds(bsl::move(original.d_removedAppIds)),
@@ -6402,12 +6431,14 @@ QueueStreamParameters::QueueStreamParameters(
 , d_maxUnconfirmedBytes(original.d_maxUnconfirmedBytes)
 , d_subIdInfo(original.d_subIdInfo, basicAllocator)
 , d_consumerPriority(original.d_consumerPriority)
-, d_consumerPriorityCount(original.d_consumerPriorityCount){}
+, d_consumerPriorityCount(original.d_consumerPriorityCount)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueStreamParameters::QueueStreamParameters(QueueStreamParameters &&
-                                             original) noexcept
+QueueStreamParameters::QueueStreamParameters(
+    QueueStreamParameters&& original) noexcept
 : d_maxUnconfirmedMessages(bsl::move(original.d_maxUnconfirmedMessages)),
   d_maxUnconfirmedBytes(bsl::move(original.d_maxUnconfirmedBytes)),
   d_subIdInfo(bsl::move(original.d_subIdInfo)),
@@ -7259,11 +7290,13 @@ Status::Status(bslma::Allocator* basicAllocator)
 Status::Status(const Status& original, bslma::Allocator* basicAllocator)
 : d_message(original.d_message, basicAllocator)
 , d_code(original.d_code)
-, d_category(original.d_category){}
+, d_category(original.d_category)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Status::Status(Status && original) noexcept
+Status::Status(Status&& original) noexcept
 : d_message(bsl::move(original.d_message)),
   d_code(bsl::move(original.d_code)),
   d_category(bsl::move(original.d_category))
@@ -7572,12 +7605,14 @@ AuthenticationResponse::AuthenticationResponse(
     const AuthenticationResponse& original,
     bslma::Allocator*             basicAllocator)
 : d_status(original.d_status, basicAllocator)
-, d_lifetimeMs(original.d_lifetimeMs){}
+, d_lifetimeMs(original.d_lifetimeMs)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-AuthenticationResponse::AuthenticationResponse(AuthenticationResponse &&
-                                               original) noexcept
+AuthenticationResponse::AuthenticationResponse(
+    AuthenticationResponse&& original) noexcept
 : d_status(bsl::move(original.d_status)),
   d_lifetimeMs(bsl::move(original.d_lifetimeMs))
 {
@@ -7754,11 +7789,13 @@ BrokerResponse::BrokerResponse(const BrokerResponse& original,
 , d_brokerVersion(original.d_brokerVersion)
 , d_heartbeatIntervalMs(original.d_heartbeatIntervalMs)
 , d_maxMissedHeartbeats(original.d_maxMissedHeartbeats)
-, d_isDeprecatedSdk(original.d_isDeprecatedSdk){}
+, d_isDeprecatedSdk(original.d_isDeprecatedSdk)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-BrokerResponse::BrokerResponse(BrokerResponse && original) noexcept
+BrokerResponse::BrokerResponse(BrokerResponse&& original) noexcept
 : d_result(bsl::move(original.d_result)),
   d_brokerIdentity(bsl::move(original.d_brokerIdentity)),
   d_protocolVersion(bsl::move(original.d_protocolVersion)),
@@ -7913,11 +7950,13 @@ CloseQueue::CloseQueue(bslma::Allocator* basicAllocator)
 CloseQueue::CloseQueue(const CloseQueue& original,
                        bslma::Allocator* basicAllocator)
 : d_handleParameters(original.d_handleParameters, basicAllocator)
-, d_isFinal(original.d_isFinal){}
+, d_isFinal(original.d_isFinal)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-CloseQueue::CloseQueue(CloseQueue && original) noexcept
+CloseQueue::CloseQueue(CloseQueue&& original) noexcept
 : d_handleParameters(bsl::move(original.d_handleParameters)),
   d_isFinal(bsl::move(original.d_isFinal))
 {
@@ -8038,14 +8077,15 @@ ConfigureQueueStream::ConfigureQueueStream(
     const ConfigureQueueStream& original,
     bslma::Allocator*           basicAllocator)
 : d_streamParameters(original.d_streamParameters, basicAllocator)
-, d_qId(original.d_qId){}
+, d_qId(original.d_qId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureQueueStream::ConfigureQueueStream(ConfigureQueueStream &&
-                                           original) noexcept
-: d_streamParameters(bsl::move(original.d_streamParameters)),
-  d_qId(bsl::move(original.d_qId))
+ConfigureQueueStream::ConfigureQueueStream(ConfigureQueueStream&& original)
+    noexcept : d_streamParameters(bsl::move(original.d_streamParameters)),
+               d_qId(bsl::move(original.d_qId))
 {
 }
 
@@ -8293,11 +8333,13 @@ LeaderAdvisory::LeaderAdvisory(const LeaderAdvisory& original,
                                bslma::Allocator*     basicAllocator)
 : d_queues(original.d_queues, basicAllocator)
 , d_partitions(original.d_partitions, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber){}
+, d_sequenceNumber(original.d_sequenceNumber)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-LeaderAdvisory::LeaderAdvisory(LeaderAdvisory && original) noexcept
+LeaderAdvisory::LeaderAdvisory(LeaderAdvisory&& original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_partitions(bsl::move(original.d_partitions)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
@@ -8417,11 +8459,13 @@ OpenQueue::OpenQueue(bslma::Allocator* basicAllocator)
 
 OpenQueue::OpenQueue(const OpenQueue&  original,
                      bslma::Allocator* basicAllocator)
-: d_handleParameters(original.d_handleParameters, basicAllocator){}
+: d_handleParameters(original.d_handleParameters, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-OpenQueue::OpenQueue(OpenQueue && original) noexcept
+OpenQueue::OpenQueue(OpenQueue&& original) noexcept
 : d_handleParameters(bsl::move(original.d_handleParameters))
 {
 }
@@ -9307,12 +9351,14 @@ PartitionSyncDataQueryStatus::PartitionSyncDataQueryStatus(
     const PartitionSyncDataQueryStatus& original,
     bslma::Allocator*                   basicAllocator)
 : d_status(original.d_status, basicAllocator)
-, d_partitionId(original.d_partitionId){}
+, d_partitionId(original.d_partitionId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 PartitionSyncDataQueryStatus::PartitionSyncDataQueryStatus(
-    PartitionSyncDataQueryStatus && original) noexcept
+    PartitionSyncDataQueryStatus&& original) noexcept
 : d_status(bsl::move(original.d_status)),
   d_partitionId(bsl::move(original.d_partitionId))
 {
@@ -9545,12 +9591,14 @@ QueueAssignmentAdvisory::QueueAssignmentAdvisory(
     const QueueAssignmentAdvisory& original,
     bslma::Allocator*              basicAllocator)
 : d_queues(original.d_queues, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber){}
+, d_sequenceNumber(original.d_sequenceNumber)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueAssignmentAdvisory::QueueAssignmentAdvisory(QueueAssignmentAdvisory &&
-                                                 original) noexcept
+QueueAssignmentAdvisory::QueueAssignmentAdvisory(
+    QueueAssignmentAdvisory&& original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
@@ -9708,12 +9756,14 @@ QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
 , d_sequenceNumber(original.d_sequenceNumber)
 , d_primaryLeaseId(original.d_primaryLeaseId)
 , d_partitionId(original.d_partitionId)
-, d_primaryNodeId(original.d_primaryNodeId){}
+, d_primaryNodeId(original.d_primaryNodeId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 QueueUnAssignmentAdvisory::QueueUnAssignmentAdvisory(
-    QueueUnAssignmentAdvisory && original) noexcept
+    QueueUnAssignmentAdvisory&& original) noexcept
 : d_queues(bsl::move(original.d_queues)),
   d_sequenceNumber(bsl::move(original.d_sequenceNumber)),
   d_primaryLeaseId(bsl::move(original.d_primaryLeaseId)),
@@ -9857,14 +9907,15 @@ QueueUpdateAdvisory::QueueUpdateAdvisory(bslma::Allocator* basicAllocator)
 QueueUpdateAdvisory::QueueUpdateAdvisory(const QueueUpdateAdvisory& original,
                                          bslma::Allocator* basicAllocator)
 : d_queueUpdates(original.d_queueUpdates, basicAllocator)
-, d_sequenceNumber(original.d_sequenceNumber){}
+, d_sequenceNumber(original.d_sequenceNumber)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-QueueUpdateAdvisory::QueueUpdateAdvisory(QueueUpdateAdvisory &&
-                                         original) noexcept
-: d_queueUpdates(bsl::move(original.d_queueUpdates)),
-  d_sequenceNumber(bsl::move(original.d_sequenceNumber))
+QueueUpdateAdvisory::QueueUpdateAdvisory(QueueUpdateAdvisory&& original)
+    noexcept : d_queueUpdates(bsl::move(original.d_queueUpdates)),
+               d_sequenceNumber(bsl::move(original.d_sequenceNumber))
 {
 }
 
@@ -10160,11 +10211,13 @@ Subscription::Subscription(const Subscription& original,
                            bslma::Allocator*   basicAllocator)
 : d_consumers(original.d_consumers, basicAllocator)
 , d_expression(original.d_expression, basicAllocator)
-, d_sId(original.d_sId){}
+, d_sId(original.d_sId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-Subscription::Subscription(Subscription && original) noexcept
+Subscription::Subscription(Subscription&& original) noexcept
 : d_consumers(bsl::move(original.d_consumers)),
   d_expression(bsl::move(original.d_expression)),
   d_sId(bsl::move(original.d_sId))
@@ -10631,12 +10684,14 @@ ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
 ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
     const ConfigureQueueStreamResponse& original,
     bslma::Allocator*                   basicAllocator)
-: d_request(original.d_request, basicAllocator){}
+: d_request(original.d_request, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 ConfigureQueueStreamResponse::ConfigureQueueStreamResponse(
-    ConfigureQueueStreamResponse && original) noexcept
+    ConfigureQueueStreamResponse&& original) noexcept
 : d_request(bsl::move(original.d_request))
 {
 }
@@ -10753,12 +10808,14 @@ FollowerClusterStateResponse::FollowerClusterStateResponse(
 FollowerClusterStateResponse::FollowerClusterStateResponse(
     const FollowerClusterStateResponse& original,
     bslma::Allocator*                   basicAllocator)
-: d_clusterStateSnapshot(original.d_clusterStateSnapshot, basicAllocator){}
+: d_clusterStateSnapshot(original.d_clusterStateSnapshot, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 FollowerClusterStateResponse::FollowerClusterStateResponse(
-    FollowerClusterStateResponse && original) noexcept
+    FollowerClusterStateResponse&& original) noexcept
 : d_clusterStateSnapshot(bsl::move(original.d_clusterStateSnapshot))
 {
 }
@@ -10876,12 +10933,14 @@ LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
 LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
     const LeaderSyncDataQueryResponse& original,
     bslma::Allocator*                  basicAllocator)
-: d_leaderSyncData(original.d_leaderSyncData, basicAllocator){}
+: d_leaderSyncData(original.d_leaderSyncData, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 LeaderSyncDataQueryResponse::LeaderSyncDataQueryResponse(
-    LeaderSyncDataQueryResponse && original) noexcept
+    LeaderSyncDataQueryResponse&& original) noexcept
 : d_leaderSyncData(bsl::move(original.d_leaderSyncData))
 {
 }
@@ -11420,11 +11479,13 @@ OpenQueueResponse::OpenQueueResponse(const OpenQueueResponse& original,
                                      bslma::Allocator*        basicAllocator)
 : d_routingConfiguration(original.d_routingConfiguration)
 , d_originalRequest(original.d_originalRequest, basicAllocator)
-, d_deduplicationTimeMs(original.d_deduplicationTimeMs){}
+, d_deduplicationTimeMs(original.d_deduplicationTimeMs)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-OpenQueueResponse::OpenQueueResponse(OpenQueueResponse && original) noexcept
+OpenQueueResponse::OpenQueueResponse(OpenQueueResponse&& original) noexcept
 : d_routingConfiguration(bsl::move(original.d_routingConfiguration)),
   d_originalRequest(bsl::move(original.d_originalRequest)),
   d_deduplicationTimeMs(bsl::move(original.d_deduplicationTimeMs))
@@ -11661,11 +11722,13 @@ StreamParameters::StreamParameters(bslma::Allocator* basicAllocator)
 StreamParameters::StreamParameters(const StreamParameters& original,
                                    bslma::Allocator*       basicAllocator)
 : d_subscriptions(original.d_subscriptions, basicAllocator)
-, d_appId(original.d_appId, basicAllocator){}
+, d_appId(original.d_appId, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-StreamParameters::StreamParameters(StreamParameters && original) noexcept
+StreamParameters::StreamParameters(StreamParameters&& original) noexcept
 : d_subscriptions(bsl::move(original.d_subscriptions)),
   d_appId(bsl::move(original.d_appId))
 {
@@ -12502,11 +12565,13 @@ ConfigureStream::ConfigureStream(bslma::Allocator* basicAllocator)
 ConfigureStream::ConfigureStream(const ConfigureStream& original,
                                  bslma::Allocator*      basicAllocator)
 : d_streamParameters(original.d_streamParameters, basicAllocator)
-, d_qId(original.d_qId){}
+, d_qId(original.d_qId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureStream::ConfigureStream(ConfigureStream && original) noexcept
+ConfigureStream::ConfigureStream(ConfigureStream&& original) noexcept
 : d_streamParameters(bsl::move(original.d_streamParameters)),
   d_qId(bsl::move(original.d_qId))
 {
@@ -12658,12 +12723,14 @@ ClusterStateFSMMessage::ClusterStateFSMMessage(
 ClusterStateFSMMessage::ClusterStateFSMMessage(
     const ClusterStateFSMMessage& original,
     bslma::Allocator*             basicAllocator)
-: d_choice(original.d_choice, basicAllocator){}
+: d_choice(original.d_choice, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClusterStateFSMMessage::ClusterStateFSMMessage(ClusterStateFSMMessage &&
-                                               original) noexcept
+ClusterStateFSMMessage::ClusterStateFSMMessage(
+    ClusterStateFSMMessage&& original) noexcept
 : d_choice(bsl::move(original.d_choice))
 {
 }
@@ -12776,12 +12843,14 @@ ConfigureStreamResponse::ConfigureStreamResponse(
 ConfigureStreamResponse::ConfigureStreamResponse(
     const ConfigureStreamResponse& original,
     bslma::Allocator*              basicAllocator)
-: d_request(original.d_request, basicAllocator){}
+: d_request(original.d_request, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ConfigureStreamResponse::ConfigureStreamResponse(ConfigureStreamResponse &&
-                                                 original) noexcept
+ConfigureStreamResponse::ConfigureStreamResponse(
+    ConfigureStreamResponse&& original) noexcept
 : d_request(bsl::move(original.d_request))
 {
 }
@@ -15933,11 +16002,13 @@ ClusterMessage::ClusterMessage(bslma::Allocator* basicAllocator)
 
 ClusterMessage::ClusterMessage(const ClusterMessage& original,
                                bslma::Allocator*     basicAllocator)
-: d_choice(original.d_choice, basicAllocator){}
+: d_choice(original.d_choice, basicAllocator)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ClusterMessage::ClusterMessage(ClusterMessage && original) noexcept
+ClusterMessage::ClusterMessage(ClusterMessage&& original) noexcept
 : d_choice(bsl::move(original.d_choice))
 {
 }
@@ -17509,11 +17580,13 @@ ControlMessage::ControlMessage(bslma::Allocator* basicAllocator)
 ControlMessage::ControlMessage(const ControlMessage& original,
                                bslma::Allocator*     basicAllocator)
 : d_choice(original.d_choice, basicAllocator)
-, d_rId(original.d_rId){}
+, d_rId(original.d_rId)
+{
+}
 
 #if defined(BSLS_COMPILERFEATURES_SUPPORT_RVALUE_REFERENCES) &&               \
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
-ControlMessage::ControlMessage(ControlMessage && original) noexcept
+ControlMessage::ControlMessage(ControlMessage&& original) noexcept
 : d_choice(bsl::move(original.d_choice)),
   d_rId(bsl::move(original.d_rId))
 {

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -1,4 +1,4 @@
-// Copyright 2014-2025 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -550,7 +550,7 @@ class AdminCommand {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AdminCommand)
+    bmqp_ctrlmsg::AdminCommand);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::AdminCommand>
 : bsl::true_type {};
@@ -769,7 +769,7 @@ class AdminCommandResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AdminCommandResponse)
+    bmqp_ctrlmsg::AdminCommandResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::AdminCommandResponse>
 : bsl::true_type {};
@@ -988,7 +988,7 @@ class AppIdInfo {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AppIdInfo)
+    bmqp_ctrlmsg::AppIdInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::AppIdInfo> : bsl::true_type {};
 
@@ -1217,7 +1217,7 @@ class AuthenticationRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AuthenticationRequest)
+    bmqp_ctrlmsg::AuthenticationRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::AuthenticationRequest>
 : bsl::true_type {};
@@ -1284,7 +1284,7 @@ struct ClientLanguage {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ClientLanguage)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ClientLanguage);
 
 namespace bmqp_ctrlmsg {
 
@@ -1353,7 +1353,7 @@ struct ClientType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ClientType)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ClientType);
 
 namespace bmqp_ctrlmsg {
 
@@ -1503,7 +1503,7 @@ class CloseQueueResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::CloseQueueResponse)
+    bmqp_ctrlmsg::CloseQueueResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::CloseQueueResponse>
 : bsl::true_type {};
@@ -1733,7 +1733,7 @@ class ConsumerInfo {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ConsumerInfo)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ConsumerInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ConsumerInfo>
 : bsl::true_type {};
@@ -1883,7 +1883,7 @@ class Disconnect {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::Disconnect)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::Disconnect);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::Disconnect> : bsl::true_type {
 };
@@ -2038,7 +2038,7 @@ class DisconnectResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::DisconnectResponse)
+    bmqp_ctrlmsg::DisconnectResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::DisconnectResponse>
 : bsl::true_type {};
@@ -2187,7 +2187,7 @@ class DummyType {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::DummyType)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::DummyType);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::DummyType> : bsl::true_type {};
 
@@ -2255,7 +2255,7 @@ struct DumpActionType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::DumpActionType)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::DumpActionType);
 
 namespace bmqp_ctrlmsg {
 
@@ -2323,7 +2323,7 @@ struct DumpMsgType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::DumpMsgType)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::DumpMsgType);
 
 namespace bmqp_ctrlmsg {
 
@@ -2472,7 +2472,8 @@ class ElectionProposal {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ElectionProposal)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
+    bmqp_ctrlmsg::ElectionProposal);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ElectionProposal>
 : bsl::true_type {};
@@ -2624,7 +2625,8 @@ class ElectionResponse {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ElectionResponse)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
+    bmqp_ctrlmsg::ElectionResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ElectionResponse>
 : bsl::true_type {};
@@ -2800,7 +2802,7 @@ class ElectorNodeStatus {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ElectorNodeStatus)
+    bmqp_ctrlmsg::ElectorNodeStatus);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ElectorNodeStatus>
 : bsl::true_type {};
@@ -2866,7 +2868,7 @@ struct ExpressionVersion {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ExpressionVersion)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ExpressionVersion);
 
 namespace bmqp_ctrlmsg {
 
@@ -3018,7 +3020,7 @@ class FollowerClusterStateRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::FollowerClusterStateRequest)
+    bmqp_ctrlmsg::FollowerClusterStateRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::FollowerClusterStateRequest>
 : bsl::true_type {};
@@ -3172,7 +3174,7 @@ class FollowerLSNRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::FollowerLSNRequest)
+    bmqp_ctrlmsg::FollowerLSNRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::FollowerLSNRequest>
 : bsl::true_type {};
@@ -3406,7 +3408,7 @@ class GuidInfo {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::GuidInfo)
+    bmqp_ctrlmsg::GuidInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::GuidInfo> : bsl::true_type {};
 
@@ -3558,7 +3560,7 @@ class HeartbeatResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::HeartbeatResponse)
+    bmqp_ctrlmsg::HeartbeatResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::HeartbeatResponse>
 : bsl::true_type {};
@@ -3710,7 +3712,7 @@ class LeaderHeartbeat {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::LeaderHeartbeat)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::LeaderHeartbeat);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderHeartbeat>
 : bsl::true_type {};
@@ -3898,7 +3900,7 @@ class LeaderMessageSequence {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderMessageSequence)
+    bmqp_ctrlmsg::LeaderMessageSequence);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderMessageSequence>
 : bsl::true_type {};
@@ -4050,7 +4052,7 @@ class LeaderPassive {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::LeaderPassive)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::LeaderPassive);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderPassive>
 : bsl::true_type {};
@@ -4205,7 +4207,7 @@ class LeaderSyncDataQuery {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderSyncDataQuery)
+    bmqp_ctrlmsg::LeaderSyncDataQuery);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderSyncDataQuery>
 : bsl::true_type {};
@@ -4359,7 +4361,7 @@ class LeaderSyncStateQuery {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderSyncStateQuery)
+    bmqp_ctrlmsg::LeaderSyncStateQuery);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderSyncStateQuery>
 : bsl::true_type {};
@@ -4514,7 +4516,7 @@ class LeadershipCessionNotification {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeadershipCessionNotification)
+    bmqp_ctrlmsg::LeadershipCessionNotification);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeadershipCessionNotification>
 : bsl::true_type {};
@@ -4586,7 +4588,7 @@ struct NodeStatus {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::NodeStatus)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::NodeStatus);
 
 namespace bmqp_ctrlmsg {
 
@@ -4786,7 +4788,7 @@ class PartitionPrimaryInfo {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionPrimaryInfo)
+    bmqp_ctrlmsg::PartitionPrimaryInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionPrimaryInfo>
 : bsl::true_type {};
@@ -4976,7 +4978,7 @@ class PartitionSequenceNumber {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSequenceNumber)
+    bmqp_ctrlmsg::PartitionSequenceNumber);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionSequenceNumber>
 : bsl::true_type {};
@@ -5182,7 +5184,7 @@ class PartitionSyncDataQueryResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSyncDataQueryResponse)
+    bmqp_ctrlmsg::PartitionSyncDataQueryResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionSyncDataQueryResponse>
 : bsl::true_type {};
@@ -5360,7 +5362,7 @@ class PartitionSyncStateQuery {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSyncStateQuery)
+    bmqp_ctrlmsg::PartitionSyncStateQuery);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionSyncStateQuery>
 : bsl::true_type {};
@@ -5426,7 +5428,7 @@ struct PrimaryStatus {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::PrimaryStatus)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::PrimaryStatus);
 
 namespace bmqp_ctrlmsg {
 
@@ -5640,7 +5642,7 @@ class QueueAssignmentRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueAssignmentRequest)
+    bmqp_ctrlmsg::QueueAssignmentRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueAssignmentRequest>
 : bsl::true_type {};
@@ -5887,7 +5889,7 @@ class QueueUnassignmentRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueUnassignmentRequest)
+    bmqp_ctrlmsg::QueueUnassignmentRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueUnassignmentRequest>
 : bsl::true_type {};
@@ -6041,7 +6043,7 @@ class RegistrationResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::RegistrationResponse)
+    bmqp_ctrlmsg::RegistrationResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::RegistrationResponse>
 : bsl::true_type {};
@@ -6107,7 +6109,7 @@ struct ReplicaDataType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ReplicaDataType)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::ReplicaDataType);
 
 namespace bmqp_ctrlmsg {
 
@@ -6282,7 +6284,7 @@ class RoutingConfiguration {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::RoutingConfiguration)
+    bmqp_ctrlmsg::RoutingConfiguration);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::RoutingConfiguration>
 : bsl::true_type {};
@@ -6366,7 +6368,7 @@ struct RoutingConfigurationFlags {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::RoutingConfigurationFlags)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::RoutingConfigurationFlags);
 
 namespace bmqp_ctrlmsg {
 
@@ -6516,7 +6518,7 @@ class ScoutingRequest {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ScoutingRequest)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ScoutingRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ScoutingRequest>
 : bsl::true_type {};
@@ -6693,7 +6695,8 @@ class ScoutingResponse {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ScoutingResponse)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
+    bmqp_ctrlmsg::ScoutingResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ScoutingResponse>
 : bsl::true_type {};
@@ -6774,7 +6777,7 @@ struct StatusCategory {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::StatusCategory)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::StatusCategory);
 
 namespace bmqp_ctrlmsg {
 
@@ -6995,7 +6998,7 @@ class StopRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StopRequest)
+    bmqp_ctrlmsg::StopRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StopRequest> : bsl::true_type {
 };
@@ -7209,7 +7212,7 @@ class StopResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StopResponse)
+    bmqp_ctrlmsg::StopResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StopResponse>
 : bsl::true_type {};
@@ -7281,7 +7284,7 @@ struct StorageSyncResponseType {
 
 // TRAITS
 
-BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::StorageSyncResponseType)
+BDLAT_DECL_ENUMERATION_TRAITS(bmqp_ctrlmsg::StorageSyncResponseType);
 
 namespace bmqp_ctrlmsg {
 
@@ -7509,7 +7512,7 @@ class SubQueueIdInfo {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::SubQueueIdInfo)
+    bmqp_ctrlmsg::SubQueueIdInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::SubQueueIdInfo>
 : bsl::true_type {};
@@ -7727,7 +7730,7 @@ class SyncPoint {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::SyncPoint)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::SyncPoint);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::SyncPoint> : bsl::true_type {};
 
@@ -8115,7 +8118,7 @@ class ClientIdentity {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ClientIdentity)
+    bmqp_ctrlmsg::ClientIdentity);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ClientIdentity>
 : bsl::true_type {};
@@ -8314,7 +8317,7 @@ class DumpMessages {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::DumpMessages)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::DumpMessages);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::DumpMessages>
 : bsl::true_type {};
@@ -8741,7 +8744,7 @@ class ElectorMessageChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ElectorMessageChoice)
+    bmqp_ctrlmsg::ElectorMessageChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -8962,7 +8965,7 @@ class Expression {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::Expression)
+    bmqp_ctrlmsg::Expression);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::Expression> : bsl::true_type {
 };
@@ -9139,7 +9142,7 @@ class FollowerLSNResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::FollowerLSNResponse)
+    bmqp_ctrlmsg::FollowerLSNResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::FollowerLSNResponse>
 : bsl::true_type {};
@@ -9315,7 +9318,7 @@ class LeaderAdvisoryAck {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderAdvisoryAck)
+    bmqp_ctrlmsg::LeaderAdvisoryAck);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderAdvisoryAck>
 : bsl::true_type {};
@@ -9508,7 +9511,7 @@ class LeaderAdvisoryCommit {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderAdvisoryCommit)
+    bmqp_ctrlmsg::LeaderAdvisoryCommit);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderAdvisoryCommit>
 : bsl::true_type {};
@@ -9684,7 +9687,7 @@ class LeaderSyncStateQueryResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderSyncStateQueryResponse)
+    bmqp_ctrlmsg::LeaderSyncStateQueryResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderSyncStateQueryResponse>
 : bsl::true_type {};
@@ -9859,7 +9862,7 @@ class NodeStatusAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::NodeStatusAdvisory)
+    bmqp_ctrlmsg::NodeStatusAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::NodeStatusAdvisory>
 : bsl::true_type {};
@@ -10091,7 +10094,7 @@ class PartitionPrimaryAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionPrimaryAdvisory)
+    bmqp_ctrlmsg::PartitionPrimaryAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionPrimaryAdvisory>
 : bsl::true_type {};
@@ -10107,34 +10110,39 @@ class PrimaryStateRequest {
     // for primary's sequence number.  The replica also sends it own sequence
     // numbers as part of this request.
     // partitionId:    partition id for corresponding partition.
-    // latestSequenceNumber: Replica's latest sequence number for corresponding
-    // partition.  firstSyncPointAfterRolloverSequenceNumber: Sequence number
-    // of replica's first sync point  after rollover for corresponding
-    // partition.
+    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // Replica's latest sequence number for corresponding partition.
+    // firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's
+    // first sync point after rollover for corresponding partition.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_latestSequenceNumber;
     PartitionSequenceNumber d_firstSyncPointAfterRolloverSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
     void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
 
+    bool isEqualTo(const PrimaryStateRequest& rhs) const;
+
   public:
     // TYPES
     enum {
         ATTRIBUTE_ID_PARTITION_ID                                    = 0,
-        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
-    enum { NUM_ATTRIBUTES = 3 };
+    enum { NUM_ATTRIBUTES = 4 };
 
     enum {
         ATTRIBUTE_INDEX_PARTITION_ID                                    = 0,
-        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
     // CONSTANTS
@@ -10197,6 +10205,10 @@ class PrimaryStateRequest {
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
 
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
     PartitionSequenceNumber& latestSequenceNumber();
     // Return a reference to the modifiable "LatestSequenceNumber"
     // attribute of this object.
@@ -10252,6 +10264,9 @@ class PrimaryStateRequest {
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
 
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
     const PartitionSequenceNumber& latestSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
     // "LatestSequenceNumber" attribute of this object.
@@ -10269,10 +10284,7 @@ class PrimaryStateRequest {
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.partitionId() == rhs.partitionId() &&
-               lhs.latestSequenceNumber() == rhs.latestSequenceNumber() &&
-               lhs.firstSyncPointAfterRolloverSequenceNumber() ==
-                   rhs.firstSyncPointAfterRolloverSequenceNumber();
+        return lhs.isEqualTo(rhs);
     }
 
     friend bool operator!=(const PrimaryStateRequest& lhs,
@@ -10307,7 +10319,7 @@ class PrimaryStateRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PrimaryStateRequest)
+    bmqp_ctrlmsg::PrimaryStateRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PrimaryStateRequest>
 : bsl::true_type {};
@@ -10322,34 +10334,39 @@ class PrimaryStateResponse {
     // This type represents a response sent by a primary to the replica along
     // with its sequence numbers.
     // partitionId:    partition id for corresponding partition.
-    // latestSequenceNumber: Primary's latest sequence number for corresponding
-    // partition.  firstSyncPointAfterRolloverSequenceNumber: Sequence number
-    // of primary's first sync point after rollover for corresponding
-    // partition.
+    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // Primary's latest sequence number for corresponding partition.
+    // firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's
+    // first sync point after rollover for corresponding partition.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_latestSequenceNumber;
     PartitionSequenceNumber d_firstSyncPointAfterRolloverSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
     void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
 
+    bool isEqualTo(const PrimaryStateResponse& rhs) const;
+
   public:
     // TYPES
     enum {
         ATTRIBUTE_ID_PARTITION_ID                                    = 0,
-        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
-    enum { NUM_ATTRIBUTES = 3 };
+    enum { NUM_ATTRIBUTES = 4 };
 
     enum {
         ATTRIBUTE_INDEX_PARTITION_ID                                    = 0,
-        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
     // CONSTANTS
@@ -10412,6 +10429,10 @@ class PrimaryStateResponse {
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
 
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
     PartitionSequenceNumber& latestSequenceNumber();
     // Return a reference to the modifiable "LatestSequenceNumber"
     // attribute of this object.
@@ -10467,6 +10488,9 @@ class PrimaryStateResponse {
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
 
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
     const PartitionSequenceNumber& latestSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
     // "LatestSequenceNumber" attribute of this object.
@@ -10484,10 +10508,7 @@ class PrimaryStateResponse {
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.partitionId() == rhs.partitionId() &&
-               lhs.latestSequenceNumber() == rhs.latestSequenceNumber() &&
-               lhs.firstSyncPointAfterRolloverSequenceNumber() ==
-                   rhs.firstSyncPointAfterRolloverSequenceNumber();
+        return lhs.isEqualTo(rhs);
     }
 
     friend bool operator!=(const PrimaryStateResponse& lhs,
@@ -10522,7 +10543,7 @@ class PrimaryStateResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PrimaryStateResponse)
+    bmqp_ctrlmsg::PrimaryStateResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PrimaryStateResponse>
 : bsl::true_type {};
@@ -10730,7 +10751,7 @@ class PrimaryStatusAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PrimaryStatusAdvisory)
+    bmqp_ctrlmsg::PrimaryStatusAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PrimaryStatusAdvisory>
 : bsl::true_type {};
@@ -11028,7 +11049,7 @@ class QueueHandleParameters {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueHandleParameters)
+    bmqp_ctrlmsg::QueueHandleParameters);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueHandleParameters>
 : bsl::true_type {};
@@ -11276,7 +11297,7 @@ class QueueInfo {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueInfo)
+    bmqp_ctrlmsg::QueueInfo);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueInfo> : bsl::true_type {};
 
@@ -11554,7 +11575,7 @@ class QueueInfoUpdate {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueInfoUpdate)
+    bmqp_ctrlmsg::QueueInfoUpdate);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueInfoUpdate>
 : bsl::true_type {};
@@ -11841,7 +11862,7 @@ class QueueStreamParameters {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueStreamParameters)
+    bmqp_ctrlmsg::QueueStreamParameters);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueStreamParameters>
 : bsl::true_type {};
@@ -12018,7 +12039,7 @@ class RegistrationRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::RegistrationRequest)
+    bmqp_ctrlmsg::RegistrationRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::RegistrationRequest>
 : bsl::true_type {};
@@ -12240,7 +12261,7 @@ class ReplicaDataRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ReplicaDataRequest)
+    bmqp_ctrlmsg::ReplicaDataRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ReplicaDataRequest>
 : bsl::true_type {};
@@ -12464,7 +12485,7 @@ class ReplicaDataResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ReplicaDataResponse)
+    bmqp_ctrlmsg::ReplicaDataResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ReplicaDataResponse>
 : bsl::true_type {};
@@ -12480,34 +12501,39 @@ class ReplicaStateRequest {
     // for replica's sequence numbers.  The primary also sends its own sequence
     // numbers as part of this request.
     // partitionId:    partition id for corresponding partition.
-    // latestSequenceNumber: Primary's latest sequence number for corresponding
-    // partition.  firstSyncPointAfterRolloverSequenceNumber: Sequence number
-    // of primary's first sync point after rollover for corresponding
-    // partition.
+    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // Primary's latest sequence number for corresponding partition.
+    // firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's
+    // first sync point after rollover for corresponding partition.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_latestSequenceNumber;
     PartitionSequenceNumber d_firstSyncPointAfterRolloverSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
     void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
 
+    bool isEqualTo(const ReplicaStateRequest& rhs) const;
+
   public:
     // TYPES
     enum {
         ATTRIBUTE_ID_PARTITION_ID                                    = 0,
-        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
-    enum { NUM_ATTRIBUTES = 3 };
+    enum { NUM_ATTRIBUTES = 4 };
 
     enum {
         ATTRIBUTE_INDEX_PARTITION_ID                                    = 0,
-        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
     // CONSTANTS
@@ -12570,6 +12596,10 @@ class ReplicaStateRequest {
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
 
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
     PartitionSequenceNumber& latestSequenceNumber();
     // Return a reference to the modifiable "LatestSequenceNumber"
     // attribute of this object.
@@ -12625,6 +12655,9 @@ class ReplicaStateRequest {
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
 
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
     const PartitionSequenceNumber& latestSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
     // "LatestSequenceNumber" attribute of this object.
@@ -12642,10 +12675,7 @@ class ReplicaStateRequest {
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.partitionId() == rhs.partitionId() &&
-               lhs.latestSequenceNumber() == rhs.latestSequenceNumber() &&
-               lhs.firstSyncPointAfterRolloverSequenceNumber() ==
-                   rhs.firstSyncPointAfterRolloverSequenceNumber();
+        return lhs.isEqualTo(rhs);
     }
 
     friend bool operator!=(const ReplicaStateRequest& lhs,
@@ -12680,7 +12710,7 @@ class ReplicaStateRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ReplicaStateRequest)
+    bmqp_ctrlmsg::ReplicaStateRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ReplicaStateRequest>
 : bsl::true_type {};
@@ -12695,34 +12725,39 @@ class ReplicaStateResponse {
     // This type represents a response sent by a replica to the primary along
     // with its sequence numbers.
     // partitionId:    partition id for corresponding partition.
-    // latestSequenceNumber: Replica's latest sequence number for corresponding
-    // partition.  firstSyncPointAfterRolloverSequenceNumber: Sequence number
-    // of replica's first sync point after rollover for corresponding
-    // partition.
+    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // Replica's latest sequence number for corresponding partition.
+    // firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's
+    // first sync point after rollover for corresponding partition.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_latestSequenceNumber;
     PartitionSequenceNumber d_firstSyncPointAfterRolloverSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
 
     // PRIVATE ACCESSORS
     template <typename t_HASH_ALGORITHM>
     void hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const;
 
+    bool isEqualTo(const ReplicaStateResponse& rhs) const;
+
   public:
     // TYPES
     enum {
         ATTRIBUTE_ID_PARTITION_ID                                    = 0,
-        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_ID_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
-    enum { NUM_ATTRIBUTES = 3 };
+    enum { NUM_ATTRIBUTES = 4 };
 
     enum {
         ATTRIBUTE_INDEX_PARTITION_ID                                    = 0,
-        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 1,
-        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 2
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID                                = 1,
+        ATTRIBUTE_INDEX_LATEST_SEQUENCE_NUMBER                          = 2,
+        ATTRIBUTE_INDEX_FIRST_SYNC_POINT_AFTER_ROLLOVER_SEQUENCE_NUMBER = 3
     };
 
     // CONSTANTS
@@ -12785,6 +12820,10 @@ class ReplicaStateResponse {
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
 
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
     PartitionSequenceNumber& latestSequenceNumber();
     // Return a reference to the modifiable "LatestSequenceNumber"
     // attribute of this object.
@@ -12840,6 +12879,9 @@ class ReplicaStateResponse {
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
 
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
     const PartitionSequenceNumber& latestSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
     // "LatestSequenceNumber" attribute of this object.
@@ -12857,10 +12899,7 @@ class ReplicaStateResponse {
     // have the same value, and 'false' otherwise.  Two attribute objects
     // have the same value if each respective attribute has the same value.
     {
-        return lhs.partitionId() == rhs.partitionId() &&
-               lhs.latestSequenceNumber() == rhs.latestSequenceNumber() &&
-               lhs.firstSyncPointAfterRolloverSequenceNumber() ==
-                   rhs.firstSyncPointAfterRolloverSequenceNumber();
+        return lhs.isEqualTo(rhs);
     }
 
     friend bool operator!=(const ReplicaStateResponse& lhs,
@@ -12895,7 +12934,7 @@ class ReplicaStateResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ReplicaStateResponse)
+    bmqp_ctrlmsg::ReplicaStateResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ReplicaStateResponse>
 : bsl::true_type {};
@@ -13105,7 +13144,7 @@ class StateNotificationChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StateNotificationChoice)
+    bmqp_ctrlmsg::StateNotificationChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -13342,7 +13381,8 @@ class Status {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::Status)
+BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
+    bmqp_ctrlmsg::Status);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::Status> : bsl::true_type {};
 
@@ -13562,7 +13602,7 @@ class StorageSyncResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StorageSyncResponse)
+    bmqp_ctrlmsg::StorageSyncResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StorageSyncResponse>
 : bsl::true_type {};
@@ -13750,7 +13790,7 @@ class SyncPointOffsetPair {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::SyncPointOffsetPair)
+    bmqp_ctrlmsg::SyncPointOffsetPair);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::SyncPointOffsetPair>
 : bsl::true_type {};
@@ -13983,7 +14023,7 @@ class AuthenticationResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AuthenticationResponse)
+    bmqp_ctrlmsg::AuthenticationResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::AuthenticationResponse>
 : bsl::true_type {};
@@ -14281,7 +14321,7 @@ class BrokerResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::BrokerResponse)
+    bmqp_ctrlmsg::BrokerResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::BrokerResponse>
 : bsl::true_type {};
@@ -14511,7 +14551,7 @@ class CloseQueue {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::CloseQueue)
+    bmqp_ctrlmsg::CloseQueue);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::CloseQueue> : bsl::true_type {
 };
@@ -14739,7 +14779,7 @@ class ConfigureQueueStream {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ConfigureQueueStream)
+    bmqp_ctrlmsg::ConfigureQueueStream);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ConfigureQueueStream>
 : bsl::true_type {};
@@ -14924,7 +14964,7 @@ class ElectorMessage {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ElectorMessage)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::ElectorMessage);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ElectorMessage>
 : bsl::true_type {};
@@ -15171,7 +15211,7 @@ class LeaderAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderAdvisory)
+    bmqp_ctrlmsg::LeaderAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderAdvisory>
 : bsl::true_type {};
@@ -15381,7 +15421,7 @@ class OpenQueue {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::OpenQueue)
+    bmqp_ctrlmsg::OpenQueue);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::OpenQueue> : bsl::true_type {};
 
@@ -15754,7 +15794,7 @@ class PartitionMessageChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionMessageChoice)
+    bmqp_ctrlmsg::PartitionMessageChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -15990,7 +16030,7 @@ class PartitionSyncDataQuery {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSyncDataQuery)
+    bmqp_ctrlmsg::PartitionSyncDataQuery);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionSyncDataQuery>
 : bsl::true_type {};
@@ -16226,7 +16266,7 @@ class PartitionSyncDataQueryStatus {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSyncDataQueryStatus)
+    bmqp_ctrlmsg::PartitionSyncDataQueryStatus);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionSyncDataQueryStatus>
 : bsl::true_type {};
@@ -16444,7 +16484,7 @@ class PartitionSyncStateQueryResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::PartitionSyncStateQueryResponse)
+    bmqp_ctrlmsg::PartitionSyncStateQueryResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<
     bmqp_ctrlmsg::PartitionSyncStateQueryResponse> : bsl::true_type {};
@@ -16672,7 +16712,7 @@ class QueueAssignmentAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueAssignmentAdvisory)
+    bmqp_ctrlmsg::QueueAssignmentAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueAssignmentAdvisory>
 : bsl::true_type {};
@@ -16942,7 +16982,7 @@ class QueueUnAssignmentAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueUnAssignmentAdvisory)
+    bmqp_ctrlmsg::QueueUnAssignmentAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueUnAssignmentAdvisory>
 : bsl::true_type {};
@@ -17172,7 +17212,7 @@ class QueueUpdateAdvisory {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::QueueUpdateAdvisory)
+    bmqp_ctrlmsg::QueueUpdateAdvisory);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::QueueUpdateAdvisory>
 : bsl::true_type {};
@@ -17350,7 +17390,7 @@ class StateNotification {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StateNotification)
+    bmqp_ctrlmsg::StateNotification);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StateNotification>
 : bsl::true_type {};
@@ -17562,7 +17602,7 @@ class StorageSyncRequest {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StorageSyncRequest)
+    bmqp_ctrlmsg::StorageSyncRequest);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StorageSyncRequest>
 : bsl::true_type {};
@@ -17807,7 +17847,7 @@ class Subscription {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::Subscription)
+    bmqp_ctrlmsg::Subscription);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::Subscription>
 : bsl::true_type {};
@@ -18079,7 +18119,7 @@ class AuthenticationMessage {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::AuthenticationMessage)
+    bmqp_ctrlmsg::AuthenticationMessage);
 
 namespace bmqp_ctrlmsg {
 
@@ -18297,7 +18337,7 @@ class ConfigureQueueStreamResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ConfigureQueueStreamResponse)
+    bmqp_ctrlmsg::ConfigureQueueStreamResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ConfigureQueueStreamResponse>
 : bsl::true_type {};
@@ -18521,7 +18561,7 @@ class FollowerClusterStateResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::FollowerClusterStateResponse)
+    bmqp_ctrlmsg::FollowerClusterStateResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::FollowerClusterStateResponse>
 : bsl::true_type {};
@@ -18740,7 +18780,7 @@ class LeaderSyncDataQueryResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::LeaderSyncDataQueryResponse)
+    bmqp_ctrlmsg::LeaderSyncDataQueryResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::LeaderSyncDataQueryResponse>
 : bsl::true_type {};
@@ -19034,7 +19074,7 @@ class NegotiationMessage {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::NegotiationMessage)
+    bmqp_ctrlmsg::NegotiationMessage);
 
 namespace bmqp_ctrlmsg {
 
@@ -19285,7 +19325,7 @@ class OpenQueueResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::OpenQueueResponse)
+    bmqp_ctrlmsg::OpenQueueResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::OpenQueueResponse>
 : bsl::true_type {};
@@ -19463,7 +19503,8 @@ class PartitionMessage {
 
 // TRAITS
 
-BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(bmqp_ctrlmsg::PartitionMessage)
+BDLAT_DECL_SEQUENCE_WITH_BITWISEMOVEABLE_TRAITS(
+    bmqp_ctrlmsg::PartitionMessage);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::PartitionMessage>
 : bsl::true_type {};
@@ -19696,7 +19737,7 @@ class StreamParameters {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::StreamParameters)
+    bmqp_ctrlmsg::StreamParameters);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::StreamParameters>
 : bsl::true_type {};
@@ -20095,7 +20136,7 @@ class ClusterStateFSMMessageChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ClusterStateFSMMessageChoice)
+    bmqp_ctrlmsg::ClusterStateFSMMessageChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -20320,7 +20361,7 @@ class ConfigureStream {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ConfigureStream)
+    bmqp_ctrlmsg::ConfigureStream);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ConfigureStream>
 : bsl::true_type {};
@@ -20540,7 +20581,7 @@ class ClusterStateFSMMessage {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ClusterStateFSMMessage)
+    bmqp_ctrlmsg::ClusterStateFSMMessage);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ClusterStateFSMMessage>
 : bsl::true_type {};
@@ -20757,7 +20798,7 @@ class ConfigureStreamResponse {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ConfigureStreamResponse)
+    bmqp_ctrlmsg::ConfigureStreamResponse);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ConfigureStreamResponse>
 : bsl::true_type {};
@@ -21910,7 +21951,7 @@ class ClusterMessageChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ClusterMessageChoice)
+    bmqp_ctrlmsg::ClusterMessageChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -22125,7 +22166,7 @@ class ClusterMessage {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ClusterMessage)
+    bmqp_ctrlmsg::ClusterMessage);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ClusterMessage>
 : bsl::true_type {};
@@ -22742,7 +22783,7 @@ class ControlMessageChoice {
 // TRAITS
 
 BDLAT_DECL_CHOICE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ControlMessageChoice)
+    bmqp_ctrlmsg::ControlMessageChoice);
 
 namespace bmqp_ctrlmsg {
 
@@ -22969,7 +23010,7 @@ class ControlMessage {
 // TRAITS
 
 BDLAT_DECL_SEQUENCE_WITH_ALLOCATOR_BITWISEMOVEABLE_TRAITS(
-    bmqp_ctrlmsg::ControlMessage)
+    bmqp_ctrlmsg::ControlMessage);
 template <>
 struct bdlat_UsesDefaultValueFlag<bmqp_ctrlmsg::ControlMessage>
 : bsl::true_type {};
@@ -29038,9 +29079,20 @@ void PrimaryStateRequest::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
 {
     using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
     hashAppend(hashAlgorithm, this->latestSequenceNumber());
     hashAppend(hashAlgorithm,
                this->firstSyncPointAfterRolloverSequenceNumber());
+}
+
+inline bool
+PrimaryStateRequest::isEqualTo(const PrimaryStateRequest& rhs) const
+{
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->latestSequenceNumber() == rhs.latestSequenceNumber() &&
+           this->firstSyncPointAfterRolloverSequenceNumber() ==
+               rhs.firstSyncPointAfterRolloverSequenceNumber();
 }
 
 // CLASS METHODS
@@ -29052,6 +29104,12 @@ int PrimaryStateRequest::manipulateAttributes(t_MANIPULATOR& manipulator)
 
     ret = manipulator(&d_partitionId,
                       ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -29084,6 +29142,11 @@ int PrimaryStateRequest::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_PARTITION_ID: {
         return manipulator(&d_partitionId,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return manipulator(
@@ -29121,6 +29184,11 @@ inline int& PrimaryStateRequest::partitionId()
     return d_partitionId;
 }
 
+inline unsigned int& PrimaryStateRequest::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
 inline PartitionSequenceNumber& PrimaryStateRequest::latestSequenceNumber()
 {
     return d_latestSequenceNumber;
@@ -29140,6 +29208,12 @@ int PrimaryStateRequest::accessAttributes(t_ACCESSOR& accessor) const
 
     ret = accessor(d_partitionId,
                    ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -29171,6 +29245,11 @@ int PrimaryStateRequest::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PARTITION_ID: {
         return accessor(d_partitionId,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return accessor(
@@ -29208,6 +29287,11 @@ inline int PrimaryStateRequest::partitionId() const
     return d_partitionId;
 }
 
+inline unsigned int PrimaryStateRequest::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
+}
+
 inline const PartitionSequenceNumber&
 PrimaryStateRequest::latestSequenceNumber() const
 {
@@ -29231,9 +29315,20 @@ void PrimaryStateResponse::hashAppendImpl(
 {
     using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
     hashAppend(hashAlgorithm, this->latestSequenceNumber());
     hashAppend(hashAlgorithm,
                this->firstSyncPointAfterRolloverSequenceNumber());
+}
+
+inline bool
+PrimaryStateResponse::isEqualTo(const PrimaryStateResponse& rhs) const
+{
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->latestSequenceNumber() == rhs.latestSequenceNumber() &&
+           this->firstSyncPointAfterRolloverSequenceNumber() ==
+               rhs.firstSyncPointAfterRolloverSequenceNumber();
 }
 
 // CLASS METHODS
@@ -29245,6 +29340,12 @@ int PrimaryStateResponse::manipulateAttributes(t_MANIPULATOR& manipulator)
 
     ret = manipulator(&d_partitionId,
                       ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -29277,6 +29378,11 @@ int PrimaryStateResponse::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_PARTITION_ID: {
         return manipulator(&d_partitionId,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return manipulator(
@@ -29314,6 +29420,11 @@ inline int& PrimaryStateResponse::partitionId()
     return d_partitionId;
 }
 
+inline unsigned int& PrimaryStateResponse::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
 inline PartitionSequenceNumber& PrimaryStateResponse::latestSequenceNumber()
 {
     return d_latestSequenceNumber;
@@ -29333,6 +29444,12 @@ int PrimaryStateResponse::accessAttributes(t_ACCESSOR& accessor) const
 
     ret = accessor(d_partitionId,
                    ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -29364,6 +29481,11 @@ int PrimaryStateResponse::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PARTITION_ID: {
         return accessor(d_partitionId,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return accessor(
@@ -29399,6 +29521,11 @@ int PrimaryStateResponse::accessAttribute(t_ACCESSOR& accessor,
 inline int PrimaryStateResponse::partitionId() const
 {
     return d_partitionId;
+}
+
+inline unsigned int PrimaryStateResponse::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
 }
 
 inline const PartitionSequenceNumber&
@@ -31198,9 +31325,20 @@ void ReplicaStateRequest::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
 {
     using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
     hashAppend(hashAlgorithm, this->latestSequenceNumber());
     hashAppend(hashAlgorithm,
                this->firstSyncPointAfterRolloverSequenceNumber());
+}
+
+inline bool
+ReplicaStateRequest::isEqualTo(const ReplicaStateRequest& rhs) const
+{
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->latestSequenceNumber() == rhs.latestSequenceNumber() &&
+           this->firstSyncPointAfterRolloverSequenceNumber() ==
+               rhs.firstSyncPointAfterRolloverSequenceNumber();
 }
 
 // CLASS METHODS
@@ -31212,6 +31350,12 @@ int ReplicaStateRequest::manipulateAttributes(t_MANIPULATOR& manipulator)
 
     ret = manipulator(&d_partitionId,
                       ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -31244,6 +31388,11 @@ int ReplicaStateRequest::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_PARTITION_ID: {
         return manipulator(&d_partitionId,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return manipulator(
@@ -31281,6 +31430,11 @@ inline int& ReplicaStateRequest::partitionId()
     return d_partitionId;
 }
 
+inline unsigned int& ReplicaStateRequest::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
 inline PartitionSequenceNumber& ReplicaStateRequest::latestSequenceNumber()
 {
     return d_latestSequenceNumber;
@@ -31300,6 +31454,12 @@ int ReplicaStateRequest::accessAttributes(t_ACCESSOR& accessor) const
 
     ret = accessor(d_partitionId,
                    ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -31331,6 +31491,11 @@ int ReplicaStateRequest::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PARTITION_ID: {
         return accessor(d_partitionId,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return accessor(
@@ -31368,6 +31533,11 @@ inline int ReplicaStateRequest::partitionId() const
     return d_partitionId;
 }
 
+inline unsigned int ReplicaStateRequest::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
+}
+
 inline const PartitionSequenceNumber&
 ReplicaStateRequest::latestSequenceNumber() const
 {
@@ -31391,9 +31561,20 @@ void ReplicaStateResponse::hashAppendImpl(
 {
     using bslh::hashAppend;
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
     hashAppend(hashAlgorithm, this->latestSequenceNumber());
     hashAppend(hashAlgorithm,
                this->firstSyncPointAfterRolloverSequenceNumber());
+}
+
+inline bool
+ReplicaStateResponse::isEqualTo(const ReplicaStateResponse& rhs) const
+{
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->latestSequenceNumber() == rhs.latestSequenceNumber() &&
+           this->firstSyncPointAfterRolloverSequenceNumber() ==
+               rhs.firstSyncPointAfterRolloverSequenceNumber();
 }
 
 // CLASS METHODS
@@ -31405,6 +31586,12 @@ int ReplicaStateResponse::manipulateAttributes(t_MANIPULATOR& manipulator)
 
     ret = manipulator(&d_partitionId,
                       ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -31437,6 +31624,11 @@ int ReplicaStateResponse::manipulateAttribute(t_MANIPULATOR& manipulator,
     case ATTRIBUTE_ID_PARTITION_ID: {
         return manipulator(&d_partitionId,
                            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return manipulator(
@@ -31474,6 +31666,11 @@ inline int& ReplicaStateResponse::partitionId()
     return d_partitionId;
 }
 
+inline unsigned int& ReplicaStateResponse::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
 inline PartitionSequenceNumber& ReplicaStateResponse::latestSequenceNumber()
 {
     return d_latestSequenceNumber;
@@ -31493,6 +31690,12 @@ int ReplicaStateResponse::accessAttributes(t_ACCESSOR& accessor) const
 
     ret = accessor(d_partitionId,
                    ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     if (ret) {
         return ret;
     }
@@ -31524,6 +31727,11 @@ int ReplicaStateResponse::accessAttribute(t_ACCESSOR& accessor, int id) const
     case ATTRIBUTE_ID_PARTITION_ID: {
         return accessor(d_partitionId,
                         ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
     }
     case ATTRIBUTE_ID_LATEST_SEQUENCE_NUMBER: {
         return accessor(
@@ -31559,6 +31767,11 @@ int ReplicaStateResponse::accessAttribute(t_ACCESSOR& accessor,
 inline int ReplicaStateResponse::partitionId() const
 {
     return d_partitionId;
+}
+
+inline unsigned int ReplicaStateResponse::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
 }
 
 inline const PartitionSequenceNumber&
@@ -38721,6 +38934,6 @@ inline const ControlMessageChoice& ControlMessage::choice() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2025.11.13
+// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -10110,7 +10110,7 @@ class PrimaryStateRequest {
     // for primary's sequence number.  The replica also sends it own sequence
     // numbers as part of this request.
     // partitionId:    partition id for corresponding partition.
-    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // primaryLeaseId: lease id of the current primary.  latestSequenceNumber:
     // Replica's latest sequence number for corresponding partition.
     // firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's
     // first sync point after rollover for corresponding partition.
@@ -10334,7 +10334,7 @@ class PrimaryStateResponse {
     // This type represents a response sent by a primary to the replica along
     // with its sequence numbers.
     // partitionId:    partition id for corresponding partition.
-    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // primaryLeaseId: lease id of the current primary.  latestSequenceNumber:
     // Primary's latest sequence number for corresponding partition.
     // firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's
     // first sync point after rollover for corresponding partition.
@@ -12501,7 +12501,7 @@ class ReplicaStateRequest {
     // for replica's sequence numbers.  The primary also sends its own sequence
     // numbers as part of this request.
     // partitionId:    partition id for corresponding partition.
-    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // primaryLeaseId: lease id of the current primary.  latestSequenceNumber:
     // Primary's latest sequence number for corresponding partition.
     // firstSyncPointAfterRolloverSequenceNumber: Sequence number of primary's
     // first sync point after rollover for corresponding partition.
@@ -12725,7 +12725,7 @@ class ReplicaStateResponse {
     // This type represents a response sent by a replica to the primary along
     // with its sequence numbers.
     // partitionId:    partition id for corresponding partition.
-    // primaryLeaseId: lease id of the current primary latestSequenceNumber:
+    // primaryLeaseId: lease id of the current primary.  latestSequenceNumber:
     // Replica's latest sequence number for corresponding partition.
     // firstSyncPointAfterRolloverSequenceNumber: Sequence number of replica's
     // first sync point after rollover for corresponding partition.

--- a/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterorchestrator.cpp
@@ -500,7 +500,6 @@ void ClusterOrchestrator::onNodeUnavailable(mqbnet::ClusterNode* node)
     // by the leader, and followers should update the info only upon being
     // notified from the leader?
     d_stateManager_mp->markOrphan(ns->primaryPartitions(), node);
-    ns->removeAllPartitions();
 
     if (mqbnet::ElectorState::e_LEADER !=
             d_clusterData_p->electorInfo().electorState() ||

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -1653,6 +1653,11 @@ void ClusterStateManager::markOrphan(
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(primary);
 
+    // Copy `partitions` to metadata before calling
+    // `d_state_p->setPartitionPrimary` below, because that code path can
+    // modify the `partitions` vector.
+    ClusterFSMEventMetadata metadata(partitions, d_allocator_p);
+
     for (int i = static_cast<int>(partitions.size()) - 1; 0 <= i; --i) {
         const mqbc::ClusterStatePartitionInfo& pinfo = d_state_p->partition(
             partitions[i]);
@@ -1663,8 +1668,7 @@ void ClusterStateManager::markOrphan(
 
     // Go through Cluster FSM to inform Partiton FSMs about the orphaned
     // partitions
-    applyFSMEvent(ClusterFSM::Event::e_RST_PRIMARY,
-                  ClusterFSMEventMetadata(partitions, d_allocator_p));
+    applyFSMEvent(ClusterFSM::Event::e_RST_PRIMARY, metadata);
 }
 
 void ClusterStateManager::assignPartitions(

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1382,9 +1382,8 @@ void StorageManager::processPrimaryStateResponseDispatched(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId
-                  << "]: Received PrimaryStateResponse "
-                  << context->response() << " from "
-                  << responder->nodeDescription();
+                  << "]: Received PrimaryStateResponse " << context->response()
+                  << " from " << responder->nodeDescription();
 
     EventData eventDataVec;
     eventDataVec.emplace_back(
@@ -1472,11 +1471,10 @@ void StorageManager::processReplicaStateResponseDispatched(
             const bmqp_ctrlmsg::Status& status = cit->second.choice().status();
             if (status.category() ==
                 bmqp_ctrlmsg::StatusCategory::E_CANCELED) {
-                BALL_LOG_WARN
-                    << d_clusterData_p->identity().description()
-                    << " Partition [" << requestPartitionId
-                    << "]: Request was canceled, skip processing of "
-                    << "ReplicaStateResponse.";
+                BALL_LOG_WARN << d_clusterData_p->identity().description()
+                              << " Partition [" << requestPartitionId
+                              << "]: Request was canceled, skip processing of "
+                              << "ReplicaStateResponse.";
                 return;  // RETURN
             }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1327,7 +1327,7 @@ void StorageManager::processPrimaryStateResponseDispatched(
 
     if (context->result() != bmqt::GenericResult::e_SUCCESS) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << ": received FAIL_PrmryStateRspn event "
+                      << ": Received failure PrimaryStateResponse event "
                       << context->response() << " from primary "
                       << responder->nodeDescription();
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -329,10 +329,9 @@ void StorageManager::onPartitionRecovery(int partitionId)
         d_recoveryStartTimes[partitionId]);
     BALL_LOG_INFO << out.str();
 
-    if (++d_numPartitionsRecoveredFully !=
-        static_cast<int>(d_fileStores.size())) {
-        BSLS_ASSERT_SAFE(d_numPartitionsRecoveredFully <
-                         static_cast<int>(d_fileStores.size()));
+    const int numRecovered = ++d_numPartitionsRecoveredFully;
+    if (numRecovered != static_cast<int>(d_fileStores.size())) {
+        BSLS_ASSERT_SAFE(numRecovered < static_cast<int>(d_fileStores.size()));
         return;  // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1760,12 +1760,6 @@ void StorageManager::processShutdownEventDispatched(int partitionId)
         &d_partitionInfoVec[partitionId],
         fs,
         partitionId);
-
-    StorageUtil::clearPrimaryForPartition(
-        fs,
-        &d_partitionInfoVec[partitionId],
-        d_clusterData_p->identity().description(),
-        partitionId);
 }
 
 void StorageManager::forceFlushFileStores()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -493,7 +493,7 @@ void StorageManager::enqueuePartitionFSMEventDispatched(
                 BALL_LOG_INFO << d_clusterData_p->identity().description()
                               << " Partition [" << partitionId
                               << "]: dropping redundant " << event
-                              << " event with" << " identical primary: "
+                              << " event with identical primary: "
                               << evt.primary()->nodeDescription()
                               << " and leaseId: " << evt.primaryLeaseId()
                               << ".";

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1382,7 +1382,7 @@ void StorageManager::processPrimaryStateResponseDispatched(
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId
-                  << "]: " << "Received PrimaryStateResponse "
+                  << "]: Received PrimaryStateResponse "
                   << context->response() << " from "
                   << responder->nodeDescription();
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1475,7 +1475,7 @@ void StorageManager::processReplicaStateResponseDispatched(
                 BALL_LOG_WARN
                     << d_clusterData_p->identity().description()
                     << " Partition [" << requestPartitionId
-                    << "]: " << "Request was canceled, skip processing of "
+                    << "]: Request was canceled, skip processing of "
                     << "ReplicaStateResponse.";
                 return;  // RETURN
             }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -490,13 +490,13 @@ void StorageManager::enqueuePartitionFSMEventDispatched(
                  event == PartitionFSM::Event::e_DETECT_SELF_REPLICA);
 
             if (isIdentical && isDetectEvent) {
-                BALL_LOG_INFO
-                    << d_clusterData_p->identity().description()
-                    << " Partition [" << partitionId
-                    << "]: dropping redundant " << event << " event with"
-                    << " identical primary: "
-                    << evt.primary()->nodeDescription()
-                    << " and leaseId: " << evt.primaryLeaseId() << ".";
+                BALL_LOG_INFO << d_clusterData_p->identity().description()
+                              << " Partition [" << partitionId
+                              << "]: dropping redundant " << event
+                              << " event with" << " identical primary: "
+                              << evt.primary()->nodeDescription()
+                              << " and leaseId: " << evt.primaryLeaseId()
+                              << ".";
                 return;
             }
         }
@@ -1381,9 +1381,10 @@ void StorageManager::processPrimaryStateResponseDispatched(
     BSLS_ASSERT_SAFE(response.partitionId() == partitionId);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId << "]: "
-                  << "Received PrimaryStateResponse " << context->response()
-                  << " from " << responder->nodeDescription();
+                  << " Partition [" << partitionId
+                  << "]: " << "Received PrimaryStateResponse "
+                  << context->response() << " from "
+                  << responder->nodeDescription();
 
     EventData eventDataVec;
     eventDataVec.emplace_back(
@@ -1471,10 +1472,11 @@ void StorageManager::processReplicaStateResponseDispatched(
             const bmqp_ctrlmsg::Status& status = cit->second.choice().status();
             if (status.category() ==
                 bmqp_ctrlmsg::StatusCategory::E_CANCELED) {
-                BALL_LOG_WARN << d_clusterData_p->identity().description()
-                              << " Partition [" << requestPartitionId << "]: "
-                              << "Request was canceled, skip processing of "
-                              << "ReplicaStateResponse.";
+                BALL_LOG_WARN
+                    << d_clusterData_p->identity().description()
+                    << " Partition [" << requestPartitionId
+                    << "]: " << "Request was canceled, skip processing of "
+                    << "ReplicaStateResponse.";
                 return;  // RETURN
             }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1327,12 +1327,28 @@ void StorageManager::processPrimaryStateResponseDispatched(
 
     if (context->result() != bmqt::GenericResult::e_SUCCESS) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << ": Received failure PrimaryStateResponse event "
+                      << " Partition [" << partitionId << "]: "
+                      << "Received failure PrimaryStateResponse event "
                       << context->response() << " from primary "
                       << responder->nodeDescription();
 
+        BSLS_ASSERT_SAFE(context->response().choice().isStatusValue());
+        const bmqp_ctrlmsg::Status& status =
+            context->response().choice().status();
+        if (status.category() == bmqp_ctrlmsg::StatusCategory::E_CANCELED) {
+            BALL_LOG_WARN << d_clusterData_p->identity().description()
+                          << " Partition [" << partitionId << "]: "
+                          << "Request was canceled, skip processing of "
+                          << "PrimaryStateResponse.";
+            return;  // RETURN
+        }
+
         EventData eventDataVec;
-        eventDataVec.emplace_back(responder, responseId, partitionId, 1);
+        eventDataVec.emplace_back(responder,
+                                  responseId,
+                                  partitionId,
+                                  1,
+                                  responder);
 
         enqueuePartitionFSMEvent(
             PartitionFSM::Event::e_FAIL_PRIMARY_STATE_RSPN,
@@ -1365,7 +1381,8 @@ void StorageManager::processPrimaryStateResponseDispatched(
     BSLS_ASSERT_SAFE(response.partitionId() == partitionId);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": received PrimaryStateResponse " << context->response()
+                  << " Partition [" << partitionId << "]: "
+                  << "Received PrimaryStateResponse " << context->response()
                   << " from " << responder->nodeDescription();
 
     EventData eventDataVec;
@@ -1374,6 +1391,8 @@ void StorageManager::processPrimaryStateResponseDispatched(
         responseId,
         partitionId,
         1,
+        responder,
+        response.primaryLeaseId(),
         response.latestSequenceNumber(),
         response.firstSyncPointAfterRolloverSequenceNumber());
 
@@ -1447,13 +1466,24 @@ void StorageManager::processReplicaStateResponseDispatched(
                           << " Partition [" << requestPartitionId
                           << "]: " << "Received failed ReplicaStateResponse "
                           << cit->second.choice().status() << " from "
-                          << cit->first->nodeDescription()
-                          << ". Skipping this node's response.";
+                          << cit->first->nodeDescription() << ".";
+
+            const bmqp_ctrlmsg::Status& status = cit->second.choice().status();
+            if (status.category() ==
+                bmqp_ctrlmsg::StatusCategory::E_CANCELED) {
+                BALL_LOG_WARN << d_clusterData_p->identity().description()
+                              << " Partition [" << requestPartitionId << "]: "
+                              << "Request was canceled, skip processing of "
+                              << "ReplicaStateResponse.";
+                return;  // RETURN
+            }
+
             failedEventDataVec.emplace_back(
                 cit->first,
                 cit->second.rId().isNull() ? -1 : cit->second.rId().value(),
                 requestPartitionId,
-                1);
+                1,
+                d_clusterData_p->membership().selfNode());
             continue;  // CONTINUE
         }
 
@@ -2080,6 +2110,8 @@ void StorageManager::do_replicaStateRequest(const EventWithData& event)
             .makeReplicaStateRequest();
 
     replicaStateRequest.partitionId() = partitionId;
+    replicaStateRequest.primaryLeaseId() =
+        d_partitionInfoVec.at(partitionId).primaryLeaseId();
 
     mqbnet::ClusterNode* selfNode = d_clusterData_p->membership().selfNode();
     BSLS_ASSERT_SAFE(d_nodeToPSNCtxMapVec[partitionId].find(selfNode) !=
@@ -2133,6 +2165,8 @@ void StorageManager::do_replicaStateResponse(const EventWithData& event)
         partitionMessage.choice().makeReplicaStateResponse();
 
     response.partitionId() = partitionId;
+    response.primaryLeaseId() =
+        d_partitionInfoVec.at(partitionId).primaryLeaseId();
     response.latestSequenceNumber() =
         d_nodeToPSNCtxMapVec[partitionId]
                             [d_clusterData_p->membership().selfNode()]
@@ -2344,6 +2378,8 @@ void StorageManager::do_primaryStateRequest(const EventWithData& event)
             .makePrimaryStateRequest();
 
     primaryStateRequest.partitionId() = partitionId;
+    primaryStateRequest.primaryLeaseId() =
+        d_partitionInfoVec.at(partitionId).primaryLeaseId();
     primaryStateRequest.latestSequenceNumber() =
         d_nodeToPSNCtxMapVec[partitionId]
                             [d_clusterData_p->membership().selfNode()]
@@ -2402,6 +2438,8 @@ void StorageManager::do_primaryStateResponse(const EventWithData& event)
         partitionMessage.choice().makePrimaryStateResponse();
 
     response.partitionId() = partitionId;
+    response.primaryLeaseId() =
+        d_partitionInfoVec.at(partitionId).primaryLeaseId();
     response.latestSequenceNumber() =
         d_nodeToPSNCtxMapVec[partitionId]
                             [d_clusterData_p->membership().selfNode()]
@@ -4468,7 +4506,7 @@ void StorageManager::processPrimaryStateRequest(
             .choice()
             .primaryStateRequest();
 
-    int partitionId = primaryStateRequest.partitionId();
+    const int partitionId = primaryStateRequest.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
 
@@ -4491,6 +4529,8 @@ void StorageManager::processPrimaryStateRequest(
         message.rId().isNull() ? -1 : message.rId().value(),
         partitionId,
         1,
+        d_clusterData_p->membership().selfNode(),  // primary
+        primaryStateRequest.primaryLeaseId(),
         primaryStateRequest.latestSequenceNumber(),
         primaryStateRequest.firstSyncPointAfterRolloverSequenceNumber());
 
@@ -4524,7 +4564,7 @@ void StorageManager::processReplicaStateRequest(
             .choice()
             .replicaStateRequest();
 
-    int partitionId = replicaStateRequest.partitionId();
+    const int partitionId = replicaStateRequest.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
 
@@ -4548,7 +4588,7 @@ void StorageManager::processReplicaStateRequest(
         partitionId,
         1,
         source,
-        replicaStateRequest.latestSequenceNumber().primaryLeaseId(),
+        replicaStateRequest.primaryLeaseId(),
         replicaStateRequest.latestSequenceNumber(),
         replicaStateRequest.firstSyncPointAfterRolloverSequenceNumber());
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -444,18 +444,18 @@ void StorageManager::enqueuePartitionFSMEventDispatched(
             if (isLeaseIdOutdated || isPrimaryMismatch) {
                 BALL_LOG_WARN
                     << d_clusterData_p->identity().description()
-                    << " Partition [" << partitionId
-                    << "]: dropping stale event: source "
+                    << " Partition [" << partitionId << "]: dropping stale "
+                    << event << " event: source "
                     << evt.source()->nodeDescription()
                     << ", event primaryLeaseId [" << evt.primaryLeaseId()
                     << "], current primaryLeaseId [" << pinfo.primaryLeaseId()
-                    << "], event primary ["
+                    << "], event primary: "
                     << (evt.primary() ? evt.primary()->nodeDescription()
-                                      : "null")
-                    << "], current primary ["
+                                      : "** NULL **")
+                    << ", current primary: "
                     << (pinfo.primary() ? pinfo.primary()->nodeDescription()
-                                        : "null")
-                    << "]";
+                                        : "** NULL **")
+                    << ".";
 
                 if (0 <= evt.requestId()) {
                     bmqp_ctrlmsg::ControlMessage controlMsg;
@@ -490,13 +490,13 @@ void StorageManager::enqueuePartitionFSMEventDispatched(
                  event == PartitionFSM::Event::e_DETECT_SELF_REPLICA);
 
             if (isIdentical && isDetectEvent) {
-                BALL_LOG_INFO << d_clusterData_p->identity().description()
-                              << " Partition [" << partitionId
-                              << "]: dropping redundant DETECT event with"
-                              << " identical primary ["
-                              << evt.primary()->nodeDescription()
-                              << "] and leaseId [" << evt.primaryLeaseId()
-                              << "]";
+                BALL_LOG_INFO
+                    << d_clusterData_p->identity().description()
+                    << " Partition [" << partitionId
+                    << "]: dropping redundant " << event << " event with"
+                    << " identical primary: "
+                    << evt.primary()->nodeDescription()
+                    << " and leaseId: " << evt.primaryLeaseId() << ".";
                 return;
             }
         }

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -623,8 +623,8 @@ struct TestHelper {
         bmqp_ctrlmsg::Status& failureResponse =
             failureMessage.choice().makeStatus();
         failureResponse.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
-        failureResponse.code()     = mqbi::ClusterErrorCode::e_NOT_PRIMARY;
-        failureResponse.message()  = "Not a primary";
+        failureResponse.code()     = mqbi::ClusterErrorCode::e_UNKNOWN;
+        failureResponse.message()  = "Primary mismatch";
 
         for (TestChannelMapCIter cit = d_cluster_mp->_channels().cbegin();
              cit != d_cluster_mp->_channels().cend();
@@ -684,7 +684,8 @@ struct TestHelper {
         int                                   partitionId,
         int                                   primaryNodeId,
         bmqp_ctrlmsg::PartitionSequenceNumber PSN =
-            bmqp_ctrlmsg::PartitionSequenceNumber())
+            bmqp_ctrlmsg::PartitionSequenceNumber(),
+        unsigned int primaryLeaseId = 1U)
     {
         bmqp_ctrlmsg::ClusterMessage        expectedMessage;
         bmqp_ctrlmsg::ReplicaStateResponse& replicaStateResponse =
@@ -694,6 +695,7 @@ struct TestHelper {
                 .makeReplicaStateResponse();
 
         replicaStateResponse.partitionId()          = partitionId;
+        replicaStateResponse.primaryLeaseId()       = primaryLeaseId;
         replicaStateResponse.latestSequenceNumber() = PSN;
 
         for (TestChannelMapCIter cit = d_cluster_mp->_channels().cbegin();
@@ -1289,6 +1291,7 @@ static void test4_primaryHealingStage1ReceivesReplicaStateRqst()
     PSN.primaryLeaseId() = 1U;
 
     replicaStateRequest.partitionId()          = k_PARTITION_ID;
+    replicaStateRequest.primaryLeaseId()       = 1U;
     replicaStateRequest.latestSequenceNumber() = PSN;
 
     mqbnet::ClusterNode* source = helper.d_cluster_mp->_clusterData()
@@ -1399,6 +1402,7 @@ static void test5_primaryHealingStage1ReceivesReplicaStateRspnQuorum()
     PSN.primaryLeaseId() = 1U;
 
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
+    replicaStateResponse.primaryLeaseId()       = 1U;
     replicaStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -1508,6 +1512,7 @@ static void test6_primaryHealingStage1ReceivesPrimaryStateRequestQuorum()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateRequest.partitionId()          = k_PARTITION_ID;
+    primaryStateRequest.primaryLeaseId()       = 1U;
     primaryStateRequest.latestSequenceNumber() = PSN;
 
     storageManager.processPrimaryStateRequest(message, replica1);
@@ -1625,6 +1630,7 @@ static void test7_primaryHealingStage1ReceivesPrimaryStateRqst()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateRequest.partitionId()          = k_PARTITION_ID;
+    primaryStateRequest.primaryLeaseId()       = 1U;
     primaryStateRequest.latestSequenceNumber() = PSN;
 
     storageManager.processPrimaryStateRequest(message, replicaNode);
@@ -1729,6 +1735,7 @@ static void test8_primaryHealingStage1ReceivesReplicaStateRspnNoQuorum()
     PSN.primaryLeaseId() = 1U;
 
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
+    replicaStateResponse.primaryLeaseId()       = 1U;
     replicaStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -1844,6 +1851,7 @@ static void test9_primaryHealingStage1QuorumSendsReplicaDataRequestPull()
     PSN.primaryLeaseId() = 1U;
 
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
+    replicaStateResponse.primaryLeaseId()       = 1U;
     replicaStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -2087,6 +2095,7 @@ static void test11_replicaWaitingReceivesReplicaStateRqst()
     PSN.primaryLeaseId() = 1U;
 
     replicaStateRequest.partitionId()          = k_PARTITION_ID;
+    replicaStateRequest.primaryLeaseId()       = 1U;
     replicaStateRequest.latestSequenceNumber() = PSN;
 
     storageManager.processReplicaStateRequest(requestMessage, primaryNode);
@@ -2193,6 +2202,7 @@ static void test12_replicaWaitingReceivesPrimaryStateRspn()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateResponse.partitionId()          = k_PARTITION_ID;
+    primaryStateResponse.primaryLeaseId()       = 1U;
     primaryStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -2395,6 +2405,7 @@ static void test14_replicaWaitingReceivesPrimaryStateRqst()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateRequest.partitionId()          = k_PARTITION_ID;
+    primaryStateRequest.primaryLeaseId()       = 1U;
     primaryStateRequest.latestSequenceNumber() = PSN;
 
     storageManager.processPrimaryStateRequest(message, rogueNode);
@@ -2529,6 +2540,7 @@ static void test15_replicaWaitingReceivesReplicaDataRqstPull()
     k_PRIMARY_SEQ_NUM.primaryLeaseId() = 1U;
 
     replicaStateRequest.partitionId()          = k_PARTITION_ID;
+    replicaStateRequest.primaryLeaseId()       = 1U;
     replicaStateRequest.latestSequenceNumber() = k_PRIMARY_SEQ_NUM;
 
     storageManager.processReplicaStateRequest(requestMessage, primaryNode);
@@ -2676,6 +2688,7 @@ static void test16_primaryHealingStage1SelfHighestSendsDataChunks()
     k_REPLICA_SEQ_NUM_1.primaryLeaseId()        = k_PRIMARY_LEASE_ID;
     k_REPLICA_SEQ_NUM_1.sequenceNumber()        = 3U;
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
+    replicaStateResponse.primaryLeaseId()       = k_PRIMARY_LEASE_ID;
     replicaStateResponse.latestSequenceNumber() = k_REPLICA_SEQ_NUM_1;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -2928,6 +2941,7 @@ static void test18_primaryHealingWatchdogRetry()
     PSN.primaryLeaseId() = k_PRIMARY_LEASE_ID;
 
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
+    replicaStateResponse.primaryLeaseId()       = k_PRIMARY_LEASE_ID;
     replicaStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -3061,6 +3075,7 @@ static void test19_replicaWaitingWatchdogRetry()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateResponse.partitionId()          = k_PARTITION_ID;
+    primaryStateResponse.primaryLeaseId()       = 1U;
     primaryStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);

--- a/src/python/blazingmq/dev/it/tweaks/generated.py
+++ b/src/python/blazingmq/dev/it/tweaks/generated.py
@@ -384,6 +384,16 @@ class TweakFactory:
 
                 clusters = Clusters()
 
+                class AlarmTimeoutMs(metaclass=TweakMetaclass):
+                    def __call__(self, value: int) -> Callable: ...
+
+                alarm_timeout_ms = AlarmTimeoutMs()
+
+                class WarningTimeoutMs(metaclass=TweakMetaclass):
+                    def __call__(self, value: int) -> Callable: ...
+
+                warning_timeout_ms = WarningTimeoutMs()
+
                 def __call__(
                     self,
                     value: typing.Union[
@@ -501,6 +511,14 @@ class TweakFactory:
                         def __call__(self, value: int) -> Callable: ...
 
                     rotate_days = RotateDays()
+
+                    class Encoding(metaclass=TweakMetaclass):
+                        def __call__(
+                            self,
+                            value: blazingmq.schemas.mqbcfg.StatsPrinterEncodingFormat,
+                        ) -> Callable: ...
+
+                    encoding = Encoding()
 
                     def __call__(
                         self,
@@ -852,6 +870,81 @@ class TweakFactory:
 
                 max_threads = MaxThreads()
 
+                class CredentialProvider(metaclass=TweakMetaclass):
+                    class Name(metaclass=TweakMetaclass):
+                        def __call__(
+                            self, value: typing.Union[str, NoneType]
+                        ) -> Callable: ...
+
+                    name = Name()
+
+                    class Settings(metaclass=TweakMetaclass):
+                        class Key(metaclass=TweakMetaclass):
+                            def __call__(
+                                self, value: typing.Union[str, NoneType]
+                            ) -> Callable: ...
+
+                        key = Key()
+
+                        class Value(metaclass=TweakMetaclass):
+                            class BoolVal(metaclass=TweakMetaclass):
+                                def __call__(
+                                    self, value: typing.Union[bool, NoneType]
+                                ) -> Callable: ...
+
+                            bool_val = BoolVal()
+
+                            class IntVal(metaclass=TweakMetaclass):
+                                def __call__(
+                                    self, value: typing.Union[int, NoneType]
+                                ) -> Callable: ...
+
+                            int_val = IntVal()
+
+                            class LongVal(metaclass=TweakMetaclass):
+                                def __call__(
+                                    self, value: typing.Union[int, NoneType]
+                                ) -> Callable: ...
+
+                            long_val = LongVal()
+
+                            class DoubleVal(metaclass=TweakMetaclass):
+                                def __call__(
+                                    self, value: typing.Union[float, NoneType]
+                                ) -> Callable: ...
+
+                            double_val = DoubleVal()
+
+                            class StringVal(metaclass=TweakMetaclass):
+                                def __call__(
+                                    self, value: typing.Union[str, NoneType]
+                                ) -> Callable: ...
+
+                            string_val = StringVal()
+
+                            def __call__(
+                                self,
+                                value: typing.Union[
+                                    blazingmq.schemas.mqbcfg.PluginSettingValue,
+                                    NoneType,
+                                ],
+                            ) -> Callable: ...
+
+                        value = Value()
+
+                        def __call__(self, value: None) -> Callable: ...
+
+                    settings = Settings()
+
+                    def __call__(
+                        self,
+                        value: typing.Union[
+                            blazingmq.schemas.mqbcfg.CredentialProviderConfig, NoneType
+                        ],
+                    ) -> Callable: ...
+
+                credential_provider = CredentialProvider()
+
                 def __call__(
                     self,
                     value: typing.Union[
@@ -884,9 +977,7 @@ class TweakFactory:
                 key = Key()
 
                 class Versions(metaclass=TweakMetaclass):
-                    def __call__(
-                        self, value: typing.Union[str, NoneType]
-                    ) -> Callable: ...
+                    def __call__(self, value: str) -> Callable: ...
 
                 versions = Versions()
 


### PR DESCRIPTION
> Fix for Internal Ticket 184450660

In `bmqp::ReplicaStateRequest` and similar PFSM state requests/responses, the `latestSequenceNumber()` refers to the latest PSN we retrieve from storage, but it does not necessarily equal our known primaryLeaseId. Then, we add a `primaryLeaseId()` field explicitly. We use this field to detect and drop stale events.

*Note*: This PR introduces backward incompatible changes to `bmqp_ctrlmsg.xsd`, but it is fine as long as we restart all nodes together for any FSM-enabled clusters.