### PR TITLE
Fix[mqb]: notify queue after pending close

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -857,22 +857,26 @@ void ClusterQueueHelper::onQueueContextAssigned(
     }
 }
 
-void ClusterQueueHelper::finishReopening(QueueContext*        queueContext,
-                                         StreamsMap::iterator sqit)
+void ClusterQueueHelper::finishReopening(
+    QueueContext*                                queueContext,
+    StreamsMap::iterator                         sqit,
+    mqbnet::ClusterNode*                         activeNode,
+    const bsl::shared_ptr<PartitionReopenCycle>& cycle)
 {
     // executed by the cluster *DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
 
+    SubQueueContext&      subQueueContext    = sqit->value();
+    SubQueueContext::Enum state              = subQueueContext.d_state;
+    bool                  isValid            = true;
+    const unsigned int    upstreamSubQueueId = sqit->subId();
+
     bsl::vector<SubQueueContext::PendingClose> pendingClose(d_allocator_p);
-    pendingClose.swap(sqit->value().d_pendingCloseRequests);
-
-    const bool isOpen  = (sqit->value().d_state == SubQueueContext::k_OPEN);
-    bool       isValid = true;
-
+    pendingClose.swap(subQueueContext.d_pendingCloseRequests);
     for (size_t i = 0; i < pendingClose.size(); ++i) {
-        if (isOpen && isValid) {
+        if (state == SubQueueContext::k_OPEN && isValid) {
             BMQ_LOGTHROTTLE_INFO
                 << d_cluster_p->description()
                 << ": sending pending Close request with parameters ["
@@ -909,6 +913,95 @@ void ClusterQueueHelper::finishReopening(QueueContext*        queueContext,
                                        sqit);
             // 'false' means 'sqit' is deleted (all counters are zeroes)
         }
+    }
+    const bsls::Types::Uint64 generationCount = cycle->generationCount();
+
+    if (isValid && state == SubQueueContext::k_OPEN) {
+        // Remain valid after all pending close
+        // Did not erase subQueueContext.
+
+        QueueLiveState& qinfo = queueContext->d_liveQInfo;
+
+        mqbi::Queue*     queueptr = qinfo.d_queue_sp.get();
+        const bmqt::Uri& uri      = queueContext->uri();
+
+        BSLS_ASSERT_SAFE(queueptr);
+        BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext));
+
+        // We have upstream node.  Send the configure-queue request.
+
+        // Make a copy of the stream parameters, and replace the upstreamSubId
+        // if needed.
+        bmqp_ctrlmsg::StreamParameters streamParamsCopy;
+
+        // TODO: remove this not thread-safe use of 'getUpstreamParameters'.
+        if (!queueptr->getUpstreamParameters(&streamParamsCopy,
+                                             upstreamSubQueueId)) {
+            ball::Severity::Level logSeverity = ball::Severity::e_WARN;
+
+            if (bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID == upstreamSubQueueId) {
+                // There is an optimization in
+                // RelayQueueEngine::configureHandle not to send producer
+                // parameters upstream if they are the same as default
+                // constructed.  In this case the UpstreamParameters cache does
+                // not have parameters for the k_DEFAULT_SUBQUEUE_ID.
+                logSeverity = ball::Severity::e_INFO;
+
+                // Consider this queue successfully reopen
+                notifyQueue(queueContext,
+                            bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID,
+                            generationCount,
+                            true);
+            }
+            BALL_LOGTHROTTLE_INFO_BLOCK(k_MAX_INSTANT_MESSAGES,
+                                        k_NS_PER_MESSAGE)
+            {
+                BALL_LOG_STREAM(logSeverity)
+                    << d_cluster_p->description()
+                    << ": not sending a configure-queue request in response to"
+                    << " ReopenQueue response, for queue [" << uri
+                    << "], as the queue is not configured for upstream "
+                       "subQueue "
+                    << bmqp::QueueId::SubQueueIdInt(upstreamSubQueueId);
+            }
+        }
+        else if (!sendConfigureQueueRequest(
+                     streamParamsCopy,
+                     queueptr->id(),
+                     queueptr->uri(),
+                     bdlf::BindUtil::bindS(
+                         d_allocator_p,
+                         &ClusterQueueHelper::reconfigureCallback,
+                         this,
+                         bdlf::PlaceHolders::_1,
+                         bdlf::PlaceHolders::_2,
+                         cycle),
+                     true,  // is a reconfigure-queue request
+                     activeNode,
+                     generationCount,
+                     sqit->subId())) {
+            // Assume sending has failed due to a disconnect, therefore, there
+            // is no need to roll back the result of ReOpen request. Decrement
+            // all counters. Do not report "state is restored"
+            state = SubQueueContext::k_CLOSED;
+            setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
+
+            // TBD: Note that invoking 'd_queue_p->streamParameters()' above is
+            // not thread safe as queue's parameteres are supposed to be
+            // read/written only from the queue-dispatcher thread.  This will
+            // be fixed eventually.
+
+            // Abort restore of the state: the channel is no longer valid,
+            // we'll wait for a new one to be active and will restart restoring
+            // the state from the beginning.
+        }
+    }
+    if (state == SubQueueContext::k_FAILED) {
+        notifyQueue(queueContext,
+                    upstreamSubQueueId,
+                    generationCount,
+                    false,
+                    false);  // isWriterOnly
     }
 
     if (0 == --queueContext->d_liveQInfo.d_numReopenQueueRequests) {
@@ -1572,7 +1665,9 @@ void ClusterQueueHelper::onReopenQueueResponse(
                               &ClusterQueueHelper::finishReopening,
                               this,
                               queueContext,
-                              sqit));
+                              sqit,
+                              activeNode,
+                              cycle));
 
     // Same upstream node, which means num pending request counter must be
     // non-zero.
@@ -1613,12 +1708,6 @@ void ClusterQueueHelper::onReopenQueueResponse(
             BSLS_ASSERT_SAFE(sqit->appId() == appId);
 
             setStreamState(&subQueueContext, SubQueueContext::k_FAILED);
-
-            notifyQueue(queueContext,
-                        upstreamSubQueueId,
-                        generationCount,
-                        false,
-                        false);  // isWriterOnly
 
             // No need to send a configure-queue request for this queue.
             // Decrement the num pending reopen queue request counter though,
@@ -1672,14 +1761,6 @@ void ClusterQueueHelper::onReopenQueueResponse(
         return;  // RETURN
     }
 
-    // Queue has been successfully reopened;
-    // send configure-queue request now.
-
-    BSLS_ASSERT_SAFE(sqit != qinfo.d_subQueueIds.end());
-    BSLS_ASSERT_SAFE(appId == sqit->appId());
-
-    BSLS_ASSERT_SAFE(subQueueContext.d_state == SubQueueContext::k_REOPENING);
-
     if (d_cluster_p->isStopping()) {
         // Self is stopping.  Drop the response.
         BMQ_LOGTHROTTLE_WARN
@@ -1691,88 +1772,21 @@ void ClusterQueueHelper::onReopenQueueResponse(
         return;  // RETURN
     }
 
+    // Queue has been successfully reopened;
+    // send configure-queue request now.
+    BSLS_ASSERT_SAFE(
+        requestContext->response().choice().isOpenQueueResponseValue());
+    BSLS_ASSERT_SAFE(sqit != qinfo.d_subQueueIds.end());
+    BSLS_ASSERT_SAFE(appId == sqit->appId());
+
+    BSLS_ASSERT_SAFE(subQueueContext.d_state == SubQueueContext::k_REOPENING);
+
     setStreamState(&subQueueContext, SubQueueContext::k_OPEN);
 
     BMQ_LOGTHROTTLE_INFO
         << d_cluster_p->description() << ": queue successfully reopened ["
         << requestContext->request()
         << "]. Attempting to send a configure-queue request now.";
-
-    mqbi::Queue* queueptr = qinfo.d_queue_sp.get();
-
-    BSLS_ASSERT_SAFE(queueptr);
-    BSLS_ASSERT_SAFE(isQueueAssigned(*queueContext));
-
-    // We have upstream node.  Send the configure-queue request.
-
-    BSLS_ASSERT_SAFE(
-        requestContext->response().choice().isOpenQueueResponseValue());
-
-    // Make a copy of the stream parameters, and replace the upstreamSubId if
-    // needed.
-    bmqp_ctrlmsg::StreamParameters streamParamsCopy;
-
-    // TODO: remove this not thread-safe use of 'getUpstreamParameters'.
-    if (!queueptr->getUpstreamParameters(&streamParamsCopy,
-                                         upstreamSubQueueId)) {
-        ball::Severity::Level logSeverity = ball::Severity::e_WARN;
-
-        if (bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID == upstreamSubQueueId) {
-            // There is an optimization in RelayQueueEngine::configureHandle
-            // not to send producer parameters upstream if they are the same as
-            // default constructed.  In this case the UpstreamParameters cache
-            // does not have parameters for the k_DEFAULT_SUBQUEUE_ID.
-            logSeverity = ball::Severity::e_INFO;
-
-            // Consider this queue successfully reopen
-            notifyQueue(queueContext,
-                        bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID,
-                        generationCount,
-                        true);
-        }
-        BALL_LOGTHROTTLE_INFO_BLOCK(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
-        {
-            BALL_LOG_STREAM(logSeverity)
-                << d_cluster_p->description()
-                << ": not sending a configure-queue request in response to"
-                << " ReopenQueue response, for queue [" << uri
-                << "], as the queue is not configured for upstream subQueue "
-                << bmqp::QueueId::SubQueueIdInt(upstreamSubQueueId);
-        }
-
-        return;  // RETURN
-    }
-
-    if (!sendConfigureQueueRequest(
-            streamParamsCopy,
-            queueptr->id(),
-            queueptr->uri(),
-            bdlf::BindUtil::bindS(d_allocator_p,
-                                  &ClusterQueueHelper::reconfigureCallback,
-                                  this,
-                                  bdlf::PlaceHolders::_1,
-                                  bdlf::PlaceHolders::_2,
-                                  cycle),
-            true,  // is a reconfigure-queue request
-            activeNode,
-            generationCount,
-            sqit->subId())) {
-        // Assume sending has failed due to a disconnect, therefore, there is
-        // no need to roll back the result of ReOpen request.
-        // Decrement all counters.
-        // Do not report "state is restored"
-
-        setStreamState(&subQueueContext, SubQueueContext::k_CLOSED);
-
-        // TBD: Note that invoking 'd_queue_p->streamParameters()' above is not
-        // thread safe as queue's parameteres are supposed to be read/written
-        // only from the queue-dispatcher thread.  This will be fixed
-        // eventually.
-
-        // Abort restore of the state: the channel is no longer valid, we'll
-        // wait for a new one to be active and will restart restoring the state
-        // from the beginning.
-    }
 }
 
 void ClusterQueueHelper::onConfigureQueueResponse(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -917,8 +917,8 @@ void ClusterQueueHelper::finishReopening(
     const bsls::Types::Uint64 generationCount = cycle->generationCount();
 
     if (isValid && state == SubQueueContext::k_OPEN) {
-        // Remain valid after all pending close
-        // Did not erase subQueueContext.
+        // Remains valid if subQueueContext was not erased
+        // after processing all pending close requests.
 
         QueueLiveState& qinfo = queueContext->d_liveQInfo;
 
@@ -1783,10 +1783,10 @@ void ClusterQueueHelper::onReopenQueueResponse(
 
     setStreamState(&subQueueContext, SubQueueContext::k_OPEN);
 
-    BMQ_LOGTHROTTLE_INFO
-        << d_cluster_p->description() << ": queue successfully reopened ["
-        << requestContext->request()
-        << "]. Attempting to send a configure-queue request now.";
+    BMQ_LOGTHROTTLE_INFO << d_cluster_p->description()
+                         << ": queue successfully reopened ["
+                         << requestContext->request()
+                         << "].";
 }
 
 void ClusterQueueHelper::onConfigureQueueResponse(

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -557,11 +557,14 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     void onQueueContextAssigned(const QueueContextSp& queueContext);
 
     /// Upon Reopen response, process pending Close requests (if any) for the
-    /// specified `queueContext` and the specified `sqit`.  If there are no
-    /// more pending Reopen queue requests, process all pending Open queue
-    /// requests.
+    /// specified `queueContext` and the specified `sqit`.  Notify queue and
+    /// send Configure request if needed to the specified `activeNode` using
+    /// the specified `cycle`.  If there are no more pending Reopen queue
+    /// requests, process all pending Open queue requests.
     void finishReopening(QueueContext*        queueContext,
-                         StreamsMap::iterator sqit);
+                         StreamsMap::iterator sqit,
+                         mqbnet::ClusterNode* activeNode,
+                         const bsl::shared_ptr<PartitionReopenCycle>& cycle);
 
     /// Process pending contexts, if any, from the specified `queueContext`.
     void processPendingContexts(QueueContext* queueContext);


### PR DESCRIPTION
`ClusterQueueHelper` calls `RemoteQueue::onOpenUpstream` when it reopens queue so that `RemoteQueue` can retransmit pending PUTs.  But `ClusterQueueHelper` may receive Close queue while reopening in which case it buffers it in `d_pendingCloseRequests`.  When `ClusterQueueHelper` receives reopen response, it calls `onOpenUpstream` and _then_ sends pending close.  Resulting in RemoteQueue retransmitting PUT after close which may fail an assertion, if the close drops writeCount to 0.

Fix - first process pending close requests and if anything left, call `RemoteQueue::onOpenUpstream` (and send Configure request)