### PR TITLE
Fix[mqb]: getting rid of resetQueue

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -2342,13 +2342,10 @@ bsl::shared_ptr<mqbi::Queue> ClusterQueueHelper::createQueueFactory(
     /// corresponding storage.  Make sure we unset this if we exit the scope
     /// on error.
 
-    bdlb::ScopeExitAny queuePtrGuard(
-        bdlf::BindUtil::bindS(d_allocator_p,
-                              &mqbi::StorageManager::resetQueue,
-                              d_storageManager_p,
-                              queueContext->uri(),
-                              queueContext->partitionId(),
-                              queueSp));
+    bdlb::ScopeExitAny queuePtrGuard(bdlf::BindUtil::bindS(d_allocator_p,
+                                                           &mqbi::Queue::close,
+                                                           queueSp.get(),
+                                                           VoidFunctor()));
 
     if (rc != 0) {
         // Queue.configure() failed.
@@ -4091,17 +4088,6 @@ void ClusterQueueHelper::deleteQueue(QueueContext* queueContext)
     BSLS_ASSERT_SAFE(queueContext->d_liveQInfo.d_queue_sp);
 
     mqbi::Queue* queue = queueContext->d_liveQInfo.d_queue_sp.get();
-
-    // If in cluster, need to *synchronously* notify queue's storage about
-    // queue's deletion, before deleting the queue.  Note that invoking
-    // 'setQueue' in proxy is undefined as there is no StorageMgr, no valid
-    // partitionId assigned to queue, etc.
-
-    if (!d_cluster_p->isRemote()) {
-        d_storageManager_p->resetQueue(queueContext->uri(),
-                                       queueContext->partitionId(),
-                                       queueContext->d_liveQInfo.d_queue_sp);
-    }
 
     queue->domain()->unregisterQueue(queue);
     queueContext->d_liveQInfo.d_queue_sp.reset();

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -227,7 +227,10 @@ void LocalQueue::close()
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_state_p->queue()->inDispatcherThread());
-    BSLS_ASSERT_SAFE(d_state_p->storage());
+
+    if (d_state_p->storage() == 0) {
+        return;  // RETURN
+    }
 
     mqbi::Storage* storage = d_state_p->storage();
     BALL_LOG_INFO << "Closing queue "

--- a/src/groups/mqb/mqbblp/mqbblp_queue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queue.cpp
@@ -355,17 +355,23 @@ void Queue::closeDispatched(const bsl::function<void(void)>& callback)
 
     updateStats();
 
-    // Enqueue the holder AFTER 'engine->close()'.  Any two-hop callbacks
-    // (scheduler -> queue dispatcher) triggered during 'cancelEventAndWait'
-    // are already on the dispatcher queue ahead of this holder, so the
-    // queue stays alive until they complete.
+    if (storage()) {
+        storage()->setQueue(0);
+    }
 
-    // We need to make sure the 'queue' is not in the dispatcher's flush list:
-    // for that purpose, enqueue an 'e_DISPATCHER' type event.
+    if (callback) {
+        // Enqueue the holder AFTER 'engine->close()'.  Any two-hop callbacks
+        // (scheduler -> queue dispatcher) triggered during
+        // 'cancelEventAndWait' are already on the dispatcher queue ahead of
+        // this holder, so the queue stays alive until they complete.
 
-    dispatcher()->execute(callback,
-                          this,
-                          mqbi::DispatcherEventType::e_DISPATCHER);
+        // We need to make sure the 'queue' is not in the dispatcher's flush
+        // list: for that purpose, enqueue an 'e_DISPATCHER' type event.
+
+        dispatcher()->execute(callback,
+                              this,
+                              mqbi::DispatcherEventType::e_DISPATCHER);
+    }
 }
 
 void Queue::convertToLocalDispatched()

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1191,33 +1191,6 @@ int StorageManager::updateQueuePrimary(const bmqt::Uri& uri,
         removedIdKeyPairs);
 }
 
-void StorageManager::resetQueue(const bmqt::Uri& uri,
-                                int              partitionId,
-                                const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-{
-    // executed by the *CLUSTER DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(uri.isValid());
-
-    // Note that 'queue' can be null, which is a valid scenario.
-
-    mqbs::FileStore* fs = d_fileStores[partitionId].get();
-
-    bsl::shared_ptr<mqbevt::DispatcherEvent> event_sp =
-        d_cluster_p->getEvent<mqbevt::DispatcherEvent>();
-    (*event_sp).callback().set(
-        bdlf::BindUtil::bind(&mqbc::StorageUtil::resetQueueDispatched,
-                             &d_storages[partitionId],
-                             d_storageLockVec[partitionId].get(),
-                             bsl::string(fs->description(), d_allocator_p),
-                             uri,
-                             queue_sp));
-
-    fs->dispatchEvent(bslmf::MovableRefUtil::move(event_sp));
-}
-
 int StorageManager::start(bsl::ostream& errorDescription)
 {
     // executed by the *CLUSTER DISPATCHER* thread

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -474,15 +474,6 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
                            const AppInfos&  removedIdKeyPairs)
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the queue instance associated with the file-backed storage for
-    /// the specified `uri` mapped to the specified `partitionId` to the
-    /// specified `queue` value.  The specified `queue_sp` keeps the queue
-    /// until the reset is complete.
-    void resetQueue(const bmqt::Uri&                    uri,
-                    int                                 partitionId,
-                    const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-        BSLS_KEYWORD_OVERRIDE;
-
     /// Behavior is undefined unless the specified 'partitionId' is in range
     /// and the specified 'primaryNode' is not null.
     ///

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4241,31 +4241,6 @@ int StorageManager::updateQueuePrimary(const bmqt::Uri& uri,
                                            removedIdKeyPairs);
 }
 
-void StorageManager::resetQueue(const bmqt::Uri& uri,
-                                int              partitionId,
-                                const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-{
-    // executed by the *CLUSTER DISPATCHER* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(uri.isValid());
-
-    mqbs::FileStore* fs = d_fileStores[partitionId].get();
-
-    bsl::shared_ptr<mqbevt::DispatcherEvent> event_sp =
-        d_cluster_p->getEvent<mqbevt::DispatcherEvent>();
-    (*event_sp).setCallback(
-        bdlf::BindUtil::bind(&StorageUtil::resetQueueDispatched,
-                             &d_storages[partitionId],
-                             d_storageLockVec[partitionId].get(),
-                             bsl::string(fs->description(), d_allocator_p),
-                             uri,
-                             queue_sp));
-
-    fs->dispatchEvent(bslmf::MovableRefUtil::move(event_sp));
-}
-
 void StorageManager::setPrimaryForPartition(int,
                                             mqbnet::ClusterNode*,
                                             unsigned int)

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -860,15 +860,6 @@ class StorageManager BSLS_KEYWORD_FINAL
                            const AppInfos&  removedIdKeyPairs)
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the queue instance associated with the file-backed storage for
-    /// the specified `uri` mapped to the specified `partitionId` to the
-    /// specified `queue` value.  The specified `queue_sp` keeps the queue
-    /// until the reset is complete.
-    void resetQueue(const bmqt::Uri&                    uri,
-                    int                                 partitionId,
-                    const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-        BSLS_KEYWORD_OVERRIDE;
-
     /// Behavior is undefined unless the specified 'partitionId' is in range
     /// and the specified 'primaryNode' is not null.
     ///

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3136,34 +3136,6 @@ void StorageUtil::updateQueueStorageDispatched(
     }
 }
 
-void StorageUtil::resetQueueDispatched(
-    StorageSpMap*           storageMap,
-    bslmt::Mutex*           storagesLock,
-    const bsl::string&      description,
-    const bmqt::Uri&        uri,
-    BSLA_MAYBE_UNUSED const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-{
-    // executed by *QUEUE_DISPATCHER* thread with the specified 'partitionId'
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(storageMap);
-
-    bslmt::LockGuard<bslmt::Mutex> guard(storagesLock);  // LOCK
-
-    StorageSpMapIter it = storageMap->find(uri);
-    if (it == storageMap->end()) {
-        BALL_LOG_ERROR << description << ": queue [" << uri
-                       << "] not found in storage manager.";
-        // While transitioning to CSL, Replica can receive both
-        // QueueUnassignmentAdvisory and Queue DELETION.  The latter can delete
-        // the storage.
-
-        return;  // RETURN
-    }
-
-    it->second->setQueue(0);
-}
-
 int StorageUtil::configureStorage(
     bsl::ostream&                      errorDescription,
     bsl::shared_ptr<mqbi::Storage>*    out,

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -706,15 +706,6 @@ struct StorageUtil {
                                  const AppInfos&         addedIdKeyPairs,
                                  mqbi::Domain*           domain = 0);
 
-    /// Executed by queue-dispatcher thread with the specified
-    /// `processorId`.
-    static void
-    resetQueueDispatched(StorageSpMap*                       storageMap,
-                         bslmt::Mutex*                       storagesLock,
-                         const bsl::string&                  description,
-                         const bmqt::Uri&                    uri,
-                         const bsl::shared_ptr<mqbi::Queue>& queue_sp);
-
     static int configureStorage(bsl::ostream& errorDescription,
                                 bsl::shared_ptr<mqbi::Storage>* out,
                                 StorageSpMap*                   storageMap,

--- a/src/groups/mqb/mqbi/mqbi_storagemanager.h
+++ b/src/groups/mqb/mqbi/mqbi_storagemanager.h
@@ -267,14 +267,6 @@ class StorageManager {
                                    const AppInfos&  addedIdKeyPairs,
                                    const AppInfos&  removedIdKeyPairs) = 0;
 
-    /// Reset the queue instance associated with the file-backed storage for
-    /// the specified `uri` mapped to the specified `partitionId` to the
-    /// specified `queue` value.  The specified `queue_sp` keeps the queue
-    /// until the reset is complete.
-    virtual void resetQueue(const bmqt::Uri&                    uri,
-                            int                                 partitionId,
-                            const bsl::shared_ptr<mqbi::Queue>& queue_sp) = 0;
-
     /// Behavior is undefined unless the specified 'partitionId' is in range
     /// and the specified 'primaryNode' is not null.
     ///

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.cpp
@@ -81,14 +81,6 @@ int StorageManager::updateQueuePrimary(
     return 0;
 }
 
-void StorageManager::resetQueue(
-    BSLA_MAYBE_UNUSED const bmqt::Uri& uri,
-    BSLA_MAYBE_UNUSED int              partitionId,
-    BSLA_MAYBE_UNUSED const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-{
-    // NOTHING
-}
-
 void StorageManager::setPrimaryForPartition(
     BSLA_MAYBE_UNUSED int partitionId,
     BSLA_MAYBE_UNUSED mqbnet::ClusterNode* primaryNode,

--- a/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
+++ b/src/groups/mqb/mqbmock/mqbmock_storagemanager.h
@@ -107,15 +107,6 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
                            const AppInfos&  removedIdKeyPairs)
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Reset the queue instance associated with the file-backed storage for
-    /// the specified `uri` mapped to the specified `partitionId` to the
-    /// specified `queue` value.  The specified `queue_sp` keeps the queue
-    /// until the reset is complete.
-    void resetQueue(const bmqt::Uri&                    uri,
-                    int                                 partitionId,
-                    const bsl::shared_ptr<mqbi::Queue>& queue_sp)
-        BSLS_KEYWORD_OVERRIDE;
-
     /// Behavior is undefined unless the specified 'partitionId' is in range
     /// and the specified 'primaryNode' is not null.
     ///


### PR DESCRIPTION
upon shutdown, domain may 'teardown', close queue and then shutdown stops dispatcher.  
meanwhile `ClusterQueueHelper::onQueueHandleDestroyedDispatched` attempts to 'deleteQueue' and calls 'resetQueue' which tries to use dispatcher which is already stopped.

Fix, get rid of 'resetQueue'  and make `closeDispatched' call `setQueue(0)`