### PR TITLE
Fix[mqbstat]: Pass `shared_ptr` to `FileObserver2::publish`

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.cpp
@@ -31,6 +31,7 @@
 #include <bdlt_datetime.h>
 #include <bdlt_epochutil.h>
 #include <bsl_ctime.h>
+#include <bsl_memory.h>
 #include <bsl_ostream.h>
 #include <bslma_allocator.h>
 #include <bslmt_threadutil.h>
@@ -56,6 +57,7 @@ StatsFileLogger::StatsFileLogger(bsl::string_view       filePattern,
 : d_filePattern(filePattern, allocator)
 , d_statsLogFile(allocator)
 , d_statLogCleaner(eventScheduler, allocator)
+, d_allocator_p(allocator)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(eventScheduler);
@@ -107,8 +109,9 @@ void StatsFileLogger::logStats(const PrinterCb& printerCb)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(printerCb);
 
-    ball::Record            record;
-    ball::RecordAttributes& attributes = record.fixedFields();
+    bsl::shared_ptr<ball::Record> record_sp =
+        bsl::allocate_shared<ball::Record>(d_allocator_p);
+    ball::RecordAttributes& attributes = record_sp->fixedFields();
     bdlt::Datetime          now;
     bdlt::EpochUtil::convertFromTimeT(&now, time(0));
     attributes.setTimestamp(now);
@@ -123,9 +126,8 @@ void StatsFileLogger::logStats(const PrinterCb& printerCb)
     bsl::ostream os(&attributes.messageStreamBuf());
 
     printerCb(os);
-
     d_statsLogFile.publish(
-        record,
+        record_sp,
         ball::Context(ball::Transmission::e_MANUAL_PUBLISH, 0, 1));
 }
 

--- a/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statsfilelogger.h
@@ -68,6 +68,9 @@ class StatsFileLogger {
     /// Mechanism to clean up old stat logs.
     bmqtsk::LogCleaner d_statLogCleaner;
 
+    /// Allocator.
+    bslma::Allocator* d_allocator_p;
+
     // NOT IMPLEMENTED
     StatsFileLogger(const StatsFileLogger& other) BSLS_KEYWORD_DELETED;
     StatsFileLogger&


### PR DESCRIPTION
`StatsFileLogger::logStats` passes a stack-allocated `ball::Record` by reference to `ball::FileObserver2::publish`.  `FileObserver2` only overrides the `shared_ptr<const Record>` overload of `publish`; it does not override the deprecated `const Record&` overload.  The base class `ball::Observer::publish(const Record&, const Context&)` default implementation contains `BSLS_ASSERT_OPT(false)`, so the broker crashes on the first stats print interval after startup.

The crash is delayed because `snapshotAndNotify` fires every `snapshotInterval` seconds, but `logStats` is only called when the snapshot counter reaches the `printInterval` (i.e., after `printInterval / snapshotInterval` snapshots).  With typical configuration values, this means the broker runs for about a minute before hitting the assertion.

This pull request wraps the record in a `bsl::shared_ptr` before calling `publish`, so that the call resolves to the `shared_ptr` overload that `FileObserver2` implements.