### PR TITLE
Refactor: replace new with allocate_shared

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.h
@@ -51,6 +51,8 @@
 
 // BDE
 #include <bsla_annotations.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 
 namespace BloombergLP {
 namespace m_bmqstoragetool {
@@ -105,6 +107,10 @@ class CslSearchShortResult : public CslSearchResult {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CslSearchShortResult,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `printer`, `processCslRecordTypes`
     /// and `allocator`.
     explicit CslSearchShortResult(
@@ -150,6 +156,10 @@ class CslSearchDetailResult : public CslSearchResult {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CslSearchDetailResult,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `printer`, `processCslRecordTypes`
     /// and `allocator`.
@@ -231,6 +241,10 @@ class CslSearchSequenceNumberDecorator : public CslSearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CslSearchSequenceNumberDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `seqNums`, `ostream` and
     /// `allocator`.
     CslSearchSequenceNumberDecorator(
@@ -267,6 +281,10 @@ class CslSearchOffsetDecorator : public CslSearchResultDecorator {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CslSearchOffsetDecorator,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `component`, `seqNums`, `ostream` and
     /// `allocator`.
@@ -315,6 +333,10 @@ class CslSummaryResult : public CslSearchResult {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CslSummaryResult,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `ostream`, `processCslRecordTypes` and
     /// `allocator`.

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -72,6 +72,8 @@
 #include <bsl_utility.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
 
 namespace BloombergLP {
@@ -198,6 +200,10 @@ class SearchShortResult : public SearchResult {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchShortResult,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `printer`, `processRecordTypes`,
     /// `payloadDumper`, `printImmediately`, `eraseDeleted`, `printOnDelete`
@@ -329,6 +335,10 @@ class SearchDetailResult : public SearchResult {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchDetailResult,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `printer`, `processRecordTypes`,
     /// `queueMap`, `payloadDumper`, `printImmediately`, `eraseDeleted`,
     /// `cleanUnprinted` and `allocator`.
@@ -434,6 +444,10 @@ class SearchExactMatchResult : public SearchResult {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchExactMatchResult,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `printer`, `processRecordTypes`,
     /// `isDetail`, `queueMap`, `payloadDumper` and `allocator`.
@@ -575,6 +589,10 @@ class SearchResultTimestampDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchResultTimestampDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `timestampLt` and
     /// `allocator`.
     SearchResultTimestampDecorator(
@@ -623,6 +641,10 @@ class SearchResultOffsetDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchResultOffsetDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `offsetLt` and
     /// `allocator`.
     SearchResultOffsetDecorator(const bsl::shared_ptr<SearchResult>& component,
@@ -670,6 +692,10 @@ class SearchResultSequenceNumberDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchResultSequenceNumberDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `seqNumberLt` and
     /// `allocator`.
     SearchResultSequenceNumberDecorator(
@@ -708,6 +734,10 @@ class SearchAllDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchAllDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component` and `allocator`.
     SearchAllDecorator(const bsl::shared_ptr<SearchResult>& component,
                        bslma::Allocator*                    allocator);
@@ -741,6 +771,10 @@ class SearchOutstandingDecorator : public SearchResultDecorator {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchOutstandingDecorator,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `component`, `ostream` and `allocator`.
     SearchOutstandingDecorator(const bsl::shared_ptr<SearchResult>& component,
@@ -790,6 +824,10 @@ class SearchPartiallyConfirmedDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchPartiallyConfirmedDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `ostream` and `allocator`.
     SearchPartiallyConfirmedDecorator(
         const bsl::shared_ptr<SearchResult>& component,
@@ -837,6 +875,10 @@ class SearchGuidDecorator : public SearchResultDecorator {
   public:
     // CREATORS
 
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchGuidDecorator,
+                                   bslma::UsesBslmaAllocator);
+
     /// Constructor using the specified `component`, `guids`, `ostream`,
     /// `withDetails` and `allocator`.
     SearchGuidDecorator(const bsl::shared_ptr<SearchResult>& component,
@@ -877,6 +919,10 @@ class SearchOffsetDecorator : public SearchResultDecorator {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchOffsetDecorator,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `component`, `offsets`, `ostream`,
     /// `withDetails` and `allocator`.
@@ -938,6 +984,10 @@ class SearchSequenceNumberDecorator : public SearchResultDecorator {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SearchSequenceNumberDecorator,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `component`, `seqNums`, `ostream`,
     /// `withDetails` and `allocator`.
@@ -1042,6 +1092,10 @@ class SummaryProcessor : public SearchResult {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SummaryProcessor,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructor using the specified `printer`, `journalFile_p`,
     /// `dataFile_p` , `processRecordTypes`, `queueMap`, `minRecordsPerQueue`

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
@@ -36,8 +36,6 @@ bsl::shared_ptr<SearchResult> SearchResultFactory::createSearchResult(
     // PRECONDITIONS
     BSLS_ASSERT(params);
 
-    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
-
     // Set up processing flags
     const bool details    = params->d_details;
     const bool exactMatch = !params->d_seqNum.empty() ||
@@ -58,123 +56,115 @@ bsl::shared_ptr<SearchResult> SearchResultFactory::createSearchResult(
     // summary, exact match, detail or short result.
     bsl::shared_ptr<SearchResult> searchResult;
     if (params->d_summary) {
-        searchResult.reset(
-            new (*alloc) SummaryProcessor(printer,
-                                          fileManager->journalFileIterator(),
-                                          fileManager->dataFileIterator(),
-                                          params->d_processRecordTypes,
-                                          params->d_queueMap,
-                                          params->d_minRecordsPerQueue,
-                                          alloc),
-            alloc);
+        searchResult = bsl::allocate_shared<SummaryProcessor>(
+            allocator,
+            printer,
+            fileManager->journalFileIterator(),
+            fileManager->dataFileIterator(),
+            params->d_processRecordTypes,
+            params->d_queueMap,
+            params->d_minRecordsPerQueue);
     }
     else if (exactMatch) {
-        searchResult.reset(
-            new (*alloc) SearchExactMatchResult(printer,
-                                                params->d_processRecordTypes,
-                                                details,
-                                                params->d_queueMap,
-                                                payloadDumper,
-                                                alloc),
-            alloc);
+        searchResult = bsl::allocate_shared<SearchExactMatchResult>(
+            allocator,
+            printer,
+            params->d_processRecordTypes,
+            details,
+            params->d_queueMap,
+            payloadDumper);
     }
     else if (details) {
-        searchResult.reset(new (*alloc)
-                               SearchDetailResult(printer,
-                                                  params->d_processRecordTypes,
-                                                  params->d_queueMap,
-                                                  payloadDumper,
-                                                  printImmediately,
-                                                  eraseDeleted,
-                                                  cleanUnprinted,
-                                                  alloc),
-                           alloc);
+        searchResult = bsl::allocate_shared<SearchDetailResult>(
+            allocator,
+            printer,
+            params->d_processRecordTypes,
+            params->d_queueMap,
+            payloadDumper,
+            printImmediately,
+            eraseDeleted,
+            cleanUnprinted);
     }
     else {
-        searchResult.reset(new (*alloc)
-                               SearchShortResult(printer,
-                                                 params->d_processRecordTypes,
-                                                 payloadDumper,
-                                                 printImmediately,
-                                                 eraseDeleted,
-                                                 printOnDelete,
-                                                 alloc),
-                           alloc);
+        searchResult = bsl::allocate_shared<SearchShortResult>(
+            allocator,
+            printer,
+            params->d_processRecordTypes,
+            payloadDumper,
+            printImmediately,
+            eraseDeleted,
+            printOnDelete);
     }
 
     if (!params->d_summary) {
         // Create Decorator for specific search
         if (!params->d_guid.empty()) {
             // Search GUIDs
-            searchResult.reset(new (*alloc) SearchGuidDecorator(searchResult,
-                                                                params->d_guid,
-                                                                details,
-                                                                alloc),
-                               alloc);
+            searchResult = bsl::allocate_shared<SearchGuidDecorator>(
+                allocator,
+                searchResult,
+                params->d_guid,
+                details);
         }
         else if (!params->d_seqNum.empty()) {
             // Search composite sequence numbers
-            searchResult.reset(
-                new (*alloc) SearchSequenceNumberDecorator(searchResult,
-                                                           params->d_seqNum,
-                                                           details,
-                                                           alloc),
-                alloc);
+            searchResult = bsl::allocate_shared<SearchSequenceNumberDecorator>(
+                allocator,
+                searchResult,
+                params->d_seqNum,
+                details);
         }
         else if (!params->d_offset.empty()) {
             // Search offsets
-            searchResult.reset(new (*alloc)
-                                   SearchOffsetDecorator(searchResult,
-                                                         params->d_offset,
-                                                         details,
-                                                         alloc),
-                               alloc);
+            searchResult = bsl::allocate_shared<SearchOffsetDecorator>(
+                allocator,
+                searchResult,
+                params->d_offset,
+                details);
         }
         else if (params->d_outstanding || params->d_confirmed) {
             // Search outstanding or confirmed
-            searchResult.reset(
-                new (*alloc) SearchOutstandingDecorator(searchResult, alloc),
-                alloc);
+            searchResult = bsl::allocate_shared<SearchOutstandingDecorator>(
+                allocator,
+                searchResult);
         }
         else if (params->d_partiallyConfirmed) {
             // Search partially confirmed
             BSLS_ASSERT(!exactMatch);
-            searchResult.reset(
-                new (*alloc)
-                    SearchPartiallyConfirmedDecorator(searchResult, alloc),
-                alloc);
+            searchResult =
+                bsl::allocate_shared<SearchPartiallyConfirmedDecorator>(
+                    allocator,
+                    searchResult);
         }
         else {
             // Drefault: search all
-            searchResult.reset(new (*alloc)
-                                   SearchAllDecorator(searchResult, alloc),
-                               alloc);
+            searchResult = bsl::allocate_shared<SearchAllDecorator>(
+                allocator,
+                searchResult);
         }
     }
 
     // Add TimestampDecorator if 'timestampLt' is given.
     if (params->d_range.d_timestampLt) {
-        searchResult.reset(new (*alloc) SearchResultTimestampDecorator(
-                               searchResult,
-                               params->d_range.d_timestampLt.value(),
-                               alloc),
-                           alloc);
+        searchResult = bsl::allocate_shared<SearchResultTimestampDecorator>(
+            allocator,
+            searchResult,
+            params->d_range.d_timestampLt.value());
     }
     else if (params->d_range.d_offsetLt) {
         // Add OffsetDecorator if 'offsetLt' is given.
-        searchResult.reset(new (*alloc) SearchResultOffsetDecorator(
-                               searchResult,
-                               params->d_range.d_offsetLt.value(),
-                               alloc),
-                           alloc);
+        searchResult = bsl::allocate_shared<SearchResultOffsetDecorator>(
+            allocator,
+            searchResult,
+            params->d_range.d_offsetLt.value());
     }
     else if (params->d_range.d_seqNumLt) {
         // Add SequenceNumberDecorator if 'seqNumLt' is given.
-        searchResult.reset(new (*alloc) SearchResultSequenceNumberDecorator(
-                               searchResult,
-                               params->d_range.d_seqNumLt.value(),
-                               alloc),
-                           alloc);
+        searchResult =
+            bsl::allocate_shared<SearchResultSequenceNumberDecorator>(
+                allocator,
+                searchResult,
+                params->d_range.d_seqNumLt.value());
     }
 
     BSLS_ASSERT(searchResult);
@@ -190,49 +180,43 @@ bsl::shared_ptr<CslSearchResult> SearchResultFactory::createCslSearchResult(
     // PRECONDITIONS
     BSLS_ASSERT(params);
 
-    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
-
     // Create CslSearchResult implementation
     bsl::shared_ptr<CslSearchResult> cslSearchResult;
     if (params->d_details) {
-        cslSearchResult.reset(
-            new (*alloc) CslSearchDetailResult(printer,
-                                               params->d_processCslRecordTypes,
-                                               alloc),
-            alloc);
+        cslSearchResult = bsl::allocate_shared<CslSearchDetailResult>(
+            allocator,
+            printer,
+            params->d_processCslRecordTypes);
     }
     else if (params->d_summary) {
-        cslSearchResult.reset(
-            new (*alloc) CslSummaryResult(printer,
-                                          params->d_processCslRecordTypes,
-                                          params->d_queueMap,
-                                          params->d_cslSummaryQueuesLimit,
-                                          alloc),
-            alloc);
+        cslSearchResult = bsl::allocate_shared<CslSummaryResult>(
+            allocator,
+            printer,
+            params->d_processCslRecordTypes,
+            params->d_queueMap,
+            params->d_cslSummaryQueuesLimit);
     }
     else {
-        cslSearchResult.reset(
-            new (*alloc) CslSearchShortResult(printer,
-                                              params->d_processCslRecordTypes,
-                                              alloc),
-            alloc);
+        cslSearchResult = bsl::allocate_shared<CslSearchShortResult>(
+            allocator,
+            printer,
+            params->d_processCslRecordTypes);
     }
 
     if (!params->d_seqNum.empty()) {
         // Search composite sequence numbers
-        cslSearchResult.reset(
-            new (*alloc) CslSearchSequenceNumberDecorator(cslSearchResult,
-                                                          params->d_seqNum,
-                                                          alloc),
-            alloc);
+        cslSearchResult =
+            bsl::allocate_shared<CslSearchSequenceNumberDecorator>(
+                allocator,
+                cslSearchResult,
+                params->d_seqNum);
     }
     else if (!params->d_offset.empty()) {
         // Search offsets
-        cslSearchResult.reset(new (*alloc)
-                                  CslSearchOffsetDecorator(cslSearchResult,
-                                                           params->d_offset,
-                                                           alloc),
-                              alloc);
+        cslSearchResult = bsl::allocate_shared<CslSearchOffsetDecorator>(
+            allocator,
+            cslSearchResult,
+            params->d_offset);
     }
 
     BSLS_ASSERT(cslSearchResult);

--- a/src/groups/bmq/bmqa/bmqa_manualhosthealthmonitor.cpp
+++ b/src/groups/bmq/bmqa/bmqa_manualhosthealthmonitor.cpp
@@ -33,13 +33,11 @@ namespace bmqa {
 ManualHostHealthMonitor::ManualHostHealthMonitor(
     bmqt::HostHealthState::Enum initialState,
     bslma::Allocator*           allocator)
-: d_impl_sp()
+: d_impl_sp(
+      bsl::allocate_shared<bmqimp::ManualHostHealthMonitor>(allocator,
+                                                            initialState))
 {
-    bslma::Allocator* alloc = bslma::Default::allocator(allocator);
-
-    d_impl_sp.reset(new (*alloc)
-                        bmqimp::ManualHostHealthMonitor(initialState, alloc),
-                    alloc);
+    // NOTHING
 }
 
 ManualHostHealthMonitor::~ManualHostHealthMonitor()

--- a/src/groups/bmq/bmqimp/bmqimp_manualhosthealthmonitor.h
+++ b/src/groups/bmq/bmqimp/bmqimp_manualhosthealthmonitor.h
@@ -38,6 +38,8 @@
 #include <bsl_cstddef.h>
 #include <bsl_functional.h>
 #include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
 
 namespace BloombergLP {
@@ -63,6 +65,10 @@ class ManualHostHealthMonitor : public bmqpi::HostHealthMonitor {
 
   public:
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(ManualHostHealthMonitor,
+                                   bslma::UsesBslmaAllocator);
 
     /// Constructs a `ManualHostHealthMonitor` with the given initial state.
     /// Optionally specify an `allocator` to supply memory. If `allocator`

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -182,9 +182,7 @@ int Dispatcher::startContext(bsl::ostream&                    errorDescription,
 
     DispatcherContextSp& context = d_contexts[type];
 
-    context.reset(new (*d_allocator_p)
-                      DispatcherContext(config, d_allocator_p),
-                  d_allocator_p);
+    context = bsl::allocate_shared<DispatcherContext>(d_allocator_p, config);
 
     // Create client stat context
     context->d_clientStatContext_mp =

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -4337,9 +4337,8 @@ void ClusterQueueHelper::onQueueAssigned(
         BSLS_ASSERT_SAFE(insertRc.second);
 
         // Create the queueContext.
-        queueContext.reset(new (*d_allocator_p)
-                               QueueContext(info->uri(), d_allocator_p),
-                           d_allocator_p);
+        queueContext = bsl::allocate_shared<QueueContext>(d_allocator_p,
+                                                          info->uri());
 
         d_queues[info->uri()] = queueContext;
     }

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -1261,9 +1261,10 @@ ClusterQueueHelper::startPartitionReopen(int                 partitionId,
     }
 
     // Start new restore cycle
-    cycle.reset(new (*d_allocator_p)
-                    PartitionReopenCycle(this, generationCount, partitionId),
-                d_allocator_p);
+    cycle = bsl::allocate_shared<PartitionReopenCycle>(d_allocator_p,
+                                                       this,
+                                                       generationCount,
+                                                       partitionId);
     d_reopenCycles[partitionId] = cycle;
 
     return cycle;

--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -1234,9 +1234,8 @@ int QueueHandle::transferUnconfirmedMessageGUID(
     }
 
     // Reset unconfirmed messages and associated state
-    data.reset(new (*d_allocator_p)
-                   mqbi::QueueHandle::UnconfirmedMessageInfoMap(d_allocator_p),
-               d_allocator_p);
+    data = bsl::allocate_shared<mqbi::QueueHandle::UnconfirmedMessageInfoMap>(
+        d_allocator_p);
 
     // Reset unconfirmed messages and associated state
 

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -663,9 +663,8 @@ inline void RelayQueueEngine::ConfigureContext::resetCallback()
 inline void RelayQueueEngine::ConfigureContext::initializeRouting(
     Routers::QueueRoutingContext& queueContext)
 {
-    d_routing_sp.reset(new (*d_allocator_p)
-                           Routers::AppContext(queueContext, d_allocator_p),
-                       d_allocator_p);
+    d_routing_sp = bsl::allocate_shared<Routers::AppContext>(d_allocator_p,
+                                                             queueContext);
 }
 
 // ----------------------

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1052,10 +1052,9 @@ void RootQueueEngine::configureHandle(
     const bsl::shared_ptr<Routers::AppContext> previous =
         affectedApp->routing();
 
-    affectedApp->routing().reset(new (*d_allocator_p) Routers::AppContext(
-                                     d_queueState_p->routingContext(),
-                                     d_allocator_p),
-                                 d_allocator_p);
+    affectedApp->routing() = bsl::allocate_shared<Routers::AppContext>(
+        d_allocator_p,
+        d_queueState_p->routingContext());
 
     d_queueState_p->handleCatalog().iterateConsumers(
         bdlf::BindUtil::bind(&RootQueueEngine::rebuildSelectedApp,

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -450,9 +450,8 @@ inline bmqt::EventBuilderResult::Enum Tester<bmqp::PutEventBuilder>::build()
     const int                          flags      = 0;
     bsl::shared_ptr<bdlbb::Blob>       payload_sp = d_blobSpPool.getObject();
     bdlbb::BlobBuffer                  blobBuffer;
-    bsl::shared_ptr<bmqu::AtomicState> state(new (*d_allocator_p)
-                                                 bmqu::AtomicState,
-                                             d_allocator_p);
+    bsl::shared_ptr<bmqu::AtomicState> state =
+        bsl::allocate_shared<bmqu::AtomicState>(d_allocator_p);
 
     d_bufferFactory.allocate(&blobBuffer);
 


### PR DESCRIPTION
- Replace `new (*alloc) T(...)` / `shared_ptr::reset()` with `bsl::allocate_shared<T>(allocator, ...)`                                                                                     
- Add `BSLMF_NESTED_TRAIT_DECLARATION(T, bslma::UsesBslmaAllocator)` to enable allocator propagation                                                                                        
- Remove redundant `bslma::Default::allocator(allocator)` calls — `allocate_shared` handles default allocator internally
- Reduce allocations from two (object + control block) to one per `shared_ptr` creation
