### PR TITLE
Fix[bmqp]: Change authn lifetime type to unsigned long

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
@@ -42,6 +42,7 @@
 #include <bslma_default.h>
 #include <bsls_assert.h>
 #include <bsls_timeinterval.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 namespace bmqimp {
@@ -64,10 +65,19 @@ enum RcEnum {
 };
 
 /// Minimum buffer to subtract from lifetimeMs to avoid cutting too close
-static const int k_REAUTHN_EARLY_BUFFER = 5000;
+static const bsls::Types::Uint64 k_REAUTHN_EARLY_BUFFER = 5000;
 
 /// Proportion of lifetimeMs after which to initiate reauthentication.
 const double k_REAUTHN_EARLY_RATIO = 0.9;
+
+/// Compute `a - b` which saturates on underflow.
+bsls::Types::Uint64 saturatingSub(bsls::Types::Uint64 a, bsls::Types::Uint64 b)
+{
+    if (a <= b) {
+        return 0;
+    }
+    return a - b;
+}
 
 }  // close unnamed namespace
 
@@ -213,14 +223,13 @@ void AuthenticatedChannelFactory::authenticate(
     }
 }
 
-int AuthenticatedChannelFactory::timeoutInterval(int lifetimeMs) const
+bsls::Types::Uint64 AuthenticatedChannelFactory::timeoutInterval(
+    bsls::Types::Uint64 lifetimeMs) const
 {
-    BSLS_ASSERT_SAFE(lifetimeMs >= 0);
-    const int intervalMsWithRatio  = static_cast<int>(lifetimeMs *
-                                                     k_REAUTHN_EARLY_RATIO);
-    const int intervalMsWithBuffer = bsl::max(0,
-                                              lifetimeMs -
-                                                  k_REAUTHN_EARLY_BUFFER);
+    const bsls::Types::Uint64 intervalMsWithRatio =
+        static_cast<bsls::Types::Uint64>(lifetimeMs * k_REAUTHN_EARLY_RATIO);
+    const bsls::Types::Uint64 intervalMsWithBuffer =
+        saturatingSub(lifetimeMs, k_REAUTHN_EARLY_BUFFER);
     return bsl::min(intervalMsWithRatio, intervalMsWithBuffer);
 }
 
@@ -385,7 +394,7 @@ bool AuthenticatedChannelFactory::processAuthenticationEvent(
     // Authentication SUCCEEDED.  Schedule reauthentication if lifetime is
     // specified in the response.
     if (authenticationResponse.lifetimeMs().has_value()) {
-        int intervalMs = timeoutInterval(
+        bsls::Types::Uint64 intervalMs = timeoutInterval(
             authenticationResponse.lifetimeMs().value());
 
         bdlt::Datetime reauthTime = bdlt::CurrentTime::utc();

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.h
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.h
@@ -47,6 +47,7 @@
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
 #include <bsls_timeinterval.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 
@@ -153,7 +154,7 @@ class AuthenticatedChannelFactory : public bmqio::ChannelFactory {
     /// after which reauthentication should be performed.  This interval is
     /// calculated with a buffer to avoid cutting too close to the actual
     /// expiration time.
-    int timeoutInterval(int lifetimeMs) const;
+    bsls::Types::Uint64 timeoutInterval(bsls::Types::Uint64 lifetimeMs) const;
 
     // PRIVATE MANIPULATORS
 

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.t.cpp
@@ -141,9 +141,9 @@ class TestContext {
     /// Build an authentication response blob with the specified
     /// `statusCategory`.  Optionally specify `lifetimeMs` to include a
     /// session lifetime in the response.
-    bdlbb::Blob
-    buildAuthResponse(bmqp_ctrlmsg::StatusCategory::Value statusCategory,
-                      int                                 lifetimeMs = -1);
+    bdlbb::Blob buildAuthResponse(
+        bmqp_ctrlmsg::StatusCategory::Value statusCategory,
+        bsl::optional<bsls::Types::Uint64>  lifetimeMs = bsl::nullopt);
 
     /// Pop the ReadCall from the test channel and invoke its read callback
     /// with success status and the specified `blob`.
@@ -255,7 +255,7 @@ void TestContext::emitChannelUp()
 
 bdlbb::Blob TestContext::buildAuthResponse(
     bmqp_ctrlmsg::StatusCategory::Value statusCategory,
-    int                                 lifetimeMs)
+    bsl::optional<bsls::Types::Uint64>  lifetimeMs)
 {
     bmqp_ctrlmsg::AuthenticationMessage authMessage(
         bmqtst::TestHelperUtil::allocator());
@@ -263,9 +263,7 @@ bdlbb::Blob TestContext::buildAuthResponse(
         authMessage.makeAuthenticationResponse();
     resp.status().category() = statusCategory;
 
-    if (lifetimeMs >= 0) {
-        resp.lifetimeMs().makeValue(lifetimeMs);
-    }
+    resp.lifetimeMs() = lifetimeMs;
 
     bmqp::SchemaEventBuilder builder(d_blobSpPool.get(),
                                      bmqp::EncodingType::e_BER,

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -1781,7 +1781,7 @@
     </annotation>
     <sequence>
       <element name='status'      type='tns:Status' />
-      <element name='lifetimeMs'  type='int'   minOccurs='0'/>
+      <element name='lifetimeMs'  type='unsignedLong'   minOccurs='0'/>
     </sequence>
   </complexType>
 

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -544,18 +544,18 @@ bsl::ostream& AuthenticationRequest::print(bsl::ostream& stream,
 const char ClientLanguage::CLASS_NAME[] = "ClientLanguage";
 
 const bdlat_EnumeratorInfo ClientLanguage::ENUMERATOR_INFO_ARRAY[] = {
-    {ClientLanguage::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ClientLanguage::E_CPP, "E_CPP", sizeof("E_CPP") - 1, ""},
-    {ClientLanguage::E_JAVA, "E_JAVA", sizeof("E_JAVA") - 1, ""}};
+    {ClientLanguage::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ClientLanguage::e_E_CPP, "E_CPP", sizeof("E_CPP") - 1, ""},
+    {ClientLanguage::e_E_JAVA, "E_JAVA", sizeof("E_JAVA") - 1, ""}};
 
 // CLASS METHODS
 
 int ClientLanguage::fromInt(ClientLanguage::Value* result, int number)
 {
     switch (number) {
-    case ClientLanguage::E_UNKNOWN:
-    case ClientLanguage::E_CPP:
-    case ClientLanguage::E_JAVA:
+    case ClientLanguage::e_E_UNKNOWN:
+    case ClientLanguage::e_E_CPP:
+    case ClientLanguage::e_E_JAVA:
         *result = static_cast<ClientLanguage::Value>(number);
         return 0;
     default: return -1;
@@ -584,13 +584,13 @@ int ClientLanguage::fromString(ClientLanguage::Value* result,
 const char* ClientLanguage::toString(ClientLanguage::Value value)
 {
     switch (value) {
-    case E_UNKNOWN: {
+    case e_E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case E_CPP: {
+    case e_E_CPP: {
         return "E_CPP";
     }
-    case E_JAVA: {
+    case e_E_JAVA: {
         return "E_JAVA";
     }
     }
@@ -608,20 +608,20 @@ const char* ClientLanguage::toString(ClientLanguage::Value value)
 const char ClientType::CLASS_NAME[] = "ClientType";
 
 const bdlat_EnumeratorInfo ClientType::ENUMERATOR_INFO_ARRAY[] = {
-    {ClientType::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ClientType::E_TCPCLIENT, "E_TCPCLIENT", sizeof("E_TCPCLIENT") - 1, ""},
-    {ClientType::E_TCPBROKER, "E_TCPBROKER", sizeof("E_TCPBROKER") - 1, ""},
-    {ClientType::E_TCPADMIN, "E_TCPADMIN", sizeof("E_TCPADMIN") - 1, ""}};
+    {ClientType::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ClientType::e_E_TCPCLIENT, "E_TCPCLIENT", sizeof("E_TCPCLIENT") - 1, ""},
+    {ClientType::e_E_TCPBROKER, "E_TCPBROKER", sizeof("E_TCPBROKER") - 1, ""},
+    {ClientType::e_E_TCPADMIN, "E_TCPADMIN", sizeof("E_TCPADMIN") - 1, ""}};
 
 // CLASS METHODS
 
 int ClientType::fromInt(ClientType::Value* result, int number)
 {
     switch (number) {
-    case ClientType::E_UNKNOWN:
-    case ClientType::E_TCPCLIENT:
-    case ClientType::E_TCPBROKER:
-    case ClientType::E_TCPADMIN:
+    case ClientType::e_E_UNKNOWN:
+    case ClientType::e_E_TCPCLIENT:
+    case ClientType::e_E_TCPBROKER:
+    case ClientType::e_E_TCPADMIN:
         *result = static_cast<ClientType::Value>(number);
         return 0;
     default: return -1;
@@ -649,16 +649,16 @@ int ClientType::fromString(ClientType::Value* result,
 const char* ClientType::toString(ClientType::Value value)
 {
     switch (value) {
-    case E_UNKNOWN: {
+    case e_E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case E_TCPCLIENT: {
+    case e_E_TCPCLIENT: {
         return "E_TCPCLIENT";
     }
-    case E_TCPBROKER: {
+    case e_E_TCPBROKER: {
         return "E_TCPBROKER";
     }
-    case E_TCPADMIN: {
+    case e_E_TCPADMIN: {
         return "E_TCPADMIN";
     }
     }
@@ -946,13 +946,13 @@ bsl::ostream& DummyType::print(bsl::ostream& stream, int, int) const
 const char DumpActionType::CLASS_NAME[] = "DumpActionType";
 
 const bdlat_EnumeratorInfo DumpActionType::ENUMERATOR_INFO_ARRAY[] = {
-    {DumpActionType::E_ON, "E_ON", sizeof("E_ON") - 1, ""},
-    {DumpActionType::E_OFF, "E_OFF", sizeof("E_OFF") - 1, ""},
-    {DumpActionType::E_MESSAGE_COUNT,
+    {DumpActionType::e_E_ON, "E_ON", sizeof("E_ON") - 1, ""},
+    {DumpActionType::e_E_OFF, "E_OFF", sizeof("E_OFF") - 1, ""},
+    {DumpActionType::e_E_MESSAGE_COUNT,
      "E_MESSAGE_COUNT",
      sizeof("E_MESSAGE_COUNT") - 1,
      ""},
-    {DumpActionType::E_TIME_IN_SECONDS,
+    {DumpActionType::e_E_TIME_IN_SECONDS,
      "E_TIME_IN_SECONDS",
      sizeof("E_TIME_IN_SECONDS") - 1,
      ""}};
@@ -962,10 +962,10 @@ const bdlat_EnumeratorInfo DumpActionType::ENUMERATOR_INFO_ARRAY[] = {
 int DumpActionType::fromInt(DumpActionType::Value* result, int number)
 {
     switch (number) {
-    case DumpActionType::E_ON:
-    case DumpActionType::E_OFF:
-    case DumpActionType::E_MESSAGE_COUNT:
-    case DumpActionType::E_TIME_IN_SECONDS:
+    case DumpActionType::e_E_ON:
+    case DumpActionType::e_E_OFF:
+    case DumpActionType::e_E_MESSAGE_COUNT:
+    case DumpActionType::e_E_TIME_IN_SECONDS:
         *result = static_cast<DumpActionType::Value>(number);
         return 0;
     default: return -1;
@@ -994,16 +994,16 @@ int DumpActionType::fromString(DumpActionType::Value* result,
 const char* DumpActionType::toString(DumpActionType::Value value)
 {
     switch (value) {
-    case E_ON: {
+    case e_E_ON: {
         return "E_ON";
     }
-    case E_OFF: {
+    case e_E_OFF: {
         return "E_OFF";
     }
-    case E_MESSAGE_COUNT: {
+    case e_E_MESSAGE_COUNT: {
         return "E_MESSAGE_COUNT";
     }
-    case E_TIME_IN_SECONDS: {
+    case e_E_TIME_IN_SECONDS: {
         return "E_TIME_IN_SECONDS";
     }
     }
@@ -1021,24 +1021,24 @@ const char* DumpActionType::toString(DumpActionType::Value value)
 const char DumpMsgType::CLASS_NAME[] = "DumpMsgType";
 
 const bdlat_EnumeratorInfo DumpMsgType::ENUMERATOR_INFO_ARRAY[] = {
-    {DumpMsgType::E_INCOMING, "E_INCOMING", sizeof("E_INCOMING") - 1, ""},
-    {DumpMsgType::E_OUTGOING, "E_OUTGOING", sizeof("E_OUTGOING") - 1, ""},
-    {DumpMsgType::E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
-    {DumpMsgType::E_ACK, "E_ACK", sizeof("E_ACK") - 1, ""},
-    {DumpMsgType::E_PUT, "E_PUT", sizeof("E_PUT") - 1, ""},
-    {DumpMsgType::E_CONFIRM, "E_CONFIRM", sizeof("E_CONFIRM") - 1, ""}};
+    {DumpMsgType::e_E_INCOMING, "E_INCOMING", sizeof("E_INCOMING") - 1, ""},
+    {DumpMsgType::e_E_OUTGOING, "E_OUTGOING", sizeof("E_OUTGOING") - 1, ""},
+    {DumpMsgType::e_E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
+    {DumpMsgType::e_E_ACK, "E_ACK", sizeof("E_ACK") - 1, ""},
+    {DumpMsgType::e_E_PUT, "E_PUT", sizeof("E_PUT") - 1, ""},
+    {DumpMsgType::e_E_CONFIRM, "E_CONFIRM", sizeof("E_CONFIRM") - 1, ""}};
 
 // CLASS METHODS
 
 int DumpMsgType::fromInt(DumpMsgType::Value* result, int number)
 {
     switch (number) {
-    case DumpMsgType::E_INCOMING:
-    case DumpMsgType::E_OUTGOING:
-    case DumpMsgType::E_PUSH:
-    case DumpMsgType::E_ACK:
-    case DumpMsgType::E_PUT:
-    case DumpMsgType::E_CONFIRM:
+    case DumpMsgType::e_E_INCOMING:
+    case DumpMsgType::e_E_OUTGOING:
+    case DumpMsgType::e_E_PUSH:
+    case DumpMsgType::e_E_ACK:
+    case DumpMsgType::e_E_PUT:
+    case DumpMsgType::e_E_CONFIRM:
         *result = static_cast<DumpMsgType::Value>(number);
         return 0;
     default: return -1;
@@ -1066,22 +1066,22 @@ int DumpMsgType::fromString(DumpMsgType::Value* result,
 const char* DumpMsgType::toString(DumpMsgType::Value value)
 {
     switch (value) {
-    case E_INCOMING: {
+    case e_E_INCOMING: {
         return "E_INCOMING";
     }
-    case E_OUTGOING: {
+    case e_E_OUTGOING: {
         return "E_OUTGOING";
     }
-    case E_PUSH: {
+    case e_E_PUSH: {
         return "E_PUSH";
     }
-    case E_ACK: {
+    case e_E_ACK: {
         return "E_ACK";
     }
-    case E_PUT: {
+    case e_E_PUT: {
         return "E_PUT";
     }
-    case E_CONFIRM: {
+    case e_E_CONFIRM: {
         return "E_CONFIRM";
     }
     }
@@ -1248,11 +1248,11 @@ bsl::ostream& ElectorNodeStatus::print(bsl::ostream& stream,
 const char ExpressionVersion::CLASS_NAME[] = "ExpressionVersion";
 
 const bdlat_EnumeratorInfo ExpressionVersion::ENUMERATOR_INFO_ARRAY[] = {
-    {ExpressionVersion::E_UNDEFINED,
+    {ExpressionVersion::e_E_UNDEFINED,
      "E_UNDEFINED",
      sizeof("E_UNDEFINED") - 1,
      ""},
-    {ExpressionVersion::E_VERSION_1,
+    {ExpressionVersion::e_E_VERSION_1,
      "E_VERSION_1",
      sizeof("E_VERSION_1") - 1,
      ""}};
@@ -1262,8 +1262,8 @@ const bdlat_EnumeratorInfo ExpressionVersion::ENUMERATOR_INFO_ARRAY[] = {
 int ExpressionVersion::fromInt(ExpressionVersion::Value* result, int number)
 {
     switch (number) {
-    case ExpressionVersion::E_UNDEFINED:
-    case ExpressionVersion::E_VERSION_1:
+    case ExpressionVersion::e_E_UNDEFINED:
+    case ExpressionVersion::e_E_VERSION_1:
         *result = static_cast<ExpressionVersion::Value>(number);
         return 0;
     default: return -1;
@@ -1292,10 +1292,10 @@ int ExpressionVersion::fromString(ExpressionVersion::Value* result,
 const char* ExpressionVersion::toString(ExpressionVersion::Value value)
 {
     switch (value) {
-    case E_UNDEFINED: {
+    case e_E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case E_VERSION_1: {
+    case e_E_VERSION_1: {
         return "E_VERSION_1";
     }
     }
@@ -1852,11 +1852,11 @@ LeadershipCessionNotification::print(bsl::ostream& stream, int, int) const
 const char NodeStatus::CLASS_NAME[] = "NodeStatus";
 
 const bdlat_EnumeratorInfo NodeStatus::ENUMERATOR_INFO_ARRAY[] = {
-    {NodeStatus::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {NodeStatus::E_STARTING, "E_STARTING", sizeof("E_STARTING") - 1, ""},
-    {NodeStatus::E_AVAILABLE, "E_AVAILABLE", sizeof("E_AVAILABLE") - 1, ""},
-    {NodeStatus::E_STOPPING, "E_STOPPING", sizeof("E_STOPPING") - 1, ""},
-    {NodeStatus::E_UNAVAILABLE,
+    {NodeStatus::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {NodeStatus::e_E_STARTING, "E_STARTING", sizeof("E_STARTING") - 1, ""},
+    {NodeStatus::e_E_AVAILABLE, "E_AVAILABLE", sizeof("E_AVAILABLE") - 1, ""},
+    {NodeStatus::e_E_STOPPING, "E_STOPPING", sizeof("E_STOPPING") - 1, ""},
+    {NodeStatus::e_E_UNAVAILABLE,
      "E_UNAVAILABLE",
      sizeof("E_UNAVAILABLE") - 1,
      ""}};
@@ -1866,11 +1866,11 @@ const bdlat_EnumeratorInfo NodeStatus::ENUMERATOR_INFO_ARRAY[] = {
 int NodeStatus::fromInt(NodeStatus::Value* result, int number)
 {
     switch (number) {
-    case NodeStatus::E_UNKNOWN:
-    case NodeStatus::E_STARTING:
-    case NodeStatus::E_AVAILABLE:
-    case NodeStatus::E_STOPPING:
-    case NodeStatus::E_UNAVAILABLE:
+    case NodeStatus::e_E_UNKNOWN:
+    case NodeStatus::e_E_STARTING:
+    case NodeStatus::e_E_AVAILABLE:
+    case NodeStatus::e_E_STOPPING:
+    case NodeStatus::e_E_UNAVAILABLE:
         *result = static_cast<NodeStatus::Value>(number);
         return 0;
     default: return -1;
@@ -1898,19 +1898,19 @@ int NodeStatus::fromString(NodeStatus::Value* result,
 const char* NodeStatus::toString(NodeStatus::Value value)
 {
     switch (value) {
-    case E_UNKNOWN: {
+    case e_E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case E_STARTING: {
+    case e_E_STARTING: {
         return "E_STARTING";
     }
-    case E_AVAILABLE: {
+    case e_E_AVAILABLE: {
         return "E_AVAILABLE";
     }
-    case E_STOPPING: {
+    case e_E_STOPPING: {
         return "E_STOPPING";
     }
-    case E_UNAVAILABLE: {
+    case e_E_UNAVAILABLE: {
         return "E_UNAVAILABLE";
     }
     }
@@ -2260,18 +2260,21 @@ bsl::ostream& PartitionSyncStateQuery::print(bsl::ostream& stream,
 const char PrimaryStatus::CLASS_NAME[] = "PrimaryStatus";
 
 const bdlat_EnumeratorInfo PrimaryStatus::ENUMERATOR_INFO_ARRAY[] = {
-    {PrimaryStatus::E_UNDEFINED, "E_UNDEFINED", sizeof("E_UNDEFINED") - 1, ""},
-    {PrimaryStatus::E_PASSIVE, "E_PASSIVE", sizeof("E_PASSIVE") - 1, ""},
-    {PrimaryStatus::E_ACTIVE, "E_ACTIVE", sizeof("E_ACTIVE") - 1, ""}};
+    {PrimaryStatus::e_E_UNDEFINED,
+     "E_UNDEFINED",
+     sizeof("E_UNDEFINED") - 1,
+     ""},
+    {PrimaryStatus::e_E_PASSIVE, "E_PASSIVE", sizeof("E_PASSIVE") - 1, ""},
+    {PrimaryStatus::e_E_ACTIVE, "E_ACTIVE", sizeof("E_ACTIVE") - 1, ""}};
 
 // CLASS METHODS
 
 int PrimaryStatus::fromInt(PrimaryStatus::Value* result, int number)
 {
     switch (number) {
-    case PrimaryStatus::E_UNDEFINED:
-    case PrimaryStatus::E_PASSIVE:
-    case PrimaryStatus::E_ACTIVE:
+    case PrimaryStatus::e_E_UNDEFINED:
+    case PrimaryStatus::e_E_PASSIVE:
+    case PrimaryStatus::e_E_ACTIVE:
         *result = static_cast<PrimaryStatus::Value>(number);
         return 0;
     default: return -1;
@@ -2300,13 +2303,13 @@ int PrimaryStatus::fromString(PrimaryStatus::Value* result,
 const char* PrimaryStatus::toString(PrimaryStatus::Value value)
 {
     switch (value) {
-    case E_UNDEFINED: {
+    case e_E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case E_PASSIVE: {
+    case e_E_PASSIVE: {
         return "E_PASSIVE";
     }
-    case E_ACTIVE: {
+    case e_E_ACTIVE: {
         return "E_ACTIVE";
     }
     }
@@ -2644,20 +2647,20 @@ bsl::ostream& RegistrationResponse::print(bsl::ostream& stream, int, int) const
 const char ReplicaDataType::CLASS_NAME[] = "ReplicaDataType";
 
 const bdlat_EnumeratorInfo ReplicaDataType::ENUMERATOR_INFO_ARRAY[] = {
-    {ReplicaDataType::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ReplicaDataType::E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""},
-    {ReplicaDataType::E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
-    {ReplicaDataType::E_DROP, "E_DROP", sizeof("E_DROP") - 1, ""}};
+    {ReplicaDataType::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ReplicaDataType::e_E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""},
+    {ReplicaDataType::e_E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
+    {ReplicaDataType::e_E_DROP, "E_DROP", sizeof("E_DROP") - 1, ""}};
 
 // CLASS METHODS
 
 int ReplicaDataType::fromInt(ReplicaDataType::Value* result, int number)
 {
     switch (number) {
-    case ReplicaDataType::E_UNKNOWN:
-    case ReplicaDataType::E_PULL:
-    case ReplicaDataType::E_PUSH:
-    case ReplicaDataType::E_DROP:
+    case ReplicaDataType::e_E_UNKNOWN:
+    case ReplicaDataType::e_E_PULL:
+    case ReplicaDataType::e_E_PUSH:
+    case ReplicaDataType::e_E_DROP:
         *result = static_cast<ReplicaDataType::Value>(number);
         return 0;
     default: return -1;
@@ -2686,16 +2689,16 @@ int ReplicaDataType::fromString(ReplicaDataType::Value* result,
 const char* ReplicaDataType::toString(ReplicaDataType::Value value)
 {
     switch (value) {
-    case E_UNKNOWN: {
+    case e_E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case E_PULL: {
+    case e_E_PULL: {
         return "E_PULL";
     }
-    case E_PUSH: {
+    case e_E_PUSH: {
         return "E_PUSH";
     }
-    case E_DROP: {
+    case e_E_DROP: {
         return "E_DROP";
     }
     }
@@ -2783,19 +2786,19 @@ const char RoutingConfigurationFlags::CLASS_NAME[] =
     "RoutingConfigurationFlags";
 
 const bdlat_EnumeratorInfo RoutingConfigurationFlags::ENUMERATOR_INFO_ARRAY[] =
-    {{RoutingConfigurationFlags::E_AT_MOST_ONCE,
+    {{RoutingConfigurationFlags::e_E_AT_MOST_ONCE,
       "E_AT_MOST_ONCE",
       sizeof("E_AT_MOST_ONCE") - 1,
       ""},
-     {RoutingConfigurationFlags::E_DELIVER_CONSUMER_PRIORITY,
+     {RoutingConfigurationFlags::e_E_DELIVER_CONSUMER_PRIORITY,
       "E_DELIVER_CONSUMER_PRIORITY",
       sizeof("E_DELIVER_CONSUMER_PRIORITY") - 1,
       ""},
-     {RoutingConfigurationFlags::E_DELIVER_ALL,
+     {RoutingConfigurationFlags::e_E_DELIVER_ALL,
       "E_DELIVER_ALL",
       sizeof("E_DELIVER_ALL") - 1,
       ""},
-     {RoutingConfigurationFlags::E_HAS_MULTIPLE_SUB_STREAMS,
+     {RoutingConfigurationFlags::e_E_HAS_MULTIPLE_SUB_STREAMS,
       "E_HAS_MULTIPLE_SUB_STREAMS",
       sizeof("E_HAS_MULTIPLE_SUB_STREAMS") - 1,
       ""}};
@@ -2807,10 +2810,10 @@ int RoutingConfigurationFlags::fromInt(
     int                               number)
 {
     switch (number) {
-    case RoutingConfigurationFlags::E_AT_MOST_ONCE:
-    case RoutingConfigurationFlags::E_DELIVER_CONSUMER_PRIORITY:
-    case RoutingConfigurationFlags::E_DELIVER_ALL:
-    case RoutingConfigurationFlags::E_HAS_MULTIPLE_SUB_STREAMS:
+    case RoutingConfigurationFlags::e_E_AT_MOST_ONCE:
+    case RoutingConfigurationFlags::e_E_DELIVER_CONSUMER_PRIORITY:
+    case RoutingConfigurationFlags::e_E_DELIVER_ALL:
+    case RoutingConfigurationFlags::e_E_HAS_MULTIPLE_SUB_STREAMS:
         *result = static_cast<RoutingConfigurationFlags::Value>(number);
         return 0;
     default: return -1;
@@ -2841,16 +2844,16 @@ const char*
 RoutingConfigurationFlags::toString(RoutingConfigurationFlags::Value value)
 {
     switch (value) {
-    case E_AT_MOST_ONCE: {
+    case e_E_AT_MOST_ONCE: {
         return "E_AT_MOST_ONCE";
     }
-    case E_DELIVER_CONSUMER_PRIORITY: {
+    case e_E_DELIVER_CONSUMER_PRIORITY: {
         return "E_DELIVER_CONSUMER_PRIORITY";
     }
-    case E_DELIVER_ALL: {
+    case e_E_DELIVER_ALL: {
         return "E_DELIVER_ALL";
     }
-    case E_HAS_MULTIPLE_SUB_STREAMS: {
+    case e_E_HAS_MULTIPLE_SUB_STREAMS: {
         return "E_HAS_MULTIPLE_SUB_STREAMS";
     }
     }
@@ -2977,24 +2980,24 @@ bsl::ostream& ScoutingResponse::print(bsl::ostream& stream,
 const char StatusCategory::CLASS_NAME[] = "StatusCategory";
 
 const bdlat_EnumeratorInfo StatusCategory::ENUMERATOR_INFO_ARRAY[] = {
-    {StatusCategory::E_SUCCESS, "E_SUCCESS", sizeof("E_SUCCESS") - 1, ""},
-    {StatusCategory::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {StatusCategory::E_TIMEOUT, "E_TIMEOUT", sizeof("E_TIMEOUT") - 1, ""},
-    {StatusCategory::E_NOT_CONNECTED,
+    {StatusCategory::e_E_SUCCESS, "E_SUCCESS", sizeof("E_SUCCESS") - 1, ""},
+    {StatusCategory::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {StatusCategory::e_E_TIMEOUT, "E_TIMEOUT", sizeof("E_TIMEOUT") - 1, ""},
+    {StatusCategory::e_E_NOT_CONNECTED,
      "E_NOT_CONNECTED",
      sizeof("E_NOT_CONNECTED") - 1,
      ""},
-    {StatusCategory::E_CANCELED, "E_CANCELED", sizeof("E_CANCELED") - 1, ""},
-    {StatusCategory::E_NOT_SUPPORTED,
+    {StatusCategory::e_E_CANCELED, "E_CANCELED", sizeof("E_CANCELED") - 1, ""},
+    {StatusCategory::e_E_NOT_SUPPORTED,
      "E_NOT_SUPPORTED",
      sizeof("E_NOT_SUPPORTED") - 1,
      ""},
-    {StatusCategory::E_REFUSED, "E_REFUSED", sizeof("E_REFUSED") - 1, ""},
-    {StatusCategory::E_INVALID_ARGUMENT,
+    {StatusCategory::e_E_REFUSED, "E_REFUSED", sizeof("E_REFUSED") - 1, ""},
+    {StatusCategory::e_E_INVALID_ARGUMENT,
      "E_INVALID_ARGUMENT",
      sizeof("E_INVALID_ARGUMENT") - 1,
      ""},
-    {StatusCategory::E_NOT_READY,
+    {StatusCategory::e_E_NOT_READY,
      "E_NOT_READY",
      sizeof("E_NOT_READY") - 1,
      ""}};
@@ -3004,15 +3007,15 @@ const bdlat_EnumeratorInfo StatusCategory::ENUMERATOR_INFO_ARRAY[] = {
 int StatusCategory::fromInt(StatusCategory::Value* result, int number)
 {
     switch (number) {
-    case StatusCategory::E_SUCCESS:
-    case StatusCategory::E_UNKNOWN:
-    case StatusCategory::E_TIMEOUT:
-    case StatusCategory::E_NOT_CONNECTED:
-    case StatusCategory::E_CANCELED:
-    case StatusCategory::E_NOT_SUPPORTED:
-    case StatusCategory::E_REFUSED:
-    case StatusCategory::E_INVALID_ARGUMENT:
-    case StatusCategory::E_NOT_READY:
+    case StatusCategory::e_E_SUCCESS:
+    case StatusCategory::e_E_UNKNOWN:
+    case StatusCategory::e_E_TIMEOUT:
+    case StatusCategory::e_E_NOT_CONNECTED:
+    case StatusCategory::e_E_CANCELED:
+    case StatusCategory::e_E_NOT_SUPPORTED:
+    case StatusCategory::e_E_REFUSED:
+    case StatusCategory::e_E_INVALID_ARGUMENT:
+    case StatusCategory::e_E_NOT_READY:
         *result = static_cast<StatusCategory::Value>(number);
         return 0;
     default: return -1;
@@ -3041,31 +3044,31 @@ int StatusCategory::fromString(StatusCategory::Value* result,
 const char* StatusCategory::toString(StatusCategory::Value value)
 {
     switch (value) {
-    case E_SUCCESS: {
+    case e_E_SUCCESS: {
         return "E_SUCCESS";
     }
-    case E_UNKNOWN: {
+    case e_E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case E_TIMEOUT: {
+    case e_E_TIMEOUT: {
         return "E_TIMEOUT";
     }
-    case E_NOT_CONNECTED: {
+    case e_E_NOT_CONNECTED: {
         return "E_NOT_CONNECTED";
     }
-    case E_CANCELED: {
+    case e_E_CANCELED: {
         return "E_CANCELED";
     }
-    case E_NOT_SUPPORTED: {
+    case e_E_NOT_SUPPORTED: {
         return "E_NOT_SUPPORTED";
     }
-    case E_REFUSED: {
+    case e_E_REFUSED: {
         return "E_REFUSED";
     }
-    case E_INVALID_ARGUMENT: {
+    case e_E_INVALID_ARGUMENT: {
         return "E_INVALID_ARGUMENT";
     }
-    case E_NOT_READY: {
+    case e_E_NOT_READY: {
         return "E_NOT_READY";
     }
     }
@@ -3326,17 +3329,20 @@ StopResponse::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 const char StorageSyncResponseType::CLASS_NAME[] = "StorageSyncResponseType";
 
 const bdlat_EnumeratorInfo StorageSyncResponseType::ENUMERATOR_INFO_ARRAY[] = {
-    {StorageSyncResponseType::E_UNDEFINED,
+    {StorageSyncResponseType::e_E_UNDEFINED,
      "E_UNDEFINED",
      sizeof("E_UNDEFINED") - 1,
      ""},
-    {StorageSyncResponseType::E_PATCH, "E_PATCH", sizeof("E_PATCH") - 1, ""},
-    {StorageSyncResponseType::E_FILE, "E_FILE", sizeof("E_FILE") - 1, ""},
-    {StorageSyncResponseType::E_IN_SYNC,
+    {StorageSyncResponseType::e_E_PATCH, "E_PATCH", sizeof("E_PATCH") - 1, ""},
+    {StorageSyncResponseType::e_E_FILE, "E_FILE", sizeof("E_FILE") - 1, ""},
+    {StorageSyncResponseType::e_E_IN_SYNC,
      "E_IN_SYNC",
      sizeof("E_IN_SYNC") - 1,
      ""},
-    {StorageSyncResponseType::E_EMPTY, "E_EMPTY", sizeof("E_EMPTY") - 1, ""}};
+    {StorageSyncResponseType::e_E_EMPTY,
+     "E_EMPTY",
+     sizeof("E_EMPTY") - 1,
+     ""}};
 
 // CLASS METHODS
 
@@ -3344,11 +3350,11 @@ int StorageSyncResponseType::fromInt(StorageSyncResponseType::Value* result,
                                      int                             number)
 {
     switch (number) {
-    case StorageSyncResponseType::E_UNDEFINED:
-    case StorageSyncResponseType::E_PATCH:
-    case StorageSyncResponseType::E_FILE:
-    case StorageSyncResponseType::E_IN_SYNC:
-    case StorageSyncResponseType::E_EMPTY:
+    case StorageSyncResponseType::e_E_UNDEFINED:
+    case StorageSyncResponseType::e_E_PATCH:
+    case StorageSyncResponseType::e_E_FILE:
+    case StorageSyncResponseType::e_E_IN_SYNC:
+    case StorageSyncResponseType::e_E_EMPTY:
         *result = static_cast<StorageSyncResponseType::Value>(number);
         return 0;
     default: return -1;
@@ -3378,19 +3384,19 @@ const char*
 StorageSyncResponseType::toString(StorageSyncResponseType::Value value)
 {
     switch (value) {
-    case E_UNDEFINED: {
+    case e_E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case E_PATCH: {
+    case e_E_PATCH: {
         return "E_PATCH";
     }
-    case E_FILE: {
+    case e_E_FILE: {
         return "E_FILE";
     }
-    case E_IN_SYNC: {
+    case e_E_IN_SYNC: {
         return "E_IN_SYNC";
     }
-    case E_EMPTY: {
+    case e_E_EMPTY: {
         return "E_EMPTY";
     }
     }
@@ -7596,16 +7602,16 @@ const bdlat_AttributeInfo* AuthenticationResponse::lookupAttributeInfo(int id)
 
 AuthenticationResponse::AuthenticationResponse(
     bslma::Allocator* basicAllocator)
-: d_status(basicAllocator)
-, d_lifetimeMs()
+: d_lifetimeMs()
+, d_status(basicAllocator)
 {
 }
 
 AuthenticationResponse::AuthenticationResponse(
     const AuthenticationResponse& original,
     bslma::Allocator*             basicAllocator)
-: d_status(original.d_status, basicAllocator)
-, d_lifetimeMs(original.d_lifetimeMs)
+: d_lifetimeMs(original.d_lifetimeMs)
+, d_status(original.d_status, basicAllocator)
 {
 }
 
@@ -7613,16 +7619,16 @@ AuthenticationResponse::AuthenticationResponse(
     defined(BSLS_COMPILERFEATURES_SUPPORT_NOEXCEPT)
 AuthenticationResponse::AuthenticationResponse(
     AuthenticationResponse&& original) noexcept
-: d_status(bsl::move(original.d_status)),
-  d_lifetimeMs(bsl::move(original.d_lifetimeMs))
+: d_lifetimeMs(bsl::move(original.d_lifetimeMs)),
+  d_status(bsl::move(original.d_status))
 {
 }
 
 AuthenticationResponse::AuthenticationResponse(
     AuthenticationResponse&& original,
     bslma::Allocator*        basicAllocator)
-: d_status(bsl::move(original.d_status), basicAllocator)
-, d_lifetimeMs(bsl::move(original.d_lifetimeMs))
+: d_lifetimeMs(bsl::move(original.d_lifetimeMs))
+, d_status(bsl::move(original.d_status), basicAllocator)
 {
 }
 #endif
@@ -17652,6 +17658,6 @@ bsl::ostream& ControlMessage::print(bsl::ostream& stream,
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -46,6 +46,7 @@
 
 #include <bsl_iosfwd.h>
 #include <bsl_limits.h>
+#include <bsl_type_traits.h>
 
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -1234,9 +1235,17 @@ struct ClientLanguage {
 
   public:
     // TYPES
-    enum Value { E_UNKNOWN = 0, E_CPP = 1, E_JAVA = 2 };
+    enum Value {
+        e_E_UNKNOWN = 0,
+        e_E_CPP     = 1,
+        e_E_JAVA    = 2,
 
-    enum { NUM_ENUMERATORS = 3 };
+        E_UNKNOWN = e_E_UNKNOWN,
+        E_CPP     = e_E_CPP,
+        E_JAVA    = e_E_JAVA
+    };
+
+    enum { k_NUM_ENUMERATORS = 3, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -1299,13 +1308,18 @@ struct ClientType {
   public:
     // TYPES
     enum Value {
-        E_UNKNOWN   = 0,
-        E_TCPCLIENT = 1,
-        E_TCPBROKER = 2,
-        E_TCPADMIN  = 3
+        e_E_UNKNOWN   = 0,
+        e_E_TCPCLIENT = 1,
+        e_E_TCPBROKER = 2,
+        e_E_TCPADMIN  = 3,
+
+        E_UNKNOWN   = e_E_UNKNOWN,
+        E_TCPCLIENT = e_E_TCPCLIENT,
+        E_TCPBROKER = e_E_TCPBROKER,
+        E_TCPADMIN  = e_E_TCPADMIN
     };
 
-    enum { NUM_ENUMERATORS = 4 };
+    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2201,13 +2215,18 @@ struct DumpActionType {
   public:
     // TYPES
     enum Value {
-        E_ON              = 0,
-        E_OFF             = 1,
-        E_MESSAGE_COUNT   = 2,
-        E_TIME_IN_SECONDS = 3
+        e_E_ON              = 0,
+        e_E_OFF             = 1,
+        e_E_MESSAGE_COUNT   = 2,
+        e_E_TIME_IN_SECONDS = 3,
+
+        E_ON              = e_E_ON,
+        E_OFF             = e_E_OFF,
+        E_MESSAGE_COUNT   = e_E_MESSAGE_COUNT,
+        E_TIME_IN_SECONDS = e_E_TIME_IN_SECONDS
     };
 
-    enum { NUM_ENUMERATORS = 4 };
+    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2267,15 +2286,22 @@ struct DumpMsgType {
   public:
     // TYPES
     enum Value {
-        E_INCOMING = 0,
-        E_OUTGOING = 1,
-        E_PUSH     = 2,
-        E_ACK      = 3,
-        E_PUT      = 4,
-        E_CONFIRM  = 5
+        e_E_INCOMING = 0,
+        e_E_OUTGOING = 1,
+        e_E_PUSH     = 2,
+        e_E_ACK      = 3,
+        e_E_PUT      = 4,
+        e_E_CONFIRM  = 5,
+
+        E_INCOMING = e_E_INCOMING,
+        E_OUTGOING = e_E_OUTGOING,
+        E_PUSH     = e_E_PUSH,
+        E_ACK      = e_E_ACK,
+        E_PUT      = e_E_PUT,
+        E_CONFIRM  = e_E_CONFIRM
     };
 
-    enum { NUM_ENUMERATORS = 6 };
+    enum { k_NUM_ENUMERATORS = 6, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2818,9 +2844,15 @@ struct ExpressionVersion {
 
   public:
     // TYPES
-    enum Value { E_UNDEFINED = 0, E_VERSION_1 = 1 };
+    enum Value {
+        e_E_UNDEFINED = 0,
+        e_E_VERSION_1 = 1,
 
-    enum { NUM_ENUMERATORS = 2 };
+        E_UNDEFINED = e_E_UNDEFINED,
+        E_VERSION_1 = e_E_VERSION_1
+    };
+
+    enum { k_NUM_ENUMERATORS = 2, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -4533,14 +4565,20 @@ struct NodeStatus {
   public:
     // TYPES
     enum Value {
-        E_UNKNOWN     = 0,
-        E_STARTING    = 10,
-        E_AVAILABLE   = 20,
-        E_STOPPING    = 30,
-        E_UNAVAILABLE = 40
+        e_E_UNKNOWN     = 0,
+        e_E_STARTING    = 10,
+        e_E_AVAILABLE   = 20,
+        e_E_STOPPING    = 30,
+        e_E_UNAVAILABLE = 40,
+
+        E_UNKNOWN     = e_E_UNKNOWN,
+        E_STARTING    = e_E_STARTING,
+        E_AVAILABLE   = e_E_AVAILABLE,
+        E_STOPPING    = e_E_STOPPING,
+        E_UNAVAILABLE = e_E_UNAVAILABLE
     };
 
-    enum { NUM_ENUMERATORS = 5 };
+    enum { k_NUM_ENUMERATORS = 5, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -5378,9 +5416,17 @@ struct PrimaryStatus {
 
   public:
     // TYPES
-    enum Value { E_UNDEFINED = 0, E_PASSIVE = 1, E_ACTIVE = 5 };
+    enum Value {
+        e_E_UNDEFINED = 0,
+        e_E_PASSIVE   = 1,
+        e_E_ACTIVE    = 5,
 
-    enum { NUM_ENUMERATORS = 3 };
+        E_UNDEFINED = e_E_UNDEFINED,
+        E_PASSIVE   = e_E_PASSIVE,
+        E_ACTIVE    = e_E_ACTIVE
+    };
+
+    enum { k_NUM_ENUMERATORS = 3, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6059,9 +6105,19 @@ struct ReplicaDataType {
 
   public:
     // TYPES
-    enum Value { E_UNKNOWN = 0, E_PULL = 10, E_PUSH = 20, E_DROP = 30 };
+    enum Value {
+        e_E_UNKNOWN = 0,
+        e_E_PULL    = 10,
+        e_E_PUSH    = 20,
+        e_E_DROP    = 30,
 
-    enum { NUM_ENUMERATORS = 4 };
+        E_UNKNOWN = e_E_UNKNOWN,
+        E_PULL    = e_E_PULL,
+        E_PUSH    = e_E_PUSH,
+        E_DROP    = e_E_DROP
+    };
+
+    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6314,13 +6370,18 @@ struct RoutingConfigurationFlags {
   public:
     // TYPES
     enum Value {
-        E_AT_MOST_ONCE              = 0,
-        E_DELIVER_CONSUMER_PRIORITY = 1,
-        E_DELIVER_ALL               = 2,
-        E_HAS_MULTIPLE_SUB_STREAMS  = 3
+        e_E_AT_MOST_ONCE              = 0,
+        e_E_DELIVER_CONSUMER_PRIORITY = 1,
+        e_E_DELIVER_ALL               = 2,
+        e_E_HAS_MULTIPLE_SUB_STREAMS  = 3,
+
+        E_AT_MOST_ONCE              = e_E_AT_MOST_ONCE,
+        E_DELIVER_CONSUMER_PRIORITY = e_E_DELIVER_CONSUMER_PRIORITY,
+        E_DELIVER_ALL               = e_E_DELIVER_ALL,
+        E_HAS_MULTIPLE_SUB_STREAMS  = e_E_HAS_MULTIPLE_SUB_STREAMS
     };
 
-    enum { NUM_ENUMERATORS = 4 };
+    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6718,18 +6779,28 @@ struct StatusCategory {
   public:
     // TYPES
     enum Value {
-        E_SUCCESS          = 0,
-        E_UNKNOWN          = -1,
-        E_TIMEOUT          = -2,
-        E_NOT_CONNECTED    = -3,
-        E_CANCELED         = -4,
-        E_NOT_SUPPORTED    = -5,
-        E_REFUSED          = -6,
-        E_INVALID_ARGUMENT = -7,
-        E_NOT_READY        = -8
+        e_E_SUCCESS          = 0,
+        e_E_UNKNOWN          = -1,
+        e_E_TIMEOUT          = -2,
+        e_E_NOT_CONNECTED    = -3,
+        e_E_CANCELED         = -4,
+        e_E_NOT_SUPPORTED    = -5,
+        e_E_REFUSED          = -6,
+        e_E_INVALID_ARGUMENT = -7,
+        e_E_NOT_READY        = -8,
+
+        E_SUCCESS          = e_E_SUCCESS,
+        E_UNKNOWN          = e_E_UNKNOWN,
+        E_TIMEOUT          = e_E_TIMEOUT,
+        E_NOT_CONNECTED    = e_E_NOT_CONNECTED,
+        E_CANCELED         = e_E_CANCELED,
+        E_NOT_SUPPORTED    = e_E_NOT_SUPPORTED,
+        E_REFUSED          = e_E_REFUSED,
+        E_INVALID_ARGUMENT = e_E_INVALID_ARGUMENT,
+        E_NOT_READY        = e_E_NOT_READY
     };
 
-    enum { NUM_ENUMERATORS = 9 };
+    enum { k_NUM_ENUMERATORS = 9, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -7229,14 +7300,20 @@ struct StorageSyncResponseType {
   public:
     // TYPES
     enum Value {
-        E_UNDEFINED = 0,
-        E_PATCH     = 1,
-        E_FILE      = 2,
-        E_IN_SYNC   = 3,
-        E_EMPTY     = 4
+        e_E_UNDEFINED = 0,
+        e_E_PATCH     = 1,
+        e_E_FILE      = 2,
+        e_E_IN_SYNC   = 3,
+        e_E_EMPTY     = 4,
+
+        E_UNDEFINED = e_E_UNDEFINED,
+        E_PATCH     = e_E_PATCH,
+        E_FILE      = e_E_FILE,
+        E_IN_SYNC   = e_E_IN_SYNC,
+        E_EMPTY     = e_E_EMPTY
     };
 
-    enum { NUM_ENUMERATORS = 5 };
+    enum { k_NUM_ENUMERATORS = 5, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -13811,8 +13888,8 @@ class AuthenticationResponse {
     // The session lifetime is valid indefinitely if this value is unset.
 
     // INSTANCE DATA
-    Status                   d_status;
-    bdlb::NullableValue<int> d_lifetimeMs;
+    bdlb::NullableValue<bsls::Types::Uint64> d_lifetimeMs;
+    Status                                   d_status;
 
   public:
     // TYPES
@@ -13923,7 +14000,7 @@ class AuthenticationResponse {
     // Return a reference to the modifiable "Status" attribute of this
     // object.
 
-    bdlb::NullableValue<int>& lifetimeMs();
+    bdlb::NullableValue<bsls::Types::Uint64>& lifetimeMs();
     // Return a reference to the modifiable "LifetimeMs" attribute of this
     // object.
 
@@ -13974,7 +14051,7 @@ class AuthenticationResponse {
     // Return a reference offering non-modifiable access to the "Status"
     // attribute of this object.
 
-    const bdlb::NullableValue<int>& lifetimeMs() const;
+    const bdlb::NullableValue<bsls::Types::Uint64>& lifetimeMs() const;
     // Return a reference offering non-modifiable access to the
     // "LifetimeMs" attribute of this object.
 
@@ -32485,7 +32562,8 @@ inline Status& AuthenticationResponse::status()
     return d_status;
 }
 
-inline bdlb::NullableValue<int>& AuthenticationResponse::lifetimeMs()
+inline bdlb::NullableValue<bsls::Types::Uint64>&
+AuthenticationResponse::lifetimeMs()
 {
     return d_lifetimeMs;
 }
@@ -32549,7 +32627,7 @@ inline const Status& AuthenticationResponse::status() const
     return d_status;
 }
 
-inline const bdlb::NullableValue<int>&
+inline const bdlb::NullableValue<bsls::Types::Uint64>&
 AuthenticationResponse::lifetimeMs() const
 {
     return d_lifetimeMs;
@@ -38934,6 +39012,6 @@ inline const ControlMessageChoice& ControlMessage::choice() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
+// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.t.cpp
@@ -100,9 +100,8 @@ struct FailingCredentialCb {
     }
 };
 
-bmqp_ctrlmsg::AuthenticationMessage
-makeSuccessResponse(const bdlb::NullableValue<bsls::Types::Int64>& lifetimeMs =
-                        bdlb::NullableValue<bsls::Types::Int64>())
+bmqp_ctrlmsg::AuthenticationMessage makeSuccessResponse(
+    const bdlb::NullableValue<bsls::Types::Uint64>& lifetimeMs = bsl::nullopt)
 {
     bmqp_ctrlmsg::AuthenticationMessage   msg;
     bmqp_ctrlmsg::AuthenticationResponse& resp =
@@ -427,9 +426,9 @@ static void test6_handleResponseSuccessWithLifetime()
 
     size_t writeCountAfterAuth = tb.d_channel->numWriteCalls();
 
-    const bsls::Types::Int64            lifetimeMs = 10000;  // 10 seconds
+    const bsls::Types::Uint64           lifetimeMs = 10000;  // 10 seconds
     bmqp_ctrlmsg::AuthenticationMessage response   = makeSuccessResponse(
-        bdlb::NullableValue<bsls::Types::Int64>(lifetimeMs));
+        bdlb::NullableValue<bsls::Types::Uint64>(lifetimeMs));
 
     errStream.reset();
     rc = client->handleResponse(errStream, response);

--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -120,12 +120,12 @@ int Authenticator::onAuthenticationResponse(
 }
 
 int Authenticator::sendAuthenticationResponse(
-    bsl::ostream&                            errorDescription,
-    int                                      authnRc,
-    bsl::string_view                         errorMsg,
-    const bsl::optional<bsls::Types::Int64>& lifetimeMs,
-    const bsl::shared_ptr<bmqio::Channel>&   channel,
-    bmqp::EncodingType::Enum                 authenticationEncodingType)
+    bsl::ostream&                             errorDescription,
+    int                                       authnRc,
+    bsl::string_view                          errorMsg,
+    const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
+    const bsl::shared_ptr<bmqio::Channel>&    channel,
+    bmqp::EncodingType::Enum                  authenticationEncodingType)
 {
     // executed by an *AUTHENTICATION* thread
     enum RcEnum {

--- a/src/groups/mqb/mqba/mqba_authenticator.h
+++ b/src/groups/mqb/mqba/mqba_authenticator.h
@@ -153,12 +153,12 @@ class Authenticator : public mqbnet::Authenticator {
     /// otherwise, return a non-zero error code and populate `errorDescription`
     /// with details of the failure.
     int sendAuthenticationResponse(
-        bsl::ostream&                            errorDescription,
-        int                                      authnRc,
-        bsl::string_view                         errorMsg,
-        const bsl::optional<bsls::Types::Int64>& lifetimeMs,
-        const bsl::shared_ptr<bmqio::Channel>&   channel,
-        bmqp::EncodingType::Enum                 authenticationEncodingType);
+        bsl::ostream&                             errorDescription,
+        int                                       authnRc,
+        bsl::string_view                          errorMsg,
+        const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
+        const bsl::shared_ptr<bmqio::Channel>&    channel,
+        bmqp::EncodingType::Enum                  authenticationEncodingType);
 
     /// Schedule an authentication job in the thread pool using the
     /// specified `context` and `channel`.  The specified `isAnonAuthn` is set

--- a/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.cpp
@@ -42,9 +42,9 @@ const char* AnonAuthenticator::k_PRINCIPAL = "anonymous";
 // ------------------------------
 
 AnonAuthenticationResult::AnonAuthenticationResult(
-    bsl::string_view                  principal,
-    bsl::optional<bsls::Types::Int64> lifetimeMs,
-    bslma::Allocator*                 allocator)
+    bsl::string_view                   principal,
+    bsl::optional<bsls::Types::Uint64> lifetimeMs,
+    bslma::Allocator*                  allocator)
 : d_principal(principal, allocator)
 , d_lifetimeMs(lifetimeMs)
 {
@@ -59,7 +59,7 @@ bsl::string_view AnonAuthenticationResult::principal() const
     return d_principal;
 }
 
-const bsl::optional<bsls::Types::Int64>&
+const bsl::optional<bsls::Types::Uint64>&
 AnonAuthenticationResult::lifetimeMs() const
 {
     return d_lifetimeMs;

--- a/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_anonauthenticator.h
@@ -77,8 +77,8 @@ namespace mqbauthn {
 class AnonAuthenticationResult : public mqbplug::AuthenticationResult {
   private:
     // DATA
-    bsl::string                       d_principal;
-    bsl::optional<bsls::Types::Int64> d_lifetimeMs;
+    bsl::string                        d_principal;
+    bsl::optional<bsls::Types::Uint64> d_lifetimeMs;
 
   public:
     // TRAITS
@@ -88,16 +88,16 @@ class AnonAuthenticationResult : public mqbplug::AuthenticationResult {
     // CREATORS
 
     /// Construct this object using the optionally specified `allocator`.
-    AnonAuthenticationResult(bsl::string_view                  principal,
-                             bsl::optional<bsls::Types::Int64> lifetimeMs,
-                             bslma::Allocator*                 allocator);
+    AnonAuthenticationResult(bsl::string_view                   principal,
+                             bsl::optional<bsls::Types::Uint64> lifetimeMs,
+                             bslma::Allocator*                  allocator);
 
     ~AnonAuthenticationResult() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
 
     bsl::string_view principal() const BSLS_KEYWORD_OVERRIDE;
-    const bsl::optional<bsls::Types::Int64>&
+    const bsl::optional<bsls::Types::Uint64>&
     lifetimeMs() const BSLS_KEYWORD_OVERRIDE;
 };
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.cpp
@@ -52,9 +52,9 @@ const int k_AUTHN_DURATION_SECONDS = 600;
 // -------------------------------
 
 BasicAuthenticationResult::BasicAuthenticationResult(
-    bsl::string_view   principal,
-    bsls::Types::Int64 lifetimeMs,
-    bslma::Allocator*  allocator)
+    bsl::string_view    principal,
+    bsls::Types::Uint64 lifetimeMs,
+    bslma::Allocator*   allocator)
 : d_principal(principal, allocator)
 , d_lifetimeMs(lifetimeMs)
 {
@@ -69,7 +69,7 @@ bsl::string_view BasicAuthenticationResult::principal() const
     return d_principal;
 }
 
-const bsl::optional<bsls::Types::Int64>&
+const bsl::optional<bsls::Types::Uint64>&
 BasicAuthenticationResult::lifetimeMs() const
 {
     return d_lifetimeMs;

--- a/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_basicauthenticator.h
@@ -64,8 +64,8 @@ namespace mqbauthn {
 class BasicAuthenticationResult : public mqbplug::AuthenticationResult {
   private:
     // DATA
-    bsl::string                       d_principal;
-    bsl::optional<bsls::Types::Int64> d_lifetimeMs;
+    bsl::string                        d_principal;
+    bsl::optional<bsls::Types::Uint64> d_lifetimeMs;
 
   public:
     // TRAITS
@@ -75,16 +75,16 @@ class BasicAuthenticationResult : public mqbplug::AuthenticationResult {
     // CREATORS
 
     /// Construct this object using the optionally specified `allocator`.
-    BasicAuthenticationResult(bsl::string_view   principal,
-                              bsls::Types::Int64 lifetimeMs,
-                              bslma::Allocator*  allocator);
+    BasicAuthenticationResult(bsl::string_view    principal,
+                              bsls::Types::Uint64 lifetimeMs,
+                              bslma::Allocator*   allocator);
 
     ~BasicAuthenticationResult() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
 
     bsl::string_view principal() const BSLS_KEYWORD_OVERRIDE;
-    const bsl::optional<bsls::Types::Int64>&
+    const bsl::optional<bsls::Types::Uint64>&
     lifetimeMs() const BSLS_KEYWORD_OVERRIDE;
 };
 

--- a/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.cpp
+++ b/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.cpp
@@ -53,9 +53,9 @@ const int k_AUTHN_DURATION_SECONDS = 600;
 // ------------------------------
 
 TestAuthenticationResult::TestAuthenticationResult(
-    bsl::string_view   principal,
-    bsls::Types::Int64 lifetimeMs,
-    bslma::Allocator*  allocator)
+    bsl::string_view    principal,
+    bsls::Types::Uint64 lifetimeMs,
+    bslma::Allocator*   allocator)
 : d_principal(principal, allocator)
 , d_lifetimeMs(lifetimeMs)
 {
@@ -70,7 +70,7 @@ bsl::string_view TestAuthenticationResult::principal() const
     return d_principal;
 }
 
-const bsl::optional<bsls::Types::Int64>&
+const bsl::optional<bsls::Types::Uint64>&
 TestAuthenticationResult::lifetimeMs() const
 {
     return d_lifetimeMs;

--- a/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.h
+++ b/src/groups/mqb/mqbauthn/mqbauthn_testauthenticator.h
@@ -62,7 +62,7 @@ class TestAuthenticationResult : public mqbplug::AuthenticationResult {
   private:
     // DATA
     bsl::string                       d_principal;
-    bsl::optional<bsls::Types::Int64> d_lifetimeMs;
+    bsl::optional<bsls::Types::Uint64> d_lifetimeMs;
 
   public:
     // TRAITS
@@ -72,16 +72,16 @@ class TestAuthenticationResult : public mqbplug::AuthenticationResult {
     // CREATORS
 
     /// Construct this object using the optionally specified `allocator`.
-    TestAuthenticationResult(bsl::string_view   principal,
-                             bsls::Types::Int64 lifetimeMs,
-                             bslma::Allocator*  allocator);
+    TestAuthenticationResult(bsl::string_view    principal,
+                             bsls::Types::Uint64 lifetimeMs,
+                             bslma::Allocator*   allocator);
 
     ~TestAuthenticationResult() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
 
     bsl::string_view principal() const BSLS_KEYWORD_OVERRIDE;
-    const bsl::optional<bsls::Types::Int64>&
+    const bsl::optional<bsls::Types::Uint64>&
     lifetimeMs() const BSLS_KEYWORD_OVERRIDE;
 };
 

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
@@ -154,7 +154,7 @@ void AuthenticationContext::resetAuthenticationMessage()
 int AuthenticationContext::setAuthenticatedAndScheduleReauthn(
     bsl::ostream&           errorDescription,
     bdlmt::EventScheduler*  scheduler_p,
-    BSLA_MAYBE_UNUSED const bsl::optional<bsls::Types::Int64>& lifetimeMs,
+    BSLA_MAYBE_UNUSED const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
     BSLA_MAYBE_UNUSED const bsl::shared_ptr<bmqio::Channel>& channel)
 {
     // executed by an *AUTHENTICATION* thread

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
@@ -207,10 +207,10 @@ class AuthenticationContext {
     /// Return 0 on success, and a non-zero value populating the specified
     /// `errorDescription` with details on failure.
     int setAuthenticatedAndScheduleReauthn(
-        bsl::ostream&                            errorDescription,
-        bdlmt::EventScheduler*                   scheduler_p,
-        const bsl::optional<bsls::Types::Int64>& lifetimeMs,
-        const bsl::shared_ptr<bmqio::Channel>&   channel);
+        bsl::ostream&                             errorDescription,
+        bdlmt::EventScheduler*                    scheduler_p,
+        const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
+        const bsl::shared_ptr<bmqio::Channel>&    channel);
 
     /// Close the specified `channel` with `errorCode`, `errorName`, and
     /// `errorDescription`, indicating a reauthentication error or

--- a/src/groups/mqb/mqbplug/mqbplug_authenticator.h
+++ b/src/groups/mqb/mqbplug/mqbplug_authenticator.h
@@ -99,7 +99,7 @@ class AuthenticationResult {
     virtual bsl::string_view principal() const = 0;
 
     /// Return the remaining lifetime of an authenticated session.
-    virtual const bsl::optional<bsls::Types::Int64>& lifetimeMs() const = 0;
+    virtual const bsl::optional<bsls::Types::Uint64>& lifetimeMs() const = 0;
 };
 
 // ===================


### PR DESCRIPTION
Change authn response lifetimes to unsigned long, since negative lifetime values don't make sense and 32-bit signed ints can only represent 24 days of time.