### PR TITLE
cancelEventAndWait

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -433,7 +433,7 @@ void Application::channelStateCallback(
 
         // Cancel the timeout event (if the handle is invalid, this will just
         // do nothing)
-        d_scheduler.cancelEvent(&d_startTimeoutHandle);
+        d_scheduler.cancelEventAndWait(&d_startTimeoutHandle);
 
         startHeartbeat(channel, monitor);
     } break;  // BREAK

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
@@ -334,7 +334,8 @@ void AuthenticatedChannelFactory::onChannelDown(
     // executed by the *IO* thread
 
     // Cancel pending reauthentication event when a channel goes down.
-    d_config.d_scheduler_p->cancelEvent(&d_reauthenticationTimeoutHandle);
+    d_config.d_scheduler_p->cancelEventAndWait(
+        &d_reauthenticationTimeoutHandle);
 }
 
 bool AuthenticatedChannelFactory::processAuthenticationEvent(

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -533,7 +533,7 @@ void BrokerSession::SessionFsm::setStopped(FsmEvent::Enum event,
                      "The request was canceled [reason: disconnected]");
 
     // Cancel pending PUTs expiration timer
-    d_session.d_scheduler_p->cancelEvent(
+    d_session.d_scheduler_p->cancelEventAndWait(
         &d_session.d_messageExpirationTimeoutHandle);
 
     // The session is fully stopped, we can now reset its state to release any
@@ -4921,7 +4921,7 @@ void BrokerSession::retransmitPendingMessages()
     BSLS_ASSERT_SAFE(d_fsmThreadChecker.inSameThread());
 
     // Cancel pending PUTs expiration timer
-    d_scheduler_p->cancelEvent(&d_messageExpirationTimeoutHandle);
+    d_scheduler_p->cancelEventAndWait(&d_messageExpirationTimeoutHandle);
 
     bmqp::PutEventBuilder putBuilder(d_blobSpPool_p, d_allocator_p);
 

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -1259,7 +1259,12 @@ void RequestManager<REQUEST, RESPONSE>::applyResponse(const RequestSp& request,
     // mutex *NOT* locked
 
     // Cancel the timeout event
-    d_scheduler_p->cancelEvent(&(request->d_timeoutSchedulerHandle));
+    if (d_scheduler_p->isInDispatcherThread()) {
+        d_scheduler_p->cancelEvent(&request->d_timeoutSchedulerHandle);
+    }
+    else {
+        d_scheduler_p->cancelEventAndWait(&request->d_timeoutSchedulerHandle);
+    }
 
     // Populate response field.
 

--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -226,7 +226,7 @@ int AuthenticationClient::handleResponse(
         {
             bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
 
-            d_scheduler_p->cancelEvent(&d_reauthHandle);
+            d_scheduler_p->cancelEventAndWait(&d_reauthHandle);
             d_scheduler_p->scheduleEvent(
                 &d_reauthHandle,
                 bsls::TimeInterval(bmqu::Time::nowMonotonicClock())

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -295,7 +295,7 @@ void ClusterProxy::processActiveNodeManagerResult(
     if (result & mqbnet::ClusterActiveNodeManager::e_NEW_ACTIVE) {
         // Cancel the scheduler event, if any.
         if (d_activeNodeLookupEventHandle) {
-            d_clusterData.scheduler().cancelEvent(
+            d_clusterData.scheduler().cancelEventAndWait(
                 &d_activeNodeLookupEventHandle);
             d_activeNodeManager.enableExtendedSelection();
         }

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -153,7 +153,7 @@ void ClusterStateManager::do_stopWatchdog(
     d_watchdogCtx.d_retriesRemaining = d_watchdogNumRetries;
     d_watchdogCtx.d_active           = false;
 
-    const int rc = d_clusterData_p->scheduler().cancelEvent(
+    const int rc = d_clusterData_p->scheduler().cancelEventAndWait(
         d_watchdogCtx.d_eventHandle);
     if (rc != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1794,7 +1794,8 @@ void StorageManager::do_stopWatchdog(const EventWithData& event)
     ctx.d_retriesRemaining = d_watchdogNumRetries;
     ctx.d_active           = false;
 
-    const int rc = d_clusterData_p->scheduler().cancelEvent(ctx.d_eventHandle);
+    const int rc = d_clusterData_p->scheduler().cancelEventAndWait(
+        ctx.d_eventHandle);
     if (rc != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
                        << " Partition [" << partitionId

--- a/src/groups/mqb/mqbnet/mqbnet_elector.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_elector.cpp
@@ -1939,12 +1939,22 @@ void Elector::cancelSchedulerEvents()
 {
     // executed by *ANY* thread (including scheduler's dispatcher thread)
 
-    d_scheduler.cancelEvent(&d_initialWaitTimeoutHandle);
-    d_scheduler.cancelEvent(&d_randomWaitTimeoutHandle);
-    d_scheduler.cancelEvent(&d_electionResultTimeoutHandle);
-    d_scheduler.cancelEvent(&d_heartbeatSenderRecurringHandle);
-    d_scheduler.cancelEvent(&d_heartbeatCheckerRecurringHandle);
-    d_scheduler.cancelEvent(&d_scoutingResultTimeoutHandle);
+    if (d_scheduler.isInDispatcherThread()) {
+        d_scheduler.cancelEvent(&d_initialWaitTimeoutHandle);
+        d_scheduler.cancelEvent(&d_randomWaitTimeoutHandle);
+        d_scheduler.cancelEvent(&d_electionResultTimeoutHandle);
+        d_scheduler.cancelEvent(&d_heartbeatSenderRecurringHandle);
+        d_scheduler.cancelEvent(&d_heartbeatCheckerRecurringHandle);
+        d_scheduler.cancelEvent(&d_scoutingResultTimeoutHandle);
+    }
+    else {
+        d_scheduler.cancelEventAndWait(&d_initialWaitTimeoutHandle);
+        d_scheduler.cancelEventAndWait(&d_randomWaitTimeoutHandle);
+        d_scheduler.cancelEventAndWait(&d_electionResultTimeoutHandle);
+        d_scheduler.cancelEventAndWait(&d_heartbeatSenderRecurringHandle);
+        d_scheduler.cancelEventAndWait(&d_heartbeatCheckerRecurringHandle);
+        d_scheduler.cancelEventAndWait(&d_scoutingResultTimeoutHandle);
+    }
 }
 
 void Elector::scheduleTimer(ElectorTimerEventType::Enum type)


### PR DESCRIPTION
Replacing `cancelEvent` with `cancelEventAndWait` where possible
1) as a workaround for BDE bug
2) to mimimize contention