### PR TITLE
Feat[mqb]: Integrate per-connection AuthentiactionClient into outbound connection FSM

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -29,6 +29,7 @@
 /// asynchronously.
 
 // MQB
+#include <mqba_authenticationclient.h>
 #include <mqbcfg_messages.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_initialconnectioncontext.h>
@@ -104,19 +105,6 @@ int Authenticator::onAuthenticationRequest(
         false);
 
     return rc;
-}
-
-int Authenticator::onAuthenticationResponse(
-    BSLA_MAYBE_UNUSED bsl::ostream& errorDescription,
-    BSLA_MAYBE_UNUSED mqbnet::InitialConnectionContext* context_p,
-    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::AuthenticationMessage&
-                            authenticationMsg)
-{
-    // executed by one of the *IO* threads
-
-    BALL_LOG_ERROR << "Not Implemented";
-
-    return -1;
 }
 
 int Authenticator::sendAuthenticationResponse(
@@ -485,12 +473,6 @@ int Authenticator::handleAuthentication(
                                      context_p,
                                      authenticationMsg);
     } break;  // BREAK
-    case bmqp_ctrlmsg::AuthenticationMessage::
-        SELECTION_ID_AUTHENTICATION_RESPONSE: {
-        rc = onAuthenticationResponse(errorDescription,
-                                      context_p,
-                                      authenticationMsg);
-    } break;  // BREAK
     default: {
         errorDescription
             << "Invalid authentication message received (unknown type): "
@@ -542,13 +524,22 @@ int Authenticator::handleReauthentication(
     return rc;
 }
 
-int Authenticator::authenticationOutbound(
-    BSLA_MAYBE_UNUSED bsl::ostream&                  errorDescription,
-    BSLA_MAYBE_UNUSED const AuthenticationContextSp& context)
+bool Authenticator::hasOutboundAuthentication() const
 {
-    BALL_LOG_ERROR << "Not Implemented";
+    return d_authnController_p->hasCredentialProvider();
+}
 
-    return -1;
+bsl::shared_ptr<mqbnet::AuthenticationClient>
+Authenticator::createAuthenticationClient(
+    const bsl::shared_ptr<bmqio::Channel>& channel,
+    bslma::Allocator*                      allocator) const
+{
+    return bsl::allocate_shared<mqba::AuthenticationClient>(
+        allocator,
+        d_authnController_p->credentialCb(),
+        channel,
+        d_blobSpPool_p,
+        d_scheduler_p);
 }
 
 // ACCESSORS

--- a/src/groups/mqb/mqba/mqba_authenticator.h
+++ b/src/groups/mqb/mqba/mqba_authenticator.h
@@ -135,18 +135,6 @@ class Authenticator : public mqbnet::Authenticator {
         mqbnet::InitialConnectionContext*          context_p,
         const bmqp_ctrlmsg::AuthenticationMessage& authenticationMsg);
 
-    /// Handle an incoming AuthenticationResponse message by authenticating
-    /// using the specified `authenticationMsg` and `context_p`.  On success,
-    /// create an AuthenticationContext and stores it in `context_p`. The
-    /// behavior of this function is undefined unless `authenticationMsg` is an
-    /// `AuthenticationResponse`.  Return 0 on success; otherwise, return a
-    /// non-zero error code and populate `errorDescription` with details of the
-    /// failure.
-    int onAuthenticationResponse(
-        bsl::ostream&                              errorDescription,
-        mqbnet::InitialConnectionContext*          context_p,
-        const bmqp_ctrlmsg::AuthenticationMessage& authenticationMsg);
-
     /// Send an authentication response message with the specified `authnRc`,
     /// `errorMsg`, and `lifetimeMs` via the specified `channel`, using the
     /// specified `authenticationEncodingType`.  Return 0 on success;
@@ -236,15 +224,14 @@ class Authenticator : public mqbnet::Authenticator {
                                const bsl::shared_ptr<bmqio::Channel>& channel)
         BSLS_KEYWORD_OVERRIDE;
 
-    /// Send out an outbound authentication message with the specified
-    /// `context`.  Return 0 on success, or a non-zero error code and populate
-    /// the specified `errorDescription` with a description of the error
-    /// otherwise.
-    int authenticationOutbound(bsl::ostream&                  errorDescription,
-                               const AuthenticationContextSp& context_sp)
-        BSLS_KEYWORD_OVERRIDE;
+    // ACCESSORS
+    //   (virtual: mqbnet::Authenticator)
 
-    /// ACCESSORS
+    bsl::shared_ptr<mqbnet::AuthenticationClient> createAuthenticationClient(
+        const bsl::shared_ptr<bmqio::Channel>& channel,
+        bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE;
+
+    bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the anonymous credential used for authentication.
     /// If no anonymous credential is set, return an empty optional.

--- a/src/groups/mqb/mqbnet/mqbnet_authenticator.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticator.h
@@ -28,6 +28,7 @@
 #include <mqbnet_authenticationcontext.h>
 
 // BMQ
+#include <bmqio_channel.h>
 #include <bmqp_ctrlmsg_messages.h>
 
 // BDE
@@ -40,6 +41,7 @@ namespace BloombergLP {
 namespace mqbnet {
 
 // FORWARD DECLARATION
+class AuthenticationClient;
 class InitialConnectionContext;
 
 // ===================
@@ -86,14 +88,15 @@ class Authenticator {
         const bsl::shared_ptr<AuthenticationContext>& context_sp,
         const bsl::shared_ptr<bmqio::Channel>&        channel) = 0;
 
-    /// Produce and send outbound authentication message with the specified
-    /// `context_sp`.  Return 0 on success, or a non-zero error code and
-    /// populate the specified `errorDescription` with a description of the
-    /// error otherwise.
-    /// TODO: Rethink the need for this method in the interface.
-    virtual int authenticationOutbound(
-        bsl::ostream&                                 errorDescription,
-        const bsl::shared_ptr<AuthenticationContext>& context_sp) = 0;
+    /// Return true if outbound authentication is configured for this host.
+    virtual bool hasOutboundAuthentication() const = 0;
+
+    /// Create and return a per-connection AuthenticationClient for the
+    /// specified outbound `channel` using the specified `allocator`.  The
+    /// behavior is undefined unless `hasOutboundAuthentication()` is true.
+    virtual bsl::shared_ptr<AuthenticationClient>
+    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>& channel,
+                               bslma::Allocator* allocator) const = 0;
 
     // ACCESSORS
 

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -19,6 +19,7 @@
 
 // MQB
 #include <mqbcfg_messages.h>
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_negotiationcontext.h>
 
@@ -83,6 +84,7 @@ const char* InitialConnectionState::toAscii(InitialConnectionState::Enum value)
         CASE(ANON_AUTHENTICATING)
         CASE(NEGOTIATING_OUTBOUND)
         CASE(NEGOTIATED)
+        CASE(AUTHENTICATING_OUTBOUND)
         CASE(FAILED)
     default: return "(* UNKNOWN *)";
     }
@@ -108,6 +110,7 @@ bool InitialConnectionState::fromAscii(InitialConnectionState::Enum* out,
     CHECKVALUE(ANON_AUTHENTICATING)
     CHECKVALUE(NEGOTIATING_OUTBOUND)
     CHECKVALUE(NEGOTIATED)
+    CHECKVALUE(AUTHENTICATING_OUTBOUND)
     CHECKVALUE(FAILED)
 
     // Invalid string
@@ -148,9 +151,10 @@ const char* InitialConnectionEvent::toAscii(InitialConnectionEvent::Enum value)
         CASE(NONE)
         CASE(OUTBOUND_NEGOTIATION)
         CASE(INCOMING)
-        CASE(AUTHN_REQUEST)
+        CASE(AUTHN_MESSAGE)
         CASE(NEGOTIATION_MESSAGE)
         CASE(AUTHN_SUCCESS)
+        CASE(OUTBOUND_AUTHENTICATION)
         CASE(ERROR)
     default: return "(* UNKNOWN *)";
     }
@@ -173,9 +177,10 @@ bool InitialConnectionEvent::fromAscii(InitialConnectionEvent::Enum* out,
     CHECKVALUE(NONE)
     CHECKVALUE(OUTBOUND_NEGOTIATION)
     CHECKVALUE(INCOMING)
-    CHECKVALUE(AUTHN_REQUEST)
+    CHECKVALUE(AUTHN_MESSAGE)
     CHECKVALUE(NEGOTIATION_MESSAGE)
     CHECKVALUE(AUTHN_SUCCESS)
+    CHECKVALUE(OUTBOUND_AUTHENTICATION)
     CHECKVALUE(ERROR)
 
     // Invalid string
@@ -206,6 +211,7 @@ InitialConnectionContext::InitialConnectionContext(
 , d_userData_p(userData)
 , d_channelSp(channel)
 , d_authenticationCtxSp()
+, d_authenticationClientSp()
 , d_negotiationCtxSp()
 , d_initialConnectionCompleteCb(initialConnectionCompleteCb)
 , d_authenticationEncodingType(bmqp::EncodingType::e_BER)
@@ -307,7 +313,7 @@ int InitialConnectionContext::processBlob(bsl::ostream&      errorDescription,
     else if (bsl::holds_alternative<bmqp_ctrlmsg::AuthenticationMessage>(
                  message)) {
         handleEvent(bsl::string(),
-                    InitialConnectionEvent::e_AUTHN_REQUEST,
+                    InitialConnectionEvent::e_AUTHN_MESSAGE,
                     message);
     }
     else {
@@ -497,11 +503,16 @@ void InitialConnectionContext::readCallback(const bmqio::Status& status,
 void InitialConnectionContext::handleInitialConnection()
 {
     if (!isIncoming()) {
-        // TODO: When we are ready to move on to the next step, we should
-        // call `authenticationOutbound` here instead before calling
-        // `negotiateOutbound`.
-        handleEvent(bsl::string(),
-                    mqbnet::InitialConnectionEvent::e_OUTBOUND_NEGOTIATION);
+        if (d_authenticator_p->hasOutboundAuthentication()) {
+            handleEvent(
+                bsl::string(),
+                mqbnet::InitialConnectionEvent::e_OUTBOUND_AUTHENTICATION);
+        }
+        else {
+            handleEvent(
+                bsl::string(),
+                mqbnet::InitialConnectionEvent::e_OUTBOUND_NEGOTIATION);
+        }
     }
     else {
         handleEvent(bsl::string(), mqbnet::InitialConnectionEvent::e_INCOMING);
@@ -554,6 +565,29 @@ void InitialConnectionContext::handleEvent(
         }
         break;
     }
+    case InitialConnectionEvent::e_OUTBOUND_AUTHENTICATION: {
+        if (oldState == InitialConnectionState::e_INITIAL) {
+            setState(InitialConnectionState::e_AUTHENTICATING_OUTBOUND, event);
+
+            // Initialize an authentication client for this outbound connection
+            // to a broker.  This will be stored and if needed, reused for the
+            // lifetime of this connection for reauthentication.
+            d_authenticationClientSp =
+                d_authenticator_p->createAuthenticationClient(d_channelSp,
+                                                              d_allocator_p);
+            rc = d_authenticationClientSp->authenticate(errStream);
+            if (rc == rc_SUCCESS) {
+                rc = scheduleRead(errStream);
+            }
+        }
+        else {
+            errStream << "Unexpected event received: " << oldState << " -> "
+                      << event;
+            BALL_LOG_ERROR << "#UNEXPECTED_STATE " << errStream.str()
+                           << " [peer: " << channel().get() << "]";
+        }
+        break;
+    }
     case InitialConnectionEvent::e_INCOMING: {
         if (oldState == InitialConnectionState::e_INITIAL) {
             // For incoming connections, start reading the first message
@@ -567,7 +601,7 @@ void InitialConnectionContext::handleEvent(
         }
         break;
     }
-    case InitialConnectionEvent::e_AUTHN_REQUEST: {
+    case InitialConnectionEvent::e_AUTHN_MESSAGE: {
         BSLS_ASSERT_SAFE(
             bsl::holds_alternative<bmqp_ctrlmsg::AuthenticationMessage>(
                 message));
@@ -583,6 +617,27 @@ void InitialConnectionContext::handleEvent(
             rc = d_authenticator_p->handleAuthentication(errStream,
                                                          this,
                                                          authenticationMsg);
+        }
+        else if (oldState ==
+                 InitialConnectionState::e_AUTHENTICATING_OUTBOUND) {
+            BSLS_ASSERT_SAFE(d_authenticationClientSp);
+            rc = d_authenticationClientSp->handleResponse(errStream,
+                                                          authenticationMsg);
+            if (rc != rc_SUCCESS) {
+                break;
+            }
+
+            setState(InitialConnectionState::e_NEGOTIATING_OUTBOUND, event);
+
+            // Send negotiation directly instead of calling 'handleEvent'
+            // with e_OUTBOUND_NEGOTIATION, as 'd_mutex' is currently held
+            // and calling 'handleEvent' would attempt to acquire it again.
+            createNegotiationContext();
+
+            rc = d_negotiator_p->negotiateOutbound(errStream, this);
+            if (rc == rc_SUCCESS) {
+                rc = scheduleRead(errStream);
+            }
         }
         else {
             errStream << "Unexpected event received: " << oldState << " -> "
@@ -734,6 +789,12 @@ const bsl::shared_ptr<AuthenticationContext>&
 InitialConnectionContext::authenticationContext() const
 {
     return d_authenticationCtxSp;
+}
+
+const bsl::shared_ptr<AuthenticationClient>&
+InitialConnectionContext::authenticationClient() const
+{
+    return d_authenticationClientSp;
 }
 
 const bsl::shared_ptr<NegotiationContext>&

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -87,9 +87,12 @@ struct InitialConnectionState {
         e_AUTHENTICATING      = 1,  // First message is authentication Request.
         e_AUTHENTICATED       = 2,  // Authentication success.
         e_ANON_AUTHENTICATING = 3,  // First message is Negotiation Request.
-        e_NEGOTIATING_OUTBOUND = 4,  // Outbound negotiation.
-        e_NEGOTIATED           = 5,  // Negotiation success.  Final state.
-        e_FAILED               = 6   // Final state.
+        e_NEGOTIATING_OUTBOUND    = 4,  // Outbound negotiation.
+        e_NEGOTIATED              = 5,  // Negotiation success.  Final state.
+        e_AUTHENTICATING_OUTBOUND = 6,  // Outbound authentication in progress.
+        // Note: 'e_AUTHENTICATED_OUTBOUND' is omitted as outbound authn
+        // directly transitions to e_NEGOTIATING_OUTBOUND or e_FAILED.
+        e_FAILED = 7  // Final state.
     };
 
     // CLASS METHODS
@@ -143,13 +146,20 @@ bsl::ostream& operator<<(bsl::ostream&                stream,
 struct InitialConnectionEvent {
     // TYPES
     enum Enum {
-        e_NONE                 = 0,
+        e_NONE = 0,
+        /// Negotiate session with a server (as a client)
         e_OUTBOUND_NEGOTIATION = 1,
-        e_INCOMING             = 2,
-        e_AUTHN_REQUEST        = 3,
-        e_NEGOTIATION_MESSAGE  = 4,
-        e_AUTHN_SUCCESS        = 5,
-        e_ERROR                = 6
+        /// New connection from a client
+        e_INCOMING = 2,
+        /// Received authentication message from client or server
+        e_AUTHN_MESSAGE = 3,
+        /// Received negotiation message from client or server
+        e_NEGOTIATION_MESSAGE = 4,
+        /// Client authenticated, proceed to negotiation
+        e_AUTHN_SUCCESS = 5,
+        /// Send authentication message as client
+        e_OUTBOUND_AUTHENTICATION = 6,
+        e_ERROR                   = 7
     };
 
     // CLASS METHODS
@@ -269,6 +279,11 @@ class InitialConnectionContext {
     /// The AuthenticationContext updated upon receiving an
     /// authentication message.
     bsl::shared_ptr<AuthenticationContext> d_authenticationCtxSp;
+
+    /// Per-connection client for outbound authentication and
+    /// reauthentication.  Non-null for outbound connections if broker
+    /// has a credential provider configured.  Null for inbound connections.
+    bsl::shared_ptr<AuthenticationClient> d_authenticationClientSp;
 
     /// The NegotiationContext updated upon receiving a negotiation message.
     bsl::shared_ptr<NegotiationContext> d_negotiationCtxSp;
@@ -415,6 +430,7 @@ class InitialConnectionContext {
     bmqp::EncodingType::Enum               authenticationEncodingType() const;
     const bsl::shared_ptr<AuthenticationContext>&
                                                authenticationContext() const;
+    const bsl::shared_ptr<AuthenticationClient>& authenticationClient() const;
     const bsl::shared_ptr<NegotiationContext>& negotiationContext() const;
     bool                                       isClosed() const;
     InitialConnectionState::Enum               state() const;

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -77,13 +77,18 @@ struct MockAuthenticator : public mqbnet::Authenticator {
     {
         return 0;
     }
-    int authenticationOutbound(
-        bsl::ostream&,
-        const bsl::shared_ptr<mqbnet::AuthenticationContext>&)
-        BSLS_KEYWORD_OVERRIDE
+
+    bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE
     {
-        return 0;
+        return false;
     }
+    bsl::shared_ptr<mqbnet::AuthenticationClient>
+    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>&,
+                               bslma::Allocator*) const BSLS_KEYWORD_OVERRIDE
+    {
+        return bsl::shared_ptr<mqbnet::AuthenticationClient>();
+    }
+
     const bsl::optional<mqbcfg::Credential>&
     anonymousCredential() const BSLS_KEYWORD_OVERRIDE
     {

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -16,12 +16,14 @@
 #include <mqbnet_initialconnectioncontext.h>
 
 // MQB
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_initialconnectioncontext.h>
 #include <mqbnet_negotiationcontext.h>
 #include <mqbnet_session.h>
 
 // BMQ
 #include <bmqio_testchannel.h>
+#include <bmqp_ctrlmsg_messages.h>
 
 // BDE
 #include <bsl_memory.h>
@@ -55,12 +57,38 @@ void complete(const bsl::shared_ptr<int>&             check,
     (void)channel;
 }
 
+// Mock authentication client
+struct MockAuthenticationClient : public mqbnet::AuthenticationClient {
+    bool d_authenticateCalled;
+    int  d_authenticateRc;
+    bool d_handleResponseCalled;
+    int  d_handleResponseRc;
+    bool d_stopCalled;
+
+    int authenticate(bsl::ostream&) BSLS_KEYWORD_OVERRIDE
+    {
+        d_authenticateCalled = true;
+        return d_authenticateRc;
+    }
+
+    int handleResponse(bsl::ostream&,
+                       const bmqp_ctrlmsg::AuthenticationMessage&)
+        BSLS_KEYWORD_OVERRIDE
+    {
+        d_handleResponseCalled = true;
+        return d_handleResponseRc;
+    }
+};
+
 // Mock authenticator
 struct MockAuthenticator : public mqbnet::Authenticator {
-  private:
-    bsl::optional<mqbcfg::Credential> d_anonymousCredential;
+    bsl::optional<mqbcfg::Credential>         d_anonymousCredential;
+    bool                                      d_hasOutboundAuthentication;
+    int                                       d_authenticateRc;
+    int                                       d_handleResponseRc;
+    bsl::shared_ptr<MockAuthenticationClient> d_mockClient;
+    bool                                      d_negotiateOutboundCalled;
 
-  public:
     int  start(bsl::ostream&) BSLS_KEYWORD_OVERRIDE { return 0; }
     void stop() BSLS_KEYWORD_OVERRIDE {}
     int  handleAuthentication(bsl::ostream&,
@@ -80,13 +108,21 @@ struct MockAuthenticator : public mqbnet::Authenticator {
 
     bool hasOutboundAuthentication() const BSLS_KEYWORD_OVERRIDE
     {
-        return false;
+        return d_hasOutboundAuthentication;
     }
-    bsl::shared_ptr<mqbnet::AuthenticationClient>
-    createAuthenticationClient(const bsl::shared_ptr<bmqio::Channel>&,
-                               bslma::Allocator*) const BSLS_KEYWORD_OVERRIDE
+
+    bsl::shared_ptr<mqbnet::AuthenticationClient> createAuthenticationClient(
+        const bsl::shared_ptr<bmqio::Channel>&,
+        bslma::Allocator* allocator) const BSLS_KEYWORD_OVERRIDE
     {
-        return bsl::shared_ptr<mqbnet::AuthenticationClient>();
+        // const_cast because the mock needs to store the client for later
+        // inspection by the test, but the interface is const.
+        MockAuthenticator* self = const_cast<MockAuthenticator*>(this);
+        self->d_mockClient = bsl::allocate_shared<MockAuthenticationClient>(
+            allocator);
+        self->d_mockClient->d_authenticateRc   = d_authenticateRc;
+        self->d_mockClient->d_handleResponseRc = d_handleResponseRc;
+        return self->d_mockClient;
     }
 
     const bsl::optional<mqbcfg::Credential>&
@@ -98,6 +134,8 @@ struct MockAuthenticator : public mqbnet::Authenticator {
 
 // Mock negotiator
 struct MockNegotiator : public mqbnet::Negotiator {
+    bool d_negotiateOutboundCalled;
+
     int createSessionOnMsgType(bsl::ostream&,
                                bsl::shared_ptr<mqbnet::Session>*,
                                mqbnet::InitialConnectionContext*)
@@ -108,7 +146,31 @@ struct MockNegotiator : public mqbnet::Negotiator {
     int negotiateOutbound(bsl::ostream&, mqbnet::InitialConnectionContext*)
         BSLS_KEYWORD_OVERRIDE
     {
+        d_negotiateOutboundCalled = true;
         return 0;
+    }
+};
+
+struct TestBench {
+    bsl::shared_ptr<MockAuthenticator>  d_authenticator;
+    bsl::shared_ptr<MockNegotiator>     d_negotiator;
+    bsl::shared_ptr<bmqio::TestChannel> d_channel;
+    bsl::shared_ptr<int>                d_completionStatus;
+
+    mqbnet::InitialConnectionContext::InitialConnectionCompleteCb d_completeCb;
+
+    explicit TestBench(bslma::Allocator* allocator)
+    : d_authenticator(bsl::allocate_shared<MockAuthenticator>(allocator))
+    , d_negotiator(bsl::allocate_shared<MockNegotiator>(allocator))
+    , d_channel(bsl::allocate_shared<bmqio::TestChannel>(allocator))
+    , d_completionStatus(bsl::allocate_shared<int>(allocator, 0))
+    , d_completeCb(bdlf::BindUtil::bind(&complete,
+                                        d_completionStatus,
+                                        bdlf::PlaceHolders::_1,
+                                        bdlf::PlaceHolders::_2,
+                                        bdlf::PlaceHolders::_3,
+                                        bdlf::PlaceHolders::_4))
+    {
     }
 };
 
@@ -121,33 +183,19 @@ struct MockNegotiator : public mqbnet::Negotiator {
 static void test1_initialConnectionContext()
 {
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
-    bsl::shared_ptr<MockAuthenticator> authenticator =
-        bsl::allocate_shared<MockAuthenticator>(alloc);
-    bsl::shared_ptr<MockNegotiator> negotiator =
-        bsl::allocate_shared<MockNegotiator>(alloc);
-    bsl::shared_ptr<bmqio::TestChannel> channel =
-        bsl::allocate_shared<bmqio::TestChannel>(alloc);
-
-    bsl::shared_ptr<int> check = bsl::allocate_shared<int>(alloc, 0);
-    mqbnet::InitialConnectionContext::InitialConnectionCompleteCb completeCb =
-        bdlf::BindUtil::bind(&complete,
-                             check,
-                             bdlf::PlaceHolders::_1,  // status
-                             bdlf::PlaceHolders::_2,  // errorDescription
-                             bdlf::PlaceHolders::_3,  // session
-                             bdlf::PlaceHolders::_4   // channel
-        );
+    TestBench         tb(alloc);
 
     bmqtst::TestHelper::printTestName("test1_basicConstruction");
     {
         PV("Constructor");
         mqbnet::InitialConnectionContext obj1(false,
-                                              authenticator.get(),
-                                              negotiator.get(),
+                                              0,
+                                              0,
                                               static_cast<void*>(0),
                                               static_cast<void*>(0),
-                                              channel,
-                                              completeCb);
+                                              tb.d_channel,
+                                              tb.d_completeCb,
+                                              alloc);
         BMQTST_ASSERT_EQ(obj1.isIncoming(), false);
         BMQTST_ASSERT_EQ(obj1.resultState(), static_cast<void*>(0));
         BMQTST_ASSERT_EQ(obj1.userData(), static_cast<void*>(0));
@@ -157,12 +205,13 @@ static void test1_initialConnectionContext()
         PV("Manipulators/Accessors");
 
         mqbnet::InitialConnectionContext obj(true,
-                                             authenticator.get(),
-                                             negotiator.get(),
+                                             tb.d_authenticator.get(),
+                                             tb.d_negotiator.get(),
                                              static_cast<void*>(0),
                                              static_cast<void*>(0),
-                                             channel,
-                                             completeCb);
+                                             tb.d_channel,
+                                             tb.d_completeCb,
+                                             alloc);
 
         {  // ResultState
             int value = 9;
@@ -191,9 +240,224 @@ static void test1_initialConnectionContext()
                          bsl::string(),
                          bsl::shared_ptr<mqbnet::Session>());
 
-            BMQTST_ASSERT_EQ(*check, rc);
+            BMQTST_ASSERT_EQ(*tb.d_completionStatus, rc);
         }
     }
+}
+
+static void test2_outboundAuthenticate()
+// ------------------------------------------------------------------------
+// OUTBOUND AUTHENTICATE
+//
+// Concerns:
+//   - 'handleInitialConnection()' on an outbound context with
+//     authentication enters 'e_AUTHENTICATING_OUTBOUND'.
+//   - 'authenticate()' is called on the created client.
+//   - After receiving a successful 'e_AUTHN_MESSAGE', the FSM
+//     transitions to 'e_NEGOTIATING_OUTBOUND'.
+//   - 'handleResponse()' is called on the client.
+//   - 'negotiateOutbound()' is called on the negotiator.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_AUTHENTICATING_OUTBOUND and authenticate() was
+//      called.
+//   4) Fire e_AUTHN_MESSAGE event with a success AuthenticationResponse.
+//   5) Verify state is e_NEGOTIATING_OUTBOUND, handleResponse() was
+//      called, and negotiateOutbound() was called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND AUTHENTICATE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(
+        ctx.state(),
+        mqbnet::InitialConnectionState::e_AUTHENTICATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_authenticateCalled);
+
+    // 4)
+    bmqp_ctrlmsg::AuthenticationMessage   response;
+    bmqp_ctrlmsg::AuthenticationResponse& resp =
+        response.makeAuthenticationResponse();
+    resp.status().category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
+    resp.status().code()     = 0;
+    resp.status().message()  = "OK";
+
+    ctx.handleEvent(bsl::string(),
+                    mqbnet::InitialConnectionEvent::e_AUTHN_MESSAGE,
+                    response);
+
+    // 5)
+    BMQTST_ASSERT_EQ(ctx.state(),
+                     mqbnet::InitialConnectionState::e_NEGOTIATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_handleResponseCalled);
+    BMQTST_ASSERT(tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test3_outboundAuthenticateFailure()
+// ------------------------------------------------------------------------
+// OUTBOUND AUTHENTICATE FAILURE
+//
+// Concerns:
+//   - When 'authenticate()' fails, the FSM transitions to 'e_FAILED'.
+//   - The completion callback is invoked with a non-zero status.
+//   - 'negotiateOutbound()' is never called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true
+//      and the mock client's authenticateRc = -1.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_FAILED, the completion callback fired with
+//      non-zero status, and negotiateOutbound() was not called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND AUTHENTICATE FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+    tb.d_authenticator->d_authenticateRc            = -1;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(ctx.state(), mqbnet::InitialConnectionState::e_FAILED);
+    BMQTST_ASSERT_NE(*tb.d_completionStatus, 0);
+    BMQTST_ASSERT(!tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test4_outboundHandleResponseFailure()
+// ------------------------------------------------------------------------
+// OUTBOUND HANDLE RESPONSE FAILURE
+//
+// Concerns:
+//   - When 'authenticate()' succeeds but 'handleResponse()' fails, the
+//     FSM transitions to 'e_FAILED'.
+//   - The completion callback is invoked with a non-zero status.
+//   - 'negotiateOutbound()' is never called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = true
+//      and the mock client's handleResponseRc = -1.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_AUTHENTICATING_OUTBOUND (authenticate succeeded).
+//   4) Fire e_AUTHN_MESSAGE with an AuthenticationResponse.
+//   5) Verify state is e_FAILED, completion callback fired with non-zero
+//      status, and negotiateOutbound() was not called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND HANDLE RESPONSE FAILURE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1)
+    tb.d_authenticator->d_hasOutboundAuthentication = true;
+    tb.d_authenticator->d_handleResponseRc          = -1;
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(
+        ctx.state(),
+        mqbnet::InitialConnectionState::e_AUTHENTICATING_OUTBOUND);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_authenticateCalled);
+
+    // 4)
+    bmqp_ctrlmsg::AuthenticationMessage response;
+    response.makeAuthenticationResponse();
+
+    ctx.handleEvent(bsl::string(),
+                    mqbnet::InitialConnectionEvent::e_AUTHN_MESSAGE,
+                    response);
+
+    // 5)
+    BMQTST_ASSERT_EQ(ctx.state(), mqbnet::InitialConnectionState::e_FAILED);
+    BMQTST_ASSERT(tb.d_authenticator->d_mockClient->d_handleResponseCalled);
+    BMQTST_ASSERT_NE(*tb.d_completionStatus, 0);
+    BMQTST_ASSERT(!tb.d_negotiator->d_negotiateOutboundCalled);
+}
+
+static void test5_outboundNoAuthentication()
+// ------------------------------------------------------------------------
+// OUTBOUND NO AUTHENTICATION
+//
+// Concerns:
+//   - When 'hasOutboundAuthentication()' is false,
+//     'handleInitialConnection()' skips authentication and goes directly
+//     to 'e_NEGOTIATING_OUTBOUND'.
+//   - No AuthenticationClient is created.
+//   - 'negotiateOutbound()' is called.
+//
+// Plan:
+//   1) Configure MockAuthenticator with hasOutboundAuthentication = false.
+//   2) Construct an outbound context, call 'handleInitialConnection()'.
+//   3) Verify state is e_NEGOTIATING_OUTBOUND, authenticationClient() is
+//      null, and negotiateOutbound() was called.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("OUTBOUND NO AUTHENTICATION");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+    TestBench         tb(alloc);
+
+    // 1) d_hasOutboundAuthentication defaults to false
+
+    // 2)
+    mqbnet::InitialConnectionContext ctx(false,
+                                         tb.d_authenticator.get(),
+                                         tb.d_negotiator.get(),
+                                         static_cast<void*>(0),
+                                         static_cast<void*>(0),
+                                         tb.d_channel,
+                                         tb.d_completeCb,
+                                         alloc);
+    ctx.handleInitialConnection();
+
+    // 3)
+    BMQTST_ASSERT_EQ(ctx.state(),
+                     mqbnet::InitialConnectionState::e_NEGOTIATING_OUTBOUND);
+    BMQTST_ASSERT(!ctx.authenticationClient());
+    BMQTST_ASSERT(tb.d_negotiator->d_negotiateOutboundCalled);
 }
 
 // ============================================================================
@@ -206,6 +470,10 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 5: test5_outboundNoAuthentication(); break;
+    case 4: test4_outboundHandleResponseFailure(); break;
+    case 3: test3_outboundAuthenticateFailure(); break;
+    case 2: test2_outboundAuthenticate(); break;
     case 1: test1_initialConnectionContext(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -30,6 +30,7 @@
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbcfg_tcpinterfaceconfigvalidator.h>
+#include <mqbnet_authenticationclient.h>
 #include <mqbnet_authenticationcontext.h>
 #include <mqbnet_authenticator.h>
 #include <mqbnet_cluster.h>
@@ -80,6 +81,7 @@
 #include <bsl_iostream.h>
 #include <bsl_limits.h>
 #include <bsl_memory.h>
+#include <bsl_string_view.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
@@ -342,6 +344,84 @@ struct ChannelFactoryBuilders {
     }
 };
 
+/// Process a reauthentication response received on an outbound connection.
+/// Forwards the specified `message` to the specified `authClient` for
+/// handling.  Log using the specified `channel` and `description`.
+void handleOutboundReauthentication(
+    const bmqp_ctrlmsg::AuthenticationMessage&   message,
+    const bsl::shared_ptr<AuthenticationClient>& authClient,
+    const bsl::shared_ptr<bmqio::Channel>&       channel,
+    const bsl::string_view&                      description,
+    bslma::Allocator*                            allocator)
+{
+    // executed by the *IO* thread
+
+    BSLS_ASSERT_SAFE(authClient);
+
+    BALL_LOG_INFO << description
+                  << ": Received outbound reauthentication response"
+                  << " [peer: " << channel.get() << "]";
+
+    bmqu::MemOutStream errorStream(allocator);
+    int                rc = authClient->handleResponse(errorStream, message);
+    if (rc != 0) {
+        BALL_LOG_ERROR << "#AUTHENTICATION_FAILED " << description
+                       << ": Outbound reauthentication failed"
+                       << " [peer: " << channel.get() << "] [reason: '"
+                       << errorStream.str() << "', rc: " << rc << "]";
+    }
+}
+
+/// Process a reauthentication request received on an inbound connection.
+/// Store the specified `message` and `encodingType` on the specified
+/// `context`, then invoke the specified `authenticator` to perform
+/// authentication.  Log using the specified `channel` and `description`.
+void handleInboundReauthentication(
+    const bmqp_ctrlmsg::AuthenticationMessage&    message,
+    bmqp::EncodingType::Enum                      encodingType,
+    const bsl::shared_ptr<AuthenticationContext>& context,
+    const bsl::shared_ptr<bmqio::Channel>&        channel,
+    const bsl::string_view&                       description,
+    Authenticator*                                authenticator,
+    bslma::Allocator*                             allocator)
+{
+    // executed by the *IO* thread
+
+    BSLS_ASSERT_SAFE(context);
+    BSLS_ASSERT_SAFE(authenticator);
+
+    BALL_LOG_INFO << description
+                  << ": Received inbound reauthentication request"
+                  << " [peer: " << channel.get() << "]";
+
+    context->setAuthenticationMessage(message);
+    context->setAuthenticationEncodingType(encodingType);
+
+    if (!context->tryStartReauthentication()) {
+        BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR " << description
+                       << ": Dropping Authentication event since "
+                          "authentication is in progress"
+                       << " [peer: " << channel.get() << "]";
+        return;  // RETURN
+    }
+
+    bmqu::MemOutStream errorStream(allocator);
+    int                rc = authenticator->handleReauthentication(errorStream,
+                                                   context,
+                                                   channel);
+    if (rc != 0) {
+        bmqu::MemOutStream errStream(allocator);
+        errStream << "#AUTHENTICATION_FAILED " << description
+                  << ": Inbound reauthentication failed"
+                  << " [peer: " << channel.get() << "] [reason: '"
+                  << errorStream.str() << "', rc: " << rc << "]";
+        context->onReauthenticateErrorOrTimeout(rc,
+                                                "reauthenticationError",
+                                                errStream.str(),
+                                                channel);
+    }
+}
+
 }  // close unnamed namespace
 
 // -----------------------------------------
@@ -571,7 +651,7 @@ void TCPSessionFactory::read(ChannelInfo*       channelInfo,
     if (channelInfo->d_monitor_mp->checkData(channelInfo->d_channel_sp.get(),
                                              event)) {
         if (event.isAuthenticationEvent()) {
-            reauthnOnAuthenticationEvent(event, channelInfo);
+            handleAuthenticationEvent(event, channelInfo);
         }
         else {
             channelInfo->d_eventProcessor_p->processEvent(
@@ -691,12 +771,14 @@ void TCPSessionFactory::initialConnectionComplete(
             d_allocator_p,
             channel,
             initialConnectionContext_sp->authenticationContext(),
+            initialConnectionContext_sp->authenticationClient(),
             monitoredSession,
             initialConnectionContext_sp->negotiationContext()
                 ->eventProcessor(),
             initialConnectionContext_sp->negotiationContext()
                 ->maxMissedHeartbeats(),
-            d_initialMissedHeartbeatCounter);
+            d_initialMissedHeartbeatCounter,
+            initialConnectionContext_sp->isIncoming());
         // See comments in 'calculateInitialMissedHbCounter'.
 
         bsl::pair<bmqio::Channel*, ChannelInfoSp> toInsert(channel.get(),
@@ -1072,7 +1154,7 @@ int TCPSessionFactory::validateTcpInterfaces() const
     return validator(*d_config_mp);
 }
 
-void TCPSessionFactory::reauthnOnAuthenticationEvent(
+void TCPSessionFactory::handleAuthenticationEvent(
     const bmqp::Event& event,
     const ChannelInfo* channelInfo) const
 {
@@ -1080,55 +1162,37 @@ void TCPSessionFactory::reauthnOnAuthenticationEvent(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(channelInfo);
-    BSLS_ASSERT_SAFE(channelInfo->d_authenticationCtx_sp);
     BSLS_ASSERT_SAFE(channelInfo->d_session_sp);
 
-    const bsl::shared_ptr<AuthenticationContext>& context =
-        channelInfo->d_authenticationCtx_sp;
     const bsl::string_view description =
         channelInfo->d_session_sp->description();
-    bmqu::MemOutStream errStream(d_allocator_p);
 
     bmqp_ctrlmsg::AuthenticationMessage authenticationMessage;
     int rc = event.loadAuthenticationEvent(&authenticationMessage);
     if (rc != 0) {
         BALL_LOG_ERROR << "#CORRUPTED_EVENT " << description
                        << ": Received invalid authentication message "
-                          "from client [reason: 'failed to decode', rc: "
+                          "[reason: 'failed to decode', rc: "
                        << rc << "]:\n"
                        << bmqu::BlobStartHexDumper(event.blob());
         return;  // RETURN
     }
 
-    BALL_LOG_INFO << description << ": Received an authentication message";
-
-    context->setAuthenticationMessage(authenticationMessage);
-    context->setAuthenticationEncodingType(
-        event.authenticationEventEncodingType());
-
-    // Try to start reauthentication.  If another reauthentication is
-    // in progress, drop this event.
-    if (!context->tryStartReauthentication()) {
-        BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR " << description
-                       << ": Dropping Authentication event since "
-                          "authentication is in progress: "
-                       << event;
-        return;  // RETURN
+    if (channelInfo->d_isIncoming) {
+        handleInboundReauthentication(authenticationMessage,
+                                      event.authenticationEventEncodingType(),
+                                      channelInfo->d_authenticationCtx_sp,
+                                      channelInfo->d_channel_sp,
+                                      description,
+                                      d_authenticator_p,
+                                      d_allocator_p);
     }
-
-    bmqu::MemOutStream errorStream;
-    rc = d_authenticator_p->handleReauthentication(errorStream,
-                                                   context,
-                                                   channelInfo->d_channel_sp);
-    if (rc != 0) {
-        errStream << "#AUTHENTICATION_FAILED " << description
-                  << ": Authentication failed [reason: '" << errorStream.str()
-                  << "', rc: " << rc << "]";
-        context->onReauthenticateErrorOrTimeout(rc,
-                                                "reauthenticationError",
-                                                errStream.str(),
-                                                channelInfo->d_channel_sp);
-        return;  // RETURN
+    else {
+        handleOutboundReauthentication(authenticationMessage,
+                                       channelInfo->d_authenticationClient_sp,
+                                       channelInfo->d_channel_sp,
+                                       description,
+                                       d_allocator_p);
     }
 }
 
@@ -1670,19 +1734,23 @@ bool TCPSessionFactory::isEndpointLoopback(bsl::string_view uri) const
 TCPSessionFactory::ChannelInfo::ChannelInfo(
     const bsl::shared_ptr<bmqio::Channel>&        channel_sp,
     const bsl::shared_ptr<AuthenticationContext>& authenticationContext,
+    const bsl::shared_ptr<AuthenticationClient>&  authenticationClient,
     const bsl::shared_ptr<Session>&               monitoredSession,
     SessionEventProcessor*                        eventProcessor,
     int                                           maxMissedHeartbeats,
     int               initialMissedHeartbeatCounter,
+    bool              isIncoming,
     bslma::Allocator* allocator)
 : d_channel_sp(channel_sp)
 , d_authenticationCtx_sp(authenticationContext)
+, d_authenticationClient_sp(authenticationClient)
 , d_session_sp(monitoredSession)
 , d_eventProcessor_p(eventProcessor)
 , d_monitor_mp(bslma::ManagedPtrUtil::allocateManaged<bmqp::HeartbeatMonitor>(
       allocator,
       maxMissedHeartbeats,
       initialMissedHeartbeatCounter))
+, d_isIncoming(isIncoming)
 {
     if (!d_eventProcessor_p) {
         // No eventProcessor was provided default to the negotiated session

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.g.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.g.cpp
@@ -63,6 +63,13 @@ class MockAuthenticator : public mqbnet::Authenticator {
         int(bsl::ostream& errorDescription,
             const bsl::shared_ptr<mqbnet::AuthenticationContext>& context_sp));
 
+    MOCK_CONST_METHOD0(hasOutboundAuthentication, bool());
+
+    MOCK_CONST_METHOD2(createAuthenticationClient,
+                       bsl::shared_ptr<mqbnet::AuthenticationClient>(
+                           const bsl::shared_ptr<bmqio::Channel>& channel,
+                           bslma::Allocator*                      allocator));
+
     MOCK_CONST_METHOD0(anonymousCredential,
                        const bsl::optional<mqbcfg::Credential>&());
 };

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -139,6 +139,7 @@ class StatController;
 namespace mqbnet {
 
 // FORWARD DECLARATION
+class AuthenticationClient;
 class AuthenticationContext;
 class Cluster;
 class InitialConnectionContext;
@@ -211,8 +212,14 @@ class TCPSessionFactory {
         /// The channel
         bsl::shared_ptr<bmqio::Channel> d_channel_sp;
 
-        // The context of authentication
+        /// The authentication context for an incoming connection.  Null for
+        /// outbound connections.
         bsl::shared_ptr<AuthenticationContext> d_authenticationCtx_sp;
+
+        /// Per-connection client for outbound authentication and
+        /// reauthentication.  Non-null for outbound connections if broker
+        /// has a credential provider.  Null for inbound connections.
+        bsl::shared_ptr<AuthenticationClient> d_authenticationClient_sp;
 
         /// The session tied to the channel
         bsl::shared_ptr<Session> d_session_sp;
@@ -221,6 +228,10 @@ class TCPSessionFactory {
         SessionEventProcessor* d_eventProcessor_p;
 
         bslma::ManagedPtr<bmqp::HeartbeatMonitor> d_monitor_mp;
+
+        /// True if this channel is from an incoming (listen) connection;
+        /// false if it is an outbound (connect) connection.
+        bool d_isIncoming;
 
         // CREATORS
 
@@ -234,14 +245,19 @@ class TCPSessionFactory {
         /// missed heartbeats on this channel.
         /// @param initialMissedHeartbeatCounter The initial missed heartbeats
         /// for this channel.
-        explicit ChannelInfo(const bsl::shared_ptr<bmqio::Channel>& channel_sp,
-                             const bsl::shared_ptr<AuthenticationContext>&
-                                 authenticationContext,
-                             const bsl::shared_ptr<Session>& session,
-                             SessionEventProcessor*          eventProcessor,
-                             int               maxMissedHeartbeats,
-                             int               initialMissedHeartbeatCounter,
-                             bslma::Allocator* allocator);
+        /// @param isIncoming True if the channel is from an incoming
+        /// connection.
+        explicit ChannelInfo(
+            const bsl::shared_ptr<bmqio::Channel>& channel_sp,
+            const bsl::shared_ptr<AuthenticationContext>&
+                                                         authenticationContext,
+            const bsl::shared_ptr<AuthenticationClient>& authenticationClient,
+            const bsl::shared_ptr<Session>&              session,
+            SessionEventProcessor*                       eventProcessor,
+            int                                          maxMissedHeartbeats,
+            int               initialMissedHeartbeatCounter,
+            bool              isIncoming,
+            bslma::Allocator* allocator);
 
       private:
         // NOT IMPLEMENTED
@@ -566,11 +582,11 @@ class TCPSessionFactory {
     /// @returns 0 on success, nonzero on failure.
     int validateTcpInterfaces() const;
 
-    /// Handle an authentication event for the specified `event` by
-    /// performing reauthentication using the authentication context stored
-    /// in the specified `channelInfo`.
-    void reauthnOnAuthenticationEvent(const bmqp::Event& event,
-                                      const ChannelInfo* channelInfo) const;
+    /// Handle an authentication event for the specified `event` on the
+    /// specified `channelInfo`.  Decodes the message and dispatches to the
+    /// appropriate inbound or outbound handler.
+    void handleAuthenticationEvent(const bmqp::Event& event,
+                                   const ChannelInfo* channelInfo) const;
 
   private:
     // NOT IMPLEMENTED

--- a/src/integration-tests/test_authn_broker_to_broker.py
+++ b/src/integration-tests/test_authn_broker_to_broker.py
@@ -1,0 +1,145 @@
+# Copyright 2025 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Broker-to-broker authentication integration tests using built-in auth."""
+
+import blazingmq.dev.it.testconstants as tc
+
+from blazingmq.dev.it.fixtures import (
+    Cluster,
+    order,
+    tweak,
+    start_cluster,
+)
+
+pytestmark = order(99)
+
+
+@start_cluster(False)
+@tweak.broker.app_config.authentication(
+    {
+        "authenticators": [
+            {
+                "name": "BasicAuthenticator",
+                "settings": [
+                    {"key": "broker", "value": {"stringVal": "secret"}},
+                ],
+            }
+        ],
+        "credentialProvider": {
+            "name": "BasicCredentialProvider",
+            "settings": [
+                {"key": "username", "value": {"stringVal": "broker"}},
+                {"key": "password", "value": {"stringVal": "secret"}},
+            ],
+        },
+    }
+)
+def test_broker_to_broker_basic_auth(
+    multi_node: Cluster,
+    sc_domain_urls: tc.DomainUrls,  # pylint: disable=unused-argument
+) -> None:
+    """
+    Test broker-to-broker authentication with matching credentials.
+
+    Start two nodes so they connect and authenticate to each other. Verify
+    that at least one node sent an outbound AuthenticationRequest and that no
+    authentication failures occurred.
+    """
+    east1 = multi_node.start_node("east1")
+    east2 = multi_node.start_node("east2")
+
+    authn_sent = east1.outputs_regex(
+        r"Sending AuthenticationRequest", timeout=10
+    ) or east2.outputs_regex(r"Sending AuthenticationRequest", timeout=10)
+    assert authn_sent, "No node sent an outbound AuthenticationRequest"
+
+    assert not east1.outputs_regex(r"#AUTHENTICATION_FAILED", timeout=0)
+    assert not east2.outputs_regex(r"#AUTHENTICATION_FAILED", timeout=0)
+
+
+@start_cluster(False)
+@tweak.broker.app_config.authentication(
+    {
+        "authenticators": [
+            {
+                "name": "BasicAuthenticator",
+                "settings": [
+                    {"key": "broker", "value": {"stringVal": "secret"}},
+                ],
+            }
+        ],
+        "credentialProvider": {
+            "name": "BasicCredentialProvider",
+            "settings": [
+                {"key": "username", "value": {"stringVal": "broker"}},
+                {"key": "password", "value": {"stringVal": "wrong"}},
+            ],
+        },
+    }
+)
+def test_broker_to_broker_wrong_credentials(
+    multi_node: Cluster,
+    sc_domain_urls: tc.DomainUrls,  # pylint: disable=unused-argument
+) -> None:
+    """
+    Test that broker-to-broker authentication fails with wrong credentials.
+
+    Start two nodes. The BasicCredentialProvider sends 'broker:wrong' but the
+    BasicAuthenticator expects 'broker:secret'. Verify that at least one node
+    logs an authentication failure.
+    """
+    east1 = multi_node.start_node("east1")
+    east2 = multi_node.start_node("east2")
+
+    authn_failed = east1.outputs_regex(
+        r"Authentication failed", timeout=10
+    ) or east2.outputs_regex(r"Authentication failed", timeout=10)
+    assert authn_failed, "Expected authentication failure not logged"
+
+
+@start_cluster(False)
+@tweak.broker.app_config.authentication(
+    {
+        "authenticators": [
+            {
+                "name": "BasicAuthenticator",
+                "settings": [
+                    {"key": "broker", "value": {"stringVal": "secret"}},
+                ],
+            }
+        ],
+    }
+)
+def test_broker_to_broker_no_credential_provider(
+    multi_node: Cluster,
+    sc_domain_urls: tc.DomainUrls,  # pylint: disable=unused-argument
+) -> None:
+    """
+    Test that outbound broker-to-broker connections do not initiate an
+    AuthenticationRequest when no credentialProvider is configured.
+
+    Start two nodes with a BasicAuthenticator but no credentialProvider.
+    Verify that no outbound AuthenticationRequest is sent.
+    """
+    east1 = multi_node.start_node("east1")
+    east2 = multi_node.start_node("east2")
+
+    # Wait for nodes to connect to each other.
+    assert east1.outputs_regex(r"BMQbrkr started successfully", timeout=10)
+    assert east2.outputs_regex(r"BMQbrkr started successfully", timeout=10)
+
+    assert not east1.outputs_regex(r"Sending AuthenticationRequest", timeout=1)
+    assert not east2.outputs_regex(r"Sending AuthenticationRequest", timeout=1)

--- a/src/integration-tests/test_authn_client_to_broker.py
+++ b/src/integration-tests/test_authn_client_to_broker.py
@@ -14,10 +14,13 @@
 # limitations under the License.
 
 """
-Authentication test suite using ONLY built-in authenticators.
+Client-to-broker authentication integration tests using built-in auth.
 
-This test suite validates authentication logic without any external plugins.
-All tests use the built-in authenticators:
+This test suite validates client authentication logic without external
+plugins.
+Tests in this file cover built-in authenticators:
+
+  Authenticators (validate incoming connections):
   - BasicAuthenticator: BASIC mechanism, validates credentials from config
                         Config format: {"key": "username", "value": {"stringVal": "password"}}
   - AnonAuthenticator: ANONYMOUS mechanism, passes if "shouldPass" setting is true (default),
@@ -25,7 +28,6 @@ All tests use the built-in authenticators:
   - TestAuthenticator: TEST mechanism, sleeps for a configured duration (default 0)
                        Config format: {"key": "sleepTimeMs", "value": {"intVal": "duration"}}
 
-This approach tests all authentication scenarios without needing external plugins.
 """
 
 import threading


### PR DESCRIPTION
This PR contains the third subset of changes in #1428 for easier reviewing, follows from #1447.           

Outbound broker-to-broker connections now optionally authenticate before negotiating a session. Previously, outbound connections performed negotiation immediately. Now, when a credential provider is configured, the connecting broker authenticates with the peer first, then performs negotiation.

Control flow summary:

1. A broker opens a TCP connection to a peer.
2. If outbound authentication is configured (via a credential provider plugin), the connection enters a new `AUTHENTICATING_OUTBOUND` state. An `AuthenticationClient` is created for this connection and sends and authentication request to the peer.
3. The peer authenticates the broker and replies. On success, the broker's connection transitions to `NEGOTIATING_OUTBOUND` and proceeds with session negotiation. On failure, the connection is failed.
4. If no outbound authentication is configured, the connection skips directly to negotiation as before.

The `AuthenticationClient` is stored per-connection in `ChannelInfo` for the lifetime of the channel. It can be reused for reauthenticating with the peer for the lifetime of the connection.

Some notes on the changes:

- `Authenticator` now serves as a factory for `AuthenticationClient` objects
- Reauthentication is direction-aware: `TCPSessionFactory` now properly distinguishes inbound reauthentication requests (handled by the `Authenticator`) from outbound reauthentication responses (routed to the connection's `AuthenticationClient`).
- Connection FSM changes: `InitialConnectionContext` now has an `e_AUTHENTICATING_OUTBOUND` state and an `e_OUTBOUND_AUTHENTICATION` event. 