### PR TITLE
Fix[mqbblp]: correct operator precedence in Cluster confirm/reject handlers

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.cpp
@@ -1069,7 +1069,7 @@ void Cluster::onConfirmEvent(const mqbevt::ConfirmEvent& event)
     int msgNum = 0;
     int rc     = 0;
 
-    while ((rc = confIt.next() == 1)) {
+    while ((rc = confIt.next()) == 1) {
         const int          id    = confIt.message().queueId();
         const unsigned int subId = static_cast<unsigned int>(
             confIt.message().subQueueId());
@@ -1097,7 +1097,7 @@ void Cluster::onConfirmEvent(const mqbevt::ConfirmEvent& event)
         }
         else {
             BMQU_THROTTLEDACTION_THROTTLE(
-                d_throttledFailedRejectMessages,
+                d_throttledFailedConfirmMessages,
                 BMQTSK_ALARMLOG_ALARM("CLUSTER")
                     << ": CONFIRM " << ValidationResult::toAscii(result)
                     << " [queue: '"
@@ -1170,7 +1170,7 @@ void Cluster::onRejectEvent(const mqbevt::RejectEvent& event)
     int msgNum = 0;
     int rc     = 0;
 
-    while ((rc = rejectIt.next() == 1)) {
+    while ((rc = rejectIt.next()) == 1) {
         const int          id    = rejectIt.message().queueId();
         const unsigned int subId = static_cast<unsigned int>(
             rejectIt.message().subQueueId());


### PR DESCRIPTION
Closes #1477

The confirm and reject iterator loops in `mqbblp_cluster.cpp` had a misplaced parenthesis causing `next() == 1` to evaluate as a bool before assignment to `rc`, making the `if (rc < 0)` corrupt event error path unreachable. Fixed to match the PUT and ACK handlers. Also corrected the confirm handler's throttle object from `d_throttledFailedRejectMessages` to `d_throttledFailedConfirmMessages`.