### PR TITLE
Refactor: less heavy includes, part 2

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -27,7 +27,7 @@
 #include <bmqp_confirmeventbuilder.h>
 #include <bmqp_confirmmessageiterator.h>
 #include <bmqp_controlmessageutil.h>
-#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_conversionutil.h>
 #include <bmqp_event.h>
 #include <bmqp_eventutil.h>
 #include <bmqp_protocol.h>
@@ -1331,11 +1331,11 @@ BrokerSession::QueueFsm::actionReconfigureQueue(
         }
     }
     else {
-        bmqp::ProtocolUtil::convert(&ci,
-                                    response.choice()
-                                        .configureQueueStreamResponse()
-                                        .request()
-                                        .streamParameters());
+        bmqp::ConversionUtil::convert(&ci,
+                                      response.choice()
+                                          .configureQueueStreamResponse()
+                                          .request()
+                                          .streamParameters());
     }
 
     bmqt::QueueOptions options(d_session.d_allocator_p);
@@ -6316,11 +6316,11 @@ void BrokerSession::onConfigureQueueResponse(
             BSLS_ASSERT_SAFE(context->response()
                                  .choice()
                                  .isConfigureQueueStreamResponseValue());
-            bmqp::ProtocolUtil::convert(&respAdaptor,
-                                        context->response()
-                                            .choice()
-                                            .configureQueueStreamResponse()
-                                            .request());
+            bmqp::ConversionUtil::convert(&respAdaptor,
+                                          context->response()
+                                              .choice()
+                                              .configureQueueStreamResponse()
+                                              .request());
         }
         else {
             BSLS_ASSERT_SAFE(
@@ -6337,7 +6337,7 @@ void BrokerSession::onConfigureQueueResponse(
         bmqp_ctrlmsg::ConfigureStream  reqAdaptor;
         bmqp_ctrlmsg::ConfigureStream& req = reqAdaptor;
         if (context->request().choice().isConfigureQueueStreamValue()) {
-            bmqp::ProtocolUtil::convert(
+            bmqp::ConversionUtil::convert(
                 &reqAdaptor,
                 context->request().choice().configureQueueStream());
         }

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.t.cpp
@@ -22,6 +22,7 @@
 #include <bmqp_ackeventbuilder.h>
 #include <bmqp_blobpoolutil.h>
 #include <bmqp_confirmeventbuilder.h>
+#include <bmqp_conversionutil.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_event.h>
@@ -75,6 +76,23 @@ using bmqimp::ManualHostHealthMonitor;
 //                            TEST HELPERS UTILITY
 // ----------------------------------------------------------------------------
 namespace {
+
+const bmqp_ctrlmsg::ConsumerInfo&
+consumerInfo(const bmqp_ctrlmsg::StreamParameters& from)
+{
+    size_t n = from.subscriptions().size();
+
+    if (n == 0) {
+        static const bmqp_ctrlmsg::ConsumerInfo& defaultValues = *(
+            new bmqp_ctrlmsg::ConsumerInfo());
+
+        return defaultValues;
+    }
+
+    BSLS_ASSERT_SAFE(from.subscriptions()[0].consumers().size() > 0);
+
+    return from.subscriptions()[0].consumers()[0];
+}
 
 // CONSTANTS
 const char k_URI[] = "bmq://ts.trades.myapp/my.queue?id=my.app";
@@ -302,15 +320,15 @@ void getConsumerInfo(bmqp_ctrlmsg::ConsumerInfo*  out,
                      bmqp_ctrlmsg::ControlMessage request)
 {
     if (request.choice().isConfigureStreamValue()) {
-        *out = bmqp::ProtocolUtil::consumerInfo(
+        *out = consumerInfo(
             request.choice().configureStream().streamParameters());
     }
     else {
         bmqp_ctrlmsg::StreamParameters             temp;
         const bmqp_ctrlmsg::QueueStreamParameters& in =
             request.choice().configureQueueStream().streamParameters();
-        bmqp::ProtocolUtil::convert(&temp, in);
-        *out = bmqp::ProtocolUtil::consumerInfo(temp);
+        bmqp::ConversionUtil::convert(&temp, in);
+        *out = consumerInfo(temp);
     }
 }
 

--- a/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.h
+++ b/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.h
@@ -33,8 +33,8 @@
 // Thread safe.
 
 // BMQ
-
 #include <bmqp_protocol.h>
+#include <bmqp_queueid.h>
 #include <bmqp_requestmanager.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_messageguid.h>

--- a/src/groups/bmq/bmqimp/bmqimp_sessionid.h
+++ b/src/groups/bmq/bmqimp/bmqimp_sessionid.h
@@ -28,12 +28,14 @@
 ///-------------
 // Thread safe.
 
-#include <bmqp_ctrlmsg_messages.h>
-
 // BDE
 #include <bsl_ostream.h>
 
 namespace BloombergLP {
+
+namespace bmqp_ctrlmsg {
+class NegotiationMessage;
+}
 
 namespace bmqimp {
 
@@ -62,15 +64,6 @@ inline bsl::ostream& operator<<(bsl::ostream&            stream,
 
 inline SessionId::SessionId()
 : d_sessionId(0)
-{
-    // NOTHING
-}
-
-inline SessionId::SessionId(
-    const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage)
-: d_sessionId(negotiationMessage.isClientIdentityValue()
-                  ? negotiationMessage.clientIdentity().sessionId()
-                  : 0)
 {
     // NOTHING
 }

--- a/src/groups/bmq/bmqp/bmqp_conversionutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_conversionutil.cpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,22 +13,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <bmqimp_sessionid.h>
+#include <bmqp_conversionutil.h>
 
 #include <bmqscm_version.h>
 
-#include <bmqp_ctrlmsg_messages.h>
+// BMQ
+#include <bmqp_queueid.h>
 
 namespace BloombergLP {
-namespace bmqimp {
+namespace bmqp {
 
-SessionId::SessionId(
-    const bmqp_ctrlmsg::NegotiationMessage& negotiationMessage)
-: d_sessionId(negotiationMessage.isClientIdentityValue()
-                  ? negotiationMessage.clientIdentity().sessionId()
-                  : 0)
+// ---------------------
+// struct ConversionUtil
+// ---------------------
+
+bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>
+ConversionUtil::makeSubQueueIdInfo(const bsl::string& appId,
+                                   unsigned int       subId)
 {
-    // NOTHING
+    bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> result;
+    if (subId != bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID) {
+        result.makeValue();
+        result.value().appId() = appId;
+        result.value().subId() = subId;
+    }
+
+    return result;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_conversionutil.h
+++ b/src/groups/bmq/bmqp/bmqp_conversionutil.h
@@ -1,0 +1,170 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_BMQP_CONVERSIONUTIL
+#define INCLUDED_BMQP_CONVERSIONUTIL
+
+//@PURPOSE: Provide utilities for converting between old-style and new-style
+// BlazingMQ control messages.
+//
+//@CLASSES:
+//  bmqp::ConversionUtil: utilities for control message conversion
+//
+//@DESCRIPTION: 'bmqp::ConversionUtil' provides a set of utility methods for
+// converting between old-style 'ConfigureQueueStream' /
+// 'QueueStreamParameters' and new-style 'ConfigureStream' /
+// 'StreamParameters' control message formats.
+
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_protocol.h>
+
+// BDE
+#include <bdlb_nullablevalue.h>
+#include <bsl_string.h>
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace bmqp {
+
+// =====================
+// struct ConversionUtil
+// =====================
+
+/// Utilities for control message conversion
+struct ConversionUtil {
+    // CLASS METHODS
+
+    /// Convert between old-style 'QueueStreamParameters' and new-style
+    /// 'StreamParameters'.
+    static void convert(
+        bmqp_ctrlmsg::QueueStreamParameters*                     to,
+        const bmqp_ctrlmsg::StreamParameters&                    from,
+        const bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>& subIdInfo);
+
+    static void convert(bmqp_ctrlmsg::StreamParameters*            to,
+                        const bmqp_ctrlmsg::QueueStreamParameters& from);
+
+    static void convert(bmqp_ctrlmsg::ConfigureStream*            to,
+                        const bmqp_ctrlmsg::ConfigureQueueStream& from);
+
+    static void convert(bmqp_ctrlmsg::ConsumerInfo*                to,
+                        const bmqp_ctrlmsg::QueueStreamParameters& from);
+
+    static bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>
+    makeSubQueueIdInfo(const bsl::string& appId, unsigned int subId);
+};
+
+// ============================================================================
+//                             INLINE DEFINITIONS
+// ============================================================================
+
+// ---------------------
+// struct ConversionUtil
+// ---------------------
+
+inline void ConversionUtil::convert(
+    bmqp_ctrlmsg::QueueStreamParameters*                     to,
+    const bmqp_ctrlmsg::StreamParameters&                    from,
+    const bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>& subIdInfo)
+{
+    BSLS_ASSERT_SAFE(from.subscriptions().size() < 2);
+
+    to->subIdInfo() = subIdInfo;
+
+    if (from.subscriptions().size() > 0) {
+        BSLS_ASSERT_SAFE(from.subscriptions().size() == 1);
+        // Enable multiple subscriptions in SDK only when all brokers support
+        // them.
+        BSLS_ASSERT_SAFE(from.subscriptions()[0].consumers().size() > 0);
+        // New ConfigureStream request can carry multiple priorities but the
+        // first element in the array is the highest priority one.
+        const bmqp_ctrlmsg::ConsumerInfo& ci =
+            from.subscriptions()[0].consumers()[0];
+
+        to->consumerPriority()       = ci.consumerPriority();
+        to->consumerPriorityCount()  = ci.consumerPriorityCount();
+        to->maxUnconfirmedMessages() = ci.maxUnconfirmedMessages();
+        to->maxUnconfirmedBytes()    = ci.maxUnconfirmedBytes();
+    }
+    else {
+        to->consumerPriority()       = Protocol::k_CONSUMER_PRIORITY_INVALID;
+        to->consumerPriorityCount()  = 0;
+        to->maxUnconfirmedMessages() = 0;
+        to->maxUnconfirmedBytes()    = 0;
+    }
+}
+
+inline void
+ConversionUtil::convert(bmqp_ctrlmsg::ConfigureStream*            to,
+                        const bmqp_ctrlmsg::ConfigureQueueStream& from)
+{
+    const bmqp_ctrlmsg::QueueStreamParameters& oldStype =
+        from.streamParameters();
+
+    to->qId() = from.qId();
+    to->streamParameters().subscriptions().resize(1);
+    bmqp_ctrlmsg::Subscription& subscription =
+        to->streamParameters().subscriptions()[0];
+
+    if (!oldStype.subIdInfo().isNull()) {
+        subscription.sId()             = oldStype.subIdInfo().value().subId();
+        to->streamParameters().appId() = oldStype.subIdInfo().value().appId();
+    }
+    // else DEFAULT_INITIALIZER_ID      (0),
+    //      DEFAULT_INITIALIZER_APP_ID  ("__default")
+
+    subscription.consumers().resize(1);
+    convert(&subscription.consumers()[0], oldStype);
+}
+
+inline void
+ConversionUtil::convert(bmqp_ctrlmsg::StreamParameters*            to,
+                        const bmqp_ctrlmsg::QueueStreamParameters& from)
+{
+    if (!from.subIdInfo().isNull()) {
+        to->appId() = from.subIdInfo().value().appId();
+    }
+    // else DEFAULT_INITIALIZER_APP_ID  ("__default")
+
+    if (from.consumerPriorityCount()) {
+        to->subscriptions().resize(1);
+        to->subscriptions()[0].consumers().resize(1);
+
+        convert(&to->subscriptions()[0].consumers()[0], from);
+    }
+    else {
+        BSLS_ASSERT_SAFE(from.consumerPriority() ==
+                         Protocol::k_CONSUMER_PRIORITY_INVALID);
+        BSLS_ASSERT_SAFE(from.consumerPriorityCount() == 0);
+        BSLS_ASSERT_SAFE(from.maxUnconfirmedMessages() == 0);
+        BSLS_ASSERT_SAFE(from.maxUnconfirmedBytes() == 0);
+    }
+}
+
+inline void
+ConversionUtil::convert(bmqp_ctrlmsg::ConsumerInfo*                to,
+                        const bmqp_ctrlmsg::QueueStreamParameters& from)
+{
+    to->consumerPriority()       = from.consumerPriority();
+    to->consumerPriorityCount()  = from.consumerPriorityCount();
+    to->maxUnconfirmedMessages() = from.maxUnconfirmedMessages();
+    to->maxUnconfirmedBytes()    = from.maxUnconfirmedBytes();
+}
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqp/bmqp_conversionutil.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_conversionutil.t.cpp
@@ -1,0 +1,124 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqp_conversionutil.h>
+
+// BMQ
+#include <bmqp_ctrlmsg_messages.h>
+#include <bmqp_queueid.h>
+
+// BDE
+#include <bdlb_nullablevalue.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+static void test1_breathingTest()
+// ------------------------------------------------------------------------
+// BREATHING TEST
+//
+// Concerns:
+//   Exercise basic functionality before beginning testing in earnest.
+//
+// Plan:
+//   - Verify 'convert' roundtrips between QueueStreamParameters and
+//     StreamParameters.
+//   - Verify 'makeSubQueueIdInfo' and 'verify'.
+//
+// Testing:
+//   Basic functionality
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    // 1. convert: StreamParameters -> QueueStreamParameters ->
+    // StreamParameters
+    {
+        bmqp_ctrlmsg::StreamParameters sp(alloc);
+        sp.subscriptions().resize(1);
+        sp.subscriptions()[0].consumers().resize(1);
+
+        bmqp_ctrlmsg::ConsumerInfo& ci = sp.subscriptions()[0].consumers()[0];
+        ci.consumerPriority()          = 1;
+        ci.consumerPriorityCount()     = 2;
+        ci.maxUnconfirmedMessages()    = 100;
+        ci.maxUnconfirmedBytes()       = 2048;
+
+        bmqp_ctrlmsg::QueueStreamParameters               qsp(alloc);
+        bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> subIdInfo(alloc);
+        bmqp::ConversionUtil::convert(&qsp, sp, subIdInfo);
+
+        BMQTST_ASSERT_EQ(qsp.consumerPriority(), 1);
+        BMQTST_ASSERT_EQ(qsp.consumerPriorityCount(), 2);
+        BMQTST_ASSERT_EQ(qsp.maxUnconfirmedMessages(), 100);
+        BMQTST_ASSERT_EQ(qsp.maxUnconfirmedBytes(), 2048);
+
+        bmqp_ctrlmsg::StreamParameters sp2(alloc);
+        bmqp::ConversionUtil::convert(&sp2, qsp);
+
+        BMQTST_ASSERT_EQ(sp2.subscriptions().size(), 1u);
+        BMQTST_ASSERT_EQ(sp2.subscriptions()[0].consumers().size(), 1u);
+
+        const bmqp_ctrlmsg::ConsumerInfo& ci2 =
+            sp2.subscriptions()[0].consumers()[0];
+        BMQTST_ASSERT_EQ(ci2.consumerPriority(), 1);
+        BMQTST_ASSERT_EQ(ci2.consumerPriorityCount(), 2);
+        BMQTST_ASSERT_EQ(ci2.maxUnconfirmedMessages(), 100);
+        BMQTST_ASSERT_EQ(ci2.maxUnconfirmedBytes(), 2048);
+    }
+
+    // 2. makeSubQueueIdInfo
+    {
+        bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> result =
+            bmqp::ConversionUtil::makeSubQueueIdInfo(
+                "myApp",
+                bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID);
+        BMQTST_ASSERT(result.isNull());
+
+        result = bmqp::ConversionUtil::makeSubQueueIdInfo("myApp", 42);
+        BMQTST_ASSERT(!result.isNull());
+        BMQTST_ASSERT_EQ(result.value().appId(), "myApp");
+        BMQTST_ASSERT_EQ(result.value().subId(), 42u);
+    }
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 1: test1_breathingTest(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqp/bmqp_event.h
+++ b/src/groups/bmq/bmqp/bmqp_event.h
@@ -46,9 +46,7 @@
 // BDE
 #include <ball_log.h>
 #include <bdlbb_blob.h>
-#include <bsl_iosfwd.h>
 #include <bsl_memory.h>
-#include <bsl_string.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_movableref.h>

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -143,7 +143,6 @@
 // BMQ
 
 #include <bmqc_array.h>
-#include <bmqp_queueid.h>
 #include <bmqt_compressionalgorithmtype.h>
 #include <bmqt_messageguid.h>
 

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
@@ -16,9 +16,9 @@
 #include <bmqp_protocolutil.h>
 
 #include <bmqscm_version.h>
+
 // BMQ
 #include <bmqp_compression.h>
-#include <bmqp_queueid.h>
 #include <bmqu_blobiterator.h>
 #include <bmqu_blobobjectproxy.h>
 #include <bmqu_memoutstream.h>
@@ -660,31 +660,6 @@ int ProtocolUtil::parse(bdlbb::Blob*              messagePropertiesOutput,
     }  // else, de-compressed directly to the 'dataOutput'
 
     return rc_OK;
-}
-
-// static
-bool ProtocolUtil::verify(const bmqp_ctrlmsg::ConsumerInfo& ci)
-{
-    if (ci.consumerPriority() == bmqp::Protocol::k_CONSUMER_PRIORITY_INVALID) {
-        return ci.consumerPriorityCount() == 0;
-    }
-    else {
-        return ci.consumerPriorityCount() > 0;
-    }
-}
-
-// static
-bool ProtocolUtil::verify(const bmqp_ctrlmsg::StreamParameters& parameters)
-{
-    for (size_t i = 0; i < parameters.subscriptions().size(); ++i) {
-        const bmqp_ctrlmsg::Subscription& s = parameters.subscriptions()[i];
-        for (size_t n = 0; n < s.consumers().size(); ++n) {
-            if (!verify(s.consumers()[n])) {
-                return false;
-            }
-        }
-    }
-    return true;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -40,7 +40,6 @@
 // Thread safe.
 
 // BMQ
-#include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocol.h>
 #include <bmqt_resultcode.h>
 #include <bmqu_blob.h>
@@ -293,37 +292,6 @@ struct ProtocolUtil {
                      bmqt::CompressionAlgorithmType::Enum cat,
                      bdlbb::BlobBufferFactory*            blobBufferFactory,
                      bslma::Allocator*                    allocator);
-
-    /// Temporary
-    static void convert(
-        bmqp_ctrlmsg::QueueStreamParameters*                     to,
-        const bmqp_ctrlmsg::StreamParameters&                    from,
-        const bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>& subIdInfo);
-
-    /// Temporary
-    static void convert(bmqp_ctrlmsg::StreamParameters*            to,
-                        const bmqp_ctrlmsg::QueueStreamParameters& from);
-
-    /// Temporary
-    static void convert(bmqp_ctrlmsg::ConfigureStream*            to,
-                        const bmqp_ctrlmsg::ConfigureQueueStream& from);
-
-    static void makeResponse(bmqp_ctrlmsg::ControlMessage*         response,
-                             const bmqp_ctrlmsg::StreamParameters& from,
-                             const bmqp_ctrlmsg::ControlMessage&   request);
-
-    /// Temporary
-    static void convert(bmqp_ctrlmsg::ConsumerInfo*                to,
-                        const bmqp_ctrlmsg::QueueStreamParameters& from);
-    static const bmqp_ctrlmsg::ConsumerInfo&
-    consumerInfo(const bmqp_ctrlmsg::StreamParameters& from);
-
-    static bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>
-    makeSubQueueIdInfo(const bsl::string& appId, unsigned int subId);
-
-    static bool verify(const bmqp_ctrlmsg::ConsumerInfo& ci);
-
-    static bool verify(const bmqp_ctrlmsg::StreamParameters& parameters);
 };
 
 // ============================================================================
@@ -578,162 +546,6 @@ inline void ProtocolUtil::buildReceipt(bdlbb::Blob*        blob,
         .setPartitionId(partitionId)
         .setPrimaryLeaseId(primaryLeaseId)
         .setSequenceNum(sequenceNumber);
-}
-
-inline bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>
-ProtocolUtil::makeSubQueueIdInfo(const bsl::string& appId, unsigned int subId)
-{
-    bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo> result;
-    if (subId != bmqp::QueueId::k_DEFAULT_SUBQUEUE_ID) {
-        result.makeValue();
-        result.value().appId() = appId;
-        result.value().subId() = subId;
-    }
-
-    return result;
-}
-
-inline void ProtocolUtil::convert(
-    bmqp_ctrlmsg::QueueStreamParameters*                     to,
-    const bmqp_ctrlmsg::StreamParameters&                    from,
-    const bdlb::NullableValue<bmqp_ctrlmsg::SubQueueIdInfo>& subIdInfo)
-{
-    BSLS_ASSERT_SAFE(from.subscriptions().size() < 2);
-
-    to->subIdInfo() = subIdInfo;
-
-    if (from.subscriptions().size() > 0) {
-        BSLS_ASSERT_SAFE(from.subscriptions().size() == 1);
-        // Enable multiple subscriptions in SDK only when all brokers support
-        // them.
-        BSLS_ASSERT_SAFE(from.subscriptions()[0].consumers().size() > 0);
-        // New ConfigureStream request can carry multiple priorities but the
-        // first element in the array is the highest priority one.
-        const bmqp_ctrlmsg::ConsumerInfo& ci =
-            from.subscriptions()[0].consumers()[0];
-
-        to->consumerPriority()       = ci.consumerPriority();
-        to->consumerPriorityCount()  = ci.consumerPriorityCount();
-        to->maxUnconfirmedMessages() = ci.maxUnconfirmedMessages();
-        to->maxUnconfirmedBytes()    = ci.maxUnconfirmedBytes();
-    }
-    else {
-        to->consumerPriority()       = Protocol::k_CONSUMER_PRIORITY_INVALID;
-        to->consumerPriorityCount()  = 0;
-        to->maxUnconfirmedMessages() = 0;
-        to->maxUnconfirmedBytes()    = 0;
-    }
-}
-
-inline void
-ProtocolUtil::convert(bmqp_ctrlmsg::ConfigureStream*            to,
-                      const bmqp_ctrlmsg::ConfigureQueueStream& from)
-{
-    const bmqp_ctrlmsg::QueueStreamParameters& oldStype =
-        from.streamParameters();
-
-    to->qId() = from.qId();
-    to->streamParameters().subscriptions().resize(1);
-    bmqp_ctrlmsg::Subscription& subscription =
-        to->streamParameters().subscriptions()[0];
-
-    if (!oldStype.subIdInfo().isNull()) {
-        subscription.sId()             = oldStype.subIdInfo().value().subId();
-        to->streamParameters().appId() = oldStype.subIdInfo().value().appId();
-    }
-    // else DEFAULT_INITIALIZER_ID      (0),
-    //      DEFAULT_INITIALIZER_APP_ID  ("__default")
-
-    subscription.consumers().resize(1);
-    convert(&subscription.consumers()[0], oldStype);
-}
-
-inline void
-ProtocolUtil::convert(bmqp_ctrlmsg::StreamParameters*            to,
-                      const bmqp_ctrlmsg::QueueStreamParameters& from)
-{
-    if (!from.subIdInfo().isNull()) {
-        to->appId() = from.subIdInfo().value().appId();
-    }
-    // else DEFAULT_INITIALIZER_APP_ID  ("__default")
-
-    if (from.consumerPriorityCount()) {
-        to->subscriptions().resize(1);
-        to->subscriptions()[0].consumers().resize(1);
-
-        convert(&to->subscriptions()[0].consumers()[0], from);
-    }
-    else {
-        BSLS_ASSERT_SAFE(from.consumerPriority() ==
-                         Protocol::k_CONSUMER_PRIORITY_INVALID);
-        BSLS_ASSERT_SAFE(from.consumerPriorityCount() == 0);
-        BSLS_ASSERT_SAFE(from.maxUnconfirmedMessages() == 0);
-        BSLS_ASSERT_SAFE(from.maxUnconfirmedBytes() == 0);
-    }
-}
-
-inline void
-ProtocolUtil::convert(bmqp_ctrlmsg::ConsumerInfo*                to,
-                      const bmqp_ctrlmsg::QueueStreamParameters& from)
-{
-    to->consumerPriority()       = from.consumerPriority();
-    to->consumerPriorityCount()  = from.consumerPriorityCount();
-    to->maxUnconfirmedMessages() = from.maxUnconfirmedMessages();
-    to->maxUnconfirmedBytes()    = from.maxUnconfirmedBytes();
-}
-
-inline void
-ProtocolUtil::makeResponse(bmqp_ctrlmsg::ControlMessage*         response,
-                           const bmqp_ctrlmsg::StreamParameters& from,
-                           const bmqp_ctrlmsg::ControlMessage&   request)
-{
-    response->rId() = request.rId();
-
-    if (request.choice().isConfigureQueueStreamValue()) {
-        bmqp_ctrlmsg::ConfigureQueueStream& oldStyleRequest =
-            response->choice().makeConfigureQueueStreamResponse().request();
-        const bmqp_ctrlmsg::ConfigureQueueStream& original =
-            request.choice().configureQueueStream();
-        bmqp_ctrlmsg::QueueStreamParameters parameters =
-            oldStyleRequest.streamParameters();
-
-        oldStyleRequest.qId() = original.qId();
-
-        // QE::configureHandle mirrors parameters currently but let's leave
-        // the possibility for changing them.  For this reason, reconstruct
-        // parameters.
-
-        convert(&parameters, from, original.streamParameters().subIdInfo());
-    }
-    else {
-        BSLS_ASSERT_SAFE(request.choice().isConfigureStreamValue());
-
-        bmqp_ctrlmsg::ConfigureStream& newStyleRequest =
-            response->choice().makeConfigureStreamResponse().request();
-
-        newStyleRequest = request.choice().configureStream();
-    }
-}
-
-inline const bmqp_ctrlmsg::ConsumerInfo&
-ProtocolUtil::consumerInfo(const bmqp_ctrlmsg::StreamParameters& from)
-{
-    size_t n = from.subscriptions().size();
-
-    if (n == 0) {
-        static const bmqp_ctrlmsg::ConsumerInfo& defaultValues = *(
-            new bmqp_ctrlmsg::ConsumerInfo());
-
-        // Heap allocate it to prevent 'exit-time-destructor needed' compiler
-        // warning.  Causes valgrind-reported memory leak.
-
-        return defaultValues;
-    }
-
-    BSLS_ASSERT_SAFE(from.subscriptions()[0].consumers().size() > 0);
-
-    // Consider only the first (highest priority) consumer
-    return from.subscriptions()[0].consumers()[0];
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_queueid.h
+++ b/src/groups/bmq/bmqp/bmqp_queueid.h
@@ -25,8 +25,6 @@
 // which is used as a key for a queue.
 //
 
-// BMQ
-
 // BDE
 #include <bsl_iosfwd.h>
 #include <bslh_hash.h>

--- a/src/groups/bmq/bmqp/doc/bmqp.txt
+++ b/src/groups/bmq/bmqp/doc/bmqp.txt
@@ -13,7 +13,7 @@
 
 /Hierarchical Synopsis
 /---------------------
-The 'bmqp' package currently has 31 components having 4 level of physical
+The 'bmqp' package currently has 32 components having 4 level of physical
 dependency.  The list below shows the hierarchical ordering of the components.
 ..
   4. bmqp_requestmanager
@@ -30,6 +30,7 @@ dependency.  The list below shows the hierarchical ordering of the components.
      bmqp_ackmessageiterator
      bmqp_confirmmessageiterator
      bmqp_controlmessageutil
+     bmqp_conversionutil
      bmqp_eventutil
      bmqp_messageproperties
      bmqp_optionsview
@@ -72,6 +73,10 @@ dependency.  The list below shows the hierarchical ordering of the components.
 :
 : 'bmqp_controlmessageutil':
 :      Provide utilities related to control messages.
+:
+: 'bmqp_conversionutil':
+:      Provide utilities for converting between old-style and new-style control
+:      messages.
 :
 : 'bmqp_crc32c':
 :      Provide utilities for calculating crc32c.

--- a/src/groups/bmq/bmqp/package/bmqp.mem
+++ b/src/groups/bmq/bmqp/package/bmqp.mem
@@ -5,6 +5,7 @@ bmqp_compression
 bmqp_confirmeventbuilder
 bmqp_confirmmessageiterator
 bmqp_controlmessageutil
+bmqp_conversionutil
 bmqp_crc32c
 bmqp_ctrlmsg_messages
 bmqp_event

--- a/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
+++ b/src/groups/bmq/bmqt/bmqt_compressionalgorithmtype.h
@@ -26,10 +26,8 @@
 ///   - *NONE*: No compression algorithm was specified
 ///   - *ZLIB*: The compression algorithm is ZLIB
 
-// BMQ
-
 // BDE
-#include <bsl_ostream.h>
+#include <bsl_iosfwd.h>
 #include <bsl_string.h>
 
 namespace BloombergLP {

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.cpp
@@ -67,7 +67,7 @@ bslma::Allocator*& bmqtst::TestHelperUtil::allocator()
 // -----------------
 
 // CLASS METHODS
-void TestHelper::printTestName(bslstl::StringRef value)
+void TestHelper::printTestName(bsl::string_view value)
 {
     if (bmqtst::TestHelperUtil::verbosityLevel() < 1) {
         return;  // RETURN

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -287,13 +287,12 @@
 #include <balst_stacktracetestallocator.h>
 #include <bdlm_metricsregistry.h>
 #include <bdlsb_memoutstreambuf.h>
-#include <bsl_cstddef.h>
 #include <bsl_cstdio.h>
 #include <bsl_cstdlib.h>
 #include <bsl_iostream.h>
 #include <bsl_map.h>
 #include <bsl_set.h>
-#include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bsl_unordered_map.h>
 #include <bsl_unordered_set.h>
 #include <bsl_utility.h>
@@ -348,11 +347,10 @@
             bdlsb::MemOutStreamBuf buffer(                                    \
                 bmqtst::TestHelperUtil::allocator());                         \
             bsl::ostream os(&buffer);                                         \
-            os << prefix << "'" << xStr << "' " << "("                        \
-               << bmqtst::printer(xResult) << ")" << " " #OP " " << "'"       \
-               << yStr << "' " << "(" << bmqtst::printer(yResult) << ")"      \
-               << bsl::ends;                                                  \
-            bslstl::StringRef str(buffer.data(), buffer.length());            \
+            os << prefix << "'" << xStr << "' (" << bmqtst::printer(xResult)  \
+               << ") " #OP " '" << yStr << "' (" << bmqtst::printer(yResult)  \
+               << ")" << bsl::ends;                                           \
+            bsl::string_view str(buffer.data(), buffer.length());             \
             BloombergLP::_assert(false, str.data(), file, line);              \
         }                                                                     \
     }
@@ -392,7 +390,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << '\0';                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         if (!(X)) {                                                           \
             BloombergLP::_assert(false, _osStr.data(), __FILE__, __LINE__);   \
         }                                                                     \
@@ -402,7 +400,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareEquals(_osStr, X, Y, #X, #Y, __FILE__, __LINE__);       \
     }
 #define BMQTST_ASSERT_NE_D(D, X, Y)                                           \
@@ -410,7 +408,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareNotEquals(_osStr, X, Y, #X, #Y, __FILE__, __LINE__);    \
     }
 #define BMQTST_ASSERT_LT_D(D, X, Y)                                           \
@@ -418,7 +416,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareLess(_osStr, X, Y, #X, #Y, __FILE__, __LINE__);         \
     }
 #define BMQTST_ASSERT_LE_D(D, X, Y)                                           \
@@ -426,7 +424,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareLessEquals(_osStr, X, Y, #X, #Y, __FILE__, __LINE__);   \
     }
 #define BMQTST_ASSERT_GT_D(D, X, Y)                                           \
@@ -434,7 +432,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareGreater(_osStr, X, Y, #X, #Y, __FILE__, __LINE__);      \
     }
 #define BMQTST_ASSERT_GE_D(D, X, Y)                                           \
@@ -442,7 +440,7 @@
         bdlsb::MemOutStreamBuf _buf(bmqtst::TestHelperUtil::allocator());     \
         bsl::ostream           _os(&_buf);                                    \
         _os << D << ": ";                                                     \
-        bslstl::StringRef _osStr(_buf.data(), _buf.length());                 \
+        bsl::string_view _osStr(_buf.data(), _buf.length());                  \
         _assertCompareGreaterEquals(_osStr,                                   \
                                     X,                                        \
                                     Y,                                        \
@@ -939,7 +937,7 @@ struct TestHelper {
     // CLASS METHODS
 
     /// Print the banner of the name of the test, in the specified `value`.
-    static void printTestName(bslstl::StringRef value);
+    static void printTestName(bsl::string_view value);
 
     /// Return true if the specified `x` and `y` should be considered equal,
     /// with respect to floating numerics imprecision.

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -166,6 +166,7 @@
 #include <bmqp_compression.h>
 #include <bmqp_confirmmessageiterator.h>
 #include <bmqp_controlmessageutil.h>
+#include <bmqp_conversionutil.h>
 #include <bmqp_event.h>
 #include <bmqp_messageproperties.h>
 #include <bmqp_protocolutil.h>
@@ -871,7 +872,7 @@ void ClientSession::onHandleConfiguredDispatched(
                 response.choice().makeConfigureQueueStreamResponse().request();
 
             configureQueueStream.qId() = qId;
-            bmqp::ProtocolUtil::convert(
+            bmqp::ConversionUtil::convert(
                 &configureQueueStream.streamParameters(),
                 streamParameters,
                 streamParamsCtrlMsg.choice()
@@ -1309,7 +1310,7 @@ void ClientSession::processConfigureStream(
     bmqp_ctrlmsg::ConfigureStream& req = adaptor;
 
     if (streamParamsCtrlMsg.choice().isConfigureQueueStreamValue()) {
-        bmqp::ProtocolUtil::convert(
+        bmqp::ConversionUtil::convert(
             &adaptor,
             streamParamsCtrlMsg.choice().configureQueueStream());
     }

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -50,6 +50,7 @@
 
 // BMQ
 #include <bmqimp_queuemanager.h>
+#include <bmqp_conversionutil.h>
 #include <bmqp_protocol.h>
 #include <bmqp_protocolutil.h>
 #include <bmqp_queueid.h>
@@ -2538,7 +2539,7 @@ void ClusterQueueHelper::onHandleConfigured(
             qId = request.choice().configureQueueStream().qId();
             configureQueueStream.qId() = qId;
 
-            bmqp::ProtocolUtil::convert(
+            bmqp::ConversionUtil::convert(
                 &configureQueueStream.streamParameters(),
                 streamParameters,
                 request.choice()
@@ -3454,11 +3455,11 @@ bool ClusterQueueHelper::sendConfigureQueueRequest(
             request->request().choice().makeConfigureQueueStream();
         qs.qId() = queueId;
 
-        bmqp::ProtocolUtil::convert(
+        bmqp::ConversionUtil::convert(
             &qs.streamParameters(),
             streamParameters,
-            bmqp::ProtocolUtil::makeSubQueueIdInfo(streamParameters.appId(),
-                                                   subId));
+            bmqp::ConversionUtil::makeSubQueueIdInfo(streamParameters.appId(),
+                                                     subId));
     }
 
     request->setResponseCb(
@@ -5131,8 +5132,8 @@ void ClusterQueueHelper::processPeerConfigureStreamRequest(
                              << ": Received configureQueueStreamRequest from ["
                              << requester->description() << "]: " << request;
 
-        bmqp::ProtocolUtil::convert(&adaptor,
-                                    request.choice().configureQueueStream());
+        bmqp::ConversionUtil::convert(&adaptor,
+                                      request.choice().configureQueueStream());
     }
     else {
         BSLS_ASSERT_SAFE(request.choice().isConfigureStreamValue());

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -26,6 +26,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_queueid.h>
 #include <bmqp_queueutil.h>
 #include <bmqp_routingconfigurationutils.h>

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -34,7 +34,6 @@
 #include <mqbu_capacitymeter.h>
 
 // BMQ
-#include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_uri.h>
 
 // BDE
@@ -60,6 +59,12 @@
 namespace BloombergLP {
 
 // FORWARD DECLARATION
+namespace bmqp_ctrlmsg {
+class OpenQueueResponse;
+class QueueHandleParameters;
+class RoutingConfiguration;
+class Status;
+}
 namespace mqbcmd {
 class DomainCommand;
 }

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -31,6 +31,7 @@
 #include <mqbu_storagekey.h>
 
 // BMQ
+#include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocolutil.h>
 #include <bmqt_queueflags.h>
 #include <bmqt_resultcode.h>

--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.h
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.h
@@ -28,7 +28,6 @@
 #include <mqbi_queue.h>
 
 // BMQ
-#include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocol.h>
 #include <bmqt_messageguid.h>
 #include <bmqu_throttledaction.h>
@@ -49,6 +48,10 @@
 namespace BloombergLP {
 
 // FORWARD DECLARATION
+namespace bmqp_ctrlmsg {
+class QueueHandleParameters;
+class StreamParameters;
+}
 namespace mqbcmd {
 class LocalQueue;
 }

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -70,6 +70,29 @@ namespace mqbblp {
 
 namespace {
 
+bool verifyConsumerInfo(const bmqp_ctrlmsg::ConsumerInfo& ci)
+{
+    if (ci.consumerPriority() == bmqp::Protocol::k_CONSUMER_PRIORITY_INVALID) {
+        return ci.consumerPriorityCount() == 0;
+    }
+    else {
+        return ci.consumerPriorityCount() > 0;
+    }
+}
+
+bool verifyStreamParameters(const bmqp_ctrlmsg::StreamParameters& parameters)
+{
+    for (size_t i = 0; i < parameters.subscriptions().size(); ++i) {
+        const bmqp_ctrlmsg::Subscription& s = parameters.subscriptions()[i];
+        for (size_t n = 0; n < s.consumers().size(); ++n) {
+            if (!verifyConsumerInfo(s.consumers()[n])) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
 const int k_MAX_INSTANT_MESSAGES = 10;
 // Maximum messages logged with throttling in a short period of time.
 
@@ -1015,7 +1038,7 @@ void RootQueueEngine::configureHandle(
     // Verify consumer priority validity
     // Note: 'consumerPriorityCount() == 0' means that handle is being
     // deconfigured, in this case priority expected to be invalid
-    if (!bmqp::ProtocolUtil::verify(streamParameters)) {
+    if (!verifyStreamParameters(streamParameters)) {
         BALL_LOG_ERROR
             << "#CLIENT_IMPROPER_BEHAVIOR "
             << "Attempting to configure stream with invalid priority. "

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -28,7 +28,6 @@
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocol.h>
-#include <bmqp_protocolutil.h>
 #include <bmqp_routingconfigurationutils.h>
 
 // BDE
@@ -65,6 +64,23 @@ using namespace bsl;
 //                            TEST HELPERS UTILITY
 // ----------------------------------------------------------------------------
 namespace {
+
+const bmqp_ctrlmsg::ConsumerInfo&
+consumerInfo(const bmqp_ctrlmsg::StreamParameters& from)
+{
+    size_t n = from.subscriptions().size();
+
+    if (n == 0) {
+        static const bmqp_ctrlmsg::ConsumerInfo& defaultValues = *(
+            new bmqp_ctrlmsg::ConsumerInfo());
+
+        return defaultValues;
+    }
+
+    BSLS_ASSERT_SAFE(from.subscriptions()[0].consumers().size() > 0);
+
+    return from.subscriptions()[0].consumers()[0];
+}
 
 const mqbmock::QueueHandle* k_nullMockHandle_p = 0;
 
@@ -2467,16 +2483,13 @@ static void test21_breathingTest()
         PV(L_ << ": C3@c stream parameters:" << C3->_streamParameters("c"));
 
         BMQTST_ASSERT_EQ(
-            bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("a"))
-                .maxUnconfirmedMessages(),
+            consumerInfo(C1->_streamParameters("a")).maxUnconfirmedMessages(),
             11);
         BMQTST_ASSERT_EQ(
-            bmqp::ProtocolUtil::consumerInfo(C2->_streamParameters("b"))
-                .maxUnconfirmedMessages(),
+            consumerInfo(C2->_streamParameters("b")).maxUnconfirmedMessages(),
             12);
         BMQTST_ASSERT_EQ(
-            bmqp::ProtocolUtil::consumerInfo(C3->_streamParameters("c"))
-                .maxUnconfirmedMessages(),
+            consumerInfo(C3->_streamParameters("c")).maxUnconfirmedMessages(),
             13);
 
         // 2. Post 3 messages to the queue, and invoke the engine to deliver
@@ -2873,30 +2886,24 @@ static void test27_configureHandleMultipleAppIds()
     PV(L_ << ": C1@c stream parameters:" << C1->_streamParameters("c"));
 
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("a"))
-            .maxUnconfirmedMessages(),
+        consumerInfo(C1->_streamParameters("a")).maxUnconfirmedMessages(),
         11);
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("a"))
-            .maxUnconfirmedBytes(),
+        consumerInfo(C1->_streamParameters("a")).maxUnconfirmedBytes(),
         111);
 
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("b"))
-            .maxUnconfirmedMessages(),
+        consumerInfo(C1->_streamParameters("b")).maxUnconfirmedMessages(),
         22);
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("b"))
-            .maxUnconfirmedBytes(),
+        consumerInfo(C1->_streamParameters("b")).maxUnconfirmedBytes(),
         222);
 
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("c"))
-            .maxUnconfirmedMessages(),
+        consumerInfo(C1->_streamParameters("c")).maxUnconfirmedMessages(),
         33);
     BMQTST_ASSERT_EQ(
-        bmqp::ProtocolUtil::consumerInfo(C1->_streamParameters("c"))
-            .maxUnconfirmedBytes(),
+        consumerInfo(C1->_streamParameters("c")).maxUnconfirmedBytes(),
         333);
 }
 


### PR DESCRIPTION
- Remove `#include <bmqp_ctrlmsg_messages.h>` from `bmqp_protocolutil.h`
- Move QueueStream conversion functions from `bmqp_protocolutil` to a new component `bmqp_conversionutil`
- Remove unused `bmqp::ProtocolUtil::makeResponse`
- Define local functions `consumerInfo` in 2 unit tests that only use them
- Move both `bmqp::ProtocolUtil::verify` functions to `mqbblp::RootQueueEngine` (the only place that uses them), rename to `verifyStreamParameters` and `verifyConsumerInfo`
- `bmqtst_testhelper`: use `bsl::string_view`