### PR TITLE
Build[build-ubuntu.sh]: Use CMake Presets to build

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
     "include": [
         "etc/presets/vcpkg.json",
         "etc/presets/gh-ci.json",
-        "etc/presets/build-darwin.json"
+        "etc/presets/build-darwin.json",
+        "etc/presets/build-ubuntu.json"
     ]
 }

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -165,28 +165,16 @@ if [ "${BUILD_PROMETHEUS}" == true ]; then
 fi
 
 # :: Build the BlazingMQ repo :::::::::::::::::::::::::::::::::::::::::::::::::
-CMAKE_OPTIONS=(
-    -DBDE_BUILD_TARGET_64=1
-    -DBDE_BUILD_TARGET_CPP23=1
-    -DCMAKE_BUILD_TYPE=Debug
-    -DCMAKE_INSTALL_LIBDIR="lib"
-    -DCMAKE_INSTALL_PREFIX="${DIR_INSTALL}"
-    -DCMAKE_MODULE_PATH="${DIR_THIRDPARTY}/bde-tools/cmake;${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem"
-    -DCMAKE_PREFIX_PATH="${DIR_INSTALL}"
-    -DCMAKE_TOOLCHAIN_FILE="${DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake"
-    -DCMAKE_CXX_STANDARD=23
-    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-    -DFLEX_ROOT=/usr/lib/x86_64-linux-gnu)
+export DIR_THIRDPARTY DIR_BUILD DIR_INSTALL
 
 if [ "${BUILD_PROMETHEUS}" == true ]; then
-    CMAKE_OPTIONS+=(-DINSTALL_TARGETS=prometheus)
+    PRESET="ubuntu-x64-prometheus"
 else
-    CMAKE_OPTIONS+=(-UINSTALL_TARGETS)
+    PRESET="ubuntu-x64"
 fi
 
-PKG_CONFIG_PATH="${DIR_INSTALL}/lib64/pkgconfig:${DIR_INSTALL}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
-    cmake -G Ninja -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" "${CMAKE_OPTIONS[@]}"
-ninja -C "${DIR_BUILD}/blazingmq"
+cmake --preset "${PRESET}"
+cmake --build --preset "${PRESET}"
 
 echo broker is here: "${DIR_BUILD}/blazingmq/src/applications/bmqbrkr/bmqbrkr.tsk"
 echo to run the broker: "${DIR_BUILD}/blazingmq/src/applications/bmqbrkr/run"

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -185,8 +185,8 @@ else
 fi
 
 PKG_CONFIG_PATH="${DIR_INSTALL}/lib64/pkgconfig:${DIR_INSTALL}/lib/pkgconfig:$(pkg-config --variable pc_path pkg-config)" \
-    cmake -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" "${CMAKE_OPTIONS[@]}"
-make -C "${DIR_BUILD}/blazingmq" -j 16
+    cmake -G Ninja -B "${DIR_BUILD}/blazingmq" -S "${DIR_ROOT}" "${CMAKE_OPTIONS[@]}"
+ninja -C "${DIR_BUILD}/blazingmq"
 
 echo broker is here: "${DIR_BUILD}/blazingmq/src/applications/bmqbrkr/bmqbrkr.tsk"
 echo to run the broker: "${DIR_BUILD}/blazingmq/src/applications/bmqbrkr/run"

--- a/etc/presets/build-ubuntu.json
+++ b/etc/presets/build-ubuntu.json
@@ -1,0 +1,58 @@
+{
+    "version": 6,
+    "include": [
+        "default.json"
+    ],
+    "configurePresets": [
+        {
+            "name": "ubuntu-base",
+            "hidden": true,
+            "description":
+                "Base configuration for building on Ubuntu with BDE dependencies",
+            "inherits": "base",
+            "generator": "Ninja",
+            "toolchainFile":
+                "$env{DIR_THIRDPARTY}/bde-tools/BdeBuildSystem/toolchains/linux/gcc-default.cmake",
+            "cacheVariables": {
+                "CMAKE_INSTALL_LIBDIR": "lib",
+                "CMAKE_INSTALL_PREFIX": "$env{DIR_INSTALL}",
+                "CMAKE_MODULE_PATH":
+                    "$env{DIR_THIRDPARTY}/bde-tools/cmake;$env{DIR_THIRDPARTY}/bde-tools/BdeBuildSystem"
+            }
+        },
+        {
+            "name": "ubuntu-x64",
+            "description": "Ubuntu x86_64 build with apt dependencies",
+            "inherits": "ubuntu-base",
+            "binaryDir": "$env{DIR_BUILD}/blazingmq",
+            "environment": {
+                "PKG_CONFIG_PATH":
+                    "$env{DIR_INSTALL}/lib64/pkgconfig:$env{DIR_INSTALL}/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig"
+            },
+            "cacheVariables": {
+                "CMAKE_PREFIX_PATH": "$env{DIR_INSTALL}",
+                "FLEX_ROOT": "/usr/lib/x86_64-linux-gnu"
+            }
+        },
+        {
+            "name": "ubuntu-x64-prometheus",
+            "description": "Ubuntu x86_64 build with Prometheus plugin",
+            "inherits": "ubuntu-x64",
+            "cacheVariables": {
+                "INSTALL_TARGETS": "prometheus"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "ubuntu-x64",
+            "description": "Build on Ubuntu x86_64",
+            "configurePreset": "ubuntu-x64"
+        },
+        {
+            "name": "ubuntu-x64-prometheus",
+            "description": "Build on Ubuntu x86_64 with Prometheus plugin",
+            "configurePreset": "ubuntu-x64-prometheus"
+        }
+    ]
+}


### PR DESCRIPTION
This pull request brings build-ubuntu.sh into line with build-darwin.sh by using `ninja` and `CMakePresets` to build.