### PR TITLE
CI: Update `actions/` actions to Node 24 versions

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -54,7 +54,7 @@ jobs:
       artifact_key: ${{ steps.get_cache_key.outputs.artifact_key }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -137,7 +137,7 @@ jobs:
           echo "Please set the target to include 'all.t' to build unit tests."
           exit 1
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         if: inputs.save_build_as_artifacts == true # Variable type is boolean, thus no quotes
         with:
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Python Unit Tests
         env:
@@ -100,14 +100,14 @@ jobs:
     env:
         RUN_UID: ${{ matrix.cluster }}_${{ matrix.mode }}_${{ matrix.consistency }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ${{needs.build_ubuntu.outputs.artifact_key }}
 
         # Solaris: make sure all ITs scripts are compatible with python3.8
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.8'
 
@@ -161,7 +161,7 @@ jobs:
 
       - name: Upload failure-logs as artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ github.run_id }}_failure_logs_${{ env.RUN_UID }}
           path: ${{ github.workspace }}/src/integration-tests/failure-logs
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload broker executable as artifacts to debug the core
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ github.run_id }}_bmqbrkr
           overwrite: true # broker binary is the same across all matrix runs
@@ -196,9 +196,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ${{needs.build_ubuntu.outputs.artifact_key }}
 
@@ -240,7 +240,7 @@ jobs:
 
       - name: Upload fuzz-logs as artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ matrix.request }}_fuzz.log
           path: ${{ github.workspace }}/src/python/${{ matrix.request }}_fuzz.log
@@ -257,9 +257,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build_ubuntu
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: ${{needs.build_ubuntu.outputs.artifact_key }}
 
@@ -283,7 +283,7 @@ jobs:
           - os: macos-14
             arch: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up dependencies
         run: |
@@ -308,7 +308,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: get_dependencies
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/cache/restore@v4
         with:
@@ -384,7 +384,7 @@ jobs:
     name: "Documentation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up dependencies
         run: |
@@ -405,7 +405,7 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # 20 Jun 2024
@@ -414,7 +414,7 @@ jobs:
     name: "Docker [ubuntu]"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Docker Single-Node Workflow
         run: docker compose -f docker/single-node/docker-compose.yaml up --build -d

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       cache_key: ${{ steps.get-cache-key.outputs.cache_key }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate dependencies cache key
         id: get-cache-key

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Checkout `main`
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clear out `docs/` subdirectory
         run: rm -rf docs
 
       - name: Checkout `gh-pages` into `docs/`
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: docs
           ref: gh-pages

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-slim
     name: License Check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: license check
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-slim
     name: PR Title Check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: pr title check
@@ -58,7 +58,7 @@ jobs:
     name: Check .mem files sorting
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check alphabetical order in .mem files
         run: |
@@ -94,7 +94,7 @@ jobs:
     name: C++ Formatting Check
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: clang-format style check
@@ -113,7 +113,7 @@ jobs:
           fi
       - name: Upload formatting patch
         if: failure() && steps.format-check.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: clang-format-patch
           path: clang_format.patch
@@ -128,10 +128,10 @@ jobs:
     name: Python Formatting Check
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
       - name: ruff style check
         id: format-check
         run: |
@@ -150,7 +150,7 @@ jobs:
           fi
       - name: Upload formatting patch
         if: failure() && steps.format-check.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ruff-format-patch
           path: ruff_format.patch
@@ -159,10 +159,10 @@ jobs:
     name: Python Linter Check
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12.4'
       - name: Install dependencies

--- a/.github/workflows/manual.yaml
+++ b/.github/workflows/manual.yaml
@@ -68,31 +68,31 @@ jobs:
       RUN_UID: ${{ matrix.cluster }}_${{ matrix.mode }}_${{ matrix.consistency }}
     steps:
       - name: Checkout ITs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # The ref of the workflow that triggered this workflow
           path: repoit
           fetch-depth: 0
 
       - name: Checkout repo1
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref1 }}
           path: repo1
           fetch-depth: 0
 
       - name: Checkout repo2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref2 }}
           path: repo2
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: ./repo1
           name: ${{needs.build1.outputs.artifact_key }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: ./repo2
           name: ${{needs.build2.outputs.artifact_key }}
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload failure-logs as artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ github.run_id }}_failure_logs_${{ env.RUN_UID }}
           path: ${{ github.workspace }}/repoit/src/integration-tests/failure-logs
@@ -158,31 +158,31 @@ jobs:
       RUN_UID: ${{ matrix.cluster }}_${{ matrix.mode }}_${{ matrix.consistency }}
     steps:
       - name: Checkout ITs repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # The ref of the workflow that triggered this workflow
           path: repoit
           fetch-depth: 0
 
       - name: Checkout repo1
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref1 }}
           path: repo1
           fetch-depth: 0
 
       - name: Checkout repo2
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.ref2 }}
           path: repo2
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: ./repo1
           name: ${{needs.build1.outputs.artifact_key }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: ./repo2
           name: ${{needs.build2.outputs.artifact_key }}
@@ -236,7 +236,7 @@ jobs:
 
       - name: Upload failure-logs as artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ github.run_id }}_failure_logs_${{ env.RUN_UID }}
           path: ${{ github.workspace }}/repoit/src/integration-tests/failure-logs

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc  # 7 Jun 2023, v2.2.0

--- a/.github/workflows/pytest-coverage.yaml
+++ b/.github/workflows/pytest-coverage.yaml
@@ -21,7 +21,7 @@ jobs:
     name: UT coverage [python]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Generate Python Unit Tests Coverage report
         env:
@@ -35,7 +35,7 @@ jobs:
             --cov-report xml:python-coverage.xml
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: code-coverage-report
           path: |

--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Purge runner
       # Strip the runner to avoid space quota exceeding
         run: |


### PR DESCRIPTION
Node 20 actions are being deprecated very soon, so this patch updates action versions to ones that support the newer Node 24.