### PR TITLE
Fix[mqb]: use safe copies of identity and statContext

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusternodesession.cpp
@@ -172,9 +172,7 @@ void ClusterNodeSession::createQueueHandleRequesterContext()
     const bsl::shared_ptr<bmqst::StatContext> statContext =
         d_queueHandleRequesterContext_sp->statContext();
 
-    createQueueHandleRequesterContextImpl(
-        d_queueHandleRequesterContext_sp->identity(),
-        d_queueHandleRequesterContext_sp->statContext());
+    createQueueHandleRequesterContextImpl(identity, statContext);
 }
 
 void ClusterNodeSession::createQueueHandleRequesterContextImpl(


### PR DESCRIPTION
dangling pointers use.
