### PR TITLE
Feat[mqbstat]: clusters flat json stats

### DIFF
--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.cpp
@@ -64,8 +64,20 @@ bsls::Types::Int64 ClusterStats::getValue(const bmqst::StatContext& context,
 {
     // invoked from the SNAPSHOT thread
 
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(snapshotId >= -1);
+
     const bmqst::StatValue::SnapshotLocation latestSnapshot(0, 0);
-    const bmqst::StatValue::SnapshotLocation oldestSnapshot(0, snapshotId);
+
+#define OLDEST_SNAPSHOT(STAT)                                                 \
+    (bmqst::StatValue::SnapshotLocation(                                      \
+        0,                                                                    \
+        (snapshotId >= 0) ? snapshotId                                        \
+                          : (context                                          \
+                                 .value(bmqst::StatContext::e_DIRECT_VALUE,   \
+                                        ClusterStatsIndex::STAT)              \
+                                 .historySize(0) -                            \
+                             1)))
 
 #define STAT_SINGLE(OPERATION, STAT)                                          \
     bmqst::StatUtil::OPERATION(                                               \
@@ -78,7 +90,7 @@ bsls::Types::Int64 ClusterStats::getValue(const bmqst::StatContext& context,
         context.value(bmqst::StatContext::e_DIRECT_VALUE,                     \
                       ClusterStatsIndex::STAT),                               \
         latestSnapshot,                                                       \
-        oldestSnapshot)
+        OLDEST_SNAPSHOT(STAT))
 
     switch (stat) {
     case Stat::e_CLUSTER_STATUS: {
@@ -207,6 +219,7 @@ bsls::Types::Int64 ClusterStats::getValue(const bmqst::StatContext& context,
     return 0;
 #undef STAT_RANGE
 #undef STAT_SINGLE
+#undef OLDEST_SNAPSHOT
 }
 
 bsl::shared_ptr<PartitionStats>
@@ -357,6 +370,52 @@ bsl::ostream& ClusterStats::Role::print(bsl::ostream& stream,
     }
 
     return stream;
+}
+
+const char* ClusterStats::Stat::toString(Stat::Enum value)
+{
+#define MQBSTAT_CASE(VAL, DESC)                                               \
+    case (VAL): {                                                             \
+        return (DESC);                                                        \
+    } break;
+
+    switch (value) {
+        MQBSTAT_CASE(e_CLUSTER_STATUS, "cluster_status")
+        MQBSTAT_CASE(e_ROLE, "cluster_role")
+        MQBSTAT_CASE(e_LEADER_STATUS, "cluster_leader_status")
+        MQBSTAT_CASE(e_CSL_REPLICATION_TIME_NS_AVG,
+                     "cluster_csl_replication_time_avg_ns")
+        MQBSTAT_CASE(e_CSL_REPLICATION_TIME_NS_MAX,
+                     "cluster_csl_replication_time_max_ns")
+        MQBSTAT_CASE(e_CSL_LOG_OFFSET_BYTES, "cluster_csl_offset_bytes")
+        MQBSTAT_CASE(e_CSL_WRITE_BYTES, "cluster_csl_write_bytes")
+        MQBSTAT_CASE(e_CSL_CFG_BYTES, "cluster_csl_cfg_bytes")
+        MQBSTAT_CASE(e_PARTITION_CFG_DATA_BYTES,
+                     "cluster_partition_cfg_data_bytes")
+        MQBSTAT_CASE(e_PARTITION_CFG_JOURNAL_BYTES,
+                     "cluster_partition_cfg_journal_bytes")
+        MQBSTAT_CASE(e_PARTITION_PRIMARY_STATUS, "partition_primary_status")
+        MQBSTAT_CASE(e_PARTITION_ROLLOVER_TIME, "partition_rollover_time_ns")
+        MQBSTAT_CASE(e_PARTITION_DATA_CONTENT, "partition_data_content_bytes")
+        MQBSTAT_CASE(e_PARTITION_JOURNAL_CONTENT,
+                     "partition_journal_content_bytes")
+        MQBSTAT_CASE(e_PARTITION_DATA_OFFSET, "partition_data_offset_bytes")
+        MQBSTAT_CASE(e_PARTITION_JOURNAL_OFFSET,
+                     "partition_journal_offset_bytes")
+        MQBSTAT_CASE(e_PARTITION_DATA_UTILIZATION_MAX,
+                     "partition_data_utilization_max")
+        MQBSTAT_CASE(e_PARTITION_JOURNAL_UTILIZATION_MAX,
+                     "partition_journal_utilization_max")
+        MQBSTAT_CASE(e_PARTITION_SEQUENCE_NUMBER, "partition_sequence_number")
+        MQBSTAT_CASE(e_PARTITION_REPLICATION_TIME_NS_AVG,
+                     "partition_replication_time_avg_ns")
+        MQBSTAT_CASE(e_PARTITION_REPLICATION_TIME_NS_MAX,
+                     "partition_replication_time_max_ns")
+    default:
+        BSLS_ASSERT(false && "invalid enumerator");
+        BSLS_ASSERT_INVOKE_NORETURN("");
+    }
+#undef MQBSTAT_CASE
 }
 
 const char* ClusterStats::Role::toAscii(Enum value)

--- a/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_clusterstats.h
@@ -130,6 +130,13 @@ class ClusterStats {
             /// the cluster.
             e_PARTITION_REPLICATION_TIME_NS_MAX
         };
+
+        // CLASS METHODS
+
+        /// Return the non-modifiable string representation corresponding to
+        /// the specified enumeration `value`, if it exists, and a unique
+        /// (error) string otherwise.
+        static const char* toString(Stat::Enum value);
     };
 
     /// Enum representing the leader status (leader or follower) of a node.

--- a/src/groups/mqb/mqbstat/mqbstat_flatjsonprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_flatjsonprinter.cpp
@@ -18,6 +18,7 @@
 #include <mqbscm_version.h>
 
 // MQB
+#include <mqbstat_clusterstats.h>
 #include <mqbstat_queuestats.h>
 
 // BDE
@@ -202,6 +203,131 @@ struct DomainQueuesVisitor {
     }
 };
 
+// ===========================
+// class ClusterStatsTraversal
+// ===========================
+
+/// Helper class for traversing cluster stat contexts within the "clusters"
+/// top-level stat context.  Calls `onClusterStatsVisited` for each cluster
+/// and each partition within that cluster.
+class ClusterStatsTraversal {
+  public:
+    // PUBLIC TYPES
+    typedef bsl::function<void(bsl::string_view          clusterName,
+                               bsl::string_view          partitionName,
+                               const bmqst::StatContext& ctx)>
+        OnClusterStatsVisited;
+
+  private:
+    // DATA
+    const bmqst::StatContext& d_ctx;
+
+  public:
+    // CREATORS
+
+    /// Create a new traversal over the specified `clustersCtx`.
+    explicit ClusterStatsTraversal(const bmqst::StatContext& clustersCtx);
+
+    // ACCESSORS
+
+    /// Iterate all clusters and partitions, calling the specified
+    /// `onClusterStatsVisited` for each stat context found.  For
+    /// cluster-level contexts, `partitionName` is empty.
+    void
+    forEachCluster(const OnClusterStatsVisited& onClusterStatsVisited) const;
+};
+
+inline ClusterStatsTraversal::ClusterStatsTraversal(
+    const bmqst::StatContext& clustersCtx)
+: d_ctx(clustersCtx)
+{
+    // NOTHING
+}
+
+inline void ClusterStatsTraversal::forEachCluster(
+    const OnClusterStatsVisited& onClusterStatsVisited) const
+{
+    for (bmqst::StatContextIterator clusterIt = d_ctx.subcontextIterator();
+         clusterIt;
+         ++clusterIt) {
+        const bsl::string_view clusterName = clusterIt->name();
+
+        onClusterStatsVisited(clusterName, bsl::string_view(), *clusterIt);
+
+        for (bmqst::StatContextIterator partIt =
+                 clusterIt->subcontextIterator();
+             partIt;
+             ++partIt) {
+            onClusterStatsVisited(clusterName, partIt->name(), *partIt);
+        }
+    }
+}
+
+// ======================
+// struct ClustersVisitor
+// ======================
+
+struct ClustersVisitor {
+    bsl::ostream&    d_os;
+    bsl::string_view d_prefix;
+
+    explicit ClustersVisitor(bsl::ostream& os, bsl::string_view prefix)
+    : d_os(os)
+    , d_prefix(prefix)
+    {
+        // NOTHING
+    }
+
+    void operator()(bsl::string_view          clusterName,
+                    bsl::string_view          partitionName,
+                    const bmqst::StatContext& ctx) const
+    {
+#define WRAP(KEY, VAL) ",\"" << (KEY) << "\":\"" << (VAL) << "\""
+
+#define METRIC(STAT)                                                          \
+    WRAP(mqbstat::ClusterStats::Stat::toString(STAT),                         \
+         mqbstat::ClusterStats::getValue(ctx, -1, (STAT)))
+
+        typedef mqbstat::ClusterStats::Stat Stat;
+
+        d_os << "{" << d_prefix;
+        if (partitionName.empty()) {
+            d_os << WRAP("type", "cluster");
+            d_os << WRAP("cluster", clusterName);
+            d_os << METRIC(Stat::e_CLUSTER_STATUS);
+            d_os << METRIC(Stat::e_ROLE);
+            d_os << METRIC(Stat::e_LEADER_STATUS);
+            d_os << METRIC(Stat::e_CSL_REPLICATION_TIME_NS_AVG);
+            d_os << METRIC(Stat::e_CSL_REPLICATION_TIME_NS_MAX);
+            d_os << METRIC(Stat::e_CSL_LOG_OFFSET_BYTES);
+            d_os << METRIC(Stat::e_CSL_WRITE_BYTES);
+            d_os << METRIC(Stat::e_CSL_CFG_BYTES);
+            d_os << METRIC(Stat::e_PARTITION_CFG_DATA_BYTES);
+            d_os << METRIC(Stat::e_PARTITION_CFG_JOURNAL_BYTES);
+        }
+        else {
+            d_os << WRAP("type", "cluster_partition");
+            d_os << WRAP("cluster", clusterName);
+            d_os << WRAP("partition", partitionName);
+            d_os << METRIC(Stat::e_PARTITION_PRIMARY_STATUS);
+            d_os << METRIC(Stat::e_PARTITION_ROLLOVER_TIME);
+            d_os << METRIC(Stat::e_PARTITION_DATA_CONTENT);
+            d_os << METRIC(Stat::e_PARTITION_JOURNAL_CONTENT);
+            d_os << METRIC(Stat::e_PARTITION_DATA_OFFSET);
+            d_os << METRIC(Stat::e_PARTITION_JOURNAL_OFFSET);
+            d_os << METRIC(Stat::e_PARTITION_DATA_UTILIZATION_MAX);
+            d_os << METRIC(Stat::e_PARTITION_JOURNAL_UTILIZATION_MAX);
+            d_os << METRIC(Stat::e_PARTITION_SEQUENCE_NUMBER);
+            d_os << METRIC(Stat::e_PARTITION_REPLICATION_TIME_NS_AVG);
+            d_os << METRIC(Stat::e_PARTITION_REPLICATION_TIME_NS_MAX);
+        }
+        d_os << "}" << bsl::endl;
+
+#undef METRIC
+#undef WRAP
+    }
+};
+
 }  // close unnamed namespace
 
 // ------------------------------------------
@@ -284,6 +410,13 @@ FlatJsonPrinter::FlatJsonPrinterImpl::printStats(bsl::ostream& stream,
     DomainQueueStatsTraversal traversal(ctx);
 
     traversal.forEachQueue(DomainQueuesVisitor(stream, commonPrefix));
+
+    // Clusters
+    const bmqst::StatContext& clustersCtx =
+        *d_contexts.find("clusters")->second;
+    ClusterStatsTraversal clusterTraversal(clustersCtx);
+
+    clusterTraversal.forEachCluster(ClustersVisitor(stream, commonPrefix));
 }
 
 // ---------------------

--- a/src/groups/mqb/mqbstat/mqbstat_flatjsonprinter.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_flatjsonprinter.cpp
@@ -147,13 +147,13 @@ struct DomainQueuesVisitor {
 
         d_os << "{" << d_prefix;
         if (appId.empty()) {
-            d_os << WRAP("type", "queue");
+            d_os << WRAP("stat", "queue");
             d_os << WRAP("domain", domainName);
             d_os << WRAP("queue", queueName);
             // no `app`
         }
         else {
-            d_os << WRAP("type", "queue_app");
+            d_os << WRAP("stat", "queue_app");
             d_os << WRAP("domain", domainName);
             d_os << WRAP("queue", queueName);
             d_os << WRAP("app", appId);
@@ -292,7 +292,7 @@ struct ClustersVisitor {
 
         d_os << "{" << d_prefix;
         if (partitionName.empty()) {
-            d_os << WRAP("type", "cluster");
+            d_os << WRAP("stat", "cluster");
             d_os << WRAP("cluster", clusterName);
             d_os << METRIC(Stat::e_CLUSTER_STATUS);
             d_os << METRIC(Stat::e_ROLE);
@@ -306,7 +306,7 @@ struct ClustersVisitor {
             d_os << METRIC(Stat::e_PARTITION_CFG_JOURNAL_BYTES);
         }
         else {
-            d_os << WRAP("type", "cluster_partition");
+            d_os << WRAP("stat", "cluster_partition");
             d_os << WRAP("cluster", clusterName);
             d_os << WRAP("partition", partitionName);
             d_os << METRIC(Stat::e_PARTITION_PRIMARY_STATUS);


### PR DESCRIPTION
Introduce 2 more flat json types: `cluster`, `cluster_partition`
```
{"ts":"10JUN2026_17:17:38.887032","stat_id":1,"stat":"cluster","cluster":"local","cluster_status":"2","cluster_role":"1","cluster_leader_status":"1","cluster_csl_replication_time_avg_ns":"74000","cluster_csl_replication_time_max_ns":"74000","cluster_csl_offset_bytes":"3176","cluster_csl_write_bytes":"504","cluster_csl_cfg_bytes":"8388608","cluster_partition_cfg_data_bytes":"268435456","cluster_partition_cfg_journal_bytes":"67108864"}
{"ts":"10JUN2026_17:17:38.887032","stat_id":1,"stat":"cluster_partition","cluster":"local","partition":"partition0","partition_primary_status":"2","partition_rollover_time_ns":"0","partition_data_content_bytes":"136","partition_journal_content_bytes":"464","partition_data_offset_bytes":"168","partition_journal_offset_bytes":"1484","partition_data_utilization_max":"0","partition_journal_utilization_max":"0","partition_sequence_number":"7","partition_replication_time_avg_ns":"0","partition_replication_time_max_ns":"0"}
```

Rename `"type"` -> `"stat"`