### PR TITLE
Fix: Add missing storage flag bit

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_protocol.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.cpp
@@ -826,6 +826,7 @@ const char* StorageHeaderFlags::toAscii(StorageHeaderFlags::Enum value)
         CASE(UNUSED2)
         CASE(UNUSED3)
         CASE(UNUSED4)
+        CASE(UNUSED5)
     default: return "(* UNKNOWN *)";
     }
 
@@ -847,6 +848,7 @@ bool StorageHeaderFlags::fromAscii(StorageHeaderFlags::Enum* out,
     CHECKVALUE(UNUSED2)
     CHECKVALUE(UNUSED3)
     CHECKVALUE(UNUSED4)
+    CHECKVALUE(UNUSED5)
 
     // Invalid string
     return false;
@@ -863,7 +865,8 @@ bool StorageHeaderFlagUtil::isValid(bsl::ostream& errorDescription,
 {
     if (isSet(flags, StorageHeaderFlags::e_UNUSED2) ||
         isSet(flags, StorageHeaderFlags::e_UNUSED3) ||
-        isSet(flags, StorageHeaderFlags::e_UNUSED4)) {
+        isSet(flags, StorageHeaderFlags::e_UNUSED4) ||
+        isSet(flags, StorageHeaderFlags::e_UNUSED5)) {
         errorDescription << "UNUSED flags are invalid.";
         return false;  // RETURN
     }
@@ -887,6 +890,7 @@ bsl::ostream& StorageHeaderFlagUtil::prettyPrint(bsl::ostream& stream,
     CHECKVALUE(UNUSED2)
     CHECKVALUE(UNUSED3)
     CHECKVALUE(UNUSED4)
+    CHECKVALUE(UNUSED5)
 
     return stream;
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.h
+++ b/src/groups/bmq/bmqp/bmqp_protocol.h
@@ -156,6 +156,7 @@
 #include <bsl_string.h>  // for bslstl::StringRef
 #include <bsl_type_traits.h>
 #include <bsla_annotations.h>
+#include <bslmf_assert.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_assert.h>
 #include <bsls_types.h>
@@ -3012,7 +3013,8 @@ struct StorageHeaderFlags {
         e_RECEIPT_REQUESTED = (1 << 0),
         e_UNUSED2           = (1 << 1),
         e_UNUSED3           = (1 << 2),
-        e_UNUSED4           = (1 << 3)
+        e_UNUSED4           = (1 << 3),
+        e_UNUSED5           = (1 << 4)
     };
 
     // PUBLIC CONSTANTS
@@ -3030,10 +3032,12 @@ struct StorageHeaderFlags {
     /// NOTE: This value must always be equal to the highest type in the
     /// enum because it is being used as an upper bound to verify a
     /// StorageHeader's `Flags` field is a valid type.
-    static const int k_HIGHEST_STORAGE_FLAG = e_UNUSED4;
+    static const int k_HIGHEST_STORAGE_FLAG = e_UNUSED5;
 
     /// Used by test drivers
     static const int k_VALUE_COUNT = StorageHeader::k_FLAGS_NUM_BITS;
+
+    BSLMF_ASSERT(1 << (k_VALUE_COUNT - 1) == k_HIGHEST_STORAGE_FLAG);
 
     // CLASS METHODS
 

--- a/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocol.t.cpp
@@ -1521,7 +1521,7 @@ static void test4_enumPrint()
             bmqp::StorageHeaderFlags::e_RECEIPT_REQUESTED);
 
         BSLMF_ASSERT(bmqp::StorageHeaderFlags::k_HIGHEST_STORAGE_FLAG ==
-                     bmqp::StorageHeaderFlags::e_UNUSED4);
+                     bmqp::StorageHeaderFlags::e_UNUSED5);
 
         PrintTestData k_DATA[] = {
             {L_,
@@ -1530,7 +1530,7 @@ static void test4_enumPrint()
             {L_, bmqp::StorageHeaderFlags::e_UNUSED2, "UNUSED2"},
             {L_, bmqp::StorageHeaderFlags::e_UNUSED3, "UNUSED3"},
             {L_, bmqp::StorageHeaderFlags::e_UNUSED4, "UNUSED4"},
-            {L_, -1, "(* UNKNOWN *)"}};
+            {L_, bmqp::StorageHeaderFlags::e_UNUSED5, "UNUSED5"}};
 
         printEnumHelper<bmqp::StorageHeaderFlags>(k_DATA);
     }


### PR DESCRIPTION
We have always reserved 5 bits for the storage header flags, but the implementation of the protocol never included the fifth top-most bit. This causes out of range loads in test drivers, but is also definitely wrong.