### PR TITLE
Fix[mqb]: race between stopListening and setChannel

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -333,7 +333,7 @@ void Channel::setChannel(const bsl::weak_ptr<bmqio::Channel>& value)
     wakeUp();
 
     // Case 1, 2: wait until `threadFn` gets the new channel.
-    while (d_state == e_RESET) {
+    while (d_state == e_RESET && !d_isStopping) {
         // Synchronize with the writing thread.
         // This is to not reject writes after 'setChannel' returns.
         d_stateCondition.wait(&d_mutex);
@@ -916,7 +916,7 @@ void Channel::threadFn()
                               << bmqu::PrintUtil::prettyBytes(numBytes())
                               << " pending bytes";
                 // If 'onWatermark' did not happen yet, do go into e_HWM to
-                // avoid calling BTE until LWM
+                // avoid calling transport layer until LWM
                 d_state.testAndSwap(e_READY, e_HWM);
             }
             else if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -818,7 +818,17 @@ void TCPSessionFactory::channelStateCallback(
         BSLS_ASSERT_SAFE(status);  // got a channel up, it must be success
         BSLS_ASSERT_SAFE(channel);
 
-        if (channel->peerUri().empty()) {
+        if (!d_isListening) {
+            BALL_LOG_INFO << "#SESSION_NEGOTIATION TCPSessionFactory '"
+                          << d_config.name()
+                          << "' has stopped listening and rejecting '"
+                          << channel.get() << "'";
+
+            bmqio::Status closeStatus(bmqio::StatusCategory::e_GENERIC_ERROR,
+                                      d_allocator_p);
+            channel->close(closeStatus);
+        }
+        else if (channel->peerUri().empty()) {
             BALL_LOG_ERROR << "#SESSION_NEGOTIATION "
                            << "TCPSessionFactory '" << d_config.name() << "' "
                            << "rejecting empty peer URI: '" << channel.get()

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -719,20 +719,24 @@ void TCPSessionFactory::initialConnectionComplete(
     // Do not initiate reading from the channel.  Transport observer(s) will
     // enable the read when they are ready.
 
-    const bool result = operationContext->d_resultCb(
-        bmqio::ChannelFactoryEvent::e_CHANNEL_UP,
-        bmqio::Status(),
-        monitoredSession,
-        initialConnectionContext_sp->negotiationContext()->cluster(),
-        initialConnectionContext_sp->resultState(),
-        bdlf::BindUtil::bind(&TCPSessionFactory::readCallback,
-                             this,
-                             bdlf::PlaceHolders::_1,  // status
-                             bdlf::PlaceHolders::_2,  // numNeeded
-                             bdlf::PlaceHolders::_3,  // blob
-                             info.get()));
+    bool result = false;
 
-    if (!result || !d_isListening) {
+    if (d_isListening) {
+        result = operationContext->d_resultCb(
+            bmqio::ChannelFactoryEvent::e_CHANNEL_UP,
+            bmqio::Status(),
+            monitoredSession,
+            initialConnectionContext_sp->negotiationContext()->cluster(),
+            initialConnectionContext_sp->resultState(),
+            bdlf::BindUtil::bind(&TCPSessionFactory::readCallback,
+                                 this,
+                                 bdlf::PlaceHolders::_1,  // status
+                                 bdlf::PlaceHolders::_2,  // numNeeded
+                                 bdlf::PlaceHolders::_3,  // blob
+                                 info.get()));
+    }
+
+    if (!result) {
         // TODO: Revisit if still needed, following move to bmqio.
         //
         //       If 'stopListening' have been called, 'tearDown' may or may not
@@ -740,10 +744,10 @@ void TCPSessionFactory::initialConnectionComplete(
         //       called before or after 'stopListening'.  Invoke 'tearDown'
         //       explicitly (it supports subsequent calls).
 
-        BALL_LOG_WARN << "#TCP_UNEXPECTED_STATE "
-                      << "TCPSessionFactory '" << d_config.name()
-                      << (result ? "' has initiated shutdown "
-                                 : "' has encountered an error ")
+        BALL_LOG_WARN << "#TCP_UNEXPECTED_STATE TCPSessionFactory '"
+                      << d_config.name()
+                      << (d_isListening ? "' has encountered an error "
+                                        : "' has initiated shutdown ")
                       << "while negotiating a session [session: '"
                       << monitoredSession->description() << "', channel: '"
                       << channel.get() << "']";
@@ -1384,11 +1388,11 @@ void TCPSessionFactory::stopListening()
     }
     d_isListening = false;
 
-    cancelListeners();
-
     if (d_reconnectingChannelFactory_mp) {
         d_reconnectingChannelFactory_mp->disableReconnect();
     }
+
+    cancelListeners();
 }
 
 void TCPSessionFactory::closeClients()


### PR DESCRIPTION
If a new connection happens before `TCPSessionFactory::stopListening()` and  the IO / authenticator thread is slow and calls  `mqbnet::Channel::setChannel` after `Cluster::initiateShutdown` has called `mqbnet::Channel::stop` which joins the channel thread.
Then, `mqbnet::Channel::setChannel` gets stuck holding IO thread.
The fix - do not call `mqbnet::Channel::setChannel` after `TCPSessionFactory::stopListening()`