### PR TITLE
Fix[bmqeval]: guard against INT64_MIN / -1 quotient overflow

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -58,6 +58,7 @@
 // BDE
 #include <bdld_datum.h>
 #include <bsl_functional.h>
+#include <bsl_limits.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
@@ -966,7 +967,8 @@ bdld::Datum SimpleEvaluator::NumBinaryOperation<Op>::evaluate(
 
     if ((bsl::is_same<Op<int>, bsl::divides<int> >::value ||
          bsl::is_same<Op<int>, bsl::modulus<int> >::value) &&
-        b == 0) {
+        (b == 0 ||
+         (a == bsl::numeric_limits<bsls::Types::Int64>::min() && b == -1))) {
         context.setError(ErrorType::e_ARITHMETIC);
         return bdld::Datum::createNull();  // RETURN
     }

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -23,6 +23,7 @@
 #include <bmqtst_testhelper.h>
 
 #include <bdlma_localsequentialallocator.h>
+#include <bsl_limits.h>
 #include <bsl_sstream.h>
 
 // BENCHMARKING LIBRARY
@@ -63,6 +64,10 @@ MockPropertiesReader::MockPropertiesReader(bslma::Allocator* allocator)
     d_map["i_3"]     = bdld::Datum::createInteger(3);
     d_map["i_42"]    = bdld::Datum::createInteger(42);
     d_map["i64_42"]  = bdld::Datum::createInteger64(42, allocator);
+    d_map["i64_min"] = bdld::Datum::createInteger64(
+        bsl::numeric_limits<bsls::Types::Int64>::min(),
+        allocator);
+    d_map["i_neg1"]  = bdld::Datum::createInteger(-1);
     d_map["s_foo"]   = bdld::Datum::createStringRef("foo", allocator);
     d_map["exists"]  = bdld::Datum::createInteger(42);
 }
@@ -612,6 +617,9 @@ static void test4_evaluationErrors()
         // modulo by zero
         {"i_42 % i_0 == 0", ErrorType::e_ARITHMETIC},
         {"i_42 % i_0 > 1", ErrorType::e_ARITHMETIC},
+        // quotient overflow
+        {"i64_min / i_neg1 == 0", ErrorType::e_ARITHMETIC},
+        {"i64_min % i_neg1 == 0", ErrorType::e_ARITHMETIC},
 
     };
     const TestParameters* testParametersEnd = testParameters +


### PR DESCRIPTION
Closes #1504

This PR extends the existing zero-divisor guard in `NumBinaryOperation::evaluate` to also cover the case where the dividend is `INT64_MIN` and the divisor is `-1`. On x86, the IDIV instruction faults when the quotient overflows the destination register, resulting in SIGFPE.

Both division and modulus with these operands now return `e_ARITHMETIC`.