### PR TITLE
Perf[mqbblp::QueueEngineUtil]: remove `bind` for visitors

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -111,7 +111,8 @@ getMessageQueueTime(const mqbi::StorageMessageAttributes& attributes)
 }
 
 /// Result of a consumer selection, populated by visitors below.
-struct FoundConsumer {
+class FoundConsumer {
+  public:
     mqbi::QueueHandle* d_handle;
     Routers::Consumer* d_consumer;
     unsigned int       d_downstreamSubscriptionId;
@@ -126,13 +127,14 @@ struct FoundConsumer {
 };
 
 /// Visitor that selects the first available consumer.
-struct OneConsumerVisitor : Routers::Visitor {
+class OneConsumerVisitor : public Routers::Visitor {
+  public:
     FoundConsumer* d_result_p;
 
     explicit OneConsumerVisitor(FoundConsumer* result)
     : d_result_p(result)
     {
-        BSLS_ASSERT_SAFE(d_result_p);
+        BSLS_ASSERT(d_result_p);
     }
 
     bool visit(mqbi::QueueHandle* handle,
@@ -149,31 +151,32 @@ struct OneConsumerVisitor : Routers::Visitor {
 
 /// Visitor that selects the first consumer whose message delay has elapsed,
 /// tracking the lowest remaining delay across all consumers.
-struct MinDelayConsumerVisitor : Routers::Visitor {
+class MinDelayConsumerVisitor : public Routers::Visitor {
+  public:
     FoundConsumer*           d_result_p;
     bsls::TimeInterval*      d_delay_p;
     bsls::TimeInterval       d_lowestDelay;
     const bsls::TimeInterval d_delta;
 
-    MinDelayConsumerVisitor(FoundConsumer*            result,
-                            bsls::TimeInterval*       delay,
-                            const bsls::TimeInterval& messageDelay,
-                            const bsls::TimeInterval& now)
+    explicit MinDelayConsumerVisitor(FoundConsumer*            result,
+                                     bsls::TimeInterval*       delay,
+                                     const bsls::TimeInterval& messageDelay,
+                                     const bsls::TimeInterval& now)
     : d_result_p(result)
     , d_delay_p(delay)
     , d_lowestDelay(k_MAX_SECONDS, k_MAX_NANOSECONDS)
     , d_delta(messageDelay - now)
     {
-        BSLS_ASSERT_SAFE(d_result_p);
-        BSLS_ASSERT_SAFE(d_delay_p);
+        BSLS_ASSERT(d_result_p);
+        BSLS_ASSERT(d_delay_p);
     }
 
     bool visit(mqbi::QueueHandle* handle,
                Routers::Consumer* consumer,
                unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
-        BSLS_ASSERT_SAFE(handle);
-        BSLS_ASSERT_SAFE(consumer);
+        BSLS_ASSERT(handle);
+        BSLS_ASSERT(consumer);
 
         bsls::TimeInterval delayLeft = consumer->d_timeLastMessageSent +
                                        d_delta;
@@ -193,20 +196,22 @@ struct MinDelayConsumerVisitor : Routers::Visitor {
 };
 
 /// Visitor that delivers a message to every consumer without tracking.
-struct BroadcastNoTrackVisitor : Routers::Visitor {
+class BroadcastNoTrackVisitor : public Routers::Visitor {
+  private:
     const mqbi::StorageIterator* d_message_p;
 
+  public:
     explicit BroadcastNoTrackVisitor(const mqbi::StorageIterator* message)
     : d_message_p(message)
     {
-        BSLS_ASSERT_SAFE(d_message_p);
+        BSLS_ASSERT(d_message_p);
     }
 
     bool visit(mqbi::QueueHandle* handle,
                BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
                unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
-        BSLS_ASSERT_SAFE(handle);
+        BSLS_ASSERT(handle);
 
         handle->deliverMessageNoTrack(
             *d_message_p,
@@ -219,24 +224,27 @@ struct BroadcastNoTrackVisitor : Routers::Visitor {
 };
 
 /// Visitor that collects a consumer for fanout delivery.
-struct FanoutVisitor : Routers::Visitor {
+class FanoutVisitor : public Routers::Visitor {
+  private:
     QueueEngineUtil_AppsDeliveryContext::Consumers* d_consumers_p;
     const mqbi::AppMessage*                         d_appView_p;
 
-    FanoutVisitor(QueueEngineUtil_AppsDeliveryContext::Consumers* consumers,
-                  const mqbi::AppMessage*                         appView)
+  public:
+    explicit FanoutVisitor(
+        QueueEngineUtil_AppsDeliveryContext::Consumers* consumers,
+        const mqbi::AppMessage*                         appView)
     : d_consumers_p(consumers)
     , d_appView_p(appView)
     {
-        BSLS_ASSERT_SAFE(d_consumers_p);
-        BSLS_ASSERT_SAFE(d_appView_p);
+        BSLS_ASSERT(d_consumers_p);
+        BSLS_ASSERT(d_appView_p);
     }
 
     bool visit(mqbi::QueueHandle* handle,
                BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
                unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
-        BSLS_ASSERT_SAFE(handle);
+        BSLS_ASSERT(handle);
 
         (*d_consumers_p)[handle].push_back(
             bmqp::SubQueueInfo(downstreamSubscriptionId,
@@ -247,21 +255,23 @@ struct FanoutVisitor : Routers::Visitor {
 };
 
 /// Visitor that collects all consumers for broadcast delivery.
-struct BroadcastVisitor : Routers::Visitor {
+class BroadcastVisitor : public Routers::Visitor {
+  private:
     QueueEngineUtil_AppsDeliveryContext::Consumers* d_consumers_p;
 
+  public:
     explicit BroadcastVisitor(
         QueueEngineUtil_AppsDeliveryContext::Consumers* consumers)
     : d_consumers_p(consumers)
     {
-        BSLS_ASSERT_SAFE(d_consumers_p);
+        BSLS_ASSERT(d_consumers_p);
     }
 
     bool visit(mqbi::QueueHandle* handle,
                BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
                unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
-        BSLS_ASSERT_SAFE(handle);
+        BSLS_ASSERT(handle);
 
         (*d_consumers_p)[handle].push_back(
             bmqp::SubQueueInfo(downstreamSubscriptionId));

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.cpp
@@ -110,54 +110,162 @@ getMessageQueueTime(const mqbi::StorageMessageAttributes& attributes)
     return timeDelta;
 }
 
-/// Callback to use in `QueueEngineUtil_AppState::tryDeliverOneMessage`
-struct Visitor {
+/// Result of a consumer selection, populated by visitors below.
+struct FoundConsumer {
     mqbi::QueueHandle* d_handle;
     Routers::Consumer* d_consumer;
-    bsls::TimeInterval d_lowestDelay;
     unsigned int       d_downstreamSubscriptionId;
 
-    Visitor()
+    FoundConsumer()
     : d_handle(0)
     , d_consumer(0)
-    , d_lowestDelay(k_MAX_SECONDS, k_MAX_NANOSECONDS)
     , d_downstreamSubscriptionId(bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID)
     {
         // NOTHING
     }
-    bool oneConsumer(mqbi::QueueHandle* handle,
-                     Routers::Consumer* consumer,
-                     unsigned int       downstreamSubscriptionId)
+};
+
+/// Visitor that selects the first available consumer.
+struct OneConsumerVisitor : Routers::Visitor {
+    FoundConsumer* d_result_p;
+
+    explicit OneConsumerVisitor(FoundConsumer* result)
+    : d_result_p(result)
     {
-        d_handle                   = handle;
-        d_consumer                 = consumer;
-        d_downstreamSubscriptionId = downstreamSubscriptionId;
+        BSLS_ASSERT_SAFE(d_result_p);
+    }
+
+    bool visit(mqbi::QueueHandle* handle,
+               Routers::Consumer* consumer,
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
+    {
+        d_result_p->d_handle                   = handle;
+        d_result_p->d_consumer                 = consumer;
+        d_result_p->d_downstreamSubscriptionId = downstreamSubscriptionId;
 
         return true;
     }
-    bool minDelayConsumer(bsls::TimeInterval*       delay,
-                          mqbi::QueueHandle*        handle,
-                          Routers::Consumer*        consumer,
-                          unsigned int              downstreamSubscriptionId,
-                          const bsls::TimeInterval& messageDelay,
-                          const bsls::TimeInterval& now)
+};
+
+/// Visitor that selects the first consumer whose message delay has elapsed,
+/// tracking the lowest remaining delay across all consumers.
+struct MinDelayConsumerVisitor : Routers::Visitor {
+    FoundConsumer*           d_result_p;
+    bsls::TimeInterval*      d_delay_p;
+    bsls::TimeInterval       d_lowestDelay;
+    const bsls::TimeInterval d_delta;
+
+    MinDelayConsumerVisitor(FoundConsumer*            result,
+                            bsls::TimeInterval*       delay,
+                            const bsls::TimeInterval& messageDelay,
+                            const bsls::TimeInterval& now)
+    : d_result_p(result)
+    , d_delay_p(delay)
+    , d_lowestDelay(k_MAX_SECONDS, k_MAX_NANOSECONDS)
+    , d_delta(messageDelay - now)
+    {
+        BSLS_ASSERT_SAFE(d_result_p);
+        BSLS_ASSERT_SAFE(d_delay_p);
+    }
+
+    bool visit(mqbi::QueueHandle* handle,
+               Routers::Consumer* consumer,
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
         BSLS_ASSERT_SAFE(handle);
         BSLS_ASSERT_SAFE(consumer);
 
         bsls::TimeInterval delayLeft = consumer->d_timeLastMessageSent +
-                                       messageDelay - now;
+                                       d_delta;
 
         if (delayLeft <= 0) {
-            d_handle                   = handle;
-            d_consumer                 = consumer;
-            d_downstreamSubscriptionId = downstreamSubscriptionId;
+            d_result_p->d_handle                   = handle;
+            d_result_p->d_consumer                 = consumer;
+            d_result_p->d_downstreamSubscriptionId = downstreamSubscriptionId;
 
             return true;
         }
         if (d_lowestDelay > delayLeft) {
-            *delay = d_lowestDelay = delayLeft;
+            *d_delay_p = d_lowestDelay = delayLeft;
         }
+        return false;
+    }
+};
+
+/// Visitor that delivers a message to every consumer without tracking.
+struct BroadcastNoTrackVisitor : Routers::Visitor {
+    const mqbi::StorageIterator* d_message_p;
+
+    explicit BroadcastNoTrackVisitor(const mqbi::StorageIterator* message)
+    : d_message_p(message)
+    {
+        BSLS_ASSERT_SAFE(d_message_p);
+    }
+
+    bool visit(mqbi::QueueHandle* handle,
+               BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
+    {
+        BSLS_ASSERT_SAFE(handle);
+
+        handle->deliverMessageNoTrack(
+            *d_message_p,
+            bmqp::Protocol::SubQueueInfosArray(
+                1,
+                bmqp::SubQueueInfo(downstreamSubscriptionId)));
+
+        return false;
+    }
+};
+
+/// Visitor that collects a consumer for fanout delivery.
+struct FanoutVisitor : Routers::Visitor {
+    QueueEngineUtil_AppsDeliveryContext::Consumers* d_consumers_p;
+    const mqbi::AppMessage*                         d_appView_p;
+
+    FanoutVisitor(QueueEngineUtil_AppsDeliveryContext::Consumers* consumers,
+                  const mqbi::AppMessage*                         appView)
+    : d_consumers_p(consumers)
+    , d_appView_p(appView)
+    {
+        BSLS_ASSERT_SAFE(d_consumers_p);
+        BSLS_ASSERT_SAFE(d_appView_p);
+    }
+
+    bool visit(mqbi::QueueHandle* handle,
+               BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
+    {
+        BSLS_ASSERT_SAFE(handle);
+
+        (*d_consumers_p)[handle].push_back(
+            bmqp::SubQueueInfo(downstreamSubscriptionId,
+                               d_appView_p->d_rdaInfo));
+
+        return true;
+    }
+};
+
+/// Visitor that collects all consumers for broadcast delivery.
+struct BroadcastVisitor : Routers::Visitor {
+    QueueEngineUtil_AppsDeliveryContext::Consumers* d_consumers_p;
+
+    explicit BroadcastVisitor(
+        QueueEngineUtil_AppsDeliveryContext::Consumers* consumers)
+    : d_consumers_p(consumers)
+    {
+        BSLS_ASSERT_SAFE(d_consumers_p);
+    }
+
+    bool visit(mqbi::QueueHandle* handle,
+               BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
+    {
+        BSLS_ASSERT_SAFE(handle);
+
+        (*d_consumers_p)[handle].push_back(
+            bmqp::SubQueueInfo(downstreamSubscriptionId));
+
         return false;
     }
 };
@@ -638,21 +746,6 @@ QueueEngineUtil_AppsDeliveryContext::QueueEngineUtil_AppsDeliveryContext(
 , d_currentMessage_p(0)
 , d_queue_p(queue)
 , d_timeDelta()
-, d_currentAppView_p(0)
-, d_fanoutVisitor(
-      bdlf::BindUtil::bindS(allocator,
-                            &QueueEngineUtil_AppsDeliveryContext::visit,
-                            this,
-                            bdlf::PlaceHolders::_1,
-                            bdlf::PlaceHolders::_2,
-                            bdlf::PlaceHolders::_3))
-, d_broadcastVisitor(bdlf::BindUtil::bindS(
-      allocator,
-      &QueueEngineUtil_AppsDeliveryContext::visitBroadcast,
-      this,
-      bdlf::PlaceHolders::_1,
-      bdlf::PlaceHolders::_2,
-      bdlf::PlaceHolders::_3))
 , d_revCounter(0)
 {
     BSLS_ASSERT_SAFE(queue);
@@ -693,8 +786,8 @@ bool QueueEngineUtil_AppsDeliveryContext::processApp(
 
     if (d_queue_p->isDeliverAll()) {
         // collect all handles
-        app.routing()->iterateConsumers(d_broadcastVisitor,
-                                        d_currentMessage_p);
+        BroadcastVisitor visitor(&d_consumers);
+        app.routing()->iterateConsumers(visitor, d_currentMessage_p);
 
         // Broadcast does not need stats nor any special per-message treatment.
         return false;  // RETURN
@@ -725,14 +818,10 @@ bool QueueEngineUtil_AppsDeliveryContext::processApp(
     // mapped file, which can delay the unmapping of files in case this
     // message has a huge TTL and there are no consumers for this message.
 
-    d_currentAppView_p     = &appView;
-    Routers::Result result = app.selectConsumer(d_fanoutVisitor,
+    FanoutVisitor   fanoutVisitor(&d_consumers, &appView);
+    Routers::Result result = app.selectConsumer(fanoutVisitor,
                                                 d_currentMessage_p,
                                                 ordinal);
-    // We use this pointer only from `d_visitVisitor`, so not cleaning it is
-    // okay, but we clean it to keep contract that `d_currentAppView_p` only
-    // points at the actual AppView.
-    d_currentAppView_p = NULL;
 
     if (result == Routers::e_SUCCESS) {
         // RootQueueEngine makes stat reports
@@ -765,36 +854,6 @@ bool QueueEngineUtil_AppsDeliveryContext::processApp(
     app.putAside(d_currentMessage_p->guid());
 
     return putAsideReturnValue;
-}
-
-bool QueueEngineUtil_AppsDeliveryContext::visit(
-    mqbi::QueueHandle* handle,
-    BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
-    unsigned int                         downstreamSubscriptionId)
-{
-    BSLS_ASSERT_SAFE(handle);
-    BSLS_ASSERT_SAFE(
-        d_currentAppView_p &&
-        "`d_currentAppView_p` must be assigned before calling this function");
-
-    d_consumers[handle].push_back(
-        bmqp::SubQueueInfo(downstreamSubscriptionId,
-                           d_currentAppView_p->d_rdaInfo));
-
-    return true;
-}
-
-bool QueueEngineUtil_AppsDeliveryContext::visitBroadcast(
-    mqbi::QueueHandle* handle,
-    BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
-    unsigned int                         downstreamSubscriptionId)
-{
-    BSLS_ASSERT_SAFE(handle);
-
-    d_consumers[handle].push_back(
-        bmqp::SubQueueInfo(downstreamSubscriptionId));
-
-    return false;
 }
 
 void QueueEngineUtil_AppsDeliveryContext::deliverMessage()
@@ -1003,34 +1062,21 @@ Routers::Result QueueEngineUtil_AppState::tryDeliverOneMessage(
 
     bsls::TimeInterval messageDelay;
     bsls::TimeInterval now = bmqu::Time::nowMonotonicClock();
-    Visitor            visitor;
+    FoundConsumer      found;
 
     Routers::Result result = Routers::e_SUCCESS;
 
     if (!QueueEngineUtil::loadMessageDelay(appView.d_rdaInfo,
                                            d_queue_p->messageThrottleConfig(),
                                            &messageDelay)) {
-        result = selectConsumer(bdlf::BindUtil::bind(&Visitor::oneConsumer,
-                                                     &visitor,
-                                                     bdlf::PlaceHolders::_1,
-                                                     bdlf::PlaceHolders::_2,
-                                                     bdlf::PlaceHolders::_3),
-                                message,
-                                ordinal());
+        OneConsumerVisitor visitor(&found);
+        result = selectConsumer(visitor, message, ordinal());
         // RelayQueueEngine_VirtualPushStorageIterator ignores ordinal
     }
     else {
+        MinDelayConsumerVisitor visitor(&found, delay, messageDelay, now);
         // Iterate all highest priority consumers and find the lowest delay
-        if (!d_routing_sp->iterateConsumers(
-                bdlf::BindUtil::bind(&Visitor::minDelayConsumer,
-                                     &visitor,
-                                     delay,
-                                     bdlf::PlaceHolders::_1,
-                                     bdlf::PlaceHolders::_2,
-                                     bdlf::PlaceHolders::_3,
-                                     messageDelay,
-                                     now),
-                message)) {
+        if (!d_routing_sp->iterateConsumers(visitor, message)) {
             result = Routers::e_DELAY;
         }
 
@@ -1040,23 +1086,23 @@ Routers::Result QueueEngineUtil_AppState::tryDeliverOneMessage(
         // one consumer so we don't return a lowestDelay set to its max value.
     }
 
-    if (!visitor.d_handle) {
+    if (!found.d_handle) {
         return result;  // RETURN
     }
-    BSLS_ASSERT_SAFE(visitor.d_consumer);
+    BSLS_ASSERT_SAFE(found.d_consumer);
 
     BSLS_ASSERT_SAFE(result == Routers::e_SUCCESS);
 
     const bmqp::Protocol::SubQueueInfosArray subQueueInfos(
         1,
-        bmqp::SubQueueInfo(visitor.d_downstreamSubscriptionId,
+        bmqp::SubQueueInfo(found.d_downstreamSubscriptionId,
                            message->appMessageView(ordinal()).d_rdaInfo));
-    visitor.d_handle->deliverMessage(*message,
-                                     subQueueInfos,
-                                     true /* out of order */);
+    found.d_handle->deliverMessage(*message,
+                                   subQueueInfos,
+                                   true /* out of order */);
 
-    visitor.d_consumer->d_timeLastMessageSent = now;
-    visitor.d_consumer->d_lastSentMessage     = message->guid();
+    found.d_consumer->d_timeLastMessageSent = now;
+    found.d_consumer->d_lastSentMessage     = message->guid();
 
     return result;
 }
@@ -1064,31 +1110,8 @@ Routers::Result QueueEngineUtil_AppState::tryDeliverOneMessage(
 void QueueEngineUtil_AppState::broadcastOneMessage(
     const mqbi::StorageIterator* storageIter)
 {
-    d_routing_sp->iterateConsumers(
-        bdlf::BindUtil::bind(&QueueEngineUtil_AppState::visitBroadcast,
-                             this,
-                             storageIter,
-                             bdlf::PlaceHolders::_1,
-                             bdlf::PlaceHolders::_2,
-                             bdlf::PlaceHolders::_3),
-        storageIter);
-}
-
-bool QueueEngineUtil_AppState::visitBroadcast(
-    const mqbi::StorageIterator* message,
-    mqbi::QueueHandle*           handle,
-    BSLA_MAYBE_UNUSED Routers::Consumer* consumer,
-    unsigned int                         downstreamSubscriptionId)
-{
-    BSLS_ASSERT_SAFE(handle);
-    // TBD: groupId: send 'options' as well...
-    handle->deliverMessageNoTrack(
-        *message,
-        bmqp::Protocol::SubQueueInfosArray(
-            1,
-            bmqp::SubQueueInfo(downstreamSubscriptionId)));
-
-    return false;
+    BroadcastNoTrackVisitor visitor(storageIter);
+    d_routing_sp->iterateConsumers(visitor, storageIter);
 }
 
 size_t
@@ -1344,7 +1367,7 @@ bool QueueEngineUtil_AppState::transferUnconfirmedMessages(
 }
 
 Routers::Result QueueEngineUtil_AppState::selectConsumer(
-    const Routers::Visitor&      visitor,
+    Routers::Visitor&            visitor,
     const mqbi::StorageIterator* currentMessage,
     unsigned int                 ordinal)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueengineutil.h
@@ -433,10 +433,6 @@ struct QueueEngineUtil_AppState {
     /// `appData`, `options`, `guid` and `attributes`.  Behavior is
     /// undefined unless `appData` is non-null.
     void broadcastOneMessage(const mqbi::StorageIterator* storageIter);
-    bool visitBroadcast(const mqbi::StorageIterator* message,
-                        mqbi::QueueHandle*           handle,
-                        Routers::Consumer*           consumer,
-                        unsigned int                 downstreamSubscriptionId);
 
     size_t processDeliveryLists(bsls::TimeInterval*    delay,
                                 mqbi::StorageIterator* reader);
@@ -495,7 +491,7 @@ struct QueueEngineUtil_AppState {
 
     void invalidate(mqbi::QueueHandle* handle);
 
-    Routers::Result selectConsumer(const Routers::Visitor&      visitor,
+    Routers::Result selectConsumer(Routers::Visitor&            visitor,
                                    const mqbi::StorageIterator* currentMessage,
                                    unsigned int                 ordinal);
 
@@ -616,16 +612,6 @@ struct QueueEngineUtil_AppsDeliveryContext {
     mqbi::Queue*                      d_queue_p;
     bsl::optional<bsls::Types::Int64> d_timeDelta;
 
-    /// Mutable additional argument used in `visit()`, when it is called from
-    /// `d_visitVisitor` functor.
-    const mqbi::AppMessage* d_currentAppView_p;
-
-    /// Cached functor to `QueueEngineUtil_AppsDeliveryContext::visit`
-    const Routers::Visitor d_fanoutVisitor;
-
-    /// Cached functor to `QueueEngineUtil_AppsDeliveryContext::visitBroadcast`
-    const Routers::Visitor d_broadcastVisitor;
-
     /// Count delivery attempts (as a means to invalidate `lastPush`)
     int d_revCounter;
 
@@ -670,14 +656,6 @@ struct QueueEngineUtil_AppsDeliveryContext {
     bool processApp(QueueEngineUtil_AppState& app,
                     unsigned int              ordina,
                     bool                      putAsideReturnValue);
-
-    /// Collect and prepare data for the subsequent `deliverMessage` call.
-    bool visit(mqbi::QueueHandle* handle,
-               Routers::Consumer* consumer,
-               unsigned int       downstreamSubscriptionId);
-    bool visitBroadcast(mqbi::QueueHandle* handle,
-                        Routers::Consumer* consumer,
-                        unsigned int       downstreamSubscriptionId);
 
     /// Deliver message to the previously processed handles.
     void deliverMessage();

--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -85,6 +85,15 @@ void Routers::Consumer::registerSubscriptions(mqbi::QueueHandle* handle)
     }
 }
 
+// ----------------------
+// struct Routers::Visitor
+// ----------------------
+
+Routers::Visitor::~Visitor()
+{
+    // NOTHING
+}
+
 // =======================================
 // struct Routers::MessagePropertiesReader
 // =======================================
@@ -632,7 +641,7 @@ void Routers::AppContext::reset()
 }
 
 Routers::Result Routers::AppContext::selectConsumer(
-    const Visitor&               visitor,
+    Visitor&                     visitor,
     const mqbi::StorageIterator* currentMessage,
     unsigned int                 subscriptionId)
 {
@@ -675,7 +684,7 @@ Routers::Result Routers::AppContext::selectConsumer(
 // class Routers::RoundRobin
 // -------------------------
 
-Routers::Result Routers::RoundRobin::iterateGroups(const Visitor& visitor)
+Routers::Result Routers::RoundRobin::iterateGroups(Visitor& visitor)
 {
     bool haveMatch        = false;
     bool noneHaveCapacity = true;
@@ -722,7 +731,7 @@ Routers::Result Routers::RoundRobin::iterateGroups(const Visitor& visitor)
     }
 }
 
-bool Routers::RoundRobin::iterateSubscriptions(const Visitor& visitor,
+bool Routers::RoundRobin::iterateSubscriptions(Visitor&       visitor,
                                                PriorityGroup& group)
 {
     SubscriptionList& subscriptions = group.d_highestSubscriptions;
@@ -736,9 +745,9 @@ bool Routers::RoundRobin::iterateSubscriptions(const Visitor& visitor,
 
         if (BSLS_PERFORMANCEHINT_PREDICT_LIKELY(handle->canDeliver(
                 subscription->d_downstreamSubscriptionId))) {
-            if (visitor(handle,
-                        subscription->consumer(),
-                        subscription->d_downstreamSubscriptionId)) {
+            if (visitor.visit(handle,
+                              subscription->consumer(),
+                              subscription->d_downstreamSubscriptionId)) {
                 // Before returning, move the subscription to the end if needed
                 // for the round-robin.
                 if (subscription->advance()) {
@@ -755,7 +764,7 @@ bool Routers::RoundRobin::iterateSubscriptions(const Visitor& visitor,
 }
 
 bool Routers::AppContext::iterateConsumers(
-    const Visitor&               visitor,
+    Visitor&                     visitor,
     const mqbi::StorageIterator* message)
 {
     // PRECONDITIONS
@@ -777,9 +786,9 @@ bool Routers::AppContext::iterateConsumers(
             if (!consumer.d_highestSubscriptions.empty()) {
                 // If this is not SDK, ignore subscriptions and PUSH
                 // unconditionally.
-                if (visitor(cit->first,
-                            &consumer,
-                            bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID)) {
+                if (visitor.visit(cit->first,
+                                  &consumer,
+                                  bmqp::Protocol::k_DEFAULT_SUBSCRIPTION_ID)) {
                     return true;  // RETURN
                 }
             }
@@ -790,9 +799,9 @@ bool Routers::AppContext::iterateConsumers(
             const Routers::Subscription* subscription = selectSubscription(
                 itConsumer);
             if (subscription) {
-                if (visitor(cit->first,
-                            &consumer,
-                            subscription->d_downstreamSubscriptionId)) {
+                if (visitor.visit(cit->first,
+                                  &consumer,
+                                  subscription->d_downstreamSubscriptionId)) {
                     return true;  // RETURN
                 }
             }

--- a/src/groups/mqb/mqbblp/mqbblp_routers.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.cpp
@@ -86,7 +86,7 @@ void Routers::Consumer::registerSubscriptions(mqbi::QueueHandle* handle)
 }
 
 // ----------------------
-// struct Routers::Visitor
+// class Routers::Visitor
 // ----------------------
 
 Routers::Visitor::~Visitor()

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -639,10 +639,12 @@ class Routers {
         void loadInternals(mqbcmd::Routing* out) const;
     };
 
-    typedef bsl::function<bool(mqbi::QueueHandle* handle,
-                               Routers::Consumer* consumer,
-                               unsigned int       downstreamSubscriptionId)>
-        Visitor;
+    struct Visitor {
+        virtual ~Visitor();
+        virtual bool visit(mqbi::QueueHandle* handle,
+                           Consumer*          consumer,
+                           unsigned int       downstreamSubscriptionId) = 0;
+    };
 
     enum Result {
         /// Found Subscription and there is capacity.
@@ -682,7 +684,7 @@ class Routers {
         /// subscription to the end of round-robind selection list if it has
         /// been selected `d_consumerPriorityCount` times , and return
         /// `true`.
-        Result iterateGroups(const Visitor& visitor);
+        Result iterateGroups(Visitor& visitor);
 
         /// Iterate all highest priority `Subscription`s within the
         /// specified `group` and call the specified `visitor` for each
@@ -690,8 +692,7 @@ class Routers {
         /// `visitor` returns `true`, stop iterating, move the subscription
         /// to the end of round-robind selection list if it has been
         /// selected `d_consumerPriorityCount` times, and return `true`.
-        bool iterateSubscriptions(const Visitor& visitor,
-                                  PriorityGroup& group);
+        bool iterateSubscriptions(Visitor& visitor, PriorityGroup& group);
 
         void print(bsl::ostream& os, int level, int spacesPerLevel) const;
     };
@@ -770,7 +771,7 @@ class Routers {
         /// been selected `d_consumerPriorityCount` times, and return
         /// `true`.
         Routers::Result
-        selectConsumer(const Visitor&               visitor,
+        selectConsumer(Visitor&                     visitor,
                        const mqbi::StorageIterator* currentMessage,
                        unsigned int                 subscriptionId);
 
@@ -779,7 +780,7 @@ class Routers {
         /// which has `canDeliver` consumer and which `Expression` matches
         /// the specified `currentMessage`.  If the `visitor` returns
         /// `true`, stop iterating and return `true`.
-        bool iterateConsumers(const Visitor&               visitor,
+        bool iterateConsumers(Visitor&                     visitor,
                               const mqbi::StorageIterator* message);
 
         /// Iterate all highest priority highest priority `Subscription`s

--- a/src/groups/mqb/mqbblp/mqbblp_routers.h
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.h
@@ -639,7 +639,8 @@ class Routers {
         void loadInternals(mqbcmd::Routing* out) const;
     };
 
-    struct Visitor {
+    class Visitor {
+      public:
         virtual ~Visitor();
         virtual bool visit(mqbi::QueueHandle* handle,
                            Consumer*          consumer,

--- a/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
@@ -120,7 +120,8 @@ struct TestStorage {
     }
 };
 
-struct Visitor : mqbblp::Routers::Visitor {
+class Visitor : public mqbblp::Routers::Visitor {
+  public:
     mqbi::QueueHandle*         d_handle;
     unsigned int               d_subQueueId;
     mqbblp::Routers::Consumer* d_consumer;

--- a/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_routers.t.cpp
@@ -34,7 +34,6 @@
 #include <bdlbb_blob.h>
 #include <bdlbb_blobutil.h>
 #include <bdlbb_pooledblobbufferfactory.h>
-#include <bdlf_bind.h>
 #include <bsla_annotations.h>
 #include <bsls_platform.h>
 #include <bsls_protocoltest.h>
@@ -121,7 +120,7 @@ struct TestStorage {
     }
 };
 
-struct Visitor {
+struct Visitor : mqbblp::Routers::Visitor {
     mqbi::QueueHandle*         d_handle;
     unsigned int               d_subQueueId;
     mqbblp::Routers::Consumer* d_consumer;
@@ -133,9 +132,11 @@ struct Visitor {
     {
         // NOTHING
     }
+    ~Visitor() BSLS_KEYWORD_OVERRIDE;
+
     bool visit(mqbi::QueueHandle*         handle,
                mqbblp::Routers::Consumer* consumer,
-               unsigned int               downstreamSubscriptionId)
+               unsigned int downstreamSubscriptionId) BSLS_KEYWORD_OVERRIDE
     {
         d_subQueueId = downstreamSubscriptionId;
         d_consumer   = consumer;
@@ -144,6 +145,11 @@ struct Visitor {
         return true;
     }
 };
+
+Visitor::~Visitor()
+{
+    // NOTHING
+}
 
 struct Item {
     int d_i;
@@ -312,12 +318,7 @@ static void test3_parse()
             appContext.registerSubscriptions();
 
             mqbblp::Routers::RoundRobin router(appContext.d_priorities);
-            BMQTST_ASSERT_EQ(router.iterateGroups(
-                                 bdlf::BindUtil::bind(&Visitor::visit,
-                                                      &visitor1,
-                                                      bdlf::PlaceHolders::_1,
-                                                      bdlf::PlaceHolders::_2,
-                                                      bdlf::PlaceHolders::_3)),
+            BMQTST_ASSERT_EQ(router.iterateGroups(visitor1),
                              mqbblp::Routers::e_SUCCESS);
 
             BMQTST_ASSERT_EQ(&handle1, visitor1.d_handle);
@@ -352,12 +353,7 @@ static void test3_parse()
 
             mqbblp::Routers::RoundRobin router(appContext.d_priorities);
 
-            BMQTST_ASSERT_EQ(router.iterateGroups(
-                                 bdlf::BindUtil::bind(&Visitor::visit,
-                                                      &visitor1,
-                                                      bdlf::PlaceHolders::_1,
-                                                      bdlf::PlaceHolders::_2,
-                                                      bdlf::PlaceHolders::_3)),
+            BMQTST_ASSERT_EQ(router.iterateGroups(visitor1),
                              mqbblp::Routers::e_SUCCESS);
 
             BMQTST_ASSERT_EQ(&handle1, visitor1.d_handle);
@@ -403,31 +399,16 @@ static void test3_parse()
             BMQTST_ASSERT_EQ(appContext.finalize(), size_t(2 * priorityCount));
             appContext.registerSubscriptions();
 
-            BMQTST_ASSERT_EQ(router.iterateGroups(
-                                 bdlf::BindUtil::bind(&Visitor::visit,
-                                                      &visitor1,
-                                                      bdlf::PlaceHolders::_1,
-                                                      bdlf::PlaceHolders::_2,
-                                                      bdlf::PlaceHolders::_3)),
+            BMQTST_ASSERT_EQ(router.iterateGroups(visitor1),
                              mqbblp::Routers::e_SUCCESS);
 
-            BMQTST_ASSERT_EQ(router.iterateGroups(
-                                 bdlf::BindUtil::bind(&Visitor::visit,
-                                                      &visitor2,
-                                                      bdlf::PlaceHolders::_1,
-                                                      bdlf::PlaceHolders::_2,
-                                                      bdlf::PlaceHolders::_3)),
+            BMQTST_ASSERT_EQ(router.iterateGroups(visitor2),
                              mqbblp::Routers::e_SUCCESS);
 
             BMQTST_ASSERT_EQ(visitor2.d_handle, visitor1.d_handle);
             BMQTST_ASSERT_EQ(visitor2.d_subQueueId, visitor1.d_subQueueId);
 
-            BMQTST_ASSERT_EQ(router.iterateGroups(
-                                 bdlf::BindUtil::bind(&Visitor::visit,
-                                                      &visitor2,
-                                                      bdlf::PlaceHolders::_1,
-                                                      bdlf::PlaceHolders::_2,
-                                                      bdlf::PlaceHolders::_3)),
+            BMQTST_ASSERT_EQ(router.iterateGroups(visitor2),
                              mqbblp::Routers::e_SUCCESS);
 
             if (visitor1.d_handle == &handle1) {


### PR DESCRIPTION
Changes:

- Replace `Routers::Visitor` `bsl::function` with an abstract interface.

- 5 dedicated visitor implementations:
`Visitor::oneConsumer` -> `OneConsumerVisitor`
`Visitor::minDelayConsumer` -> `MinDelayConsumerVisitor`
`QueueEngineUtil_AppState::visitBroadcast` -> `BroadcastNoTrackVisitor`
`QueueEngineUtil_AppsDeliveryContext::visit` -> `FanoutVisitor`
`QueueEngineUtil_AppsDeliveryContext::visitBroadcast` -> `BroadcastVisitor`

- Remove `Visitor` struct that is not needed anymore.
- Remove `bind`, use stack-constructed visitor implementations for iteration.
- Remove cached `d_fanoutVisitor`, `d_broadcastVisitor`, `d_currentAppView_p`.

Stack constructed interface implementations are a few times faster than the cached `bsl::function` (**RelWithDebInfo**):
```
Iterations: 10000000, consumers per call: 4

  Cached bsl::function (old):     5 ns/call (55 ms total)
  Virtual interface (new):        1 ns/call (15 ms total)

  Virtual interface is 72% FASTER
```