### PR TITLE
Fix[bmqbrkr]: keep `bmqu::Time` initialized

### DIFF
--- a/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
+++ b/src/applications/bmqbrkr/m_bmqbrkr_task.cpp
@@ -25,6 +25,7 @@
 #include <bmqtsk_alarmlog.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
+#include <bmqu_time.h>
 
 // BDE
 #include <bdlb_string.h>
@@ -277,6 +278,8 @@ int Task::initialize(bsl::ostream&             errorDescription,
     int                rc = rc_SUCCESS;
     bmqu::MemOutStream localError;
 
+    bmqu::Time::initialize();
+
     // ---------
     // Scheduler
     rc = d_scheduler.start();
@@ -378,6 +381,8 @@ void Task::shutdown()
 
     // Stop the scheduler
     d_scheduler.stop();
+
+    bmqu::Time::shutdown();
 
     d_isInitialized = false;
 }

--- a/src/groups/bmq/bmqu/bmqu_time.cpp
+++ b/src/groups/bmq/bmqu/bmqu_time.cpp
@@ -67,12 +67,7 @@ void Time::initialize(bslma::Allocator* allocator)
     // PRECONDITIONS
     bslmt::QLockGuard qlockGuard(&g_initLock);
 
-    // NOTE: We pre-increment here instead of post-incrementing inside the
-    //       conditional check below because the post-increment of an int does
-    //       not work correctly with versions of IBM xlc12 released following
-    //       the Dec 2015 PTF.
-    ++g_initialized;
-    if (g_initialized > 1) {
+    if (++g_initialized > 1) {
         return;  // RETURN
     }
 
@@ -104,12 +99,7 @@ void Time::initialize(const SystemTimeCb&         realTimeClockCb,
     // PRECONDITIONS
     bslmt::QLockGuard qlockGuard(&g_initLock);
 
-    // NOTE: We pre-increment here instead of post-incrementing inside the
-    //       conditional check below because the post-increment of an int does
-    //       not work correctly with versions of IBM xlc12 released following
-    //       the Dec 2015 PTF.
-    ++g_initialized;
-    if (g_initialized > 1) {
+    if (++g_initialized > 1) {
         return;  // RETURN
     }
 
@@ -121,6 +111,8 @@ void Time::initialize(const SystemTimeCb&         realTimeClockCb,
         SystemTimeCb(bsl::allocator_arg, alloc, monotonicClockCb);
     new (g_highResTimer.buffer())
         HighResolutionTimeCb(bsl::allocator_arg, alloc, highResTimeCb);
+
+    bsls::TimeUtil::initialize();
 }
 
 void Time::shutdown()


### PR DESCRIPTION
There was a brief time window between `bmqu::Time::shutdown` and `scheduler->stop()` when `bmqu::Time` is not initialized. Any time call will cause a crash.

`bmqu::Time::initialize`/`bmqu::Time::shutdown` are refcounted so I extend the life scope of `bmqu::Time` to the `Task` lifetime

This PR fixes the following crash
```
    #6  0x00007f2d0eabb0da in ?? () from /lib/x86_64-linux-gnu/libstdc++.so.6                                         
    No symbol table info available.                                                                                   
    #7  0x00007f2d0eaa5a55 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6                           
    No symbol table info available.                                                                                   
    #8  0x00007f2d0eabb391 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6                                
    No symbol table info available.                                                                                   
    #9  0x000055a66f9ef222 in BloombergLP::bslstl::Function_Variadic<long long ()>::operator()() const [clone         
  .part.0] ()                                                                                                         
    No symbol table info available.                                                                                   
    #10 0x000055a66f9ef22b in BloombergLP::defaultDispatcherFunction(bsl::function<void ()> const&) [clone .cold] ()  
    No symbol table info available.                                                                                   
    #11 0x000055a670aac60d in BloombergLP::bdlmt::EventScheduler::dispatchEvents() ()                                 
    No symbol table info available. 
```