### PR TITLE
FIX: Broker now receives the PUT message sent in the fuzztests

### DIFF
--- a/src/python/blazingmq/dev/fuzztest/__init__.py
+++ b/src/python/blazingmq/dev/fuzztest/__init__.py
@@ -180,11 +180,13 @@ def wrap_event(
         endian=">",
         inclusive=True,
         length=NumBytes.WORD,
+        fuzzable=False,
     )
     event_desc = boofuzz.Bytes(
         name="event_desc",
         default_value=bytes([0x40 + event_type, 0x02, type_specific, 0x00]),
         size=NumBytes.WORD,
+        fuzzable=False,
     )
 
     build_block = PaddingBlock if add_padding else boofuzz.Block


### PR DESCRIPTION
**Describe your changes**
Turned off fuzz for event size and description. The broker wasn't recognizing PUT messages with malformed event descriptions and sizes. 

**Testing performed**
Manually viewing on wireshark. 

**Additional context**

Before Changes:
<img width="1495" height="530" alt="image" src="https://github.com/user-attachments/assets/887d459c-563d-4f35-8784-b83f53b9952f" />

After:
<img width="3597" height="1214" alt="image" src="https://github.com/user-attachments/assets/9a6902e7-e728-4697-8e1a-263ae96b9c44" />
