### PR TITLE
Cleanup[bmqp_ctrlmsg.xsd]: Primary lease id in ReplicaDataRequest/Response

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg.xsd
@@ -786,9 +786,10 @@
         This type represents a request sent to the replica by the primary to
         start the synchronization of data.
 
+        partitionId:         partition id for corresponding partition.
+        primaryLeaseId:      lease id of the current primary.
         replicaDataType:     type of request i.e. PULL, PUSH or DROP for
                              corresponding partition.
-        partitionId:         partition id for corresponding partition.
         beginSequenceNumber: Primary's begin sequence number for corresponding
                              partition for corresponding data chunks.
         endSequenceNumber:   Primary's end sequence number for corresponding
@@ -796,8 +797,9 @@
       </documentation>
     </annotation>
     <sequence>
-      <element name='replicaDataType'     type='tns:ReplicaDataType'/>
       <element name='partitionId'         type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
+      <element name='replicaDataType'     type='tns:ReplicaDataType'/>
       <element name='beginSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='endSequenceNumber'   type='tns:PartitionSequenceNumber'/>
     </sequence>
@@ -809,12 +811,13 @@
         This type represents a response sent by a replica to the primary for
         the data synchronization request received by it.
 
+        partitionId:         partition id for corresponding partition.
+        primaryLeaseId:      lease id of the current primary.
         replicaDataType:     type of request received i.e. PULL, PUSH or DROP
                              for corresponding partition. Note, this field will
                              be set as per the request received and the primary
                              purpose of sending this field back in response is
                              for debugging and sanity checking.
-        partitionId:         partition id for corresponding partition.
         beginSequenceNumber: Replica's begin sequence number for corresponding
                              partition for corresponding data chunks.
         endSequenceNumber:   Replica's end sequence number for corresponding
@@ -822,8 +825,9 @@
       </documentation>
     </annotation>
     <sequence>
-      <element name='replicaDataType' type='tns:ReplicaDataType'/>
       <element name='partitionId'     type='int'/>
+      <element name='primaryLeaseId' type='unsignedInt'/>
+      <element name='replicaDataType' type='tns:ReplicaDataType'/>
       <element name='beginSequenceNumber' type='tns:PartitionSequenceNumber'/>
       <element name='endSequenceNumber'   type='tns:PartitionSequenceNumber'/>
     </sequence>

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.cpp
@@ -544,18 +544,18 @@ bsl::ostream& AuthenticationRequest::print(bsl::ostream& stream,
 const char ClientLanguage::CLASS_NAME[] = "ClientLanguage";
 
 const bdlat_EnumeratorInfo ClientLanguage::ENUMERATOR_INFO_ARRAY[] = {
-    {ClientLanguage::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ClientLanguage::e_E_CPP, "E_CPP", sizeof("E_CPP") - 1, ""},
-    {ClientLanguage::e_E_JAVA, "E_JAVA", sizeof("E_JAVA") - 1, ""}};
+    {ClientLanguage::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ClientLanguage::E_CPP, "E_CPP", sizeof("E_CPP") - 1, ""},
+    {ClientLanguage::E_JAVA, "E_JAVA", sizeof("E_JAVA") - 1, ""}};
 
 // CLASS METHODS
 
 int ClientLanguage::fromInt(ClientLanguage::Value* result, int number)
 {
     switch (number) {
-    case ClientLanguage::e_E_UNKNOWN:
-    case ClientLanguage::e_E_CPP:
-    case ClientLanguage::e_E_JAVA:
+    case ClientLanguage::E_UNKNOWN:
+    case ClientLanguage::E_CPP:
+    case ClientLanguage::E_JAVA:
         *result = static_cast<ClientLanguage::Value>(number);
         return 0;
     default: return -1;
@@ -584,13 +584,13 @@ int ClientLanguage::fromString(ClientLanguage::Value* result,
 const char* ClientLanguage::toString(ClientLanguage::Value value)
 {
     switch (value) {
-    case e_E_UNKNOWN: {
+    case E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case e_E_CPP: {
+    case E_CPP: {
         return "E_CPP";
     }
-    case e_E_JAVA: {
+    case E_JAVA: {
         return "E_JAVA";
     }
     }
@@ -608,20 +608,20 @@ const char* ClientLanguage::toString(ClientLanguage::Value value)
 const char ClientType::CLASS_NAME[] = "ClientType";
 
 const bdlat_EnumeratorInfo ClientType::ENUMERATOR_INFO_ARRAY[] = {
-    {ClientType::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ClientType::e_E_TCPCLIENT, "E_TCPCLIENT", sizeof("E_TCPCLIENT") - 1, ""},
-    {ClientType::e_E_TCPBROKER, "E_TCPBROKER", sizeof("E_TCPBROKER") - 1, ""},
-    {ClientType::e_E_TCPADMIN, "E_TCPADMIN", sizeof("E_TCPADMIN") - 1, ""}};
+    {ClientType::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ClientType::E_TCPCLIENT, "E_TCPCLIENT", sizeof("E_TCPCLIENT") - 1, ""},
+    {ClientType::E_TCPBROKER, "E_TCPBROKER", sizeof("E_TCPBROKER") - 1, ""},
+    {ClientType::E_TCPADMIN, "E_TCPADMIN", sizeof("E_TCPADMIN") - 1, ""}};
 
 // CLASS METHODS
 
 int ClientType::fromInt(ClientType::Value* result, int number)
 {
     switch (number) {
-    case ClientType::e_E_UNKNOWN:
-    case ClientType::e_E_TCPCLIENT:
-    case ClientType::e_E_TCPBROKER:
-    case ClientType::e_E_TCPADMIN:
+    case ClientType::E_UNKNOWN:
+    case ClientType::E_TCPCLIENT:
+    case ClientType::E_TCPBROKER:
+    case ClientType::E_TCPADMIN:
         *result = static_cast<ClientType::Value>(number);
         return 0;
     default: return -1;
@@ -649,16 +649,16 @@ int ClientType::fromString(ClientType::Value* result,
 const char* ClientType::toString(ClientType::Value value)
 {
     switch (value) {
-    case e_E_UNKNOWN: {
+    case E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case e_E_TCPCLIENT: {
+    case E_TCPCLIENT: {
         return "E_TCPCLIENT";
     }
-    case e_E_TCPBROKER: {
+    case E_TCPBROKER: {
         return "E_TCPBROKER";
     }
-    case e_E_TCPADMIN: {
+    case E_TCPADMIN: {
         return "E_TCPADMIN";
     }
     }
@@ -946,13 +946,13 @@ bsl::ostream& DummyType::print(bsl::ostream& stream, int, int) const
 const char DumpActionType::CLASS_NAME[] = "DumpActionType";
 
 const bdlat_EnumeratorInfo DumpActionType::ENUMERATOR_INFO_ARRAY[] = {
-    {DumpActionType::e_E_ON, "E_ON", sizeof("E_ON") - 1, ""},
-    {DumpActionType::e_E_OFF, "E_OFF", sizeof("E_OFF") - 1, ""},
-    {DumpActionType::e_E_MESSAGE_COUNT,
+    {DumpActionType::E_ON, "E_ON", sizeof("E_ON") - 1, ""},
+    {DumpActionType::E_OFF, "E_OFF", sizeof("E_OFF") - 1, ""},
+    {DumpActionType::E_MESSAGE_COUNT,
      "E_MESSAGE_COUNT",
      sizeof("E_MESSAGE_COUNT") - 1,
      ""},
-    {DumpActionType::e_E_TIME_IN_SECONDS,
+    {DumpActionType::E_TIME_IN_SECONDS,
      "E_TIME_IN_SECONDS",
      sizeof("E_TIME_IN_SECONDS") - 1,
      ""}};
@@ -962,10 +962,10 @@ const bdlat_EnumeratorInfo DumpActionType::ENUMERATOR_INFO_ARRAY[] = {
 int DumpActionType::fromInt(DumpActionType::Value* result, int number)
 {
     switch (number) {
-    case DumpActionType::e_E_ON:
-    case DumpActionType::e_E_OFF:
-    case DumpActionType::e_E_MESSAGE_COUNT:
-    case DumpActionType::e_E_TIME_IN_SECONDS:
+    case DumpActionType::E_ON:
+    case DumpActionType::E_OFF:
+    case DumpActionType::E_MESSAGE_COUNT:
+    case DumpActionType::E_TIME_IN_SECONDS:
         *result = static_cast<DumpActionType::Value>(number);
         return 0;
     default: return -1;
@@ -994,16 +994,16 @@ int DumpActionType::fromString(DumpActionType::Value* result,
 const char* DumpActionType::toString(DumpActionType::Value value)
 {
     switch (value) {
-    case e_E_ON: {
+    case E_ON: {
         return "E_ON";
     }
-    case e_E_OFF: {
+    case E_OFF: {
         return "E_OFF";
     }
-    case e_E_MESSAGE_COUNT: {
+    case E_MESSAGE_COUNT: {
         return "E_MESSAGE_COUNT";
     }
-    case e_E_TIME_IN_SECONDS: {
+    case E_TIME_IN_SECONDS: {
         return "E_TIME_IN_SECONDS";
     }
     }
@@ -1021,24 +1021,24 @@ const char* DumpActionType::toString(DumpActionType::Value value)
 const char DumpMsgType::CLASS_NAME[] = "DumpMsgType";
 
 const bdlat_EnumeratorInfo DumpMsgType::ENUMERATOR_INFO_ARRAY[] = {
-    {DumpMsgType::e_E_INCOMING, "E_INCOMING", sizeof("E_INCOMING") - 1, ""},
-    {DumpMsgType::e_E_OUTGOING, "E_OUTGOING", sizeof("E_OUTGOING") - 1, ""},
-    {DumpMsgType::e_E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
-    {DumpMsgType::e_E_ACK, "E_ACK", sizeof("E_ACK") - 1, ""},
-    {DumpMsgType::e_E_PUT, "E_PUT", sizeof("E_PUT") - 1, ""},
-    {DumpMsgType::e_E_CONFIRM, "E_CONFIRM", sizeof("E_CONFIRM") - 1, ""}};
+    {DumpMsgType::E_INCOMING, "E_INCOMING", sizeof("E_INCOMING") - 1, ""},
+    {DumpMsgType::E_OUTGOING, "E_OUTGOING", sizeof("E_OUTGOING") - 1, ""},
+    {DumpMsgType::E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
+    {DumpMsgType::E_ACK, "E_ACK", sizeof("E_ACK") - 1, ""},
+    {DumpMsgType::E_PUT, "E_PUT", sizeof("E_PUT") - 1, ""},
+    {DumpMsgType::E_CONFIRM, "E_CONFIRM", sizeof("E_CONFIRM") - 1, ""}};
 
 // CLASS METHODS
 
 int DumpMsgType::fromInt(DumpMsgType::Value* result, int number)
 {
     switch (number) {
-    case DumpMsgType::e_E_INCOMING:
-    case DumpMsgType::e_E_OUTGOING:
-    case DumpMsgType::e_E_PUSH:
-    case DumpMsgType::e_E_ACK:
-    case DumpMsgType::e_E_PUT:
-    case DumpMsgType::e_E_CONFIRM:
+    case DumpMsgType::E_INCOMING:
+    case DumpMsgType::E_OUTGOING:
+    case DumpMsgType::E_PUSH:
+    case DumpMsgType::E_ACK:
+    case DumpMsgType::E_PUT:
+    case DumpMsgType::E_CONFIRM:
         *result = static_cast<DumpMsgType::Value>(number);
         return 0;
     default: return -1;
@@ -1066,22 +1066,22 @@ int DumpMsgType::fromString(DumpMsgType::Value* result,
 const char* DumpMsgType::toString(DumpMsgType::Value value)
 {
     switch (value) {
-    case e_E_INCOMING: {
+    case E_INCOMING: {
         return "E_INCOMING";
     }
-    case e_E_OUTGOING: {
+    case E_OUTGOING: {
         return "E_OUTGOING";
     }
-    case e_E_PUSH: {
+    case E_PUSH: {
         return "E_PUSH";
     }
-    case e_E_ACK: {
+    case E_ACK: {
         return "E_ACK";
     }
-    case e_E_PUT: {
+    case E_PUT: {
         return "E_PUT";
     }
-    case e_E_CONFIRM: {
+    case E_CONFIRM: {
         return "E_CONFIRM";
     }
     }
@@ -1248,11 +1248,11 @@ bsl::ostream& ElectorNodeStatus::print(bsl::ostream& stream,
 const char ExpressionVersion::CLASS_NAME[] = "ExpressionVersion";
 
 const bdlat_EnumeratorInfo ExpressionVersion::ENUMERATOR_INFO_ARRAY[] = {
-    {ExpressionVersion::e_E_UNDEFINED,
+    {ExpressionVersion::E_UNDEFINED,
      "E_UNDEFINED",
      sizeof("E_UNDEFINED") - 1,
      ""},
-    {ExpressionVersion::e_E_VERSION_1,
+    {ExpressionVersion::E_VERSION_1,
      "E_VERSION_1",
      sizeof("E_VERSION_1") - 1,
      ""}};
@@ -1262,8 +1262,8 @@ const bdlat_EnumeratorInfo ExpressionVersion::ENUMERATOR_INFO_ARRAY[] = {
 int ExpressionVersion::fromInt(ExpressionVersion::Value* result, int number)
 {
     switch (number) {
-    case ExpressionVersion::e_E_UNDEFINED:
-    case ExpressionVersion::e_E_VERSION_1:
+    case ExpressionVersion::E_UNDEFINED:
+    case ExpressionVersion::E_VERSION_1:
         *result = static_cast<ExpressionVersion::Value>(number);
         return 0;
     default: return -1;
@@ -1292,10 +1292,10 @@ int ExpressionVersion::fromString(ExpressionVersion::Value* result,
 const char* ExpressionVersion::toString(ExpressionVersion::Value value)
 {
     switch (value) {
-    case e_E_UNDEFINED: {
+    case E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case e_E_VERSION_1: {
+    case E_VERSION_1: {
         return "E_VERSION_1";
     }
     }
@@ -1852,11 +1852,11 @@ LeadershipCessionNotification::print(bsl::ostream& stream, int, int) const
 const char NodeStatus::CLASS_NAME[] = "NodeStatus";
 
 const bdlat_EnumeratorInfo NodeStatus::ENUMERATOR_INFO_ARRAY[] = {
-    {NodeStatus::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {NodeStatus::e_E_STARTING, "E_STARTING", sizeof("E_STARTING") - 1, ""},
-    {NodeStatus::e_E_AVAILABLE, "E_AVAILABLE", sizeof("E_AVAILABLE") - 1, ""},
-    {NodeStatus::e_E_STOPPING, "E_STOPPING", sizeof("E_STOPPING") - 1, ""},
-    {NodeStatus::e_E_UNAVAILABLE,
+    {NodeStatus::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {NodeStatus::E_STARTING, "E_STARTING", sizeof("E_STARTING") - 1, ""},
+    {NodeStatus::E_AVAILABLE, "E_AVAILABLE", sizeof("E_AVAILABLE") - 1, ""},
+    {NodeStatus::E_STOPPING, "E_STOPPING", sizeof("E_STOPPING") - 1, ""},
+    {NodeStatus::E_UNAVAILABLE,
      "E_UNAVAILABLE",
      sizeof("E_UNAVAILABLE") - 1,
      ""}};
@@ -1866,11 +1866,11 @@ const bdlat_EnumeratorInfo NodeStatus::ENUMERATOR_INFO_ARRAY[] = {
 int NodeStatus::fromInt(NodeStatus::Value* result, int number)
 {
     switch (number) {
-    case NodeStatus::e_E_UNKNOWN:
-    case NodeStatus::e_E_STARTING:
-    case NodeStatus::e_E_AVAILABLE:
-    case NodeStatus::e_E_STOPPING:
-    case NodeStatus::e_E_UNAVAILABLE:
+    case NodeStatus::E_UNKNOWN:
+    case NodeStatus::E_STARTING:
+    case NodeStatus::E_AVAILABLE:
+    case NodeStatus::E_STOPPING:
+    case NodeStatus::E_UNAVAILABLE:
         *result = static_cast<NodeStatus::Value>(number);
         return 0;
     default: return -1;
@@ -1898,19 +1898,19 @@ int NodeStatus::fromString(NodeStatus::Value* result,
 const char* NodeStatus::toString(NodeStatus::Value value)
 {
     switch (value) {
-    case e_E_UNKNOWN: {
+    case E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case e_E_STARTING: {
+    case E_STARTING: {
         return "E_STARTING";
     }
-    case e_E_AVAILABLE: {
+    case E_AVAILABLE: {
         return "E_AVAILABLE";
     }
-    case e_E_STOPPING: {
+    case E_STOPPING: {
         return "E_STOPPING";
     }
-    case e_E_UNAVAILABLE: {
+    case E_UNAVAILABLE: {
         return "E_UNAVAILABLE";
     }
     }
@@ -2260,21 +2260,18 @@ bsl::ostream& PartitionSyncStateQuery::print(bsl::ostream& stream,
 const char PrimaryStatus::CLASS_NAME[] = "PrimaryStatus";
 
 const bdlat_EnumeratorInfo PrimaryStatus::ENUMERATOR_INFO_ARRAY[] = {
-    {PrimaryStatus::e_E_UNDEFINED,
-     "E_UNDEFINED",
-     sizeof("E_UNDEFINED") - 1,
-     ""},
-    {PrimaryStatus::e_E_PASSIVE, "E_PASSIVE", sizeof("E_PASSIVE") - 1, ""},
-    {PrimaryStatus::e_E_ACTIVE, "E_ACTIVE", sizeof("E_ACTIVE") - 1, ""}};
+    {PrimaryStatus::E_UNDEFINED, "E_UNDEFINED", sizeof("E_UNDEFINED") - 1, ""},
+    {PrimaryStatus::E_PASSIVE, "E_PASSIVE", sizeof("E_PASSIVE") - 1, ""},
+    {PrimaryStatus::E_ACTIVE, "E_ACTIVE", sizeof("E_ACTIVE") - 1, ""}};
 
 // CLASS METHODS
 
 int PrimaryStatus::fromInt(PrimaryStatus::Value* result, int number)
 {
     switch (number) {
-    case PrimaryStatus::e_E_UNDEFINED:
-    case PrimaryStatus::e_E_PASSIVE:
-    case PrimaryStatus::e_E_ACTIVE:
+    case PrimaryStatus::E_UNDEFINED:
+    case PrimaryStatus::E_PASSIVE:
+    case PrimaryStatus::E_ACTIVE:
         *result = static_cast<PrimaryStatus::Value>(number);
         return 0;
     default: return -1;
@@ -2303,13 +2300,13 @@ int PrimaryStatus::fromString(PrimaryStatus::Value* result,
 const char* PrimaryStatus::toString(PrimaryStatus::Value value)
 {
     switch (value) {
-    case e_E_UNDEFINED: {
+    case E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case e_E_PASSIVE: {
+    case E_PASSIVE: {
         return "E_PASSIVE";
     }
-    case e_E_ACTIVE: {
+    case E_ACTIVE: {
         return "E_ACTIVE";
     }
     }
@@ -2647,20 +2644,20 @@ bsl::ostream& RegistrationResponse::print(bsl::ostream& stream, int, int) const
 const char ReplicaDataType::CLASS_NAME[] = "ReplicaDataType";
 
 const bdlat_EnumeratorInfo ReplicaDataType::ENUMERATOR_INFO_ARRAY[] = {
-    {ReplicaDataType::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {ReplicaDataType::e_E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""},
-    {ReplicaDataType::e_E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
-    {ReplicaDataType::e_E_DROP, "E_DROP", sizeof("E_DROP") - 1, ""}};
+    {ReplicaDataType::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {ReplicaDataType::E_PULL, "E_PULL", sizeof("E_PULL") - 1, ""},
+    {ReplicaDataType::E_PUSH, "E_PUSH", sizeof("E_PUSH") - 1, ""},
+    {ReplicaDataType::E_DROP, "E_DROP", sizeof("E_DROP") - 1, ""}};
 
 // CLASS METHODS
 
 int ReplicaDataType::fromInt(ReplicaDataType::Value* result, int number)
 {
     switch (number) {
-    case ReplicaDataType::e_E_UNKNOWN:
-    case ReplicaDataType::e_E_PULL:
-    case ReplicaDataType::e_E_PUSH:
-    case ReplicaDataType::e_E_DROP:
+    case ReplicaDataType::E_UNKNOWN:
+    case ReplicaDataType::E_PULL:
+    case ReplicaDataType::E_PUSH:
+    case ReplicaDataType::E_DROP:
         *result = static_cast<ReplicaDataType::Value>(number);
         return 0;
     default: return -1;
@@ -2689,16 +2686,16 @@ int ReplicaDataType::fromString(ReplicaDataType::Value* result,
 const char* ReplicaDataType::toString(ReplicaDataType::Value value)
 {
     switch (value) {
-    case e_E_UNKNOWN: {
+    case E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case e_E_PULL: {
+    case E_PULL: {
         return "E_PULL";
     }
-    case e_E_PUSH: {
+    case E_PUSH: {
         return "E_PUSH";
     }
-    case e_E_DROP: {
+    case E_DROP: {
         return "E_DROP";
     }
     }
@@ -2786,19 +2783,19 @@ const char RoutingConfigurationFlags::CLASS_NAME[] =
     "RoutingConfigurationFlags";
 
 const bdlat_EnumeratorInfo RoutingConfigurationFlags::ENUMERATOR_INFO_ARRAY[] =
-    {{RoutingConfigurationFlags::e_E_AT_MOST_ONCE,
+    {{RoutingConfigurationFlags::E_AT_MOST_ONCE,
       "E_AT_MOST_ONCE",
       sizeof("E_AT_MOST_ONCE") - 1,
       ""},
-     {RoutingConfigurationFlags::e_E_DELIVER_CONSUMER_PRIORITY,
+     {RoutingConfigurationFlags::E_DELIVER_CONSUMER_PRIORITY,
       "E_DELIVER_CONSUMER_PRIORITY",
       sizeof("E_DELIVER_CONSUMER_PRIORITY") - 1,
       ""},
-     {RoutingConfigurationFlags::e_E_DELIVER_ALL,
+     {RoutingConfigurationFlags::E_DELIVER_ALL,
       "E_DELIVER_ALL",
       sizeof("E_DELIVER_ALL") - 1,
       ""},
-     {RoutingConfigurationFlags::e_E_HAS_MULTIPLE_SUB_STREAMS,
+     {RoutingConfigurationFlags::E_HAS_MULTIPLE_SUB_STREAMS,
       "E_HAS_MULTIPLE_SUB_STREAMS",
       sizeof("E_HAS_MULTIPLE_SUB_STREAMS") - 1,
       ""}};
@@ -2810,10 +2807,10 @@ int RoutingConfigurationFlags::fromInt(
     int                               number)
 {
     switch (number) {
-    case RoutingConfigurationFlags::e_E_AT_MOST_ONCE:
-    case RoutingConfigurationFlags::e_E_DELIVER_CONSUMER_PRIORITY:
-    case RoutingConfigurationFlags::e_E_DELIVER_ALL:
-    case RoutingConfigurationFlags::e_E_HAS_MULTIPLE_SUB_STREAMS:
+    case RoutingConfigurationFlags::E_AT_MOST_ONCE:
+    case RoutingConfigurationFlags::E_DELIVER_CONSUMER_PRIORITY:
+    case RoutingConfigurationFlags::E_DELIVER_ALL:
+    case RoutingConfigurationFlags::E_HAS_MULTIPLE_SUB_STREAMS:
         *result = static_cast<RoutingConfigurationFlags::Value>(number);
         return 0;
     default: return -1;
@@ -2844,16 +2841,16 @@ const char*
 RoutingConfigurationFlags::toString(RoutingConfigurationFlags::Value value)
 {
     switch (value) {
-    case e_E_AT_MOST_ONCE: {
+    case E_AT_MOST_ONCE: {
         return "E_AT_MOST_ONCE";
     }
-    case e_E_DELIVER_CONSUMER_PRIORITY: {
+    case E_DELIVER_CONSUMER_PRIORITY: {
         return "E_DELIVER_CONSUMER_PRIORITY";
     }
-    case e_E_DELIVER_ALL: {
+    case E_DELIVER_ALL: {
         return "E_DELIVER_ALL";
     }
-    case e_E_HAS_MULTIPLE_SUB_STREAMS: {
+    case E_HAS_MULTIPLE_SUB_STREAMS: {
         return "E_HAS_MULTIPLE_SUB_STREAMS";
     }
     }
@@ -2980,24 +2977,24 @@ bsl::ostream& ScoutingResponse::print(bsl::ostream& stream,
 const char StatusCategory::CLASS_NAME[] = "StatusCategory";
 
 const bdlat_EnumeratorInfo StatusCategory::ENUMERATOR_INFO_ARRAY[] = {
-    {StatusCategory::e_E_SUCCESS, "E_SUCCESS", sizeof("E_SUCCESS") - 1, ""},
-    {StatusCategory::e_E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
-    {StatusCategory::e_E_TIMEOUT, "E_TIMEOUT", sizeof("E_TIMEOUT") - 1, ""},
-    {StatusCategory::e_E_NOT_CONNECTED,
+    {StatusCategory::E_SUCCESS, "E_SUCCESS", sizeof("E_SUCCESS") - 1, ""},
+    {StatusCategory::E_UNKNOWN, "E_UNKNOWN", sizeof("E_UNKNOWN") - 1, ""},
+    {StatusCategory::E_TIMEOUT, "E_TIMEOUT", sizeof("E_TIMEOUT") - 1, ""},
+    {StatusCategory::E_NOT_CONNECTED,
      "E_NOT_CONNECTED",
      sizeof("E_NOT_CONNECTED") - 1,
      ""},
-    {StatusCategory::e_E_CANCELED, "E_CANCELED", sizeof("E_CANCELED") - 1, ""},
-    {StatusCategory::e_E_NOT_SUPPORTED,
+    {StatusCategory::E_CANCELED, "E_CANCELED", sizeof("E_CANCELED") - 1, ""},
+    {StatusCategory::E_NOT_SUPPORTED,
      "E_NOT_SUPPORTED",
      sizeof("E_NOT_SUPPORTED") - 1,
      ""},
-    {StatusCategory::e_E_REFUSED, "E_REFUSED", sizeof("E_REFUSED") - 1, ""},
-    {StatusCategory::e_E_INVALID_ARGUMENT,
+    {StatusCategory::E_REFUSED, "E_REFUSED", sizeof("E_REFUSED") - 1, ""},
+    {StatusCategory::E_INVALID_ARGUMENT,
      "E_INVALID_ARGUMENT",
      sizeof("E_INVALID_ARGUMENT") - 1,
      ""},
-    {StatusCategory::e_E_NOT_READY,
+    {StatusCategory::E_NOT_READY,
      "E_NOT_READY",
      sizeof("E_NOT_READY") - 1,
      ""}};
@@ -3007,15 +3004,15 @@ const bdlat_EnumeratorInfo StatusCategory::ENUMERATOR_INFO_ARRAY[] = {
 int StatusCategory::fromInt(StatusCategory::Value* result, int number)
 {
     switch (number) {
-    case StatusCategory::e_E_SUCCESS:
-    case StatusCategory::e_E_UNKNOWN:
-    case StatusCategory::e_E_TIMEOUT:
-    case StatusCategory::e_E_NOT_CONNECTED:
-    case StatusCategory::e_E_CANCELED:
-    case StatusCategory::e_E_NOT_SUPPORTED:
-    case StatusCategory::e_E_REFUSED:
-    case StatusCategory::e_E_INVALID_ARGUMENT:
-    case StatusCategory::e_E_NOT_READY:
+    case StatusCategory::E_SUCCESS:
+    case StatusCategory::E_UNKNOWN:
+    case StatusCategory::E_TIMEOUT:
+    case StatusCategory::E_NOT_CONNECTED:
+    case StatusCategory::E_CANCELED:
+    case StatusCategory::E_NOT_SUPPORTED:
+    case StatusCategory::E_REFUSED:
+    case StatusCategory::E_INVALID_ARGUMENT:
+    case StatusCategory::E_NOT_READY:
         *result = static_cast<StatusCategory::Value>(number);
         return 0;
     default: return -1;
@@ -3044,31 +3041,31 @@ int StatusCategory::fromString(StatusCategory::Value* result,
 const char* StatusCategory::toString(StatusCategory::Value value)
 {
     switch (value) {
-    case e_E_SUCCESS: {
+    case E_SUCCESS: {
         return "E_SUCCESS";
     }
-    case e_E_UNKNOWN: {
+    case E_UNKNOWN: {
         return "E_UNKNOWN";
     }
-    case e_E_TIMEOUT: {
+    case E_TIMEOUT: {
         return "E_TIMEOUT";
     }
-    case e_E_NOT_CONNECTED: {
+    case E_NOT_CONNECTED: {
         return "E_NOT_CONNECTED";
     }
-    case e_E_CANCELED: {
+    case E_CANCELED: {
         return "E_CANCELED";
     }
-    case e_E_NOT_SUPPORTED: {
+    case E_NOT_SUPPORTED: {
         return "E_NOT_SUPPORTED";
     }
-    case e_E_REFUSED: {
+    case E_REFUSED: {
         return "E_REFUSED";
     }
-    case e_E_INVALID_ARGUMENT: {
+    case E_INVALID_ARGUMENT: {
         return "E_INVALID_ARGUMENT";
     }
-    case e_E_NOT_READY: {
+    case E_NOT_READY: {
         return "E_NOT_READY";
     }
     }
@@ -3329,20 +3326,17 @@ StopResponse::print(bsl::ostream& stream, int level, int spacesPerLevel) const
 const char StorageSyncResponseType::CLASS_NAME[] = "StorageSyncResponseType";
 
 const bdlat_EnumeratorInfo StorageSyncResponseType::ENUMERATOR_INFO_ARRAY[] = {
-    {StorageSyncResponseType::e_E_UNDEFINED,
+    {StorageSyncResponseType::E_UNDEFINED,
      "E_UNDEFINED",
      sizeof("E_UNDEFINED") - 1,
      ""},
-    {StorageSyncResponseType::e_E_PATCH, "E_PATCH", sizeof("E_PATCH") - 1, ""},
-    {StorageSyncResponseType::e_E_FILE, "E_FILE", sizeof("E_FILE") - 1, ""},
-    {StorageSyncResponseType::e_E_IN_SYNC,
+    {StorageSyncResponseType::E_PATCH, "E_PATCH", sizeof("E_PATCH") - 1, ""},
+    {StorageSyncResponseType::E_FILE, "E_FILE", sizeof("E_FILE") - 1, ""},
+    {StorageSyncResponseType::E_IN_SYNC,
      "E_IN_SYNC",
      sizeof("E_IN_SYNC") - 1,
      ""},
-    {StorageSyncResponseType::e_E_EMPTY,
-     "E_EMPTY",
-     sizeof("E_EMPTY") - 1,
-     ""}};
+    {StorageSyncResponseType::E_EMPTY, "E_EMPTY", sizeof("E_EMPTY") - 1, ""}};
 
 // CLASS METHODS
 
@@ -3350,11 +3344,11 @@ int StorageSyncResponseType::fromInt(StorageSyncResponseType::Value* result,
                                      int                             number)
 {
     switch (number) {
-    case StorageSyncResponseType::e_E_UNDEFINED:
-    case StorageSyncResponseType::e_E_PATCH:
-    case StorageSyncResponseType::e_E_FILE:
-    case StorageSyncResponseType::e_E_IN_SYNC:
-    case StorageSyncResponseType::e_E_EMPTY:
+    case StorageSyncResponseType::E_UNDEFINED:
+    case StorageSyncResponseType::E_PATCH:
+    case StorageSyncResponseType::E_FILE:
+    case StorageSyncResponseType::E_IN_SYNC:
+    case StorageSyncResponseType::E_EMPTY:
         *result = static_cast<StorageSyncResponseType::Value>(number);
         return 0;
     default: return -1;
@@ -3384,19 +3378,19 @@ const char*
 StorageSyncResponseType::toString(StorageSyncResponseType::Value value)
 {
     switch (value) {
-    case e_E_UNDEFINED: {
+    case E_UNDEFINED: {
         return "E_UNDEFINED";
     }
-    case e_E_PATCH: {
+    case E_PATCH: {
         return "E_PATCH";
     }
-    case e_E_FILE: {
+    case E_FILE: {
         return "E_FILE";
     }
-    case e_E_IN_SYNC: {
+    case E_IN_SYNC: {
         return "E_IN_SYNC";
     }
-    case e_E_EMPTY: {
+    case E_EMPTY: {
         return "E_EMPTY";
     }
     }
@@ -6607,16 +6601,21 @@ bsl::ostream& RegistrationRequest::print(bsl::ostream& stream,
 const char ReplicaDataRequest::CLASS_NAME[] = "ReplicaDataRequest";
 
 const bdlat_AttributeInfo ReplicaDataRequest::ATTRIBUTE_INFO_ARRAY[] = {
-    {ATTRIBUTE_ID_REPLICA_DATA_TYPE,
-     "replicaDataType",
-     sizeof("replicaDataType") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT},
     {ATTRIBUTE_ID_PARTITION_ID,
      "partitionId",
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_REPLICA_DATA_TYPE,
+     "replicaDataType",
+     sizeof("replicaDataType") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT},
     {ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER,
      "beginSequenceNumber",
      sizeof("beginSequenceNumber") - 1,
@@ -6633,7 +6632,7 @@ const bdlat_AttributeInfo ReplicaDataRequest::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 ReplicaDataRequest::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 5; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             ReplicaDataRequest::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -6649,10 +6648,12 @@ ReplicaDataRequest::lookupAttributeInfo(const char* name, int nameLength)
 const bdlat_AttributeInfo* ReplicaDataRequest::lookupAttributeInfo(int id)
 {
     switch (id) {
-    case ATTRIBUTE_ID_REPLICA_DATA_TYPE:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE];
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
+    case ATTRIBUTE_ID_REPLICA_DATA_TYPE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE];
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_END_SEQUENCE_NUMBER:
@@ -6666,6 +6667,7 @@ const bdlat_AttributeInfo* ReplicaDataRequest::lookupAttributeInfo(int id)
 ReplicaDataRequest::ReplicaDataRequest()
 : d_beginSequenceNumber()
 , d_endSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 , d_replicaDataType(static_cast<ReplicaDataType::Value>(0))
 {
@@ -6675,8 +6677,9 @@ ReplicaDataRequest::ReplicaDataRequest()
 
 void ReplicaDataRequest::reset()
 {
-    bdlat_ValueTypeFunctions::reset(&d_replicaDataType);
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
+    bdlat_ValueTypeFunctions::reset(&d_replicaDataType);
     bdlat_ValueTypeFunctions::reset(&d_beginSequenceNumber);
     bdlat_ValueTypeFunctions::reset(&d_endSequenceNumber);
 }
@@ -6689,8 +6692,9 @@ bsl::ostream& ReplicaDataRequest::print(bsl::ostream& stream,
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
-    printer.printAttribute("replicaDataType", this->replicaDataType());
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
+    printer.printAttribute("replicaDataType", this->replicaDataType());
     printer.printAttribute("beginSequenceNumber", this->beginSequenceNumber());
     printer.printAttribute("endSequenceNumber", this->endSequenceNumber());
     printer.end();
@@ -6706,16 +6710,21 @@ bsl::ostream& ReplicaDataRequest::print(bsl::ostream& stream,
 const char ReplicaDataResponse::CLASS_NAME[] = "ReplicaDataResponse";
 
 const bdlat_AttributeInfo ReplicaDataResponse::ATTRIBUTE_INFO_ARRAY[] = {
-    {ATTRIBUTE_ID_REPLICA_DATA_TYPE,
-     "replicaDataType",
-     sizeof("replicaDataType") - 1,
-     "",
-     bdlat_FormattingMode::e_DEFAULT},
     {ATTRIBUTE_ID_PARTITION_ID,
      "partitionId",
      sizeof("partitionId") - 1,
      "",
      bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_PRIMARY_LEASE_ID,
+     "primaryLeaseId",
+     sizeof("primaryLeaseId") - 1,
+     "",
+     bdlat_FormattingMode::e_DEC},
+    {ATTRIBUTE_ID_REPLICA_DATA_TYPE,
+     "replicaDataType",
+     sizeof("replicaDataType") - 1,
+     "",
+     bdlat_FormattingMode::e_DEFAULT},
     {ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER,
      "beginSequenceNumber",
      sizeof("beginSequenceNumber") - 1,
@@ -6732,7 +6741,7 @@ const bdlat_AttributeInfo ReplicaDataResponse::ATTRIBUTE_INFO_ARRAY[] = {
 const bdlat_AttributeInfo*
 ReplicaDataResponse::lookupAttributeInfo(const char* name, int nameLength)
 {
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 5; ++i) {
         const bdlat_AttributeInfo& attributeInfo =
             ReplicaDataResponse::ATTRIBUTE_INFO_ARRAY[i];
 
@@ -6748,10 +6757,12 @@ ReplicaDataResponse::lookupAttributeInfo(const char* name, int nameLength)
 const bdlat_AttributeInfo* ReplicaDataResponse::lookupAttributeInfo(int id)
 {
     switch (id) {
-    case ATTRIBUTE_ID_REPLICA_DATA_TYPE:
-        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE];
     case ATTRIBUTE_ID_PARTITION_ID:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID];
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID];
+    case ATTRIBUTE_ID_REPLICA_DATA_TYPE:
+        return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE];
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER:
         return &ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER];
     case ATTRIBUTE_ID_END_SEQUENCE_NUMBER:
@@ -6765,6 +6776,7 @@ const bdlat_AttributeInfo* ReplicaDataResponse::lookupAttributeInfo(int id)
 ReplicaDataResponse::ReplicaDataResponse()
 : d_beginSequenceNumber()
 , d_endSequenceNumber()
+, d_primaryLeaseId()
 , d_partitionId()
 , d_replicaDataType(static_cast<ReplicaDataType::Value>(0))
 {
@@ -6774,8 +6786,9 @@ ReplicaDataResponse::ReplicaDataResponse()
 
 void ReplicaDataResponse::reset()
 {
-    bdlat_ValueTypeFunctions::reset(&d_replicaDataType);
     bdlat_ValueTypeFunctions::reset(&d_partitionId);
+    bdlat_ValueTypeFunctions::reset(&d_primaryLeaseId);
+    bdlat_ValueTypeFunctions::reset(&d_replicaDataType);
     bdlat_ValueTypeFunctions::reset(&d_beginSequenceNumber);
     bdlat_ValueTypeFunctions::reset(&d_endSequenceNumber);
 }
@@ -6788,8 +6801,9 @@ bsl::ostream& ReplicaDataResponse::print(bsl::ostream& stream,
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
-    printer.printAttribute("replicaDataType", this->replicaDataType());
     printer.printAttribute("partitionId", this->partitionId());
+    printer.printAttribute("primaryLeaseId", this->primaryLeaseId());
+    printer.printAttribute("replicaDataType", this->replicaDataType());
     printer.printAttribute("beginSequenceNumber", this->beginSequenceNumber());
     printer.printAttribute("endSequenceNumber", this->endSequenceNumber());
     printer.end();
@@ -17658,6 +17672,6 @@ bsl::ostream& ControlMessage::print(bsl::ostream& stream,
 }  // close package namespace
 }  // close enterprise namespace
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
+// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
+++ b/src/groups/bmq/bmqp/bmqp_ctrlmsg_messages.h
@@ -46,11 +46,9 @@
 
 #include <bsl_iosfwd.h>
 #include <bsl_limits.h>
-#include <bsl_type_traits.h>
 
 #include <bsl_ostream.h>
 #include <bsl_string.h>
-#include <bsl_type_traits.h>
 
 namespace BloombergLP {
 
@@ -1236,17 +1234,9 @@ struct ClientLanguage {
 
   public:
     // TYPES
-    enum Value {
-        e_E_UNKNOWN = 0,
-        e_E_CPP     = 1,
-        e_E_JAVA    = 2,
+    enum Value { E_UNKNOWN = 0, E_CPP = 1, E_JAVA = 2 };
 
-        E_UNKNOWN = e_E_UNKNOWN,
-        E_CPP     = e_E_CPP,
-        E_JAVA    = e_E_JAVA
-    };
-
-    enum { k_NUM_ENUMERATORS = 3, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 3 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -1309,18 +1299,13 @@ struct ClientType {
   public:
     // TYPES
     enum Value {
-        e_E_UNKNOWN   = 0,
-        e_E_TCPCLIENT = 1,
-        e_E_TCPBROKER = 2,
-        e_E_TCPADMIN  = 3,
-
-        E_UNKNOWN   = e_E_UNKNOWN,
-        E_TCPCLIENT = e_E_TCPCLIENT,
-        E_TCPBROKER = e_E_TCPBROKER,
-        E_TCPADMIN  = e_E_TCPADMIN
+        E_UNKNOWN   = 0,
+        E_TCPCLIENT = 1,
+        E_TCPBROKER = 2,
+        E_TCPADMIN  = 3
     };
 
-    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 4 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2216,18 +2201,13 @@ struct DumpActionType {
   public:
     // TYPES
     enum Value {
-        e_E_ON              = 0,
-        e_E_OFF             = 1,
-        e_E_MESSAGE_COUNT   = 2,
-        e_E_TIME_IN_SECONDS = 3,
-
-        E_ON              = e_E_ON,
-        E_OFF             = e_E_OFF,
-        E_MESSAGE_COUNT   = e_E_MESSAGE_COUNT,
-        E_TIME_IN_SECONDS = e_E_TIME_IN_SECONDS
+        E_ON              = 0,
+        E_OFF             = 1,
+        E_MESSAGE_COUNT   = 2,
+        E_TIME_IN_SECONDS = 3
     };
 
-    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 4 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2287,22 +2267,15 @@ struct DumpMsgType {
   public:
     // TYPES
     enum Value {
-        e_E_INCOMING = 0,
-        e_E_OUTGOING = 1,
-        e_E_PUSH     = 2,
-        e_E_ACK      = 3,
-        e_E_PUT      = 4,
-        e_E_CONFIRM  = 5,
-
-        E_INCOMING = e_E_INCOMING,
-        E_OUTGOING = e_E_OUTGOING,
-        E_PUSH     = e_E_PUSH,
-        E_ACK      = e_E_ACK,
-        E_PUT      = e_E_PUT,
-        E_CONFIRM  = e_E_CONFIRM
+        E_INCOMING = 0,
+        E_OUTGOING = 1,
+        E_PUSH     = 2,
+        E_ACK      = 3,
+        E_PUT      = 4,
+        E_CONFIRM  = 5
     };
 
-    enum { k_NUM_ENUMERATORS = 6, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 6 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -2845,15 +2818,9 @@ struct ExpressionVersion {
 
   public:
     // TYPES
-    enum Value {
-        e_E_UNDEFINED = 0,
-        e_E_VERSION_1 = 1,
+    enum Value { E_UNDEFINED = 0, E_VERSION_1 = 1 };
 
-        E_UNDEFINED = e_E_UNDEFINED,
-        E_VERSION_1 = e_E_VERSION_1
-    };
-
-    enum { k_NUM_ENUMERATORS = 2, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 2 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -4566,20 +4533,14 @@ struct NodeStatus {
   public:
     // TYPES
     enum Value {
-        e_E_UNKNOWN     = 0,
-        e_E_STARTING    = 10,
-        e_E_AVAILABLE   = 20,
-        e_E_STOPPING    = 30,
-        e_E_UNAVAILABLE = 40,
-
-        E_UNKNOWN     = e_E_UNKNOWN,
-        E_STARTING    = e_E_STARTING,
-        E_AVAILABLE   = e_E_AVAILABLE,
-        E_STOPPING    = e_E_STOPPING,
-        E_UNAVAILABLE = e_E_UNAVAILABLE
+        E_UNKNOWN     = 0,
+        E_STARTING    = 10,
+        E_AVAILABLE   = 20,
+        E_STOPPING    = 30,
+        E_UNAVAILABLE = 40
     };
 
-    enum { k_NUM_ENUMERATORS = 5, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 5 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -5417,17 +5378,9 @@ struct PrimaryStatus {
 
   public:
     // TYPES
-    enum Value {
-        e_E_UNDEFINED = 0,
-        e_E_PASSIVE   = 1,
-        e_E_ACTIVE    = 5,
+    enum Value { E_UNDEFINED = 0, E_PASSIVE = 1, E_ACTIVE = 5 };
 
-        E_UNDEFINED = e_E_UNDEFINED,
-        E_PASSIVE   = e_E_PASSIVE,
-        E_ACTIVE    = e_E_ACTIVE
-    };
-
-    enum { k_NUM_ENUMERATORS = 3, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 3 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6106,19 +6059,9 @@ struct ReplicaDataType {
 
   public:
     // TYPES
-    enum Value {
-        e_E_UNKNOWN = 0,
-        e_E_PULL    = 10,
-        e_E_PUSH    = 20,
-        e_E_DROP    = 30,
+    enum Value { E_UNKNOWN = 0, E_PULL = 10, E_PUSH = 20, E_DROP = 30 };
 
-        E_UNKNOWN = e_E_UNKNOWN,
-        E_PULL    = e_E_PULL,
-        E_PUSH    = e_E_PUSH,
-        E_DROP    = e_E_DROP
-    };
-
-    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 4 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6371,18 +6314,13 @@ struct RoutingConfigurationFlags {
   public:
     // TYPES
     enum Value {
-        e_E_AT_MOST_ONCE              = 0,
-        e_E_DELIVER_CONSUMER_PRIORITY = 1,
-        e_E_DELIVER_ALL               = 2,
-        e_E_HAS_MULTIPLE_SUB_STREAMS  = 3,
-
-        E_AT_MOST_ONCE              = e_E_AT_MOST_ONCE,
-        E_DELIVER_CONSUMER_PRIORITY = e_E_DELIVER_CONSUMER_PRIORITY,
-        E_DELIVER_ALL               = e_E_DELIVER_ALL,
-        E_HAS_MULTIPLE_SUB_STREAMS  = e_E_HAS_MULTIPLE_SUB_STREAMS
+        E_AT_MOST_ONCE              = 0,
+        E_DELIVER_CONSUMER_PRIORITY = 1,
+        E_DELIVER_ALL               = 2,
+        E_HAS_MULTIPLE_SUB_STREAMS  = 3
     };
 
-    enum { k_NUM_ENUMERATORS = 4, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 4 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -6780,28 +6718,18 @@ struct StatusCategory {
   public:
     // TYPES
     enum Value {
-        e_E_SUCCESS          = 0,
-        e_E_UNKNOWN          = -1,
-        e_E_TIMEOUT          = -2,
-        e_E_NOT_CONNECTED    = -3,
-        e_E_CANCELED         = -4,
-        e_E_NOT_SUPPORTED    = -5,
-        e_E_REFUSED          = -6,
-        e_E_INVALID_ARGUMENT = -7,
-        e_E_NOT_READY        = -8,
-
-        E_SUCCESS          = e_E_SUCCESS,
-        E_UNKNOWN          = e_E_UNKNOWN,
-        E_TIMEOUT          = e_E_TIMEOUT,
-        E_NOT_CONNECTED    = e_E_NOT_CONNECTED,
-        E_CANCELED         = e_E_CANCELED,
-        E_NOT_SUPPORTED    = e_E_NOT_SUPPORTED,
-        E_REFUSED          = e_E_REFUSED,
-        E_INVALID_ARGUMENT = e_E_INVALID_ARGUMENT,
-        E_NOT_READY        = e_E_NOT_READY
+        E_SUCCESS          = 0,
+        E_UNKNOWN          = -1,
+        E_TIMEOUT          = -2,
+        E_NOT_CONNECTED    = -3,
+        E_CANCELED         = -4,
+        E_NOT_SUPPORTED    = -5,
+        E_REFUSED          = -6,
+        E_INVALID_ARGUMENT = -7,
+        E_NOT_READY        = -8
     };
 
-    enum { k_NUM_ENUMERATORS = 9, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 9 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -7301,20 +7229,14 @@ struct StorageSyncResponseType {
   public:
     // TYPES
     enum Value {
-        e_E_UNDEFINED = 0,
-        e_E_PATCH     = 1,
-        e_E_FILE      = 2,
-        e_E_IN_SYNC   = 3,
-        e_E_EMPTY     = 4,
-
-        E_UNDEFINED = e_E_UNDEFINED,
-        E_PATCH     = e_E_PATCH,
-        E_FILE      = e_E_FILE,
-        E_IN_SYNC   = e_E_IN_SYNC,
-        E_EMPTY     = e_E_EMPTY
+        E_UNDEFINED = 0,
+        E_PATCH     = 1,
+        E_FILE      = 2,
+        E_IN_SYNC   = 3,
+        E_EMPTY     = 4
     };
 
-    enum { k_NUM_ENUMERATORS = 5, NUM_ENUMERATORS = k_NUM_ENUMERATORS };
+    enum { NUM_ENUMERATORS = 5 };
 
     // CONSTANTS
     static const char CLASS_NAME[];
@@ -12131,16 +12053,18 @@ namespace bmqp_ctrlmsg {
 class ReplicaDataRequest {
     // This type represents a request sent to the replica by the primary to
     // start the synchronization of data.
-    // replicaDataType:     type of request i.e.  PULL, PUSH or DROP for
-    // corresponding partition.  partitionId:         partition id for
-    // corresponding partition.  beginSequenceNumber: Primary's begin sequence
-    // number for corresponding partition for corresponding data chunks.
-    // endSequenceNumber:   Primary's end sequence number for corresponding
-    // partition for corresponding data chunks.
+    // partitionId:         partition id for corresponding partition.
+    // primaryLeaseId:      lease id of the current primary.  replicaDataType:
+    //    type of request i.e.  PULL, PUSH or DROP for corresponding partition.
+    //  beginSequenceNumber: Primary's begin sequence number for corresponding
+    // partition for corresponding data chunks.  endSequenceNumber:   Primary's
+    // end sequence number for corresponding partition for corresponding data
+    // chunks.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_beginSequenceNumber;
     PartitionSequenceNumber d_endSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
     ReplicaDataType::Value  d_replicaDataType;
 
@@ -12153,19 +12077,21 @@ class ReplicaDataRequest {
   public:
     // TYPES
     enum {
-        ATTRIBUTE_ID_REPLICA_DATA_TYPE     = 0,
-        ATTRIBUTE_ID_PARTITION_ID          = 1,
-        ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER = 2,
-        ATTRIBUTE_ID_END_SEQUENCE_NUMBER   = 3
+        ATTRIBUTE_ID_PARTITION_ID          = 0,
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID      = 1,
+        ATTRIBUTE_ID_REPLICA_DATA_TYPE     = 2,
+        ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER = 3,
+        ATTRIBUTE_ID_END_SEQUENCE_NUMBER   = 4
     };
 
-    enum { NUM_ATTRIBUTES = 4 };
+    enum { NUM_ATTRIBUTES = 5 };
 
     enum {
-        ATTRIBUTE_INDEX_REPLICA_DATA_TYPE     = 0,
-        ATTRIBUTE_INDEX_PARTITION_ID          = 1,
-        ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER = 2,
-        ATTRIBUTE_INDEX_END_SEQUENCE_NUMBER   = 3
+        ATTRIBUTE_INDEX_PARTITION_ID          = 0,
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID      = 1,
+        ATTRIBUTE_INDEX_REPLICA_DATA_TYPE     = 2,
+        ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER = 3,
+        ATTRIBUTE_INDEX_END_SEQUENCE_NUMBER   = 4
     };
 
     // CONSTANTS
@@ -12224,13 +12150,17 @@ class ReplicaDataRequest {
     // returned from the invocation of 'manipulator' if 'name' identifies
     // an attribute of this class, and -1 otherwise.
 
-    ReplicaDataType::Value& replicaDataType();
-    // Return a reference to the modifiable "ReplicaDataType" attribute of
-    // this object.
-
     int& partitionId();
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
+
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
+    ReplicaDataType::Value& replicaDataType();
+    // Return a reference to the modifiable "ReplicaDataType" attribute of
+    // this object.
 
     PartitionSequenceNumber& beginSequenceNumber();
     // Return a reference to the modifiable "BeginSequenceNumber" attribute
@@ -12283,11 +12213,14 @@ class ReplicaDataRequest {
     // invocation of 'accessor' if 'name' identifies an attribute of this
     // class, and -1 otherwise.
 
-    ReplicaDataType::Value replicaDataType() const;
-    // Return the value of the "ReplicaDataType" attribute of this object.
-
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
+
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
+    ReplicaDataType::Value replicaDataType() const;
+    // Return the value of the "ReplicaDataType" attribute of this object.
 
     const PartitionSequenceNumber& beginSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
@@ -12353,18 +12286,20 @@ namespace bmqp_ctrlmsg {
 class ReplicaDataResponse {
     // This type represents a response sent by a replica to the primary for the
     // data synchronization request received by it.
-    // replicaDataType:     type of request received i.e.  PULL, PUSH or DROP
-    // for corresponding partition.  Note, this field will be set as per the
-    // request received and the primary purpose of sending this field back in
-    // response is for debugging and sanity checking.  partitionId:
-    // partition id for corresponding partition.  beginSequenceNumber:
-    // Replica's begin sequence number for corresponding partition for
-    // corresponding data chunks.  endSequenceNumber:   Replica's end sequence
-    // number for corresponding partition for corresponding data chunks.
+    // partitionId:         partition id for corresponding partition.
+    // primaryLeaseId:      lease id of the current primary.  replicaDataType:
+    //    type of request received i.e.  PULL, PUSH or DROP for corresponding
+    // partition.  Note, this field will be set as per the request received and
+    // the primary purpose of sending this field back in response is for
+    // debugging and sanity checking.  beginSequenceNumber: Replica's begin
+    // sequence number for corresponding partition for corresponding data
+    // chunks.  endSequenceNumber:   Replica's end sequence number for
+    // corresponding partition for corresponding data chunks.
 
     // INSTANCE DATA
     PartitionSequenceNumber d_beginSequenceNumber;
     PartitionSequenceNumber d_endSequenceNumber;
+    unsigned int            d_primaryLeaseId;
     int                     d_partitionId;
     ReplicaDataType::Value  d_replicaDataType;
 
@@ -12377,19 +12312,21 @@ class ReplicaDataResponse {
   public:
     // TYPES
     enum {
-        ATTRIBUTE_ID_REPLICA_DATA_TYPE     = 0,
-        ATTRIBUTE_ID_PARTITION_ID          = 1,
-        ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER = 2,
-        ATTRIBUTE_ID_END_SEQUENCE_NUMBER   = 3
+        ATTRIBUTE_ID_PARTITION_ID          = 0,
+        ATTRIBUTE_ID_PRIMARY_LEASE_ID      = 1,
+        ATTRIBUTE_ID_REPLICA_DATA_TYPE     = 2,
+        ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER = 3,
+        ATTRIBUTE_ID_END_SEQUENCE_NUMBER   = 4
     };
 
-    enum { NUM_ATTRIBUTES = 4 };
+    enum { NUM_ATTRIBUTES = 5 };
 
     enum {
-        ATTRIBUTE_INDEX_REPLICA_DATA_TYPE     = 0,
-        ATTRIBUTE_INDEX_PARTITION_ID          = 1,
-        ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER = 2,
-        ATTRIBUTE_INDEX_END_SEQUENCE_NUMBER   = 3
+        ATTRIBUTE_INDEX_PARTITION_ID          = 0,
+        ATTRIBUTE_INDEX_PRIMARY_LEASE_ID      = 1,
+        ATTRIBUTE_INDEX_REPLICA_DATA_TYPE     = 2,
+        ATTRIBUTE_INDEX_BEGIN_SEQUENCE_NUMBER = 3,
+        ATTRIBUTE_INDEX_END_SEQUENCE_NUMBER   = 4
     };
 
     // CONSTANTS
@@ -12448,13 +12385,17 @@ class ReplicaDataResponse {
     // returned from the invocation of 'manipulator' if 'name' identifies
     // an attribute of this class, and -1 otherwise.
 
-    ReplicaDataType::Value& replicaDataType();
-    // Return a reference to the modifiable "ReplicaDataType" attribute of
-    // this object.
-
     int& partitionId();
     // Return a reference to the modifiable "PartitionId" attribute of this
     // object.
+
+    unsigned int& primaryLeaseId();
+    // Return a reference to the modifiable "PrimaryLeaseId" attribute of
+    // this object.
+
+    ReplicaDataType::Value& replicaDataType();
+    // Return a reference to the modifiable "ReplicaDataType" attribute of
+    // this object.
 
     PartitionSequenceNumber& beginSequenceNumber();
     // Return a reference to the modifiable "BeginSequenceNumber" attribute
@@ -12507,11 +12448,14 @@ class ReplicaDataResponse {
     // invocation of 'accessor' if 'name' identifies an attribute of this
     // class, and -1 otherwise.
 
-    ReplicaDataType::Value replicaDataType() const;
-    // Return the value of the "ReplicaDataType" attribute of this object.
-
     int partitionId() const;
     // Return the value of the "PartitionId" attribute of this object.
+
+    unsigned int primaryLeaseId() const;
+    // Return the value of the "PrimaryLeaseId" attribute of this object.
+
+    ReplicaDataType::Value replicaDataType() const;
+    // Return the value of the "ReplicaDataType" attribute of this object.
 
     const PartitionSequenceNumber& beginSequenceNumber() const;
     // Return a reference offering non-modifiable access to the
@@ -30950,16 +30894,18 @@ template <typename t_HASH_ALGORITHM>
 void ReplicaDataRequest::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
 {
     using bslh::hashAppend;
-    hashAppend(hashAlgorithm, this->replicaDataType());
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
+    hashAppend(hashAlgorithm, this->replicaDataType());
     hashAppend(hashAlgorithm, this->beginSequenceNumber());
     hashAppend(hashAlgorithm, this->endSequenceNumber());
 }
 
 inline bool ReplicaDataRequest::isEqualTo(const ReplicaDataRequest& rhs) const
 {
-    return this->replicaDataType() == rhs.replicaDataType() &&
-           this->partitionId() == rhs.partitionId() &&
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->replicaDataType() == rhs.replicaDataType() &&
            this->beginSequenceNumber() == rhs.beginSequenceNumber() &&
            this->endSequenceNumber() == rhs.endSequenceNumber();
 }
@@ -30971,14 +30917,20 @@ int ReplicaDataRequest::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
     int ret;
 
-    ret = manipulator(&d_replicaDataType,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
+    ret = manipulator(&d_partitionId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     if (ret) {
         return ret;
     }
 
-    ret = manipulator(&d_partitionId,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_replicaDataType,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
     if (ret) {
         return ret;
     }
@@ -31006,14 +30958,19 @@ int ReplicaDataRequest::manipulateAttribute(t_MANIPULATOR& manipulator, int id)
     enum { NOT_FOUND = -1 };
 
     switch (id) {
+    case ATTRIBUTE_ID_PARTITION_ID: {
+        return manipulator(&d_partitionId,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    }
     case ATTRIBUTE_ID_REPLICA_DATA_TYPE: {
         return manipulator(
             &d_replicaDataType,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return manipulator(&d_partitionId,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     }
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER: {
         return manipulator(
@@ -31045,14 +31002,19 @@ int ReplicaDataRequest::manipulateAttribute(t_MANIPULATOR& manipulator,
     return manipulateAttribute(manipulator, attributeInfo->d_id);
 }
 
-inline ReplicaDataType::Value& ReplicaDataRequest::replicaDataType()
-{
-    return d_replicaDataType;
-}
-
 inline int& ReplicaDataRequest::partitionId()
 {
     return d_partitionId;
+}
+
+inline unsigned int& ReplicaDataRequest::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
+inline ReplicaDataType::Value& ReplicaDataRequest::replicaDataType()
+{
+    return d_replicaDataType;
 }
 
 inline PartitionSequenceNumber& ReplicaDataRequest::beginSequenceNumber()
@@ -31071,14 +31033,20 @@ int ReplicaDataRequest::accessAttributes(t_ACCESSOR& accessor) const
 {
     int ret;
 
-    ret = accessor(d_replicaDataType,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
+    ret = accessor(d_partitionId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     if (ret) {
         return ret;
     }
 
-    ret = accessor(d_partitionId,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_replicaDataType,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
     if (ret) {
         return ret;
     }
@@ -31105,14 +31073,19 @@ int ReplicaDataRequest::accessAttribute(t_ACCESSOR& accessor, int id) const
     enum { NOT_FOUND = -1 };
 
     switch (id) {
+    case ATTRIBUTE_ID_PARTITION_ID: {
+        return accessor(d_partitionId,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    }
     case ATTRIBUTE_ID_REPLICA_DATA_TYPE: {
         return accessor(
             d_replicaDataType,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return accessor(d_partitionId,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     }
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER: {
         return accessor(
@@ -31144,14 +31117,19 @@ int ReplicaDataRequest::accessAttribute(t_ACCESSOR& accessor,
     return accessAttribute(accessor, attributeInfo->d_id);
 }
 
-inline ReplicaDataType::Value ReplicaDataRequest::replicaDataType() const
-{
-    return d_replicaDataType;
-}
-
 inline int ReplicaDataRequest::partitionId() const
 {
     return d_partitionId;
+}
+
+inline unsigned int ReplicaDataRequest::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
+}
+
+inline ReplicaDataType::Value ReplicaDataRequest::replicaDataType() const
+{
+    return d_replicaDataType;
 }
 
 inline const PartitionSequenceNumber&
@@ -31175,8 +31153,9 @@ template <typename t_HASH_ALGORITHM>
 void ReplicaDataResponse::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
 {
     using bslh::hashAppend;
-    hashAppend(hashAlgorithm, this->replicaDataType());
     hashAppend(hashAlgorithm, this->partitionId());
+    hashAppend(hashAlgorithm, this->primaryLeaseId());
+    hashAppend(hashAlgorithm, this->replicaDataType());
     hashAppend(hashAlgorithm, this->beginSequenceNumber());
     hashAppend(hashAlgorithm, this->endSequenceNumber());
 }
@@ -31184,8 +31163,9 @@ void ReplicaDataResponse::hashAppendImpl(t_HASH_ALGORITHM& hashAlgorithm) const
 inline bool
 ReplicaDataResponse::isEqualTo(const ReplicaDataResponse& rhs) const
 {
-    return this->replicaDataType() == rhs.replicaDataType() &&
-           this->partitionId() == rhs.partitionId() &&
+    return this->partitionId() == rhs.partitionId() &&
+           this->primaryLeaseId() == rhs.primaryLeaseId() &&
+           this->replicaDataType() == rhs.replicaDataType() &&
            this->beginSequenceNumber() == rhs.beginSequenceNumber() &&
            this->endSequenceNumber() == rhs.endSequenceNumber();
 }
@@ -31197,14 +31177,20 @@ int ReplicaDataResponse::manipulateAttributes(t_MANIPULATOR& manipulator)
 {
     int ret;
 
-    ret = manipulator(&d_replicaDataType,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
+    ret = manipulator(&d_partitionId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     if (ret) {
         return ret;
     }
 
-    ret = manipulator(&d_partitionId,
-                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    ret = manipulator(&d_primaryLeaseId,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = manipulator(&d_replicaDataType,
+                      ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
     if (ret) {
         return ret;
     }
@@ -31233,14 +31219,19 @@ int ReplicaDataResponse::manipulateAttribute(t_MANIPULATOR& manipulator,
     enum { NOT_FOUND = -1 };
 
     switch (id) {
+    case ATTRIBUTE_ID_PARTITION_ID: {
+        return manipulator(&d_partitionId,
+                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return manipulator(
+            &d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    }
     case ATTRIBUTE_ID_REPLICA_DATA_TYPE: {
         return manipulator(
             &d_replicaDataType,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return manipulator(&d_partitionId,
-                           ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     }
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER: {
         return manipulator(
@@ -31272,14 +31263,19 @@ int ReplicaDataResponse::manipulateAttribute(t_MANIPULATOR& manipulator,
     return manipulateAttribute(manipulator, attributeInfo->d_id);
 }
 
-inline ReplicaDataType::Value& ReplicaDataResponse::replicaDataType()
-{
-    return d_replicaDataType;
-}
-
 inline int& ReplicaDataResponse::partitionId()
 {
     return d_partitionId;
+}
+
+inline unsigned int& ReplicaDataResponse::primaryLeaseId()
+{
+    return d_primaryLeaseId;
+}
+
+inline ReplicaDataType::Value& ReplicaDataResponse::replicaDataType()
+{
+    return d_replicaDataType;
 }
 
 inline PartitionSequenceNumber& ReplicaDataResponse::beginSequenceNumber()
@@ -31298,14 +31294,20 @@ int ReplicaDataResponse::accessAttributes(t_ACCESSOR& accessor) const
 {
     int ret;
 
-    ret = accessor(d_replicaDataType,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
+    ret = accessor(d_partitionId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     if (ret) {
         return ret;
     }
 
-    ret = accessor(d_partitionId,
-                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    ret = accessor(d_primaryLeaseId,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    if (ret) {
+        return ret;
+    }
+
+    ret = accessor(d_replicaDataType,
+                   ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
     if (ret) {
         return ret;
     }
@@ -31332,14 +31334,19 @@ int ReplicaDataResponse::accessAttribute(t_ACCESSOR& accessor, int id) const
     enum { NOT_FOUND = -1 };
 
     switch (id) {
+    case ATTRIBUTE_ID_PARTITION_ID: {
+        return accessor(d_partitionId,
+                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
+    }
+    case ATTRIBUTE_ID_PRIMARY_LEASE_ID: {
+        return accessor(
+            d_primaryLeaseId,
+            ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PRIMARY_LEASE_ID]);
+    }
     case ATTRIBUTE_ID_REPLICA_DATA_TYPE: {
         return accessor(
             d_replicaDataType,
             ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_REPLICA_DATA_TYPE]);
-    }
-    case ATTRIBUTE_ID_PARTITION_ID: {
-        return accessor(d_partitionId,
-                        ATTRIBUTE_INFO_ARRAY[ATTRIBUTE_INDEX_PARTITION_ID]);
     }
     case ATTRIBUTE_ID_BEGIN_SEQUENCE_NUMBER: {
         return accessor(
@@ -31371,14 +31378,19 @@ int ReplicaDataResponse::accessAttribute(t_ACCESSOR& accessor,
     return accessAttribute(accessor, attributeInfo->d_id);
 }
 
-inline ReplicaDataType::Value ReplicaDataResponse::replicaDataType() const
-{
-    return d_replicaDataType;
-}
-
 inline int ReplicaDataResponse::partitionId() const
 {
     return d_partitionId;
+}
+
+inline unsigned int ReplicaDataResponse::primaryLeaseId() const
+{
+    return d_primaryLeaseId;
+}
+
+inline ReplicaDataType::Value ReplicaDataResponse::replicaDataType() const
+{
+    return d_replicaDataType;
 }
 
 inline const PartitionSequenceNumber&
@@ -39013,6 +39025,6 @@ inline const ControlMessageChoice& ControlMessage::choice() const
 }  // close enterprise namespace
 #endif
 
-// GENERATED BY BLP_BAS_CODEGEN_2026.05.21
+// GENERATED BY BLP_BAS_CODEGEN_9999.99.99
 // USING bas_codegen.pl -m msg --noAggregateConversion --noExternalization
 // --noIdent --package bmqp_ctrlmsg --msgComponent messages bmqp_ctrlmsg.xsd

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -1111,10 +1111,10 @@ void ClusterQueueHelper::processOpenQueueRequest(
         return;  // RETURN
     }
 
-    const int pid = context->queueContext()->partitionId();
+    const int  pid = context->queueContext()->partitionId();
     const bool isSelfAvailable =
         d_clusterData_p->membership().selfNodeStatus() ==
-        bmqp_ctrlmsg::NodeStatus::e_E_AVAILABLE;
+        bmqp_ctrlmsg::NodeStatus::E_AVAILABLE;
     if (hasActiveAvailablePrimary(pid) && isSelfAvailable) {
         if (d_clusterState_p->isSelfPrimary(pid)) {
             // At primary.

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -1706,7 +1706,8 @@ void RecoveryManager::clearBufferedStorageEvent(int partitionId)
 // ACCESSORS
 void RecoveryManager::loadReplicaDataResponsePush(
     bmqp_ctrlmsg::ControlMessage* out,
-    int                           partitionId) const
+    int                           partitionId,
+    unsigned int                  primaryLeaseId) const
 {
     // executed by the *QUEUE DISPATCHER* thread associated with 'partitionId'
 
@@ -1727,8 +1728,9 @@ void RecoveryManager::loadReplicaDataResponsePush(
             .choice()
             .makeReplicaDataResponse();
 
-    response.replicaDataType()     = bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
     response.partitionId()         = partitionId;
+    response.primaryLeaseId()      = primaryLeaseId;
+    response.replicaDataType()     = bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
     response.beginSequenceNumber() = receiveDataCtx.d_beginPSN;
     response.endSequenceNumber()   = receiveDataCtx.d_endPSN;
 }

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -440,12 +440,13 @@ class RecoveryManager {
 
     /// Load into the specified `out` a ReplicaDataResponsePush using
     /// information in self's ReceiveDataContext for the specified
-    /// `partitionId`.
+    /// `partitionId` and `primaryLeaseId`.
     ///
     /// THREAD: Executed in the dispatcher thread associated with the
     /// specified `partitionId`.
     void loadReplicaDataResponsePush(bmqp_ctrlmsg::ControlMessage* out,
-                                     int partitionId) const;
+                                     int                           partitionId,
+                                     unsigned int primaryLeaseId) const;
 };
 
 // ============================================================================

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -786,9 +786,11 @@ void StorageManager::sendReplicaDataRequestPush(
                 .choice()
                 .makeReplicaDataRequest();
 
+        replicaDataRqst.partitionId() = partitionId;
+        replicaDataRqst.primaryLeaseId() =
+            d_partitionInfoVec.at(partitionId).primaryLeaseId();
         replicaDataRqst.replicaDataType() =
             bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
-        replicaDataRqst.partitionId()         = partitionId;
         replicaDataRqst.beginSequenceNumber() = (*cit)->second.d_PSN;
         replicaDataRqst.endSequenceNumber() =
             nodeToPSNCtxMap.at(selfNode).d_PSN;
@@ -858,9 +860,11 @@ void StorageManager::sendReplicaDataRequestDrop(
                 .choice()
                 .makeReplicaDataRequest();
 
+        replicaDataRqst.partitionId() = partitionId;
+        replicaDataRqst.primaryLeaseId() =
+            d_partitionInfoVec.at(partitionId).primaryLeaseId();
         replicaDataRqst.replicaDataType() =
             bmqp_ctrlmsg::ReplicaDataType::E_DROP;
-        replicaDataRqst.partitionId() = partitionId;
 
         request->setResponseCb(
             bdlf::BindUtil::bind(&StorageManager::processReplicaDataResponse,
@@ -1011,15 +1015,6 @@ void StorageManager::processReplicaDataRequestPull(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(source);
-    BSLS_ASSERT_SAFE(message.choice().isClusterMessageValue());
-    BSLS_ASSERT_SAFE(
-        message.choice().clusterMessage().choice().isPartitionMessageValue());
-    BSLS_ASSERT_SAFE(message.choice()
-                         .clusterMessage()
-                         .choice()
-                         .partitionMessage()
-                         .choice()
-                         .isReplicaDataRequestValue());
 
     const bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
         message.choice()
@@ -1094,6 +1089,11 @@ void StorageManager::processReplicaDataRequestPull(
         message.rId().isNull() ? -1 : message.rId().value(),
         partitionId,
         1,
+        source,
+        replicaDataRequest.primaryLeaseId(),
+        bmqp_ctrlmsg::PartitionSequenceNumber(),
+        bmqp_ctrlmsg::PartitionSequenceNumber(),
+        0,
         PartitionSeqNumDataRange(replicaDataRequest.beginSequenceNumber(),
                                  replicaDataRequest.endSequenceNumber()));
 
@@ -1109,15 +1109,6 @@ void StorageManager::processReplicaDataRequestPush(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(message.choice().isClusterMessageValue());
-    BSLS_ASSERT_SAFE(
-        message.choice().clusterMessage().choice().isPartitionMessageValue());
-    BSLS_ASSERT_SAFE(message.choice()
-                         .clusterMessage()
-                         .choice()
-                         .partitionMessage()
-                         .choice()
-                         .isReplicaDataRequestValue());
 
     const bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
         message.choice()
@@ -1167,7 +1158,7 @@ void StorageManager::processReplicaDataRequestPush(
         partitionId,
         1,
         source,
-        d_clusterState_p->partitionsInfo().at(partitionId).primaryLeaseId(),
+        replicaDataRequest.primaryLeaseId(),
         bmqp_ctrlmsg::PartitionSequenceNumber(),
         bmqp_ctrlmsg::PartitionSequenceNumber(),
         source,
@@ -1282,7 +1273,9 @@ void StorageManager::processReplicaDataRequestDrop(
         source,
         message.rId().isNull() ? -1 : message.rId().value(),
         partitionId,
-        1);
+        1,
+        source,
+        replicaDataRequest.primaryLeaseId());
 
     enqueuePartitionFSMEvent(PartitionFSM::Event::e_REPLICA_DATA_RQST_DROP,
                              eventData);
@@ -1307,17 +1300,19 @@ void StorageManager::processPrimaryStateResponseDispatched(
                          context->response().rId().value());
     }
 
-    const int responseId  = context->response().rId().isNull()
-                                ? -1
-                                : context->response().rId().value();
-    const int partitionId = context->request()
-                                .choice()
-                                .clusterMessage()
-                                .choice()
-                                .partitionMessage()
-                                .choice()
-                                .primaryStateRequest()
-                                .partitionId();
+    const int responseId = context->response().rId().isNull()
+                               ? -1
+                               : context->response().rId().value();
+    const bmqp_ctrlmsg::PrimaryStateRequest& request =
+        context->request()
+            .choice()
+            .clusterMessage()
+            .choice()
+            .partitionMessage()
+            .choice()
+            .primaryStateRequest();
+    const int          partitionId    = request.partitionId();
+    const unsigned int primaryLeaseId = request.primaryLeaseId();
 
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
@@ -1348,7 +1343,12 @@ void StorageManager::processPrimaryStateResponseDispatched(
             return;  // RETURN
         }
 
-        PartitionFSMEventData eventData(responder, responseId, partitionId, 1);
+        PartitionFSMEventData eventData(responder,
+                                        responseId,
+                                        partitionId,
+                                        1,
+                                        responder,
+                                        primaryLeaseId);
 
         enqueuePartitionFSMEvent(
             PartitionFSM::Event::e_FAIL_PRIMARY_STATE_RSPN,
@@ -1379,6 +1379,7 @@ void StorageManager::processPrimaryStateResponseDispatched(
             .choice()
             .primaryStateResponse();
     BSLS_ASSERT_SAFE(response.partitionId() == partitionId);
+    BSLS_ASSERT_SAFE(response.primaryLeaseId() == primaryLeaseId);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId
@@ -1391,7 +1392,7 @@ void StorageManager::processPrimaryStateResponseDispatched(
         partitionId,
         1,
         responder,
-        response.primaryLeaseId(),
+        primaryLeaseId,
         response.latestSequenceNumber(),
         response.firstSyncPointAfterRolloverSequenceNumber());
 
@@ -1430,15 +1431,16 @@ void StorageManager::processReplicaStateResponseDispatched(
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(!d_clusterData_p->cluster().isLocal());
 
-    // Fetch partitionId from request
-    const int requestPartitionId = requestContext->request()
-                                       .choice()
-                                       .clusterMessage()
-                                       .choice()
-                                       .partitionMessage()
-                                       .choice()
-                                       .replicaStateRequest()
-                                       .partitionId();
+    const bmqp_ctrlmsg::ReplicaStateRequest& replicaStateRequest =
+        requestContext->request()
+            .choice()
+            .clusterMessage()
+            .choice()
+            .partitionMessage()
+            .choice()
+            .replicaStateRequest();
+    const int          requestPartitionId = replicaStateRequest.partitionId();
+    const unsigned int primaryLeaseId = replicaStateRequest.primaryLeaseId();
 
     BSLS_ASSERT_SAFE(0 <= requestPartitionId &&
                      requestPartitionId <
@@ -1474,28 +1476,14 @@ void StorageManager::processReplicaStateResponseDispatched(
             -1,  // placeholder requestId
             requestPartitionId,
             1,
-            d_clusterData_p->membership().selfNode());
+            d_clusterData_p->membership().selfNode(),
+            primaryLeaseId);
 
         enqueuePartitionFSMEvent(
             PartitionFSM::Event::e_FAIL_REPLICA_STATE_RSPN,
             eventData);
         return;  // RETURN
     }
-
-    BSLS_ASSERT_SAFE(
-        requestContext->response().choice().isClusterMessageValue());
-    BSLS_ASSERT_SAFE(requestContext->response()
-                         .choice()
-                         .clusterMessage()
-                         .choice()
-                         .isPartitionMessageValue());
-    BSLS_ASSERT_SAFE(requestContext->response()
-                         .choice()
-                         .clusterMessage()
-                         .choice()
-                         .partitionMessage()
-                         .choice()
-                         .isReplicaStateResponseValue());
 
     const int requestId = requestContext->response().rId().value();
 
@@ -1508,6 +1496,7 @@ void StorageManager::processReplicaStateResponseDispatched(
             .choice()
             .replicaStateResponse();
     BSLS_ASSERT_SAFE(response.partitionId() == requestPartitionId);
+    BSLS_ASSERT_SAFE(response.primaryLeaseId() == primaryLeaseId);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << requestPartitionId << "]: "
@@ -1519,10 +1508,6 @@ void StorageManager::processReplicaStateResponseDispatched(
                          .at(response.partitionId())
                          .primaryNodeId() ==
                      d_clusterData_p->membership().selfNode()->nodeId());
-
-    const unsigned int primaryLeaseId = d_clusterState_p->partitionsInfo()
-                                            .at(response.partitionId())
-                                            .primaryLeaseId();
 
     PartitionFSMEventData eventData(
         responder,
@@ -1576,9 +1561,10 @@ void StorageManager::processReplicaDataResponseDispatched(
             .partitionMessage()
             .choice()
             .replicaDataRequest();
+    const int          partitionId    = request.partitionId();
+    const unsigned int primaryLeaseId = request.primaryLeaseId();
     const bmqp_ctrlmsg::ReplicaDataType::Value& dataType =
         request.replicaDataType();
-    const int partitionId = request.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
 
@@ -1607,7 +1593,7 @@ void StorageManager::processReplicaDataResponseDispatched(
                     partitionId,
                     1,
                     d_clusterData_p->membership().selfNode(),
-                    d_partitionInfoVec[partitionId].primaryLeaseId(),
+                    primaryLeaseId,
                     request.endSequenceNumber(),
                     bmqp_ctrlmsg::PartitionSequenceNumber(),
                     responder);  // highestSeqNumNode
@@ -1617,30 +1603,38 @@ void StorageManager::processReplicaDataResponseDispatched(
                     eventData);
             }
             else {
-                PartitionFSMEventData eventData(responder,
-                                                responseId,
-                                                partitionId,
-                                                1);
-
+                PartitionFSMEventData eventData(
+                    responder,
+                    responseId,
+                    partitionId,
+                    1,
+                    d_clusterData_p->membership().selfNode(),
+                    primaryLeaseId);
                 enqueuePartitionFSMEvent(
                     PartitionFSM::Event::e_FAIL_REPLICA_DATA_RSPN_PULL,
                     eventData);
             }
         } break;
         case bmqp_ctrlmsg::ReplicaDataType::E_PUSH: {
-            PartitionFSMEventData eventData(responder,
-                                            responseId,
-                                            partitionId,
-                                            1);
+            PartitionFSMEventData eventData(
+                responder,
+                responseId,
+                partitionId,
+                1,
+                d_clusterData_p->membership().selfNode(),
+                primaryLeaseId);
             enqueuePartitionFSMEvent(
                 PartitionFSM::Event::e_FAIL_REPLICA_DATA_RSPN_PUSH,
                 eventData);
         } break;
         case bmqp_ctrlmsg::ReplicaDataType::E_DROP: {
-            PartitionFSMEventData eventData(responder,
-                                            responseId,
-                                            partitionId,
-                                            1);
+            PartitionFSMEventData eventData(
+                responder,
+                responseId,
+                partitionId,
+                1,
+                d_clusterData_p->membership().selfNode(),
+                primaryLeaseId);
             enqueuePartitionFSMEvent(
                 PartitionFSM::Event::e_FAIL_REPLICA_DATA_RSPN_DROP,
                 eventData);
@@ -1655,20 +1649,6 @@ void StorageManager::processReplicaDataResponseDispatched(
         return;  // RETURN
     }
 
-    BSLS_ASSERT_SAFE(context->response().choice().isClusterMessageValue());
-    BSLS_ASSERT_SAFE(context->response()
-                         .choice()
-                         .clusterMessage()
-                         .choice()
-                         .isPartitionMessageValue());
-    BSLS_ASSERT_SAFE(context->response()
-                         .choice()
-                         .clusterMessage()
-                         .choice()
-                         .partitionMessage()
-                         .choice()
-                         .isReplicaDataResponseValue());
-
     const bmqp_ctrlmsg::ReplicaDataResponse& response =
         context->response()
             .choice()
@@ -1678,6 +1658,7 @@ void StorageManager::processReplicaDataResponseDispatched(
             .choice()
             .replicaDataResponse();
     BSLS_ASSERT_SAFE(response.partitionId() == partitionId);
+    BSLS_ASSERT_SAFE(response.primaryLeaseId() == primaryLeaseId);
     BSLS_ASSERT_SAFE(response.beginSequenceNumber() ==
                      request.beginSequenceNumber());
     BSLS_ASSERT_SAFE(response.endSequenceNumber() ==
@@ -1697,6 +1678,11 @@ void StorageManager::processReplicaDataResponseDispatched(
         responseId,
         partitionId,
         incrementCount,
+        d_clusterData_p->membership().selfNode(),
+        primaryLeaseId,
+        bmqp_ctrlmsg::PartitionSequenceNumber(),
+        bmqp_ctrlmsg::PartitionSequenceNumber(),
+        0,
         PartitionSeqNumDataRange(response.beginSequenceNumber(),
                                  response.endSequenceNumber()));
 
@@ -2515,8 +2501,10 @@ void StorageManager::do_replicaDataResponsePush(
                 .choice()
                 .makeReplicaDataResponse();
 
+        response.partitionId() = partitionId;
+        response.primaryLeaseId() =
+            d_partitionInfoVec[partitionId].primaryLeaseId();
         response.replicaDataType() = bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
-        response.partitionId()     = partitionId;
         response.beginSequenceNumber() =
             eventData.partitionSeqNumDataRange().first;
         response.endSequenceNumber() =
@@ -2525,8 +2513,10 @@ void StorageManager::do_replicaDataResponsePush(
     else {
         // Responding after receiving all data chunks
 
-        d_recoveryManager_mp->loadReplicaDataResponsePush(&controlMsg,
-                                                          partitionId);
+        d_recoveryManager_mp->loadReplicaDataResponsePush(
+            &controlMsg,
+            partitionId,
+            d_partitionInfoVec[partitionId].primaryLeaseId());
     }
 
     fileStore(partitionId).sendMessage(controlMsg, destNode);
@@ -2567,9 +2557,11 @@ void StorageManager::do_replicaDataRequestPull(
             .choice()
             .makeReplicaDataRequest();
 
+    replicaDataRequest.partitionId() = partitionId;
+    replicaDataRequest.primaryLeaseId() =
+        d_partitionInfoVec[partitionId].primaryLeaseId();
     replicaDataRequest.replicaDataType() =
         bmqp_ctrlmsg::ReplicaDataType::E_PULL;
-    replicaDataRequest.partitionId() = partitionId;
     replicaDataRequest.beginSequenceNumber() =
         d_nodeToPSNCtxMapVec[partitionId]
                             [d_clusterData_p->membership().selfNode()]
@@ -2630,8 +2622,10 @@ void StorageManager::do_replicaDataResponsePull(
             .choice()
             .makeReplicaDataResponse();
 
+    response.partitionId() = partitionId;
+    response.primaryLeaseId() =
+        d_partitionInfoVec[partitionId].primaryLeaseId();
     response.replicaDataType() = bmqp_ctrlmsg::ReplicaDataType::E_PULL;
-    response.partitionId()     = partitionId;
     response.beginSequenceNumber() =
         eventData.partitionSeqNumDataRange().first;
     response.endSequenceNumber() = eventData.partitionSeqNumDataRange().second;
@@ -3461,8 +3455,10 @@ void StorageManager::do_removeStorageAndSendReplicaDataDropResponse(
                 .choice()
                 .makeReplicaDataResponse();
 
+        response.partitionId() = partitionId;
+        response.primaryLeaseId() =
+            d_partitionInfoVec[partitionId].primaryLeaseId();
         response.replicaDataType() = bmqp_ctrlmsg::ReplicaDataType::E_DROP;
-        response.partitionId()     = partitionId;
         response.beginSequenceNumber() =
             eventData.partitionSeqNumDataRange().first;
         response.endSequenceNumber() =

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -499,7 +499,8 @@ struct TestHelper {
     void verifyPrimarySendsReplicaDataRqstPull(
         int                                          partitionId,
         int                                          highestSeqNumNodeId,
-        const bmqp_ctrlmsg::PartitionSequenceNumber& highestSeqNum)
+        const bmqp_ctrlmsg::PartitionSequenceNumber& highestSeqNum,
+        unsigned int                                 primaryLeaseId = 1U)
     {
         bmqp_ctrlmsg::ClusterMessage      expectedMessage;
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
@@ -508,7 +509,8 @@ struct TestHelper {
                 .choice()
                 .makeReplicaDataRequest();
 
-        replicaDataRequest.partitionId() = partitionId;
+        replicaDataRequest.partitionId()    = partitionId;
+        replicaDataRequest.primaryLeaseId() = primaryLeaseId;
         replicaDataRequest.replicaDataType() =
             bmqp_ctrlmsg::ReplicaDataType::E_PULL;
         replicaDataRequest.endSequenceNumber() = highestSeqNum;
@@ -542,7 +544,8 @@ struct TestHelper {
     void verifyPrimarySendsReplicaDataRqstPush(
         int                                          partitionId,
         const NodeIdToPSNMap&                        destinationReplicas,
-        const bmqp_ctrlmsg::PartitionSequenceNumber& selfSeqNum)
+        const bmqp_ctrlmsg::PartitionSequenceNumber& selfSeqNum,
+        unsigned int                                 primaryLeaseId = 1U)
     {
         bmqp_ctrlmsg::ClusterMessage      expectedMessage;
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
@@ -554,6 +557,7 @@ struct TestHelper {
         replicaDataRequest.replicaDataType() =
             bmqp_ctrlmsg::ReplicaDataType::E_PUSH;
         replicaDataRequest.partitionId()       = partitionId;
+        replicaDataRequest.primaryLeaseId()    = primaryLeaseId;
         replicaDataRequest.endSequenceNumber() = selfSeqNum;
 
         for (TestChannelMapCIter cit = d_cluster_mp->_channels().cbegin();
@@ -2571,6 +2575,7 @@ static void test15_replicaWaitingReceivesReplicaDataRqstPull()
     replicaDataRequest.replicaDataType() =
         bmqp_ctrlmsg::ReplicaDataType::E_PULL;
     replicaDataRequest.partitionId()         = k_PARTITION_ID;
+    replicaDataRequest.primaryLeaseId()      = 1U;
     replicaDataRequest.beginSequenceNumber() = k_PRIMARY_SEQ_NUM;
     replicaDataRequest.endSequenceNumber()   = selfSeqNum;
 
@@ -2943,7 +2948,7 @@ static void test18_primaryHealingWatchdogRetry()
     PSN.primaryLeaseId() = k_PRIMARY_LEASE_ID;
 
     replicaStateResponse.partitionId()          = k_PARTITION_ID;
-    replicaStateResponse.primaryLeaseId()       = k_PRIMARY_LEASE_ID;
+    replicaStateResponse.primaryLeaseId()       = 1U;
     replicaStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(message);
@@ -3490,6 +3495,7 @@ static void test23_replicaHealingReceivesReplicaDataRqstDropInvalidPid()
     PSN.primaryLeaseId() = 1U;
 
     primaryStateResponse.partitionId()          = k_PARTITION_ID;
+    primaryStateResponse.primaryLeaseId()       = 1U;
     primaryStateResponse.latestSequenceNumber() = PSN;
 
     helper.d_cluster_mp->requestManager().processResponse(pstMessage);

--- a/src/integration-tests/test_fsm_partition_sync.py
+++ b/src/integration-tests/test_fsm_partition_sync.py
@@ -750,7 +750,7 @@ def test_sync_after_primary_extra_records(
     # consumption issues.
     matches = leader.capture_n(
         [
-            r"Sending request to '\[(\w+), \d+\]'.*replicaDataRequest = \[ replicaDataType = E_PULL",
+            r"Sending request to '\[(\w+), \d+\]'.*replicaDataRequest = \[ partitionId = \d+ primaryLeaseId = \d+ replicaDataType = E_PULL",
             r"Removing entire storage and requesting it from replica",
             r"Cluster \(itCluster\) is available",
         ],


### PR DESCRIPTION
  ## Summary
  - Add a `primaryLeaseId` field to `ReplicaDataRequest` and `ReplicaDataResponse` control messages so that replicas can detect stale primaries during partition data synchronization.
  - Verify that the `primaryLeaseId` in responses matches the one sent in the corresponding request, catching mismatches early.
  - Pass `primaryLeaseId` through `PartitionFSMEventData` for all PULL, PUSH, DROP, and failure event paths so the partition FSM has the correct lease context for stale detection.