### PR TITLE
Refactor[bmqp::Event]: less includes, more forward declarations

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_event.cpp
+++ b/src/groups/bmq/bmqp/bmqp_event.cpp
@@ -15,6 +15,14 @@
 
 #include <bmqp_event.h>
 
+#include <bmqp_ackmessageiterator.h>
+#include <bmqp_confirmmessageiterator.h>
+#include <bmqp_pushmessageiterator.h>
+#include <bmqp_putmessageiterator.h>
+#include <bmqp_recoverymessageiterator.h>
+#include <bmqp_rejectmessageiterator.h>
+#include <bmqp_storagemessageiterator.h>
+
 #include <bmqscm_version.h>
 // BDE
 #include <bsl_iostream.h>
@@ -26,6 +34,72 @@ namespace bmqp {
 // -----------
 // class Event
 // -----------
+
+void Event::loadAckMessageIterator(AckMessageIterator* iterator) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isAckEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header);
+}
+
+void Event::loadConfirmMessageIterator(ConfirmMessageIterator* iterator) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isConfirmEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header);
+}
+
+void Event::loadPushMessageIterator(PushMessageIterator* iterator,
+                                    bool                 decompressFlag) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isPushEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header, decompressFlag);
+}
+
+void Event::loadPutMessageIterator(PutMessageIterator* iterator,
+                                   bool                decompressFlag) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isPutEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header, decompressFlag);
+}
+
+void Event::loadStorageMessageIterator(StorageMessageIterator* iterator) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isStorageEvent() || isPartitionSyncEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header);
+}
+
+void Event::loadRecoveryMessageIterator(
+    RecoveryMessageIterator* iterator) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isRecoveryEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header);
+}
+
+void Event::loadRejectMessageIterator(RejectMessageIterator* iterator) const
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(isRejectEvent());
+    BSLS_ASSERT_SAFE(isValid());
+
+    iterator->reset(blob(), *d_header);
+}
 
 bsl::ostream&
 Event::print(bsl::ostream& stream, int level, int spacesPerLevel) const

--- a/src/groups/bmq/bmqp/bmqp_event.h
+++ b/src/groups/bmq/bmqp/bmqp_event.h
@@ -29,15 +29,8 @@
 
 // BMQ
 
-#include <bmqp_ackmessageiterator.h>
-#include <bmqp_confirmmessageiterator.h>
 #include <bmqp_protocol.h>
 #include <bmqp_protocolutil.h>
-#include <bmqp_pushmessageiterator.h>
-#include <bmqp_putmessageiterator.h>
-#include <bmqp_recoverymessageiterator.h>
-#include <bmqp_rejectmessageiterator.h>
-#include <bmqp_storagemessageiterator.h>
 
 #include <bmqu_blob.h>
 #include <bmqu_blobobjectproxy.h>
@@ -56,6 +49,15 @@
 
 namespace BloombergLP {
 namespace bmqp {
+
+// FORWARD DECLARATIONS
+class AckMessageIterator;
+class ConfirmMessageIterator;
+class PushMessageIterator;
+class PutMessageIterator;
+class RecoveryMessageIterator;
+class RejectMessageIterator;
+class StorageMessageIterator;
 
 // ===========
 // class Event
@@ -632,75 +634,6 @@ int Event::loadAuthenticationEvent(TYPE* message) const
     BSLS_ASSERT_SAFE(isAuthenticationEvent());
 
     return loadSchemaEvent(message);
-}
-
-inline void Event::loadAckMessageIterator(AckMessageIterator* iterator) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isAckEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header);
-}
-
-inline void
-Event::loadConfirmMessageIterator(ConfirmMessageIterator* iterator) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isConfirmEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header);
-}
-
-inline void Event::loadPushMessageIterator(PushMessageIterator* iterator,
-                                           bool decompressFlag) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isPushEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header, decompressFlag);
-}
-
-inline void Event::loadPutMessageIterator(PutMessageIterator* iterator,
-                                          bool decompressFlag) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isPutEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header, decompressFlag);
-}
-
-inline void
-Event::loadStorageMessageIterator(StorageMessageIterator* iterator) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isStorageEvent() || isPartitionSyncEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header);
-}
-
-inline void
-Event::loadRecoveryMessageIterator(RecoveryMessageIterator* iterator) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isRecoveryEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header);
-}
-
-inline void
-Event::loadRejectMessageIterator(RejectMessageIterator* iterator) const
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(isRejectEvent());
-    BSLS_ASSERT_SAFE(isValid());
-
-    iterator->reset(blob(), *d_header);
 }
 
 inline const bdlbb::Blob* Event::blob() const

--- a/src/groups/bmq/bmqp/bmqp_event.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_event.t.cpp
@@ -16,9 +16,15 @@
 #include <bmqp_event.h>
 
 // BMQ
+#include <bmqp_ackmessageiterator.h>
+#include <bmqp_confirmmessageiterator.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocol.h>
+#include <bmqp_pushmessageiterator.h>
+#include <bmqp_putmessageiterator.h>
+#include <bmqp_recoverymessageiterator.h>
 #include <bmqp_schemaeventbuilder.h>
+#include <bmqp_storagemessageiterator.h>
 
 #include <bmqu_memoutstream.h>
 

--- a/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoveryeventbuilder.t.cpp
@@ -17,6 +17,7 @@
 
 // BMQ
 #include <bmqp_event.h>
+#include <bmqp_recoverymessageiterator.h>
 
 #include <bmqu_blob.h>
 

--- a/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storageeventbuilder.t.cpp
@@ -17,6 +17,7 @@
 
 // BMQ
 #include <bmqp_event.h>
+#include <bmqp_storagemessageiterator.h>
 
 // BDE
 #include <bdlbb_blob.h>

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -33,6 +33,7 @@
 #include <mqbu_messageguidutil.h>
 
 // BMQ
+#include <bmqp_ackmessageiterator.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_messageguidgenerator.h>

--- a/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.t.cpp
@@ -16,10 +16,15 @@
 #include <mqbnet_channel.h>
 
 // BMQ
+#include <bmqp_ackmessageiterator.h>
+#include <bmqp_confirmmessageiterator.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_event.h>
 #include <bmqp_messageguidgenerator.h>
 #include <bmqp_protocol.h>
+#include <bmqp_pushmessageiterator.h>
+#include <bmqp_putmessageiterator.h>
+#include <bmqp_rejectmessageiterator.h>
 #include <bmqt_messageguid.h>
 
 #include <bmqio_testchannel.h>


### PR DESCRIPTION
Reduces include cost for `bmqp_event.h` from 13.7k to 10k lines.
This header is included 118 times.