### PR TITLE
CI: Fix clang-tidy checker

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,27 @@
+Checks: bugprone-*,cert-*,clang-analyzer-*,clang-diagnostic-*,cppcoreguidelines-*,modernize-make-*,performance-*,modernize-use-emplace,-bugprone-easily-swappable-parameters,-cppcoreguidelines-avoid-const-or-ref-data-members,-cppcoreguidelines-owning-memory,-cppcoreguidelines-use-default-member-init,-,-performance-enum-size
+CheckOptions:
+  cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
+  bugprone-string-constructor.StringNames: ::bsl::basic_string; ::std::basic_string; ::std::basic_string_view
+  bugprone-optional-value-conversion.OptionalTypes: ::bsl::optional; ::BloombergLP::bdlb::NullableValue; ::std::optional; ::absl::optional; ::boost::optional
+  bugprone-capturing-this-in-member-variable.FunctionWrapperTypes: ::bsl::function; ::bsl::move_only_function; ::std::function; ::std::move_only_function;
+    ::boost::function
+  modernize-make-shared.MakeSmartPtrFunction: bsl::make_shared
+  modernize-make-shared.MakeSmartPtrFunctionHeader: bsl_memory.h
+  modernize-make-unique.MakeSmartPtrFunction: bsl::make_unique
+  modernize-make-unique.MakeSmartPtrFunctionHeader: bsl_memory.h
+  modernize-use-emplace.ContainersWithPushBack: ::bsl::vector; ::bsl::list; ::bsl::deque; ::std::vector; ::std::list; ::std::deque
+  modernize-use-emplace.ContainersWithPush: ::bsl::stack; ::bsl::queue; ::bsl::priority_queue; ::std::stack; ::std::queue; ::std::priority_queue
+  modernize-use-emplace.ContainersWithPushFront: ::bsl::forward_list; ::bsl::list; ::bsl::deque; ::std::forward_list; ::std::list; ::std::deque
+  modernize-use-emplace.SmartPointers: ::bsl::shared_ptr; ::bsl::unique_ptr; ::bsl::auto_ptr; ::bsl::weak_ptr; ::std::shared_ptr; ::std::unique_ptr; ::std::auto_ptr;
+    ::std::weak_ptr
+  modernize-use-emplace.TupleMakeFunctions: ::bsl::make_pair; ::bsl::make_tuple; ::std::make_pair; ::std::make_tuple
+  modernize-use-emplace.TupleTypes: ::bsl::pair; ::bsl::tuple; ::std::pair; ::std::tuple
+  performance-faster-string-find.StringLikeClasses: ::bsl::basic_string; ::std::basic_string; ::std::basic_string_view
+  performance-for-range-copy.WarnOnAllAutoCopies: true
+  performance-inefficient-vector-operation.VectorLikeClasses: ::bsl::vector; ::std::vector
+  modernize-use-override.OverrideSpelling: BSLS_KEYWORD_OVERRIDE
+  modernize-use-noexcept.ReplacementString: BSLS_KEYWORD_NOEXCEPT
+WarningsAsErrors: '*'
+ExtraArgs:
+- -Wno-unknown-warning-option
+HeaderFilterRegex: .*,.*,.*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -426,3 +426,25 @@ jobs:
 
       - name: Inspect Docker images
         run: docker image ls
+
+  cpp-linter-check:
+    name: C++ Linter Check
+    needs: build_ubuntu
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v5
+      - uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: ''  # Disable clang-format checks
+          tidy-checks: '' # Use .clang-tidy config file
+          # only 'update' a single comment in a pull request thread.
+          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
+          lines-changed-only: diff
+          version: '21'
+          database: build/blazingmq
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -184,23 +184,3 @@ jobs:
         run: |
           export PYTHONPATH=${{ github.workspace }}/src/python:$PYTHONPATH
           git diff -U0 origin/main | lint-diffs
-
-  cpp-linter-check:
-    name: C++ Linter Check
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@v5
-      - uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: ''  # Disable clang-format checks
-          tidy-checks: '' # Use .clang-tidy config file
-          # only 'update' a single comment in a pull request thread.
-          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
-          lines-changed-only: diff
-          version: '18'
-      - name: Fail fast?!
-        if: steps.linter.outputs.checks-failed > 0
-        run: exit 1


### PR DESCRIPTION
The basic cpp-linter setup didn't work because of the way that we include files in BlazingMQ, but we can directly pass it a path to a compilation_commands.json, which we only have access to after configuring the project. We don't have a way to get to the state of the build right after we call configure, but we can grab the post build step. We could in theory start the checks earlier, but this is simple.
