### PR TITLE
Build: disable C++03 autogen in base CMake preset

### DIFF
--- a/etc/presets/default.json
+++ b/etc/presets/default.json
@@ -13,7 +13,8 @@
                 "BMQ_ASSERT_LEVEL": "SAFE",
                 "CMAKE_CXX_STANDARD": "23",
                 "BDE_BUILD_TARGET_CPP23": "ON",
-                "CMAKE_INSTALL_LIBDIR": "lib64"
+                "CMAKE_INSTALL_LIBDIR": "lib64",
+                "SIM_CPP11": ""
             }
         }
     ]


### PR DESCRIPTION
Set `SIM_CPP11=""` in the base CMake preset to prevent `sim_cpp11_features.pl` from running during local builds. The script embeds a timestamp in generated `*_cpp03.h` files, causing them to appear dirty after every build even when nothing changed.

CI presets (`gh-base`) are unaffected — they don't inherit from base, so C++03 codegen validation still runs in GitHub Actions.