### PR TITLE
CI: Add compile commands exporting to CI builds

### DIFF
--- a/etc/presets/gh-ci.json
+++ b/etc/presets/gh-ci.json
@@ -12,7 +12,8 @@
                 "BDE_BUILD_TARGET_64": "ON",
                 "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_PREFIX_PATH":
-                    "$env{GITHUB_WORKSPACE}/deps/srcs/bde-tools/BdeBuildSystem"
+                    "$env{GITHUB_WORKSPACE}/deps/srcs/bde-tools/BdeBuildSystem",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "1"
             }
         },
         {


### PR DESCRIPTION
We need this for clang tooling we run on CI
