### PR TITLE
CI: Download artifacts from build during cpp lints

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -433,6 +433,9 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v5
+        with:
+          name: ${{needs.build_ubuntu.outputs.artifact_key }}
       - uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5
         id: linter
         env:


### PR DESCRIPTION
There are issues from clang tidy still. This should restore the build directory like we expect.
