### PR TITLE
Refactor: simplify stat includes

### DIFF
--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -466,7 +466,7 @@
 
 #define BMQTST_ASSERT_NEF(X, Y)                                               \
     {                                                                         \
-        if (bmqtst::TestHelper : areFuzzyEqual((X), (Y))) {                   \
+        if (bmqtst::TestHelper::areFuzzyEqual((X), (Y))) {                    \
             bsl::cout << "Error " << __FILE__ << "(" << __LINE__              \
                       << "): " << #X << " (" << bmqtst::printer(X)            \
                       << ") !~= " << #Y << " (" << bmqtst::printer(Y) << ")"  \

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -73,6 +73,7 @@ namespace BloombergLP {
 
 // FORWARD DECLARATION
 namespace mqbcmd {
+class ClusterQueueHelper;
 class StorageContent;
 }
 namespace mqbi {

--- a/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterdata.cpp
@@ -16,16 +16,21 @@
 #include <mqbc_clusterdata.h>
 
 // MQB
+#include <mqbi_domain.h>
 #include <mqbnet_cluster.h>
 #include <mqbnet_elector.h>
+#include <mqbnet_transportmanager.h>
 #include <mqbscm_version.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_protocol.h>
 #include <bmqscm_version.h>
+#include <bmqst_statcontext.h>
+#include <bmqu_memoutstream.h>
 
 // BDE
+#include <bdlma_localsequentialallocator.h>
 #include <bdls_processutil.h>
 #include <bsl_map.h>
 #include <bsl_memory.h>

--- a/src/groups/mqb/mqbc/mqbc_clusterdata.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterdata.h
@@ -30,41 +30,41 @@
 #include <mqbcfg_messages.h>
 #include <mqbi_cluster.h>
 #include <mqbi_dispatcher.h>
-#include <mqbi_domain.h>
-#include <mqbnet_cluster.h>
 #include <mqbnet_controlmessagetransmitter.h>
-#include <mqbnet_elector.h>
 #include <mqbnet_multirequestmanager.h>
-#include <mqbnet_transportmanager.h>
 #include <mqbstat_clusterstats.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_requestmanager.h>
-#include <bmqst_statcontext.h>
 #include <bmqu_atomicstate.h>
-#include <bmqu_memoutstream.h>
 
 // BDE
 #include <bdlbb_blob.h>
 #include <bdlcc_objectpool.h>
-#include <bdlma_localsequentialallocator.h>
 #include <bdlmt_eventscheduler.h>
 #include <bdlmt_fixedthreadpool.h>
-#include <bsl_map.h>
-#include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
-#include <bsl_unordered_set.h>
-#include <bsl_vector.h>
-#include <bslma_default.h>
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
-#include <bsls_types.h>
 
 namespace BloombergLP {
+
+// FORWARD DECLARATIONS
+namespace bmqst {
+class StatContext;
+}
+namespace mqbi {
+class DomainFactory;
+}
+namespace mqbnet {
+class Cluster;
+class TransportManager;
+}
+
 namespace mqbc {
 
 // =========================

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -30,6 +30,7 @@
 #include <mqbnet_elector.h>
 
 // BMQ
+#include <bmqio_testchannel.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.cpp
@@ -19,11 +19,14 @@
 
 #include <mqbscm_version.h>
 // MQB
+#include <mqbc_clusterdata.h>
 #include <mqbc_clusternodesession.h>
+#include <mqbc_clusterstateledgeriterator.h>
 #include <mqbc_clusterstateledgerprotocol.h>
 #include <mqbc_electorinfo.h>
 #include <mqbc_incoreclusterstateledgeriterator.h>
 #include <mqbcfg_brokerconfig.h>
+#include <mqbconfm_messages.h>
 #include <mqbi_domain.h>
 #include <mqbi_queueengine.h>
 #include <mqbi_storagemanager.h>
@@ -32,6 +35,7 @@
 #include <mqbs_datastore.h>
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_storageutil.h>
+#include <mqbu_storagekey.h>
 
 // BMQ
 #include <bmqp_protocol.h>
@@ -46,8 +50,11 @@
 
 // BDE
 #include <bdlb_print.h>
+#include <bdlbb_blob.h>
 #include <bdlde_md5.h>
+#include <bdlf_bind.h>
 #include <bdlma_localsequentialallocator.h>
+#include <bsl_iostream.h>
 #include <bsl_limits.h>
 #include <bsl_unordered_set.h>
 #include <bsl_utility.h>

--- a/src/groups/mqb/mqbc/mqbc_clusterutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterutil.h
@@ -29,28 +29,16 @@
 /// thread.
 
 // MQB
-#include <mqbc_clusterdata.h>
+#include <mqbc_clustermembership.h>
 #include <mqbc_clusterstate.h>
-#include <mqbc_clusterstateledger.h>
-#include <mqbc_clusterstateledgeriterator.h>
 #include <mqbcfg_messages.h>
-#include <mqbconfm_messages.h>
 #include <mqbi_clusterstatemanager.h>
-#include <mqbi_dispatcher.h>
-#include <mqbu_storagekey.h>
 
 // BMQ
 #include <bmqp_ctrlmsg_messages.h>
-#include <bmqp_protocolutil.h>
-#include <bmqp_puteventbuilder.h>
-#include <bmqt_resultcode.h>
-#include <bmqt_uri.h>
 
 // BDE
-#include <bdlbb_blob.h>
-#include <bdlf_bind.h>
-#include <bsl_iostream.h>
-#include <bsl_memory.h>
+#include <bsl_iosfwd.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bsl_vector.h>
@@ -58,7 +46,16 @@
 
 namespace BloombergLP {
 
-// FORWARD DECLARATION
+// FORWARD DECLARATIONS
+namespace bdlbb {
+class Blob;
+}
+namespace bmqt {
+class Uri;
+}
+namespace mqbconfm {
+class QueueMode;
+}
 namespace mqbi {
 class Domain;
 }
@@ -68,11 +65,17 @@ class StorageManager;
 namespace mqbnet {
 class ClusterNode;
 }
+namespace mqbu {
+class StorageKey;
+}
 
 namespace mqbc {
 
-// FORWARD DECLARATION
+// FORWARD DECLARATIONS
+class ClusterData;
 class ClusterNodeSession;
+class ClusterStateLedger;
+class ClusterStateLedgerIterator;
 
 // ==================
 // struct ClusterUtil

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -22,6 +22,7 @@
 // MQB
 #include <mqbc_clusterutil.h>
 #include <mqbc_recoverymanager.h>
+#include <mqbcmd_messages.h>
 #include <mqbevt_dispatcherevent.h>
 #include <mqbevt_storageevent.h>
 #include <mqbi_storage.h>

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -16,6 +16,7 @@
 #include <mqbc_storagemanager.h>
 
 // BMQ
+#include <bmqio_testchannel.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
 #include <bmqp_event.h>

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.cpp
@@ -20,11 +20,14 @@
 #include <mqbc_clustermembership.h>
 #include <mqbc_clusterutil.h>
 #include <mqbcmd_messages.h>
+#include <mqbconfm_messages.h>
 #include <mqbnet_mockcluster.h>
 #include <mqbstat_clusterstats.h>
 
 // BMQ
+#include <bmqio_testchannel.h>
 #include <bmqp_ctrlmsg_messages.h>
+#include <bmqst_statcontext.h>
 
 #include <bmqio_channel.h>
 #include <bmqu_memoutstream.h>

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -42,23 +42,16 @@
 #include <mqbc_clusterdata.h>
 #include <mqbc_clusterstate.h>
 #include <mqbcfg_messages.h>
-#include <mqbconfm_messages.h>
 #include <mqbi_cluster.h>
 #include <mqbi_dispatcher.h>
 #include <mqbmock_dispatcher.h>
 #include <mqbmock_domain.h>
-#include <mqbnet_channel.h>
 #include <mqbnet_cluster.h>
 #include <mqbnet_transportmanager.h>
-
-#include <bmqio_status.h>
-#include <bmqio_testchannel.h>
-#include <bmqst_statcontext.h>
 
 // BDE
 #include <bdlbb_blob.h>
 #include <bdlbb_pooledblobbufferfactory.h>
-#include <bdlcc_objectpool.h>
 #include <bdlcc_sharedobjectpool.h>
 #include <bdlmt_eventscheduler.h>
 #include <bsl_functional.h>
@@ -81,11 +74,17 @@ namespace BloombergLP {
 namespace bdlmt {
 class FixedThreadPool;
 }
+namespace bmqio {
+class TestChannel;
+}
 namespace bmqp_ctrlmsg {
 class QueueHandleParameters;
 }
 namespace bmqp_ctrlmsg {
 class QueueStreamParameters;
+}
+namespace bmqst {
+class StatContext;
 }
 namespace bmqt {
 class Uri;
@@ -95,6 +94,9 @@ class ClusterCommand;
 }
 namespace mqbcmd {
 class ClusterResult;
+}
+namespace mqbconfm {
+class Domain;
 }
 namespace mqbi {
 class Domain;

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -391,10 +391,10 @@ TCPSessionFactory::channelStatContextCreator(
 
     ntsa::Ipv4Address   ipv4Address(static_cast<bsl::uint32_t>(peerAddress));
     ntsa::IpAddress     ipAddress(ipv4Address);
-    bmqst::StatContext* parent = d_statController_p->channelsStatContext(
+    bmqst::StatContext* parent =
         bmqio::ChannelUtil::isLocalHost(ipAddress)
-            ? mqbstat::StatController::ChannelSelector::e_LOCAL
-            : mqbstat::StatController::ChannelSelector::e_REMOTE);
+            ? d_statController_p->localChannelsStatContext()
+            : d_statController_p->remoteChannelsStatContext();
     BSLS_ASSERT_SAFE(parent);
 
     bsl::string endpoint =

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.cpp
@@ -18,6 +18,7 @@
 #include <mqbscm_version.h>
 // BMQ
 #include <bmqt_queueflags.h>
+#include <bmqt_uri.h>
 
 // MQB
 #include <mqbcfg_brokerconfig.h>
@@ -26,9 +27,12 @@
 #include <mqbi_domain.h>
 #include <mqbi_queue.h>
 
+#include <bmqst_basictableinfoprovider.h>
 #include <bmqst_statcontext.h>
 #include <bmqst_statutil.h>
 #include <bmqst_statvalue.h>
+#include <bmqst_table.h>
+#include <bmqst_tablerecords.h>
 
 // BDE
 #include <ball_log.h>

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -30,13 +30,6 @@
 // 'mqbstat::QueueStatsUtil' is a utility namespace exposing methods to
 // initialize the stat contexts and associated objects.
 
-// BMQ
-#include <bmqt_uri.h>
-
-#include <bmqst_basictableinfoprovider.h>
-#include <bmqst_table.h>
-#include <bmqst_tablerecords.h>
-
 // BDE
 #include <bsl_list.h>
 #include <bsl_memory.h>
@@ -49,14 +42,19 @@
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
-#include <bsls_cpp11.h>
+#include <bsls_keyword.h>
 #include <bsls_types.h>
 
 namespace BloombergLP {
 
 // FORWARD DECLARATION
+namespace bmqt {
+class Uri;
+}
 namespace bmqst {
+class BasicTableInfoProvider;
 class StatContext;
+class Table;
 }
 namespace mqbi {
 class Domain;
@@ -217,10 +215,10 @@ class QueueStatsDomain {
 
   private:
     // NOT IMPLEMENTED
-    QueueStatsDomain(const QueueStatsDomain&) BSLS_CPP11_DELETED;
+    QueueStatsDomain(const QueueStatsDomain&) BSLS_KEYWORD_DELETED;
 
     /// Copy constructor and assignment operator are not implemented.
-    QueueStatsDomain& operator=(const QueueStatsDomain&) BSLS_CPP11_DELETED;
+    QueueStatsDomain& operator=(const QueueStatsDomain&) BSLS_KEYWORD_DELETED;
 
     // ACCESSORS
     /// Look for the specified `appId` among the stored appId subcontexts and
@@ -347,10 +345,10 @@ class QueueStatsClient {
 
   private:
     // NOT IMPLEMENTED
-    QueueStatsClient(const QueueStatsClient&) BSLS_CPP11_DELETED;
+    QueueStatsClient(const QueueStatsClient&) BSLS_KEYWORD_DELETED;
 
     /// Copy constructor and assignment operator are not implemented.
-    QueueStatsClient& operator=(const QueueStatsClient&) BSLS_CPP11_DELETED;
+    QueueStatsClient& operator=(const QueueStatsClient&) BSLS_KEYWORD_DELETED;
 
   public:
     // CLASS METHODS

--- a/src/groups/mqb/mqbstat/mqbstat_queuestats.h
+++ b/src/groups/mqb/mqbstat/mqbstat_queuestats.h
@@ -30,6 +30,9 @@
 // 'mqbstat::QueueStatsUtil' is a utility namespace exposing methods to
 // initialize the stat contexts and associated objects.
 
+// BMQ
+#include <bmqst_statcontext.h>
+
 // BDE
 #include <bsl_list.h>
 #include <bsl_memory.h>

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp
@@ -29,7 +29,12 @@
 #include <mqbstat_clusterstats.h>
 #include <mqbstat_dispatcherstats.h>
 #include <mqbstat_domainstats.h>
+#include <mqbstat_flatjsonprinter.h>
+#include <mqbstat_jsonprinter.h>
 #include <mqbstat_queuestats.h>
+#include <mqbstat_statmonitor.h>
+#include <mqbstat_statsfilelogger.h>
+#include <mqbstat_tableprinter.h>
 
 #include <bmqio_statchannelfactory.h>
 #include <bmqst_statcontext.h>
@@ -52,6 +57,7 @@
 #include <bdlf_bind.h>
 #include <bdlf_placeholder.h>
 #include <bdlmt_eventscheduler.h>
+#include <bdlmt_timereventscheduler.h>
 #include <bdlt_timeunitratio.h>
 #include <bsl_algorithm.h>
 #include <bsl_ctime.h>
@@ -301,24 +307,26 @@ void StatController::initializeStats()
 }
 
 void StatController::captureStatsAndSemaphorePost(
-    mqbcmd::StatResult*                  result,
-    bslmt::Semaphore*                    semaphore,
-    const mqbcmd::EncodingFormat::Value& encoding)
+    mqbcmd::StatResult* result_p,
+    bslmt::Semaphore*   semaphore_p,
+    int                 encoding)
 {
     // executed by the *SCHEDULER* thread
 
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(result_p);
+    BSLS_ASSERT_SAFE(semaphore_p);
+
     if (d_allocatorsStatContext_p) {
-        // When using test allocator, we don't have a stat context
         d_allocatorsStatContext_p->snapshot();
     }
 
     switch (encoding) {
     case mqbcmd::EncodingFormat::TEXT: {
-        bmqu::MemOutStream os;
+        bmqu::MemOutStream os(d_allocator_p);
         d_tablePrinter_mp->printStats(os, -1);
-        result->makeStats() = os.str();
+        result_p->makeStats() = os.str();
     } break;  // BREAK
-
     case mqbcmd::EncodingFormat::JSON_COMPACT: BSLA_FALLTHROUGH;
     case mqbcmd::EncodingFormat::JSON_PRETTY: {
         // Make an unscheduled snapshot, but do not notify stats consumers
@@ -328,25 +336,24 @@ void StatController::captureStatsAndSemaphorePost(
         // outdated existing one.
         const bool savedNextSnapshot = snapshot();
         if (savedNextSnapshot) {
-            const bool compact = (encoding ==
+            const bool         compact = (encoding ==
                                   mqbcmd::EncodingFormat::JSON_COMPACT);
             bmqu::MemOutStream os(d_allocator_p);
             d_jsonPrinter_mp->printStats(os, compact);
-            result->makeStats() = os.str();
+            result_p->makeStats() = os.str();
         }
         else {
-            result->makeError().message() =
+            result_p->makeError().message() =
                 "Cannot save the recent snapshot, trying to make snapshots "
                 "too often";
         }
     } break;  // BREAK
-
     default: {
         BSLS_ASSERT(!"invalid enumerator");
     } break;  // BREAK
     }
 
-    semaphore->post();
+    semaphore_p->post();
 }
 
 void StatController::setTunable(mqbcmd::StatResult*       result,
@@ -1047,10 +1054,9 @@ void StatController::loadStatContexts(StatContexts* contexts)
     }
 }
 
-int StatController::processCommand(
-    mqbcmd::StatResult*                  result,
-    const mqbcmd::StatCommand&           command,
-    const mqbcmd::EncodingFormat::Value& encoding)
+int StatController::processCommand(mqbcmd::StatResult*        result,
+                                   const mqbcmd::StatCommand& command,
+                                   int                        encoding)
 {
     if (command.isShowValue()) {
         bslmt::Semaphore semaphore;

--- a/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
+++ b/src/groups/mqb/mqbstat/mqbstat_statcontroller.h
@@ -27,24 +27,15 @@
 // config) dumping the stats to a dedicated log file.
 
 // MQB
-#include <mqbcmd_messages.h>
-#include <mqbstat_flatjsonprinter.h>
-#include <mqbstat_jsonprinter.h>
-#include <mqbstat_statmonitor.h>
-#include <mqbstat_statsfilelogger.h>
-#include <mqbstat_tableprinter.h>
-
 #include <bmqma_countingallocatorstore.h>
-#include <bmqst_statcontext.h>
 
 // BDE
 #include <ball_log.h>
 #include <bdlbb_blob.h>
 #include <bdlmt_throttle.h>
-#include <bdlmt_timereventscheduler.h>
 #include <bsl_functional.h>
+#include <bsl_iosfwd.h>
 #include <bsl_memory.h>
-#include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bsl_vector.h>
@@ -52,7 +43,6 @@
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
-#include <bsls_assert.h>
 #include <bsls_keyword.h>
 #include <bsls_types.h>
 
@@ -61,14 +51,14 @@ namespace BloombergLP {
 // FORWARD DECLARATION
 namespace bdlmt {
 class EventScheduler;
+class TimerEventScheduler;
 }
 namespace bslmt {
 class Semaphore;
 }
 namespace mqbcmd {
+class SetTunable;
 class StatCommand;
-}
-namespace mqbcmd {
 class StatResult;
 }
 namespace mqbplug {
@@ -89,6 +79,13 @@ class BasicTableInfoProvider;
 
 namespace mqbstat {
 
+// FORWARD DECLARATION
+class FlatJsonPrinter;
+class JsonPrinter;
+class StatMonitor;
+class StatsFileLogger;
+class TablePrinter;
+
 // ====================
 // class StatController
 // ====================
@@ -96,13 +93,6 @@ namespace mqbstat {
 class StatController {
   public:
     // PUBLIC TYPES
-
-    /// Enum representing the available types of stat context selections for
-    /// the `channels` stats.
-    struct ChannelSelector {
-        // TYPES
-        enum Enum { e_ALL, e_LOCAL, e_REMOTE };
-    };
 
     /// Signature of a method for processing the command in the specified
     /// `cmd` coming from the specified `source`, and writing the result of
@@ -273,10 +263,9 @@ class StatController {
     /// Note that the JSON format is typically used within integration tests
     /// so we make an out of order stats snapshot when compact or pretty JSON
     /// encoding is passed.
-    void captureStatsAndSemaphorePost(
-        mqbcmd::StatResult*                  result,
-        bslmt::Semaphore*                    semaphore,
-        const mqbcmd::EncodingFormat::Value& encoding);
+    void captureStatsAndSemaphorePost(mqbcmd::StatResult* result_p,
+                                      bslmt::Semaphore*   semaphore_p,
+                                      int                 encoding);
 
     /// Process specified `tunable` subcommand and load the result into the
     /// specified `result` and post on the optionally specified `semaphore`
@@ -356,9 +345,9 @@ class StatController {
     /// object.  Return zero on success or a nonzero value otherwise.
     /// The specified `encoding` parameter controls whether the result should
     /// be in a text format or in a JSON.
-    int processCommand(mqbcmd::StatResult*                  result,
-                       const mqbcmd::StatCommand&           command,
-                       const mqbcmd::EncodingFormat::Value& encoding);
+    int processCommand(mqbcmd::StatResult*        result,
+                       const mqbcmd::StatCommand& command,
+                       int                        encoding);
 
     /// Retrieve the dispatcher top-level stat context.
     bmqst::StatContext* dispatcherStatContext();
@@ -378,9 +367,11 @@ class StatController {
     /// Retrieve the clusters top-level stat context.
     bmqst::StatContext* clustersStatContext();
 
-    /// Retrieve the channels stat context corresponding to the specified
-    /// `selector`.
-    bmqst::StatContext* channelsStatContext(ChannelSelector::Enum selector);
+    /// Retrieve the local channels stat context.
+    bmqst::StatContext* localChannelsStatContext();
+
+    /// Retrieve the remote channels stat context.
+    bmqst::StatContext* remoteChannelsStatContext();
 };
 
 // ============================================================================
@@ -421,19 +412,14 @@ inline bmqst::StatContext* StatController::clustersStatContext()
     return d_statContextsMap["clusters"].d_statContext_sp.get();
 }
 
-inline bmqst::StatContext*
-StatController::channelsStatContext(ChannelSelector::Enum selector)
+inline bmqst::StatContext* StatController::localChannelsStatContext()
 {
-    switch (selector) {
-    case ChannelSelector::e_ALL:
-        return d_statContextsMap["channels"].d_statContext_sp.get();
-    case ChannelSelector::e_LOCAL: return d_statContextChannelsLocal_mp.get();
-    case ChannelSelector::e_REMOTE:
-        return d_statContextChannelsRemote_mp.get();
-    default: BSLS_ASSERT_OPT(false && "unknown channel selector");
-    }
+    return d_statContextChannelsLocal_mp.get();
+}
 
-    return 0;  // compiler happiness
+inline bmqst::StatContext* StatController::remoteChannelsStatContext()
+{
+    return d_statContextChannelsRemote_mp.get();
 }
 
 }  // close package namespace


### PR DESCRIPTION
This PR removes 3.4kk (-10%) intermediate lines in preprocessed files during compilation.

# Before
```
Codebase Stats
-----------------------------------------------------
  Total source files:                             956
  Total own lines:                             650373
  Total transitive includes:                    20797
  Total include cost (lines):                32926286
```

# After

```
Codebase Stats
-----------------------------------------------------
  Total source files:                             956
  Total own lines:                             650380
  Total transitive includes:                    19255
  Total include cost (lines):                29446938
```