### PR TITLE
Refactor[bmqp::MessageGUIDGenerator]: forward declaration

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -421,7 +421,7 @@ int SessionUtil::createApplication(SessionImpl* sessionImpl)
     sessionImpl->d_guidGenerator_sp.createInplace(sessionImpl->d_allocator_p,
                                                   ci.sessionId());
 
-    ci.guidInfo() = sessionImpl->d_guidGenerator_sp->guidInfo();
+    sessionImpl->d_guidGenerator_sp->loadGuidInfo(&ci.guidInfo());
 
     // EventHandlerCB
     bmqimp::EventQueue::EventHandlerCallback eventHandler;

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.cpp
@@ -18,6 +18,7 @@
 #include <bmqscm_version.h>
 
 #include <bmqio_resolveutil.h>
+#include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_messageguid.h>
 #include <bmqu_memoutstream.h>
 
@@ -339,14 +340,13 @@ bsl::ostream& MessageGUIDGenerator::print(bsl::ostream&            stream,
     return stream;
 }
 
-bmqp_ctrlmsg::GuidInfo MessageGUIDGenerator::guidInfo() const
+void MessageGUIDGenerator::loadGuidInfo(bmqp_ctrlmsg::GuidInfo* guidInfo) const
 {
-    bmqp_ctrlmsg::GuidInfo ret;
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(guidInfo);
 
-    ret.clientId()             = d_clientIdHex;
-    ret.nanoSecondsFromEpoch() = d_nanoSecondsFromEpoch;
-
-    return ret;
+    guidInfo->clientId()             = d_clientIdHex;
+    guidInfo->nanoSecondsFromEpoch() = d_nanoSecondsFromEpoch;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_messageguidgenerator.h
+++ b/src/groups/bmq/bmqp/bmqp_messageguidgenerator.h
@@ -77,7 +77,6 @@
 
 // BMQ
 
-#include <bmqp_ctrlmsg_messages.h>
 #include <bmqt_messageguid.h>
 
 // BDE
@@ -88,6 +87,12 @@
 #include <bsls_types.h>
 
 namespace BloombergLP {
+
+// FORWARD DECLARATION
+namespace bmqp_ctrlmsg {
+class GuidInfo;
+}
+
 namespace bmqp {
 
 // ==========================
@@ -157,8 +162,8 @@ class MessageGUIDGenerator {
     /// component level documentation for details about how it is computed).
     const char* clientIdHex() const;
 
-    /// Return the `guidInfo` populated with the attributes of this object.
-    bmqp_ctrlmsg::GuidInfo guidInfo() const;
+    /// Populate the specified `guidInfo` with the attributes of this object.
+    void loadGuidInfo(bmqp_ctrlmsg::GuidInfo* guidInfo) const;
 
     /// --------------------------
     /// For testing/debugging only


### PR DESCRIPTION
Removes ~200k lines from intermediate files during compilation