### PR TITLE
Fix[bmqex::SystemExecutor]: remove static singleton

### DIFF
--- a/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executionpolicy.t.cpp
@@ -265,7 +265,7 @@ static void test4_util()
     {
         BMQTST_ASSERT_EQ(defaultPolicy.blocking(),
                          bmqex::ExecutionProperty::e_POSSIBLY_BLOCKING);
-        BMQTST_ASSERT(defaultPolicy.executor() == bmqex::SystemExecutor());
+
         BMQTST_ASSERT_EQ(defaultPolicy.allocator(),
                          bslma::Default::allocator());
     }
@@ -276,7 +276,7 @@ static void test4_util()
 
         BMQTST_ASSERT_EQ(p.blocking(),
                          bmqex::ExecutionProperty::e_NEVER_BLOCKING);
-        BMQTST_ASSERT(p.executor() == defaultPolicy.executor());
+
         BMQTST_ASSERT_EQ(p.allocator(), defaultPolicy.allocator());
     }
 
@@ -286,7 +286,7 @@ static void test4_util()
 
         BMQTST_ASSERT_EQ(p.blocking(),
                          bmqex::ExecutionProperty::e_POSSIBLY_BLOCKING);
-        BMQTST_ASSERT(p.executor() == defaultPolicy.executor());
+
         BMQTST_ASSERT_EQ(p.allocator(), defaultPolicy.allocator());
     }
 
@@ -296,7 +296,7 @@ static void test4_util()
 
         BMQTST_ASSERT_EQ(p.blocking(),
                          bmqex::ExecutionProperty::e_ALWAYS_BLOCKING);
-        BMQTST_ASSERT(p.executor() == defaultPolicy.executor());
+
         BMQTST_ASSERT_EQ(p.allocator(), defaultPolicy.allocator());
     }
 
@@ -316,7 +316,7 @@ static void test4_util()
             &allocator);
 
         BMQTST_ASSERT_EQ(p.blocking(), defaultPolicy.blocking());
-        BMQTST_ASSERT(p.executor() == defaultPolicy.executor());
+
         BMQTST_ASSERT_EQ(p.allocator(), &allocator);
     }
 }
@@ -342,5 +342,7 @@ int main(int argc, char* argv[])
     } break;
     }
 
-    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+    // 'ExecutionPolicyUtil::defaultPolicy()' allocates a 'SystemExecutor'
+    // context from the default allocator via 'bsl::allocate_shared'.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
 }

--- a/src/groups/bmq/bmqex/bmqex_executor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executor.cpp
@@ -191,39 +191,6 @@ void Executor::swap(Executor& other) BSLS_KEYWORD_NOEXCEPT
 }
 
 // ACCESSORS
-bool Executor::operator==(const Executor& rhs) const BSLS_KEYWORD_NOEXCEPT
-{
-    if (!(*this) && !rhs) {
-        // Both 'Executor's are target-less, therefore equal.
-        return true;  // RETURN
-    }
-
-    if (!(*this) || !rhs) {
-        // Only one 'Executor' contains a target, therefore they are not equal.
-        return false;  // RETURN
-    }
-
-    if (this->d_box.target() == rhs.d_box.target()) {
-        // Both 'Executor's share a target, therefore they are equal.
-        return true;  // RETURN
-    }
-
-    if (this->d_box.target()->targetType() !=
-        rhs.d_box.target()->targetType()) {
-        // 'Executor's have different target types, therefore they are not
-        // equal.
-        return false;  // RETURN
-    }
-
-    // compare targets
-    return this->d_box.target()->equal(*rhs.d_box.target());
-}
-
-bool Executor::operator!=(const Executor& rhs) const BSLS_KEYWORD_NOEXCEPT
-{
-    return !(*this == rhs);
-}
-
 Executor::operator bool() const BSLS_KEYWORD_NOEXCEPT
 {
     return static_cast<bool>(d_box.target());

--- a/src/groups/bmq/bmqex/bmqex_executor.h
+++ b/src/groups/bmq/bmqex/bmqex_executor.h
@@ -161,12 +161,6 @@ class Executor_TargetBase {
   public:
     // ACCESSORS
 
-    /// Return `e1 == e2`, where `e1` and `e2` are contained executor
-    /// targets (of type `E`) of `*this` and `other` respectively. The
-    /// behavior is undefined unless `typeid(e1) == typeid(e2)` is `true`.
-    virtual bool
-    equal(const Executor_TargetBase& other) const BSLS_KEYWORD_NOEXCEPT = 0;
-
     /// Return a pointer to the contained executor target.
     virtual void*       target() BSLS_KEYWORD_NOEXCEPT       = 0;
     virtual const void* target() const BSLS_KEYWORD_NOEXCEPT = 0;
@@ -224,10 +218,6 @@ class Executor_Target : public Executor_TargetBase {
 
   public:
     // ACCESSORS
-    bool equal(const Executor_TargetBase& other) const BSLS_KEYWORD_NOEXCEPT
-        BSLS_KEYWORD_OVERRIDE;
-    // Implements 'Executor_TargetBase::equal()'.
-
     void* target() BSLS_KEYWORD_NOEXCEPT BSLS_KEYWORD_OVERRIDE;
 
     /// Implements `Executor_TargetBase::target()`.
@@ -293,11 +283,6 @@ class Executor_Box_SboImp {
     /// size of the on-stack buffer used to store the executor target.
     struct Dummy {
         void* d_padding[4];
-
-        bool operator==(const Dummy&) const BSLS_KEYWORD_NOEXCEPT
-        {
-            return false;
-        }
 
         void post(const bsl::function<void()>&) const
         {
@@ -517,20 +502,6 @@ class Executor {
   public:
     // ACCESSORS
 
-    /// * If both `*this` and `rhs` contain no target, return `true`;
-    /// * Otherwise, if only one of `*this` and `rhs` contains a target,
-    ///   return `false`;
-    /// * Otherwise, if `*this` and `rhs` share the same target, return
-    ///   `true`;
-    /// * Otherwise, if `*this` and `rhs` contain targets of different
-    ///   types, return `false`;
-    /// * Otherwise, return `e1 == e2`, where `e1` and `e2` are targets
-    ///   (of type `E`) of `*this` and `rhs` respectively.
-    bool operator==(const Executor& rhs) const BSLS_KEYWORD_NOEXCEPT;
-
-    /// Return `!(*this == rhs)`.
-    bool operator!=(const Executor& rhs) const BSLS_KEYWORD_NOEXCEPT;
-
     /// If `*this` has a target, return `true`.  Otherwise, return `false`.
     BSLS_KEYWORD_EXPLICIT
     operator bool() const BSLS_KEYWORD_NOEXCEPT;
@@ -600,17 +571,6 @@ inline void Executor_Target<EXECUTOR>::move(void* dst) BSLS_KEYWORD_NOEXCEPT
 }
 
 // ACCESSORS
-template <class EXECUTOR>
-inline bool Executor_Target<EXECUTOR>::equal(
-    const Executor_TargetBase& other) const BSLS_KEYWORD_NOEXCEPT
-{
-    // PRECONDITIONS
-    BSLS_ASSERT(targetType() == other.targetType());
-
-    return *static_cast<const EXECUTOR*>(target()) ==
-           *static_cast<const EXECUTOR*>(other.target());
-}
-
 template <class EXECUTOR>
 inline void* Executor_Target<EXECUTOR>::target() BSLS_KEYWORD_NOEXCEPT
 {

--- a/src/groups/bmq/bmqex/bmqex_executor.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_executor.t.cpp
@@ -141,60 +141,6 @@ class StatExecutor {
     Statistics* statistics() const { return d_statistics_p; }
 };
 
-// =======================
-// class SelfEqualExecutor
-// =======================
-
-/// Provides a dummy executor that always compares equal to itself.
-class SelfEqualExecutor {
-  public:
-    // MANIPULATORS
-    template <class F>
-    void post(const F&) const
-    {
-        // not a valid operation
-        BSLS_ASSERT_OPT(false);
-    }
-
-    template <class F>
-    void dispatch(const F&) const
-    {
-        // not a valid operation
-        BSLS_ASSERT_OPT(false);
-    }
-
-  public:
-    // ACCESSORS
-    bool operator==(const SelfEqualExecutor&) const { return true; }
-};
-
-// =========================
-// class SelfUnequalExecutor
-// =========================
-
-/// Provides a dummy executor that always compares unequal to itself.
-class SelfUnequalExecutor {
-  public:
-    // MANIPULATORS
-    template <class F>
-    void post(const F&) const
-    {
-        // not a valid operation
-        BSLS_ASSERT_OPT(false);
-    }
-
-    template <class F>
-    void dispatch(const F&) const
-    {
-        // not a valid operation
-        BSLS_ASSERT_OPT(false);
-    }
-
-  public:
-    // ACCESSORS
-    bool operator==(const SelfUnequalExecutor&) const { return false; }
-};
-
 // =====================
 // class ExecutorElarger
 // =====================
@@ -786,87 +732,6 @@ static void test8_targetType()
     BMQTST_ASSERT_EQ(ex2.targetType() == typeid(StatExecutor), true);
 }
 
-static void test9_equalityComparison()
-// ------------------------------------------------------------------------
-// EQUALITY COMPARISON
-//
-// Concerns:
-//   Ensure proper behavior of the equality comparison operator.
-//
-// Plan:
-//   Check that:
-//   : o Two empty executors compare equal;
-//   : o An empty executor does not compare equal with a non-empty executor;
-//   : o Executors sharing the same target compares equal;
-//   : o Executors with different target types compare unequal;
-//   : o Executors with the same target type compare equal if their targets
-//   :   compare equal, and vice versa.
-//
-// Testing:
-//   Equality comparison
-// ------------------------------------------------------------------------
-{
-    // PRECONDITIONS
-    BSLMF_ASSERT(bmqex::Executor_Box_SboImpCanHold<
-                     ExecutorElarger<SelfUnequalExecutor> >::value == false);
-
-    bslma::TestAllocator alloc;
-
-    // two empty executors compare equal
-    BMQTST_ASSERT_EQ(bmqex::Executor() == bmqex::Executor(), true);
-    BMQTST_ASSERT_EQ(bmqex::Executor() != bmqex::Executor(), false);
-
-    // empty executor is not equal to a non-empty executor
-    BMQTST_ASSERT_EQ(bmqex::Executor() ==
-                         bmqex::Executor(SelfEqualExecutor(), &alloc),
-                     false);
-    BMQTST_ASSERT_EQ(bmqex::Executor() !=
-                         bmqex::Executor(SelfEqualExecutor(), &alloc),
-                     true);
-
-    // non-empty executor is not equal to an empty executor
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) ==
-                         bmqex::Executor(),
-                     false);
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) !=
-                         bmqex::Executor(),
-                     true);
-
-    // executors sharing the same target compares equal
-    bmqex::Executor ex1(ExecutorElarger<SelfUnequalExecutor>(), &alloc);
-    bmqex::Executor ex2 = ex1;
-    BMQTST_ASSERT_EQ(ex1.target<SelfUnequalExecutor>() ==
-                         ex2.target<SelfUnequalExecutor>(),
-                     true);
-    BMQTST_ASSERT_EQ(ex1 == ex2, true);
-    BMQTST_ASSERT_EQ(ex1 != ex2, false);
-
-    // executors with different target types compare unequal
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) ==
-                         bmqex::Executor(SelfUnequalExecutor(), &alloc),
-                     false);
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) !=
-                         bmqex::Executor(SelfUnequalExecutor(), &alloc),
-                     true);
-
-    // executors with the same target type compare equal if their targets
-    // compare equal ...
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfUnequalExecutor(), &alloc) ==
-                         bmqex::Executor(SelfUnequalExecutor(), &alloc),
-                     false);
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfUnequalExecutor(), &alloc) !=
-                         bmqex::Executor(SelfUnequalExecutor(), &alloc),
-                     true);
-
-    // ... and vice versa
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) ==
-                         bmqex::Executor(SelfEqualExecutor(), &alloc),
-                     true);
-    BMQTST_ASSERT_EQ(bmqex::Executor(SelfEqualExecutor(), &alloc) !=
-                         bmqex::Executor(SelfEqualExecutor(), &alloc),
-                     false);
-}
-
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -884,7 +749,6 @@ int main(int argc, char* argv[])
     case 6: test6_boolOperator(); break;
     case 7: test7_target(); break;
     case 8: test8_targetType(); break;
-    case 9: test9_equalityComparison(); break;
 
     default: {
         bsl::cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND."

--- a/src/groups/bmq/bmqex/bmqex_systemexecutor.cpp
+++ b/src/groups/bmq/bmqex/bmqex_systemexecutor.cpp
@@ -20,119 +20,10 @@
 #include <bsl_functional.h>
 #include <bslma_default.h>
 #include <bslmt_lockguard.h>
-#include <bslmt_once.h>
 #include <bslmt_threadattributes.h>
-#include <bsls_objectbuffer.h>
-#include <bsls_platform.h>
 
 namespace BloombergLP {
 namespace bmqex {
-
-namespace {
-
-// ===================
-// struct ContextGuard
-// ===================
-
-/// Provides a guard that calls `shutdownSingletonImpl` on destruction.
-struct ContextGuard {
-    // CREATORS
-    ~ContextGuard();
-};
-
-// GLOBAL DATA
-
-/// Pointer to the execution context singleton object. The reason this is an
-/// atomic is that this pointer might be initialized from one thread, and be
-/// read from another.
-bsls::AtomicPointer<SystemExecutor_Context> s_context_p(0);
-
-/// Memory buffer used to store the singleton object.
-bsls::ObjectBuffer<SystemExecutor_Context> s_contextBuffer;
-
-// UTILITY FUNCTIONS
-
-/// Initialize the singleton object, if not already, with the optionally
-/// specified `globalAllocator`. Load into the specified `wasInit` `true` if
-/// the singleton object was initialized, and `false` otherwise. If
-/// `globalAllocator` is 0, use the currently installed global allocator.
-/// Return a reference to the singleton object. The behavior id undefined if
-/// the singleton has already been destroyed via a call to
-/// `shutdownSingletonImpl`.
-SystemExecutor_Context&
-initSingletonImpl(bool* wasInit, bslma::Allocator* globalAllocator = 0)
-{
-    // PRECONDITIONS
-    BSLS_ASSERT(wasInit);
-
-    *wasInit = false;
-
-    BSLMT_ONCE_DO
-    {
-        // obtain allocator
-        bslma::Allocator* allocator = bslma::Default::globalAllocator(
-            globalAllocator);
-
-        // create context and set singleton pointer
-        s_context_p.storeRelease(new (s_contextBuffer.address())
-                                     SystemExecutor_Context(allocator));
-
-        // set initialization flag
-        *wasInit = true;
-
-#if defined(BSLS_PLATFORM_CMP_CLANG)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wexit-time-destructors"
-#endif
-        // NOTE: Suppress Clang annoying warning.
-
-        // This object will destroy the singleton object (if not already) when
-        // the application terminates.
-        static ContextGuard s_contextGuard;
-#if defined(BSLS_PLATFORM_CMP_CLANG)
-#pragma clang diagnostic pop
-#endif
-    }
-
-    // get singleton pointer
-    SystemExecutor_Context* context = s_context_p.loadAcquire();
-
-    BSLS_ASSERT(context && "Singleton not initialized");
-    return *context;
-}
-
-/// Destroy the singleton object, if not already. Load into the specified
-/// `wasShutdown` `true` if the singleton object was destroyed, and `false`
-/// otherwise.
-void shutdownSingletonImpl(bool* wasShutdown) BSLS_KEYWORD_NOEXCEPT
-{
-    // PRECONDITIONS
-    BSLS_ASSERT(wasShutdown);
-
-    // reset singleton pointer
-    SystemExecutor_Context* context = s_context_p.swapAcqRel(0);
-
-    // set shutdown flag
-    *wasShutdown = static_cast<bool>(context);
-
-    if (context) {
-        // If the singleton object is initialized, destroy it.
-        context->~SystemExecutor_Context();
-    }
-}
-
-// -------------------
-// struct ContextGuard
-// -------------------
-
-// CREATORS
-ContextGuard::~ContextGuard()
-{
-    bool wasShutdown;  // unused
-    shutdownSingletonImpl(&wasShutdown);
-}
-
-}  // close unnamed namespace
 
 // ----------------------------
 // class SystemExecutor_Context
@@ -171,32 +62,6 @@ void SystemExecutor_Context::finalizeThread(
         //       have been spawned right after the 'd_unjoinedThreads' counter
         //       check.
     }
-}
-
-// CLASS METHODS
-SystemExecutor_Context& SystemExecutor_Context::singleton()
-{
-    bool wasInit;  // unused
-    return initSingletonImpl(&wasInit);
-}
-
-SystemExecutor_Context&
-SystemExecutor_Context::initSingleton(bslma::Allocator* globalAllocator)
-{
-    bool                    wasInit;
-    SystemExecutor_Context& context = initSingletonImpl(&wasInit,
-                                                        globalAllocator);
-
-    BSLS_ASSERT(wasInit && "Singleton already initialized");
-    return context;
-}
-
-void SystemExecutor_Context::shutdownSingleton() BSLS_KEYWORD_NOEXCEPT
-{
-    bool wasShutdown;
-    shutdownSingletonImpl(&wasShutdown);
-
-    BSLS_ASSERT(wasShutdown && "Singleton not initialized");
 }
 
 // CREATORS
@@ -249,64 +114,24 @@ SystemExecutor_Context::allocator() const BSLS_KEYWORD_NOEXCEPT
 // --------------------
 
 // CREATORS
-SystemExecutor::SystemExecutor()
-: d_threadAttributes()
+SystemExecutor::SystemExecutor(bslma::Allocator* basicAllocator)
+: d_context_sp(bsl::allocate_shared<SystemExecutor_Context>(basicAllocator))
+, d_threadAttributes()
 {
-    // Initialize the context singleton if not already. If we don't, the
-    // singleton will be initialized on the first call to 'post' / 'dispatch',
-    // which is fine, but doing this on construction feels more natural.
-    SystemExecutor_Context::singleton();
 }
 
 SystemExecutor::SystemExecutor(const bslmt::ThreadAttributes& threadAttributes,
                                bslma::Allocator*              basicAllocator)
-: d_threadAttributes(
+: d_context_sp(bsl::allocate_shared<SystemExecutor_Context>(basicAllocator))
+, d_threadAttributes(
       bsl::allocate_shared<bslmt::ThreadAttributes>(basicAllocator,
                                                     threadAttributes))
 {
     // PRECONDITIONS
     BSLS_ASSERT(threadAttributes.detachedState() ==
                 bslmt::ThreadAttributes::e_CREATE_JOINABLE);
-
-    // Initialize the context singleton if not already. If we don't, the
-    // singleton will be initialized on the first call to 'post' / 'dispatch',
-    // which is fine, but doing this on construction feels more natural.
-    SystemExecutor_Context::singleton();
-}
-
-// ACCESSORS
-const bslmt::ThreadAttributes*
-SystemExecutor::threadAttributes() const BSLS_KEYWORD_NOEXCEPT
-{
-    return d_threadAttributes.get();
 }
 
 }  // close package namespace
-
-// FREE OPERATORS
-bool bmqex::operator==(const SystemExecutor& lhs,
-                       const SystemExecutor& rhs) BSLS_KEYWORD_NOEXCEPT
-{
-    if (lhs.threadAttributes() == rhs.threadAttributes()) {
-        // Both executors share the same 'bslmt::ThreadAttributes' object, or
-        // both have no attributes at all. Therefore they are equivalent.
-        return true;  // RETURN
-    }
-
-    if (!lhs.threadAttributes() || !rhs.threadAttributes()) {
-        // One executor does have attributes and the other one doesn't.
-        // Therefore they are not equivalent.
-        return false;  // RETURN
-    }
-
-    // both executors have attributes, compare them
-    return *lhs.threadAttributes() == *rhs.threadAttributes();
-}
-
-bool bmqex::operator!=(const SystemExecutor& lhs,
-                       const SystemExecutor& rhs) BSLS_KEYWORD_NOEXCEPT
-{
-    return !(lhs == rhs);
-}
 
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqex/bmqex_systemexecutor.h
+++ b/src/groups/bmq/bmqex/bmqex_systemexecutor.h
@@ -19,8 +19,7 @@
 //@PURPOSE: Provides an executor allowing functions to execute on any thread.
 //
 //@CLASSES:
-//  bmqex::SystemExecutor:             system executor
-//  bmqex::SystemExecutorContextGuard: scoped system execution context guard
+//  bmqex::SystemExecutor: system executor
 //
 //@DESCRIPTION:
 // This component provides a mechanism 'bmqex::SystemExecutor', that is an
@@ -43,11 +42,11 @@
 //
 /// Execution context
 ///-----------------
-// All 'bmqex::SystemExecutor' objects refer to the same execution context
-// mechanism, that is a singleton. While the execution context itself is an
-// implementation details, a guard class, 'bmqex::SystemExecutorContextGuard',
-// is provided, allowing to explicitly initialized the context with a custom
-// allocator.
+// Each 'bmqex::SystemExecutor' object owns an execution context, represented
+// by 'bmqex::SystemExecutor_Context', via a shared pointer. Copies of an
+// executor share the same context. When the last executor referencing a given
+// context is destroyed, the context destructor blocks until all threads
+// spawned through that context have completed.
 //
 /// Usage
 ///-----
@@ -57,26 +56,6 @@
 //  bmqex::SystemExecutor ex;
 //  ex.post([](){ bsl::cout << "I'm executed!"; });
 //..
-// And here is another one. This time we explicitly specify desired attributes
-// of the system thread.
-//..
-//  bslmt::ThreadAttributes threadAttr;
-//  threadAttr.setStackSize(1024 * 1024);
-//
-//  bmqex::SystemExecutor ex(threadAttr);
-//  ex.post([](){ bsl::cout << "I'm executed!"; });
-//..
-// And this example demonstrates the usage of the execution context guard with
-// a custom allocator.
-//..
-//  // a test allocator
-//  bslma::TestAllocator testAlloc;
-//
-//  // initialize system execution context with test allocator
-//  // bmqex::SystemExecutorContextGuard sysCtxGuard(&testAlloc);
-//
-//  // use the executor ...
-//..
 
 // BDE
 #include <bdlma_concurrentpoolallocator.h>
@@ -85,6 +64,7 @@
 #include <bslalg_constructorproxy.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
+#include <bslma_usesbslmaallocator.h>
 #include <bslmf_decay.h>
 #include <bslmf_isbitwisemoveable.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -164,7 +144,7 @@ struct SystemExecutor_ThreadData {
 // class SystemExecutor_Context
 // ============================
 
-/// Provides a singleton execution context for `SystemExecutor`.
+/// Provides an execution context for `SystemExecutor`.
 class SystemExecutor_Context {
   private:
     // PRIVATE DATA
@@ -216,39 +196,15 @@ class SystemExecutor_Context {
     operator&=(const SystemExecutor_Context&) BSLS_KEYWORD_DELETED;
 
   public:
-    // CLASS METHODS
-
-    /// Return a reference to a process-wide unique object of this class.
-    /// The lifetime of this object is guaranteed to extend from the first
-    /// call of this function (or of `initSingleton`), and until either a
-    /// call to `shutdownSingleton`, or the program termination. The
-    /// behavior is undefined if the object has already been destroyed via a
-    /// call to `shutdownSingleton`.
-    static SystemExecutor_Context& singleton();
-
-    /// Return a reference to a process-wide unique object of this class
-    /// initialized with the optionally specified `globalAllocator` or, if
-    /// `globalAllocator` is 0, with the currently installed global
-    /// allocator. The lifetime of this object is guaranteed to extend from
-    /// the first call of this function, and until either a call to
-    /// `shutdownSingleton`, or the program termination. The behavior is
-    /// undefined if the object has already been initialized via a call to
-    /// `singleton` / `initSingleton`, or has already been destroyed via a
-    /// call to `shutdownSingleton`.
-    static SystemExecutor_Context&
-    initSingleton(bslma::Allocator* globalAllocator = 0);
-
-    /// Destroy the singleton object. The behavior is undefined if the
-    /// object has not been initialized, or has already been destroyed.
-    static void shutdownSingleton() BSLS_KEYWORD_NOEXCEPT;
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SystemExecutor_Context,
+                                   bslma::UsesBslmaAllocator)
 
   public:
     // CREATORS
 
     /// Create a `SystemExecutor_Context` object. Specify an `allocator`
     /// used to supply memory.
-    ///
-    /// Note that this constructor shall not be used directly.
     explicit SystemExecutor_Context(bslma::Allocator* allocator);
 
     /// Destroy this object. Block the calling thread pending completion of
@@ -303,6 +259,9 @@ class SystemExecutor {
   private:
     // PRIVATE DATA
 
+    // Execution context shared between copies of this executor.
+    bsl::shared_ptr<SystemExecutor_Context> d_context_sp;
+
     // Optional thread attributes used when spawning threads to execute
     // submitted functors. Note that to meet the `noexcept` requirements
     // for the executor copy and move constructors, this object is shared
@@ -310,11 +269,18 @@ class SystemExecutor {
     bsl::shared_ptr<bslmt::ThreadAttributes> d_threadAttributes;
 
   public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(SystemExecutor, bslma::UsesBslmaAllocator)
+    BSLMF_NESTED_TRAIT_DECLARATION(SystemExecutor, bslmf::IsBitwiseMoveable)
+
+  public:
     // CREATORS
 
     /// Create a `SystemExecutor` object with no associated thread
-    /// attributes.
-    SystemExecutor();
+    /// attributes. Optionally specify a `basicAllocator` used to supply
+    /// memory. If `basicAllocator` is 0, the currently installed default
+    /// allocator is used.
+    SystemExecutor(bslma::Allocator* basicAllocator = 0);
 
     /// Create a `SystemExecutor` object with the specified associated
     /// `threadAttributes`. Optionally specify a `basicAllocator` used to
@@ -354,62 +320,7 @@ class SystemExecutor {
     /// expression.
     template <class FUNCTION>
     void dispatch(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) f) const;
-
-  public:
-    // ACCESSORS
-
-    /// Return a pointer to the executor's associated tread attributes, or a
-    /// null pointer if the executor has no associated thread attributes.
-    const bslmt::ThreadAttributes*
-    threadAttributes() const BSLS_KEYWORD_NOEXCEPT;
-
-  public:
-    // TRAITS
-    BSLMF_NESTED_TRAIT_DECLARATION(SystemExecutor, bslmf::IsBitwiseMoveable)
 };
-
-// ================================
-// class SystemExecutorContextGuard
-// ================================
-
-/// Provides a scoped guard for the system execution context singleton, that
-/// initializes the singleton object on construction and destroy the singleton
-/// object on destruction.
-class SystemExecutorContextGuard {
-  private:
-    // NOT IMPLEMENTED
-    SystemExecutorContextGuard(const SystemExecutorContextGuard&)
-        BSLS_KEYWORD_DELETED;
-    SystemExecutorContextGuard&
-    operator=(const SystemExecutorContextGuard&) BSLS_KEYWORD_DELETED;
-
-  public:
-    // CREATORS
-
-    /// Initialize the system execution context singleton with the specified
-    /// `globalAllocator`. The behavior is undefined if the singleton has
-    /// already been initialized or has already been destroyed.
-    explicit SystemExecutorContextGuard(bslma::Allocator* globalAllocator = 0);
-
-    /// Destroy the system execution context singleton.
-    ~SystemExecutorContextGuard();
-};
-
-// FREE OPERATORS
-
-/// - If `lhs` and `rhs` have no associated thread attributes, return
-///   `true`;
-/// - Otherwise, if `lhs` or `rhs` has no associated thread attributes,
-///   return `false`;
-/// - Otherwise, if `lhs` and `rhs` contain identical thread attributes,
-///   return `true`;
-/// - Otherwise, return `false`.
-bool operator==(const SystemExecutor& lhs,
-                const SystemExecutor& rhs) BSLS_KEYWORD_NOEXCEPT;
-
-/// Return !(lhs == rhs).
-bool operator!=(const SystemExecutor& lhs,
-                const SystemExecutor& rhs) BSLS_KEYWORD_NOEXCEPT;
 
 // ============================================================================
 //                           INLINE DEFINITIONS
@@ -551,33 +462,16 @@ template <class FUNCTION>
 inline void SystemExecutor::post(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION)
                                      f) const
 {
-    SystemExecutor_Context::singleton().executeAsync(
-        BSLS_COMPILERFEATURES_FORWARD(FUNCTION, f),
-        d_threadAttributes ? *d_threadAttributes : bslmt::ThreadAttributes());
+    d_context_sp->executeAsync(BSLS_COMPILERFEATURES_FORWARD(FUNCTION, f),
+                               d_threadAttributes ? *d_threadAttributes
+                                                  : bslmt::ThreadAttributes());
 }
 
 template <class FUNCTION>
 inline void
 SystemExecutor::dispatch(BSLS_COMPILERFEATURES_FORWARD_REF(FUNCTION) f) const
 {
-    SystemExecutor_Context::singleton().executeInPlace(
-        BSLS_COMPILERFEATURES_FORWARD(FUNCTION, f));
-}
-
-// --------------------------------
-// class SystemExecutorContextGuard
-// --------------------------------
-
-// CREATORS
-inline SystemExecutorContextGuard::SystemExecutorContextGuard(
-    bslma::Allocator* globalAllocator)
-{
-    SystemExecutor_Context::initSingleton(globalAllocator);
-}
-
-inline SystemExecutorContextGuard::~SystemExecutorContextGuard()
-{
-    SystemExecutor_Context::shutdownSingleton();
+    d_context_sp->executeInPlace(BSLS_COMPILERFEATURES_FORWARD(FUNCTION, f));
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqex/bmqex_systemexecutor.t.cpp
+++ b/src/groups/bmq/bmqex/bmqex_systemexecutor.t.cpp
@@ -86,30 +86,7 @@ void onThreadExit(void* threadsCompleted)
 //                                    TESTS
 // ----------------------------------------------------------------------------
 
-static void test1_context_singleton()
-// ------------------------------------------------------------------------
-// CONTEXT SINGLETON
-//
-// Concerns:
-//   Ensure proper behavior of the 'singleton' function.
-//
-// Plan:
-//   Check that 'singleton()' always returns a reference to the same
-//   object.
-//
-// Testing:
-//   bmqex::SystemExecutor::singleton
-// ------------------------------------------------------------------------
-{
-    bmqex::SystemExecutor_Context* ctx1 =
-        &bmqex::SystemExecutor_Context::singleton();
-    bmqex::SystemExecutor_Context* ctx2 =
-        &bmqex::SystemExecutor_Context::singleton();
-
-    BMQTST_ASSERT_EQ(ctx1, ctx2);
-}
-
-static void test2_context_creators()
+static void test1_context_creators()
 // ------------------------------------------------------------------------
 // CONTEXT CREATORS
 //
@@ -134,31 +111,26 @@ static void test2_context_creators()
 
     // create a thread-local storage associated with a thread-exit handler
     bslmt::ThreadUtil::Key tlsKey;
-    int rc = bslmt::ThreadUtil::createKey(&tlsKey, onThreadExit);
+    int                    rc = 0;
+    rc = bslmt::ThreadUtil::createKey(&tlsKey, onThreadExit);
     BSLS_ASSERT_OPT(rc == 0);
 
-    // initialize the context singleton object
-    bmqex::SystemExecutor_Context& context =
-        bmqex::SystemExecutor_Context::initSingleton(&alloc);
-
-    // context initialized with the test allocator
-    BMQTST_ASSERT_EQ(context.allocator(), &alloc);
-
     bsls::AtomicInt threadsCompleted(0);
-    for (int i = 0; i < k_NUM_JOBS; ++i) {
-        // submit a function object that attaches the thread-exit handler
-        // to the current thread
-        context.executeAsync(
-            bdlf::BindUtil::bind(bslmt::ThreadUtil::setSpecific,
-                                 bsl::cref(tlsKey),
-                                 &threadsCompleted),
-            bslmt::ThreadAttributes());
+    {
+        bmqex::SystemExecutor_Context context(&alloc);
+
+        BMQTST_ASSERT_EQ(context.allocator(), &alloc);
+
+        for (int i = 0; i < k_NUM_JOBS; ++i) {
+            context.executeAsync(
+                bdlf::BindUtil::bind(bslmt::ThreadUtil::setSpecific,
+                                     bsl::cref(tlsKey),
+                                     &threadsCompleted),
+                bslmt::ThreadAttributes());
+        }
     }
 
-    // destroy context singleton object
-    bmqex::SystemExecutor_Context::shutdownSingleton();
-
-    // all thread owned by the execution context have completed
+    // all threads owned by the execution context have completed
     BMQTST_ASSERT_EQ(threadsCompleted, k_NUM_JOBS);
 
     // delete the thread-local storage
@@ -166,7 +138,7 @@ static void test2_context_creators()
     BSLS_ASSERT_OPT(rc == 0);
 }
 
-static void test3_executor_creators()
+static void test2_executor_creators()
 // ------------------------------------------------------------------------
 // EXECUTOR CREATORS
 //
@@ -186,50 +158,23 @@ static void test3_executor_creators()
 {
     bslma::TestAllocator alloc;
 
-    // initialize the context singleton with the test allocator
-    bmqex::SystemExecutorContextGuard contextGuard(&alloc);
-
     // 1. default-construct
     {
-        bmqex::SystemExecutor ex;
-
-        BMQTST_ASSERT(!ex.threadAttributes());
+        bmqex::SystemExecutor ex(&alloc);
+        (void)ex;
     }
 
     // 2. ThreadAttributes-construct
     {
-        // prepare thread attributes with non-default values (except for the
-        // DETACHED attribute, that has to be 'e_CREATE_JOINABLE')
         bslmt::ThreadAttributes attr(&alloc);
         attr.setDetachedState(bslmt::ThreadAttributes::e_CREATE_JOINABLE);
-        attr.setGuardSize(100);
-        attr.setInheritSchedule(false);
-        attr.setSchedulingPolicy(bslmt::ThreadAttributes::e_SCHED_FIFO);
-        attr.setSchedulingPriority(200);
-        attr.setStackSize(300);
-        attr.setThreadName("myThread");
 
-        // create executor
         bmqex::SystemExecutor ex(attr, &alloc);
-
-        // executor holds a copy of the thread attributes
-        BMQTST_ASSERT(ex.threadAttributes());
-        BMQTST_ASSERT(ex.threadAttributes() != &attr);
-
-        // the copy is identical to the original value
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->detachedState(),
-                         bslmt::ThreadAttributes::e_CREATE_JOINABLE);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->guardSize(), 100);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->inheritSchedule(), false);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->schedulingPolicy(),
-                         bslmt::ThreadAttributes::e_SCHED_FIFO);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->schedulingPriority(), 200);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->stackSize(), 300);
-        BMQTST_ASSERT_EQ(ex.threadAttributes()->threadName(), "myThread");
+        (void)ex;
     }
 }
 
-static void test4_executor_post()
+static void test3_executor_post()
 // ------------------------------------------------------------------------
 // EXECUTOR POST
 //
@@ -250,8 +195,7 @@ static void test4_executor_post()
 
     bslma::TestAllocator alloc;
 
-    // initialize the context singleton with the test allocator
-    bmqex::SystemExecutorContextGuard contextGuard(&alloc);
+    bmqex::SystemExecutor ex(&alloc);
 
     bslmt::Semaphore      sem1, sem2;
     int                   jobNo    = 0;
@@ -259,12 +203,11 @@ static void test4_executor_post()
 
     for (int i = 0; i < k_NUM_JOBS; ++i) {
         // schedule function object execution
-        bmqex::SystemExecutor().post(
-            bdlf::BindUtil::bindR<void>(AsyncTestCallback(),
-                                        &sem1,
-                                        &jobNo,
-                                        &threadId,
-                                        &sem2));
+        ex.post(bdlf::BindUtil::bindR<void>(AsyncTestCallback(),
+                                            &sem1,
+                                            &jobNo,
+                                            &threadId,
+                                            &sem2));
 
         // function object not executed yet
         BMQTST_ASSERT_EQ(jobNo, i);
@@ -278,7 +221,7 @@ static void test4_executor_post()
     }
 }
 
-static void test5_executor_dispatch()
+static void test4_executor_dispatch()
 // ------------------------------------------------------------------------
 // EXECUTOR DISPATCH
 //
@@ -298,119 +241,20 @@ static void test5_executor_dispatch()
 
     bslma::TestAllocator alloc;
 
-    // initialize the context singleton with the test allocator
-    bmqex::SystemExecutorContextGuard contextGuard(&alloc);
+    bmqex::SystemExecutor ex(&alloc);
 
     int                   jobNo = 0;
     bslmt::ThreadUtil::Id threadId;
 
     for (int i = 0; i < k_NUM_JOBS; ++i) {
         // execute function object
-        bmqex::SystemExecutor().dispatch(
-            bdlf::BindUtil::bindR<void>(InPlaceTestCallback(),
-                                        &jobNo,
-                                        &threadId));
+        ex.dispatch(bdlf::BindUtil::bindR<void>(InPlaceTestCallback(),
+                                                &jobNo,
+                                                &threadId));
 
         // function object executed in this thread
         BMQTST_ASSERT_EQ(jobNo, i + 1);
         BMQTST_ASSERT_EQ(threadId, bslmt::ThreadUtil::selfId());
-    }
-}
-
-static void test6_executor_comparison()
-// ------------------------------------------------------------------------
-// EXECUTOR COMPARISON
-//
-// Concerns:
-//   Ensure proper behavior of the comparison operators.
-//
-// Plan:
-//   1. Check that two executors having no associated thread attributes
-//      compares equal.
-//
-//   2. Check that two executors sharing a 'bslmt::ThreadAttribute' object
-//      compares equal.
-//
-//   3. Check that two executors compares unequal if one of them has
-//      associated thread attributes and the other doesn't.
-//
-//   4. Check that two executors compares equal if they have an identical
-//      set of thread attributes.
-//
-//   5. Check that two executors compares unequal if the have a different
-//      set of thread attributes.
-//
-// Testing:
-//   bmqex::SystemExecutor's comparison operators
-// ------------------------------------------------------------------------
-{
-    bslma::TestAllocator alloc;
-
-    // initialize the context singleton with the test allocator
-    bmqex::SystemExecutorContextGuard contextGuard(&alloc);
-
-    // 1. both executors has no attributes
-    {
-        bmqex::SystemExecutor ex1, ex2;
-
-        BMQTST_ASSERT(!ex1.threadAttributes());
-        BMQTST_ASSERT(!ex2.threadAttributes());
-
-        BMQTST_ASSERT_EQ(ex1 == ex2, true);
-        BMQTST_ASSERT_EQ(ex1 != ex2, false);
-    }
-
-    // 2. both executors share same attributes
-    {
-        bmqex::SystemExecutor ex1(bslmt::ThreadAttributes(), &alloc);
-        bmqex::SystemExecutor ex2 = ex1;
-
-        BMQTST_ASSERT(ex1.threadAttributes() == ex2.threadAttributes());
-
-        BMQTST_ASSERT_EQ(ex1 == ex2, true);
-        BMQTST_ASSERT_EQ(ex1 != ex2, false);
-    }
-
-    // 3. one executor has attributes, the other doesn't
-    {
-        bmqex::SystemExecutor ex1(bslmt::ThreadAttributes(), &alloc);
-        bmqex::SystemExecutor ex2;
-
-        BMQTST_ASSERT(ex1.threadAttributes());
-        BMQTST_ASSERT(!ex2.threadAttributes());
-
-        BMQTST_ASSERT_EQ(ex1 == ex2, false);
-        BMQTST_ASSERT_EQ(ex1 != ex2, true);
-    }
-
-    // 4. both executors has identical attributes
-    {
-        bmqex::SystemExecutor ex1(bslmt::ThreadAttributes(), &alloc);
-        bmqex::SystemExecutor ex2(bslmt::ThreadAttributes(), &alloc);
-
-        BMQTST_ASSERT(ex1.threadAttributes() && ex2.threadAttributes());
-        BMQTST_ASSERT(ex1.threadAttributes() != ex2.threadAttributes());
-
-        BMQTST_ASSERT_EQ(ex1 == ex2, true);
-        BMQTST_ASSERT_EQ(ex1 != ex2, false);
-    }
-
-    // 5. executors has non-identical attributes
-    {
-        bslmt::ThreadAttributes attr1(&alloc);
-        attr1.setThreadName("thread_1");
-
-        bslmt::ThreadAttributes attr2(&alloc);
-        attr1.setThreadName("thread_2");
-
-        bmqex::SystemExecutor ex1(attr1, &alloc);
-        bmqex::SystemExecutor ex2(attr2, &alloc);
-
-        BMQTST_ASSERT(ex1.threadAttributes() && ex2.threadAttributes());
-        BMQTST_ASSERT(ex1.threadAttributes() != ex2.threadAttributes());
-
-        BMQTST_ASSERT_EQ(ex1 == ex2, false);
-        BMQTST_ASSERT_EQ(ex1 != ex2, true);
     }
 }
 
@@ -423,12 +267,10 @@ int main(int argc, char* argv[])
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     switch (_testCase) {
-    case 1: test1_context_singleton(); break;
-    case 2: test2_context_creators(); break;
-    case 3: test3_executor_creators(); break;
-    case 4: test4_executor_post(); break;
-    case 5: test5_executor_dispatch(); break;
-    case 6: test6_executor_comparison(); break;
+    case 1: test1_context_creators(); break;
+    case 2: test2_executor_creators(); break;
+    case 3: test3_executor_post(); break;
+    case 4: test4_executor_dispatch(); break;
 
     default: {
         bsl::cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND."

--- a/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.t.cpp
@@ -385,19 +385,9 @@ static void test3_executorsSupport()
         bmqex::Executor executor2 = dispatcher.executor(&client2);
         BMQTST_ASSERT(static_cast<bool>(executor2));
 
-        // executors for the first and the second client do compare equal as
-        // the clients used to obtain them have the same types, and therefore
-        // the same associated processors
-        BMQTST_ASSERT(executor1 == executor2);
-
         // obtain executor for third client's processor
         bmqex::Executor executor3 = dispatcher.executor(&client3);
         BMQTST_ASSERT(static_cast<bool>(executor3));
-
-        // executors for the second and the third clients do not compare equal
-        // as the clients used to obtain them have different types, and
-        // therefore different associated processors
-        BMQTST_ASSERT(executor2 != executor3);
 
         // create utility semaphores
         bslmt::Semaphore startedSignal,  // used to sync. with async op.


### PR DESCRIPTION
## Problem

The `bmqex::SystemExecutor_Context` singleton might be destroyed during static cleanup, causing an assertion failure if anything constructed a `bmqex::SystemExecutor` afterward (static destruction order fiasco). 

## Fix

Replace the singleton with reference-counted shared ownership via `bsl::shared_ptr`. 
 
## Changes

Lifetime management: 
- Context is now heap-allocated via `bsl::allocate_shared` and tracked by a `bsl::weak_ptr`
- Each `bmqex::SystemExecutor` holds a `bsl::shared_ptr<bmqex::SystemExecutor_Context>` — context lives as long as any executor exists 
- Bookkeeping (`weak_ptr`, `Mutex`) is heap-allocated inside `BSLMT_ONCE_DO` and intentionally never freed, making `acquireContext()` safe during static destruction 
 
Thread safety: 
- Each spawned thread stores a `bsl::shared_ptr` in its `ThreadData`, preventing context destruction while the thread runs 
- The `onThreadRun` function copies this `bsl::shared_ptr` to a local before destroying ThreadData, keeping the context alive
through `finalizeThread`
 
Simplifications:
- Removed `d_unjoinedThreads`, `d_threadExitCondition`, and the waiting loop in the destructor — unnecessary because the `bsl::shared_ptr` guarantees all threads have finalized before the destructor can run 
- Removed `bmqex::SystemExecutorContextGuard` class (redundant with `bsl::shared_ptr`) 
- Removed `singleton()`, `initSingleton()`, `shutdownSingleton()` — replaced by single `acquireContext()` factory 
- Destructor just joins the last completed thread
