### PR TITLE
Fix[test]: flaky tests

### DIFF
--- a/src/integration-tests/test_cluster_node_shutdown.py
+++ b/src/integration-tests/test_cluster_node_shutdown.py
@@ -387,10 +387,8 @@ class TestClusterNodeShutdown:
 
         assert primary.outputs_regex("LEADER lost quorum")
 
-        # After restarting nodes, a different node may win re-election.  If the
-        # old leader is still primary under the new leader, it aborts due to
-        # leader-primary divergence.  This is a known broker limitation.
-        primary.check_exit_code = False
+        # to avoid the divergence
+        primary.set_quorum(1, succeed=True)
 
         # Restart the killed nodes to restore quorum
         for node in all_replicas:

--- a/src/integration-tests/test_poison_messages.py
+++ b/src/integration-tests/test_poison_messages.py
@@ -213,8 +213,23 @@ class TestPoisonMessages:
             leader = leader_candidate
         assert leader == multi_node.wait_leader()
 
+        # Wait for the new leader to complete state-restore before killing
+        # consumer_1. If consumer_1 is killed before state-restore, the
+        # closeQueue arrives on a RelayQueue (not yet converted to LocalQueue),
+        # RelayQueueEngine processes it without calling transferUnconfirmedMessages,
+        # so d_unconfirmedMessages is never cleared. When consumer_2 opens, the
+        # primary finds the GUID still in-flight and skips as "duplicate PUSH".
+        # After state-restore, closeQueue arrives on a LocalQueue, RootQueueEngine
+        # calls transferUnconfirmedMessages ("Lost a reader"), requeues the message,
+        # and consumer_2 receives it.
+        assert leader.capture("state restored", 15)
+
+        proxy.drain()
+
         consumer.check_exit_code = False
         consumer.kill()
+
+        assert proxy.capture("rejecting.*messages because of a client crash", 10)
 
         # start new consumer to synchronize with proxy and replica
         consumer = proxy.create_client("consumer_2")

--- a/src/integration-tests/test_restart_between_modes.py
+++ b/src/integration-tests/test_restart_between_modes.py
@@ -840,7 +840,13 @@ def test_restart_between_legacy_and_fsm_add_remove_app(
     confirm_one_message(consumer, fanout_queue, "foo")
 
     current_app_ids = DEFAULT_APP_IDS + ["quux"]
-    cluster.set_app_ids(current_app_ids, du)
+    cluster.set_app_ids(current_app_ids, du, succeed=None)
+
+    # need to make sure the config has made it to the primary since this is a
+    # non-blocking op.
+    assert cluster.last_known_leader.capture(
+        r"Adding VirtualStorage for appId 'quux'", 5
+    )
 
     post_few_messages(producer, fanout_queue, ["msg3"])
 
@@ -867,7 +873,16 @@ def test_restart_between_legacy_and_fsm_add_remove_app(
     reconfigure_leader_only = switch_cluster_mode[2]
 
     current_app_ids.append("corge")
-    cluster.set_app_ids(current_app_ids, du, leader_only=reconfigure_leader_only)
+    cluster.set_app_ids(
+        current_app_ids, du, leader_only=reconfigure_leader_only, succeed=None
+    )
+
+    # need to make sure the config has made it to the primary since this is a
+    # non-blocking op.
+    assert cluster.last_known_leader.capture(
+        r"Adding VirtualStorage for appId 'corge'", 5
+    )
+
     post_few_messages(producer, fanout_queue, ["msg4"])
 
     current_app_ids.remove("foo")
@@ -980,7 +995,13 @@ def test_restart_between_legacy_and_fsm_purge_queue_app(
     confirm_one_message(consumer, fanout_queue, "foo")
 
     current_app_ids = DEFAULT_APP_IDS + ["quux"]
-    cluster.set_app_ids(current_app_ids, du)
+    cluster.set_app_ids(current_app_ids, du, succeed=None)
+
+    # need to make sure the config has made it to the primary since this is a
+    # non-blocking op.
+    assert cluster.last_known_leader.capture(
+        r"Adding VirtualStorage for appId 'quux'", 5
+    )
 
     post_few_messages(producer, fanout_queue, ["msg3"])
 
@@ -1007,7 +1028,16 @@ def test_restart_between_legacy_and_fsm_purge_queue_app(
     reconfigure_leader_only = switch_cluster_mode[2]
 
     current_app_ids.append("corge")
-    cluster.set_app_ids(current_app_ids, du, leader_only=reconfigure_leader_only)
+    cluster.set_app_ids(
+        current_app_ids, du, leader_only=reconfigure_leader_only, succeed=None
+    )
+
+    # need to make sure the config has made it to the primary since this is a
+    # non-blocking op.
+    assert cluster.last_known_leader.capture(
+        r"Adding VirtualStorage for appId 'corge'", 5
+    )
+
     post_few_messages(producer, fanout_queue, ["msg4"])
 
     current_app_ids.remove("foo")

--- a/src/python/blazingmq/dev/it/cluster.py
+++ b/src/python/blazingmq/dev/it/cluster.py
@@ -896,14 +896,20 @@ class Cluster(contextlib.AbstractContextManager):
         return True
 
     def set_app_ids(
-        self, app_ids: List[str], du: tc.DomainUrls, leader_only: bool = False
+        self,
+        app_ids: List[str],
+        du: tc.DomainUrls,
+        leader_only: bool = False,
+        succeed: Optional[bool] = True,
     ):  # noqa: F811
         """
         Set the app ids for the fanout domain to the specified list of app ids."""
         self.config.domains[
             du.domain_fanout
         ].definition.parameters.mode.fanout.app_ids = app_ids  # type: ignore
-        self.reconfigure_domain(du.domain_fanout, leader_only=leader_only, succeed=True)
+        self.reconfigure_domain(
+            du.domain_fanout, leader_only=leader_only, succeed=succeed
+        )
 
     ###########################################################################
     # Internals


### PR DESCRIPTION
`set_app_ids` is NOT blocking and needs synchronization
`test_open_queue_while_cluster_blips_quorum_and_kill_all_non_leader` does not work with divergence