### PR TITLE
CI: don't wait for full build to lint

### DIFF
--- a/.github/workflows/build-ubuntu.yaml
+++ b/.github/workflows/build-ubuntu.yaml
@@ -1,7 +1,7 @@
 name: Build Ubuntu
 
 description: |
-  This is a reusable workflow to build BlazingMQ on Ubuntu. 
+  This is a reusable workflow to build BlazingMQ on Ubuntu.
   Optionally run unit tests if the target is "all.t".
   Given a ref and a target, this workflow will build the project and will save the build results both as artifact and in cache.
   The cache key is generated based on the ref and the target, and is returned via workflow output.
@@ -87,7 +87,9 @@ jobs:
       - uses: actions/cache/restore@v4
         if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes
         with:
-          path: deps
+          path: |
+            deps
+            /opt/bb
           key: ${{ needs.get_dependencies.outputs.cache_key }}
       - name: Set up dependencies
         if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes
@@ -105,16 +107,15 @@ jobs:
             libfl-dev \
             libbenchmark-dev \
             libz-dev
-      - name: Install cached non packaged dependencies
-        if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes
-        working-directory: deps
-        run: ../docker/build_deps.sh --cxx-standard=${{ inputs.cxx_standard }}
 
       # Build BlazingMQ
-      - name: Build BlazingMQ
+      - name: Configure BlazingMQ
         if: steps.build-cache-restore-step.outputs.cache-hit != 'true' # Variable type is string, thus using quotes
+        run: cmake --preset gh-build-ubuntu-latest-${{ inputs.cxx_standard }} -S .
+
+      - name: Build BlazingMQ
+        if: steps.build-cache-restore-step.outputs.cache-hit != 'true' && inputs.target != '' # Variable type is string, thus using quotes
         run: |
-          cmake --preset gh-build-ubuntu-latest-${{ inputs.cxx_standard }} -S .
           echo "::add-matcher::.github/workflows/problem-matchers/cpp.json"
           cmake --build --preset gh-build-ubuntu-latest-${{ inputs.cxx_standard }} --target ${{ inputs.target }}
           echo "::remove-matcher owner=cpp"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -314,7 +314,9 @@ jobs:
 
       - uses: actions/cache/restore@v4
         with:
-          path: deps
+          path: |
+            deps
+            /opt/bb
           key: ${{ needs.get_dependencies.outputs.cache_key }}
 
       - name: Set up plugins dependencies
@@ -427,27 +429,3 @@ jobs:
       - name: Inspect Docker images
         run: docker image ls
 
-  cpp-linter-check:
-    name: C++ Linter Check
-    needs: build_ubuntu
-    runs-on: ubuntu-slim
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/download-artifact@v5
-        with:
-          name: ${{needs.build_ubuntu.outputs.artifact_key }}
-      - uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          style: ''  # Disable clang-format checks
-          tidy-checks: '' # Use .clang-tidy config file
-          # only 'update' a single comment in a pull request thread.
-          thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
-          lines-changed-only: diff
-          version: '21'
-          database: build/blazingmq
-      - name: Fail fast?!
-        if: steps.linter.outputs.checks-failed > 0
-        run: exit 1

--- a/.github/workflows/dependencies.yaml
+++ b/.github/workflows/dependencies.yaml
@@ -13,10 +13,6 @@ on:
         description: "GH Actions Cache key associated with the built dependencies"
         value: ${{ jobs.build_dependencies.outputs.cache_key }}
 
-concurrency:
-  group: global-${{ inputs.cxx_standard }}
-  cancel-in-progress: false
-
 jobs:
   build_dependencies:
     name: Build and cache dependencies [${{ inputs.cxx_standard }}]
@@ -29,13 +25,15 @@ jobs:
       - name: Generate dependencies cache key
         id: get-cache-key
         run: |
-          echo "cache_key=deps-`date +%y-%m-%d`-`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
+          echo "cache_key=deps-${{ inputs.cxx_standard }}-`date +%y-%m-%d`-`cat docker/build_deps.sh | shasum`" >> $GITHUB_OUTPUT
 
       - name: Cache lookup
         uses: actions/cache/restore@v4
         id: cache-lookup
         with:
-          path: deps
+          path: |
+            deps
+            /opt/bb
           key: ${{ steps.get-cache-key.outputs.cache_key }}
           lookup-only: true
 
@@ -67,5 +65,7 @@ jobs:
         if: steps.cache-lookup.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: deps
+          path: |
+            deps
+            /opt/bb
           key: ${{ steps.get-cache-key.outputs.cache_key }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -184,3 +184,38 @@ jobs:
         run: |
           export PYTHONPATH=${{ github.workspace }}/src/python:$PYTHONPATH
           git diff -U0 origin/main | lint-diffs
+
+  configure_ubuntu:
+    name: "Configure [ubuntu]"
+    uses: ./.github/workflows/build-ubuntu.yaml
+    with:
+      ref: ${{ github.sha }}
+      name: "configure-ubuntu"
+      target: ""
+      save_build_as_artifacts: true
+      run_unit_tests: false
+      cxx_standard: cpp23
+
+  cpp_linter_check:
+    name: C++ Linter Check
+    needs: configure_ubuntu
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.configure_ubuntu.outputs.artifact_key }}
+      - uses: cpp-linter/cpp-linter-action@77c390c5ba9c947ebc185a3e49cc754f1558abb5
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          style: ''  # Disable clang-format checks
+          tidy-checks: '' # Use .clang-tidy config file
+          thread-comments: update
+          lines-changed-only: diff
+          version: '21'
+          database: build/blazingmq
+      - name: Fail fast?!
+        if: steps.linter.outputs.checks-failed > 0
+        run: exit 1

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -128,9 +128,11 @@ build_google_test() {
     pushd srcs/googletest
     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_CXX_STANDARD="$cmake_cxx_standard" \
+        -DCMAKE_INSTALL_PREFIX=/opt/bb \
+        -DCMAKE_INSTALL_LIBDIR=lib64 \
         -S . -B build
     cmake --build build -j8
-    cd build && sudo make install
+    cd build && make install
     popd
 }
 


### PR DESCRIPTION
CI: don't wait for full build to lint

- Moved clang-tidy job from build.yaml to `lint.yaml`, depending on configure-only step instead of full build             
- Split build step into separate `Configure` and `Build`, allowing configure to run standalone                              
- Fixed dependency caching: added `/opt/bb` to cache paths, included C++ standard in cache key                            
- GoogleTest: install to `/opt/bb`, dropped `sudo`