### PR TITLE
Fix[bmqeval]: correct not_equal_to with single boolean literal in makeComparison

### DIFF
--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.h
@@ -1072,20 +1072,17 @@ CompilationContext::makeComparison(ExpressionPtr a, ExpressionPtr b)
     }
 
     // Handle comparisons with boolean literals at compile time.
-    //   - for 'expr = true' and 'true = expr' return 'expr'
-    //   - for 'expr = false' and 'false = expr' return '!expr'
+    //   - for 'expr == true'  and 'true == expr'  return 'expr'
+    //   - for 'expr == false' and 'false == expr' return '!expr'
+    //   - for 'expr != true'  and 'true != expr'  return '!expr'
+    //   - for 'expr != false' and 'false != expr' return 'expr'
     //   - if both sides are boolean literals, return
-    //   'BooleanLiteral(a && b)'
+    //   'BooleanLiteral(Op(a, b))'
 
     typedef SimpleEvaluator::BooleanLiteral BooleanLiteral;
     typedef SimpleEvaluator::Not            Not;
 
-    // Booleans can only be compared for (in)equality.
-    const bool isEquality =
-        bsl::is_same<Op<int>, bsl::equal_to<int> >::value ||
-        bsl::is_same<Op<int>, bsl::not_equal_to<int> >::value;
-
-    if /*constexpr*/ (isEquality) {
+    if /*constexpr*/ (bsl::is_same<Op<int>, bsl::equal_to<int> >::value) {
         const BooleanLiteral* boolean_a = dynamic_cast<const BooleanLiteral*>(
             a.get());
         const BooleanLiteral* boolean_b = dynamic_cast<const BooleanLiteral*>(
@@ -1114,6 +1111,38 @@ CompilationContext::makeComparison(ExpressionPtr a, ExpressionPtr b)
 
             return ExpressionPtr(new (*d_allocator) Not(a),
                                  d_allocator);  // RETURN
+        }
+    }
+
+    if /*constexpr*/ (bsl::is_same<Op<int>, bsl::not_equal_to<int> >::value) {
+        const BooleanLiteral* boolean_a = dynamic_cast<const BooleanLiteral*>(
+            a.get());
+        const BooleanLiteral* boolean_b = dynamic_cast<const BooleanLiteral*>(
+            b.get());
+
+        if (boolean_a) {
+            if (boolean_b) {
+                return ExpressionPtr(
+                    new (*d_allocator) BooleanLiteral(
+                        Op<bool>()(boolean_a->value(), boolean_b->value())),
+                    d_allocator);  // RETURN
+            }
+
+            if (boolean_a->value()) {
+                return ExpressionPtr(new (*d_allocator) Not(b),
+                                     d_allocator);  // RETURN
+            }
+
+            return b;  // RETURN
+        }
+
+        if (boolean_b) {
+            if (boolean_b->value()) {
+                return ExpressionPtr(new (*d_allocator) Not(a),
+                                     d_allocator);  // RETURN
+            }
+
+            return a;  // RETURN
         }
     }
 

--- a/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
+++ b/src/groups/bmq/bmqeval/bmqeval_simpleevaluator.t.cpp
@@ -542,6 +542,10 @@ static void test3_evaluation()
         {"true && b_true", true},
         {"b_true == true", true},
         {"b_true < true", false},
+        {"b_true != true", false},
+        {"b_true != false", true},
+        {"b_false != true", true},
+        {"b_false != false", false},
         // overflows
         // supported_ints
         {"i_0 != -32768", true},                // -(2 ** 15)


### PR DESCRIPTION
Closes #1523

makeComparison optimizes boolean literal comparisons at compile time. The two-literal case correctly delegates to Op<bool>(), but the one-literal case was shared across both operators under a single isEquality branch, hardcoding equal_to semantics regardless of the actual Op. This meant expr != true silently simplified to expr rather than !expr, with no compilation error to surface the problem.

The fix splits isEquality into two self-contained branches with the one-literal returns inverted in the not_equal_to block so that a true literal produces Not(expr) and a false literal returns expr directly.