### PR TITLE
Fix[mqba]: add GateKeeper check to onReauthenticate

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticationclient.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticationclient.cpp
@@ -47,6 +47,12 @@ void AuthenticationClient::onReauthenticate()
 {
     // executed by the *SCHEDULER* thread
 
+    // Skip the authentication call if destructor has been called.
+    bmqu::GateKeeper::Status gateStatus(d_gateKeeper);
+    if (!gateStatus.isOpen()) {
+        return;  // RETURN
+    }
+
     bmqu::MemOutStream errStream(d_allocator_p);
     const int          rc = authenticate(errStream);
     if (rc != 0) {


### PR DESCRIPTION
The adds a minor, defensive improvement to the authentication client used for broker-to-broker authentication. This further clarifies the component's behavior during shutdown.

If the client's destructor has been invoked, reauthentication callbacks will can sometimes be skipped, or will be completed/cancelled as before.