### PR TITLE
feat: Dev/storagewriter

### DIFF
--- a/src/applications/bmqstoragetool/integration-tests/data/queueop_result.txt
+++ b/src/applications/bmqstoragetool/integration-tests/data/queueop_result.txt
@@ -8,7 +8,7 @@
     Timestamp       : 29OCT2024_14:01:06.000000
     Epoch           : 1730210466
     QueueKey        : 26DACDC974
-    AppKey          : ** NULL **
+    AppKey          : 0000000000
     QueueOpType     : CREATION
     QLIST OffsetWords: 9
 

--- a/src/applications/bmqstoragetool/integration-tests/test_journalfile.py
+++ b/src/applications/bmqstoragetool/integration-tests/test_journalfile.py
@@ -77,8 +77,9 @@ def test_short_json(storagetool, journal_file):
         assert res.returncode == EX_OK
         json_res = json.loads(res.stdout)
         assert json_res["MessageRecords"] == "2"
-        assert TEST_GUID_1.decode() in json_res["Records"]
-        assert TEST_GUID_2.decode() in json_res["Records"]
+        guids = [r["GUID"] for r in json_res["Records"] if "GUID" in r]
+        assert TEST_GUID_1.decode() in guids
+        assert TEST_GUID_2.decode() in guids
 
 
 def test_detail_result(storagetool, journal_file, csl_file, expected_detail_result):

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslfileprocessor.t.cpp
@@ -523,7 +523,7 @@ static void test1_breathingTest()
         // standardCslIt.header() has no `operator==` defined, so skip it by
         // using `_`
         EXPECT_CALL(*printer,
-                    printShortResult(_, standardCslIt.currRecordId()))
+                    printShortResult(_, _, standardCslIt.currRecordId()))
             .InSequence(s);
 
         if (standardCslIt.header().recordType() ==
@@ -697,7 +697,7 @@ static void test2_searchRecordsByTypeTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
             recordCount.d_snapshotCount++;
         }
@@ -706,7 +706,7 @@ static void test2_searchRecordsByTypeTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
             recordCount.d_commitCount++;
         }
@@ -870,7 +870,7 @@ static void test3_searchRecordsByQueueKeyTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }
@@ -1019,7 +1019,7 @@ static void test4_searchRecordsByTimestampRangeTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }
@@ -1166,7 +1166,7 @@ static void test5_searchRecordsByOffsetRangeTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }
@@ -1316,7 +1316,7 @@ static void test6_searchRecordsBySeqNumberRangeTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }
@@ -1462,7 +1462,7 @@ static void test7_searchRecordsByOffsetTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }
@@ -1610,7 +1610,7 @@ static void test8_searchRecordsBySeqNumberTest()
             // standardCslIt.header() has no `operator==` defined, so skip it
             // by using `_`
             EXPECT_CALL(*printer,
-                        printShortResult(_, standardCslIt.currRecordId()))
+                        printShortResult(_, _, standardCslIt.currRecordId()))
                 .InSequence(s);
         }
     }

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.cpp
@@ -24,10 +24,15 @@
 #include <bmqu_memoutstream.h>
 
 // BDE
+#include <baljsn_encoder.h>
+#include <baljsn_encoderoptions.h>
+#include <bdlde_base64decoder.h>
 #include <bsl_cstring.h>
 #include <bsl_iomanip.h>
+#include <bsl_iostream.h>
 #include <bsl_memory.h>
 #include <bsl_ostream.h>
+#include <bsl_sstream.h>
 #include <bsl_vector.h>
 #include <bslim_printer.h>
 
@@ -36,28 +41,115 @@ namespace m_bmqstoragetool {
 
 namespace {
 
-// Helper to convert record to json string (escaped single line)
+bsl::string base64ToHex(const bsl::string& base64, bslma::Allocator* allocator)
+{
+    bdlde::Base64Decoder decoder(true);
+    bsl::vector<char>    bin(allocator);
+    bin.resize(bdlde::Base64Decoder::maxDecodedLength(
+        static_cast<int>(base64.size())));
+
+    int numOut = 0;
+    int numIn  = 0;
+    int rc     = decoder.convert(bin.data(),
+                             &numOut,
+                             &numIn,
+                             base64.data(),
+                             base64.data() + base64.size());
+    if (rc < 0) {
+        return base64;
+    }
+    int endOut = 0;
+    rc         = decoder.endConvert(bin.data() + numOut, &endOut);
+    if (rc < 0) {
+        return base64;
+    }
+    bin.resize(numOut + endOut);
+
+    static const char HEX[] = "0123456789ABCDEF";
+    bsl::string       result(allocator);
+    result.reserve(bin.size() * 2);
+    for (bsl::size_t i = 0; i < bin.size(); ++i) {
+        unsigned char c = static_cast<unsigned char>(bin[i]);
+        result.push_back(HEX[c >> 4]);
+        result.push_back(HEX[c & 0x0F]);
+    }
+    return result;
+}
+
+void convertKeysToHex(bsl::string* json, bslma::Allocator* allocator)
+{
+    const char* keys[]    = {"\"key\"", "\"appKey\""};
+    const int   keyLens[] = {5, 8};
+
+    for (int p = 0; p < 2; ++p) {
+        bsl::size_t pos = 0;
+        while ((pos = json->find(keys[p], pos)) != bsl::string::npos) {
+            bsl::size_t quoteStart = json->find('"', pos + keyLens[p]);
+            if (quoteStart == bsl::string::npos) {
+                break;
+            }
+            bsl::size_t valStart = quoteStart + 1;
+            bsl::size_t valEnd   = json->find('"', valStart);
+            if (valEnd == bsl::string::npos) {
+                break;
+            }
+            bsl::string b64(json->data() + valStart,
+                            valEnd - valStart,
+                            allocator);
+            bsl::string hex = base64ToHex(b64, allocator);
+            json->replace(valStart, valEnd - valStart, hex);
+            pos = valStart + hex.size() + 1;
+        }
+    }
+}
+
+// Helper to convert record to JSON using baljsn encoder.
+// Produces a JSON object string (starts with '{') that the JsonPrinter
+// will emit unquoted as a nested object.
 template <typename RECORD_TYPE>
 bsl::string recordToJsonString(const RECORD_TYPE* record,
                                bslma::Allocator*  allocator,
-                               bool               removeTrailingQuotes = true)
+                               bool               pretty)
 {
-    bmqu::MemOutStream recStr(allocator);
-    // Print record in one line string
-    record->print(recStr, -1, -1);
+    bmqu::MemOutStream os(allocator);
 
-    // Escape the string
-    bmqu::MemOutStream escapedStr(allocator);
-    escapedStr << bsl::quoted(recStr.str());
-
-    bsl::string resultStr = escapedStr.str();
-    // Remove leading and trailing quotes with '\n' character
-    if (removeTrailingQuotes && !resultStr.empty() &&
-        resultStr.front() == '"' && resultStr.back() == '"') {
-        resultStr = resultStr.substr(1, resultStr.size() - 3);
+    baljsn::Encoder        encoder(allocator);
+    baljsn::EncoderOptions options;
+    if (pretty) {
+        options.setEncodingStyle(baljsn::EncoderOptions::e_PRETTY);
+        options.setInitialIndentLevel(3);
+        options.setSpacesPerLevel(2);
+    }
+    else {
+        options.setEncodingStyle(baljsn::EncoderOptions::e_COMPACT);
     }
 
-    return resultStr;
+    const int rc = encoder.encode(os, *record, options);
+    if (rc != 0) {
+        // Encoder failed (e.g., on empty choice message). Fall back to
+        // print() method and escape the result as a string. Use bsl::quoted
+        // to escape special characters (quotes, backslashes, newlines), then
+        // strip the outer quotes added by quoted() to keep just the escaped
+        // content.
+        bmqu::MemOutStream recStr(allocator);
+        record->print(recStr, -1, -1);
+        bmqu::MemOutStream escapedStr(allocator);
+        escapedStr << bsl::quoted(recStr.str());
+        bsl::string resultStr = escapedStr.str();
+        if (!resultStr.empty() && resultStr.front() == '"' &&
+            resultStr.back() == '"') {
+            resultStr = resultStr.substr(1, resultStr.size() - 2);
+        }
+        return resultStr;
+    }
+
+    bsl::string result(os.str(), allocator);
+    convertKeysToHex(&result, allocator);
+    bsl::size_t start = result.find_first_not_of(" \n");
+    if (start != 0 && start != bsl::string::npos) {
+        result.erase(0, start);
+    }
+    return result;
 }
 
 // Helper to print queue info in json format
@@ -83,7 +175,6 @@ void printQueueInfo(bsl::ostream&     ostream,
                 ostream << ",";
             }
             bsl::string recStr = recordToJsonString(it, allocator, false);
-
             ostream << "\n      " << recStr;
         }
         ostream << "\n    ]";
@@ -123,7 +214,8 @@ class HumanReadableCslPrinter : public CslPrinter {
 
     // ACCESSORS
 
-    void printShortResult(const mqbc::ClusterStateRecordHeader& header,
+    void printShortResult(const bmqp_ctrlmsg::ClusterMessage&   record,
+                          const mqbc::ClusterStateRecordHeader& header,
                           const mqbsi::LedgerRecordId&          recordId) const
         BSLS_KEYWORD_OVERRIDE;
 
@@ -166,8 +258,9 @@ HumanReadableCslPrinter::~HumanReadableCslPrinter()
 
 // ACCESSORS
 void HumanReadableCslPrinter::printShortResult(
-    const mqbc::ClusterStateRecordHeader& header,
-    const mqbsi::LedgerRecordId&          recordId) const
+    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::ClusterMessage& record,
+    const mqbc::ClusterStateRecordHeader&                 header,
+    const mqbsi::LedgerRecordId&                          recordId) const
 {
     bslim::Printer printer(&d_ostream, 0, -1);
     printer.start();
@@ -482,7 +575,8 @@ class JsonPrettyCslPrinter : public JsonCslPrinter {
 
     // PUBLIC METHODS
 
-    void printShortResult(const mqbc::ClusterStateRecordHeader& header,
+    void printShortResult(const bmqp_ctrlmsg::ClusterMessage&   record,
+                          const mqbc::ClusterStateRecordHeader& header,
                           const mqbsi::LedgerRecordId&          recordId) const
         BSLS_KEYWORD_OVERRIDE;
 
@@ -517,8 +611,9 @@ JsonPrettyCslPrinter::~JsonPrettyCslPrinter()
 // PUBLIC METHODS
 
 void JsonPrettyCslPrinter::printShortResult(
-    const mqbc::ClusterStateRecordHeader& header,
-    const mqbsi::LedgerRecordId&          recordId) const
+    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::ClusterMessage& record,
+    const mqbc::ClusterStateRecordHeader&                 header,
+    const mqbsi::LedgerRecordId&                          recordId) const
 {
     openBraceIfNotOpen("Records");
 
@@ -535,13 +630,7 @@ void JsonPrettyCslPrinter::printDetailResult(
 {
     openBraceIfNotOpen("Records");
 
-    // Print record.
-    // Since `record` uses `bslim::Printer` to print its objects hierarchy,
-    // it is not easy (and error prone) to do the same for json printer
-    // without changing nested `record` objects.
-    // So, we will use the output of `print` method and store it in json as
-    // escaped string.
-    bsl::string recStr = recordToJsonString(&record, d_allocator_p);
+    bsl::string recStr = recordToJsonString(&record, d_allocator_p, true);
 
     CslRecordPrinter<bmqu::JsonPrinter<true, true, 4, 6> > printer(
         d_ostream,
@@ -581,7 +670,8 @@ class JsonLineCslPrinter : public JsonCslPrinter {
     ~JsonLineCslPrinter() BSLS_KEYWORD_OVERRIDE;
 
     // PUBLIC METHODS
-    void printShortResult(const mqbc::ClusterStateRecordHeader& header,
+    void printShortResult(const bmqp_ctrlmsg::ClusterMessage&   record,
+                          const mqbc::ClusterStateRecordHeader& header,
                           const mqbsi::LedgerRecordId&          recordId) const
         BSLS_KEYWORD_OVERRIDE;
 
@@ -613,8 +703,9 @@ JsonLineCslPrinter::~JsonLineCslPrinter()
 
 // PUBLIC METHODS
 void JsonLineCslPrinter::printShortResult(
-    const mqbc::ClusterStateRecordHeader& header,
-    const mqbsi::LedgerRecordId&          recordId) const
+    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::ClusterMessage& record,
+    const mqbc::ClusterStateRecordHeader&                 header,
+    const mqbsi::LedgerRecordId&                          recordId) const
 {
     openBraceIfNotOpen("Records");
 
@@ -631,13 +722,7 @@ void JsonLineCslPrinter::printDetailResult(
 {
     openBraceIfNotOpen("Records");
 
-    // Print record.
-    // Since `record` uses `bslim::Printer` to print its objects hierarchy,
-    // it is not easy (and error prone) to do the same for json printer
-    // without changing nested `record` objects.
-    // So, we will use the output of `print` method and store it in json as
-    // escaped string.
-    bsl::string recStr = recordToJsonString(&record, d_allocator_p);
+    bsl::string recStr = recordToJsonString(&record, d_allocator_p, false);
 
     CslRecordPrinter<bmqu::JsonPrinter<false, true, 4, 6> > printer(
         d_ostream,

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.h
@@ -58,7 +58,8 @@ class CslPrinter {
 
     /// Print the result in a short form.
     virtual void
-    printShortResult(const mqbc::ClusterStateRecordHeader& header,
+    printShortResult(const bmqp_ctrlmsg::ClusterMessage&   record,
+                     const mqbc::ClusterStateRecordHeader& header,
                      const mqbsi::LedgerRecordId&          recordId) const = 0;
 
     /// Print the result in a detail form.

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.t.cpp
@@ -73,7 +73,8 @@ static void test1_humanReadableShortResultTest()
     recordId.setLogId(storageKey).setOffset(2);
 
     // Print short result
-    printer->printShortResult(header, recordId);
+    bmqp_ctrlmsg::ClusterMessage msg(bmqtst::TestHelperUtil::allocator());
+    printer->printShortResult(msg, header, recordId);
 
     // Prepare expected output
     bmqu::MemOutStream expectedStream(bmqtst::TestHelperUtil::allocator());
@@ -373,7 +374,8 @@ static void test6_prettyShortResultTest()
             bmqtst::TestHelperUtil::allocator());
 
         // Print short result
-        printer->printShortResult(header, recordId);
+        bmqp_ctrlmsg::ClusterMessage msg(bmqtst::TestHelperUtil::allocator());
+        printer->printShortResult(msg, header, recordId);
     }
 
     // Prepare expected output
@@ -416,8 +418,7 @@ static void test7_prettyDetailResultTest()
     bmqu::MemOutStream resultStream(bmqtst::TestHelperUtil::allocator());
     bmqu::MemOutStream expectedStream(bmqtst::TestHelperUtil::allocator());
 
-    // Ignore check default allocator due to issue with bslim::Printer::print()
-    // used in recordToJsonString()
+    // Ignore check default allocator due to allocations in baljsn encoder
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     // Create record data
@@ -460,9 +461,15 @@ static void test7_prettyDetailResultTest()
                    << "      \"LeaderAdvisoryWords\": \"10\",\n"
                    << "      \"Timestamp\": \"29NOV1973_21:33:09.000000\",\n"
                    << "      \"Epoch\": \"123456789\",\n"
-                   << "      \"Record\": \"[ choice = [ leaderAdvisory = [ "
-                      "sequenceNumber = [ electorTerm = 0 sequenceNumber = 0 "
-                      "] partitions = [ ] queues = [ ] ] ] \"\n"
+                   << "      \"Record\": {\n"
+                   << "        \"leaderAdvisory\": {\n"
+                   << "          \"sequenceNumber\": {\n"
+                   << "            \"electorTerm\": 0,\n"
+                   << "            \"sequenceNumber\": 0\n"
+                   << "          }\n"
+                   << "        }\n"
+                   << "      }\n"
+                   << "\n"
                    << "    }\n"
                    << "  ]\n"
                    << "}\n";
@@ -538,26 +545,25 @@ static void test8_prettySummaryTest()
 
     // Prepare expected output
     bmqu::MemOutStream expectedStream(bmqtst::TestHelperUtil::allocator());
-    expectedStream
-        << "{\n"
-        << "    \"Summary\":\n"
-        << "    {\n"
-        << "      \"SnapshotRecords\": \"2\",\n"
-        << "      \"UpdateRecords\": \"3\",\n"
-        << "      \"queueAssignmentAdvisory\": \"3\",\n"
-        << "      \"leaderAdvisory\": \"2\",\n"
-        << "      \"CommitRecords\": \"4\",\n"
-        << "      \"AckRecords\": \"5\"\n"
-        << "    },\n"
-        << "    \"Queues\": [\n"
-        << "      \"[ uri = "
-           "\\\"bmq://bmq.test.persistent.priority/second-queue\\\" key = [ "
-           "62 ] partitionId = 3 appIds = [ ] ]\",\n"
-        << "      \"[ uri = "
-           "\\\"bmq://bmq.test.persistent.priority/first-queue\\\" key = [ 61 "
-           "] partitionId = 2 appIds = [ ] ]\"\n"
-        << "    ]\n"
-        << "}\n";
+    expectedStream << "{\n"
+                   << "    \"Summary\":\n"
+                   << "    {\n"
+                   << "      \"SnapshotRecords\": \"2\",\n"
+                   << "      \"UpdateRecords\": \"3\",\n"
+                   << "      \"queueAssignmentAdvisory\": \"3\",\n"
+                   << "      \"leaderAdvisory\": \"2\",\n"
+                   << "      \"CommitRecords\": \"4\",\n"
+                   << "      \"AckRecords\": \"5\"\n"
+                   << "    },\n"
+                   << "    \"Queues\": [\n"
+                   << "      "
+                      "{\"uri\":\"bmq:\\/\\/bmq.test.persistent.priority\\/"
+                      "second-queue\",\"key\":\"62\",\"partitionId\":3},\n"
+                   << "      "
+                      "{\"uri\":\"bmq:\\/\\/bmq.test.persistent.priority\\/"
+                      "first-queue\",\"key\":\"61\",\"partitionId\":2}\n"
+                   << "    ]\n"
+                   << "}\n";
 
     BMQTST_ASSERT_EQ(expectedStream.str(), resultStream.str());
 }
@@ -598,7 +604,8 @@ static void test9_lineShortResultTest()
             bmqtst::TestHelperUtil::allocator());
 
         // Print short result
-        printer->printShortResult(header, recordId);
+        bmqp_ctrlmsg::ClusterMessage msg(bmqtst::TestHelperUtil::allocator());
+        printer->printShortResult(msg, header, recordId);
     }
 
     // Prepare expected output
@@ -636,8 +643,7 @@ static void test10_lineDetailResultTest()
     bmqu::MemOutStream resultStream(bmqtst::TestHelperUtil::allocator());
     bmqu::MemOutStream expectedStream(bmqtst::TestHelperUtil::allocator());
 
-    // Ignore check default allocator due to issue with bslim::Printer::print()
-    // used in recordToJsonString()
+    // Ignore check default allocator due to allocations in baljsn encoder
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     // Create record data
@@ -675,9 +681,8 @@ static void test10_lineDetailResultTest()
            "\"3000000001\", \"ElectorTerm\": \"1\", \"SequenceNumber\": "
            "\"2\", \"HeaderWords\": \"8\", \"LeaderAdvisoryWords\": \"10\", "
            "\"Timestamp\": \"29NOV1973_21:33:09.000000\", \"Epoch\": "
-           "\"123456789\", \"Record\": \"[ choice = [ leaderAdvisory = [ "
-           "sequenceNumber = [ electorTerm = 0 sequenceNumber = 0 ] "
-           "partitions = [ ] queues = [ ] ] ] \"}\n"
+           "\"123456789\", \"Record\": {\"leaderAdvisory\":"
+           "{\"sequenceNumber\":{\"electorTerm\":0,\"sequenceNumber\":0}}}}\n"
         << "  ]\n"
         << "}\n";
 
@@ -758,12 +763,12 @@ static void test11_lineSummaryTest()
            "\"3\", \"queueAssignmentAdvisory\": \"3\", \"leaderAdvisory\": "
            "\"2\", \"CommitRecords\": \"4\", \"AckRecords\": \"5\"},\n"
         << "    \"Queues\": [\n"
-        << "      \"[ uri = "
-           "\\\"bmq://bmq.test.persistent.priority/second-queue\\\" key = [ "
-           "62 ] partitionId = 3 appIds = [ ] ]\",\n"
-        << "      \"[ uri = "
-           "\\\"bmq://bmq.test.persistent.priority/first-queue\\\" key = [ 61 "
-           "] partitionId = 2 appIds = [ ] ]\"\n"
+        << "      "
+           "{\"uri\":\"bmq:\\/\\/bmq.test.persistent.priority\\/"
+           "second-queue\",\"key\":\"62\",\"partitionId\":3},\n"
+        << "      "
+           "{\"uri\":\"bmq:\\/\\/bmq.test.persistent.priority\\/"
+           "first-queue\",\"key\":\"61\",\"partitionId\":2}\n"
         << "    ]\n"
         << "}\n";
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslrecordprinter.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslrecordprinter.h
@@ -150,9 +150,6 @@ void CslRecordPrinter<PRINTER_TYPE>::printRecordDetails(
     d_fields.push_back("LeaderAdvisoryWords");
     d_fields.push_back("Timestamp");
     d_fields.push_back("Epoch");
-    if (!recStr.empty()) {
-        d_fields.push_back("Record");
-    }
     // It's ok to pass a vector by pointer and push elements after that as
     // we've reserved it's capacity in advance. Hense, no reallocations will
     // happen and the pointer won't get invalidated.
@@ -173,12 +170,10 @@ void CslRecordPrinter<PRINTER_TYPE>::printRecordDetails(
         *d_printer_mp << datetime;
     }
     *d_printer_mp << epochValue;
-
     if (!recStr.empty()) {
-        // Print record string.
+        d_fields.push_back("Record");
         *d_printer_mp << recStr;
     }
-
     d_printer_mp.reset();
 }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslsearchresult.cpp
@@ -84,10 +84,10 @@ CslSearchShortResult::CslSearchShortResult(
 
 bool CslSearchShortResult::processRecord(
     const mqbc::ClusterStateRecordHeader& header,
-    BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::ClusterMessage& record,
-    const mqbsi::LedgerRecordId&                          recordId)
+    const bmqp_ctrlmsg::ClusterMessage&   record,
+    const mqbsi::LedgerRecordId&          recordId)
 {
-    printer()->printShortResult(header, recordId);
+    printer()->printShortResult(record, header, recordId);
 
     updateRecordCount(&d_recordCount, header.recordType());
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_journalfileprocessor.t.cpp
@@ -2381,7 +2381,7 @@ static void test24_searchConfirmAndDeletionRecordsByOffset()
                 const bsls::Types::Uint64 offset = recordOffset(confirm);
                 params.d_offset.emplace_back(offset);
 
-                EXPECT_CALL(*printer, printGuid(confirm.messageGUID()))
+                EXPECT_CALL(*printer, printConfirmRecord(testing::_))
                     .InSequence(s);
                 ++foundConfirmCnt;
             }
@@ -2394,7 +2394,7 @@ static void test24_searchConfirmAndDeletionRecordsByOffset()
                 const bsls::Types::Uint64 offset = recordOffset(deletion);
                 params.d_offset.emplace_back(offset);
 
-                EXPECT_CALL(*printer, printGuid(deletion.messageGUID()))
+                EXPECT_CALL(*printer, printDeletionRecord(testing::_))
                     .InSequence(s);
                 ++foundDeletionCnt;
             }
@@ -2481,7 +2481,7 @@ static void test25_searchConfirmAndDeletionRecordsBySeqNumber()
                     confirm.header().primaryLeaseId(),
                     confirm.header().sequenceNumber());
                 params.d_seqNum.emplace_back(expectedComposite);
-                EXPECT_CALL(*printer, printGuid(confirm.messageGUID()))
+                EXPECT_CALL(*printer, printConfirmRecord(testing::_))
                     .InSequence(s);
                 ++foundConfirmCnt;
             }
@@ -2495,7 +2495,7 @@ static void test25_searchConfirmAndDeletionRecordsBySeqNumber()
                     deletion.header().primaryLeaseId(),
                     deletion.header().sequenceNumber());
                 params.d_seqNum.emplace_back(expectedComposite);
-                EXPECT_CALL(*printer, printGuid(deletion.messageGUID()))
+                EXPECT_CALL(*printer, printDeletionRecord(testing::_))
                     .InSequence(s);
                 ++foundDeletionCnt;
             }

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.cpp
@@ -151,5 +151,10 @@ MessageDetails::deleteRecord() const
     return d_deleteRecord;
 }
 
+void MessageDetails::setPayloadHex(const bsl::string& payload)
+{
+    d_messageRecord.d_payloadHex = payload;
+}
+
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_messagedetails.h
@@ -137,6 +137,8 @@ struct RecordDetails {
     // URI of the queue.
     bsl::string d_appId;
     // ID of the application.
+    bsl::string d_payloadHex;
+    // Hex-encoded message payload (set when dump-payload is enabled).
 
     // CREATORS
 
@@ -151,6 +153,7 @@ struct RecordDetails {
     , d_recordOffset(recordOffset)
     , d_queueUri(allocator)
     , d_appId(allocator)
+    , d_payloadHex(allocator)
     {
         // NOTHING
     }
@@ -196,6 +199,9 @@ class MessageDetails {
     void addDeleteRecord(const mqbs::DeletionRecord& record,
                          bsls::Types::Uint64         recordIndex,
                          bsls::Types::Uint64         recordOffset);
+
+    /// Set hex-encoded message payload.
+    void setPayloadHex(const bsl::string& payload);
 
     // ACCESSORS
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
@@ -311,9 +311,6 @@ void CommandLineArguments::validateJournalModeArgs(bsl::ostream&     stream,
     if (d_dataFile.empty() && d_dumpPayload) {
         stream << "Can't dump payload, because data file is not specified\n";
     }
-    if (d_dumpPayload && d_printMode != CommandLineArguments::k_HUMAN_MODE) {
-        stream << "Payload dumping is not supported for Json printing mode\n";
-    }
     if (d_cslFile.empty() && !d_queueName.empty()) {
         stream << "Can't search by queue name, because csl file is not "
                   "specified\n";
@@ -610,10 +607,6 @@ Parameters::Parameters(const CommandLineArguments& arguments,
     else if (arguments.d_printMode == CommandLineArguments::k_JSON_LINE_MODE) {
         d_printMode = e_JSON_LINE;
     }
-    if (d_printMode != e_HUMAN && d_dumpPayload) {
-        BSLS_ASSERT(false && "Payload dumping is not supported for Json mode");
-    }
-
     // Set record types to process
     if (d_cslMode) {
         if (arguments.d_cslRecordType.empty()) {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_payloaddumper.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_payloaddumper.cpp
@@ -20,12 +20,65 @@
 #include <mqbs_filestoreprotocolprinter.h>
 
 // BMQ
+#include <bdlbb_blob.h>
+#include <bmqp_messageproperties.h>
 #include <bmqu_memoutstream.h>
 #include <bsl_algorithm.h>
 #include <bsl_ostream.h>
 
 namespace BloombergLP {
 namespace m_bmqstoragetool {
+
+namespace {
+
+const unsigned int k_MAX_PAYLOAD_HEX_BYTES = 64;
+
+int seekToRecord(mqbs::DataFileIterator* it, bsls::Types::Uint64 recordOffset)
+{
+    if ((it->recordOffset() > recordOffset && !it->isReverseMode()) ||
+        (it->recordOffset() < recordOffset && it->isReverseMode())) {
+        it->flipDirection();
+    }
+    while (it->recordOffset() != recordOffset) {
+        const int rc = it->nextRecord();
+        if (rc != 1) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+void loadAppData(const char**            appData,
+                 unsigned int*           appDataLen,
+                 unsigned int*           propertiesAreaLen,
+                 mqbs::DataFileIterator* it)
+{
+    *propertiesAreaLen = 0;
+    it->loadApplicationData(appData, appDataLen);
+
+    const mqbs::DataHeader& dh = it->dataHeader();
+    if (mqbs::DataHeaderFlagUtil::isSet(
+            dh.flags(),
+            mqbs::DataHeaderFlags::e_MESSAGE_PROPERTIES)) {
+        bsl::shared_ptr<char> sp(const_cast<char*>(*appData),
+                                 bslstl::SharedPtrNilDeleter(),
+                                 0);
+        bdlbb::BlobBuffer     buf(sp, *appDataLen);
+        bdlbb::Blob           blob;
+        blob.appendDataBuffer(buf);
+
+        bmqp::MessageProperties props;
+        if (0 ==
+            props.streamIn(blob,
+                           bmqp::MessagePropertiesInfo(dh).isExtended())) {
+            *propertiesAreaLen = props.totalSize();
+            *appDataLen -= *propertiesAreaLen;
+            *appData += *propertiesAreaLen;
+        }
+    }
+}
+
+}  // close unnamed namespace
 
 // ===================
 // class PayloadDumper
@@ -47,58 +100,46 @@ void PayloadDumper::outputPayload(bsls::Types::Uint64 messageOffsetDwords)
 {
     const bsls::Types::Uint64 recordOffset = messageOffsetDwords *
                                              bmqp::Protocol::k_DWORD_SIZE;
-    mqbs::DataFileIterator* it = d_dataFile_p;
 
-    // Flip iterator direction depending on recordOffset
-    if ((it->recordOffset() > recordOffset && !it->isReverseMode()) ||
-        (it->recordOffset() < recordOffset && it->isReverseMode())) {
-        it->flipDirection();
-    }
-    // Search record in data file
-    while (it->recordOffset() != recordOffset) {
-        const int rc = it->nextRecord();
-
-        if (rc != 1) {
-            d_ostream << "Failed to retrieve message from DATA "
-                      << "file rc: " << rc << bsl::endl;
-            return;  // RETURN
-        }
+    if (seekToRecord(d_dataFile_p, recordOffset) != 0) {
+        d_ostream << "Failed to retrieve message from DATA file" << bsl::endl;
+        return;
     }
 
     bmqu::MemOutStream dataHeaderOsstr(d_allocator_p);
     bmqu::MemOutStream optionsOsstr(d_allocator_p);
     bmqu::MemOutStream propsOsstr(d_allocator_p);
 
-    dataHeaderOsstr << it->dataHeader();
+    dataHeaderOsstr << d_dataFile_p->dataHeader();
 
     const char*  options    = 0;
     unsigned int optionsLen = 0;
-    it->loadOptions(&options, &optionsLen);
+    d_dataFile_p->loadOptions(&options, &optionsLen);
     mqbs::FileStoreProtocolPrinter::printOptions(optionsOsstr,
                                                  options,
                                                  optionsLen);
 
-    const char*  appData    = 0;
-    unsigned int appDataLen = 0;
-    it->loadApplicationData(&appData, &appDataLen);
+    const char*  appData           = 0;
+    unsigned int appDataLen        = 0;
+    unsigned int propertiesAreaLen = 0;
+    loadAppData(&appData, &appDataLen, &propertiesAreaLen, d_dataFile_p);
 
-    const mqbs::DataHeader& dh                = it->dataHeader();
-    unsigned int            propertiesAreaLen = 0;
+    const mqbs::DataHeader& dh = d_dataFile_p->dataHeader();
     if (mqbs::DataHeaderFlagUtil::isSet(
             dh.flags(),
             mqbs::DataHeaderFlags::e_MESSAGE_PROPERTIES)) {
+        const char*  propsData = 0;
+        unsigned int propsLen  = 0;
+        d_dataFile_p->loadApplicationData(&propsData, &propsLen);
         int rc = mqbs::FileStoreProtocolPrinter::printMessageProperties(
             &propertiesAreaLen,
             propsOsstr,
-            appData,
+            propsData,
             bmqp::MessagePropertiesInfo(dh));
         if (rc) {
             d_ostream << "Failed to retrieve message properties, rc: " << rc
                       << bsl::endl;
         }
-
-        appDataLen -= propertiesAreaLen;
-        appData += propertiesAreaLen;
     }
 
     // Payload
@@ -113,8 +154,8 @@ void PayloadDumper::outputPayload(bsls::Types::Uint64 messageOffsetDwords)
     }
 
     d_ostream << '\n'
-              << "DataRecord index: " << it->recordIndex()
-              << ", offset: " << it->recordOffset() << '\n'
+              << "DataRecord index: " << d_dataFile_p->recordIndex()
+              << ", offset: " << d_dataFile_p->recordOffset() << '\n'
               << "DataHeader: " << '\n'
               << dataHeaderOsstr.str();
 
@@ -127,6 +168,34 @@ void PayloadDumper::outputPayload(bsls::Types::Uint64 messageOffsetDwords)
     }
 
     d_ostream << "\nPayload: " << '\n' << payloadOsstr.str() << '\n';
+}
+
+int PayloadDumper::loadPayloadHex(bsl::string*        result,
+                                  bsls::Types::Uint64 messageOffsetDwords)
+{
+    const bsls::Types::Uint64 recordOffset = messageOffsetDwords *
+                                             bmqp::Protocol::k_DWORD_SIZE;
+
+    if (seekToRecord(d_dataFile_p, recordOffset) != 0) {
+        return -1;
+    }
+
+    const char*  appData           = 0;
+    unsigned int appDataLen        = 0;
+    unsigned int propertiesAreaLen = 0;
+    loadAppData(&appData, &appDataLen, &propertiesAreaLen, d_dataFile_p);
+
+    unsigned int len = bsl::min(appDataLen, k_MAX_PAYLOAD_HEX_BYTES);
+    result->clear();
+    result->reserve(len * 2);
+    for (unsigned int i = 0; i < len; ++i) {
+        const char    hexDigits[] = "0123456789ABCDEF";
+        unsigned char byte        = static_cast<unsigned char>(appData[i]);
+        result->push_back(hexDigits[byte >> 4]);
+        result->push_back(hexDigits[byte & 0x0F]);
+    }
+
+    return 0;
 }
 
 }  // close package namespace

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_payloaddumper.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_payloaddumper.h
@@ -25,6 +25,7 @@
 
 // MQB
 #include <bsl_ostream.h>
+#include <bsl_string.h>
 #include <mqbs_datafileiterator.h>
 
 namespace BloombergLP {
@@ -60,6 +61,12 @@ class PayloadDumper {
 
     /// Output message payload from the specified offset in Data file.
     void outputPayload(bsls::Types::Uint64 messageOffsetDwords);
+
+    /// Load first 64 bytes of message payload from the specified offset in
+    /// Data file and return it as a hex string via the specified `result`.
+    /// Return 0 on success, non-zero on error.
+    int loadPayloadHex(bsl::string*        result,
+                       bsls::Types::Uint64 messageOffsetDwords);
 };
 
 }  // close package namespace

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
@@ -417,6 +417,8 @@ class HumanReadablePrinter : public Printer {
 
     void printCompositesNotFound(const CompositesVec& seqNums) const
         BSLS_KEYWORD_OVERRIDE;
+
+    bool isPayloadHexMode() const BSLS_KEYWORD_OVERRIDE;
 };
 
 // CREATORS
@@ -684,6 +686,11 @@ void HumanReadablePrinter::printRecordDetails(
     d_ostream << "\n";
 }
 
+bool HumanReadablePrinter::isPayloadHexMode() const
+{
+    return false;
+}
+
 class JsonPrinter : public Printer {
   protected:
     bsl::ostream&     d_ostream;
@@ -750,6 +757,8 @@ class JsonPrinter : public Printer {
 
     void printCompositesNotFound(const CompositesVec& seqNums) const
         BSLS_KEYWORD_OVERRIDE;
+
+    bool isPayloadHexMode() const BSLS_KEYWORD_OVERRIDE;
 };
 
 // PROTECTED METHODS
@@ -955,6 +964,11 @@ void JsonPrinter::printCompositesNotFound(const CompositesVec& seqNums) const
                   << "\"}";
     }
     d_ostream << "\n  ]";
+}
+
+bool JsonPrinter::isPayloadHexMode() const
+{
+    return true;
 }
 
 class JsonPrettyPrinter : public JsonPrinter {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
@@ -160,6 +160,11 @@ class Printer {
     /// Print metadata of the specified data file `dataFile_p`.
     virtual void
     printDataFileMeta(const mqbs::DataFileIterator* dataFile_p) const = 0;
+
+    /// Return 'true' if payload should be embedded as hex in record fields
+    /// (JSON mode), 'false' if payload should be dumped separately (human
+    /// mode).
+    virtual bool isPayloadHexMode() const = 0;
 };
 
 /// Create an instance of printer to print data to the specified 'stream'

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printermock.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printermock.h
@@ -116,6 +116,7 @@ class PrinterMock : public Printer {
     MOCK_CONST_METHOD1(printGuidsNotFound, void(const GuidsList&));
     MOCK_CONST_METHOD1(printOffsetsNotFound, void(const OffsetsVec&));
     MOCK_CONST_METHOD1(printCompositesNotFound, void(const CompositesVec&));
+    MOCK_CONST_METHOD0(isPayloadHexMode, bool());
 };
 
 // ====================
@@ -131,8 +132,9 @@ class CslPrinterMock : public CslPrinter {
 
     // PUBLIC METHODS
 
-    MOCK_CONST_METHOD2(printShortResult,
-                       void(const mqbc::ClusterStateRecordHeader& header,
+    MOCK_CONST_METHOD3(printShortResult,
+                       void(const bmqp_ctrlmsg::ClusterMessage&   record,
+                            const mqbc::ClusterStateRecordHeader& header,
                             const mqbsi::LedgerRecordId&          recordId));
 
     MOCK_CONST_METHOD3(printDetailResult,

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_recordprinter.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_recordprinter.h
@@ -88,6 +88,9 @@ class RecordDetailsPrinter {
     template <typename RECORD_TYPE>
     void printQueueInfo(const RecordDetails<RECORD_TYPE>& rec);
 
+    template <typename RECORD_TYPE>
+    void printCommonHeader(const RecordDetails<RECORD_TYPE>& details);
+
   public:
     // CREATORS
     RecordDetailsPrinter(bsl::ostream& stream, bslma::Allocator* allocator);
@@ -126,12 +129,7 @@ void RecordDetailsPrinter<PRINTER_TYPE>::printAppInfo(
 {
     d_fields.push_back("AppKey");
     bmqu::MemOutStream appKeyStr(d_allocator_p);
-    if (rec.d_record.appKey().isNull()) {
-        appKeyStr << "** NULL **";
-    }
-    else {
-        appKeyStr << rec.d_record.appKey();
-    }
+    appKeyStr << rec.d_record.appKey();
     *d_printer_mp << appKeyStr.str();
 
     if (!rec.d_appId.empty()) {
@@ -169,11 +167,11 @@ inline void printDelimeter<bmqu::AlignedPrinter>(bsl::ostream& ostream)
 
 template <typename PRINTER_TYPE>
 template <typename RECORD_TYPE>
-void RecordDetailsPrinter<PRINTER_TYPE>::printRecordDetails(
+void RecordDetailsPrinter<PRINTER_TYPE>::printCommonHeader(
     const RecordDetails<RECORD_TYPE>& details)
 {
     d_fields.clear();
-    d_fields.reserve(14);  // max number of fields
+    d_fields.reserve(15);
     d_fields.push_back("RecordType");
     d_fields.push_back("Index");
     d_fields.push_back("Offset");
@@ -183,7 +181,7 @@ void RecordDetailsPrinter<PRINTER_TYPE>::printRecordDetails(
     d_fields.push_back("Epoch");
 
     // It's ok to pass a vector by pointer and push elements after that as
-    // we've reserved it's capacity in advance. Hense, no reallocations will
+    // we've reserved its capacity in advance. Hence, no reallocations will
     // happen and the pointer won't get invalidated.
     d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, &d_fields),
                       d_allocator_p);
@@ -203,7 +201,14 @@ void RecordDetailsPrinter<PRINTER_TYPE>::printRecordDetails(
         *d_printer_mp << datetime;
     }
     *d_printer_mp << epochValue;
+}
 
+template <typename PRINTER_TYPE>
+template <typename RECORD_TYPE>
+void RecordDetailsPrinter<PRINTER_TYPE>::printRecordDetails(
+    const RecordDetails<RECORD_TYPE>& details)
+{
+    printCommonHeader(details);
     printRecord(details);
     d_printer_mp.reset();
 }
@@ -226,6 +231,11 @@ void RecordDetailsPrinter<PRINTER_TYPE>::printRecord(
     *d_printer_mp << fileKeyStr.str() << rec.d_record.refCount()
                   << rec.d_record.messageOffsetDwords()
                   << rec.d_record.messageGUID() << rec.d_record.crc32c();
+
+    if (!rec.d_payloadHex.empty()) {
+        d_fields.push_back("Payload");
+        *d_printer_mp << rec.d_payloadHex;
+    }
 }
 
 template <typename PRINTER_TYPE>

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -640,14 +640,23 @@ void SearchDetailResult::addMessageDetails(const mqbs::MessageRecord& record,
     bsl::optional<bmqp_ctrlmsg::QueueInfo> queueInfo =
         d_queueMap.findInfoByKey(record.queueKey());
 
-    d_messageDetailsMap.emplace(
-        record.messageGUID(),
-        d_messageDetailsList.insert(d_messageDetailsList.cend(),
-                                    MessageDetails(record,
-                                                   recordIndex,
-                                                   recordOffset,
-                                                   queueInfo,
-                                                   d_allocator_p)));
+    DetailsList::iterator detailsIt = d_messageDetailsList.insert(
+        d_messageDetailsList.cend(),
+        MessageDetails(record,
+                       recordIndex,
+                       recordOffset,
+                       queueInfo,
+                       d_allocator_p));
+    d_messageDetailsMap.emplace(record.messageGUID(), detailsIt);
+
+    if (d_payloadDumper && d_printer->isPayloadHexMode()) {
+        bsl::string payloadHex(d_allocator_p);
+        if (0 ==
+            d_payloadDumper->loadPayloadHex(&payloadHex,
+                                            record.messageOffsetDwords())) {
+            detailsIt->setPayloadHex(payloadHex);
+        }
+    }
 }
 
 void SearchDetailResult::deleteMessageDetails(DetailsMap::iterator iterator)
@@ -661,10 +670,9 @@ void SearchDetailResult::outputMessageDetails(
     const MessageDetails& messageDetails)
 {
     d_printer->printMessage(messageDetails);
-    if (d_payloadDumper)
+    if (d_payloadDumper && !d_printer->isPayloadHexMode())
         d_payloadDumper->outputPayload(
             messageDetails.messageRecord().d_record.messageOffsetDwords());
-
     d_printedMessagesCount++;
 }
 
@@ -685,13 +693,11 @@ const bsl::shared_ptr<Printer>& SearchDetailResult::printer() const
 SearchExactMatchResult::SearchExactMatchResult(
     const bsl::shared_ptr<Printer>&       printer,
     const Parameters::ProcessRecordTypes& processRecordTypes,
-    bool                                  isDetail,
     const QueueMap&                       queueMap,
     bslma::ManagedPtr<PayloadDumper>&     payloadDumper,
     bslma::Allocator*                     allocator)
 : d_printer(printer)
 , d_processRecordTypes(processRecordTypes)
-, d_isDetail(isDetail)
 , d_queueMap(queueMap)
 , d_payloadDumper(payloadDumper)
 , d_printedMessagesCount(0)
@@ -709,23 +715,24 @@ bool SearchExactMatchResult::processMessageRecord(
     bsls::Types::Uint64        recordIndex,
     bsls::Types::Uint64        recordOffset)
 {
-    if (d_isDetail) {
-        bsl::optional<bmqp_ctrlmsg::QueueInfo> queueInfo =
-            d_queueMap.findInfoByKey(record.queueKey());
-        MessageDetails details(record,
-                               recordIndex,
-                               recordOffset,
-                               queueInfo,
-                               d_allocator_p);
-        d_printer->printMessage(details);
+    bsl::optional<bmqp_ctrlmsg::QueueInfo> queueInfo =
+        d_queueMap.findInfoByKey(record.queueKey());
+    MessageDetails details(record,
+                           recordIndex,
+                           recordOffset,
+                           queueInfo,
+                           d_allocator_p);
+    if (d_payloadDumper && d_printer->isPayloadHexMode()) {
+        bsl::string payloadHex(d_allocator_p);
+        if (0 ==
+            d_payloadDumper->loadPayloadHex(&payloadHex,
+                                            record.messageOffsetDwords())) {
+            details.setPayloadHex(payloadHex);
+        }
     }
-    else {
-        d_printer->printGuid(record.messageGUID());
-    }
-
-    if (d_payloadDumper) {
+    d_printer->printMessage(details);
+    if (d_payloadDumper && !d_printer->isPayloadHexMode())
         d_payloadDumper->outputPayload(record.messageOffsetDwords());
-    }
 
     d_printedMessagesCount++;
 
@@ -737,19 +744,14 @@ bool SearchExactMatchResult::processConfirmRecord(
     bsls::Types::Uint64        recordIndex,
     bsls::Types::Uint64        recordOffset)
 {
-    if (d_isDetail) {
-        RecordDetails<mqbs::ConfirmRecord> details(record,
-                                                   recordIndex,
-                                                   recordOffset,
-                                                   d_allocator_p);
+    RecordDetails<mqbs::ConfirmRecord> details(record,
+                                               recordIndex,
+                                               recordOffset,
+                                               d_allocator_p);
 
-        addQueueInfo(details, record.queueKey(), record.appKey());
+    addQueueInfo(details, record.queueKey(), record.appKey());
 
-        d_printer->printConfirmRecord(details);
-    }
-    else {
-        d_printer->printGuid(record.messageGUID());
-    }
+    d_printer->printConfirmRecord(details);
 
     d_printedConfirmCount++;
 
@@ -761,19 +763,14 @@ bool SearchExactMatchResult::processDeletionRecord(
     bsls::Types::Uint64         recordIndex,
     bsls::Types::Uint64         recordOffset)
 {
-    if (d_isDetail) {
-        RecordDetails<mqbs::DeletionRecord> details(record,
-                                                    recordIndex,
-                                                    recordOffset,
-                                                    d_allocator_p);
+    RecordDetails<mqbs::DeletionRecord> details(record,
+                                                recordIndex,
+                                                recordOffset,
+                                                d_allocator_p);
 
-        addQueueInfo(details, record.queueKey(), mqbu::StorageKey());
+    addQueueInfo(details, record.queueKey(), mqbu::StorageKey());
 
-        d_printer->printDeletionRecord(details);
-    }
-    else {
-        d_printer->printGuid(record.messageGUID());
-    }
+    d_printer->printDeletionRecord(details);
 
     d_printedDeletionCount++;
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -414,8 +414,6 @@ class SearchExactMatchResult : public SearchResult {
     // Pointer to 'Printer' instance.
     Parameters::ProcessRecordTypes d_processRecordTypes;
     // Record types to process
-    const bool d_isDetail;
-    // If 'true', output detail result, otherwise output short result.
     const QueueMap& d_queueMap;
     // Reference to 'QueueMap' instance.
     const bslma::ManagedPtr<PayloadDumper> d_payloadDumper;
@@ -454,7 +452,6 @@ class SearchExactMatchResult : public SearchResult {
     explicit SearchExactMatchResult(
         const bsl::shared_ptr<Printer>&       printer,
         const Parameters::ProcessRecordTypes& processRecordTypes,
-        bool                                  isDetail,
         const QueueMap&                       queueMap,
         bslma::ManagedPtr<PayloadDumper>&     payloadDumper,
         bslma::Allocator*                     allocator);

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresultfactory.cpp
@@ -70,11 +70,10 @@ bsl::shared_ptr<SearchResult> SearchResultFactory::createSearchResult(
             allocator,
             printer,
             params->d_processRecordTypes,
-            details,
             params->d_queueMap,
             payloadDumper);
     }
-    else if (details) {
+    else if (details || params->d_printMode != Parameters::e_HUMAN) {
         searchResult = bsl::allocate_shared<SearchDetailResult>(
             allocator,
             printer,

--- a/src/groups/bmq/bmqu/bmqu_jsonprinter.h
+++ b/src/groups/bmq/bmqu/bmqu_jsonprinter.h
@@ -76,6 +76,13 @@ inline bool addQuotes<bslstl::StringRef>(const bslstl::StringRef& value)
     return (pos == bsl::string::npos || value[pos] != '{');
 }
 
+template <>
+inline bool addQuotes<bsl::string>(const bsl::string& value)
+{
+    bsl::size_t pos = value.find_first_not_of(" \n");
+    return (pos == bsl::string::npos || value[pos] != '{');
+}
+
 // =================
 // class JsonPrinter
 // =================


### PR DESCRIPTION
⏺ Summary of storagetool functionality changes:

  1. Journal JSON output always shows details — `SearchResultFactory` (not just when `--details` is specified).
  2. Exact-match searches always show details — `SearchExactMatchResult` (`--guid`, `--seqnum`, `--offset`) now always prints full record details in all modes.
  Previously without `--details` only printed GUIDs.
  3. Payload dump supported in JSON mode — removed the `"not supported for Json mode"` restriction. In JSON mode, payload is embedded as a hex "Payload" field in the record.
  In human mode, payload is still dumped separately.
  4. CSL JSON output always includes the advisory payload — no `--details` needed.
  5. CSL advisory payload is proper JSON — Record field is a nested JSON object via `baljsn::Encoder`.
  6. Keys are hex in CSL JSON — instead of base64.
  7. Null AppKey is "0000000000" — instead of `"** NULL **"`.
  
  
  ⏺ bmqstoragewriter — writes BlazingMQ storage files from storagetool JSON output.

  Usage: bmqstoragewriter [options]

  Options:
  - -i|--input — journal JSON input
  - -c|--csl-input — CSL JSON input
  - -o|--output-dir — output directory (default: .)
  - -p|--partition — partition ID (default: 0)
  - --prefix — filename prefix (default: bmq_)

  Behavior:
  1. Creates journal/data/qlist files if they don't exist (with proper headers).
  2. If `--csl-input` provided: writes CSL records to a .bmq_csl file and populates an in-memory queue cache (QueueKey → URI, AppIds).
  3. If `--input` provided: appends records to journal/data/qlist files. For `QUEUE_OP` `CREATION`, looks up queue URI and AppIds from cache; falls back to hex key as URI if not
  in cache.
  4. CSL is processed before journal so the cache is available.
  5. If no options are provided, prints help.
  6. If neither `--input` nor `--csl-input` is provided (regardless of other options), just creates empty journal/data/qlist files.
  7. Appending to existing CSL file warns if input LogId differs from file's LogId.
