### PR TITLE
Perf[bmqc]: stop MQTP queues in parallel

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
@@ -865,6 +865,7 @@ inline void MultiQueueThreadPool<TYPE>::stop()
             &d_warningMonitorEventHandle);
     }
 
+    // Signal all queues to stop.
     for (size_t i = 0; i < d_queues.size(); ++i) {
         QueueInfo& info = *d_queues[i];
 
@@ -882,6 +883,11 @@ inline void MultiQueueThreadPool<TYPE>::stop()
         // It is possible that something is enqueued to the queue between the
         // last monitor event and `disablePushBack()` call, this is expected.
         info.d_queue_p->disablePushBack();
+    }
+
+    // Wait for all queues to finish, then drain and delete.
+    for (size_t i = 0; i < d_queues.size(); ++i) {
+        QueueInfo& info = *d_queues[i];
 
         const bsls::TimeInterval timeout =
             bsls::SystemTime::nowMonotonicClock().addSeconds(


### PR DESCRIPTION
Closes: #1028

Split the serial stop loop in `MultiQueueThreadPool::stop()` into two phases so all queues drain concurrently rather than sequentially. The first loop signals every queue (pushBack NULL, disablePushBack), the second waits on each queue's `d_finished` semaphore. This is safe because each queue's shutdown is self-contained: its own semaphore, ref count, and backing SingleConsumerQueue with no cross-queue state. The ref count nets to zero per queue (+1 enqueue monitor, -1 release initial reference), so finish order is irrelevant.

