### PR TITLE
Fix: Removing directory instead of file for the nightly fuzztest action. 

### DIFF
--- a/.github/workflows/nightly-fuzz-cron.yaml
+++ b/.github/workflows/nightly-fuzz-cron.yaml
@@ -51,7 +51,7 @@ jobs:
           find ./build -type f -name "*.tsk" -exec chmod +x {} +
           cp src/applications/bmqbrkr/run "$BROKER_DIR/run"
           chmod +x "$BROKER_DIR/run"
-          rm -f "$BROKER_DIR/etc"
+          rm -rf "$BROKER_DIR/etc"
           cp -r src/applications/bmqbrkr/etc "$BROKER_DIR/etc"
 
       - name: Install Python dependencies


### PR DESCRIPTION
The job fails because /etc is a directory not a file. 