### PR TITLE
Fix[mqbnet]: Always set out parameter in `InitialConnectionContext`

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -276,7 +276,8 @@ int InitialConnectionContext::readBlob(bsl::ostream& errorDescription,
 
     // Have a full blob, indicate no more bytes needed (we have to do this
     // because 'handleRead' above set it back to 4 at the end).
-    *numNeeded = 0;
+    *isFullBlob = true;
+    *numNeeded  = 0;
 
     return 0;
 }


### PR DESCRIPTION
According to the documentation of `readBlob`, we write `*isFullBlob` to whether the function reads a full blob or not.  However, we actually only set `*isFullBlob` when we do not read a full blob, never when we do read a full blob.  Instead, the implementation relies silently on the caller initializing `*isFullBlob` to `true`.  This PR brings `readBlob` into alignment with the documentation and removes the silent state coupling between the function and its caller.