### PR TITLE
Refactor[bmq,mqb]: un-template request managers

### DIFF
--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.cpp
@@ -1011,9 +1011,8 @@ void BrokerSession::QueueFsm::setQueueState(
     queue->setState(value);
 }
 
-void BrokerSession::QueueFsm::setQueueId(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+void BrokerSession::QueueFsm::setQueueId(const bsl::shared_ptr<Queue>& queue,
+                                         const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -1042,9 +1041,9 @@ void BrokerSession::QueueFsm::setQueueId(
 }
 
 void BrokerSession::QueueFsm::injectErrorResponse(
-    const RequestManagerType::RequestSp& context,
-    int                                  status,
-    const bslstl::StringRef&             reason)
+    const RequestSp&         context,
+    int                      status,
+    const bslstl::StringRef& reason)
 {
     // executed by the FSM thread
 
@@ -1059,10 +1058,10 @@ void BrokerSession::QueueFsm::injectErrorResponse(
                                          reason);
 }
 
-bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::actionOpenQueue(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    const bsls::TimeInterval&            timeout)
+bmqt::OpenQueueResult::Enum
+BrokerSession::QueueFsm::actionOpenQueue(const bsl::shared_ptr<Queue>& queue,
+                                         const RequestSp&              context,
+                                         const bsls::TimeInterval&     timeout)
 {
     // executed by the FSM thread
 
@@ -1082,10 +1081,10 @@ bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::actionOpenQueue(
     return res;
 }
 
-bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::actionReopenQueue(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    const bsls::TimeInterval&            timeout)
+bmqt::OpenQueueResult::Enum
+BrokerSession::QueueFsm::actionReopenQueue(const bsl::shared_ptr<Queue>& queue,
+                                           const RequestSp&          context,
+                                           const bsls::TimeInterval& timeout)
 {
     // executed by the FSM thread
 
@@ -1105,9 +1104,9 @@ bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::actionReopenQueue(
 
 bmqt::ConfigureQueueResult::Enum
 BrokerSession::QueueFsm::actionDeconfigureQueue(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& closeContext,
-    const bsls::TimeInterval&            timeout)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              closeContext,
+    const bsls::TimeInterval&     timeout)
 {
     // executed by the FSM thread
 
@@ -1186,11 +1185,11 @@ void BrokerSession::QueueFsm::actionRemoveQueue(
 
 bmqt::ConfigureQueueResult::Enum
 BrokerSession::QueueFsm::actionOpenConfigureQueue(
-    const RequestManagerType::RequestSp& openContext,
-    const RequestManagerType::RequestSp& configContext,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval&            timeout,
-    bool                                 isReopenRequest)
+    const RequestSp&              openContext,
+    const RequestSp&              configContext,
+    const bsl::shared_ptr<Queue>& queue,
+    const bsls::TimeInterval&     timeout,
+    bool                          isReopenRequest)
 {
     // executed by the FSM thread
 
@@ -1211,8 +1210,7 @@ void BrokerSession::QueueFsm::actionCloseQueue(
     BSLS_ASSERT_SAFE(d_session.d_fsmThreadChecker.inSameThread());
 
     // Prepare "empty" closeQueue request
-    RequestManagerType::RequestSp context =
-        d_session.d_requestManager.createRequest();
+    RequestSp context = d_session.d_requestManager.createRequest();
     context->request().choice().makeCloseQueue();
     context->setGroupId(k_NON_BUFFERED_REQUEST_GROUP_ID);
 
@@ -1223,10 +1221,10 @@ void BrokerSession::QueueFsm::actionCloseQueue(
     actionCloseQueue(context, queue, absTimeout);
 }
 
-bmqt::GenericResult::Enum BrokerSession::QueueFsm::actionCloseQueue(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval&            absTimeout)
+bmqt::GenericResult::Enum
+BrokerSession::QueueFsm::actionCloseQueue(const RequestSp& context,
+                                          const bsl::shared_ptr<Queue>& queue,
+                                          const bsls::TimeInterval& absTimeout)
 {
     // executed by the FSM thread
 
@@ -1241,9 +1239,9 @@ bmqt::GenericResult::Enum BrokerSession::QueueFsm::actionCloseQueue(
 }
 
 void BrokerSession::QueueFsm::actionInitQueue(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& openQueueContext,
-    bool                                 isReopenRequest)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              openQueueContext,
+    bool                          isReopenRequest)
 {
     // executed by the FSM thread
 
@@ -1274,10 +1272,10 @@ void BrokerSession::QueueFsm::actionInitQueue(
 }
 
 bmqt::ConfigureQueueResult::Enum BrokerSession::QueueFsm::actionConfigureQueue(
-    const bsl::shared_ptr<Queue>&  queue,
-    const bmqt::QueueOptions&      options,
-    const bsls::TimeInterval&      timeout,
-    RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const bmqt::QueueOptions&     options,
+    const bsls::TimeInterval&     timeout,
+    RequestSp&                    context)
 {
     // executed by the FSM thread
 
@@ -1380,11 +1378,11 @@ void BrokerSession::QueueFsm::actionInitiateQueueSuspend(
     suspendOptions.setMaxUnconfirmedMessages(0).setMaxUnconfirmedBytes(0);
 
     // Create request context.
-    RequestManagerType::RequestSp context =
-        d_session.createConfigureQueueContext(queue,
-                                              suspendOptions,
-                                              true,    // isDeconfigure
-                                              false);  // isBuffered
+    RequestSp context = d_session.createConfigureQueueContext(
+        queue,
+        suspendOptions,
+        true,    // isDeconfigure
+        false);  // isBuffered
 
     // Deconfigure queue to stop messages from being sent by the broker.
     d_session.sendSuspendRequest(
@@ -1402,11 +1400,11 @@ void BrokerSession::QueueFsm::actionInitiateQueueResume(
     BSLS_ASSERT_SAFE(d_session.d_fsmThreadChecker.inSameThread());
 
     // Create request context.
-    RequestManagerType::RequestSp context =
-        d_session.createConfigureQueueContext(queue,
-                                              queue->options(),
-                                              false,   // isDeconfigure
-                                              false);  // isBuffered
+    RequestSp context = d_session.createConfigureQueueContext(
+        queue,
+        queue->options(),
+        false,   // isDeconfigure
+        false);  // isBuffered
 
     // Reconfigure queue to resume receiving messages from the broker.
     d_session.sendResumeRequest(
@@ -1521,10 +1519,10 @@ BrokerSession::QueueFsm::QueueFsm(BrokerSession& session)
 }
 
 // MANIPULATORS
-bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::handleOpenRequest(
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval&            timeout,
-    const RequestManagerType::RequestSp& context)
+bmqt::OpenQueueResult::Enum
+BrokerSession::QueueFsm::handleOpenRequest(const bsl::shared_ptr<Queue>& queue,
+                                           const bsls::TimeInterval& timeout,
+                                           const RequestSp&          context)
 {
     // executed by the FSM thread
 
@@ -1582,9 +1580,9 @@ bmqt::OpenQueueResult::Enum BrokerSession::QueueFsm::handleOpenRequest(
 }
 
 void BrokerSession::QueueFsm::handleRequestNotSent(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    int                                  status)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context,
+    int                           status)
 {
     // executed by the FSM thread
 
@@ -1599,9 +1597,9 @@ void BrokerSession::QueueFsm::handleRequestNotSent(
 }
 
 void BrokerSession::QueueFsm::handleRequestWriteError(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    int                                  status)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context,
+    int                           status)
 {
     // executed by the FSM thread
 
@@ -1687,9 +1685,9 @@ void BrokerSession::QueueFsm::handleRequestWriteError(
 }
 
 void BrokerSession::QueueFsm::handleRequestBad(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    int                                  status)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context,
+    int                           status)
 {
     // executed by the FSM thread
 
@@ -1875,9 +1873,9 @@ void BrokerSession::QueueFsm::handleRequestBad(
 }
 
 void BrokerSession::QueueFsm::handleReopenRequest(
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval&            timeout,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const bsls::TimeInterval&     timeout,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -1925,10 +1923,10 @@ void BrokerSession::QueueFsm::handleReopenRequest(
 
 bmqt::ConfigureQueueResult::Enum
 BrokerSession::QueueFsm::handleConfigureRequest(
-    const bsl::shared_ptr<Queue>&  queue,
-    const bmqt::QueueOptions&      options,
-    const bsls::TimeInterval&      timeout,
-    RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const bmqt::QueueOptions&     options,
+    const bsls::TimeInterval&     timeout,
+    RequestSp&                    context)
 {
     // executed by the FSM thread
 
@@ -1991,9 +1989,9 @@ BrokerSession::QueueFsm::handleConfigureRequest(
 }
 
 bmqt::CloseQueueResult::Enum BrokerSession::QueueFsm::handleCloseRequest(
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval&            timeout,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const bsls::TimeInterval&     timeout,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -2094,9 +2092,9 @@ bmqt::CloseQueueResult::Enum BrokerSession::QueueFsm::handleCloseRequest(
 }
 
 void BrokerSession::QueueFsm::handleResponseError(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    const bsls::TimeInterval&            absTimeout)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context,
+    const bsls::TimeInterval&     absTimeout)
 {
     // executed by the FSM thread
 
@@ -2260,8 +2258,8 @@ void BrokerSession::QueueFsm::handleResponseError(
 }
 
 void BrokerSession::QueueFsm::handleSessionDown(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -2366,8 +2364,8 @@ void BrokerSession::QueueFsm::handleSessionDown(
 }
 
 void BrokerSession::QueueFsm::handleRequestCanceled(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -2470,8 +2468,8 @@ void BrokerSession::QueueFsm::handleRequestCanceled(
 }
 
 void BrokerSession::QueueFsm::handleResponseTimeout(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -2641,8 +2639,8 @@ void BrokerSession::QueueFsm::handleResponseTimeout(
 }
 
 void BrokerSession::QueueFsm::handleResponseExpired(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -2708,9 +2706,9 @@ void BrokerSession::QueueFsm::handleResponseExpired(
 }
 
 void BrokerSession::QueueFsm::handleResponseOk(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context,
-    const bsls::TimeInterval&            timeout)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context,
+    const bsls::TimeInterval&     timeout)
 {
     // executed by the FSM thread
 
@@ -2764,7 +2762,7 @@ void BrokerSession::QueueFsm::handleResponseOk(
         bslma::ManagedPtr<void> scopedSpan(
             d_session.activateDTSpan(configureSpan));
 
-        RequestManagerType::RequestSp configureQueueContext =
+        RequestSp configureQueueContext =
             d_session.createConfigureQueueContext(queue,
                                                   queue->options(),
                                                   false,  // isDeconfigure
@@ -2803,7 +2801,7 @@ void BrokerSession::QueueFsm::handleResponseOk(
             break;  // BREAK
         }
 
-        RequestManagerType::RequestSp configureQueueContext =
+        RequestSp configureQueueContext =
             d_session.createConfigureQueueContext(queue,
                                                   queue->options(),
                                                   false,   // isDeconfigure
@@ -2901,8 +2899,8 @@ void BrokerSession::QueueFsm::handleResponseOk(
 }
 
 void BrokerSession::QueueFsm::handleLateResponse(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& context)
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              context)
 {
     // executed by the FSM thread
 
@@ -3110,9 +3108,9 @@ void BrokerSession_Executor::post(const bsl::function<void()>& f) const
 // -------------------
 
 bmqt::GenericResult::Enum
-BrokerSession::sendRequest(const RequestManagerType::RequestSp& context,
-                           const bmqp::QueueId&                 queueId,
-                           bsls::TimeInterval                   timeout)
+BrokerSession::sendRequest(const RequestSp&     context,
+                           const bmqp::QueueId& queueId,
+                           bsls::TimeInterval   timeout)
 {
     // executed by the FSM thread
 
@@ -3276,11 +3274,11 @@ void BrokerSession::eventHandlerCbWrapper(
 }
 
 void BrokerSession::asyncRequestNotifier(
-    const RequestManagerType::RequestSp& context,
-    bmqt::SessionEventType::Enum         eventType,
-    const bmqt::CorrelationId&           correlationId,
-    const bsl::shared_ptr<Queue>&        queue,
-    const EventCallback&                 eventCallback)
+    const RequestSp&              context,
+    bmqt::SessionEventType::Enum  eventType,
+    const bmqt::CorrelationId&    correlationId,
+    const bsl::shared_ptr<Queue>& queue,
+    const EventCallback&          eventCallback)
 {
     // executed by *ANY* thread
 
@@ -3320,10 +3318,9 @@ void BrokerSession::asyncRequestNotifier(
     }
 }
 
-void BrokerSession::syncRequestNotifier(
-    bslmt::Semaphore*                    semaphore,
-    int*                                 status,
-    const RequestManagerType::RequestSp& context)
+void BrokerSession::syncRequestNotifier(bslmt::Semaphore* semaphore,
+                                        int*              status,
+                                        const RequestSp&  context)
 {
     // executed by *ANY* thread
     // PRECONDITIONS
@@ -3357,11 +3354,11 @@ void BrokerSession::syncRequestNotifier(
 }
 
 void BrokerSession::manualSyncRequestNotifier(
-    const RequestManagerType::RequestSp& context,
-    bmqt::SessionEventType::Enum         eventType,
-    const bmqt::CorrelationId&           correlationId,
-    const bsl::shared_ptr<Queue>&        queue,
-    const EventCallback&                 eventCallback)
+    const RequestSp&              context,
+    bmqt::SessionEventType::Enum  eventType,
+    const bmqt::CorrelationId&    correlationId,
+    const bsl::shared_ptr<Queue>& queue,
+    const EventCallback&          eventCallback)
 {
     // executed by *ANY* thread
 
@@ -3809,9 +3806,9 @@ void BrokerSession::processAckEvent(const bmqp::Event& event)
 }
 
 bmqt::OpenQueueResult::Enum
-BrokerSession::openQueueImp(const bsl::shared_ptr<Queue>&  queue,
-                            bsls::TimeInterval             timeout,
-                            RequestManagerType::RequestSp& context)
+BrokerSession::openQueueImp(const bsl::shared_ptr<Queue>& queue,
+                            bsls::TimeInterval            timeout,
+                            RequestSp&                    context)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -3850,10 +3847,10 @@ BrokerSession::openQueueImp(const bsl::shared_ptr<Queue>&  queue,
     return d_queueFsm.handleOpenRequest(queueLookup, timeout, context);
 }
 
-bmqt::OpenQueueResult::Enum BrokerSession::sendOpenQueueRequest(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue,
-    bsls::TimeInterval                   timeout)
+bmqt::OpenQueueResult::Enum
+BrokerSession::sendOpenQueueRequest(const RequestSp&              context,
+                                    const bsl::shared_ptr<Queue>& queue,
+                                    bsls::TimeInterval            timeout)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -3863,12 +3860,12 @@ bmqt::OpenQueueResult::Enum BrokerSession::sendOpenQueueRequest(
     const bsls::TimeInterval absTimeout = bmqu::Time::nowMonotonicClock() +
                                           timeout;
 
-    RequestManagerType::RequestType::ResponseCb response =
-        bdlf::BindUtil::bind(&BrokerSession::onOpenQueueResponse,
-                             this,
-                             bdlf::PlaceHolders::_1,  // context
-                             queue,
-                             absTimeout);
+    bmqp::RequestManagerRequest::ResponseCb response = bdlf::BindUtil::bind(
+        &BrokerSession::onOpenQueueResponse,
+        this,
+        bdlf::PlaceHolders::_1,  // context
+        queue,
+        absTimeout);
     context->setResponseCb(response);
 
     bmqt::GenericResult::Enum rc = sendRequest(
@@ -3880,8 +3877,8 @@ bmqt::OpenQueueResult::Enum BrokerSession::sendOpenQueueRequest(
 }
 
 bmqt::ConfigureQueueResult::Enum
-BrokerSession::configureQueueImp(const RequestManagerType::RequestSp& context,
-                                 const bsl::shared_ptr<Queue>&        queue,
+BrokerSession::configureQueueImp(const RequestSp&              context,
+                                 const bsl::shared_ptr<Queue>& queue,
                                  const bmqt::QueueOptions& newClientOptions,
                                  const bsls::TimeInterval  timeout,
                                  const ConfiguredCallback& configuredCb,
@@ -3931,13 +3928,13 @@ BrokerSession::configureQueueImp(const RequestManagerType::RequestSp& context,
     queue->setOptions(newClientOptions);
 
     // Set the response callback
-    RequestManagerType::RequestType::ResponseCb response =
-        bdlf::BindUtil::bind(&BrokerSession::onConfigureQueueResponse,
-                             this,
-                             bdlf::PlaceHolders::_1,  // context
-                             queue,
-                             previousOptions,
-                             configuredCb);
+    bmqp::RequestManagerRequest::ResponseCb response = bdlf::BindUtil::bind(
+        &BrokerSession::onConfigureQueueResponse,
+        this,
+        bdlf::PlaceHolders::_1,  // context
+        queue,
+        previousOptions,
+        configuredCb);
     context->setResponseCb(response);
 
     bmqt::GenericResult::Enum rc = sendRequest(
@@ -3963,10 +3960,10 @@ BrokerSession::configureQueueImp(const RequestManagerType::RequestSp& context,
 }
 
 bmqt::ConfigureQueueResult::Enum
-BrokerSession::sendConfigureRequest(const bsl::shared_ptr<Queue>&  queue,
-                                    const bmqt::QueueOptions&      options,
-                                    const bsls::TimeInterval       timeout,
-                                    RequestManagerType::RequestSp& context)
+BrokerSession::sendConfigureRequest(const bsl::shared_ptr<Queue>& queue,
+                                    const bmqt::QueueOptions&     options,
+                                    const bsls::TimeInterval      timeout,
+                                    RequestSp&                    context)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -4008,11 +4005,10 @@ BrokerSession::sendReconfigureRequest(const bsl::shared_ptr<Queue>& queue)
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_fsmThreadChecker.inSameThread());
 
-    RequestManagerType::RequestSp context = createConfigureQueueContext(
-        queue,
-        queue->options(),
-        false,   // isDeconfigure
-        false);  // isBuffered
+    RequestSp context = createConfigureQueueContext(queue,
+                                                    queue->options(),
+                                                    false,   // isDeconfigure
+                                                    false);  // isBuffered
     if (queue->isSuspended()) {
         context->signal();
         return bmqt::ConfigureQueueResult::e_SUCCESS;  // RETURN
@@ -4032,10 +4028,10 @@ BrokerSession::sendReconfigureRequest(const bsl::shared_ptr<Queue>& queue)
 }
 
 bmqt::ConfigureQueueResult::Enum
-BrokerSession::sendSuspendRequest(const bsl::shared_ptr<Queue>&  queueSp,
-                                  const bmqt::QueueOptions&      options,
-                                  const bsls::TimeInterval       timeout,
-                                  RequestManagerType::RequestSp& context)
+BrokerSession::sendSuspendRequest(const bsl::shared_ptr<Queue>& queueSp,
+                                  const bmqt::QueueOptions&     options,
+                                  const bsls::TimeInterval      timeout,
+                                  RequestSp&                    context)
 {
     // executed by the FSM thread
 
@@ -4091,10 +4087,10 @@ BrokerSession::sendSuspendRequest(const bsl::shared_ptr<Queue>&  queueSp,
 }
 
 bmqt::ConfigureQueueResult::Enum
-BrokerSession::sendResumeRequest(const bsl::shared_ptr<Queue>&  queueSp,
-                                 const bmqt::QueueOptions&      options,
-                                 const bsls::TimeInterval       timeout,
-                                 RequestManagerType::RequestSp& context)
+BrokerSession::sendResumeRequest(const bsl::shared_ptr<Queue>& queueSp,
+                                 const bmqt::QueueOptions&     options,
+                                 const bsls::TimeInterval      timeout,
+                                 RequestSp&                    context)
 {
     // executed by the FSM thread
 
@@ -4162,8 +4158,7 @@ BrokerSession::sendDeconfigureRequest(const bsl::shared_ptr<Queue>& queue)
         .setConsumerPriority(bmqp::Protocol::k_CONSUMER_PRIORITY_INVALID);
 
     // Set the configure callback
-    RequestManagerType::RequestSp closeQueueContext =
-        d_requestManager.createRequest();
+    RequestSp closeQueueContext = d_requestManager.createRequest();
     closeQueueContext->request().choice().makeCloseQueue();
     closeQueueContext->setGroupId(k_NON_BUFFERED_REQUEST_GROUP_ID);
 
@@ -4179,11 +4174,11 @@ BrokerSession::sendDeconfigureRequest(const bsl::shared_ptr<Queue>& queue)
         absTimeout,
         true);  // isFinal
 
-    RequestManagerType::RequestSp configureQueueContext =
-        createConfigureQueueContext(queue,
-                                    options,
-                                    true,    // isDeconfigure
-                                    false);  // isBuffered
+    RequestSp configureQueueContext = createConfigureQueueContext(
+        queue,
+        options,
+        true,    // isDeconfigure
+        false);  // isBuffered
 
     return configureQueueImp(configureQueueContext,
                              queue,
@@ -4192,10 +4187,10 @@ BrokerSession::sendDeconfigureRequest(const bsl::shared_ptr<Queue>& queue)
                              configuredCb);
 }
 
-bmqt::ConfigureQueueResult::Enum BrokerSession::sendDeconfigureRequest(
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& closeContext,
-    bsls::TimeInterval                   timeout)
+bmqt::ConfigureQueueResult::Enum
+BrokerSession::sendDeconfigureRequest(const bsl::shared_ptr<Queue>& queue,
+                                      const RequestSp&   closeContext,
+                                      bsls::TimeInterval timeout)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -4232,11 +4227,11 @@ bmqt::ConfigureQueueResult::Enum BrokerSession::sendDeconfigureRequest(
         createDTSpan("bmq.queue.closeConfigure", baggage));
     bslma::ManagedPtr<void> scopedSpan(activateDTSpan(configureSpan));
 
-    RequestManagerType::RequestSp configureQueueContext =
-        createConfigureQueueContext(queue,
-                                    options,
-                                    true,    // isDeconfigure
-                                    false);  // isBuffered
+    RequestSp configureQueueContext = createConfigureQueueContext(
+        queue,
+        options,
+        true,    // isDeconfigure
+        false);  // isBuffered
     configureQueueContext->setDTSpan(configureSpan);
 
     return configureQueueImp(configureQueueContext,
@@ -4371,9 +4366,9 @@ void BrokerSession::enqueueStateRestoredIfNeeded()
 }
 
 void BrokerSession::onSuspendQueueConfigured(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queueSp,
-    const bool                           deferred)
+    const RequestSp&              context,
+    const bsl::shared_ptr<Queue>& queueSp,
+    const bool                    deferred)
 {
     // executed by the FSM thread
 
@@ -4456,9 +4451,9 @@ void BrokerSession::onSuspendQueueConfigured(
 }
 
 void BrokerSession::onResumeQueueConfigured(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queueSp,
-    const bool                           deferred)
+    const RequestSp&              context,
+    const bsl::shared_ptr<Queue>& queueSp,
+    const bool                    deferred)
 {
     // executed by the FSM thread
 
@@ -5069,10 +5064,9 @@ void BrokerSession::doOpenQueue(
 
     // Create request and mark it as buffered so that it could be retransmitted
     // if it is not sent due to the session is not connected.
-    RequestManagerType::RequestSp context = createOpenQueueContext(
-        queue,
-        fsmCallback,
-        true);  // isBuffered
+    RequestSp context = createOpenQueueContext(queue,
+                                               fsmCallback,
+                                               true);  // isBuffered
     context->setDTSpan(span);
 
     bmqt::OpenQueueResult::Enum rc = openQueueImp(queue, timeout, context);
@@ -5113,10 +5107,9 @@ void BrokerSession::doConfigureQueue(
     bmqt::QueueOptions updatedOptions(queue->options());
     updatedOptions.merge(options);
 
-    RequestManagerType::RequestSp context =
-        createStandaloneConfigureQueueContext(queue,
-                                              updatedOptions,
-                                              fsmCallback);
+    RequestSp context = createStandaloneConfigureQueueContext(queue,
+                                                              updatedOptions,
+                                                              fsmCallback);
     context->setDTSpan(span);
 
     bmqt::ConfigureQueueResult::Enum rc = d_queueFsm.handleConfigureRequest(
@@ -5159,8 +5152,7 @@ void BrokerSession::doCloseQueue(
     BALL_LOG_INFO << id() << "Close queue [queue: " << *queue
                   << ", timeout: " << timeout << "]";
 
-    RequestManagerType::RequestSp closeContext = createCloseQueueContext(
-        fsmCallback);
+    RequestSp closeContext = createCloseQueueContext(fsmCallback);
     closeContext->setDTSpan(span);
 
     bmqt::CloseQueueResult::Enum res =
@@ -5267,14 +5259,14 @@ bmqt::GenericResult::Enum BrokerSession::disconnectBroker()
 
     BSLS_ASSERT_SAFE(d_fsmThreadChecker.inSameThread());
 
-    RequestManagerType::RequestSp context = d_requestManager.createRequest();
+    RequestSp context = d_requestManager.createRequest();
     context->request().choice().makeDisconnect();
     context->setGroupId(k_NON_BUFFERED_REQUEST_GROUP_ID);
 
-    RequestManagerType::RequestType::ResponseCb response =
-        bdlf::BindUtil::bind(&BrokerSession::onDisconnectResponse,
-                             this,
-                             bdlf::PlaceHolders::_1);  // context
+    bmqp::RequestManagerRequest::ResponseCb response = bdlf::BindUtil::bind(
+        &BrokerSession::onDisconnectResponse,
+        this,
+        bdlf::PlaceHolders::_1);  // context
     context->setResponseCb(response);
 
     bmqp::QueueId queueId(bmqimp::Queue::k_INVALID_QUEUE_ID);
@@ -5284,7 +5276,7 @@ bmqt::GenericResult::Enum BrokerSession::disconnectBroker()
     return rc;
 }
 
-BrokerSession::RequestManagerType::RequestSp
+BrokerSession::RequestSp
 BrokerSession::createOpenQueueContext(const bsl::shared_ptr<Queue>& queue,
                                       const FsmCallback& fsmCallback,
                                       bool               isBuffered)
@@ -5297,7 +5289,7 @@ BrokerSession::createOpenQueueContext(const bsl::shared_ptr<Queue>& queue,
     queue->setRequestGroupId(++d_nextRequestGroupId);
 
     // Prepare the request context
-    RequestManagerType::RequestSp context = d_requestManager.createRequest();
+    RequestSp context = d_requestManager.createRequest();
     if (isBuffered) {
         grId = queue->requestGroupId().value();
     }
@@ -5316,7 +5308,7 @@ BrokerSession::createOpenQueueContext(const bsl::shared_ptr<Queue>& queue,
     return context;
 }
 
-BrokerSession::RequestManagerType::RequestSp
+BrokerSession::RequestSp
 BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
                                            const bmqt::QueueOptions& options,
                                            bool isDeconfigure,
@@ -5330,7 +5322,7 @@ BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
     int grId = k_NON_BUFFERED_REQUEST_GROUP_ID;
 
     // Prepare the request context
-    RequestManagerType::RequestSp context = d_requestManager.createRequest();
+    RequestSp context = d_requestManager.createRequest();
     if (isBuffered) {
         grId = queue->requestGroupId().value();
     }
@@ -5459,8 +5451,7 @@ BrokerSession::createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
     return context;
 }
 
-BrokerSession::RequestManagerType::RequestSp
-BrokerSession::createStandaloneConfigureQueueContext(
+BrokerSession::RequestSp BrokerSession::createStandaloneConfigureQueueContext(
     const bsl::shared_ptr<Queue>& queue,
     const bmqt::QueueOptions&     options,
     const FsmCallback&            fsmCallback)
@@ -5470,11 +5461,10 @@ BrokerSession::createStandaloneConfigureQueueContext(
     BSLS_ASSERT_SAFE(d_fsmThreadChecker.inSameThread());
 
     // Prepare the request context
-    RequestManagerType::RequestSp context = createConfigureQueueContext(
-        queue,
-        options,
-        false,  // isDeconfigure
-        true);  // isBuffered
+    RequestSp context = createConfigureQueueContext(queue,
+                                                    options,
+                                                    false,  // isDeconfigure
+                                                    true);  // isBuffered
 
     // The result of this operation needs to be processed after all
     // pending/enqueued events in the event buffer.  The request may be
@@ -5484,11 +5474,10 @@ BrokerSession::createStandaloneConfigureQueueContext(
     return context;
 }
 
-BrokerSession::RequestManagerType::RequestSp
+BrokerSession::RequestSp
 BrokerSession::createCloseQueueContext(const FsmCallback& fsmCallback)
 {
-    RequestManagerType::RequestSp closeContext =
-        d_requestManager.createRequest();
+    RequestSp closeContext = d_requestManager.createRequest();
     closeContext->setGroupId(k_NON_BUFFERED_REQUEST_GROUP_ID);
     closeContext->request().choice().makeCloseQueue();
 
@@ -5611,10 +5600,10 @@ void BrokerSession::actionResumeHealthSensitiveQueues()
 }
 
 bmqt::GenericResult::Enum
-BrokerSession::requestWriterCb(const RequestManagerType::RequestSp& context,
-                               const bmqp::QueueId&                 queueId,
-                               const bsl::shared_ptr<bdlbb::Blob>&  blob_sp,
-                               bsls::Types::Int64                   watermark)
+BrokerSession::requestWriterCb(const RequestSp&                    context,
+                               const bmqp::QueueId&                queueId,
+                               const bsl::shared_ptr<bdlbb::Blob>& blob_sp,
+                               bsls::Types::Int64                  watermark)
 {
     // executed by the FSM thread
 
@@ -5976,8 +5965,7 @@ int BrokerSession::startAsync()
     return startStatus;
 }
 
-void BrokerSession::onDisconnectResponse(
-    const RequestManagerType::RequestSp& context)
+void BrokerSession::onDisconnectResponse(const RequestSp& context)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -6009,12 +5997,11 @@ void BrokerSession::onDisconnectResponse(
     d_sessionFsm.handleSessionClosed();
 }
 
-void BrokerSession::handleQueueFsmEvent(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue,
-    bool                                 isLocalTimeout,
-    bool                                 isLateResponse,
-    const bsls::TimeInterval             absTimeout)
+void BrokerSession::handleQueueFsmEvent(const RequestSp&              context,
+                                        const bsl::shared_ptr<Queue>& queue,
+                                        bool isLocalTimeout,
+                                        bool isLateResponse,
+                                        const bsls::TimeInterval absTimeout)
 {
     // executed by the FSM thread
 
@@ -6055,10 +6042,9 @@ void BrokerSession::handleQueueFsmEvent(
     }
 }
 
-void BrokerSession::onOpenQueueResponse(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval             absTimeout)
+void BrokerSession::onOpenQueueResponse(const RequestSp&              context,
+                                        const bsl::shared_ptr<Queue>& queue,
+                                        const bsls::TimeInterval absTimeout)
 {
     // executed by the FSM thread
 
@@ -6098,9 +6084,8 @@ void BrokerSession::onOpenQueueResponse(
                         absTimeout);
 }
 
-void BrokerSession::onCloseQueueResponse(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue)
+void BrokerSession::onCloseQueueResponse(const RequestSp&              context,
+                                         const bsl::shared_ptr<Queue>& queue)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -6126,12 +6111,12 @@ void BrokerSession::onCloseQueueResponse(
                         bsls::TimeInterval(0));
 }
 
-bmqt::ConfigureQueueResult::Enum BrokerSession::sendOpenConfigureQueue(
-    const RequestManagerType::RequestSp& openQueueContext,
-    const RequestManagerType::RequestSp& configQueueContext,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval             absTimeout,
-    bool                                 isReopenRequest)
+bmqt::ConfigureQueueResult::Enum
+BrokerSession::sendOpenConfigureQueue(const RequestSp& openQueueContext,
+                                      const RequestSp& configQueueContext,
+                                      const bsl::shared_ptr<Queue>& queue,
+                                      const bsls::TimeInterval      absTimeout,
+                                      bool isReopenRequest)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -6165,11 +6150,11 @@ bmqt::ConfigureQueueResult::Enum BrokerSession::sendOpenConfigureQueue(
     // reopening.
 }
 
-bmqt::GenericResult::Enum BrokerSession::sendCloseQueue(
-    const RequestManagerType::RequestSp& closeQueueContext,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bsls::TimeInterval             absTimeout,
-    bool                                 isFinal)
+bmqt::GenericResult::Enum
+BrokerSession::sendCloseQueue(const RequestSp&              closeQueueContext,
+                              const bsl::shared_ptr<Queue>& queue,
+                              const bsls::TimeInterval      absTimeout,
+                              bool                          isFinal)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -6183,11 +6168,11 @@ bmqt::GenericResult::Enum BrokerSession::sendCloseQueue(
     // Set the 'isFinal' flag only before closing the last subStream for
     // this canonical uri.
 
-    RequestManagerType::RequestType::ResponseCb response =
-        bdlf::BindUtil::bind(&BrokerSession::onCloseQueueResponse,
-                             this,
-                             bdlf::PlaceHolders::_1,  // context
-                             queue);
+    bmqp::RequestManagerRequest::ResponseCb response = bdlf::BindUtil::bind(
+        &BrokerSession::onCloseQueueResponse,
+        this,
+        bdlf::PlaceHolders::_1,  // context
+        queue);
     closeQueueContext->setResponseCb(response);
 
     const bsls::TimeInterval timeout = absTimeout -
@@ -6198,10 +6183,10 @@ bmqt::GenericResult::Enum BrokerSession::sendCloseQueue(
 }
 
 void BrokerSession::onOpenQueueConfigured(
-    const RequestManagerType::RequestSp& configureQueueContext,
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& openQueueContext,
-    bool                                 isReopenRequest)
+    const RequestSp&              configureQueueContext,
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              openQueueContext,
+    bool                          isReopenRequest)
 {
     // executed by the FSM thread
 
@@ -6269,10 +6254,10 @@ void BrokerSession::onOpenQueueConfigured(
 }
 
 void BrokerSession::onConfigureQueueResponse(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue,
-    const bmqt::QueueOptions&            previousOptions,
-    const ConfiguredCallback&            configuredCb)
+    const RequestSp&              context,
+    const bsl::shared_ptr<Queue>& queue,
+    const bmqt::QueueOptions&     previousOptions,
+    const ConfiguredCallback&     configuredCb)
 {
     // executed by the FSM thread
 
@@ -6400,8 +6385,8 @@ void BrokerSession::onConfigureQueueResponse(
 }
 
 void BrokerSession::onConfigureQueueConfigured(
-    const RequestManagerType::RequestSp& context,
-    const bsl::shared_ptr<Queue>&        queue)
+    const RequestSp&              context,
+    const bsl::shared_ptr<Queue>& queue)
 {
     // executed by the FSM thread
 
@@ -6445,11 +6430,11 @@ void BrokerSession::onConfigureQueueConfigured(
 }
 
 void BrokerSession::onCloseQueueConfigured(
-    const RequestManagerType::RequestSp& configureQueueContext,
-    const bsl::shared_ptr<Queue>&        queue,
-    const RequestManagerType::RequestSp& closeQueueContext,
-    const bsls::TimeInterval             absTimeout,
-    bool                                 isFinal)
+    const RequestSp&              configureQueueContext,
+    const bsl::shared_ptr<Queue>& queue,
+    const RequestSp&              closeQueueContext,
+    const bsls::TimeInterval      absTimeout,
+    bool                          isFinal)
 {
     // executed by the FSM thread
     // PRECONDITIONS
@@ -6465,7 +6450,7 @@ void BrokerSession::onCloseQueueConfigured(
     // empty if the queue has locally expired standalone configure request.
     queue->setPendingConfigureId(Queue::k_INVALID_CONFIGURE_ID);
 
-    RequestManagerType::RequestSp context = closeQueueContext;
+    RequestSp context = closeQueueContext;
 
     if (configureQueueContext->isLateResponse()) {
         context = configureQueueContext;
@@ -6581,10 +6566,9 @@ void BrokerSession::reopenQueues()
             pendingQueues[idx],
             EventCallback());
 
-        RequestManagerType::RequestSp context = createOpenQueueContext(
-            pendingQueues[idx],
-            fsmCallback,
-            false);  // isBuffered
+        RequestSp context = createOpenQueueContext(pendingQueues[idx],
+                                                   fsmCallback,
+                                                   false);  // isBuffered
         d_queueFsm.handleReopenRequest(pendingQueues[idx],
                                        d_sessionOptions.openQueueTimeout(),
                                        context);
@@ -7166,8 +7150,7 @@ void BrokerSession::setupPutExpirationTimer(const bsls::TimeInterval& timeout)
                              this));
 }
 
-void BrokerSession::removePendingControlMessage(
-    const RequestManagerType::RequestSp& context)
+void BrokerSession::removePendingControlMessage(const RequestSp& context)
 {
     // Remove the request from the retransmission buffer
     bmqt::MessageGUID guid;

--- a/src/groups/bmq/bmqimp/bmqimp_brokersession.h
+++ b/src/groups/bmq/bmqimp/bmqimp_brokersession.h
@@ -337,9 +337,7 @@ class BrokerSession BSLS_CPP11_FINAL {
 
   private:
     // TYPES
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
 
     /// This is top-most internal callback to be set as `AsyncNotifierCb` in
     /// all requests.  BS guarantees that 1) the callback will always be
@@ -347,12 +345,11 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// It can be one of two:
     ///  1) for async operations - `asyncRequestNotifier`
     ///  2) for sync operations  - `syncRequestNotifier`
-    typedef bsl::function<void(const RequestManagerType::RequestSp&)>
-        FsmCallback;
+    typedef bsl::function<void(const RequestSp&)> FsmCallback;
 
     /// Signature of the callback to provide to the `configure` method.
-    typedef bsl::function<void(const RequestManagerType::RequestSp& context,
-                               const bsl::shared_ptr<Queue>&        queue)>
+    typedef bsl::function<void(const RequestSp&              context,
+                               const bsl::shared_ptr<Queue>& queue)>
         ConfiguredCallback;
 
     typedef bdlcc::SharedObjectPool<Event,
@@ -497,8 +494,8 @@ class BrokerSession BSLS_CPP11_FINAL {
                            QueueFsmEvent::Enum           event);
 
         /// Generate and set a valid queueId to the specified `queue`.
-        void setQueueId(const bsl::shared_ptr<Queue>&        queue,
-                        const RequestManagerType::RequestSp& context);
+        void setQueueId(const bsl::shared_ptr<Queue>& queue,
+                        const RequestSp&              context);
 
         /// Start opening the specified `queue` with the specified
         /// `timeout` for the operation to complete.  Use the specified
@@ -506,18 +503,18 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// `success` on successful send of the open request, or a reason of
         /// the failure if it couldn't be sent for any reason.
         bmqt::OpenQueueResult::Enum
-        actionOpenQueue(const bsl::shared_ptr<Queue>&        queue,
-                        const RequestManagerType::RequestSp& context,
-                        const bsls::TimeInterval&            timeout);
+        actionOpenQueue(const bsl::shared_ptr<Queue>& queue,
+                        const RequestSp&              context,
+                        const bsls::TimeInterval&     timeout);
 
         /// Start reopening the specified `queue` with the specified
         /// `timeout` for the operation to complete.  Return `success` on
         /// successful send of the open request, or a reason of the failure
         /// if it couldn't be sent for any reason.
         bmqt::OpenQueueResult::Enum
-        actionReopenQueue(const bsl::shared_ptr<Queue>&        queue,
-                          const RequestManagerType::RequestSp& context,
-                          const bsls::TimeInterval&            timeout);
+        actionReopenQueue(const bsl::shared_ptr<Queue>& queue,
+                          const RequestSp&              context,
+                          const bsls::TimeInterval&     timeout);
 
         /// Start the first phase of the closing queue procedure for the
         /// specified `queue` sending a configure request with null
@@ -526,10 +523,10 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// operationon result.  Return `success` on/ successful send of the
         /// configure request, or a reason of the failure if it couldn't be
         /// sent for any reason.
-        bmqt::ConfigureQueueResult::Enum actionDeconfigureQueue(
-            const bsl::shared_ptr<Queue>&        queue,
-            const RequestManagerType::RequestSp& closeContext,
-            const bsls::TimeInterval&            timeout);
+        bmqt::ConfigureQueueResult::Enum
+        actionDeconfigureQueue(const bsl::shared_ptr<Queue>& queue,
+                               const RequestSp&              closeContext,
+                               const bsls::TimeInterval&     timeout);
 
         /// Start the first phase of the closing queue procedure for the
         /// specified expired `queue`.  Return `success` on successful send
@@ -549,12 +546,12 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// performed to reopen the `queue`.  Return `success` on successful
         /// send of the configure request, or a reason of the failure if it
         /// couldn't be sent for any reason.
-        bmqt::ConfigureQueueResult::Enum actionOpenConfigureQueue(
-            const RequestManagerType::RequestSp& openQueueContext,
-            const RequestManagerType::RequestSp& configQueueContext,
-            const bsl::shared_ptr<Queue>&        queue,
-            const bsls::TimeInterval&            timeout,
-            bool                                 isReopenRequest);
+        bmqt::ConfigureQueueResult::Enum
+        actionOpenConfigureQueue(const RequestSp& openQueueContext,
+                                 const RequestSp& configQueueContext,
+                                 const bsl::shared_ptr<Queue>& queue,
+                                 const bsls::TimeInterval&     timeout,
+                                 bool isReopenRequest);
 
         /// Send a close queue request to close the specified `queue`.
         void actionCloseQueue(const bsl::shared_ptr<Queue>& queue);
@@ -563,18 +560,17 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// the specified `context` to the request callback.  Use the
         /// specified `absTimeout` value as a request timeout.
         bmqt::GenericResult::Enum
-        actionCloseQueue(const RequestManagerType::RequestSp& context,
-                         const bsl::shared_ptr<Queue>&        queue,
-                         const bsls::TimeInterval&            absTimeout);
+        actionCloseQueue(const RequestSp&              context,
+                         const bsl::shared_ptr<Queue>& queue,
+                         const bsls::TimeInterval&     absTimeout);
 
         /// Called when the specified `queue` is successfully opened to set
         /// queue configuration parameters provided by the broker and stored
         /// in the specified `openQueueContext`.  If the specified
         /// `isReopenRequest` flag is false enable queue statistics.
-        void
-        actionInitQueue(const bsl::shared_ptr<Queue>&        queue,
-                        const RequestManagerType::RequestSp& openQueueContext,
-                        bool                                 isReopenRequest);
+        void actionInitQueue(const bsl::shared_ptr<Queue>& queue,
+                             const RequestSp&              openQueueContext,
+                             bool                          isReopenRequest);
 
         /// Make configure queue request for the specified `queue` with the
         /// specified `options` with the specified `timeout` for the
@@ -583,10 +579,10 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// send of the configure request, or a reason of the failure if it
         /// couldn't be sent for any reason.
         bmqt::ConfigureQueueResult::Enum
-        actionConfigureQueue(const bsl::shared_ptr<Queue>&  queue,
-                             const bmqt::QueueOptions&      options,
-                             const bsls::TimeInterval&      timeout,
-                             RequestManagerType::RequestSp& context);
+        actionConfigureQueue(const bsl::shared_ptr<Queue>& queue,
+                             const bmqt::QueueOptions&     options,
+                             const bsls::TimeInterval&     timeout,
+                             RequestSp&                    context);
 
         /// Send configure queue request for the specified `queue` taking in
         /// account the specified `response` from the previous configure
@@ -627,81 +623,77 @@ class BrokerSession BSLS_CPP11_FINAL {
         /// return value means that the queue FSM has not accepted the
         /// request.
         bmqt::OpenQueueResult::Enum
-        handleOpenRequest(const bsl::shared_ptr<Queue>&        queue,
-                          const bsls::TimeInterval&            timeout,
-                          const RequestManagerType::RequestSp& context);
+        handleOpenRequest(const bsl::shared_ptr<Queue>& queue,
+                          const bsls::TimeInterval&     timeout,
+                          const RequestSp&              context);
 
         /// Handle queue reopen request initiated by the session.
-        void handleReopenRequest(const bsl::shared_ptr<Queue>&        queue,
-                                 const bsls::TimeInterval&            timeout,
-                                 const RequestManagerType::RequestSp& context);
+        void handleReopenRequest(const bsl::shared_ptr<Queue>& queue,
+                                 const bsls::TimeInterval&     timeout,
+                                 const RequestSp&              context);
 
         /// Handle queue configure request initiated by the user.
         bmqt::ConfigureQueueResult::Enum
-        handleConfigureRequest(const bsl::shared_ptr<Queue>&  queue,
-                               const bmqt::QueueOptions&      options,
-                               const bsls::TimeInterval&      timeout,
-                               RequestManagerType::RequestSp& context);
+        handleConfigureRequest(const bsl::shared_ptr<Queue>& queue,
+                               const bmqt::QueueOptions&     options,
+                               const bsls::TimeInterval&     timeout,
+                               RequestSp&                    context);
 
         /// Handle queue close request initiated by the user.
         bmqt::CloseQueueResult::Enum
-        handleCloseRequest(const bsl::shared_ptr<Queue>&        queue,
-                           const bsls::TimeInterval&            timeout,
-                           const RequestManagerType::RequestSp& context);
+        handleCloseRequest(const bsl::shared_ptr<Queue>& queue,
+                           const bsls::TimeInterval&     timeout,
+                           const RequestSp&              context);
 
         /// Handle a case when a request to the broker has not been sent
         /// due to some error described with the specified `status`.
         /// Dispatches to `handleRequestWriteError` for transport errors
         /// or `handleRequestBad` for non-transport errors.
-        void handleRequestNotSent(const bsl::shared_ptr<Queue>&        queue,
-                                  const RequestManagerType::RequestSp& context,
-                                  int                                  status);
+        void handleRequestNotSent(const bsl::shared_ptr<Queue>& queue,
+                                  const RequestSp&              context,
+                                  int                           status);
 
         /// Handle a transport/write error when sending a request.  The
         /// queue stays in its current state, waiting for CHANNEL_DOWN.
-        void
-        handleRequestWriteError(const bsl::shared_ptr<Queue>&        queue,
-                                const RequestManagerType::RequestSp& context,
-                                int                                  status);
+        void handleRequestWriteError(const bsl::shared_ptr<Queue>& queue,
+                                     const RequestSp&              context,
+                                     int                           status);
 
         /// Handle a non-transport error when sending a request (e.g.,
         /// session stopped, invalid state).
-        void handleRequestBad(const bsl::shared_ptr<Queue>&        queue,
-                              const RequestManagerType::RequestSp& context,
-                              int                                  status);
+        void handleRequestBad(const bsl::shared_ptr<Queue>& queue,
+                              const RequestSp&              context,
+                              int                           status);
 
         /// Handle response error.
-        void handleResponseError(const bsl::shared_ptr<Queue>&        queue,
-                                 const RequestManagerType::RequestSp& context,
-                                 const bsls::TimeInterval& absTimeout);
+        void handleResponseError(const bsl::shared_ptr<Queue>& queue,
+                                 const RequestSp&              context,
+                                 const bsls::TimeInterval&     absTimeout);
 
-        void handleSessionDown(const bsl::shared_ptr<Queue>&        queue,
-                               const RequestManagerType::RequestSp& context);
+        void handleSessionDown(const bsl::shared_ptr<Queue>& queue,
+                               const RequestSp&              context);
 
         /// Handle the request is canceled locally.
-        void
-        handleRequestCanceled(const bsl::shared_ptr<Queue>&        queue,
-                              const RequestManagerType::RequestSp& context);
+        void handleRequestCanceled(const bsl::shared_ptr<Queue>& queue,
+                                   const RequestSp&              context);
 
         /// Handle broker response timeout.
-        void
-        handleResponseTimeout(const bsl::shared_ptr<Queue>&        queue,
-                              const RequestManagerType::RequestSp& context);
+        void handleResponseTimeout(const bsl::shared_ptr<Queue>& queue,
+                                   const RequestSp&              context);
 
         /// Handle broker response timeout while there is no connection.
-        void
-        handleResponseExpired(const bsl::shared_ptr<Queue>&        queue,
-                              const RequestManagerType::RequestSp& context);
+        void handleResponseExpired(const bsl::shared_ptr<Queue>& queue,
+                                   const RequestSp&              context);
 
         /// Handle successful response from the broker.
-        void handleResponseOk(const bsl::shared_ptr<Queue>&        queue,
-                              const RequestManagerType::RequestSp& context,
-                              const bsls::TimeInterval&            timeout);
+        void handleResponseOk(const bsl::shared_ptr<Queue>& queue,
+                              const RequestSp&              context,
+                              const bsls::TimeInterval&     timeout);
 
         /// Process a response received from the broker for a request that
         /// was already timed out internally in the client.
-        void handleLateResponse(const bsl::shared_ptr<Queue>&        queue,
-                                const RequestManagerType::RequestSp& context);
+        void handleLateResponse(const bsl::shared_ptr<Queue>& queue,
+                                const RequestSp&              context);
 
         /// Handle network channel down event.
         void handleChannelDown(const bsl::shared_ptr<Queue>& queue);
@@ -714,8 +706,8 @@ class BrokerSession BSLS_CPP11_FINAL {
 
         /// Create a status response for the specified `context` using the
         /// specified `status` code and error `reason` description.
-        void injectErrorResponse(const RequestManagerType::RequestSp& context,
-                                 int                                  status,
+        void injectErrorResponse(const RequestSp&         context,
+                                 int                      status,
                                  const bslstl::StringRef& reason = "");
     };
 
@@ -818,7 +810,7 @@ class BrokerSession BSLS_CPP11_FINAL {
     // Queue of events to deliver to the
     // application
 
-    RequestManagerType d_requestManager;
+    bmqp::RequestManager d_requestManager;
     // Request manager
 
     QueueManager d_queueManager;
@@ -926,10 +918,9 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// Return `success` on successful send of the request, or a reason of
     /// the failure if it couldn't be sent for any reason (not connected,
     /// unable to serialize the request, ...).
-    bmqt::GenericResult::Enum
-    sendRequest(const RequestManagerType::RequestSp& context,
-                const bmqp::QueueId&                 queueId,
-                bsls::TimeInterval                   timeout);
+    bmqt::GenericResult::Enum sendRequest(const RequestSp&     context,
+                                          const bmqp::QueueId& queueId,
+                                          bsls::TimeInterval   timeout);
 
     /// Send the specified `blob`, representing a `Confirm` packet over the
     /// channel and containing the specified `msgCount` message confirmation
@@ -957,8 +948,8 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// `context`.  Create and enqueue user event with the specified
     /// `eventType`, `queue`, `correlationId`, and `eventCallback`.
     /// Called from either FSM or the caller thread.
-    void asyncRequestNotifier(const RequestManagerType::RequestSp& context,
-                              bmqt::SessionEventType::Enum         eventType,
+    void asyncRequestNotifier(const RequestSp&              context,
+                              bmqt::SessionEventType::Enum  eventType,
                               const bmqt::CorrelationId&    correlationId,
                               const bsl::shared_ptr<Queue>& queue,
                               const EventCallback&          eventCallback);
@@ -966,21 +957,20 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// Callback used as a wrapper for deprecated sync operations.  Set the
     /// specified result `status`, and finally post on the specified
     /// `semaphore`.  Called from either FSM or the caller thread.
-    void syncRequestNotifier(bslmt::Semaphore*                    semaphore,
-                             int*                                 status,
-                             const RequestManagerType::RequestSp& context);
+    void syncRequestNotifier(bslmt::Semaphore* semaphore,
+                             int*              status,
+                             const RequestSp&  context);
 
     /// Callback used as a wrapper for sync operations (from the `xxxSync`
     /// APIs flavors) in the mode where event handler is not used (i.e.
     /// users explicitly controlling calls to `nextEvent`).
     /// Execute the specified `eventCallback` for the specified 'eventType,
     /// `queue`, and `correlationId` in either FSM or the caller thread.
-    void
-    manualSyncRequestNotifier(const RequestManagerType::RequestSp& context,
-                              bmqt::SessionEventType::Enum         eventType,
-                              const bmqt::CorrelationId&    correlationId,
-                              const bsl::shared_ptr<Queue>& queue,
-                              const EventCallback&          eventCallback);
+    void manualSyncRequestNotifier(const RequestSp&              context,
+                                   bmqt::SessionEventType::Enum  eventType,
+                                   const bmqt::CorrelationId&    correlationId,
+                                   const bsl::shared_ptr<Queue>& queue,
+                                   const EventCallback& eventCallback);
 
     /// Process the raw BlazingMQ event represented by the specified
     /// `event`.  This method gets called each time a new event (received
@@ -1016,30 +1006,30 @@ class BrokerSession BSLS_CPP11_FINAL {
 
     /// Callback invoked in reply to a `disconnect` with the specified
     /// `context`.
-    void onDisconnectResponse(const RequestManagerType::RequestSp& context);
+    void onDisconnectResponse(const RequestSp& context);
 
     /// Invoke queue FSM event handler depending on the specified `contex`
     /// state and the specified `isLocalTimeout` and `isLateResponse` flags.
     /// Submit the specified `queue` and `absTimeout` to the FSM handler.
-    void handleQueueFsmEvent(const RequestManagerType::RequestSp& context,
-                             const bsl::shared_ptr<Queue>&        queue,
-                             bool                     isLocalTimeout,
-                             bool                     isLateResponse,
-                             const bsls::TimeInterval absTimeout);
+    void handleQueueFsmEvent(const RequestSp&              context,
+                             const bsl::shared_ptr<Queue>& queue,
+                             bool                          isLocalTimeout,
+                             bool                          isLateResponse,
+                             const bsls::TimeInterval      absTimeout);
 
     /// Callback invoked in reply to an `openQueue` (first part in the
     /// process of opening a queue) for the specified `queue`, with the
     /// specified request `context`.  Wait until the specified `absTimeout`
     /// for the request to complete.
-    void onOpenQueueResponse(const RequestManagerType::RequestSp& context,
-                             const bsl::shared_ptr<Queue>&        queue,
-                             const bsls::TimeInterval             absTimeout);
+    void onOpenQueueResponse(const RequestSp&              context,
+                             const bsl::shared_ptr<Queue>& queue,
+                             const bsls::TimeInterval      absTimeout);
 
     /// Callback invoked in reply to a `closeQueue` (second part in the
     /// process of closing a queue) for the specified `queue`, with the
     /// specified request `context`.
-    void onCloseQueueResponse(const RequestManagerType::RequestSp& context,
-                              const bsl::shared_ptr<Queue>&        queue);
+    void onCloseQueueResponse(const RequestSp&              context,
+                              const bsl::shared_ptr<Queue>& queue);
 
     /// Send configure queue request of the open queue sequence with the
     /// specified `timeout` to complete for the specified `queue` and bind
@@ -1048,12 +1038,12 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// is performed to reopen the `queue`.  Return `success` on successful
     /// send of the configure request, or a reason of the failure if it
     /// couldn't be sent for any reason.
-    bmqt::ConfigureQueueResult::Enum sendOpenConfigureQueue(
-        const RequestManagerType::RequestSp& openQueueContext,
-        const RequestManagerType::RequestSp& configQueueContext,
-        const bsl::shared_ptr<Queue>&        queue,
-        const bsls::TimeInterval             absTimeout,
-        bool                                 isReopenRequest);
+    bmqt::ConfigureQueueResult::Enum
+    sendOpenConfigureQueue(const RequestSp&              openQueueContext,
+                           const RequestSp&              configQueueContext,
+                           const bsl::shared_ptr<Queue>& queue,
+                           const bsls::TimeInterval      absTimeout,
+                           bool                          isReopenRequest);
 
     /// Send a close queue request to close the specified `queue`.
     void sendCloseQueue(const bsl::shared_ptr<Queue>& queue);
@@ -1063,10 +1053,10 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// Use the specified `absTimeout` value as a request timeout, and the
     /// specified `isFinal` flag for the corresponding close request field.
     bmqt::GenericResult::Enum
-    sendCloseQueue(const RequestManagerType::RequestSp& closeQueueRequest,
-                   const bsl::shared_ptr<Queue>&        queue,
-                   const bsls::TimeInterval             absTimeout,
-                   bool                                 isFinal);
+    sendCloseQueue(const RequestSp&              closeQueueRequest,
+                   const bsl::shared_ptr<Queue>& queue,
+                   const bsls::TimeInterval      absTimeout,
+                   bool                          isFinal);
 
     /// Callback invoked after reply to a `configureQueue` that was sent as
     /// the second part in the process of opening the specified `queue`,
@@ -1074,34 +1064,32 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// `configureQueueContext`, and where the `isReopenRequest` flag
     /// indicates if the request was a reopen after connection was
     /// re-established.
-    void onOpenQueueConfigured(
-        const RequestManagerType::RequestSp& configureQueueContext,
-        const bsl::shared_ptr<Queue>&        queue,
-        const RequestManagerType::RequestSp& openQueueContext,
-        bool                                 isReopenRequest);
+    void onOpenQueueConfigured(const RequestSp& configureQueueContext,
+                               const bsl::shared_ptr<Queue>& queue,
+                               const RequestSp&              openQueueContext,
+                               bool                          isReopenRequest);
 
     /// Callback invoked in reply to a `configureQueue` that was configured
     /// with the options `previousOptions` for the specified `queue`, having
     /// the specified `previousOptions`, with the specified request
     /// `context`, and where the specified `configuredCb` is invoked when
     /// finished.
-    void onConfigureQueueResponse(const RequestManagerType::RequestSp& context,
-                                  const bsl::shared_ptr<Queue>&        queue,
+    void onConfigureQueueResponse(const RequestSp&              context,
+                                  const bsl::shared_ptr<Queue>& queue,
                                   const bmqt::QueueOptions& previousOptions,
                                   const ConfiguredCallback& configuredCb);
 
     /// Callback invoked after a standalone configureQueue for the specified
     /// `queue` with the specified request `context`.
-    void
-    onConfigureQueueConfigured(const RequestManagerType::RequestSp& context,
-                               const bsl::shared_ptr<Queue>&        queue);
+    void onConfigureQueueConfigured(const RequestSp&              context,
+                                    const bsl::shared_ptr<Queue>& queue);
 
     /// Callback invoked on completion of a request to suspend a queue.
     /// Enqueues a pair of session-events that will notify client of
     /// suspension and begin rejecting subsequent writes to the queue.
-    void onSuspendQueueConfigured(const RequestManagerType::RequestSp& context,
-                                  const bsl::shared_ptr<Queue>&        queueSp,
-                                  const bool deferred);
+    void onSuspendQueueConfigured(const RequestSp&              context,
+                                  const bsl::shared_ptr<Queue>& queueSp,
+                                  const bool                    deferred);
 
     /// Callback invoked on completion of a request to resume a queue.
     /// Enqueues a pair of session-events that will notify client of
@@ -1109,9 +1097,9 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// there are no other outstanding host-health requests, also enqueues
     /// an `ALL_QUEUES_RESUMED` event to notify the client that ordinary
     /// operation of the application has resumed.
-    void onResumeQueueConfigured(const RequestManagerType::RequestSp& context,
-                                 const bsl::shared_ptr<Queue>&        queueSp,
-                                 const bool deferred);
+    void onResumeQueueConfigured(const RequestSp&              context,
+                                 const bsl::shared_ptr<Queue>& queueSp,
+                                 const bool                    deferred);
 
     /// Callback invoked after reply to a `configureQueue` that was sent as
     /// the first part in the process of closing the specified `queue`, with
@@ -1119,12 +1107,11 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// `closeQueueRequest` is to be prepared and sent along with specified
     /// `isFinal` flag.  Wait until the specified `absTimeout` for the
     /// request to complete.
-    void onCloseQueueConfigured(
-        const RequestManagerType::RequestSp& configureQueueContext,
-        const bsl::shared_ptr<Queue>&        queue,
-        const RequestManagerType::RequestSp& closeQueueRequest,
-        const bsls::TimeInterval             absTimeout,
-        bool                                 isFinal);
+    void onCloseQueueConfigured(const RequestSp& configureQueueContext,
+                                const bsl::shared_ptr<Queue>& queue,
+                                const RequestSp&         closeQueueRequest,
+                                const bsls::TimeInterval absTimeout,
+                                bool                     isFinal);
 
     /// Invoked when a valid channel that was once connected is being set.
     /// Reopen all queues which were opened before connection dropped
@@ -1145,18 +1132,18 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// request, or a reason of the failure if it couldn't be sent for any
     /// reason.
     bmqt::OpenQueueResult::Enum
-    openQueueImp(const bsl::shared_ptr<Queue>&  queue,
-                 bsls::TimeInterval             timeout,
-                 RequestManagerType::RequestSp& context);
+    openQueueImp(const bsl::shared_ptr<Queue>& queue,
+                 bsls::TimeInterval            timeout,
+                 RequestSp&                    context);
 
     /// Helper method to open the specified `queue` using the specified
     /// `context`.  Wait for the specified `timeout` for the request to
     /// complete. Return `success` on successful send of the request, or a
     /// reason of the failure if it couldn't be sent for any reason.
     bmqt::OpenQueueResult::Enum
-    sendOpenQueueRequest(const RequestManagerType::RequestSp& context,
-                         const bsl::shared_ptr<Queue>&        queue,
-                         bsls::TimeInterval                   timeout);
+    sendOpenQueueRequest(const RequestSp&              context,
+                         const bsl::shared_ptr<Queue>& queue,
+                         bsls::TimeInterval            timeout);
 
     /// Configure the specified `queue` using the specified `options`, with
     /// the specified `context`.  If the specified `checkConcurrent` is
@@ -1170,12 +1157,12 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// failure if it couldn't be sent for any reason (not connected, unable
     /// to serialize the request, ...).
     bmqt::ConfigureQueueResult::Enum
-    configureQueueImp(const RequestManagerType::RequestSp& context,
-                      const bsl::shared_ptr<Queue>&        queue,
-                      const bmqt::QueueOptions&            newClientOptions,
-                      const bsls::TimeInterval             timeout,
-                      const ConfiguredCallback&            configuredCb,
-                      const bool checkConcurrent = true);
+    configureQueueImp(const RequestSp&              context,
+                      const bsl::shared_ptr<Queue>& queue,
+                      const bmqt::QueueOptions&     newClientOptions,
+                      const bsls::TimeInterval      timeout,
+                      const ConfiguredCallback&     configuredCb,
+                      const bool                    checkConcurrent = true);
 
     /// Send configure queue request for the specified `queue` with the
     /// specified `options` with the specified `timeout` for the operation
@@ -1184,10 +1171,10 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// the configure request, or a reason of the failure if it couldn't be
     /// sent for any reason.
     bmqt::ConfigureQueueResult::Enum
-    sendConfigureRequest(const bsl::shared_ptr<Queue>&  queue,
-                         const bmqt::QueueOptions&      options,
-                         const bsls::TimeInterval       timeout,
-                         RequestManagerType::RequestSp& context);
+    sendConfigureRequest(const bsl::shared_ptr<Queue>& queue,
+                         const bmqt::QueueOptions&     options,
+                         const bsls::TimeInterval      timeout,
+                         RequestSp&                    context);
 
     /// Send configure queue request for the specified `queue`.  The result
     /// of this request is not provided to the user.
@@ -1200,9 +1187,9 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// Return `success` on successful send of the configure request, or a
     /// reason of the failure if it couldn't be sent for any reason.
     bmqt::ConfigureQueueResult::Enum
-    sendDeconfigureRequest(const bsl::shared_ptr<Queue>&        queue,
-                           const RequestManagerType::RequestSp& closeContext,
-                           bsls::TimeInterval                   timeout);
+    sendDeconfigureRequest(const bsl::shared_ptr<Queue>& queue,
+                           const RequestSp&              closeContext,
+                           bsls::TimeInterval            timeout);
 
     /// For the specified `queue` send a configure request with null
     /// settings.  Return `success` on successful send of the configure
@@ -1213,17 +1200,17 @@ class BrokerSession BSLS_CPP11_FINAL {
 
     /// For the specified `queue` send a suspend request.
     bmqt::ConfigureQueueResult::Enum
-    sendSuspendRequest(const bsl::shared_ptr<Queue>&  queueSp,
-                       const bmqt::QueueOptions&      options,
-                       const bsls::TimeInterval       timeout,
-                       RequestManagerType::RequestSp& context);
+    sendSuspendRequest(const bsl::shared_ptr<Queue>& queueSp,
+                       const bmqt::QueueOptions&     options,
+                       const bsls::TimeInterval      timeout,
+                       RequestSp&                    context);
 
     /// For the specified `queue` send a resume request.
     bmqt::ConfigureQueueResult::Enum
-    sendResumeRequest(const bsl::shared_ptr<Queue>&  queueSp,
-                      const bmqt::QueueOptions&      options,
-                      const bsls::TimeInterval       timeout,
-                      RequestManagerType::RequestSp& context);
+    sendResumeRequest(const bsl::shared_ptr<Queue>& queueSp,
+                      const bmqt::QueueOptions&     options,
+                      const bsls::TimeInterval      timeout,
+                      RequestSp&                    context);
 
     /// Enqueue a `STATE_RESTORED` event if responses for all the
     /// reopen-queue requests have been received from the broker, after the
@@ -1395,33 +1382,30 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// `AsyncNotifierCb`.  The specified `isReopen` flag is used to set
     /// user event type (QUEUE_OPEN_RESULT or QUEUE_REOPEN_RESULT). The
     /// specified `isBuffered` flag is used to set request group id.
-    RequestManagerType::RequestSp
-    createOpenQueueContext(const bsl::shared_ptr<Queue>& queue,
-                           const FsmCallback&            fsmCallback,
-                           bool                          isBuffered);
+    RequestSp createOpenQueueContext(const bsl::shared_ptr<Queue>& queue,
+                                     const FsmCallback&            fsmCallback,
+                                     bool                          isBuffered);
 
     /// Return a configure queue request context for the specified `queue`
     /// and with the specified `options`.  The specified `isDeconfigure`
     /// flag is used to set specific consumer priority settings.  The
     /// specified `isBuffered` flag is used to set request group id.
-    RequestManagerType::RequestSp
-    createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
-                                const bmqt::QueueOptions&     options,
-                                bool                          isDeconfigure,
-                                bool                          isBuffered);
+    RequestSp createConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
+                                          const bmqt::QueueOptions& options,
+                                          bool isDeconfigure,
+                                          bool isBuffered);
 
     /// Return a configure queue request context for the specified `queue`
     /// and with the specified `options` and `fsmCallback` to be called as
     /// the request's `AsyncNotifierCb`.
-    RequestManagerType::RequestSp
+    RequestSp
     createStandaloneConfigureQueueContext(const bsl::shared_ptr<Queue>& queue,
                                           const bmqt::QueueOptions& options,
                                           const FsmCallback& fsmCallback);
 
     /// Return a close queue request context with the specified
     /// `fsmCallback` to be called as the request's `AsyncNotifierCb`.
-    RequestManagerType::RequestSp
-    createCloseQueueContext(const FsmCallback& fsmCallback);
+    RequestSp createCloseQueueContext(const FsmCallback& fsmCallback);
 
     /// Returns whether or not the machine the application is running on is
     /// considered healthy.
@@ -1464,10 +1448,10 @@ class BrokerSession BSLS_CPP11_FINAL {
     /// success.  In all other cases return the result of the write
     /// operation.
     bmqt::GenericResult::Enum
-    requestWriterCb(const RequestManagerType::RequestSp& context,
-                    const bmqp::QueueId&                 queueId,
-                    const bsl::shared_ptr<bdlbb::Blob>&  blob_sp,
-                    bsls::Types::Int64                   highWatermark);
+    requestWriterCb(const RequestSp&                    context,
+                    const bmqp::QueueId&                queueId,
+                    const bsl::shared_ptr<bdlbb::Blob>& blob_sp,
+                    bsls::Types::Int64                  highWatermark);
 
     /// Write the specified `blob` into the channel providing the specified
     /// channel `highWaterMark` value.  If the write operation fails with
@@ -1481,8 +1465,7 @@ class BrokerSession BSLS_CPP11_FINAL {
 
     void setupPutExpirationTimer(const bsls::TimeInterval& timeout);
 
-    void
-    removePendingControlMessage(const RequestManagerType::RequestSp& context);
+    void removePendingControlMessage(const RequestSp& context);
 
     /// If Distributed Trace is configured by the session options, this will
     /// return an object which sets `span` to the active span (as defined by

--- a/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.cpp
@@ -21,6 +21,7 @@
 #include <bmqp_protocol.h>
 #include <bmqp_protocolutil.h>
 #include <bmqp_queueid.h>
+#include <bmqp_requestmanager.h>
 
 // BDE
 #include <bsl_utility.h>
@@ -132,10 +133,10 @@ void MessageCorrelationIdContainer::add(
     d_correlationIds.insert(bsl::make_pair(key, toInsert));
 }
 
-bmqt::MessageGUID MessageCorrelationIdContainer::add(
-    const RequestManagerType::RequestSp& context,
-    const bmqp::QueueId&                 queueId,
-    const bdlbb::Blob&                   blob)
+bmqt::MessageGUID
+MessageCorrelationIdContainer::add(const RequestSp&     context,
+                                   const bmqp::QueueId& queueId,
+                                   const bdlbb::Blob&   blob)
 {
     bsls::SpinLockGuard guard(&d_lock);  // LOCK
 

--- a/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.h
+++ b/src/groups/bmq/bmqimp/bmqimp_messagecorrelationidcontainer.h
@@ -35,14 +35,16 @@
 // BMQ
 #include <bmqp_protocol.h>
 #include <bmqp_queueid.h>
-#include <bmqp_requestmanager.h>
 #include <bmqt_correlationid.h>
 #include <bmqt_messageguid.h>
 
 #include <bmqc_orderedhashmap.h>
 
 // BDE
+#include <bdlbb_blob.h>
 #include <bsl_functional.h>
+#include <bsl_memory.h>
+#include <bsl_unordered_map.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
@@ -51,6 +53,11 @@
 #include <bsls_spinlock.h>
 
 namespace BloombergLP {
+
+namespace bmqp {
+class RequestManagerRequest;
+}
+
 namespace bmqimp {
 
 // ===================================
@@ -62,9 +69,7 @@ class MessageCorrelationIdContainer {
   public:
     // PUBLIC TYPES
 
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bsl::shared_ptr<bmqp::RequestManagerRequest> RequestSp;
 
     /// Struct representing the correlationId and queueId for a given
     /// message.
@@ -84,7 +89,7 @@ class MessageCorrelationIdContainer {
         bdlbb::Blob d_messageData;
         // Message data.
 
-        RequestManagerType::RequestSp d_requestContext;
+        RequestSp d_requestContext;
         // Control request context.
 
         /// Create a `QueueAndCorrelationId` having an invalid queueId and
@@ -204,9 +209,9 @@ class MessageCorrelationIdContainer {
 
     /// Add the specified `context` and the `blob` and return a GUID key
     /// that can be used to retrieve it later.
-    bmqt::MessageGUID add(const RequestManagerType::RequestSp& context,
-                          const bmqp::QueueId&                 queueId,
-                          const bdlbb::Blob&                   blob);
+    bmqt::MessageGUID add(const RequestSp&     context,
+                          const bmqp::QueueId& queueId,
+                          const bdlbb::Blob&   blob);
 
     /// Remove the item uniquely identified by the specified `key`,
     /// and populate the optionally specified `correlationId` with the

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
@@ -19,7 +19,7 @@
 namespace BloombergLP {
 namespace bmqp {
 
-// NOTHING: Template
+// NOTHING
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -116,26 +116,24 @@
 //
 // First, let's create a 'RequestManager' object:
 //..
-//  bslma::Allocator              allocator = bslma::Default::allocator();
-//  bdlbb::PooledBlobBufferFactory blobBufferFactory(4069, allocator);
-//  bdlmt::EventScheduler         scheduler(bsls::SystemClockType::e_MONOTONIC,
-//                                          allocator);
+//  bslma::Allocator               allocator = bslma::Default::allocator();
+//  bdlbb::PooledBlobBufferFactory blobBufferFactory(4096, &allocator);
+//  bdlmt::EventScheduler          scheduler(
+//                                     bsls::SystemClockType::e_MONOTONIC,
+//                                     allocator);
 //
-//  typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-//                               bmqp_ctrlmsg::ControlMessage>
-//                                                          RequestManagerType;
-// RequestManagerType requestManager(bmqp::EventType::e_CONTROL,
-//                                   &blobBufferFactory,
-//                                   &scheduler,
-//                                   false,  // late response mode
-//                                   &allocator);
+//  bmqp::RequestManager requestManager(bmqp::EventType::e_CONTROL,
+//                                      &blobBufferFactory,
+//                                      &scheduler,
+//                                      false,  // late response mode
+//                                      &allocator);
 //..
 //
 // Then we can use it to create and send a request.  (here we assume that we
 // have an already established and valid 'bmqio::Channel' object to use)
 //..
 //  // We first ask a Request object to the RequestManager
-//  RequestManagerType::RequestSp request = requestManager.createRequest();
+//  bmqp::RequestManager::RequestSp request = requestManager.createRequest();
 //
 //  // Populate the request
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
@@ -188,7 +186,8 @@
 // invoked, let's look at a typical implementation of such a method:
 //..
 //  void
-//  MyClass::onOpenQueueResponse(const RequestManagerType::RequestSp& context)
+//  MyClass::onOpenQueueResponse(const bmqp::RequestManager::RequestSp&
+//  context)
 //  {
 //    if (context->result() != bmqt::GenericResult::e_SUCCESS) {
 //        // Request failed/timedout/got canceled
@@ -209,7 +208,7 @@
 // handle a request with a response callback.
 //
 //..
-//  RequestManagerType::RequestSp request = requestManager.createRequest();
+//  bmqp::RequestManager::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
 //  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
@@ -253,7 +252,7 @@
 // following example:
 //
 //..
-//  RequestManagerType::RequestSp request = requestManager.createRequest();
+//  bmqp::RequestManager::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
 //  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
@@ -294,7 +293,7 @@
 // asynchronously processing its response:
 //
 //..
-//  RequestManagerType::RequestSp request = requestManager.createRequest();
+//  bmqp::RequestManager::RequestSp request = requestManager.createRequest();
 //  bmqp_ctrlmsg::OpenQueue& req = request->request().choice().makeOpenQueue();
 //  req.uri() = "bmq://bmq.test.mem.priority/myQueue"
 //  [...]
@@ -378,7 +377,6 @@ namespace BloombergLP {
 namespace bmqp {
 
 // FORWARD DECLARATION
-template <class REQUEST, class RESPONSE>
 class RequestManager;
 
 // ================================
@@ -423,7 +421,6 @@ struct RequestManagerComponentId {
 /// Object representing a request sent, pending response for it; holding the
 /// request and all associated context state.  This allows for both
 /// synchronous and asynchronous response management.
-template <class REQUEST, class RESPONSE>
 class RequestManagerRequest {
   public:
     // PUBLIC CLASS DATA
@@ -431,31 +428,27 @@ class RequestManagerRequest {
 
     // TYPES
 
-    /// SelfType is an alias to this `class`.
-    typedef RequestManagerRequest<REQUEST, RESPONSE> SelfType;
-
-    typedef bsl::shared_ptr<SelfType> SelfTypeSp;
-
-    /// Shared and weak pointer to self type alias
-    typedef bsl::weak_ptr<SelfType> SelfTypeWp;
-
     /// Signature of a callback for delivering the response in the
     /// specified `context`.
-    typedef bsl::function<void(const SelfTypeSp& context)> ResponseCb;
+    typedef bsl::function<void(
+        const bsl::shared_ptr<RequestManagerRequest>& context)>
+        ResponseCb;
 
     /// Signature of a callback for signaling a response in the specified
     /// `context`.
-    typedef bsl::function<void(const SelfTypeSp& context)> AsyncNotifierCb;
+    typedef bsl::function<void(
+        const bsl::shared_ptr<RequestManagerRequest>& context)>
+        AsyncNotifierCb;
 
   private:
     // DATA
-    SelfTypeWp d_self_wp;
+    bsl::weak_ptr<RequestManagerRequest> d_self_wp;
     // Weak pointer to self
 
-    REQUEST d_requestMessage;
+    bmqp_ctrlmsg::ControlMessage d_requestMessage;
     // The request
 
-    RESPONSE d_responseMessage;
+    bmqp_ctrlmsg::ControlMessage d_responseMessage;
     // The response
 
     bslmt::Semaphore d_semaphore;
@@ -520,7 +513,7 @@ class RequestManagerRequest {
     // request.
 
     // FRIENDS
-    friend class RequestManager<REQUEST, RESPONSE>;
+    friend class RequestManager;
 
   private:
     // NOT IMPLEMENTED
@@ -565,11 +558,11 @@ class RequestManagerRequest {
     /// request times out or gets canceled).
     void wait();
 
-    REQUEST& request();
+    bmqp_ctrlmsg::ControlMessage& request();
 
     /// Return a reference offering modifiable access to the corresponding
     /// member of this object.
-    RESPONSE& response();
+    bmqp_ctrlmsg::ControlMessage& response();
 
     RequestManagerRequest& setResponseCb(const ResponseCb& value);
 
@@ -614,11 +607,11 @@ class RequestManagerRequest {
     RequestManagerRequest& adoptUserData(const bdld::Datum& value);
 
     // ACCESSORS
-    bool            isLateResponse() const;
-    bool            isLocalTimeout() const;
-    bool            isError() const;
-    const REQUEST&  request() const;
-    const RESPONSE& response() const;
+    bool                                isLateResponse() const;
+    bool                                isLocalTimeout() const;
+    bool                                isError() const;
+    const bmqp_ctrlmsg::ControlMessage& request() const;
+    const bmqp_ctrlmsg::ControlMessage& response() const;
 
     /// Return the value of the corresponding member.
     const ResponseCb& responseCb() const;
@@ -651,7 +644,6 @@ class RequestManagerRequest {
 // ====================
 
 /// Mechanism to manage requests and their response.
-template <class REQUEST, class RESPONSE>
 class RequestManager {
   public:
     // TYPES
@@ -665,7 +657,7 @@ class RequestManager {
         const bsl::shared_ptr<bdlbb::Blob>& blob)>
         SendFn;
 
-    typedef RequestManagerRequest<REQUEST, RESPONSE> RequestType;
+    typedef RequestManagerRequest RequestType;
 
     /// Shortcut to a Request object
     typedef bsl::shared_ptr<RequestType> RequestSp;
@@ -703,9 +695,9 @@ class RequestManager {
     /// but using an un-ordered map is not an option.
     typedef bmqc::OrderedHashMap<int, RequestSp> RequestMap;
 
-    typedef typename RequestMap::iterator RequestMapIter;
+    typedef RequestMap::iterator RequestMapIter;
 
-    typedef typename RequestMap::const_iterator RequestMapConstIter;
+    typedef RequestMap::const_iterator RequestMapConstIter;
 
     // DATA
     bslma::Allocator* d_allocator_p;
@@ -770,7 +762,8 @@ class RequestManager {
     void onRequestTimeout(int requestId);
 
     /// Apply the specified `response` to the specified `request`.
-    void applyResponse(const RequestSp& request, const RESPONSE& response);
+    void applyResponse(const RequestSp&                    request,
+                       const bmqp_ctrlmsg::ControlMessage& response);
 
     /// Cancel all outstanding requests matching the specified `groupId` and
     /// `componentId` filters, with the specified `reason` response
@@ -779,9 +772,9 @@ class RequestManager {
     /// disables component filtering.  Both filters are applied with AND
     /// semantics.  The corresponding response callbacks will be invoked in
     /// the order in which requests were sent.
-    void cancelAllRequestsImpl(const RESPONSE& reason,
-                               int             groupId,
-                               int             componentId);
+    void cancelAllRequestsImpl(const bmqp_ctrlmsg::ControlMessage& reason,
+                               int                                 groupId,
+                               int componentId);
 
   private:
     // NOT IMPLEMENTED
@@ -866,26 +859,28 @@ class RequestManager {
     /// Process the specified `response` and return 0 if the response is for
     /// a valid request, or non-zero otherwise (for example if the request
     /// has been removed due to timeout).
-    int processResponse(const RESPONSE& response);
+    int processResponse(const bmqp_ctrlmsg::ControlMessage& response);
 
     /// Cancel all outstanding requests with the specified `reason` response
     /// description.  The corresponding response callbacks will be invoked
     /// in the order in which requests were sent.
-    void cancelAllRequests(const RESPONSE& reason);
+    void cancelAllRequests(const bmqp_ctrlmsg::ControlMessage& reason);
 
     /// Cancel all outstanding requests belonging to the specified
     /// `groupId`, with the specified `reason` response description.  The
     /// behavior is undefined if `groupId` is `NO_GROUP_ID`.  The
     /// corresponding response callbacks will be invoked in the order in
     /// which requests were sent.
-    void cancelGroupRequests(const RESPONSE& reason, int groupId);
+    void cancelGroupRequests(const bmqp_ctrlmsg::ControlMessage& reason,
+                             int                                 groupId);
 
     /// Cancel all outstanding requests tagged with the specified
     /// `componentId`, with the specified `reason` response description.
     /// The behavior is undefined if `componentId` is
     /// `k_NO_COMPONENT_ID`.  The corresponding response callbacks will be
     /// invoked in the order in which requests were sent.
-    void cancelComponentRequests(const RESPONSE& reason, int componentId);
+    void cancelComponentRequests(const bmqp_ctrlmsg::ControlMessage& reason,
+                                 int componentId);
 };
 
 // ============================================================================
@@ -916,8 +911,7 @@ inline bool RequestManagerComponentId::isValid(int componentId)
 // class RequestManagerRequest
 // ---------------------------
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>::RequestManagerRequest(
+inline RequestManagerRequest::RequestManagerRequest(
     bslma::Allocator* allocator)
 : d_requestMessage(allocator)
 , d_responseMessage(allocator)
@@ -938,14 +932,12 @@ RequestManagerRequest<REQUEST, RESPONSE>::RequestManagerRequest(
     // NOTHING
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>::~RequestManagerRequest()
+inline RequestManagerRequest::~RequestManagerRequest()
 {
     clear();
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManagerRequest<REQUEST, RESPONSE>::clear()
+inline void RequestManagerRequest::clear()
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(!d_timeoutSchedulerHandle);
@@ -968,11 +960,10 @@ void RequestManagerRequest<REQUEST, RESPONSE>::clear()
     d_dtContext_p = NULL;
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManagerRequest<REQUEST, RESPONSE>::signal()
+inline void RequestManagerRequest::signal()
 {
     if (d_asyncNotifierCb) {
-        SelfTypeSp context = d_self_wp.lock();
+        bsl::shared_ptr<RequestManagerRequest> context = d_self_wp.lock();
         BSLS_ASSERT_SAFE(context);
 
         bslma::ManagedPtr<void> spanToken(context->activateDTSpan());
@@ -982,55 +973,44 @@ void RequestManagerRequest<REQUEST, RESPONSE>::signal()
     d_semaphore.post();
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManagerRequest<REQUEST, RESPONSE>::wait()
+inline void RequestManagerRequest::wait()
 {
     // No need to timedWait on a timedSemaphore, 'sendRequest()' schedules an
     // event for timeout that will post on the semaphore.
     d_semaphore.wait();
 }
 
-template <class REQUEST, class RESPONSE>
-REQUEST& RequestManagerRequest<REQUEST, RESPONSE>::request()
+inline bmqp_ctrlmsg::ControlMessage& RequestManagerRequest::request()
 {
     return d_requestMessage;
 }
 
-template <class REQUEST, class RESPONSE>
-RESPONSE& RequestManagerRequest<REQUEST, RESPONSE>::response()
+inline bmqp_ctrlmsg::ControlMessage& RequestManagerRequest::response()
 {
     return d_responseMessage;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setResponseCb(
-    const ResponseCb& value)
+inline RequestManagerRequest&
+RequestManagerRequest::setResponseCb(const ResponseCb& value)
 {
     d_responseCb = value;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setAsyncNotifierCb(
-    const AsyncNotifierCb& value)
+inline RequestManagerRequest&
+RequestManagerRequest::setAsyncNotifierCb(const AsyncNotifierCb& value)
 {
     d_asyncNotifierCb = value;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setGroupId(int value)
+inline RequestManagerRequest& RequestManagerRequest::setGroupId(int value)
 {
     d_groupId = value;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setComponentId(int value)
+inline RequestManagerRequest& RequestManagerRequest::setComponentId(int value)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(RequestManagerComponentId::isValid(value));
@@ -1040,35 +1020,28 @@ RequestManagerRequest<REQUEST, RESPONSE>::setComponentId(int value)
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setDTSpan(
-    const bsl::shared_ptr<bmqpi::DTSpan>& span)
+inline RequestManagerRequest&
+RequestManagerRequest::setDTSpan(const bsl::shared_ptr<bmqpi::DTSpan>& span)
 {
     d_dtSpan_sp = span;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::setDTContext(bmqpi::DTContext* ctx)
+inline RequestManagerRequest&
+RequestManagerRequest::setDTContext(bmqpi::DTContext* ctx)
 {
     d_dtContext_p = ctx;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManagerRequest<REQUEST, RESPONSE>&
-RequestManagerRequest<REQUEST, RESPONSE>::adoptUserData(
-    const bdld::Datum& value)
+inline RequestManagerRequest&
+RequestManagerRequest::adoptUserData(const bdld::Datum& value)
 {
     d_userData.adopt(value);
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-bslma::ManagedPtr<void>
-RequestManagerRequest<REQUEST, RESPONSE>::activateDTSpan() const
+inline bslma::ManagedPtr<void> RequestManagerRequest::activateDTSpan() const
 {
     bslma::ManagedPtr<void> result;
     if (d_dtSpan_sp && d_dtContext_p) {
@@ -1077,46 +1050,40 @@ RequestManagerRequest<REQUEST, RESPONSE>::activateDTSpan() const
     return result;
 }
 
-template <class REQUEST, class RESPONSE>
-bool RequestManagerRequest<REQUEST, RESPONSE>::isLateResponse() const
+inline bool RequestManagerRequest::isLateResponse() const
 {
     return d_haveTimeout && d_haveResponse;
 }
 
-template <class REQUEST, class RESPONSE>
-bool RequestManagerRequest<REQUEST, RESPONSE>::isLocalTimeout() const
+inline bool RequestManagerRequest::isLocalTimeout() const
 {
     return d_haveTimeout && !d_haveResponse;
 }
 
-template <class REQUEST, class RESPONSE>
-bool RequestManagerRequest<REQUEST, RESPONSE>::isError() const
+inline bool RequestManagerRequest::isError() const
 {
     return isLocalTimeout() ? true : response().choice().isStatusValue();
 }
 
-template <class REQUEST, class RESPONSE>
-const REQUEST& RequestManagerRequest<REQUEST, RESPONSE>::request() const
+inline const bmqp_ctrlmsg::ControlMessage&
+RequestManagerRequest::request() const
 {
     return d_requestMessage;
 }
 
-template <class REQUEST, class RESPONSE>
-const RESPONSE& RequestManagerRequest<REQUEST, RESPONSE>::response() const
+inline const bmqp_ctrlmsg::ControlMessage&
+RequestManagerRequest::response() const
 {
     return d_responseMessage;
 }
 
-template <class REQUEST, class RESPONSE>
-const typename RequestManagerRequest<REQUEST, RESPONSE>::ResponseCb&
-RequestManagerRequest<REQUEST, RESPONSE>::responseCb() const
+inline const RequestManagerRequest::ResponseCb&
+RequestManagerRequest::responseCb() const
 {
     return d_responseCb;
 }
 
-template <class REQUEST, class RESPONSE>
-bmqt::GenericResult::Enum
-RequestManagerRequest<REQUEST, RESPONSE>::result() const
+inline bmqt::GenericResult::Enum RequestManagerRequest::result() const
 {
     if (d_responseMessage.choice().isStatusValue()) {
         return static_cast<bmqt::GenericResult::Enum>(
@@ -1126,8 +1093,7 @@ RequestManagerRequest<REQUEST, RESPONSE>::result() const
     return bmqt::GenericResult::e_SUCCESS;
 }
 
-template <class REQUEST, class RESPONSE>
-int RequestManagerRequest<REQUEST, RESPONSE>::statusCode() const
+inline int RequestManagerRequest::statusCode() const
 {
     if (d_responseMessage.choice().isStatusValue()) {
         return d_responseMessage.choice().status().code();  // RETURN
@@ -1136,27 +1102,22 @@ int RequestManagerRequest<REQUEST, RESPONSE>::statusCode() const
     return bmqt::GenericResult::e_SUCCESS;
 }
 
-template <class REQUEST, class RESPONSE>
-const bsl::string&
-RequestManagerRequest<REQUEST, RESPONSE>::nodeDescription() const
+inline const bsl::string& RequestManagerRequest::nodeDescription() const
 {
     return d_nodeDescription;
 }
 
-template <class REQUEST, class RESPONSE>
-int RequestManagerRequest<REQUEST, RESPONSE>::groupId() const
+inline int RequestManagerRequest::groupId() const
 {
     return d_groupId;
 }
 
-template <class REQUEST, class RESPONSE>
-int RequestManagerRequest<REQUEST, RESPONSE>::componentId() const
+inline int RequestManagerRequest::componentId() const
 {
     return d_componentId;
 }
 
-template <class REQUEST, class RESPONSE>
-const bdld::Datum& RequestManagerRequest<REQUEST, RESPONSE>::userData() const
+inline const bdld::Datum& RequestManagerRequest::userData() const
 {
     return d_userData.datum();
 }
@@ -1165,11 +1126,10 @@ const bdld::Datum& RequestManagerRequest<REQUEST, RESPONSE>::userData() const
 // class RequestManager
 // --------------------
 
-template <class REQUEST, class RESPONSE>
-inline bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendHelper(
-    bmqio::Channel*                     channel,
-    const bsl::shared_ptr<bdlbb::Blob>& blob_sp,
-    bsls::Types::Int64                  watermark)
+inline bmqt::GenericResult::Enum
+RequestManager::sendHelper(bmqio::Channel*                     channel,
+                           const bsl::shared_ptr<bdlbb::Blob>& blob_sp,
+                           bsls::Types::Int64                  watermark)
 {
     bmqio::Status status;
     channel->write(&status, *blob_sp, watermark);
@@ -1188,8 +1148,7 @@ inline bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendHelper(
     }
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::onRequestTimeout(int requestId)
+inline void RequestManager::onRequestTimeout(int requestId)
 {
     // executed by the thread selected by 'd_executor'
 
@@ -1224,7 +1183,7 @@ void RequestManager<REQUEST, RESPONSE>::onRequestTimeout(int requestId)
                    << "' has timed out: " << request->request();
 
     // Now prepare a response and invoke the callback/signal outside the mutex.
-    RESPONSE& response = request->response();
+    bmqp_ctrlmsg::ControlMessage& response = request->response();
 
     // 1. 'fake' a response, with a Timeout status type
     response.rId().makeValue(requestId);
@@ -1265,9 +1224,9 @@ void RequestManager<REQUEST, RESPONSE>::onRequestTimeout(int requestId)
     }
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::applyResponse(const RequestSp& request,
-                                                      const RESPONSE& response)
+inline void
+RequestManager::applyResponse(const RequestSp&                    request,
+                              const bmqp_ctrlmsg::ControlMessage& response)
 {
     // mutex *NOT* locked
 
@@ -1314,13 +1273,11 @@ void RequestManager<REQUEST, RESPONSE>::applyResponse(const RequestSp& request,
     }
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManager<REQUEST, RESPONSE>::RequestManager(
-    bmqp::EventType::Enum  eventType,
-    BlobSpPool*            blobSpPool_p,
-    bdlmt::EventScheduler* scheduler,
-    bool                   lateResponseMode,
-    bslma::Allocator*      allocator)
+inline RequestManager::RequestManager(bmqp::EventType::Enum  eventType,
+                                      BlobSpPool*            blobSpPool_p,
+                                      bdlmt::EventScheduler* scheduler,
+                                      bool                   lateResponseMode,
+                                      bslma::Allocator*      allocator)
 : d_allocator_p(allocator)
 , d_eventType(eventType)
 , d_scheduler_p(scheduler)
@@ -1340,14 +1297,12 @@ RequestManager<REQUEST, RESPONSE>::RequestManager(
                      bsls::SystemClockType::e_MONOTONIC);
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManager<REQUEST, RESPONSE>::RequestManager(
-    bmqp::EventType::Enum  eventType,
-    BlobSpPool*            blobSpPool_p,
-    bdlmt::EventScheduler* scheduler,
-    bool                   lateResponseMode,
-    const bmqex::Executor& executor,
-    bslma::Allocator*      allocator)
+inline RequestManager::RequestManager(bmqp::EventType::Enum  eventType,
+                                      BlobSpPool*            blobSpPool_p,
+                                      bdlmt::EventScheduler* scheduler,
+                                      bool                   lateResponseMode,
+                                      const bmqex::Executor& executor,
+                                      bslma::Allocator*      allocator)
 : d_allocator_p(allocator)
 , d_eventType(eventType)
 , d_scheduler_p(scheduler)
@@ -1364,15 +1319,13 @@ RequestManager<REQUEST, RESPONSE>::RequestManager(
     BSLS_ASSERT_SAFE(executor);
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManager<REQUEST, RESPONSE>::RequestManager(
-    bmqp::EventType::Enum  eventType,
-    BlobSpPool*            blobSpPool_p,
-    bdlmt::EventScheduler* scheduler,
-    bool                   lateResponseMode,
-    const bmqex::Executor& executor,
-    const DTContextSp&     dtContext,
-    bslma::Allocator*      allocator)
+inline RequestManager::RequestManager(bmqp::EventType::Enum  eventType,
+                                      BlobSpPool*            blobSpPool_p,
+                                      bdlmt::EventScheduler* scheduler,
+                                      bool                   lateResponseMode,
+                                      const bmqex::Executor& executor,
+                                      const DTContextSp&     dtContext,
+                                      bslma::Allocator*      allocator)
 : d_allocator_p(allocator)
 , d_eventType(eventType)
 , d_scheduler_p(scheduler)
@@ -1389,8 +1342,7 @@ RequestManager<REQUEST, RESPONSE>::RequestManager(
     BSLS_ASSERT_SAFE(executor);
 }
 
-template <class REQUEST, class RESPONSE>
-RequestManager<REQUEST, RESPONSE>::~RequestManager()
+inline RequestManager::~RequestManager()
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_requests.empty() &&
@@ -1399,17 +1351,14 @@ RequestManager<REQUEST, RESPONSE>::~RequestManager()
                      "this object");
 }
 
-template <class REQUEST, class RESPONSE>
-inline RequestManager<REQUEST, RESPONSE>&
-RequestManager<REQUEST, RESPONSE>::setExecutor(const bmqex::Executor& executor)
+inline RequestManager&
+RequestManager::setExecutor(const bmqex::Executor& executor)
 {
     d_executor = executor;
     return *this;
 }
 
-template <class REQUEST, class RESPONSE>
-typename RequestManager<REQUEST, RESPONSE>::RequestSp
-RequestManager<REQUEST, RESPONSE>::createRequest()
+inline RequestManager::RequestSp RequestManager::createRequest()
 {
     RequestSp request;
     request.createInplace(d_allocator_p, d_allocator_p);
@@ -1423,14 +1372,13 @@ RequestManager<REQUEST, RESPONSE>::createRequest()
     return request;
 }
 
-template <class REQUEST, class RESPONSE>
-bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
-    const typename RequestManager::RequestSp& request,
-    bmqio::Channel*                           channel,
-    const bsl::string&                        nodeDescription,
-    const bsls::TimeInterval&                 timeout,
-    bsls::Types::Int64                        watermark,
-    bsl::string*                              errorDescription)
+inline bmqt::GenericResult::Enum
+RequestManager::sendRequest(const RequestSp&          request,
+                            bmqio::Channel*           channel,
+                            const bsl::string&        nodeDescription,
+                            const bsls::TimeInterval& timeout,
+                            bsls::Types::Int64        watermark,
+                            bsl::string*              errorDescription)
 {
     return sendRequest(request,
                        bdlf::BindUtil::bind(&sendHelper,
@@ -1442,13 +1390,12 @@ bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
                        errorDescription);
 }
 
-template <class REQUEST, class RESPONSE>
-bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
-    const typename RequestManager::RequestSp& request,
-    const SendFn&                             sendFn,
-    const bsl::string&                        nodeDescription,
-    const bsls::TimeInterval&                 timeout,
-    bsl::string*                              errorDescription)
+inline bmqt::GenericResult::Enum
+RequestManager::sendRequest(const RequestSp&          request,
+                            const SendFn&             sendFn,
+                            const bsl::string&        nodeDescription,
+                            const bsls::TimeInterval& timeout,
+                            bsl::string*              errorDescription)
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // MUTEX LOCKED
 
@@ -1528,9 +1475,8 @@ bmqt::GenericResult::Enum RequestManager<REQUEST, RESPONSE>::sendRequest(
     return bmqt::GenericResult::e_SUCCESS;
 }
 
-template <class REQUEST, class RESPONSE>
-int RequestManager<REQUEST, RESPONSE>::processResponse(
-    const RESPONSE& response)
+inline int
+RequestManager::processResponse(const bmqp_ctrlmsg::ControlMessage& response)
 {
     enum RcEnum {
         // Value for the various RC error categories
@@ -1570,19 +1516,17 @@ int RequestManager<REQUEST, RESPONSE>::processResponse(
     return rc_SUCCESS;
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelAllRequests(
-    const RESPONSE& reason)
+inline void
+RequestManager::cancelAllRequests(const bmqp_ctrlmsg::ControlMessage& reason)
 {
     cancelAllRequestsImpl(reason,
                           RequestType::k_NO_GROUP_ID,
                           RequestManagerComponentId::k_NO_COMPONENT_ID);
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelGroupRequests(
-    const RESPONSE& reason,
-    int             groupId)
+inline void
+RequestManager::cancelGroupRequests(const bmqp_ctrlmsg::ControlMessage& reason,
+                                    int groupId)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(groupId != RequestType::k_NO_GROUP_ID);
@@ -1592,10 +1536,9 @@ void RequestManager<REQUEST, RESPONSE>::cancelGroupRequests(
                           RequestManagerComponentId::k_NO_COMPONENT_ID);
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelComponentRequests(
-    const RESPONSE& reason,
-    int             componentId)
+inline void RequestManager::cancelComponentRequests(
+    const bmqp_ctrlmsg::ControlMessage& reason,
+    int                                 componentId)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(componentId !=
@@ -1604,11 +1547,10 @@ void RequestManager<REQUEST, RESPONSE>::cancelComponentRequests(
     cancelAllRequestsImpl(reason, RequestType::k_NO_GROUP_ID, componentId);
 }
 
-template <class REQUEST, class RESPONSE>
-void RequestManager<REQUEST, RESPONSE>::cancelAllRequestsImpl(
-    const RESPONSE& reason,
-    int             groupId,
-    int             componentId)
+inline void RequestManager::cancelAllRequestsImpl(
+    const bmqp_ctrlmsg::ControlMessage& reason,
+    int                                 groupId,
+    int                                 componentId)
 {
     // Note that requests must be cancelled in the same order in which they
     // were sent.

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -63,7 +63,7 @@ namespace {
 
 typedef bmqp_ctrlmsg::ControlMessage       Mes;
 typedef bsl::queue<Mes>                    MesQue;
-typedef bmqp::RequestManager<Mes, Mes>     ReqManagerType;
+typedef bmqp::RequestManager               ReqManagerType;
 typedef ReqManagerType::RequestType        Req;
 typedef ReqManagerType::RequestSp          ReqSp;
 typedef bsl::vector<ReqSp>                 ReqVec;

--- a/src/groups/mqb/mqba/mqba_commandrouter.cpp
+++ b/src/groups/mqb/mqba/mqba_commandrouter.cpp
@@ -168,10 +168,7 @@ int CommandRouter::route(bsl::ostream&  errorDescription,
     BSLS_ASSERT_SAFE(selfShouldExecute);
     BSLS_ASSERT_SAFE(relevantCluster);
 
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage,
-                                        mqbnet::ClusterNode*>::RequestContextSp
-        RequestContextSp;
+    typedef mqbnet::MultiRequestManager<>::RequestContextSp RequestContextSp;
 
     enum RcEnum {
         rc_SUCCESS = 0,

--- a/src/groups/mqb/mqba/mqba_commandrouter.h
+++ b/src/groups/mqb/mqba/mqba_commandrouter.h
@@ -74,7 +74,7 @@ namespace mqbnet {
 class ClusterNode;
 }
 namespace mqbnet {
-template <class REQUEST, class RESPONSE, class TARGET>
+template <class TARGET>
 class MultiRequestManagerRequestContext;
 }
 
@@ -90,9 +90,7 @@ class CommandRouter {
     /// Shared pointer to the correct multirequest context for routing control
     /// messages to @bbref{mqbnet::ClusterNode}s.
     typedef bsl::shared_ptr<
-        mqbnet::MultiRequestManagerRequestContext<bmqp_ctrlmsg::ControlMessage,
-                                                  bmqp_ctrlmsg::ControlMessage,
-                                                  mqbnet::ClusterNode*> >
+        mqbnet::MultiRequestManagerRequestContext<mqbnet::ClusterNode*> >
         MultiRequestContextSp;
 
     /// Vector of @bbref{mqbnet::ClusterNode} pointers used for routing.

--- a/src/groups/mqb/mqbblp/mqbblp_cluster.h
+++ b/src/groups/mqb/mqbblp/mqbblp_cluster.h
@@ -174,18 +174,6 @@ class Cluster : public mqbi::Cluster,
 
     typedef mqbc::ClusterData::MultiRequestManagerType MultiRequestManagerType;
 
-    typedef MultiRequestManagerType::RequestContextSp RequestContextSp;
-
-    typedef MultiRequestManagerType::NodeResponsePair NodeResponsePair;
-
-    typedef MultiRequestManagerType::NodeResponsePairs NodeResponsePairs;
-
-    typedef MultiRequestManagerType::NodeResponsePairsIter
-        NodeResponsePairsIter;
-
-    typedef MultiRequestManagerType::NodeResponsePairsConstIter
-        NodeResponsePairsConstIter;
-
     typedef bsl::shared_ptr<mqbnet::Cluster> NetClusterSp;
 
     typedef bsl::function<void(void)> VoidFunctor;
@@ -199,9 +187,7 @@ class Cluster : public mqbi::Cluster,
 
     /// Type of the MultiRequestManager used by the cluster to send
     /// StopRequest.
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage,
-                                        bsl::shared_ptr<mqbnet::Session> >
+    typedef mqbnet::MultiRequestManager<bsl::shared_ptr<mqbnet::Session> >
         StopRequestManagerType;
 
     struct ValidationResult {

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
@@ -115,13 +115,9 @@ class ClusterCatalog {
         int         d_myNodeId;
     };
 
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bmqp::RequestManager RequestManagerType;
 
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage,
-                                        bsl::shared_ptr<mqbnet::Session> >
+    typedef mqbnet::MultiRequestManager<bsl::shared_ptr<mqbnet::Session> >
         StopRequestManagerType;
 
   private:

--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.h
@@ -175,9 +175,7 @@ class ClusterProxy : public mqbc::ClusterStateObserver,
 
     /// Type of the MultiRequestManager used by the cluster proxy to send
     /// StopRequest.
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage,
-                                        bsl::shared_ptr<mqbnet::Session> >
+    typedef mqbnet::MultiRequestManager<bsl::shared_ptr<mqbnet::Session> >
         StopRequestManagerType;
 
     // DATA

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.cpp
@@ -571,8 +571,7 @@ void ClusterQueueHelper::requestQueueAssignment(const bmqt::Uri& uri)
         return;  // RETURN
     }
 
-    RequestManagerType::RequestSp request =
-        d_cluster_p->requestManager().createRequest();
+    RequestSp request = d_cluster_p->requestManager().createRequest();
     bmqp_ctrlmsg::QueueAssignmentRequest& queueAssignmentRequest =
         request->request()
             .choice()
@@ -613,9 +612,9 @@ void ClusterQueueHelper::requestQueueAssignment(const bmqt::Uri& uri)
 }
 
 void ClusterQueueHelper::onQueueAssignmentResponse(
-    const RequestManagerType::RequestSp& requestContext,
-    const bmqt::Uri&                     uri,
-    mqbnet::ClusterNode*                 responder)
+    const RequestSp&     requestContext,
+    const bmqt::Uri&     uri,
+    mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1240,8 +1239,7 @@ void ClusterQueueHelper::sendOpenQueueRequest(
     }
 
     if (subQueueContext.d_state == SubQueueContext::k_OPEN) {
-        RequestManagerType::RequestSp request =
-            d_cluster_p->requestManager().createRequest();
+        RequestSp request = d_cluster_p->requestManager().createRequest();
         bmqp_ctrlmsg::OpenQueue& openQueue =
             request->request().choice().makeOpenQueue();
 
@@ -1326,8 +1324,7 @@ bmqt::GenericResult::Enum ClusterQueueHelper::sendReopenQueueRequest(
     BSLS_ASSERT_SAFE(activeNode);
     BSLS_ASSERT_SAFE(cycle);
 
-    RequestManagerType::RequestSp request =
-        d_cluster_p->requestManager().createRequest();
+    RequestSp request = d_cluster_p->requestManager().createRequest();
     bmqp_ctrlmsg::OpenQueue& openQueue =
         request->request().choice().makeOpenQueue();
 
@@ -1391,10 +1388,9 @@ bmqt::GenericResult::Enum ClusterQueueHelper::sendReopenQueueRequest(
     return rc;
 }
 
-void ClusterQueueHelper::onOpenQueueResponse(
-    const RequestManagerType::RequestSp& requestContext,
-    const OpenQueueContextSp&            context,
-    mqbnet::ClusterNode*                 responder)
+void ClusterQueueHelper::onOpenQueueResponse(const RequestSp& requestContext,
+                                             const OpenQueueContextSp& context,
+                                             mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1585,7 +1581,7 @@ void ClusterQueueHelper::onOpenQueueResponse(
 }
 
 void ClusterQueueHelper::onReopenQueueResponse(
-    const RequestManagerType::RequestSp&         requestContext,
+    const RequestSp&                             requestContext,
     mqbnet::ClusterNode*                         activeNode,
     const bsl::shared_ptr<PartitionReopenCycle>& cycle,
     int                                          numAttempts)
@@ -1791,7 +1787,7 @@ void ClusterQueueHelper::onReopenQueueResponse(
 }
 
 void ClusterQueueHelper::onConfigureQueueResponse(
-    const RequestManagerType::RequestSp&               requestContext,
+    const RequestSp&                                   requestContext,
     const bmqt::Uri&                                   uri,
     const bmqp_ctrlmsg::StreamParameters&              streamParameters,
     bsls::Types::Uint64                                generationCount,
@@ -1819,7 +1815,7 @@ void ClusterQueueHelper::onConfigureQueueResponse(
         bmqp_ctrlmsg::StreamParameters              d_streamParams;
 
         ScopeGuard(const mqbi::QueueHandle::HandleConfiguredCallback& callback,
-                   const RequestManagerType::RequestSp&  requestContext,
+                   const RequestSp&                      requestContext,
                    const bmqp_ctrlmsg::StreamParameters& streamParameters)
         : d_callback(callback)
         , d_streamParams(streamParameters)
@@ -1899,7 +1895,7 @@ void ClusterQueueHelper::onConfigureQueueResponse(
 }
 
 void ClusterQueueHelper::onReopenQueueRetry(
-    const RequestManagerType::RequestSp&         requestContext,
+    const RequestSp&                             requestContext,
     mqbnet::ClusterNode*                         activeNode,
     const bsl::shared_ptr<PartitionReopenCycle>& cycle,
     int                                          numAttempts)
@@ -1923,7 +1919,7 @@ void ClusterQueueHelper::onReopenQueueRetry(
 }
 
 void ClusterQueueHelper::onReopenQueueRetryDispatched(
-    const RequestManagerType::RequestSp&         requestContext,
+    const RequestSp&                             requestContext,
     mqbnet::ClusterNode*                         activeNode,
     const bsl::shared_ptr<PartitionReopenCycle>& cycle,
     int                                          numAttempts)
@@ -3256,7 +3252,7 @@ void ClusterQueueHelper::sendCloseQueueRequest(
 }
 
 void ClusterQueueHelper::onCloseQueueResponse(
-    const RequestManagerType::RequestSp&         requestContext,
+    const RequestSp&                             requestContext,
     const mqbi::Cluster::HandleReleasedCallback& callback)
 {
     // executed by the cluster *DISPATCHER* thread
@@ -3437,8 +3433,7 @@ bool ClusterQueueHelper::sendConfigureQueueRequest(
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
     BSLS_ASSERT_SAFE(upstreamNode);
 
-    RequestManagerType::RequestSp request =
-        d_cluster_p->requestManager().createRequest();
+    RequestSp request = d_cluster_p->requestManager().createRequest();
 
     // TODO: Replace with 'ConfigureStream' once all brokers recognize it
 
@@ -3535,8 +3530,7 @@ void ClusterQueueHelper::sendCloseQueueRequest(
     // downstream (self) node.  This is one of the reasons that this routine
     // does not return an error code.
 
-    RequestManagerType::RequestSp request =
-        d_cluster_p->requestManager().createRequest();
+    RequestSp request = d_cluster_p->requestManager().createRequest();
     bmqp_ctrlmsg::CloseQueue& req =
         request->request().choice().makeCloseQueue();
 

--- a/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterqueuehelper.h
@@ -315,10 +315,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
 
     // PRIVATE TYPES
 
-    /// Type of the RequestManager to use
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
 
     typedef mqbc::ClusterStatePartitionInfo ClusterStatePartitionInfo;
 
@@ -549,10 +546,9 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// QueueAssignment request response handler, for a queue with the
     /// specified `uri`, and with the request and its associated response in
     /// the specified `requestContext`.
-    void onQueueAssignmentResponse(
-        const RequestManagerType::RequestSp& requestContext,
-        const bmqt::Uri&                     uri,
-        mqbnet::ClusterNode*                 responder);
+    void onQueueAssignmentResponse(const RequestSp&     requestContext,
+                                   const bmqt::Uri&     uri,
+                                   mqbnet::ClusterNode* responder);
 
     /// Method invoked when the queue in the specified `queueContext` has
     /// been assigned; to resume the operation on any pending contexts.
@@ -609,17 +605,16 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// Response callback of an open queue request, in the specified
     /// `context` and with the request and its associated response in the
     /// specified `requestContext`.
-    void
-    onOpenQueueResponse(const RequestManagerType::RequestSp& requestContext,
-                        const OpenQueueContextSp&            context,
-                        mqbnet::ClusterNode*                 responder);
+    void onOpenQueueResponse(const RequestSp&          requestContext,
+                             const OpenQueueContextSp& context,
+                             mqbnet::ClusterNode*      responder);
 
     /// Response callback of an open queue request, that was sent due to the
     /// state being restored, with the request and its associated response
     /// in the specified `requestContext`.
     void
-    onReopenQueueResponse(const RequestManagerType::RequestSp& requestContext,
-                          mqbnet::ClusterNode*                 activeNode,
+    onReopenQueueResponse(const RequestSp&     requestContext,
+                          mqbnet::ClusterNode* activeNode,
                           const bsl::shared_ptr<PartitionReopenCycle>& cycle,
                           int numAttempts);
 
@@ -627,20 +622,19 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
     /// the state being restored, with the request and its associated
     /// response in the specified `requestContext`.
     void onConfigureQueueResponse(
-        const RequestManagerType::RequestSp&               requestContext,
+        const RequestSp&                                   requestContext,
         const bmqt::Uri&                                   uri,
         const bmqp_ctrlmsg::StreamParameters&              streamParameters,
         bsls::Types::Uint64                                generationCount,
         const mqbi::QueueHandle::HandleConfiguredCallback& callback);
 
-    void
-    onReopenQueueRetry(const RequestManagerType::RequestSp& requestContext,
-                       mqbnet::ClusterNode*                 activeNode,
-                       const bsl::shared_ptr<PartitionReopenCycle>& cycle,
-                       int numAttempts);
+    void onReopenQueueRetry(const RequestSp&     requestContext,
+                            mqbnet::ClusterNode* activeNode,
+                            const bsl::shared_ptr<PartitionReopenCycle>& cycle,
+                            int numAttempts);
 
     void onReopenQueueRetryDispatched(
-        const RequestManagerType::RequestSp&         requestContext,
+        const RequestSp&                             requestContext,
         mqbnet::ClusterNode*                         activeNode,
         const bsl::shared_ptr<PartitionReopenCycle>& cycle,
         int                                          numAttempts);
@@ -767,7 +761,7 @@ class ClusterQueueHelper BSLS_KEYWORD_FINAL
         const mqbi::Cluster::HandleReleasedCallback& callback);
 
     void onCloseQueueResponse(
-        const RequestManagerType::RequestSp&         requestContext,
+        const RequestSp&                             requestContext,
         const mqbi::Cluster::HandleReleasedCallback& callback);
 
     void onQueueHandleCreatedDispatched(mqbi::Queue*     queue,

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -770,8 +770,7 @@ void RecoveryManager::sendStorageSyncRequesterHelper(RecoveryContext* context,
     BSLS_ASSERT_SAFE(context);
     BSLS_ASSERT_SAFE(context->recoveryPeer());
 
-    RequestManagerType::RequestSp request =
-        d_clusterData_p->requestManager().createRequest();
+    RequestSp request = d_clusterData_p->requestManager().createRequest();
 
     bmqp_ctrlmsg::StorageSyncRequest& storageSyncReq =
         request->request()
@@ -854,8 +853,8 @@ void RecoveryManager::sendStorageSyncRequesterHelper(RecoveryContext* context,
 }
 
 void RecoveryManager::onStorageSyncResponse(
-    const RequestManagerType::RequestSp& context,
-    const mqbnet::ClusterNode*           responder)
+    const RequestSp&           context,
+    const mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -891,9 +890,9 @@ void RecoveryManager::onStorageSyncResponse(
 }
 
 void RecoveryManager::onStorageSyncResponseDispatched(
-    int                                  partitionId,
-    const RequestManagerType::RequestSp& context,
-    const mqbnet::ClusterNode*           responder)
+    int                        partitionId,
+    const RequestSp&           context,
+    const mqbnet::ClusterNode* responder)
 {
     // executed by each of the *STORAGE (QUEUE) DISPATCHER* threads
 
@@ -2476,7 +2475,10 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
                          d_primarySyncContexts.size());
 
     PrimarySyncContext& primarySyncCtx = d_primarySyncContexts[partitionId];
-    const NodeResponsePairs& pairs     = requestContext->response();
+    typedef mqbc::ClusterData::MultiRequestManagerType::NodeResponsePairs
+        NodeResponsePairs;
+
+    const NodeResponsePairs& pairs = requestContext->response();
 
     // A new primary never sends request to zero peers.
 
@@ -2492,7 +2494,8 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
                    << " Partition [" << partitionId << "]: processing "
                    << pairs.size() << " partition sync state query responses";
 
-    for (NodeResponsePairsConstIter it = pairs.begin(); it != pairs.end();
+    for (NodeResponsePairs::const_iterator it = pairs.begin();
+         it != pairs.end();
          ++it) {
         BSLS_ASSERT_SAFE(it->first);
 
@@ -2651,8 +2654,7 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
 
     // Send PartitionSyncDataQuery to this peer.
 
-    RequestManagerType::RequestSp request =
-        d_clusterData_p->requestManager().createRequest();
+    RequestSp request = d_clusterData_p->requestManager().createRequest();
 
     bmqp_ctrlmsg::PartitionSyncDataQuery& partitionSyncDataReq =
         request->request()
@@ -2708,8 +2710,8 @@ void RecoveryManager::onPartitionSyncStateQueryResponseDispatched(
 }
 
 void RecoveryManager::onPartitionSyncDataQueryResponse(
-    const RequestManagerType::RequestSp& context,
-    const mqbnet::ClusterNode*           responder)
+    const RequestSp&           context,
+    const mqbnet::ClusterNode* responder)
 {
     // executed by *ANY* thread
 
@@ -2740,9 +2742,9 @@ void RecoveryManager::onPartitionSyncDataQueryResponse(
 }
 
 void RecoveryManager::onPartitionSyncDataQueryResponseDispatched(
-    int                                  partitionId,
-    const RequestManagerType::RequestSp& context,
-    const mqbnet::ClusterNode*           responder)
+    int                        partitionId,
+    const RequestSp&           context,
+    const mqbnet::ClusterNode* responder)
 {
     // executed by *DISPATCHER* thread
 
@@ -4413,7 +4415,7 @@ void RecoveryManager::startPartitionPrimarySync(
 
     // Send PartitionSyncStateRequest to all *AVAILABLE* peers.
 
-    MultiRequestManagerType::RequestContextSp contextSp =
+    RequestContextSp contextSp =
         d_clusterData_p->multiRequestManager().createRequestContext();
 
     bmqp_ctrlmsg::PartitionSyncStateQuery& req =

--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.h
@@ -741,21 +741,10 @@ class RecoveryManager : public mqbnet::ClusterObserver {
 
     typedef PrimarySyncContext::PartitionPrimarySyncCb PartitionPrimarySyncCb;
 
-    typedef mqbc::ClusterData::RequestManagerType RequestManagerType;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
 
-    typedef mqbc::ClusterData::MultiRequestManagerType MultiRequestManagerType;
-
-    typedef MultiRequestManagerType::RequestContextSp RequestContextSp;
-
-    typedef MultiRequestManagerType::NodeResponsePair NodeResponsePair;
-
-    typedef MultiRequestManagerType::NodeResponsePairs NodeResponsePairs;
-
-    typedef MultiRequestManagerType::NodeResponsePairsIter
-        NodeResponsePairsIter;
-
-    typedef MultiRequestManagerType::NodeResponsePairsConstIter
-        NodeResponsePairsConstIter;
+    typedef mqbc::ClusterData::MultiRequestManagerType::RequestContextSp
+        RequestContextSp;
 
     typedef mqbs::FileStore::SyncPointOffsetPairs SyncPointOffsetPairs;
 
@@ -855,15 +844,14 @@ class RecoveryManager : public mqbnet::ClusterObserver {
                                         int              partitionId);
 
     /// Executed by any thread.
-    void onStorageSyncResponse(const RequestManagerType::RequestSp& context,
-                               const mqbnet::ClusterNode*           responder);
+    void onStorageSyncResponse(const RequestSp&           context,
+                               const mqbnet::ClusterNode* responder);
 
     /// Executed by the dispatcher thread identified by the specified
     /// `processorId` assigned to the specified `partitionId`.
-    void onStorageSyncResponseDispatched(
-        int                                  partitionId,
-        const RequestManagerType::RequestSp& context,
-        const mqbnet::ClusterNode*           responder);
+    void onStorageSyncResponseDispatched(int              partitionId,
+                                         const RequestSp& context,
+                                         const mqbnet::ClusterNode* responder);
 
     /// Executed by the dispatcher thread associated with the specified
     /// `partitionId`.
@@ -914,9 +902,9 @@ class RecoveryManager : public mqbnet::ClusterObserver {
     /// specified `requestContext`.
     ///
     /// THREAD: This method is invoked in the associated cluster's IO thread.
-    void onPartitionSyncDataQueryResponse(
-        const RequestManagerType::RequestSp& context,
-        const mqbnet::ClusterNode*           responder);
+    void
+    onPartitionSyncDataQueryResponse(const RequestSp&           context,
+                                     const mqbnet::ClusterNode* responder);
 
     /// Process the partition-sync-data-query response contained in the
     /// specified `requestContext`.
@@ -924,9 +912,9 @@ class RecoveryManager : public mqbnet::ClusterObserver {
     /// THREAD: This method is invoked in the associated partition's dispatcher
     ///         thread.
     void onPartitionSyncDataQueryResponseDispatched(
-        int                                  partitionId,
-        const RequestManagerType::RequestSp& context,
-        const mqbnet::ClusterNode*           responder);
+        int                        partitionId,
+        const RequestSp&           context,
+        const mqbnet::ClusterNode* responder);
 
     bool hasSyncPoint(bmqp_ctrlmsg::SyncPoint* syncPoint,
                       mqbs::RecordHeader*      syncPointRecHeader,

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.h
@@ -165,19 +165,6 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager {
 
     typedef mqbc::ClusterStatePartitionInfo ClusterStatePartitionInfo;
 
-    typedef mqbc::ClusterData::RequestManagerType RequestManagerType;
-
-    typedef mqbc::ClusterData::MultiRequestManagerType MultiRequestManagerType;
-
-    typedef MultiRequestManagerType::RequestContextSp RequestContextSp;
-
-    typedef MultiRequestManagerType::NodeResponsePair  NodeResponsePair;
-    typedef MultiRequestManagerType::NodeResponsePairs NodeResponsePairs;
-    typedef MultiRequestManagerType::NodeResponsePairsIter
-        NodeResponsePairsIter;
-    typedef MultiRequestManagerType::NodeResponsePairsConstIter
-        NodeResponsePairsConstIter;
-
     typedef mqbc::StorageUtil::DomainQueueMessagesCountMaps
         DomainQueueMessagesCountMaps;
 

--- a/src/groups/mqb/mqbc/mqbc_clusterdata.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterdata.h
@@ -136,14 +136,10 @@ class ClusterData {
         StateSpPool;
 
     /// Type of the RequestManager used by the cluster.
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bmqp::RequestManager RequestManagerType;
 
     /// Type of the MultiRequestManager used by the cluster.
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage>
-        MultiRequestManagerType;
+    typedef mqbnet::MultiRequestManager<> MultiRequestManagerType;
 
     typedef bslma::ManagedPtr<bmqst::StatContext> StatContextMp;
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -773,8 +773,7 @@ void StorageManager::sendReplicaDataRequestPush(
         mqbnet::ClusterNode* destNode = (*cit)->first;
         BSLS_ASSERT_SAFE(destNode->nodeId() != selfNode->nodeId());
 
-        RequestManagerType::RequestSp request =
-            d_clusterData_p->requestManager().createRequest();
+        RequestSp request = d_clusterData_p->requestManager().createRequest();
         request->setComponentId(
             bmqp::RequestManagerComponentId::partitionFSM(partitionId));
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRqst =
@@ -847,8 +846,7 @@ void StorageManager::sendReplicaDataRequestDrop(
         mqbnet::ClusterNode* destNode = (*cit)->first;
         BSLS_ASSERT_SAFE(destNode->nodeId() != selfNode->nodeId());
 
-        RequestManagerType::RequestSp request =
-            d_clusterData_p->requestManager().createRequest();
+        RequestSp request = d_clusterData_p->requestManager().createRequest();
         request->setComponentId(
             bmqp::RequestManagerComponentId::partitionFSM(partitionId));
         bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRqst =
@@ -1282,8 +1280,8 @@ void StorageManager::processReplicaDataRequestDrop(
 }
 
 void StorageManager::processPrimaryStateResponseDispatched(
-    const RequestManagerType::RequestSp& context,
-    mqbnet::ClusterNode*                 responder)
+    const RequestSp&     context,
+    mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1401,8 +1399,8 @@ void StorageManager::processPrimaryStateResponseDispatched(
 }
 
 void StorageManager::processPrimaryStateResponse(
-    const RequestManagerType::RequestSp& context,
-    mqbnet::ClusterNode*                 responder)
+    const RequestSp&     context,
+    mqbnet::ClusterNode* responder)
 {
     // executed by *any* thread
     // dispatch to the CLUSTER DISPATCHER
@@ -1422,8 +1420,8 @@ void StorageManager::processPrimaryStateResponse(
 }
 
 void StorageManager::processReplicaStateResponseDispatched(
-    const RequestContextSp& requestContext,
-    mqbnet::ClusterNode*    responder)
+    const RequestSp&     requestContext,
+    mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1524,8 +1522,8 @@ void StorageManager::processReplicaStateResponseDispatched(
 }
 
 void StorageManager::processReplicaStateResponse(
-    const RequestContextSp& requestContext,
-    mqbnet::ClusterNode*    responder)
+    const RequestSp&     requestContext,
+    mqbnet::ClusterNode* responder)
 {
     // executed by *any* thread
     // dispatch to the CLUSTER DISPATCHER
@@ -1539,8 +1537,8 @@ void StorageManager::processReplicaStateResponse(
 }
 
 void StorageManager::processReplicaDataResponseDispatched(
-    const RequestManagerType::RequestSp& context,
-    mqbnet::ClusterNode*                 responder)
+    const RequestSp&     context,
+    mqbnet::ClusterNode* responder)
 {
     // executed by the cluster *DISPATCHER* thread
 
@@ -1715,9 +1713,8 @@ void StorageManager::processReplicaDataResponseDispatched(
     }
 }
 
-void StorageManager::processReplicaDataResponse(
-    const RequestManagerType::RequestSp& context,
-    mqbnet::ClusterNode*                 responder)
+void StorageManager::processReplicaDataResponse(const RequestSp&     context,
+                                                mqbnet::ClusterNode* responder)
 {
     // executed by *any* thread
 
@@ -2086,7 +2083,7 @@ void StorageManager::do_replicaStateRequest(
          ++it) {
         mqbnet::ClusterNode* replica = *it;
 
-        RequestContextSp contextSp =
+        RequestSp contextSp =
             d_clusterData_p->requestManager().createRequest();
         contextSp->setComponentId(
             bmqp::RequestManagerComponentId::partitionFSM(partitionId));
@@ -2342,8 +2339,7 @@ void StorageManager::do_primaryStateRequest(
 
     d_recoveryManager_mp->setLiveDataSource(primary, partitionId);
 
-    RequestManagerType::RequestSp request =
-        d_clusterData_p->requestManager().createRequest();
+    RequestSp request = d_clusterData_p->requestManager().createRequest();
     request->setComponentId(
         bmqp::RequestManagerComponentId::partitionFSM(partitionId));
 
@@ -2544,8 +2540,7 @@ void StorageManager::do_replicaDataRequestPull(
     BSLS_ASSERT_SAFE(destNode->nodeId() !=
                      d_clusterData_p->membership().selfNode()->nodeId());
 
-    RequestManagerType::RequestSp request =
-        d_clusterData_p->requestManager().createRequest();
+    RequestSp request = d_clusterData_p->requestManager().createRequest();
     request->setComponentId(
         bmqp::RequestManagerComponentId::partitionFSM(partitionId));
     bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -121,8 +121,7 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager,
 
     typedef bsl::function<void(int)> RecoveryStatusCb;
 
-    typedef ClusterData::RequestManagerType RequestManagerType;
-    typedef RequestManagerType::RequestSp   RequestContextSp;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
 
     typedef bdlmt::EventScheduler::RecurringEventHandle RecurringEventHandle;
 
@@ -556,53 +555,48 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager,
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void processPrimaryStateResponseDispatched(
-        const RequestManagerType::RequestSp& context,
-        mqbnet::ClusterNode*                 responder);
+    void processPrimaryStateResponseDispatched(const RequestSp&     context,
+                                               mqbnet::ClusterNode* responder);
 
     /// Process the PrimaryStateResponse contained in the specified
     /// `context` from the specified `responder`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread or scheduler thread.
-    void
-    processPrimaryStateResponse(const RequestManagerType::RequestSp& context,
-                                mqbnet::ClusterNode* responder);
+    void processPrimaryStateResponse(const RequestSp&     context,
+                                     mqbnet::ClusterNode* responder);
 
     /// Process the ReplicaStateResponse contained in the specified
     /// `requestContext`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void processReplicaStateResponseDispatched(
-        const RequestContextSp& requestContext,
-        mqbnet::ClusterNode*    responder);
+    void processReplicaStateResponseDispatched(const RequestSp& requestContext,
+                                               mqbnet::ClusterNode* responder);
 
     /// Process the ReplicaStateResponse contained in the specified
     /// `requestContext` from the specified `responder`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread or scheduler thread.
-    void processReplicaStateResponse(const RequestContextSp& requestContext,
-                                     mqbnet::ClusterNode*    responder);
+    void processReplicaStateResponse(const RequestSp&     requestContext,
+                                     mqbnet::ClusterNode* responder);
 
     /// Process the ReplicaDataResponse contained in the specified
     /// `requestContext` from the specified `responder`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread.
-    void processReplicaDataResponseDispatched(
-        const RequestManagerType::RequestSp& context,
-        mqbnet::ClusterNode*                 responder);
+    void processReplicaDataResponseDispatched(const RequestSp&     context,
+                                              mqbnet::ClusterNode* responder);
 
     /// Process the ReplicaDataResponse contained in the specified
     /// `requestContext` from the specified `responder`.
     ///
     /// THREAD: This method is invoked in the associated cluster's
     ///         dispatcher thread or scheduler thread.
-    void
-    processReplicaDataResponse(const RequestManagerType::RequestSp& context,
-                               mqbnet::ClusterNode*                 responder);
+    void processReplicaDataResponse(const RequestSp&     context,
+                                    mqbnet::ClusterNode* responder);
 
     /// THREAD: Executed by the dispatcher thread for the specified
     ///         `partitionId`.

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -99,7 +99,7 @@ namespace mqbnet {
 class ClusterNode;
 }
 namespace mqbnet {
-template <class REQUEST, class RESPONSE, class TARGET>
+template <class TARGET>
 class MultiRequestManager;
 }
 
@@ -243,13 +243,9 @@ class Cluster : public DispatcherClient {
         HandleReleasedCallback;
 
     /// Type of the RequestManager used by the cluster.
-    typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
-                                 bmqp_ctrlmsg::ControlMessage>
-        RequestManagerType;
+    typedef bmqp::RequestManager RequestManagerType;
 
-    typedef mqbnet::MultiRequestManager<bmqp_ctrlmsg::ControlMessage,
-                                        bmqp_ctrlmsg::ControlMessage,
-                                        mqbnet::ClusterNode*>
+    typedef mqbnet::MultiRequestManager<mqbnet::ClusterNode*>
         MultiRequestManagerType;
 
     /// Signature of a `void` functor method.

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.h
@@ -59,30 +59,29 @@ namespace BloombergLP {
 namespace mqbnet {
 
 // FORWARD DECLARATION
-template <class REQUEST, class RESPONSE, class TARGET>
+template <class TARGET>
 class MultiRequestManager;
 
 // =======================================
 // class MultiRequestManagerRequestContext
 // =======================================
 
-template <class REQUEST, class RESPONSE, class TARGET>
+template <class TARGET>
 class MultiRequestManagerRequestContext {
     // FRIENDS
-    friend class MultiRequestManager<REQUEST, RESPONSE, TARGET>;
+    friend class MultiRequestManager<TARGET>;
 
   public:
     // TYPES
 
     /// SelfType is an alias to this `class`.
-    typedef MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>
-        SelfType;
+    typedef MultiRequestManagerRequestContext<TARGET> SelfType;
 
     typedef bsl::shared_ptr<SelfType> SelfTypeSp;
 
     typedef bsl::vector<TARGET> Nodes;
 
-    typedef bsl::pair<TARGET, RESPONSE> NodeResponsePair;
+    typedef bsl::pair<TARGET, bmqp_ctrlmsg::ControlMessage> NodeResponsePair;
 
     typedef bsl::vector<NodeResponsePair> NodeResponsePairs;
 
@@ -97,8 +96,7 @@ class MultiRequestManagerRequestContext {
 
   private:
     // PRIVATE TYPES
-    typedef
-        typename bmqp::RequestManager<REQUEST, RESPONSE>::RequestSp RequestSp;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
 
     typedef typename Nodes::iterator NodesIter;
 
@@ -106,7 +104,7 @@ class MultiRequestManagerRequestContext {
 
   private:
     // DATA
-    REQUEST d_request;
+    bmqp_ctrlmsg::ControlMessage d_request;
 
     NodeResponsePairs d_nodeResponsePairs;
 
@@ -142,7 +140,7 @@ class MultiRequestManagerRequestContext {
 
     /// Return a reference offering modifiable access to the request
     /// associated with this context.
-    REQUEST& request();
+    bmqp_ctrlmsg::ControlMessage& request();
 
     void setDestinationNodes(const Nodes& nodes);
 
@@ -156,7 +154,7 @@ class MultiRequestManagerRequestContext {
     void setComponentId(int value);
 
     // ACCESSORS
-    const REQUEST& request() const;
+    const bmqp_ctrlmsg::ControlMessage& request() const;
 
     /// Return the component id.
     int componentId() const;
@@ -170,12 +168,11 @@ class MultiRequestManagerRequestContext {
 // class MultiRequestManager
 // =========================
 
-template <class REQUEST, class RESPONSE, class TARGET = mqbnet::ClusterNode*>
+template <class TARGET = mqbnet::ClusterNode*>
 class MultiRequestManager {
   public:
     // TYPES
-    typedef MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>
-        RequestContextType;
+    typedef MultiRequestManagerRequestContext<TARGET> RequestContextType;
 
     typedef typename RequestContextType::NodeResponsePair NodeResponsePair;
 
@@ -199,7 +196,9 @@ class MultiRequestManager {
 
     typedef typename RequestContextType::NodesIter NodesIter;
 
-    typedef bmqp::RequestManager<REQUEST, RESPONSE> RequestManagerType;
+    typedef bmqp::RequestManager::RequestSp RequestSp;
+
+    typedef bmqp::RequestManager::SendFn SendFn;
 
   private:
     // NOT IMPLEMENTED
@@ -219,10 +218,9 @@ class MultiRequestManager {
     /// Object Pool.
     void poolCreateRequestContext(void* address, bslma::Allocator* allocator);
 
-    void onSingleResponse(
-        const typename RequestManagerType::RequestSp& singleRequestContext,
-        const RequestContextSp&                       multiRequestContext,
-        TARGET                                        node);
+    void onSingleResponse(const RequestSp&        singleRequestContext,
+                          const RequestContextSp& multiRequestContext,
+                          TARGET                  node);
 
     const bsl::string&
     targetDescription(const mqbnet::ClusterNode* target) const;
@@ -230,21 +228,19 @@ class MultiRequestManager {
     bsl::string_view
     targetDescription(const bsl::shared_ptr<mqbnet::Session>& target) const;
 
-    void setGroupId(typename RequestManagerType::RequestSp& context,
-                    const mqbnet::ClusterNode*              target) const;
+    void setGroupId(RequestSp&                 context,
+                    const mqbnet::ClusterNode* target) const;
 
-    void setGroupId(typename RequestManagerType::RequestSp& context,
+    void setGroupId(RequestSp&                              context,
                     const bsl::shared_ptr<mqbnet::Session>& target) const;
 
-    const typename RequestManagerType::SendFn
-    sendFn(mqbnet::ClusterNode* target) const;
+    const SendFn sendFn(mqbnet::ClusterNode* target) const;
 
-    const typename RequestManagerType::SendFn
-    sendFn(const bsl::shared_ptr<mqbnet::Session>& target) const;
+    const SendFn sendFn(const bsl::shared_ptr<mqbnet::Session>& target) const;
 
   private:
     // DATA
-    RequestManagerType* d_requestManager_p;
+    bmqp::RequestManager* d_requestManager_p;
 
     RequestContextPool d_requestContextPool;
 
@@ -254,9 +250,8 @@ class MultiRequestManager {
                                    bslma::UsesBslmaAllocator)
 
     // CREATORS
-    MultiRequestManager(
-        bmqp::RequestManager<REQUEST, RESPONSE>* requestManager,
-        bslma::Allocator*                        allocator);
+    MultiRequestManager(bmqp::RequestManager* requestManager,
+                        bslma::Allocator*     allocator);
 
     /// Destructor
     ~MultiRequestManager();
@@ -279,9 +274,9 @@ class MultiRequestManager {
 // ---------------------------------------
 
 // CREATORS
-template <class REQUEST, class RESPONSE, class TARGET>
-MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
-    MultiRequestManagerRequestContext(bslma::Allocator* allocator)
+template <class TARGET>
+MultiRequestManagerRequestContext<TARGET>::MultiRequestManagerRequestContext(
+    bslma::Allocator* allocator)
 : d_request(allocator)
 , d_nodeResponsePairs(allocator)
 , d_numOutstandingRequests(0)
@@ -292,8 +287,8 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
 }
 
 // MANIPULATORS
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::clear()
+template <class TARGET>
+void MultiRequestManagerRequestContext<TARGET>::clear()
 {
     d_request.reset();
     d_nodeResponsePairs.clear();
@@ -302,35 +297,35 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::clear()
     d_componentId = bmqp::RequestManagerComponentId::k_NO_COMPONENT_ID;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-REQUEST&
-MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::request()
+template <class TARGET>
+bmqp_ctrlmsg::ControlMessage&
+MultiRequestManagerRequestContext<TARGET>::request()
 {
     return d_request;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
-    setDestinationNodes(const Nodes& nodes)
+template <class TARGET>
+void MultiRequestManagerRequestContext<TARGET>::setDestinationNodes(
+    const Nodes& nodes)
 {
     d_nodeResponsePairs.clear();
     for (NodesConstIter it = nodes.begin(); it != nodes.end(); ++it) {
-        d_nodeResponsePairs.push_back(bsl::make_pair(*it, RESPONSE()));
+        d_nodeResponsePairs.push_back(
+            bsl::make_pair(*it, bmqp_ctrlmsg::ControlMessage()));
     }
 
     d_numOutstandingRequests = static_cast<int>(d_nodeResponsePairs.size());
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
-    setResponseCb(const ResponseCb& value)
+template <class TARGET>
+void MultiRequestManagerRequestContext<TARGET>::setResponseCb(
+    const ResponseCb& value)
 {
     d_responseCb = value;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
-    setComponentId(int value)
+template <class TARGET>
+void MultiRequestManagerRequestContext<TARGET>::setComponentId(int value)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(bmqp::RequestManagerComponentId::isValid(value));
@@ -341,25 +336,22 @@ void MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::
 }
 
 // ACCESSORS
-template <class REQUEST, class RESPONSE, class TARGET>
-const REQUEST&
-MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::request() const
+template <class TARGET>
+const bmqp_ctrlmsg::ControlMessage&
+MultiRequestManagerRequestContext<TARGET>::request() const
 {
     return d_request;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-int MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::componentId()
-    const
+template <class TARGET>
+int MultiRequestManagerRequestContext<TARGET>::componentId() const
 {
     return d_componentId;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-const typename MultiRequestManagerRequestContext<REQUEST,
-                                                 RESPONSE,
-                                                 TARGET>::NodeResponsePairs&
-MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::response() const
+template <class TARGET>
+const typename MultiRequestManagerRequestContext<TARGET>::NodeResponsePairs&
+MultiRequestManagerRequestContext<TARGET>::response() const
 {
     return d_nodeResponsePairs;
 }
@@ -369,9 +361,8 @@ MultiRequestManagerRequestContext<REQUEST, RESPONSE, TARGET>::response() const
 // -------------------------
 
 // PRIVATE MANIPULATORS
-template <class REQUEST, class RESPONSE, class TARGET>
-inline bmqt::GenericResult::Enum
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendHelper(
+template <class TARGET>
+inline bmqt::GenericResult::Enum MultiRequestManager<TARGET>::sendHelper(
     bmqio::Channel*                     channel,
     const bsl::shared_ptr<bdlbb::Blob>& blob)
 {
@@ -393,19 +384,19 @@ MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendHelper(
     return bmqt::GenericResult::e_UNKNOWN;
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManager<REQUEST, RESPONSE, TARGET>::poolCreateRequestContext(
+template <class TARGET>
+void MultiRequestManager<TARGET>::poolCreateRequestContext(
     void*             address,
     bslma::Allocator* allocator)
 {
     new (address) RequestContextType(allocator);
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManager<REQUEST, RESPONSE, TARGET>::onSingleResponse(
-    const typename RequestManagerType::RequestSp& singleRequestContext,
-    const RequestContextSp&                       multiRequestContext,
-    TARGET                                        node)
+template <class TARGET>
+void MultiRequestManager<TARGET>::onSingleResponse(
+    const RequestSp&        singleRequestContext,
+    const RequestContextSp& multiRequestContext,
+    TARGET                  node)
 {
     BSLS_ASSERT_SAFE(node);
     BSLS_ASSERT_SAFE(0 < multiRequestContext->d_numOutstandingRequests);
@@ -435,10 +426,10 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::onSingleResponse(
 }
 
 // CREATORS
-template <class REQUEST, class RESPONSE, class TARGET>
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::MultiRequestManager(
-    bmqp::RequestManager<REQUEST, RESPONSE>* requestManager,
-    bslma::Allocator*                        allocator)
+template <class TARGET>
+MultiRequestManager<TARGET>::MultiRequestManager(
+    bmqp::RequestManager* requestManager,
+    bslma::Allocator*     allocator)
 : d_requestManager_p(requestManager)
 , d_requestContextPool(
       bdlf::BindUtil::bind(&MultiRequestManager::poolCreateRequestContext,
@@ -451,8 +442,8 @@ MultiRequestManager<REQUEST, RESPONSE, TARGET>::MultiRequestManager(
     BSLS_ASSERT_SAFE(d_requestManager_p);
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::~MultiRequestManager()
+template <class TARGET>
+MultiRequestManager<TARGET>::~MultiRequestManager()
 {
     BSLS_ASSERT_SAFE((d_requestContextPool.numAvailableObjects() ==
                       d_requestContextPool.numObjects()) &&
@@ -460,17 +451,16 @@ MultiRequestManager<REQUEST, RESPONSE, TARGET>::~MultiRequestManager()
 }
 
 // MANIPULATORS
-template <class REQUEST, class RESPONSE, class TARGET>
-typename MultiRequestManager<REQUEST, RESPONSE, TARGET>::RequestContextSp
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::createRequestContext()
+template <class TARGET>
+typename MultiRequestManager<TARGET>::RequestContextSp
+MultiRequestManager<TARGET>::createRequestContext()
 {
     return d_requestContextPool.getObject();
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
-    const RequestContextSp& context,
-    bsls::TimeInterval      timeout)
+template <class TARGET>
+void MultiRequestManager<TARGET>::sendRequest(const RequestContextSp& context,
+                                              bsls::TimeInterval      timeout)
 {
     NodeResponsePairs& nodeResponsePairs = context->d_nodeResponsePairs;
     int                numRequests       = context->d_numOutstandingRequests;
@@ -478,8 +468,7 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
     for (NodeResponsePairsIter it = nodeResponsePairs.begin();
          it != nodeResponsePairs.end();
          ++it) {
-        typename RequestManagerType::RequestSp singleRequestCtx =
-            d_requestManager_p->createRequest();
+        RequestSp singleRequestCtx  = d_requestManager_p->createRequest();
         singleRequestCtx->request() = context->d_request;
         singleRequestCtx->setResponseCb(
             bdlf::BindUtil::bind(&MultiRequestManager::onSingleResponse,
@@ -527,51 +516,47 @@ void MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendRequest(
     }
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline void MultiRequestManager<REQUEST, RESPONSE, TARGET>::processResponse(
+template <class TARGET>
+inline void MultiRequestManager<TARGET>::processResponse(
     const bmqp_ctrlmsg::ControlMessage& response)
 {
     d_requestManager_p->processResponse(response);
 };
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline const bsl::string&
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::targetDescription(
+template <class TARGET>
+inline const bsl::string& MultiRequestManager<TARGET>::targetDescription(
     const mqbnet::ClusterNode* target) const
 {
     return target->nodeDescription();
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline bsl::string_view
-MultiRequestManager<REQUEST, RESPONSE, TARGET>::targetDescription(
+template <class TARGET>
+inline bsl::string_view MultiRequestManager<TARGET>::targetDescription(
     const bsl::shared_ptr<mqbnet::Session>& target) const
 {
     return target->clusterNode() ? target->clusterNode()->nodeDescription()
                                  : target->description();
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline void MultiRequestManager<REQUEST, RESPONSE, TARGET>::setGroupId(
-    typename RequestManagerType::RequestSp& context,
-    const mqbnet::ClusterNode*              target) const
+template <class TARGET>
+inline void MultiRequestManager<TARGET>::setGroupId(
+    RequestSp&                 context,
+    const mqbnet::ClusterNode* target) const
 {
     context->setGroupId(target->nodeId());
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline void MultiRequestManager<REQUEST, RESPONSE, TARGET>::setGroupId(
-    BSLA_MAYBE_UNUSED typename RequestManagerType::RequestSp& context,
+template <class TARGET>
+inline void MultiRequestManager<TARGET>::setGroupId(
+    BSLA_MAYBE_UNUSED RequestSp& context,
     BSLA_MAYBE_UNUSED const bsl::shared_ptr<mqbnet::Session>& target) const
 {
     // NOTHING
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline const typename MultiRequestManager<REQUEST, RESPONSE, TARGET>::
-    RequestManagerType::SendFn
-    MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendFn(
-        mqbnet::ClusterNode* target) const
+template <class TARGET>
+inline const typename MultiRequestManager<TARGET>::SendFn
+MultiRequestManager<TARGET>::sendFn(mqbnet::ClusterNode* target) const
 {
     return bdlf::BindUtil::bind(&mqbnet::ClusterNode::write,
                                 target,
@@ -579,11 +564,10 @@ inline const typename MultiRequestManager<REQUEST, RESPONSE, TARGET>::
                                 bmqp::EventType::e_CONTROL);
 }
 
-template <class REQUEST, class RESPONSE, class TARGET>
-inline const typename MultiRequestManager<REQUEST, RESPONSE, TARGET>::
-    RequestManagerType::SendFn
-    MultiRequestManager<REQUEST, RESPONSE, TARGET>::sendFn(
-        const bsl::shared_ptr<mqbnet::Session>& target) const
+template <class TARGET>
+inline const typename MultiRequestManager<TARGET>::SendFn
+MultiRequestManager<TARGET>::sendFn(
+    const bsl::shared_ptr<mqbnet::Session>& target) const
 {
     return bdlf::BindUtil::bind(&sendHelper,
                                 target->channel().get(),

--- a/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_multirequestmanager.t.cpp
@@ -80,9 +80,9 @@ namespace {
 
 typedef bmqp_ctrlmsg::ControlMessage               Mes;
 typedef bsl::queue<Mes>                            MesQue;
-typedef bmqp::RequestManager<Mes, Mes>             ReqManagerType;
+typedef bmqp::RequestManager                       ReqManagerType;
 typedef bsl::shared_ptr<ReqManagerType>            ReqManagerTypeSp;
-typedef mqbnet::MultiRequestManager<Mes, Mes>      MultiReqManagerType;
+typedef mqbnet::MultiRequestManager<>              MultiReqManagerType;
 typedef bsl::shared_ptr<MultiReqManagerType>       MultiReqManagerTypeSp;
 typedef MultiReqManagerType::RequestContextType    ReqContextType;
 typedef MultiReqManagerType::RequestContextSp      ReqContextSp;


### PR DESCRIPTION
- `bmqp::RequestManager` and `mqbnet::MultiRequestManager` always have the same template args `REQUEST == RESPONSE == bmqp_ctrlmsg::ControlMessage`. The only reason why it is a template is for not including `#include <bmqp_ctrlmsg_messages.h>`. However, we still include this header. Due to this, template args are not doing anything other than making the code more complex.
- It is possible to remove `#include <bmqp_ctrlmsg_messages.h>` in both class sources, but this should be done not with templates, but with forward declarations and code organization. This PR is a preparation for this.
- Simplify arg types: `RequestManagerType::RequestSp` -> `RequestSp`