### PR TITLE
Fix[mqba]: prevent data race with snapshot thread

### DIFF
--- a/src/groups/bmq/bmqst/bmqst_statcontext.cpp
+++ b/src/groups/bmq/bmqst/bmqst_statcontext.cpp
@@ -260,6 +260,8 @@ void StatContext::clearDeletedSubcontexts(
 
 void StatContext::moveNewSubcontexts()
 {
+    // Thread: snapshot
+
     StatContextVector localNewSubcontexts(d_allocator_p);
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_newSubcontextsLock);

--- a/src/groups/bmq/bmqst/bmqst_statcontext.h
+++ b/src/groups/bmq/bmqst/bmqst_statcontext.h
@@ -723,47 +723,64 @@ class StatContext {
 
     // MANIPULATORS
 
-    /// Add a subcontext with the specified `config`.  If this
+    /// @brief Add a subcontext with the specified `config`.
+    /// @param config The configuration for the new subcontext.  If this
     /// `StatContext` is a table, the `isTable` and `valueDefinitions`
-    /// fields  of the `config` are ignored.
+    /// fields of the `config` are ignored.
+    /// @note Thread: any
     bslma::ManagedPtr<StatContext> addSubcontext(const Config& config);
 
-    /// Adjust the value at the specified index `valueKey` using the
-    /// specified `delta`.  Note that this method is thread-safe.  The
-    /// behavior is undefined unless the value corresponding to the
+    /// @brief Adjust the value at the specified index `valueKey` using the
+    /// specified `delta`.
+    /// @param valueKey The index of the value to adjust.
+    /// @param delta The delta by which the value is updated.
+    /// @note Thread: any
+    /// The behavior is undefined unless the value corresponding to the
     /// `valueKey` is continuous.
     void adjustValue(int valueKey, bsls::Types::Int64 delta);
 
-    /// Set the value at the specified index `valueKey` using the specified
-    /// `value`.  Note that this method is thread-safe.  The behavior is
-    /// undefined unless the value corresponding to the `valueKey` is
-    /// continuous.
+    /// @brief Set the value at the specified index `valueKey` using the
+    /// specified `value`.
+    /// @param valueKey The index of the value to set.
+    /// @param value The value to set.
+    /// @note Thread: any
+    /// The behavior is undefined unless the value corresponding to the
+    /// `valueKey` is continuous.
     void setValue(int valueKey, bsls::Types::Int64 value);
 
-    /// Set the value at the specified index `valueKey` using the specified
-    /// `value`.  Note that this method is thread-safe.  The behavior is
-    /// undefined unless the value corresponding to the `valueKey`
-    /// is discrete.
+    /// @brief Set the value at the specified index `valueKey` using the
+    /// specified `value`.
+    /// @param valueKey The index of the value to report.
+    /// @param value The value to report.
+    /// @note Thread: any
+    /// The behavior is undefined unless the value corresponding to the
+    /// `valueKey` is discrete.
     void reportValue(int valueKey, bsls::Types::Int64 value);
 
-    /// Snapshot all values of all subcontexts, then snapshot the user data
-    /// associated with this context, if any.
+    /// @brief Snapshot all values of all subcontexts, then snapshot the
+    /// user data associated with this context, if any.
+    /// @note Thread: snapshot
     void snapshot();
 
-    /// Remove any deleted subcontexts of this StatContext and of all
-    /// subcontexts.
+    /// @brief Remove any deleted subcontexts of this StatContext and of
+    /// all subcontexts.
+    /// @note Thread: snapshot
     void cleanup();
 
-    /// Clear all history of all values.
+    /// @brief Clear all history of all values.
+    /// @note Thread: snapshot
     void clearValues();
 
-    /// Remove all subcontexts of this StatContext.
+    /// @brief Remove all subcontexts of this StatContext.
+    /// @note Thread: snapshot
     void clearSubcontexts();
 
-    /// Add and remove subcontexts, and update the fields of all values
-    /// according to the specified `update`.  The behavior is undefined if
-    /// this method is called and the context is configured to record its
-    /// snapshots.
+    /// @brief Add and remove subcontexts, and update the fields of all
+    /// values according to the specified `update`.
+    /// @param update The update to apply.
+    /// @note Thread: snapshot
+    /// The behavior is undefined if this method is called and the context
+    /// is configured to record its snapshots.
     void snapshotFromUpdate(const bmqstm::StatContextUpdate& update);
 
     // ACCESSORS

--- a/src/groups/mqb/mqba/mqba_dispatcher.cpp
+++ b/src/groups/mqb/mqba/mqba_dispatcher.cpp
@@ -417,9 +417,6 @@ void Dispatcher::stop()
     }
 
 #undef STOP_AND_CLEAR
-
-    // Clear all stat sub contexts
-    d_statContext_p->clearSubcontexts();
 }
 
 mqbi::Dispatcher::ProcessorHandle


### PR DESCRIPTION

```
  west1            16:37:50.042 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #0             
  BloombergLP::bslalg::BidirectionalLink::nextLink() const /opt/bb/include/bslalg_bidirectionallink.h:381:12              
  (bmqbrkr.tsk+0x38eee49) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.042 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #1             
  BloombergLP::bslstl::HashTableIterator<bsl::pair<BloombergLP::bdlb::Variant2<bsl::basic_string<char,                    
  std::__1::char_traits<char>, bsl::allocator<char>>, long long> const, BloombergLP::bmqst::StatContext*>,                
  long>::advance() /opt/bb/include/bslstl_hashtableiterator.h:336:38 (bmqbrkr.tsk+0x4d56542) (BuildId:                    
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.042 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #2             
  BloombergLP::bslstl::HashTableIterator<bsl::pair<BloombergLP::bdlb::Variant2<bsl::basic_string<char,                    
  std::__1::char_traits<char>, bsl::allocator<char>>, long long> const, BloombergLP::bmqst::StatContext*>,                
  long>::operator++() /opt/bb/include/bslstl_hashtableiterator.h:346:11 (bmqbrkr.tsk+0x4d43b36) (BuildId:                 
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.043 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #3             
  BloombergLP::bmqst::StatContext::snapshotImp(long long) /blazingmq/src/groups/bmq/bmqst/bmqst_statcontext.cpp:384:13    
  (bmqbrkr.tsk+0x4d3da75) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.043 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #4             
  BloombergLP::bmqst::StatContext::snapshot() /blazingmq/src/groups/bmq/bmqst/bmqst_statcontext.cpp:640:5                 
  (bmqbrkr.tsk+0x4d3fcec) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.043 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #5             
  BloombergLP::mqbstat::StatController::snapshot() /blazingmq/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp:602:43    
  (bmqbrkr.tsk+0x49308f9) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.043 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #6             
  BloombergLP::mqbstat::StatController::snapshotAndNotify()                                                               
  /blazingmq/src/groups/mqb/mqbstat/mqbstat_statcontroller.cpp:626:10 (bmqbrkr.tsk+0x4932dc5) (BuildId:                   
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.044 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #7 void        
  BloombergLP::bdlf::MemFn<void (BloombergLP::mqbstat::StatController::*)()>::operator()<BloombergLP::mqbstat::StatContro 
  ller*>(BloombergLP::mqbstat::StatController* const&) const /opt/bb/include/bdlf_memfn.h:557:16 (bmqbrkr.tsk+0x494ba20)  
  (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                     
                                                                                                                          
  west1            16:37:50.044 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #8 void        
  BloombergLP::bdlf::Bind_Invoker<void, 1>::invoke<BloombergLP::bdlf::MemFn<void                                          
  (BloombergLP::mqbstat::StatController::*)()> const,                                                                     
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*> const,                                       
  BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::MemFn<void (BloombergLP::mqbstat::StatController::*)()> const*,   
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*> const*, BloombergLP::bdlf::Bind_ArgTuple0&)  
  const /opt/bb/include/bdlf_bind.h:8610:9 (bmqbrkr.tsk+0x494b901) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)    
                                                                                                                          
  west1            16:37:50.045 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #9 void        
  BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbstat::StatController::*)(),         
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*>>::invokeImpl<BloombergLP::bdlf::Bind_ArgTupl 
  e0>(BloombergLP::bdlf::Bind_ArgTuple0&, BloombergLP::bslmf::Tag<0u>) const /opt/bb/include/bdlf_bind.h:5950:24          
  (bmqbrkr.tsk+0x494b86c) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.045 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #10 void       
  BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbstat::StatController::*)(),         
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*>>::invoke<BloombergLP::bdlf::Bind_ArgTuple0>( 
  BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:6014:16 (bmqbrkr.tsk+0x494b7e9) (BuildId:         
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.045 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #11            
  BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbstat::StatController::*)(),         
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*>>::operator()() const                         
  /opt/bb/include/bdlf_bind.h:6023:16 (bmqbrkr.tsk+0x494b76e) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)         
                                                                                                                          
  west1            16:37:50.046 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #12            
  BloombergLP::bslstl::Function_InvokerUtil_Dispatch<4, void (), BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void    
  (BloombergLP::mqbstat::StatController::*)(),                                                                            
  BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::mqbstat::StatController*>>>::invoke(BloombergLP::bslstl::Function_Rep  
  const*) /opt/bb/include/bslstl_function_invokerutil.h:951:12 (bmqbrkr.tsk+0x494b6f2) (BuildId:                          
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.046 (139914756894464) INFO     blazingmq.tsk.bmqbrkr.mqbnet.transportmanager                  
  mqbnet_transportmanager.cpp:66  Deleting Cluster 'itCluster'                                                            
  west1            16:37:50.046 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #13            
  BloombergLP::bslstl::Function_Variadic<void ()>::operator()() const /opt/bb/include/bslstl_function.h:1545:12           
  (bmqbrkr.tsk+0x39586d0) (BuildId: 41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                             
                                                                                                                          
  west1            16:37:50.047 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #14            
  BloombergLP::defaultDispatcherFunction(bsl::function<void ()> const&)                                                   
  /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp:369:5 (bmqbrkr.tsk+0x572b315) (BuildId:         
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.047 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #15            
  BloombergLP::bslstl::Function_InvokerUtil_Dispatch<1, void (bsl::function<void ()> const&), void (*)(bsl::function<void 
   ()> const&)>::invoke(BloombergLP::bslstl::Function_Rep const*, bsl::function<void ()> const&)                          
  /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_function_invokerutil.h:807:12 (bmqbrkr.tsk+0x56ed922) (BuildId:       
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.047 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #16            
  BloombergLP::bslstl::Function_Variadic<void (bsl::function<void ()> const&)>::operator()(bsl::function<void ()> const&) 
   const /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_function.h:1545:12 (bmqbrkr.tsk+0x56e26f0) (BuildId:           
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12)                                                                               
                                                                                                                          
  west1            16:37:50.047 (140575084902080) INFO     blazingmq.tsk.bmqbrkr.stderr bmqproc.py:129     #17            
  BloombergLP::bdlmt::TimerEventSchedulerDispatcher::dispatchEvents(BloombergLP::bdlmt::TimerEventScheduler*)             
  /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_timereventscheduler.cpp:264:17 (bmqbrkr.tsk+0x5729f4a) (BuildId:        
  41ac6edd5c95a6ddee8923d45c3c7386d4041e12) 
```