### PR TITLE
Refactor[mqbc]: un-template partition fsm

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsm.cpp
@@ -47,32 +47,33 @@ const bsls::Types::Int64 k_NS_PER_MESSAGE =
 const char* PartitionFSM::k_PFSM_DEFECT_LOG_TAG = "[PFSM_DEFECT]";
 
 // PRIVATE MANIPULATORS
-void PartitionFSM::processEvent(const EventWithData& event)
+void PartitionFSM::processEvent(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
 {
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId'
 
-    const int partitionId = event.second.partitionId();
+    const int partitionId = eventData.partitionId();
 
     State::Enum oldState   = d_state;
-    Transition  transition = d_stateTable.transition(oldState, event.first);
+    Transition  transition = d_stateTable.transition(oldState, eventType);
     // Transition state
     d_state = static_cast<State::Enum>(transition.first);
 
-    if (event.first == PartitionStateTableEvent::e_RECOVERY_DATA ||
-        event.first == PartitionStateTableEvent::e_LIVE_DATA) {
+    if (eventType == PartitionStateTableEvent::e_RECOVERY_DATA ||
+        eventType == PartitionStateTableEvent::e_LIVE_DATA) {
         BMQ_LOGTHROTTLE_INFO << "Partition FSM for Partition [" << partitionId
-                             << "] on Event '" << event.first
+                             << "] on Event '" << eventType
                              << "', transition: State '" << oldState
                              << "' =>  State '" << d_state << "'";
     }
     else {
         BALL_LOG_INFO << "Partition FSM for Partition [" << partitionId
-                      << "] on Event '" << event.first
+                      << "] on Event '" << eventType
                       << "', transition: State '" << oldState
                       << "' =>  State '" << d_state << "'";
     }
 
-    (d_actions.*(transition.second))(event);
+    (d_actions.*(transition.second))(eventType, eventData);
 
     // Notify observers
     if (d_state != oldState) {
@@ -159,18 +160,20 @@ PartitionFSM& PartitionFSM::unregisterObserver(PartitionFSMObserver* observer)
     return *this;
 }
 
-void PartitionFSM::enqueueEvent(const EventWithData& event)
+void PartitionFSM::enqueueEvent(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
 {
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId'
 
-    d_eventsQueue.push(event);
+    d_eventsQueue.push(EventEntry(eventType, eventData));
     if (d_eventsQueue.size() > 1) {
         // There is already an ongoing processing, so just return.
         return;
     }
 
     while (!d_eventsQueue.empty()) {
-        processEvent(d_eventsQueue.front());
+        const EventEntry& front = d_eventsQueue.front();
+        processEvent(front.first, front.second);
         d_eventsQueue.pop();
     }
 }

--- a/src/groups/mqb/mqbc/mqbc_partitionfsm.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionfsm.h
@@ -214,10 +214,7 @@ class PartitionFSM {
 
   public:
     // TYPES
-    typedef bsl::pair<PartitionStateTableEvent::Enum, PartitionFSMEventData>
-        EventWithData;
-
-    typedef PartitionStateTable<EventWithData> StateTable;
+    typedef PartitionStateTable                StateTable;
     typedef StateTable::State                  State;
     typedef StateTable::Event                  Event;
     typedef StateTable::ActionFunctor          ActionFunctor;
@@ -228,6 +225,10 @@ class PartitionFSM {
     typedef ObserversSet::iterator                    ObserversSetIter;
 
   private:
+    // TYPES
+    typedef bsl::pair<PartitionStateTableEvent::Enum, PartitionFSMEventData>
+        EventEntry;
+
     // DATA
     bslma::Allocator* d_allocator_p;
 
@@ -235,11 +236,11 @@ class PartitionFSM {
 
     State::Enum d_state;
 
-    PartitionStateTableActions<EventWithData>& d_actions;
+    PartitionStateTableActions& d_actions;
 
     /// Internal queue containing events which need to be applied to the
     /// current state of the FSM.
-    bsl::queue<EventWithData> d_eventsQueue;
+    bsl::queue<EventEntry> d_eventsQueue;
 
     /// Observers of this object.
     ObserversSet d_observers;
@@ -258,8 +259,10 @@ class PartitionFSM {
 
     // PRIVATE MANIPULATORS
 
-    /// Process the specified `event` and notify observers.
-    void processEvent(const EventWithData& event);
+    /// Process the specified `eventType` with the specified `eventData`
+    /// and notify observers.
+    void processEvent(PartitionStateTableEvent::Enum eventType,
+                      const PartitionFSMEventData&   eventData);
 
   public:
     // TRAITS
@@ -269,8 +272,8 @@ class PartitionFSM {
 
     /// Create an instance with the specified `actions`, using the specified
     /// `allocator`.
-    PartitionFSM(PartitionStateTableActions<EventWithData>& actions,
-                 bslma::Allocator*                          allocator);
+    PartitionFSM(PartitionStateTableActions& actions,
+                 bslma::Allocator*           allocator);
 
     // MANIPULATORS
 
@@ -284,9 +287,11 @@ class PartitionFSM {
     /// object.
     PartitionFSM& unregisterObserver(PartitionFSMObserver* observer);
 
-    /// Enqueue the specified `event` to the internal events queue.  It will be
-    /// processed as an input to the FSM.
-    void enqueueEvent(const EventWithData& event);
+    /// Enqueue the specified `eventType` with the specified `eventData` to
+    /// the internal events queue.  It will be processed as an input to the
+    /// FSM.
+    void enqueueEvent(PartitionStateTableEvent::Enum eventType,
+                      const PartitionFSMEventData&   eventData);
 
     // ACCESSORS
 
@@ -500,9 +505,8 @@ PartitionFSMEventData::storageEvent() const
 // ------------------
 
 // CREATORS
-inline PartitionFSM::PartitionFSM(
-    PartitionStateTableActions<EventWithData>& actions,
-    bslma::Allocator*                          allocator)
+inline PartitionFSM::PartitionFSM(PartitionStateTableActions& actions,
+                                  bslma::Allocator*           allocator)
 : d_allocator_p(allocator)
 , d_stateTable()
 , d_state(State::e_UNKNOWN)

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.cpp
@@ -15,6 +15,7 @@
 
 #include <mqbc_partitionstatetable.h>
 
+#include <mqbc_partitionfsm.h>
 #include <mqbscm_version.h>
 // BDE
 #include <bdlb_print.h>
@@ -141,6 +142,26 @@ PartitionStateTableEvent::toAscii(PartitionStateTableEvent::Enum value)
     }
 
 #undef CASE
+}
+
+// --------------------------------
+// class PartitionStateTableActions
+// --------------------------------
+
+// CREATORS
+PartitionStateTableActions::~PartitionStateTableActions()
+{
+    // NOTHING (pure interface)
+}
+
+void PartitionStateTableActions::do_none(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
+{
+    (void)eventType;
+    const int partitionId = eventData.partitionId();
+    BALL_LOG_INFO << "Partition FSM for Partition [" << partitionId
+                  << "]: NO ACTION PERFORMED.";
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -237,12 +237,14 @@ struct PartitionStateTableEvent {
 bsl::ostream& operator<<(bsl::ostream&                  stream,
                          PartitionStateTableEvent::Enum value);
 
+// FORWARD DECLARATIONS
+class PartitionFSMEventData;
+
 // ================================
 // class PartitionStateTableActions
 // ================================
 
 /// This class defines the actions in the partition state table.
-template <typename ARGS>
 class PartitionStateTableActions {
   private:
     // CLASS-SCOPE CATEGORY
@@ -250,222 +252,354 @@ class PartitionStateTableActions {
 
   public:
     // TYPES
-    typedef void (PartitionStateTableActions<ARGS>::*ActionFunctor)(
-        const ARGS& args);
+    typedef void (PartitionStateTableActions::*ActionFunctor)(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
   public:
     virtual ~PartitionStateTableActions();
 
-    virtual void do_none(const ARGS& args);
+    virtual void do_none(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData);
 
-    virtual void do_startWatchdog(const ARGS& args) = 0;
+    virtual void do_startWatchdog(PartitionStateTableEvent::Enum eventType,
+                                  const PartitionFSMEventData& eventData) = 0;
 
-    virtual void do_stopWatchdog(const ARGS& args) = 0;
-
-    virtual void do_openRecoveryFileSet(const ARGS& args) = 0;
-
-    virtual void do_closeRecoveryFileSet(const ARGS& args) = 0;
-
-    virtual void do_storeSelfSeq(const ARGS& args) = 0;
-
-    virtual void do_storePrimarySeq(const ARGS& args) = 0;
-
-    virtual void do_storeReplicaSeq(const ARGS& args) = 0;
-
-    virtual void do_replicaStateRequest(const ARGS& args) = 0;
-
-    virtual void do_replicaStateResponse(const ARGS& args) = 0;
-
-    virtual void do_failureReplicaStateResponse(const ARGS& args) = 0;
-
-    virtual void do_logFailureReplicaStateResponse(const ARGS& args) = 0;
-
-    virtual void do_logFailurePrimaryStateResponse(const ARGS& args) = 0;
-
-    virtual void do_logUnexpectedPrimaryStateResponse(const ARGS& args) = 0;
+    virtual void do_stopWatchdog(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
 
     virtual void
-    do_logUnexpectedFailurePrimaryStateResponse(const ARGS& args) = 0;
+    do_openRecoveryFileSet(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_primaryStateRequest(const ARGS& args) = 0;
+    virtual void
+    do_closeRecoveryFileSet(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_primaryStateResponse(const ARGS& args) = 0;
+    virtual void do_storeSelfSeq(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_storePrimarySeq(PartitionStateTableEvent::Enum eventType,
+                       const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_storeReplicaSeq(PartitionStateTableEvent::Enum eventType,
+                       const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_replicaStateRequest(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_replicaStateResponse(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_failureReplicaStateResponse(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
+
+    virtual void do_logFailureReplicaStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_logFailurePrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_logUnexpectedPrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_logUnexpectedFailurePrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_primaryStateRequest(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_primaryStateResponse(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData) = 0;
 
     /// This method is called by primary to drop partition storage
     /// if needed (e.g primary missed rollover).
-    virtual void do_primaryRemoveStorageIfNeeded(const ARGS& args) = 0;
+    virtual void do_primaryRemoveStorageIfNeeded(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
 
     /// This method is called by primary to unconditionally drop partition
     /// storage (e.g. upon receiving irreconcilable data response from
     /// replica).
-    virtual void do_primaryRemoveStorage(const ARGS& args) = 0;
-
-    virtual void do_failurePrimaryStateResponse(const ARGS& args) = 0;
-
-    virtual void do_replicaDataResponsePush(const ARGS& args) = 0;
-
-    virtual void do_replicaDataRequestPull(const ARGS& args) = 0;
-
-    virtual void do_replicaDataResponsePull(const ARGS& args) = 0;
-
-    virtual void do_failureReplicaDataResponsePull(const ARGS& args) = 0;
-
-    virtual void do_failureReplicaDataResponsePush(const ARGS& args) = 0;
-
-    virtual void do_sendDataToReplicas(const ARGS& args) = 0;
-
-    virtual void do_sendDataToPrimary(const ARGS& args) = 0;
-
-    virtual void do_bufferLiveData(const ARGS& args) = 0;
-
-    virtual void do_processBufferedLiveData(const ARGS& args) = 0;
-
-    virtual void do_clearBufferedLiveData(const ARGS& args) = 0;
+    virtual void
+    do_primaryRemoveStorage(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData) = 0;
 
     virtual void
-    do_processBufferedPrimaryStatusAdvisories(const ARGS& args) = 0;
-
-    virtual void do_processLiveData(const ARGS& args) = 0;
-
-    virtual void do_setPrimary(const ARGS& args) = 0;
-
-    virtual void do_cleanupMetadata(const ARGS& args) = 0;
-
-    virtual void do_cancelRequests(const ARGS& args) = 0;
-
-    virtual void do_clearPrimary(const ARGS& args) = 0;
-
-    virtual void do_setExpectedDataChunkRange(const ARGS& args) = 0;
-
-    virtual void do_resetReceiveDataCtx(const ARGS& args) = 0;
-
-    virtual void do_attemptOpenStorage(const ARGS& args) = 0;
-
-    virtual void do_updateStorage(const ARGS& args) = 0;
+    do_failurePrimaryStateResponse(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
 
     virtual void
-    do_removeStorageAndSendReplicaDataDropResponse(const ARGS& args) = 0;
+    do_replicaDataResponsePush(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_incrementNumRplcaDataRspn(const ARGS& args) = 0;
+    virtual void
+    do_replicaDataRequestPull(PartitionStateTableEvent::Enum eventType,
+                              const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_checkQuorumRplcaDataRspn(const ARGS& args) = 0;
+    virtual void
+    do_replicaDataResponsePull(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_reapplyEvent(const ARGS& args) = 0;
+    virtual void do_failureReplicaDataResponsePull(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_checkQuorumSeq(const ARGS& args) = 0;
+    virtual void do_failureReplicaDataResponsePush(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_findHighestSeq(const ARGS& args) = 0;
+    virtual void
+    do_sendDataToReplicas(PartitionStateTableEvent::Enum eventType,
+                          const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_flagFailedReplicaSeq(const ARGS& args) = 0;
+    virtual void
+    do_sendDataToPrimary(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_transitionToActivePrimary(const ARGS& args) = 0;
+    virtual void do_bufferLiveData(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
 
-    virtual void do_reapplyDetectSelfPrimary(const ARGS& args) = 0;
+    virtual void
+    do_processBufferedLiveData(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_reapplyDetectSelfReplica(const ARGS& args) = 0;
+    virtual void
+    do_clearBufferedLiveData(PartitionStateTableEvent::Enum eventType,
+                             const PartitionFSMEventData&   eventData) = 0;
 
-    virtual void do_unsupportedPrimaryDowngrade(const ARGS& args) = 0;
+    virtual void do_processBufferedPrimaryStatusAdvisories(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_processLiveData(PartitionStateTableEvent::Enum eventType,
+                       const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_setPrimary(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_cleanupMetadata(PartitionStateTableEvent::Enum eventType,
+                       const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_cancelRequests(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
+
+    virtual void do_clearPrimary(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_setExpectedDataChunkRange(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_resetReceiveDataCtx(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_attemptOpenStorage(PartitionStateTableEvent::Enum eventType,
+                          const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_updateStorage(PartitionStateTableEvent::Enum eventType,
+                                  const PartitionFSMEventData& eventData) = 0;
+
+    virtual void do_removeStorageAndSendReplicaDataDropResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_incrementNumRplcaDataRspn(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_checkQuorumRplcaDataRspn(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_reapplyEvent(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void do_checkQuorumSeq(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
+
+    virtual void do_findHighestSeq(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
+
+    virtual void
+    do_flagFailedReplicaSeq(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_transitionToActivePrimary(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_reapplyDetectSelfPrimary(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_reapplyDetectSelfReplica(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
+    do_unsupportedPrimaryDowngrade(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData& eventData) = 0;
 
     void
     do_removeStorageAndSendReplicaDataDropResponse_reapplyDetectSelfReplica(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
+
+    void do_storeReplicaSeq_primaryStateResponse_checkQuorumSeq(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
-    do_storeReplicaSeq_primaryStateResponse_checkQuorumSeq(const ARGS& args);
+    do_storeReplicaSeq_checkQuorumSeq(PartitionStateTableEvent::Enum eventType,
+                                      const PartitionFSMEventData& eventData);
 
-    void do_storeReplicaSeq_checkQuorumSeq(const ARGS& args);
-
-    void do_storePrimarySeq_replicaStateResponse(const ARGS& args);
+    void do_storePrimarySeq_replicaStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_cleanupMetadata_clearPrimary_reapplyEvent(const ARGS& args);
+    void do_cleanupMetadata_clearPrimary_reapplyEvent(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_cleanupMetadata_closeRecoveryFileSet_cancelRequests_reapplyEvent(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_cleanupMetadata_reapplyEvent(const ARGS& args);
+    void
+    do_cleanupMetadata_reapplyEvent(PartitionStateTableEvent::Enum eventType,
+                                    const PartitionFSMEventData&   eventData);
 
-    void do_cleanupMetadata_clearPrimary(const ARGS& args);
+    void
+    do_cleanupMetadata_clearPrimary(PartitionStateTableEvent::Enum eventType,
+                                    const PartitionFSMEventData&   eventData);
 
     void do_resetReceiveDataCtx_flagFailedReplicaSeq_checkQuorumSeq(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_resetReceiveDataCtx_closeRecoveryFileSet(const ARGS& args);
+    void do_resetReceiveDataCtx_closeRecoveryFileSet(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_closeRecoveryFileSet_attemptOpenStorage_sendDataToPrimary(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_primaryRemoveStorageIfNeeded_setExpectedDataChunkRange_replicaDataRequestPull(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_resetReceiveDataCtx_primaryRemoveStorage_setExpectedDataChunkRange_replicaDataRequestPull(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_setExpectedDataChunkRange_clearBufferedLiveData(const ARGS& args);
+    void do_setExpectedDataChunkRange_clearBufferedLiveData(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_resetReceiveDataCtx_storeSelfSeq_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_stopWatchdog_transitionToActivePrimary(const ARGS& args);
+    void do_stopWatchdog_transitionToActivePrimary(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_replicaStateResponse_storePrimarySeq(const ARGS& args);
+    void do_replicaStateResponse_storePrimarySeq(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_failureReplicaDataResponsePull_reapplyDetectSelfReplica(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_failureReplicaDataResponsePush_reapplyDetectSelfReplica(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_replicaDataResponsePush_resetReceiveDataCtx_closeRecoveryFileSet_attemptOpenStorage_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void do_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
     void
     do_storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
-        const ARGS& args);
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_storeReplicaSeq_sendDataToReplicas(const ARGS& args);
+    void do_storeReplicaSeq_sendDataToReplicas(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void do_storeSelfSeq_storeReplicaSeq_sendDataToReplicas(const ARGS& args);
+    void do_storeSelfSeq_storeReplicaSeq_sendDataToReplicas(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 
-    void
-    do_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(const ARGS& args);
+    void do_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData);
 };
 
 // =========================
@@ -473,33 +607,30 @@ class PartitionStateTableActions {
 // =========================
 
 /// This class is a state table for the Partition FSM.
-template <typename ARGS>
 class PartitionStateTable
-: public mqbu::StateTable<
-      PartitionStateTableState::e_NUM_STATES,
-      PartitionStateTableEvent::e_NUM_EVENTS,
-      typename PartitionStateTableActions<ARGS>::ActionFunctor> {
+: public mqbu::StateTable<PartitionStateTableState::e_NUM_STATES,
+                          PartitionStateTableEvent::e_NUM_EVENTS,
+                          PartitionStateTableActions::ActionFunctor> {
   public:
     // TYPES
-    typedef PartitionStateTableState State;
-    typedef PartitionStateTableEvent Event;
-    typedef
-        typename PartitionStateTableActions<ARGS>::ActionFunctor ActionFunctor;
+    typedef PartitionStateTableState                  State;
+    typedef PartitionStateTableEvent                  Event;
+    typedef PartitionStateTableActions::ActionFunctor ActionFunctor;
     typedef mqbu::
         StateTable<State::e_NUM_STATES, Event::e_NUM_EVENTS, ActionFunctor>
-                                       Table;
-    typedef typename Table::Transition Transition;
+                              Table;
+    typedef Table::Transition Transition;
 
   public:
     // CREATORS
     PartitionStateTable()
-    : Table(&PartitionStateTableActions<ARGS>::do_none)
+    : Table(&PartitionStateTableActions::do_none)
     {
 #define PST_CFG(s, e, a, n)                                                   \
     Table::configure(State::e_##s,                                            \
                      Event::e_##e,                                            \
                      Transition(State::e_##n,                                 \
-                                &PartitionStateTableActions<ARGS>::do_##a));
+                                &PartitionStateTableActions::do_##a));
         //       state                 event                         action
         //       next state
         PST_CFG(
@@ -861,150 +992,138 @@ class PartitionStateTable
 /// `do_<a1>_<a2>_<a3>_<a4>`, derived from the same arguments, so the name
 /// and body cannot diverge.
 #define PST_COMPOSITE_4(a1, a2, a3, a4)                                       \
-    template <typename ARGS>                                                  \
-    void PartitionStateTableActions<ARGS>::do_##a1##_##a2##_##a3##_##a4(      \
-        const ARGS& args)                                                     \
+    inline void PartitionStateTableActions::do_##a1##_##a2##_##a3##_##a4(     \
+        PartitionStateTableEvent::Enum eventType,                             \
+        const PartitionFSMEventData&   eventData)                             \
     {                                                                         \
-        do_##a1(args);                                                        \
-        do_##a2(args);                                                        \
-        do_##a3(args);                                                        \
-        do_##a4(args);                                                        \
+        do_##a1(eventType, eventData);                                        \
+        do_##a2(eventType, eventData);                                        \
+        do_##a3(eventType, eventData);                                        \
+        do_##a4(eventType, eventData);                                        \
     }
 
 /// Generate a composite action implementation that calls exactly the 5
 /// sub-actions named by the arguments, in order.
 #define PST_COMPOSITE_5(a1, a2, a3, a4, a5)                                   \
-    template <typename ARGS>                                                  \
-    void PartitionStateTableActions<                                          \
-        ARGS>::do_##a1##_##a2##_##a3##_##a4##_##a5(const ARGS& args)          \
+    inline void                                                               \
+        PartitionStateTableActions::do_##a1##_##a2##_##a3##_##a4##_##a5(      \
+            PartitionStateTableEvent::Enum eventType,                         \
+            const PartitionFSMEventData&   eventData)                         \
     {                                                                         \
-        do_##a1(args);                                                        \
-        do_##a2(args);                                                        \
-        do_##a3(args);                                                        \
-        do_##a4(args);                                                        \
-        do_##a5(args);                                                        \
+        do_##a1(eventType, eventData);                                        \
+        do_##a2(eventType, eventData);                                        \
+        do_##a3(eventType, eventData);                                        \
+        do_##a4(eventType, eventData);                                        \
+        do_##a5(eventType, eventData);                                        \
     }
 
-// CREATORS
-template <typename ARGS>
-PartitionStateTableActions<ARGS>::~PartitionStateTableActions()
-{
-    // NOTHING (pure interface)
-}
-
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_none(const ARGS& args)
-{
-    const int partitionId = args.second.partitionId();
-    BALL_LOG_INFO << "Partition FSM for Partition [" << partitionId
-                  << "]: NO ACTION PERFORMED.";
-}
-
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_removeStorageAndSendReplicaDataDropResponse_reapplyDetectSelfReplica(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_removeStorageAndSendReplicaDataDropResponse(args);
-    do_reapplyDetectSelfReplica(args);
+    do_removeStorageAndSendReplicaDataDropResponse(eventType, eventData);
+    do_reapplyDetectSelfReplica(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_startWatchdog(args);
-    do_openRecoveryFileSet(args);
-    do_storeSelfSeq(args);
-    do_replicaStateRequest(args);
-    do_checkQuorumSeq(args);
+    do_startWatchdog(eventType, eventData);
+    do_openRecoveryFileSet(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
+    do_replicaStateRequest(eventType, eventData);
+    do_checkQuorumSeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_replicaStateRequest_checkQuorumSeq(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_setPrimary(args);
-    do_startWatchdog(args);
-    do_openRecoveryFileSet(args);
-    do_storeSelfSeq(args);
-    do_replicaStateRequest(args);
-    do_checkQuorumSeq(args);
+    do_setPrimary(eventType, eventData);
+    do_startWatchdog(eventType, eventData);
+    do_openRecoveryFileSet(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
+    do_replicaStateRequest(eventType, eventData);
+    do_checkQuorumSeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_setPrimary_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_setPrimary(args);
-    do_startWatchdog(args);
-    do_openRecoveryFileSet(args);
-    do_storeSelfSeq(args);
-    do_primaryStateRequest(args);
+    do_setPrimary(eventType, eventData);
+    do_startWatchdog(eventType, eventData);
+    do_openRecoveryFileSet(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
+    do_primaryStateRequest(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_startWatchdog_openRecoveryFileSet_storeSelfSeq_primaryStateRequest(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_startWatchdog(args);
-    do_openRecoveryFileSet(args);
-    do_storeSelfSeq(args);
-    do_primaryStateRequest(args);
+    do_startWatchdog(eventType, eventData);
+    do_openRecoveryFileSet(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
+    do_primaryStateRequest(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_storeReplicaSeq_primaryStateResponse_checkQuorumSeq(const ARGS& args)
+inline void PartitionStateTableActions::
+    do_storeReplicaSeq_primaryStateResponse_checkQuorumSeq(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_storeReplicaSeq(args);
-    do_primaryStateResponse(args);
-    do_checkQuorumSeq(args);
+    do_storeReplicaSeq(eventType, eventData);
+    do_primaryStateResponse(eventType, eventData);
+    do_checkQuorumSeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_storeReplicaSeq_checkQuorumSeq(
-    const ARGS& args)
+inline void PartitionStateTableActions::do_storeReplicaSeq_checkQuorumSeq(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_storeReplicaSeq(args);
-    do_checkQuorumSeq(args);
+    do_storeReplicaSeq(eventType, eventData);
+    do_checkQuorumSeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_storePrimarySeq_replicaStateResponse(
-    const ARGS& args)
+inline void
+PartitionStateTableActions::do_storePrimarySeq_replicaStateResponse(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_storePrimarySeq(args);
-    do_replicaStateResponse(args);
+    do_storePrimarySeq(eventType, eventData);
+    do_replicaStateResponse(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_cleanupMetadata(args);
-    do_clearPrimary(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
-    do_cancelRequests(args);
+    do_cleanupMetadata(eventType, eventData);
+    do_clearPrimary(eventType, eventData);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_stopWatchdog(eventType, eventData);
+    do_cancelRequests(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_cleanupMetadata_clearPrimary_closeRecoveryFileSet_stopWatchdog_cancelRequests_reapplyEvent(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_cleanupMetadata(args);
-    do_clearPrimary(args);
-    do_closeRecoveryFileSet(args);
-    do_stopWatchdog(args);
-    do_cancelRequests(args);
-    do_reapplyEvent(args);
+    do_cleanupMetadata(eventType, eventData);
+    do_clearPrimary(eventType, eventData);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_stopWatchdog(eventType, eventData);
+    do_cancelRequests(eventType, eventData);
+    do_reapplyEvent(eventType, eventData);
 }
 
 PST_COMPOSITE_4(cleanupMetadata,
@@ -1012,217 +1131,224 @@ PST_COMPOSITE_4(cleanupMetadata,
                 cancelRequests,
                 reapplyEvent)
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_cleanupMetadata_reapplyEvent(
-    const ARGS& args)
+inline void PartitionStateTableActions::do_cleanupMetadata_reapplyEvent(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_cleanupMetadata(args);
-    do_reapplyEvent(args);
+    do_cleanupMetadata(eventType, eventData);
+    do_reapplyEvent(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_cleanupMetadata_clearPrimary(
-    const ARGS& args)
+inline void PartitionStateTableActions::do_cleanupMetadata_clearPrimary(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_cleanupMetadata(args);
-    do_clearPrimary(args);
+    do_cleanupMetadata(eventType, eventData);
+    do_clearPrimary(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<
-    ARGS>::do_cleanupMetadata_clearPrimary_reapplyEvent(const ARGS& args)
+inline void
+PartitionStateTableActions::do_cleanupMetadata_clearPrimary_reapplyEvent(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_cleanupMetadata(args);
-    do_clearPrimary(args);
-    do_reapplyEvent(args);
+    do_cleanupMetadata(eventType, eventData);
+    do_clearPrimary(eventType, eventData);
+    do_reapplyEvent(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_resetReceiveDataCtx_flagFailedReplicaSeq_checkQuorumSeq(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_resetReceiveDataCtx(args);
-    do_flagFailedReplicaSeq(args);
-    do_checkQuorumSeq(args);
+    do_resetReceiveDataCtx(eventType, eventData);
+    do_flagFailedReplicaSeq(eventType, eventData);
+    do_checkQuorumSeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<
-    ARGS>::do_resetReceiveDataCtx_closeRecoveryFileSet(const ARGS& args)
+inline void
+PartitionStateTableActions::do_resetReceiveDataCtx_closeRecoveryFileSet(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_resetReceiveDataCtx(args);
-    do_closeRecoveryFileSet(args);
+    do_resetReceiveDataCtx(eventType, eventData);
+    do_closeRecoveryFileSet(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_closeRecoveryFileSet_attemptOpenStorage_sendDataToPrimary(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_closeRecoveryFileSet(args);
-    do_attemptOpenStorage(args);
-    do_sendDataToPrimary(args);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_attemptOpenStorage(eventType, eventData);
+    do_sendDataToPrimary(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_closeRecoveryFileSet(args);
-    do_attemptOpenStorage(args);
-    do_sendDataToReplicas(args);
-    do_incrementNumRplcaDataRspn(args);
-    do_checkQuorumRplcaDataRspn(args);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_attemptOpenStorage(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
+    do_incrementNumRplcaDataRspn(eventType, eventData);
+    do_checkQuorumRplcaDataRspn(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_primaryRemoveStorageIfNeeded_setExpectedDataChunkRange_replicaDataRequestPull(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_primaryRemoveStorageIfNeeded(args);
-    do_setExpectedDataChunkRange(args);
-    do_replicaDataRequestPull(args);
+    do_primaryRemoveStorageIfNeeded(eventType, eventData);
+    do_setExpectedDataChunkRange(eventType, eventData);
+    do_replicaDataRequestPull(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_resetReceiveDataCtx_primaryRemoveStorage_setExpectedDataChunkRange_replicaDataRequestPull(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_resetReceiveDataCtx(args);
-    do_primaryRemoveStorage(args);
-    do_setExpectedDataChunkRange(args);
-    do_replicaDataRequestPull(args);
+    do_resetReceiveDataCtx(eventType, eventData);
+    do_primaryRemoveStorage(eventType, eventData);
+    do_setExpectedDataChunkRange(eventType, eventData);
+    do_replicaDataRequestPull(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<
-    ARGS>::do_setExpectedDataChunkRange_clearBufferedLiveData(const ARGS& args)
+inline void
+PartitionStateTableActions::do_setExpectedDataChunkRange_clearBufferedLiveData(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_setExpectedDataChunkRange(args);
-    do_clearBufferedLiveData(args);
+    do_setExpectedDataChunkRange(eventType, eventData);
+    do_clearBufferedLiveData(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_resetReceiveDataCtx_storeSelfSeq_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_resetReceiveDataCtx(args);
-    do_storeSelfSeq(args);
-    do_closeRecoveryFileSet(args);
-    do_attemptOpenStorage(args);
-    do_sendDataToReplicas(args);
-    do_incrementNumRplcaDataRspn(args);
-    do_checkQuorumRplcaDataRspn(args);
+    do_resetReceiveDataCtx(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_attemptOpenStorage(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
+    do_incrementNumRplcaDataRspn(eventType, eventData);
+    do_checkQuorumRplcaDataRspn(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<
-    ARGS>::do_stopWatchdog_transitionToActivePrimary(const ARGS& args)
+inline void
+PartitionStateTableActions::do_stopWatchdog_transitionToActivePrimary(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_stopWatchdog(args);
-    do_transitionToActivePrimary(args);
+    do_stopWatchdog(eventType, eventData);
+    do_transitionToActivePrimary(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_replicaStateResponse_storePrimarySeq(
-    const ARGS& args)
+inline void
+PartitionStateTableActions::do_replicaStateResponse_storePrimarySeq(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_replicaStateResponse(args);
-    do_storePrimarySeq(args);
+    do_replicaStateResponse(eventType, eventData);
+    do_storePrimarySeq(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_replicaDataResponsePull(args);
-    do_processBufferedLiveData(args);
-    do_processBufferedPrimaryStatusAdvisories(args);
-    do_stopWatchdog(args);
+    do_replicaDataResponsePull(eventType, eventData);
+    do_processBufferedLiveData(eventType, eventData);
+    do_processBufferedPrimaryStatusAdvisories(eventType, eventData);
+    do_stopWatchdog(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_failureReplicaDataResponsePull_reapplyDetectSelfReplica(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_failureReplicaDataResponsePull(args);
-    do_reapplyDetectSelfReplica(args);
+    do_failureReplicaDataResponsePull(eventType, eventData);
+    do_reapplyDetectSelfReplica(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_failureReplicaDataResponsePush_reapplyDetectSelfReplica(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_failureReplicaDataResponsePush(args);
-    do_reapplyDetectSelfReplica(args);
+    do_failureReplicaDataResponsePush(eventType, eventData);
+    do_reapplyDetectSelfReplica(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_replicaDataResponsePush_resetReceiveDataCtx_closeRecoveryFileSet_attemptOpenStorage_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_replicaDataResponsePush(args);
-    do_resetReceiveDataCtx(args);
-    do_closeRecoveryFileSet(args);
-    do_attemptOpenStorage(args);
-    do_processBufferedLiveData(args);
-    do_processBufferedPrimaryStatusAdvisories(args);
-    do_stopWatchdog(args);
+    do_replicaDataResponsePush(eventType, eventData);
+    do_resetReceiveDataCtx(eventType, eventData);
+    do_closeRecoveryFileSet(eventType, eventData);
+    do_attemptOpenStorage(eventType, eventData);
+    do_processBufferedLiveData(eventType, eventData);
+    do_processBufferedPrimaryStatusAdvisories(eventType, eventData);
+    do_stopWatchdog(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_storeReplicaSeq(args);
-    do_primaryStateResponse(args);
-    do_sendDataToReplicas(args);
+    do_storeReplicaSeq(eventType, eventData);
+    do_primaryStateResponse(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
+inline void PartitionStateTableActions::
     do_storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
-        const ARGS& args)
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_storeSelfSeq(args);
-    do_storeReplicaSeq(args);
-    do_primaryStateResponse(args);
-    do_sendDataToReplicas(args);
+    do_storeSelfSeq(eventType, eventData);
+    do_storeReplicaSeq(eventType, eventData);
+    do_primaryStateResponse(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::do_storeReplicaSeq_sendDataToReplicas(
-    const ARGS& args)
+inline void PartitionStateTableActions::do_storeReplicaSeq_sendDataToReplicas(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_storeReplicaSeq(args);
-    do_sendDataToReplicas(args);
+    do_storeReplicaSeq(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<
-    ARGS>::do_storeSelfSeq_storeReplicaSeq_sendDataToReplicas(const ARGS& args)
+inline void
+PartitionStateTableActions::do_storeSelfSeq_storeReplicaSeq_sendDataToReplicas(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
-    do_storeSelfSeq(args);
-    do_storeReplicaSeq(args);
-    do_sendDataToReplicas(args);
+    do_storeSelfSeq(eventType, eventData);
+    do_storeReplicaSeq(eventType, eventData);
+    do_sendDataToReplicas(eventType, eventData);
 }
 
-template <typename ARGS>
-void PartitionStateTableActions<ARGS>::
-    do_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(const ARGS& args)
+inline void PartitionStateTableActions::
+    do_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData)
 {
-    do_incrementNumRplcaDataRspn(args);
-    do_checkQuorumRplcaDataRspn(args);
+    do_incrementNumRplcaDataRspn(eventType, eventData);
+    do_checkQuorumRplcaDataRspn(eventType, eventData);
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -281,8 +281,8 @@ void StorageManager::onWatchdogDispatched(int partitionId, int generation)
 
     BMQTSK_ALARMLOG_ALARM("RECOVERY")
         << d_clusterData_p->identity().description() << " Partition ["
-        << partitionId
-        << "]: " << "Watchdog triggered because partition startup healing "
+        << partitionId << "]: "
+        << "Watchdog triggered because partition startup healing "
         << "sequence was not completed in the configured time of "
         << d_watchdogTimeoutInterval.totalSeconds() << " seconds. "
         << "Retries remaining: " << retriesRemaining << " of "
@@ -302,9 +302,9 @@ void StorageManager::onWatchdogDispatched(int partitionId, int generation)
         // Retries exhausted, terminate the broker
         BMQTSK_ALARMLOG_ALARM("RECOVERY")
             << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId << "]: " << "Watchdog retries exhausted after "
-            << d_watchdogNumRetries << " attempts. Terminating broker."
-            << BMQTSK_ALARMLOG_END;
+            << partitionId << "]: "
+            << "Watchdog retries exhausted after " << d_watchdogNumRetries
+            << " attempts. Terminating broker." << BMQTSK_ALARMLOG_END;
 
         mqbu::ExitUtil::shutdown(mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
     }
@@ -492,8 +492,7 @@ void StorageManager::enqueuePartitionFSMEventDispatched(
         }
     }
 
-    d_partitionFSMVec[partitionId]->enqueueEvent(
-        PartitionFSM::EventWithData(event, eventData));
+    d_partitionFSMVec[partitionId]->enqueueEvent(event, eventData);
 }
 
 void StorageManager::setPrimaryStatusForPartitionDispatched(
@@ -511,9 +510,8 @@ void StorageManager::setPrimaryStatusForPartitionDispatched(
     if (!pinfo.primary()) {
         if (!d_cluster_p->isStopping()) {
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                           << " Partition [" << partitionId
-                           << "]: " << "Failed to set primary status to "
-                           << value
+                           << " Partition [" << partitionId << "]: "
+                           << "Failed to set primary status to " << value
                            << " because primary is perceived as ** NULL **";
         }
 
@@ -523,8 +521,8 @@ void StorageManager::setPrimaryStatusForPartitionDispatched(
 
     const bmqp_ctrlmsg::PrimaryStatus::Value oldValue = pinfo.primaryStatus();
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Setting the status of primary: "
+                  << " Partition [" << partitionId << "]: "
+                  << "Setting the status of primary: "
                   << pinfo.primary()->nodeDescription()
                   << ", primaryLeaseId: " << pinfo.primaryLeaseId()
                   << ", from " << oldValue << " to " << value << ".";
@@ -587,17 +585,16 @@ void StorageManager::clearPrimaryForPartitionDispatched(
         partitionId);
 }
 
-void StorageManager::determineDataDestinations(DataDestinations* destinations,
-                                               const EventWithData& event)
+void StorageManager::determineDataDestinations(
+    DataDestinations*              destinations,
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
+    // partitionId contained in 'eventData'
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(destinations);
-
-    const PartitionFSM::Event::Enum eventType = event.first;
-    const PartitionFSMEventData&    eventData = event.second;
 
     const int partitionId = eventData.partitionId();
 
@@ -634,8 +631,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
         }
         else {
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                           << " Partition [" << partitionId
-                           << "]: " << "Replica " << source->nodeDescription()
+                           << " Partition [" << partitionId << "]: "
+                           << "Replica " << source->nodeDescription()
                            << " not found in nodeToPSNCtxMap, skipping.";
         }
     }
@@ -673,8 +670,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
                 selfFirstSyncAfterRolloverPSN) {
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription()
+                << partitionId << "]: "
+                << "Replica " << cit->first->nodeDescription()
                 << " has non-empty storage with different first sync point, "
                 << "implying that it has missed rollover.  We need to send "
                 << "ReplicaDataRequestDrop to this replica.";
@@ -691,8 +688,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             nodePSN.sequenceNumber() > PSNCit->second) {
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription() << " has PSN "
+                << partitionId << "]: "
+                << "Replica " << cit->first->nodeDescription() << " has PSN "
                 << mqbs::printPSN(nodePSN)
                 << ", while the highest PSN for the same lease ID is "
                 << mqbs::printPSN(PSNCit->first, PSNCit->second)
@@ -706,8 +703,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             nodePSN.primaryLeaseId() < selfPSN.primaryLeaseId()) {
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription() << " has PSN "
+                << partitionId << "]: "
+                << "Replica " << cit->first->nodeDescription() << " has PSN "
                 << mqbs::printPSN(nodePSN)
                 << ", whose lease id is lower than self's PSN "
                 << mqbs::printPSN(selfPSN)
@@ -727,8 +724,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
             // replica.
             BALL_LOG_INFO
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription() << " has PSN "
+                << partitionId << "]: "
+                << "Replica " << cit->first->nodeDescription() << " has PSN "
                 << mqbs::printPSN(nodePSN)
                 << ", which is lower than or equal to self's PSN "
                 << mqbs::printPSN(selfPSN)
@@ -740,8 +737,8 @@ void StorageManager::determineDataDestinations(DataDestinations* destinations,
         else {
             BALL_LOG_WARN
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId << "]: " << "Replica "
-                << cit->first->nodeDescription() << " has PSN "
+                << partitionId << "]: "
+                << "Replica " << cit->first->nodeDescription() << " has PSN "
                 << mqbs::printPSN(nodePSN)
                 << ", which is higher than self's PSN "
                 << mqbs::printPSN(selfPSN)
@@ -758,7 +755,7 @@ void StorageManager::sendReplicaDataRequestPush(
     int                     partitionId)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
+    // partitionId contained in 'eventData'
 
     const NodeToPSNCtxMap& nodeToPSNCtxMap = d_nodeToPSNCtxMapVec.at(
         partitionId);
@@ -831,7 +828,7 @@ void StorageManager::sendReplicaDataRequestDrop(
     int                     partitionId)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
+    // partitionId contained in 'eventData'
 
     mqbnet::ClusterNode* const selfNode =
         d_clusterData_p->membership().selfNode();
@@ -907,8 +904,8 @@ void StorageManager::primaryRemoveStorageImpl(int partitionId)
     if (rc != 0) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
             << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId
-            << "]: " << "Error while deprecating file set, rc: " << rc
+            << partitionId << "]: "
+            << "Error while deprecating file set, rc: " << rc
             << BMQTSK_ALARMLOG_END;
 
         mqbu::ExitUtil::terminate(mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
@@ -921,8 +918,8 @@ void StorageManager::primaryRemoveStorageImpl(int partitionId)
     if (rc != 0) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
             << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId
-            << "]: " << "Error while creating recovery file set, rc: " << rc
+            << partitionId << "]: "
+            << "Error while creating recovery file set, rc: " << rc
             << ", error: " << errorDesc.str() << BMQTSK_ALARMLOG_END;
 
         mqbu::ExitUtil::terminate(mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
@@ -940,7 +937,7 @@ void StorageManager::startSendDataChunksAsPrimary(
     int                     requestId)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
+    // partitionId contained in 'eventData'
 
     // End PSN is primary's latest PSN.
     const bmqp_ctrlmsg::PartitionSequenceNumber& endPSN =
@@ -980,8 +977,8 @@ void StorageManager::startSendDataChunksAsPrimary(
 
         if (status != 0) {
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                           << " Partition [" << partitionId
-                           << "]: " << "Failure while sending data chunks "
+                           << " Partition [" << partitionId << "]: "
+                           << "Failure while sending data chunks "
                            << ", beginPSN = " << mqbs::printPSN(beginPSN)
                            << ", endPSN = " << mqbs::printPSN(endPSN)
                            << ", rc = " << status;
@@ -992,8 +989,8 @@ void StorageManager::startSendDataChunksAsPrimary(
         }
         else {
             BALL_LOG_INFO << d_clusterData_p->identity().description()
-                          << " Partition [" << partitionId
-                          << "]: " << "Finished sending data chunks "
+                          << " Partition [" << partitionId << "]: "
+                          << "Finished sending data chunks "
                           << ", beginPSN = " << mqbs::printPSN(beginPSN)
                           << ", endPSN = " << mqbs::printPSN(endPSN)
                           << ", rc = " << status;
@@ -1040,9 +1037,9 @@ void StorageManager::processReplicaDataRequestPull(
                      partitionId < static_cast<int>(d_fileStores.size()));
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received ReplicaDataRequestPull: " << message
-                  << " from " << source->nodeDescription() << ".";
+                  << " Partition [" << partitionId << "]: "
+                  << "Received ReplicaDataRequestPull: " << message << " from "
+                  << source->nodeDescription() << ".";
 
     if (d_cluster_p->isStopping()) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
@@ -1080,8 +1077,8 @@ void StorageManager::processReplicaDataRequestPull(
                                                               source);
 
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: " << "Received ReplicaDataRequestPull from "
+                       << " Partition [" << partitionId << "]: "
+                       << "Received ReplicaDataRequestPull from "
                        << source->nodeDescription() << " with end PSN: "
                        << mqbs::printPSN(
                               replicaDataRequest.endSequenceNumber())
@@ -1141,9 +1138,9 @@ void StorageManager::processReplicaDataRequestPush(
         d_clusterState_p->partitionsInfo().at(partitionId).primaryNodeId());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received ReplicaDataRequestPush: " << message
-                  << " from " << source->nodeDescription() << ".";
+                  << " Partition [" << partitionId << "]: "
+                  << "Received ReplicaDataRequestPush: " << message << " from "
+                  << source->nodeDescription() << ".";
 
     if (d_cluster_p->isStopping()) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
@@ -1258,9 +1255,9 @@ void StorageManager::processReplicaDataRequestDrop(
     }
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received ReplicaDataRequestDrop: " << message
-                  << " from " << source->nodeDescription() << ".";
+                  << " Partition [" << partitionId << "]: "
+                  << "Received ReplicaDataRequestDrop: " << message << " from "
+                  << source->nodeDescription() << ".";
 
     if (d_cluster_p->isStopping()) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
@@ -1457,8 +1454,8 @@ void StorageManager::processReplicaStateResponseDispatched(
 
     if (requestContext->result() != bmqt::GenericResult::e_SUCCESS) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << " Partition [" << requestPartitionId
-                      << "]: " << "Received failed ReplicaStateResponse "
+                      << " Partition [" << requestPartitionId << "]: "
+                      << "Received failed ReplicaStateResponse "
                       << requestContext->response() << " from "
                       << responder->nodeDescription() << ".";
 
@@ -1513,8 +1510,8 @@ void StorageManager::processReplicaStateResponseDispatched(
     BSLS_ASSERT_SAFE(response.partitionId() == requestPartitionId);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << requestPartitionId
-                  << "]: " << "Received ReplicaStateResponse "
+                  << " Partition [" << requestPartitionId << "]: "
+                  << "Received ReplicaStateResponse "
                   << requestContext->response() << " from "
                   << responder->nodeDescription();
 
@@ -1778,13 +1775,13 @@ void StorageManager::forceFlushFileStores()
     StorageUtil::forceFlushFileStores(&d_fileStores);
 }
 
-void StorageManager::do_startWatchdog(const EventWithData& event)
+void StorageManager::do_startWatchdog(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     WatchdogContext& ctx = d_watchdogContexts[partitionId];
 
@@ -1810,13 +1807,13 @@ void StorageManager::do_startWatchdog(const EventWithData& event)
     }
 }
 
-void StorageManager::do_stopWatchdog(const EventWithData& event)
+void StorageManager::do_stopWatchdog(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     WatchdogContext& ctx = d_watchdogContexts[partitionId];
 
@@ -1830,18 +1827,18 @@ void StorageManager::do_stopWatchdog(const EventWithData& event)
     const int rc = d_clusterData_p->scheduler().cancelEvent(ctx.d_eventHandle);
     if (rc != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: " << "Failed to cancel Watchdog, rc: " << rc;
+                       << " Partition [" << partitionId << "]: "
+                       << "Failed to cancel Watchdog, rc: " << rc;
     }
 }
 
-void StorageManager::do_openRecoveryFileSet(const EventWithData& event)
+void StorageManager::do_openRecoveryFileSet(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     mqbs::FileStore* fs = d_fileStores[partitionId].get();
     BSLS_ASSERT_SAFE(fs);
@@ -1889,13 +1886,13 @@ void StorageManager::do_openRecoveryFileSet(const EventWithData& event)
     }
 }
 
-void StorageManager::do_closeRecoveryFileSet(const EventWithData& event)
+void StorageManager::do_closeRecoveryFileSet(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     mqbs::FileStore* fs = d_fileStores[partitionId].get();
     BSLS_ASSERT_SAFE(fs);
@@ -1914,20 +1911,20 @@ void StorageManager::do_closeRecoveryFileSet(const EventWithData& event)
     if (rc != 0) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
             << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId
-            << "]: " << "Failure while closing recovery file set, rc: " << rc
+            << partitionId << "]: "
+            << "Failure while closing recovery file set, rc: " << rc
             << BMQTSK_ALARMLOG_END;
 
         mqbu::ExitUtil::terminate(mqbu::ExitCode::e_RECOVERY_FAILURE);  // EXIT
     }
 }
 
-void StorageManager::do_storeSelfSeq(const EventWithData& event)
+void StorageManager::do_storeSelfSeq(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -1950,8 +1947,8 @@ void StorageManager::do_storeSelfSeq(const EventWithData& event)
         if (rc != 0) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
                 << d_clusterData_p->identity().description() << " Partition ["
-                << partitionId
-                << "]: " << "Error while recovering PSN, rc: " << rc
+                << partitionId << "]: "
+                << "Error while recovering PSN, rc: " << rc
                 << BMQTSK_ALARMLOG_END;
 
             mqbu::ExitUtil::terminate(
@@ -1970,12 +1967,12 @@ void StorageManager::do_storeSelfSeq(const EventWithData& event)
                          nodePSNCtx.d_firstSyncPointAfterRolloverPSN);
 }
 
-void StorageManager::do_storePrimarySeq(const EventWithData& event)
+void StorageManager::do_storePrimarySeq(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     int partitionId = eventData.partitionId();
     const bmqp_ctrlmsg::PartitionSequenceNumber& PSN =
@@ -2021,12 +2018,12 @@ void StorageManager::do_storePrimarySeq(const EventWithData& event)
     }
 }
 
-void StorageManager::do_storeReplicaSeq(const EventWithData& event)
+void StorageManager::do_storeReplicaSeq(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     const bmqp_ctrlmsg::PartitionSequenceNumber& PSN =
@@ -2053,7 +2050,7 @@ void StorageManager::do_storeReplicaSeq(const EventWithData& event)
         hasNew = true;
     }
     else if (PSN > it->second.d_PSN ||
-             event.first == PartitionFSM::Event::e_PRIMARY_STATE_RQST) {
+             eventType == PartitionFSM::Event::e_PRIMARY_STATE_RQST) {
         it->second.d_PSN = PSN;
         it->second.d_firstSyncPointAfterRolloverPSN =
             eventData.firstSyncPointAfterRolloverPSN();
@@ -2072,12 +2069,12 @@ void StorageManager::do_storeReplicaSeq(const EventWithData& event)
     }
 }
 
-void StorageManager::do_replicaStateRequest(const EventWithData& event)
+void StorageManager::do_replicaStateRequest(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -2151,12 +2148,12 @@ void StorageManager::do_replicaStateRequest(const EventWithData& event)
     }
 }
 
-void StorageManager::do_replicaStateResponse(const EventWithData& event)
+void StorageManager::do_replicaStateResponse(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -2197,12 +2194,12 @@ void StorageManager::do_replicaStateResponse(const EventWithData& event)
                   << eventData.source()->nodeDescription();
 }
 
-void StorageManager::do_failureReplicaStateResponse(const EventWithData& event)
+void StorageManager::do_failureReplicaStateResponse(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -2220,9 +2217,8 @@ void StorageManager::do_failureReplicaStateResponse(const EventWithData& event)
 
         BALL_LOG_INFO
             << d_clusterData_p->identity().description() << " Partition ["
-            << partitionId
-            << "]: " << "Self not replica! Sent failure response "
-            << controlMsg
+            << partitionId << "]: "
+            << "Self not replica! Sent failure response " << controlMsg
             << " to ReplicaStateRequest from node claiming to be primary "
             << eventData.source()->nodeDescription() << ".";
     }
@@ -2251,12 +2247,11 @@ void StorageManager::do_failureReplicaStateResponse(const EventWithData& event)
 }
 
 void StorageManager::do_logFailureReplicaStateResponse(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     int                        partitionId = eventData.partitionId();
     const mqbnet::ClusterNode* sourceNode  = eventData.source();
@@ -2271,12 +2266,11 @@ void StorageManager::do_logFailureReplicaStateResponse(
 }
 
 void StorageManager::do_logFailurePrimaryStateResponse(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     int                        partitionId = eventData.partitionId();
     const mqbnet::ClusterNode* sourceNode  = eventData.source();
@@ -2293,12 +2287,11 @@ void StorageManager::do_logFailurePrimaryStateResponse(
 }
 
 void StorageManager::do_logUnexpectedPrimaryStateResponse(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     int                        partitionId = eventData.partitionId();
     const mqbnet::ClusterNode* sourceNode  = eventData.source();
@@ -2320,12 +2313,11 @@ void StorageManager::do_logUnexpectedPrimaryStateResponse(
 }
 
 void StorageManager::do_logUnexpectedFailurePrimaryStateResponse(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     int                        partitionId = eventData.partitionId();
     const mqbnet::ClusterNode* sourceNode  = eventData.source();
@@ -2345,12 +2337,12 @@ void StorageManager::do_logUnexpectedFailurePrimaryStateResponse(
         << "when in REPLICA_WAITING state.";
 }
 
-void StorageManager::do_primaryStateRequest(const EventWithData& event)
+void StorageManager::do_primaryStateRequest(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* primary     = eventData.primary();
@@ -2414,12 +2406,12 @@ void StorageManager::do_primaryStateRequest(const EventWithData& event)
     }
 }
 
-void StorageManager::do_primaryStateResponse(const EventWithData& event)
+void StorageManager::do_primaryStateResponse(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -2456,12 +2448,12 @@ void StorageManager::do_primaryStateResponse(const EventWithData& event)
                   << eventData.source()->nodeDescription();
 }
 
-void StorageManager::do_failurePrimaryStateResponse(const EventWithData& event)
+void StorageManager::do_failurePrimaryStateResponse(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(eventData.source());
@@ -2484,19 +2476,18 @@ void StorageManager::do_failurePrimaryStateResponse(const EventWithData& event)
     fileStore(partitionId).sendMessage(controlMsg, eventData.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Self not primary! Sent failure response "
-                  << controlMsg
+                  << " Partition [" << partitionId << "]: "
+                  << "Self not primary! Sent failure response " << controlMsg
                   << " to PrimaryStateRequest from node who thinks otherwise "
                   << eventData.source()->nodeDescription() << ".";
 }
 
-void StorageManager::do_replicaDataResponsePush(const EventWithData& event)
+void StorageManager::do_replicaDataResponsePush(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* destNode    = eventData.source();
@@ -2541,18 +2532,18 @@ void StorageManager::do_replicaDataResponsePush(const EventWithData& event)
     fileStore(partitionId).sendMessage(controlMsg, destNode);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId << "]: " << "Sent response "
-                  << controlMsg
+                  << " Partition [" << partitionId << "]: "
+                  << "Sent response " << controlMsg
                   << " to ReplicaDataRequestPush from primary node "
                   << destNode->nodeDescription() << ".";
 }
 
-void StorageManager::do_replicaDataRequestPull(const EventWithData& event)
+void StorageManager::do_replicaDataRequestPull(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -2610,12 +2601,12 @@ void StorageManager::do_replicaDataRequestPull(const EventWithData& event)
     }
 }
 
-void StorageManager::do_replicaDataResponsePull(const EventWithData& event)
+void StorageManager::do_replicaDataResponsePull(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -2655,12 +2646,11 @@ void StorageManager::do_replicaDataResponsePull(const EventWithData& event)
 }
 
 void StorageManager::do_failureReplicaDataResponsePull(
-    const EventWithData& event)
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -2677,7 +2667,7 @@ void StorageManager::do_failureReplicaDataResponsePull(
 
     bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
     status.category()            = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
-    if (event.first == PartitionFSM::Event::e_IRRECONCILABLE_DATA) {
+    if (eventType == PartitionFSM::Event::e_IRRECONCILABLE_DATA) {
         status.code()    = mqbi::ClusterErrorCode::e_IRRECONCILABLE_DATA;
         status.message() = "Primary has irreconcilable data";
     }
@@ -2689,24 +2679,25 @@ void StorageManager::do_failureReplicaDataResponsePull(
     fileStore(partitionId).sendMessage(controlMsg, destNode);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Sent failure response " << controlMsg
+                  << " Partition [" << partitionId << "]: "
+                  << "Sent failure response " << controlMsg
                   << " to ReplicaDataRequestPull from primary node "
                   << destNode->nodeDescription() << ".";
 }
 
 void StorageManager::do_failureReplicaDataResponsePush(
-    BSLA_MAYBE_UNUSED const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    BSLA_MAYBE_UNUSED const PartitionFSMEventData&   eventData)
 {
     // TODO: Complete Impl
 }
 
-void StorageManager::do_sendDataToReplicas(const EventWithData& event)
+void StorageManager::do_sendDataToReplicas(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -2734,7 +2725,7 @@ void StorageManager::do_sendDataToReplicas(const EventWithData& event)
     }
 
     DataDestinations destinations;
-    determineDataDestinations(&destinations, event);
+    determineDataDestinations(&destinations, eventType, eventData);
     sendReplicaDataRequestPush(destinations, partitionId);
     sendReplicaDataRequestDrop(destinations, partitionId);
     startSendDataChunksAsPrimary(destinations,
@@ -2742,13 +2733,12 @@ void StorageManager::do_sendDataToReplicas(const EventWithData& event)
                                  eventData.requestId());
 }
 
-void StorageManager::do_sendDataToPrimary(const EventWithData& event)
+void StorageManager::do_sendDataToPrimary(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSM::Event::Enum eventType = event.first;
-    const PartitionFSMEventData&    eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -2800,9 +2790,9 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
     if (PSNCit != highestPSNs.end() &&
         beginSeqNum.sequenceNumber() > PSNCit->second) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId << "]: " << "Primary "
-                      << destNode->nodeDescription() << " has PSN "
-                      << mqbs::printPSN(beginSeqNum)
+                      << " Partition [" << partitionId << "]: "
+                      << "Primary " << destNode->nodeDescription()
+                      << " has PSN " << mqbs::printPSN(beginSeqNum)
                       << ", while the highest PSN for the same lease ID is "
                       << mqbs::printPSN(PSNCit->first, PSNCit->second)
                       << ", implying that primary has irreconcilable "
@@ -2816,9 +2806,9 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
 
     if (PSNCit == highestPSNs.end() && beginSeqNum.primaryLeaseId() > 0) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId << "]: " << "Primary "
-                      << destNode->nodeDescription() << " has PSN "
-                      << mqbs::printPSN(beginSeqNum)
+                      << " Partition [" << partitionId << "]: "
+                      << "Primary " << destNode->nodeDescription()
+                      << " has PSN " << mqbs::printPSN(beginSeqNum)
                       << ", whose lease id is lower than self's PSN "
                       << mqbs::printPSN(endSeqNum)
                       << ", and there is no known highest PSN for the "
@@ -2839,8 +2829,8 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
 
     if (status != 0) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: " << "Failure while sending data chunks "
+                       << " Partition [" << partitionId << "]: "
+                       << "Failure while sending data chunks "
                        << ", beginPSN = " << mqbs::printPSN(beginSeqNum)
                        << ", endPSN = " << mqbs::printPSN(endSeqNum)
                        << ", rc = " << status;
@@ -2851,8 +2841,8 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
     }
     else {
         BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Finished sending data chunks "
+                      << " Partition [" << partitionId << "]: "
+                      << "Finished sending data chunks "
                       << ", beginPSN = " << mqbs::printPSN(beginSeqNum)
                       << ", endPSN = " << mqbs::printPSN(endSeqNum)
                       << ", rc = " << status;
@@ -2863,12 +2853,12 @@ void StorageManager::do_sendDataToPrimary(const EventWithData& event)
     }
 }
 
-void StorageManager::do_bufferLiveData(const EventWithData& event)
+void StorageManager::do_bufferLiveData(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* source      = eventData.source();
@@ -2897,12 +2887,12 @@ void StorageManager::do_bufferLiveData(const EventWithData& event)
                                              source);
 }
 
-void StorageManager::do_processBufferedLiveData(const EventWithData& event)
+void StorageManager::do_processBufferedLiveData(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* primary = d_partitionInfoVec[partitionId].primary();
@@ -2919,8 +2909,8 @@ void StorageManager::do_processBufferedLiveData(const EventWithData& event)
     BSLS_ASSERT_SAFE(fs);
     if (!fs->isOpen()) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: " << "Cannot process buffered live data because "
+                       << " Partition [" << partitionId << "]: "
+                       << "Cannot process buffered live data because "
                        << "file store is not opened.";
 
         return;  // RETURN
@@ -2936,8 +2926,8 @@ void StorageManager::do_processBufferedLiveData(const EventWithData& event)
     }
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Opened successfully, applying "
+                  << " Partition [" << partitionId << "]: "
+                  << "Opened successfully, applying "
                   << bufferedStorageEvents.size()
                   << " buffered storage events to the partition.";
 
@@ -2966,12 +2956,12 @@ void StorageManager::do_processBufferedLiveData(const EventWithData& event)
     }
 }
 
-void StorageManager::do_clearBufferedLiveData(const EventWithData& event)
+void StorageManager::do_clearBufferedLiveData(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -2984,12 +2974,11 @@ void StorageManager::do_clearBufferedLiveData(const EventWithData& event)
 }
 
 void StorageManager::do_processBufferedPrimaryStatusAdvisories(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3019,12 +3008,12 @@ void StorageManager::do_processBufferedPrimaryStatusAdvisories(
     }
 }
 
-void StorageManager::do_processLiveData(const EventWithData& event)
+void StorageManager::do_processLiveData(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* source      = eventData.source();
@@ -3058,12 +3047,12 @@ void StorageManager::do_processLiveData(const EventWithData& event)
                             source);
 }
 
-void StorageManager::do_setPrimary(const EventWithData& event)
+void StorageManager::do_setPrimary(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* primary     = eventData.primary();
@@ -3086,12 +3075,12 @@ void StorageManager::do_setPrimary(const EventWithData& event)
     pinfo.setPrimaryStatus(bmqp_ctrlmsg::PrimaryStatus::E_PASSIVE);
 }
 
-void StorageManager::do_cleanupMetadata(const EventWithData& event)
+void StorageManager::do_cleanupMetadata(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3109,12 +3098,12 @@ void StorageManager::do_cleanupMetadata(const EventWithData& event)
     d_recoveryManager_mp->resetReceiveDataCtx(partitionId);
 }
 
-void StorageManager::do_clearPrimary(const EventWithData& event)
+void StorageManager::do_clearPrimary(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3130,12 +3119,12 @@ void StorageManager::do_clearPrimary(const EventWithData& event)
         partitionId);
 }
 
-void StorageManager::do_cancelRequests(const EventWithData& event)
+void StorageManager::do_cancelRequests(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -3152,20 +3141,20 @@ void StorageManager::do_cancelRequests(const EventWithData& event)
         bmqp::RequestManagerComponentId::partitionFSM(partitionId));
 }
 
-void StorageManager::do_setExpectedDataChunkRange(const EventWithData& event)
+void StorageManager::do_setExpectedDataChunkRange(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId       = eventData.partitionId();
     mqbnet::ClusterNode* highestSeqNumNode = eventData.highestSeqNumNode();
 
     const mqbs::FileStore& fs = fileStore(partitionId);
 
-    if (event.first == PartitionFSM::Event::e_REPLICA_HIGHEST_SEQ ||
-        event.first ==
+    if (eventType == PartitionFSM::Event::e_REPLICA_HIGHEST_SEQ ||
+        eventType ==
             PartitionFSM::Event::e_IRRECONCILABLE_REPLICA_DATA_RSPN_PULL) {
         // Self Primary is expecting data from highest seq num replica.
 
@@ -3181,7 +3170,7 @@ void StorageManager::do_setExpectedDataChunkRange(const EventWithData& event)
             selfSeqNum,
             eventData.partitionSequenceNumber());
     }
-    else if (event.first == PartitionFSM::Event::e_REPLICA_DATA_RQST_PUSH) {
+    else if (eventType == PartitionFSM::Event::e_REPLICA_DATA_RQST_PUSH) {
         // Self Replica is expecting data from the primary.
 
         if (eventData.partitionSeqNumDataRange().first ==
@@ -3212,30 +3201,30 @@ void StorageManager::do_setExpectedDataChunkRange(const EventWithData& event)
     }
     else {
         bmqu::MemOutStream out;
-        out << "Partition [" << partitionId << "]'s FSM " << "(state = '"
-            << d_partitionFSMVec[partitionId]->state() << "')"
-            << ": Unexpected event '" << event.first
+        out << "Partition [" << partitionId << "]'s FSM "
+            << "(state = '" << d_partitionFSMVec[partitionId]->state() << "')"
+            << ": Unexpected event '" << eventType
             << "' caused action 'do_setExpectedDataChunkRange'.";
         BSLS_ASSERT_SAFE(false && out.str().data());
     }
 }
 
-void StorageManager::do_resetReceiveDataCtx(const EventWithData& event)
+void StorageManager::do_resetReceiveDataCtx(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     d_recoveryManager_mp->resetReceiveDataCtx(eventData.partitionId());
 }
 
-void StorageManager::do_attemptOpenStorage(const EventWithData& event)
+void StorageManager::do_attemptOpenStorage(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(!d_recoveryManager_mp->expectedDataChunks(partitionId));
@@ -3263,12 +3252,12 @@ void StorageManager::do_attemptOpenStorage(const EventWithData& event)
     }
 }
 
-void StorageManager::do_updateStorage(const EventWithData& event)
+void StorageManager::do_updateStorage(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int            partitionId = eventData.partitionId();
     mqbnet::ClusterNode* source      = eventData.source();
@@ -3300,8 +3289,8 @@ void StorageManager::do_updateStorage(const EventWithData& event)
 
         if (bmqp_ctrlmsg::PrimaryStatus::E_PASSIVE != pinfo.primaryStatus()) {
             BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                           << " Partition [" << partitionId
-                           << "]: " << "Received a partition sync event from: "
+                           << " Partition [" << partitionId << "]: "
+                           << "Received a partition sync event from: "
                            << source->nodeDescription()
                            << ", while self is ACTIVE replica.";
             return;  // RETURN
@@ -3309,8 +3298,8 @@ void StorageManager::do_updateStorage(const EventWithData& event)
     }
     else if (pinfo.primary()->nodeId() != source->nodeId()) {
         BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId
-                       << "]: " << "Received a partition sync event from: "
+                       << " Partition [" << partitionId << "]: "
+                       << "Received a partition sync event from: "
                        << source->nodeDescription()
                        << ", but neither self is primary nor the sender is "
                        << "perceived as the primary.";
@@ -3338,8 +3327,8 @@ void StorageManager::do_updateStorage(const EventWithData& event)
         firstSyncPointAfterRolloverSeqNum);
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received status " << rc
+                  << " Partition [" << partitionId << "]: "
+                  << "Received status " << rc
                   << " for receiving data chunks from Recovery Manager.";
 
     PartitionFSMEventData eventDataOut(source,
@@ -3364,16 +3353,14 @@ void StorageManager::do_updateStorage(const EventWithData& event)
 }
 
 void StorageManager::do_primaryRemoveStorageIfNeeded(
-    const EventWithData& event)
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     // Self Primary is expecting data from highest seq num replica.
-    BSLS_ASSERT_SAFE(event.first ==
-                     PartitionFSM::Event::e_REPLICA_HIGHEST_SEQ);
+    BSLS_ASSERT_SAFE(eventType == PartitionFSM::Event::e_REPLICA_HIGHEST_SEQ);
 
     const int            partitionId       = eventData.partitionId();
     mqbnet::ClusterNode* highestSeqNumNode = eventData.highestSeqNumNode();
@@ -3399,13 +3386,13 @@ void StorageManager::do_primaryRemoveStorageIfNeeded(
     }
 }
 
-void StorageManager::do_primaryRemoveStorage(const EventWithData& event)
+void StorageManager::do_primaryRemoveStorage(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
     BSLS_ASSERT_SAFE(d_partitionFSMVec.at(partitionId)->isSelfPrimary());
@@ -3414,8 +3401,8 @@ void StorageManager::do_primaryRemoveStorage(const EventWithData& event)
     BSLS_ASSERT_SAFE(highestSeqNumNode);
 
     BALL_LOG_WARN << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId << "]: " << "Replica "
-                  << highestSeqNumNode->nodeDescription()
+                  << " Partition [" << partitionId << "]: "
+                  << "Replica " << highestSeqNumNode->nodeDescription()
                   << " reported irreconcilable data on self primary. "
                   << "Removing entire storage and requesting it from replica.";
 
@@ -3423,12 +3410,11 @@ void StorageManager::do_primaryRemoveStorage(const EventWithData& event)
 }
 
 void StorageManager::do_removeStorageAndSendReplicaDataDropResponse(
-    const EventWithData& event)
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
@@ -3442,8 +3428,8 @@ void StorageManager::do_removeStorageAndSendReplicaDataDropResponse(
 
     BALL_LOG_WARN
         << d_clusterData_p->identity().description() << " Partition ["
-        << partitionId
-        << "]: " << "self's storage is out of sync with primary and cannot be "
+        << partitionId << "]: "
+        << "self's storage is out of sync with primary and cannot be "
         << "healed trivially. Removing entire storage and requesting it from "
         << "primary.";
 
@@ -3492,18 +3478,18 @@ void StorageManager::do_removeStorageAndSendReplicaDataDropResponse(
     fileStore(partitionId).sendMessage(controlMsg, eventData.source());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId << "]: " << "Sent response "
-                  << controlMsg
+                  << " Partition [" << partitionId << "]: "
+                  << "Sent response " << controlMsg
                   << " to ReplicaDataRequestDrop from primary node "
                   << destNode->nodeDescription() << ".";
 }
 
-void StorageManager::do_incrementNumRplcaDataRspn(const EventWithData& event)
+void StorageManager::do_incrementNumRplcaDataRspn(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId    = eventData.partitionId();
     const int incrementCount = eventData.incrementCount();
@@ -3527,12 +3513,12 @@ void StorageManager::do_incrementNumRplcaDataRspn(const EventWithData& event)
     d_numReplicaDataResponsesReceivedVec[partitionId] += incrementCount;
 }
 
-void StorageManager::do_checkQuorumRplcaDataRspn(const EventWithData& event)
+void StorageManager::do_checkQuorumRplcaDataRspn(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3544,7 +3530,8 @@ void StorageManager::do_checkQuorumRplcaDataRspn(const EventWithData& event)
         getSeqNumQuorum()) {
         // If we have a quorum of replica data responses (including self)
         BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId << "]: " << "A quorum ("
+                      << " Partition [" << partitionId << "]: "
+                      << "A quorum ("
                       << d_numReplicaDataResponsesReceivedVec[partitionId]
                       << ") of cluster nodes now has healed partitions. "
                       << "Transitiong self to healed primary";
@@ -3555,29 +3542,28 @@ void StorageManager::do_checkQuorumRplcaDataRspn(const EventWithData& event)
     }
 }
 
-void StorageManager::do_reapplyEvent(const EventWithData& event)
+void StorageManager::do_reapplyEvent(PartitionStateTableEvent::Enum eventType,
+                                     const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << " Re-apply event: " << event.first
+                  << " Partition [" << partitionId << "]: "
+                  << " Re-apply event: " << eventType
                   << " in the Partition FSM.";
 
-    enqueuePartitionFSMEvent(event.first, event.second);
+    enqueuePartitionFSMEvent(eventType, eventData);
 }
 
-void StorageManager::do_checkQuorumSeq(const EventWithData& event)
+void StorageManager::do_checkQuorumSeq(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3590,21 +3576,21 @@ void StorageManager::do_checkQuorumSeq(const EventWithData& event)
         // If we have a quorum of Replica PSNs (including self PSN)
 
         BALL_LOG_INFO << d_clusterData_p->identity().description()
-                      << " Partition [" << partitionId
-                      << "]: " << "Achieved a quorum of PSNs with a count of "
+                      << " Partition [" << partitionId << "]: "
+                      << "Achieved a quorum of PSNs with a count of "
                       << d_nodeToPSNCtxMapVec[partitionId].size();
 
         enqueuePartitionFSMEvent(PartitionFSM::Event::e_QUORUM_REPLICA_SEQ,
-                                 event.second);
+                                 eventData);
     }
 }
 
-void StorageManager::do_findHighestSeq(const EventWithData& event)
+void StorageManager::do_findHighestSeq(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3665,12 +3651,12 @@ void StorageManager::do_findHighestSeq(const EventWithData& event)
     }
 }
 
-void StorageManager::do_flagFailedReplicaSeq(const EventWithData& event)
+void StorageManager::do_flagFailedReplicaSeq(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData = event.second;
+    // partitionId contained in 'eventData'
 
     const int partitionId = eventData.partitionId();
 
@@ -3685,13 +3671,13 @@ void StorageManager::do_flagFailedReplicaSeq(const EventWithData& event)
     d_nodeToPSNCtxMapVec[partitionId].erase(eventData.source());
 }
 
-void StorageManager::do_transitionToActivePrimary(const EventWithData& event)
+void StorageManager::do_transitionToActivePrimary(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
@@ -3706,13 +3692,13 @@ void StorageManager::do_transitionToActivePrimary(const EventWithData& event)
                                         0);  // status
 }
 
-void StorageManager::do_reapplyDetectSelfPrimary(const EventWithData& event)
+void StorageManager::do_reapplyDetectSelfPrimary(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
@@ -3733,13 +3719,13 @@ void StorageManager::do_reapplyDetectSelfPrimary(const EventWithData& event)
                              eventDataOut);
 }
 
-void StorageManager::do_reapplyDetectSelfReplica(const EventWithData& event)
+void StorageManager::do_reapplyDetectSelfReplica(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
 
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
@@ -3760,18 +3746,17 @@ void StorageManager::do_reapplyDetectSelfReplica(const EventWithData& event)
                              eventDataOut);
 }
 
-void StorageManager::do_unsupportedPrimaryDowngrade(const EventWithData& event)
+void StorageManager::do_unsupportedPrimaryDowngrade(
+    PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&   eventData)
 {
     // executed by the *QUEUE DISPATCHER* thread associated with the
-    // paritionId contained in 'event'
-
-    const PartitionFSMEventData& eventData   = event.second;
-    const int                    partitionId = eventData.partitionId();
+    // partitionId contained in 'eventData'
+    const int partitionId = eventData.partitionId();
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
 
-    BSLS_ASSERT_SAFE(event.first ==
-                     PartitionFSM::Event::e_DETECT_SELF_REPLICA);
+    BSLS_ASSERT_SAFE(eventType == PartitionFSM::Event::e_DETECT_SELF_REPLICA);
 
     BMQTSK_ALARMLOG_ALARM("CLUSTER")
         << d_clusterData_p->identity().description() << " Partition ["
@@ -4475,9 +4460,9 @@ void StorageManager::processPrimaryStateRequest(
                      partitionId < static_cast<int>(d_fileStores.size()));
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received PrimaryStateRequest: " << message
-                  << " from " << source->nodeDescription() << ".";
+                  << " Partition [" << partitionId << "]: "
+                  << "Received PrimaryStateRequest: " << message << " from "
+                  << source->nodeDescription() << ".";
 
     if (d_cluster_p->isStopping()) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
@@ -4532,9 +4517,9 @@ void StorageManager::processReplicaStateRequest(
                      partitionId < static_cast<int>(d_fileStores.size()));
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << " Partition [" << partitionId
-                  << "]: " << "Received ReplicaStateRequest: " << message
-                  << " from " << source->nodeDescription() << ".";
+                  << " Partition [" << partitionId << "]: "
+                  << "Received ReplicaStateRequest: " << message << " from "
+                  << source->nodeDescription() << ".";
 
     if (d_cluster_p->isStopping()) {
         BALL_LOG_WARN << d_clusterData_p->identity().description()
@@ -4666,8 +4651,8 @@ void StorageManager::processStorageEvent(const mqbevt::StorageEvent& event)
     // Ensure that 'pid' is valid.
     if (pid >= d_clusterState_p->partitions().size()) {
         BMQTSK_ALARMLOG_ALARM("STORAGE")
-            << d_cluster_p->description() << " Partition [" << pid
-            << "]: " << "Received "
+            << d_cluster_p->description() << " Partition [" << pid << "]: "
+            << "Received "
             << (rawEvent.isStorageEvent() ? "storage " : "partition-sync ")
             << "event from node " << source->nodeDescription() << " with "
             << "invalid Partition Id [" << pid << "]. Ignoring "

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -100,10 +100,9 @@ class StorageManagerIterator;
 /// on storage partitions. Every operation including and not limited to change
 /// in partition node ownership and syncing partition info should be routed via
 /// this component.
-class StorageManager BSLS_KEYWORD_FINAL
-: public mqbi::StorageManager,
-  public PartitionStateTableActions<PartitionFSM::EventWithData>,
-  public PartitionFSMObserver {
+class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager,
+                                          public PartitionStateTableActions,
+                                          public PartitionFSMObserver {
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBC.STORAGEMANAGER");
@@ -181,8 +180,6 @@ class StorageManager BSLS_KEYWORD_FINAL
 
   public:
     // TYPES
-    typedef PartitionFSM::EventWithData EventWithData;
-
     /// Pool of shared pointers to Blobs
     typedef StorageUtil::BlobSpPool BlobSpPool;
 
@@ -509,8 +506,9 @@ class StorageManager BSLS_KEYWORD_FINAL
 
     /// Determine which nodes to send ReplicaDataRequestPush/Drop based on the
     /// `event`, and populate the specified `destinations`.
-    void determineDataDestinations(DataDestinations*    destinations,
-                                   const EventWithData& event);
+    void determineDataDestinations(DataDestinations*              destinations,
+                                   PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData&   eventData);
 
     /// For `partitionId`, send ReplicaDataRequestPush to the `destinations`
     /// replicas`.
@@ -614,140 +612,205 @@ class StorageManager BSLS_KEYWORD_FINAL
     void forceFlushFileStores();
 
     //   (virtual: mqbc::PartitionStateTableActions)
-    void do_startWatchdog(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_stopWatchdog(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_openRecoveryFileSet(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_closeRecoveryFileSet(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_storeSelfSeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_storePrimarySeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_storeReplicaSeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_replicaStateRequest(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_replicaStateResponse(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_failureReplicaStateResponse(const EventWithData& event)
+    void do_startWatchdog(PartitionStateTableEvent::Enum eventType,
+                          const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_logFailureReplicaStateResponse(const EventWithData& event)
+    void do_stopWatchdog(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_logFailurePrimaryStateResponse(const EventWithData& event)
+    void do_openRecoveryFileSet(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_logUnexpectedPrimaryStateResponse(const EventWithData& event)
+    void do_closeRecoveryFileSet(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
+
+    void do_storeSelfSeq(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_storePrimarySeq(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_storeReplicaSeq(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_replicaStateRequest(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_replicaStateResponse(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_failureReplicaStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_logFailureReplicaStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_logFailurePrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_logUnexpectedPrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
 
     void do_logUnexpectedFailurePrimaryStateResponse(
-        const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_primaryStateRequest(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_primaryStateResponse(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_primaryRemoveStorageIfNeeded(const EventWithData& event)
+    void do_primaryStateRequest(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_primaryRemoveStorage(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_failurePrimaryStateResponse(const EventWithData& event)
+    void do_primaryStateResponse(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_replicaDataResponsePush(const EventWithData& event)
+    void do_primaryRemoveStorageIfNeeded(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_primaryRemoveStorage(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_replicaDataRequestPull(const EventWithData& event)
+    void do_failurePrimaryStateResponse(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_replicaDataResponsePush(PartitionStateTableEvent::Enum eventType,
+                                    const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_replicaDataResponsePull(const EventWithData& event)
+    void do_replicaDataRequestPull(PartitionStateTableEvent::Enum eventType,
+                                   const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_failureReplicaDataResponsePull(const EventWithData& event)
+    void do_replicaDataResponsePull(PartitionStateTableEvent::Enum eventType,
+                                    const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_failureReplicaDataResponsePush(const EventWithData& event)
+    void do_failureReplicaDataResponsePull(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_failureReplicaDataResponsePush(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
+
+    void do_sendDataToReplicas(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_sendDataToReplicas(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_sendDataToPrimary(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_bufferLiveData(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_processBufferedLiveData(const EventWithData& event)
+    void do_sendDataToPrimary(PartitionStateTableEvent::Enum eventType,
+                              const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_clearBufferedLiveData(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_processBufferedPrimaryStatusAdvisories(const EventWithData& event)
+    void do_bufferLiveData(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_processLiveData(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_setPrimary(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_cleanupMetadata(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_cancelRequests(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_clearPrimary(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_setExpectedDataChunkRange(const EventWithData& event)
+    void do_processBufferedLiveData(PartitionStateTableEvent::Enum eventType,
+                                    const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_resetReceiveDataCtx(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+    void do_clearBufferedLiveData(PartitionStateTableEvent::Enum eventType,
+                                  const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
 
-    void
-    do_attemptOpenStorage(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+    void do_processBufferedPrimaryStatusAdvisories(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
 
-    void do_updateStorage(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+    void do_processLiveData(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_setPrimary(PartitionStateTableEvent::Enum eventType,
+                       const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_cleanupMetadata(PartitionStateTableEvent::Enum eventType,
+                            const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_cancelRequests(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_clearPrimary(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_setExpectedDataChunkRange(PartitionStateTableEvent::Enum eventType,
+                                      const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_resetReceiveDataCtx(PartitionStateTableEvent::Enum eventType,
+                                const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_attemptOpenStorage(PartitionStateTableEvent::Enum eventType,
+                               const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_updateStorage(PartitionStateTableEvent::Enum eventType,
+                          const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
 
     void do_removeStorageAndSendReplicaDataDropResponse(
-        const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
 
-    void do_incrementNumRplcaDataRspn(const EventWithData& event)
+    void do_incrementNumRplcaDataRspn(PartitionStateTableEvent::Enum eventType,
+                                      const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_checkQuorumRplcaDataRspn(const EventWithData& event)
+    void do_checkQuorumRplcaDataRspn(PartitionStateTableEvent::Enum eventType,
+                                     const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_reapplyEvent(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_checkQuorumSeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_findHighestSeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void
-    do_flagFailedReplicaSeq(const EventWithData& event) BSLS_KEYWORD_OVERRIDE;
-
-    void do_transitionToActivePrimary(const EventWithData& event)
+    void do_reapplyEvent(PartitionStateTableEvent::Enum eventType,
+                         const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_reapplyDetectSelfPrimary(const EventWithData& event)
+    void do_checkQuorumSeq(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_reapplyDetectSelfReplica(const EventWithData& event)
+    void do_findHighestSeq(PartitionStateTableEvent::Enum eventType,
+                           const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
-    void do_unsupportedPrimaryDowngrade(const EventWithData& event)
+    void do_flagFailedReplicaSeq(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
+
+    void do_transitionToActivePrimary(PartitionStateTableEvent::Enum eventType,
+                                      const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_reapplyDetectSelfPrimary(PartitionStateTableEvent::Enum eventType,
+                                     const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_reapplyDetectSelfReplica(PartitionStateTableEvent::Enum eventType,
+                                     const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_unsupportedPrimaryDowngrade(
+        PartitionStateTableEvent::Enum eventType,
+        const PartitionFSMEventData&   eventData) BSLS_KEYWORD_OVERRIDE;
 
     // PRIVATE ACCESSORS
 


### PR DESCRIPTION
Make partition fsm less complex by providing the exact type used as a template arg.
Forward-declare it in the header to prevent circular dependencies.