### PR TITLE
Fix[mqbnet::Channel]: fix data race on accessing d_description

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -121,9 +121,9 @@ void Channel::stop()
         // Do not 'e_RESET' the state to let the drain finish.
 
         d_stateCondition.signal();
-    }
 
-    BALL_LOG_INFO << "Stopped " << d_description;
+        BALL_LOG_INFO << "Stopped " << d_description;
+    }
 
     BSLA_MAYBE_UNUSED const int rc = bslmt::ThreadUtil::join(d_threadHandle);
     BSLS_ASSERT_SAFE(rc == 0);
@@ -344,7 +344,8 @@ void Channel::setChannel(const bsl::weak_ptr<bmqio::Channel>& value)
 
 void Channel::reset()
 {
-    // executed by the internal thread
+    // Thread: internal thread 'd_threadHandle'
+    // Expects 'd_mutex' to be locked by the caller.
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_internalThreadChecker.inSameThread());
 
@@ -367,8 +368,7 @@ void Channel::reset()
 
 void Channel::wakeUp()
 {
-    BALL_LOG_TRACE << "'" << d_description << "': waking up";
-
+    // Thread: any
     bslma::ManagedPtr<Item> item(new (d_itemPool.allocate())
                                      Item(d_allocator_p),
                                  this,

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -939,7 +939,7 @@ void Channel::threadFn()
             // else keep the item
         }
     }
-    {        
+    {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
         reset();
     }

--- a/src/groups/mqb/mqbnet/mqbnet_channel.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_channel.cpp
@@ -939,7 +939,10 @@ void Channel::threadFn()
             // else keep the item
         }
     }
-    reset();
+    {        
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+        reset();
+    }
     d_isStopped.store(true);
 }
 


### PR DESCRIPTION
This `d_description` read happens without mutex lock:
```
Previous read of size 8 at 0x72780011f088 by thread T20:

#0 bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>::size() const /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_string.h:7079:18 (bmqbrkr.tsk+0x58d4ced) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)

#1 std::__1::basic_ostream<char, std::__1::char_traits<char>>& bsl::operator<<<char, std::__1::char_traits<char>, bsl::allocator<char>>(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>> const&) /opt/bb/include/bslstl_string.h:8814:38 (bmqbrkr.tsk+0x38dacbd) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)

#2 BloombergLP::mqbnet::Channel::stop() /blazingmq/src/groups/mqb/mqbnet/mqbnet_channel.cpp:126:33 (bmqbrkr.tsk+0x46b4305) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)
```

This write happens under mutex:
```
Write of size 8 at 0x72780011f088 by thread T28 (mutexes: write M0, write M1):

#0 bsl::String_ClearProctor<bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>>::String_ClearProctor(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>*) /opt/bb/include/bslstl_string.h:4285:26 (bmqbrkr.tsk+0x38dd2bb) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)

#1 bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>& bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>::privateAssignDispatch<char*, unsigned long>(char*, unsigned long, char const*) /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_string.h:4634:43 (bmqbrkr.tsk+0x58d4ef1) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)

#2 bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>::operator=(bsl::basic_string<char, std::__1::char_traits<char>, bsl::allocator<char>>&&) /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_string.h:5688:13 (bmqbrkr.tsk+0x58d4e33) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)

#3 BloombergLP::mqbnet::Channel::resetChannel(bsl::shared_ptr<BloombergLP::bmqio::Channel> const&) /blazingmq/src/groups/mqb/mqbnet/mqbnet_channel.cpp:280:23 (bmqbrkr.tsk+0x46b52ec) (BuildId: cd23afb30c541862ae54b45f8af9e5b6620180e6)
```