### PR TITLE
Refactor: Fix clang-tidy lints on test helper setup

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,4 @@
-Checks: bugprone-*,cert-*,clang-analyzer-*,clang-diagnostic-*,cppcoreguidelines-*,modernize-make-*,performance-*,modernize-use-emplace,-bugprone-easily-swappable-parameters,-cppcoreguidelines-avoid-const-or-ref-data-members,-cppcoreguidelines-owning-memory,-cppcoreguidelines-use-default-member-init,-,-performance-enum-size
+Checks: bugprone-*,cert-*,clang-analyzer-*,clang-diagnostic-*,cppcoreguidelines-*,modernize-make-*,performance-*,modernize-use-emplace,-bugprone-easily-swappable-parameters,-cppcoreguidelines-avoid-const-or-ref-data-members,-cppcoreguidelines-owning-memory,-cppcoreguidelines-use-default-member-init,-,-performance-enum-size,-readability-magic-numbers
 CheckOptions:
   cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor: true
   bugprone-string-constructor.StringNames: ::bsl::basic_string; ::std::basic_string; ::std::basic_string_view

--- a/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
+++ b/src/groups/bmq/bmqio/bmqio_channelfactorypipeline.g.cpp
@@ -426,7 +426,7 @@ TEST_F(ChannelFactoryPipelineTest, getDoesntFindNonexistantSubtype)
 
 int main(int argc, char* argv[])
 {
-    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+    GTEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -287,11 +287,13 @@
 #include <balst_stacktracetestallocator.h>
 #include <bdlm_metricsregistry.h>
 #include <bdlsb_memoutstreambuf.h>
+#include <bsl_array.h>
 #include <bsl_cstdio.h>
 #include <bsl_cstdlib.h>
 #include <bsl_iostream.h>
 #include <bsl_map.h>
 #include <bsl_set.h>
+#include <bsl_stdexcept.h>
 #include <bsl_string_view.h>
 #include <bsl_unordered_map.h>
 #include <bsl_unordered_set.h>
@@ -546,8 +548,16 @@
 //                                 TEST SHELL
 // ----------------------------------------------------------------------------
 #define TEST_PROLOG(F)                                                        \
-    const int _testCase                      = argc > 1 ? atoi(argv[1]) : 0;  \
-    bmqtst::TestHelperUtil::verbosityLevel() = argc - 2;                      \
+    bsl::span<char*> _argv(argv, argc);                                       \
+    int              _testCase = 0;                                           \
+    try {                                                                     \
+        _testCase = argc > 1 ? bsl::stol(_argv[1]) : 0;                       \
+        bmqtst::TestHelperUtil::verbosityLevel() = argc - 2;                  \
+    }                                                                         \
+    catch (const bsl::invalid_argument&) {                                    \
+        bsl::cerr << "Unrecognized test case: " << _argv[1] << "\n";          \
+        bsl::exit(1);                                                         \
+    }                                                                         \
                                                                               \
     /* Install an assert handler to gracefully mark the test as failure */    \
     /* in case of assert.                                               */    \
@@ -561,7 +571,7 @@
     /* Initialize allocators */                                               \
     INIT_ALLOCATORS(F);                                                       \
                                                                               \
-    bsl::cout << "TEST " << __FILE__ << " CASE " << _testCase << bsl::endl;   \
+    bsl::cout << "TEST " << __FILE__ << " CASE " << _testCase << "\n";        \
                                                                               \
     /* Create a scope for all code in between TEST_PROLOG and TEST_EPILOG */  \
     {
@@ -759,12 +769,12 @@ struct TestHelperUtil {
     /// Verbosity to use ([0..4], the higher the more verbose).
     static int& verbosityLevel();
 
-    /// Global flag which can be set to ignore checking the default allocator
-    /// usage for a specific test case.
+    /// Global flag which can be set to ignore checking the default
+    /// allocator usage for a specific test case.
     static bool& ignoreCheckDefAlloc();
 
-    /// Global flag which can be set to ignore checking the global allocator
-    /// usage for a specific test case.
+    /// Global flag which can be set to ignore checking the global
+    /// allocator usage for a specific test case.
     static bool& ignoreCheckGblAlloc();
 
     /// Lock mechanism to serialize output in.
@@ -844,8 +854,8 @@ static inline void
 _assertViolationHandler(const bsls::AssertViolation& violation)
 {
     // Since we're handling a contract failure (as opposed to a test
-    // assertion), we want the program to die immediately. For this reason, we
-    // use stderr instead of stdout.
+    // assertion), we want the program to die immediately. For this reason,
+    // we use stderr instead of stdout.
     bsl::fprintf(stderr,
                  "Error %s(%d): %s    (failed)\n",
                  violation.fileName(),
@@ -858,8 +868,8 @@ _assertViolationHandler(const bsls::AssertViolation& violation)
     bsls::AssertTest::failTestDriver(violation);
 }
 
-// Create a definition of the assert template method for each of the 6 common
-// comparison operators.
+// Create a definition of the assert template method for each of the 6
+// common comparison operators.
 ASSERT_COMPARE_DECLARE(Equals, ==)
 ASSERT_COMPARE_DECLARE(NotEquals, !=)
 ASSERT_COMPARE_DECLARE(Less, <)
@@ -939,8 +949,8 @@ struct TestHelper {
     /// Print the banner of the name of the test, in the specified `value`.
     static void printTestName(bsl::string_view value);
 
-    /// Return true if the specified `x` and `y` should be considered equal,
-    /// with respect to floating numerics imprecision.
+    /// Return true if the specified `x` and `y` should be considered
+    /// equal, with respect to floating numerics imprecision.
     static bool areFuzzyEqual(double x, double y);
 };
 

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -551,7 +551,7 @@
     bsl::span<char*> _argv(argv, argc);                                       \
     int              _testCase = 0;                                           \
     try {                                                                     \
-        _testCase = argc > 1 ? bsl::stol(_argv[1]) : 0;                       \
+        _testCase = argc > 1 ? bsl::stoi(_argv[1]) : 0;                       \
         bmqtst::TestHelperUtil::verbosityLevel() = argc - 2;                  \
     }                                                                         \
     catch (const bsl::invalid_argument&) {                                    \
@@ -572,6 +572,21 @@
     INIT_ALLOCATORS(F);                                                       \
                                                                               \
     bsl::cout << "TEST " << __FILE__ << " CASE " << _testCase << "\n";        \
+                                                                              \
+    /* Create a scope for all code in between TEST_PROLOG and TEST_EPILOG */  \
+    {
+#define GTEST_PROLOG(F)                                                       \
+    /* Install an assert handler to gracefully mark the test as failure */    \
+    /* in case of assert.                                               */    \
+    bsls::AssertFailureHandlerGuard _assertGuard(::_assertViolationHandler);  \
+                                                                              \
+    /* Initialize BALL */                                                     \
+    /* NOTE: BALL mechanisms use the default allocator, that is why */        \
+    /*       logging is initialized before the allocators.          */        \
+    INIT_BALL_LOGGING();                                                      \
+                                                                              \
+    /* Initialize allocators */                                               \
+    INIT_ALLOCATORS(F);                                                       \
                                                                               \
     /* Create a scope for all code in between TEST_PROLOG and TEST_EPILOG */  \
     {
@@ -679,8 +694,7 @@
     /* Check test result */                                                   \
     if (bmqtst::TestHelperUtil::testStatus() > 0) {                           \
         bsl::cerr << "Error, non-zero test status: "                          \
-                  << bmqtst::TestHelperUtil::testStatus() << "."              \
-                  << bsl::endl;                                               \
+                  << bmqtst::TestHelperUtil::testStatus() << ".\n";           \
     }                                                                         \
                                                                               \
     bmqtst::TestHelperUtil::allocator() =                                     \
@@ -1012,6 +1026,10 @@ template <typename TYPE1, typename TYPE2>
 bsl::ostream&
 operator<<(bsl::ostream&                                       stream,
            const TestHelper_Printer<bsl::pair<TYPE1, TYPE2> >& printer);
+template <typename TYPE, bsl::size_t SIZE>
+bsl::ostream&
+operator<<(bsl::ostream&                                      stream,
+           const TestHelper_Printer<bsl::array<TYPE, SIZE> >& printer);
 
 // ============================================================================
 //                      INLINE FUNCTION IMPLEMENTATIONS
@@ -1163,6 +1181,25 @@ bmqtst::operator<<(bsl::ostream&                                       stream,
 {
     return stream << '<' << printer.obj().first << ", " << printer.obj().second
                   << '>';
+}
+
+template <typename TYPE, bsl::size_t SIZE>
+inline bsl::ostream&
+bmqtst::operator<<(bsl::ostream&                                      stream,
+                   const TestHelper_Printer<bsl::array<TYPE, SIZE> >& printer)
+{
+    stream << "[";
+
+    if (!printer.obj().empty()) {
+        for (size_t i = 0; i < printer.obj().size() - 1; ++i) {
+            stream << TestHelper_Printer<TYPE>(&printer.obj()[i]) << ", ";
+        }
+
+        stream << TestHelper_Printer<TYPE>(&printer.obj().back());
+    }
+
+    stream << "]";
+    return stream;
 }
 
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.g.cpp
+++ b/src/groups/mqb/mqbcfg/mqbcfg_tcpinterfaceconfigvalidator.g.cpp
@@ -118,7 +118,7 @@ TEST(TcpInterfaceConfigValidatorTest, outOfRangePortsAreInvalid)
 
 int main(int argc, char* argv[])
 {
-    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+    GTEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.g.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.g.cpp
@@ -238,7 +238,7 @@ TEST_F(TCPSessionFactoryTest, setNodeWriteQueueWatermarksFromTcpConfig)
 
 int main(int argc, char* argv[])
 {
-    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+    GTEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
     ::testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
This lightly fixes some test helper logic into using `bsl::span` instead of C-style arrays.