### PR TITLE
Refactor: User authentication credentials callback

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -133,8 +133,7 @@ struct AuthnCredentialProvider {
     }
 
     // MANIPULATORS
-    bsl::optional<bmqt::AuthnCredential>
-    operator()(bsl::ostream& /* error */) const
+    bsl::optional<bmqt::AuthnCredential> operator()() const
     {
         return bsl::optional<bmqt::AuthnCredential>(bsl::in_place,
                                                     d_mechanism,

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.cpp
@@ -128,14 +128,17 @@ bool AuthenticatedChannelFactory::sendRequest(
     const ResultCallback&                  cb,
     bool                                   isReauthentication) const
 {
-    bmqu::MemOutStream errStream;
-
-    bsl::optional<bmqt::AuthnCredential> credential =
-        d_config.d_authnCredentialCb(errStream);
+    bsl::optional<bmqt::AuthnCredential> credential;
+    try {
+        credential = d_config.d_authnCredentialCb();
+    }
+    // NOLINTNEXTLINE(bugprone-empty-catch)
+    catch (...) {
+        // Intentionally discard, we can't tolerate user exceptions
+    }
 
     if (!credential.has_value()) {
-        BALL_LOG_ERROR << "Failed to get authentication credential: "
-                       << errStream.str();
+        BALL_LOG_ERROR << "Failed to get authentication credential";
         bmqio::Status status(bmqio::StatusCategory::e_GENERIC_ERROR,
                              "authenticationError",
                              rc_AUTHENTICATION_FAILURE);

--- a/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_authenticatedchannelfactory.t.cpp
@@ -71,8 +71,7 @@ struct ResultItem {
     }
 };
 
-bsl::optional<bmqt::AuthnCredential>
-basicCredentialCb(bsl::ostream& /* error */)
+bsl::optional<bmqt::AuthnCredential> basicCredentialCb()
 {
     bslma::Allocator*      alloc   = bmqtst::TestHelperUtil::allocator();
     const bsl::string_view dataStr = "testdata";
@@ -88,8 +87,7 @@ basicCredentialCb(bsl::ostream& /* error */)
 AuthnCredentialCb makeDefaultCredentialCb()
 {
     return bdlf::BindUtil::bindS(bmqtst::TestHelperUtil::allocator(),
-                                 basicCredentialCb,
-                                 bdlf::PlaceHolders::_1);  // error stream
+                                 basicCredentialCb);  // error stream
 }
 
 // -----------------
@@ -504,18 +502,15 @@ BMQTST_TEST(CredentialCallbackFailure)
 // ------------------------------------------------------------------------
 {
     struct Local {
-        static bsl::optional<bmqt::AuthnCredential>
-        alwaysFailCb(bsl::ostream& error)
+        static bsl::optional<bmqt::AuthnCredential> alwaysFailCb()
         {
-            error << "credential unavailable";
             return bsl::nullopt;
         }
     };
 
     AuthnCredentialCb nulloptCb = bdlf::BindUtil::bindS(
         bmqtst::TestHelperUtil::allocator(),
-        Local::alwaysFailCb,
-        bdlf::PlaceHolders::_1);  // error stream
+        Local::alwaysFailCb);  // error stream
     TestContext ctx(nulloptCb);
 
     ctx.connect();

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -178,8 +178,7 @@ class SessionOptions {
     /// an `AuthnCredential` object on success, or `bsl::nullopt` if an error
     /// occurs. Any error details should be written to the provided `error`
     /// stream.
-    typedef bsl::function<bsl::optional<AuthnCredential>(bsl::ostream& error)>
-        AuthnCredentialCb;
+    typedef bsl::function<bsl::optional<AuthnCredential>()> AuthnCredentialCb;
 
     // CONSTANTS
 


### PR DESCRIPTION
This change removes the ostream& parameter from the user provided authentication credentials callback. This parameter was originally intended to allow the user to provide a message about why credentials failed to be provided in the case of an error, but this was just immediately logged by us. Instead of doing that, we are preferring the user log any helpful error messages themselves.