### PR TITLE
Fix[mqbnet]: data race on d_isReading and d_isReadEnabled in ClusterImp

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -94,7 +94,7 @@ bool ClusterNodeImp::enableRead()
 
     BSLS_ASSERT_SAFE(d_readCb);
 
-    if (d_isReading) {
+    if (d_isReading.testAndSwap(false, true) != false) {
         return true;  // RETURN
     }
 
@@ -109,10 +109,10 @@ bool ClusterNodeImp::enableRead()
 
         channelSp->close();
 
+        d_isReading = false;
+
         return false;  // RETURN
     }
-
-    d_isReading = true;
 
     BALL_LOG_INFO << nodeDescription() << ": reading from the channel '"
                   << channelSp->peerUri() << "'";

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -94,7 +94,7 @@ bool ClusterNodeImp::enableRead()
 
     BSLS_ASSERT_SAFE(d_readCb);
 
-    if (d_isReading.testAndSwap(false, true) != false) {
+    if (d_isReading.swap(true)) {
         return true;  // RETURN
     }
 

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -53,6 +53,7 @@
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bslmt_mutex.h>
+#include <bsls_atomic.h>
 #include <bsls_cpp11.h>
 
 namespace BloombergLP {
@@ -94,7 +95,7 @@ class ClusterNodeImp : public ClusterNode {
 
     bmqio::Channel::ReadCallback d_readCb;
 
-    bool d_isReading;
+    bsls::AtomicBool d_isReading;
     // Indicates if post-negotiation read has
     // started.
 
@@ -243,7 +244,7 @@ class ClusterImp : public Cluster {
     // Mutex for thread-safety of this
     // component.
 
-    bool d_isReadEnabled;
+    bsls::AtomicBool d_isReadEnabled;
     // 'true' if cluster has been
     // initialized to enable reading from
     // its nodes.


### PR DESCRIPTION
Closes #1568

`ClusterNodeImp::d_isReading` is a plain `bool` written from the transport thread in `setChannel`, the dispatcher thread in `enableRead`, and the IO thread in `resetChannel`. The check-then-act in `enableRead` has a TOCTOU window that allows concurrent calls to both pass the guard and double-enable the channel. `ClusterImp::d_isReadEnabled` is written without `d_mutex` in `enableRead` but read outside `d_mutex` in `notifyObserversOfNodeStateChange`. Convert both to `bsls::AtomicBool` and close the TOCTOU with `testAndSwap`.

@678098