### PR TITLE
IT: shorten log lines

### DIFF
--- a/src/integration-tests/pytest.ini
+++ b/src/integration-tests/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 log_cli_format = %(bmqprocess)-16s %(filename)s:%(lineno)d %(message)s
 log_level = INFO
-log_format = %(bmqprocess)-16s %(asctime)s.%(msecs)03d (%(thread)15d) %(levelname)-8s %(name)-24s %(filename)10s:%(lineno)-03d %(message)s
-log_file_format = %(bmqprocess)-16s %(asctime)s.%(msecs)03d (%(thread)15d) %(levelname)-8s %(name)-24s %(filename)10s:%(lineno)-03d %(message)s
+log_format = %(bmqprocess)-16s %(asctime)s.%(msecs)03d (%(thread)15d) %(levelname)-8s %(filename)10s:%(lineno)-03d %(message)s
+log_file_format = %(bmqprocess)-16s %(asctime)s.%(msecs)03d (%(thread)15d) %(levelname)-8s %(filename)10s:%(lineno)-03d %(message)s
 log_file_level = INFO
 log_file_date_format = %d%b%Y_%H:%M:%S
 addopts = --strict-markers -p no:cacheprovider


### PR DESCRIPTION
Removes the duplicated dotted path, making the debug simpler: we always see file line positions at the same offset.

Before:
```
west2            24Jun2026_19:16:38.020 (140545691203264) INFO     blazingmq.tsk.bmqbrkr.mqbnet.tcpsessionfactory mqbnet_tcpsessionfactory.cpp:245 Channel 0x7fd33c0053b0 with remote peer 127.0.0.1:41508 resolved to '127.0.0.1~localhost:41508' (took: 89.81 us, 89808 nanoseconds)
```

After:
```
west2            24Jun2026_19:16:38.020 (140545691203264) INFO    mqbnet_tcpsessionfactory.cpp:245 Channel 0x7fd33c0053b0 with remote peer 127.0.0.1:41508 resolved to '127.0.0.1~localhost:41508' (took: 89.81 us, 89808 nanoseconds)
```

Red rectangle: useless file path duplication that takes area from useful green area, and breaks logs alignment.

<img width="2527" height="988" alt="Screenshot 2026-06-26 at 12 50 43" src="https://github.com/user-attachments/assets/ee8b99f6-4780-4463-ac56-5fdbdd176963" />

