### PR TITLE
Fix: Breaking API change in mocksession

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -376,6 +376,24 @@ Event MockSessionUtil::createQueueSessionEvent(
     QueueId*                     queueId,
     const bmqt::CorrelationId&   correlationId,
     int                          errorCode,
+    const bslstl::StringRef&     errorDescription,
+    bslma::Allocator*            allocator)
+{
+    return createQueueSessionEvent(
+        sessionEventType,
+        queueId,
+        correlationId,
+        errorCode,
+        bmqt::GenericResult::fromStatusCode(errorCode),
+        errorDescription,
+        allocator);
+}
+
+Event MockSessionUtil::createQueueSessionEvent(
+    bmqt::SessionEventType::Enum sessionEventType,
+    QueueId*                     queueId,
+    const bmqt::CorrelationId&   correlationId,
+    int                          errorCode,
     bmqt::GenericResult::Enum    result,
     const bslstl::StringRef&     errorDescription,
     bslma::Allocator*            allocator)
@@ -1068,7 +1086,7 @@ MockSession::MockSession(const bmqt::SessionOptions& options,
                                     bdlf::PlaceHolders::_2,
                                     bdlf::PlaceHolders::_3))
 , d_lastQueueId(0)
-, d_corrIdContainer_sp(new(*bslma::Default::allocator(allocator))
+, d_corrIdContainer_sp(new (*bslma::Default::allocator(allocator))
                            bmqimp::MessageCorrelationIdContainer(
                                bslma::Default::allocator(allocator)),
                        bslma::Default::allocator(allocator))
@@ -1076,7 +1094,7 @@ MockSession::MockSession(const bmqt::SessionOptions& options,
 , d_rootStatContext_mp(bslma::ManagedPtrUtil::makeManaged<bmqst::StatContext>(
       bmqst::StatContextConfiguration("MockSession", allocator),
       allocator))
-, d_queuesStats_sp(new(*bslma::Default::allocator(allocator))
+, d_queuesStats_sp(new (*bslma::Default::allocator(allocator))
                        bmqimp::Stat(bslma::Default::allocator(allocator)),
                    bslma::Default::allocator(allocator))
 , d_sessionOptions(options, allocator)
@@ -1114,7 +1132,7 @@ MockSession::MockSession(bslma::ManagedPtr<SessionEventHandler> eventHandler,
                                     bdlf::PlaceHolders::_2,
                                     bdlf::PlaceHolders::_3))
 , d_lastQueueId(0)
-, d_corrIdContainer_sp(new(*bslma::Default::allocator(allocator))
+, d_corrIdContainer_sp(new (*bslma::Default::allocator(allocator))
                            bmqimp::MessageCorrelationIdContainer(
                                bslma::Default::allocator(allocator)),
                        bslma::Default::allocator(allocator))
@@ -1122,7 +1140,7 @@ MockSession::MockSession(bslma::ManagedPtr<SessionEventHandler> eventHandler,
 , d_rootStatContext_mp(bslma::ManagedPtrUtil::makeManaged<bmqst::StatContext>(
       bmqst::StatContextConfiguration("MockSession", allocator),
       allocator))
-, d_queuesStats_sp(new(*bslma::Default::allocator(allocator))
+, d_queuesStats_sp(new (*bslma::Default::allocator(allocator))
                        bmqimp::Stat(bslma::Default::allocator(allocator)),
                    bslma::Default::allocator(allocator))
 , d_sessionOptions(options, allocator)

--- a/src/groups/bmq/bmqa/bmqa_mocksession.h
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.h
@@ -580,6 +580,7 @@
 #include <bslmt_mutex.h>
 #include <bsls_alignedbuffer.h>
 #include <bsls_assert.h>
+#include <bsls_deprecatefeature.h>
 #include <bsls_timeinterval.h>
 #include <bsls_types.h>
 
@@ -725,11 +726,23 @@ struct MockSessionUtil {
                     bdlbb::BlobBufferFactory*             bufferFactory,
                     bslma::Allocator*                     allocator);
 
-    /// DEPRECATED: Use the `createOpenQueueStatus(...)`,
-    ///            `createConfigureQueueStatus(...)`, or
-    ///            `createCloseQueueStatus(...)` methods instead.  This method
-    ///            will be marked as `BSLA_DEPRECATED` in future release of
-    ///            libbmq.
+    BSLS_DEPRECATE_FEATURE(
+        "bmq",
+        "bmqa::MockSessionUtil::createQueueSessionEvent",
+        "Use the createOpenQueueStatus(...), createConfigureQueueStatus(...), "
+        "or createCloseQueueStatus(...) methods instead.")
+    static Event
+    createQueueSessionEvent(bmqt::SessionEventType::Enum sessionEventType,
+                            QueueId*                     queueId,
+                            const bmqt::CorrelationId&   correlationId,
+                            int                          errorCode,
+                            const bslstl::StringRef&     errorDescription,
+                            bslma::Allocator*            allocator);
+    BSLS_DEPRECATE_FEATURE(
+        "bmq",
+        "bmqa::MockSessionUtil::createQueueSessionEvent",
+        "Use the createOpenQueueStatus(...), createConfigureQueueStatus(...), "
+        "or createCloseQueueStatus(...) methods instead.")
     static Event
     createQueueSessionEvent(bmqt::SessionEventType::Enum sessionEventType,
                             QueueId*                     queueId,
@@ -743,6 +756,22 @@ struct MockSessionUtil {
     /// specified `sessionEventType`, `errorCode` and `errorDescription` and
     /// using the specified `allocator` to supply memory.  Note that this
     /// method will not create queue related session events.
+    BSLS_DEPRECATE_FEATURE(
+        "bmq",
+        "result-code",
+        "Use the createSessionEvent overload that takes a result code")
+    static Event
+    createSessionEvent(bmqt::SessionEventType::Enum sessionEventType,
+                       const bmqt::CorrelationId&   correlationId,
+                       const int                    errorCode,
+                       const bslstl::StringRef&     errorDescription,
+                       bslma::Allocator*            allocator);
+
+    /// Create and return an `Event` configured as a session event with the
+    /// specified `sessionEventType`, `errorCode`, `result`, and
+    /// `errorDescription` and using the specified `allocator` to supply
+    /// memory.  Note that this method will not create queue related session
+    /// events.
     static Event
     createSessionEvent(bmqt::SessionEventType::Enum sessionEventType,
                        const bmqt::CorrelationId&   correlationId,

--- a/src/groups/bmq/bmqa/bmqa_session.cpp
+++ b/src/groups/bmq/bmqa/bmqa_session.cpp
@@ -124,137 +124,63 @@ int validateQueueOptions(bsl::ostream& out, const bmqt::QueueOptions& options)
     return 0;
 }
 
-template <typename T>
-T fromStatusCode(int statusCode);
+template <typename RESULT_ENUM>
+struct ResultCodeType_Imp {};
 
-/// Convert a status code into a generic result. If `code` does not match one
-/// of the `GenericResult::Enum` variants, return
-/// `bmqt::GenericResult::e_UNKNOWN`. Otherwise, return the value of `code`
-/// casted as a `GenericResult::Enum`.
 template <>
-bmqt::GenericResult::Enum
-fromStatusCode<bmqt::GenericResult::Enum>(int statusCode)
-{
-    switch (statusCode) {
-    case bmqt::GenericResult::e_SUCCESS:
-    case bmqt::GenericResult::e_UNKNOWN:
-    case bmqt::GenericResult::e_TIMEOUT:
-    case bmqt::GenericResult::e_NOT_CONNECTED:
-    case bmqt::GenericResult::e_CANCELED:
-    case bmqt::GenericResult::e_NOT_SUPPORTED:
-    case bmqt::GenericResult::e_REFUSED:
-    case bmqt::GenericResult::e_INVALID_ARGUMENT:
-    case bmqt::GenericResult::e_NOT_READY: {
-        return static_cast<bmqt::GenericResult::Enum>(statusCode);
-    }
-    default: {
-        return bmqt::GenericResult::e_UNKNOWN;
-    }
-    }
-}
+struct ResultCodeType_Imp<bmqt::GenericResult::Enum> {
+    typedef bmqt::GenericResult Type;
+};
 
-/// Convert a status code into an open queue result. If `code` does not match
-/// one of the `OpenQueueResult::Enum` variants, return
-/// `bmqt::OpenQueueResult::e_UNKNOWN`. Otherwise, return the value of `code`
-/// casted as a `bmqt::OpenQueueResult::Enum`.
 template <>
-bmqt::OpenQueueResult::Enum
-fromStatusCode<bmqt::OpenQueueResult::Enum>(int code)
-{
-#define BMQA_CASE(X) case bmqt::OpenQueueResult::e_##X:
+struct ResultCodeType_Imp<bmqt::OpenQueueResult::Enum> {
+    typedef bmqt::OpenQueueResult Type;
+};
 
-    switch (code) {
-        BMQA_CASE(SUCCESS)
-        BMQA_CASE(UNKNOWN)
-        BMQA_CASE(TIMEOUT)
-        BMQA_CASE(NOT_CONNECTED)
-        BMQA_CASE(CANCELED)
-        BMQA_CASE(NOT_SUPPORTED)
-        BMQA_CASE(REFUSED)
-        BMQA_CASE(INVALID_ARGUMENT)
-        BMQA_CASE(NOT_READY)
-        BMQA_CASE(ALREADY_OPENED)
-        BMQA_CASE(ALREADY_IN_PROGRESS)
-        BMQA_CASE(INVALID_URI)
-        BMQA_CASE(INVALID_FLAGS)
-        BMQA_CASE(CORRELATIONID_NOT_UNIQUE)
-        {
-            return static_cast<bmqt::OpenQueueResult::Enum>(code);
-        }
-    default: {
-        return bmqt::OpenQueueResult::e_UNKNOWN;
-    }
-    }
-
-#undef BMQA_CASE
-}
-
-/// Convert a status code into a close queue result. If `code` does not match
-/// one of the `CloseQueueResult::Enum` variants, return
-/// `bmqt::CloseQueueResult::e_UNKNOWN`. Otherwise, return the value of `code`
-/// casted as a `bmqt::CloseQueueResult::Enum`.
 template <>
-bmqt::CloseQueueResult::Enum
-fromStatusCode<bmqt::CloseQueueResult::Enum>(int code)
-{
-#define BMQA_CASE(X) case bmqt::CloseQueueResult::e_##X:
+struct ResultCodeType_Imp<bmqt::ConfigureQueueResult::Enum> {
+    typedef bmqt::ConfigureQueueResult Type;
+};
 
-    switch (code) {
-        BMQA_CASE(SUCCESS)
-        BMQA_CASE(UNKNOWN)
-        BMQA_CASE(TIMEOUT)
-        BMQA_CASE(NOT_CONNECTED)
-        BMQA_CASE(CANCELED)
-        BMQA_CASE(NOT_SUPPORTED)
-        BMQA_CASE(REFUSED)
-        BMQA_CASE(INVALID_ARGUMENT)
-        BMQA_CASE(NOT_READY)
-        BMQA_CASE(ALREADY_CLOSED)
-        BMQA_CASE(ALREADY_IN_PROGRESS)
-        BMQA_CASE(UNKNOWN_QUEUE)
-        BMQA_CASE(INVALID_QUEUE)
-        {
-            return static_cast<bmqt::CloseQueueResult::Enum>(code);
-        }
-    default: {
-        return bmqt::CloseQueueResult::e_UNKNOWN;
-    }
-    }
-
-#undef BMQA_CASE
-}
-
-/// Convert a status code into an open queue result. If `code` does not match
-/// one of the `ConfigureQueueResult::Enum` variants, return
-/// `bmqt::ConfigureQueueResult::e_UNKNOWN`. Otherwise, return the value of
-/// `code` casted as a `bmqt::ConfigureQueueResult::Enum`.
 template <>
-bmqt::ConfigureQueueResult::Enum
-fromStatusCode<bmqt::ConfigureQueueResult::Enum>(int code)
+struct ResultCodeType_Imp<bmqt::CloseQueueResult::Enum> {
+    typedef bmqt::CloseQueueResult Type;
+};
+
+/// This is a type trait struct that maps bmqa_resultcode enums back to their
+/// wrapping type.
+///
+/// In other words, `ResultCodeType<ResultType::Enum> == ResultType`.
+template <typename RESULT_ENUM>
+struct ResultCodeType
+: public ResultCodeType_Imp<typename bsl::remove_cv<RESULT_ENUM>::type> {};
+
+// Check that every type maps as we expect.
+BSLMF_ASSERT((bsl::is_same<ResultCodeType<bmqt::GenericResult::Enum>::Type,
+                           bmqt::GenericResult>::value));
+BSLMF_ASSERT((bsl::is_same<ResultCodeType<bmqt::OpenQueueResult::Enum>::Type,
+                           bmqt::OpenQueueResult>::value));
+BSLMF_ASSERT(
+    (bsl::is_same<ResultCodeType<bmqt::ConfigureQueueResult::Enum>::Type,
+                  bmqt::ConfigureQueueResult>::value));
+BSLMF_ASSERT((bsl::is_same<ResultCodeType<bmqt::CloseQueueResult::Enum>::Type,
+                           bmqt::CloseQueueResult>::value));
+
+/// This is a templated version of the `fromStatusCode` static member functions
+/// in the types from bmqt_resultcode.
+///
+/// For example:
+/// ```c++
+/// ASSERT_EQ(
+///     fromStatusCode<bmqt::GenericResult::Enum>(status),
+///     bmqt::GenericResult::fromStatusCode(status)
+/// );
+/// ```
+template <typename RESULT_ENUM>
+RESULT_ENUM fromStatusCode(int status)
 {
-#define BMQA_CASE(X) case bmqt::ConfigureQueueResult::e_##X:
-
-    switch (code) {
-        BMQA_CASE(SUCCESS)
-        BMQA_CASE(UNKNOWN)
-        BMQA_CASE(TIMEOUT)
-        BMQA_CASE(NOT_CONNECTED)
-        BMQA_CASE(CANCELED)
-        BMQA_CASE(NOT_SUPPORTED)
-        BMQA_CASE(REFUSED)
-        BMQA_CASE(INVALID_ARGUMENT)
-        BMQA_CASE(NOT_READY)
-        BMQA_CASE(ALREADY_IN_PROGRESS)
-        BMQA_CASE(INVALID_QUEUE)
-        {
-            return static_cast<bmqt::ConfigureQueueResult::Enum>(code);
-        }
-    default: {
-        return bmqt::ConfigureQueueResult::e_UNKNOWN;
-    }
-    }
-
-#undef BMQA_CASE
+    typedef typename ResultCodeType<RESULT_ENUM>::Type ResultType;
+    return ResultType::fromStatusCode(status);
 }
 
 // CLASSES

--- a/src/groups/bmq/bmqt/bmqt_resultcode.cpp
+++ b/src/groups/bmq/bmqt/bmqt_resultcode.cpp
@@ -91,6 +91,26 @@ bool GenericResult::fromAscii(GenericResult::Enum*     out,
 #undef BMQT_CHECKVALUE
 }
 
+bmqt::GenericResult::Enum GenericResult::fromStatusCode(int statusCode)
+{
+    switch (statusCode) {
+    case bmqt::GenericResult::e_SUCCESS:
+    case bmqt::GenericResult::e_UNKNOWN:
+    case bmqt::GenericResult::e_TIMEOUT:
+    case bmqt::GenericResult::e_NOT_CONNECTED:
+    case bmqt::GenericResult::e_CANCELED:
+    case bmqt::GenericResult::e_NOT_SUPPORTED:
+    case bmqt::GenericResult::e_REFUSED:
+    case bmqt::GenericResult::e_INVALID_ARGUMENT:
+    case bmqt::GenericResult::e_NOT_READY: {
+        return static_cast<bmqt::GenericResult::Enum>(statusCode);
+    }
+    default: {
+        return bmqt::GenericResult::e_UNKNOWN;
+    }
+    }
+}
+
 // ----------------------
 // struct OpenQueueResult
 // ----------------------
@@ -168,6 +188,36 @@ bool OpenQueueResult::fromAscii(OpenQueueResult::Enum*   out,
 #undef BMQT_CHECKVALUE
 }
 
+bmqt::OpenQueueResult::Enum OpenQueueResult::fromStatusCode(int code)
+{
+#define BMQT_CASE(X) case bmqt::OpenQueueResult::e_##X:
+
+    switch (code) {
+        BMQT_CASE(SUCCESS)
+        BMQT_CASE(UNKNOWN)
+        BMQT_CASE(TIMEOUT)
+        BMQT_CASE(NOT_CONNECTED)
+        BMQT_CASE(CANCELED)
+        BMQT_CASE(NOT_SUPPORTED)
+        BMQT_CASE(REFUSED)
+        BMQT_CASE(INVALID_ARGUMENT)
+        BMQT_CASE(NOT_READY)
+        BMQT_CASE(ALREADY_OPENED)
+        BMQT_CASE(ALREADY_IN_PROGRESS)
+        BMQT_CASE(INVALID_URI)
+        BMQT_CASE(INVALID_FLAGS)
+        BMQT_CASE(CORRELATIONID_NOT_UNIQUE)
+        {
+            return static_cast<bmqt::OpenQueueResult::Enum>(code);
+        }
+    default: {
+        return bmqt::OpenQueueResult::e_UNKNOWN;
+    }
+    }
+
+#undef BMQT_CASE
+}
+
 // ---------------------------
 // struct ConfigureQueueResult
 // ---------------------------
@@ -237,6 +287,33 @@ bool ConfigureQueueResult::fromAscii(ConfigureQueueResult::Enum* out,
     return false;
 
 #undef BMQT_CHECKVALUE
+}
+
+bmqt::ConfigureQueueResult::Enum ConfigureQueueResult::fromStatusCode(int code)
+{
+#define BMQT_CASE(X) case bmqt::ConfigureQueueResult::e_##X:
+
+    switch (code) {
+        BMQT_CASE(SUCCESS)
+        BMQT_CASE(UNKNOWN)
+        BMQT_CASE(TIMEOUT)
+        BMQT_CASE(NOT_CONNECTED)
+        BMQT_CASE(CANCELED)
+        BMQT_CASE(NOT_SUPPORTED)
+        BMQT_CASE(REFUSED)
+        BMQT_CASE(INVALID_ARGUMENT)
+        BMQT_CASE(NOT_READY)
+        BMQT_CASE(ALREADY_IN_PROGRESS)
+        BMQT_CASE(INVALID_QUEUE)
+        {
+            return static_cast<bmqt::ConfigureQueueResult::Enum>(code);
+        }
+    default: {
+        return bmqt::ConfigureQueueResult::e_UNKNOWN;
+    }
+    }
+
+#undef BMQT_CASE
 }
 
 // -----------------------
@@ -312,6 +389,35 @@ bool CloseQueueResult::fromAscii(CloseQueueResult::Enum*  out,
     return false;
 
 #undef BMQT_CHECKVALUE
+}
+
+bmqt::CloseQueueResult::Enum CloseQueueResult::fromStatusCode(int code)
+{
+#define BMQT_CASE(X) case bmqt::CloseQueueResult::e_##X:
+
+    switch (code) {
+        BMQT_CASE(SUCCESS)
+        BMQT_CASE(UNKNOWN)
+        BMQT_CASE(TIMEOUT)
+        BMQT_CASE(NOT_CONNECTED)
+        BMQT_CASE(CANCELED)
+        BMQT_CASE(NOT_SUPPORTED)
+        BMQT_CASE(REFUSED)
+        BMQT_CASE(INVALID_ARGUMENT)
+        BMQT_CASE(NOT_READY)
+        BMQT_CASE(ALREADY_CLOSED)
+        BMQT_CASE(ALREADY_IN_PROGRESS)
+        BMQT_CASE(UNKNOWN_QUEUE)
+        BMQT_CASE(INVALID_QUEUE)
+        {
+            return static_cast<bmqt::CloseQueueResult::Enum>(code);
+        }
+    default: {
+        return bmqt::CloseQueueResult::e_UNKNOWN;
+    }
+    }
+
+#undef BMQT_CASE
 }
 
 // -------------------------

--- a/src/groups/bmq/bmqt/bmqt_resultcode.h
+++ b/src/groups/bmq/bmqt/bmqt_resultcode.h
@@ -117,6 +117,12 @@ struct GenericResult {
     /// the enum.
     static bool fromAscii(GenericResult::Enum*     out,
                           const bslstl::StringRef& str);
+
+    /// Convert a status code into a generic result. If `code` does not match
+    /// one of the `GenericResult::Enum` variants, return
+    /// `bmqt::GenericResult::e_UNKNOWN`. Otherwise, return the value of `code`
+    /// casted as a `GenericResult::Enum`.
+    static bmqt::GenericResult::Enum fromStatusCode(int statusCode);
 };
 
 // FREE OPERATORS
@@ -195,6 +201,12 @@ struct OpenQueueResult {
     /// the enum.
     static bool fromAscii(OpenQueueResult::Enum*   out,
                           const bslstl::StringRef& str);
+
+    /// Convert a status code into an open queue result. If `code` does not
+    /// match one of the `OpenQueueResult::Enum` variants, return
+    /// `bmqt::OpenQueueResult::e_UNKNOWN`. Otherwise, return the value of
+    /// `code` casted as a `bmqt::OpenQueueResult::Enum`.
+    static bmqt::OpenQueueResult::Enum fromStatusCode(int code);
 };
 
 // FREE OPERATORS
@@ -265,6 +277,12 @@ struct ConfigureQueueResult {
     /// the enum.
     static bool fromAscii(ConfigureQueueResult::Enum* out,
                           const bslstl::StringRef&    str);
+
+    /// Convert a status code into an open queue result. If `code` does not
+    /// match one of the `ConfigureQueueResult::Enum` variants, return
+    /// `bmqt::ConfigureQueueResult::e_UNKNOWN`. Otherwise, return the value of
+    /// `code` casted as a `bmqt::ConfigureQueueResult::Enum`.
+    static bmqt::ConfigureQueueResult::Enum fromStatusCode(int code);
 };
 
 // FREE OPERATORS
@@ -342,6 +360,12 @@ struct CloseQueueResult {
     /// the enum.
     static bool fromAscii(CloseQueueResult::Enum*  out,
                           const bslstl::StringRef& str);
+
+    /// Convert a status code into a close queue result. If `code` does not
+    /// match one of the `CloseQueueResult::Enum` variants, return
+    /// `bmqt::CloseQueueResult::e_UNKNOWN`. Otherwise, return the value of
+    /// `code` casted as a `bmqt::CloseQueueResult::Enum`.
+    static bmqt::CloseQueueResult::Enum fromStatusCode(int code);
 };
 
 // FREE OPERATORS


### PR DESCRIPTION
bmqa_mocksession had an observable (and deprecated) API change in #1385, this re-adds the old function signature as well as the deprecation macro necessary for tracking its usage in build logs.
