### PR TITLE
Fix: Add missing definition for createSessionEvent

### DIFF
--- a/src/groups/bmq/bmqa/bmqa_mocksession.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.cpp
@@ -16,6 +16,7 @@
 #include <bmqa_mocksession.h>
 
 #include <bmqscm_version.h>
+
 // BMQ
 #include <bmqa_confirmeventbuilder.h>
 #include <bmqa_message.h>
@@ -37,6 +38,7 @@
 #include <bmqp_pusheventbuilder.h>
 #include <bmqst_statcontext.h>
 #include <bmqt_messageguid.h>
+#include <bmqt_resultcode.h>
 #include <bmqt_uri.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_time.h>
@@ -340,6 +342,22 @@ MockSessionUtil::PushMessageParams::PushMessageParams(
 // ---------------------
 
 // CLASS METHODS
+Event MockSessionUtil::createSessionEvent(
+    bmqt::SessionEventType::Enum sessionEventType,
+    const bmqt::CorrelationId&   correlationId,
+    const int                    errorCode,
+    const bslstl::StringRef&     errorDescription,
+    bslma::Allocator*            allocator)
+{
+    return MockSessionUtil::createSessionEvent(
+        sessionEventType,
+        correlationId,
+        errorCode,
+        bmqt::GenericResult::fromStatusCode(errorCode),
+        errorDescription,
+        allocator);
+}
+
 Event MockSessionUtil::createSessionEvent(
     bmqt::SessionEventType::Enum sessionEventType,
     const bmqt::CorrelationId&   correlationId,

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -278,6 +278,24 @@ static void test1_staticMethods()
             bmqt::SessionEventType::e_CONNECTED,
             bmqt::CorrelationId(1),
             0,
+            errorDescription,
+            bmqtst::TestHelperUtil::allocator());
+        bmqa::SessionEvent sessionEvent = event.sessionEvent();
+
+        BMQTST_ASSERT_EQ(sessionEvent.type(),
+                         bmqt::SessionEventType::e_CONNECTED);
+        BMQTST_ASSERT_EQ(sessionEvent.statusCode(), 0);
+        BMQTST_ASSERT_EQ(sessionEvent.errorDescription(), errorDescription);
+        BMQTST_ASSERT_EQ(sessionEvent.correlationId(), bmqt::CorrelationId(1));
+    }
+
+    {
+        PVV("Create Session Event With Result");
+        bsl::string errorDescription("some random description");
+        bmqa::Event event = bmqa::MockSessionUtil::createSessionEvent(
+            bmqt::SessionEventType::e_CONNECTED,
+            bmqt::CorrelationId(1),
+            0,
             bmqt::GenericResult::e_SUCCESS,
             errorDescription,
             bmqtst::TestHelperUtil::allocator());
@@ -289,6 +307,7 @@ static void test1_staticMethods()
         BMQTST_ASSERT_EQ(sessionEvent.errorDescription(), errorDescription);
         BMQTST_ASSERT_EQ(sessionEvent.correlationId(), bmqt::CorrelationId(1));
     }
+
 
     {
         PVV("Create Queue Session Event using Session Event Method");
@@ -335,6 +354,29 @@ static void test1_staticMethods()
 
     {
         PVV("Create Queue Session Event");
+        bsl::string errorDescription("some random description");
+
+        bmqa::QueueId       queueId(1);
+        bmqt::CorrelationId corrId(1);
+
+        bmqa::Event event = bmqa::MockSessionUtil::createQueueSessionEvent(
+            bmqt::SessionEventType::e_QUEUE_OPEN_RESULT,
+            &queueId,
+            corrId,
+            0,
+            "",
+            bmqtst::TestHelperUtil::allocator());
+
+        bmqa::SessionEvent openQueueEvent = event.sessionEvent();
+        BMQTST_ASSERT_EQ(openQueueEvent.type(),
+                         bmqt::SessionEventType::e_QUEUE_OPEN_RESULT);
+        BMQTST_ASSERT_EQ(openQueueEvent.statusCode(), 0);
+        BMQTST_ASSERT_EQ(openQueueEvent.errorDescription(), "");
+        BMQTST_ASSERT_EQ(openQueueEvent.correlationId(), corrId);
+    }
+
+    {
+        PVV("Create Queue Session Event With Result");
         bsl::string errorDescription("some random description");
 
         bmqa::QueueId       queueId(1);

--- a/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
+++ b/src/groups/bmq/bmqa/bmqa_mocksession.t.cpp
@@ -308,7 +308,6 @@ static void test1_staticMethods()
         BMQTST_ASSERT_EQ(sessionEvent.correlationId(), bmqt::CorrelationId(1));
     }
 
-
     {
         PVV("Create Queue Session Event using Session Event Method");
 


### PR DESCRIPTION
Missed this implementation in #1579. Added a section in the test driver to ensure both overloads are used.
