### PR TITLE
Test: Added fuzztest for Event::Initialize method

### DIFF
--- a/src/standalones/s_bmqfuzz/package/s_bmqfuzz.mem
+++ b/src/standalones/s_bmqfuzz/package/s_bmqfuzz.mem
@@ -1,3 +1,4 @@
+s_bmqfuzz_bmqp_event_initialize.fuzz
 s_bmqfuzz_bmqt_uri.fuzz
 s_bmqfuzz_bmqu_stringutil_match.fuzz
 s_bmqfuzz_eval.fuzz

--- a/src/standalones/s_bmqfuzz/s_bmqfuzz_bmqp_event_initialize.fuzz.cpp
+++ b/src/standalones/s_bmqfuzz/s_bmqfuzz_bmqp_event_initialize.fuzz.cpp
@@ -1,0 +1,34 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <bdlbb_blob.h>
+#include <bdlbb_blobutil.h>
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bmqp_event.h>
+
+using namespace BloombergLP;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    bdlbb::PooledBlobBufferFactory factory(1024);
+    bdlbb::Blob                    blob(&factory);
+    bdlbb::BlobUtil::append(&blob, reinterpret_cast<const char*>(Data), Size);
+
+    bmqp::Event event(&blob, bslma::Default::allocator());
+
+    return 0;
+}


### PR DESCRIPTION
This fuzz test found an input that fails during safe and debug builds, which could potentially crash the broker if it was reached. However, in practice this code path isn't reachable because bmqio::ChannelUtil::handleRead frames incoming packets before they reach bmqp::Event. The framing layer reads the first 4 bytes of the stream as a 4 byte length field (EventHeader.d_fragmentBitAndLength), then accumulates bytes until the blob is exactly that declared length before passing it to Event::initialize(). This guarantees the assertion d_header->length() == blob->length() at bmqp_event.h:316 always holds in production.

It may be worthwhile to edit this fuzz test to meet this precondition. Mainly putting this here because I didn't see anything about this precondition documented anywhere in the code. 