### PR TITLE
refactor: enhance m_bmqstoragetool_parameters.h

### DIFF
--- a/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
+++ b/src/applications/bmqstoragetool/bmqstoragetool.m.cpp
@@ -32,10 +32,8 @@
 using namespace BloombergLP;
 using namespace m_bmqstoragetool;
 
-static bool parseArgs(CommandLineArguments& arguments,
-                      int                   argc,
-                      const char*           argv[],
-                      bslma::Allocator*     allocator)
+static bool
+parseArgs(CommandLineArguments& arguments, int argc, const char* argv[])
 {
     bool showHelp = false;
 
@@ -202,7 +200,7 @@ static bool parseArgs(CommandLineArguments& arguments,
     }
 
     bsl::string error;
-    if (!arguments.validate(&error, allocator)) {
+    if (!arguments.validate(&error)) {
         bsl::cerr << "Arguments validation failed:\n" << error;
         return false;  // RETURN
     }
@@ -229,7 +227,7 @@ int main(int argc, const char* argv[])
 
     // Arguments parsing
     CommandLineArguments arguments(allocator);
-    if (!parseArgs(arguments, argc, argv, allocator)) {
+    if (!parseArgs(arguments, argc, argv)) {
         return rc_ARGUMENTS_PARSING_FAILED;  // RETURN
     }
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.cpp
@@ -43,9 +43,11 @@
 #include <bsl_iostream.h>
 #include <bsl_sstream.h>
 #include <bsl_stdexcept.h>
+#include <bsl_string_view.h>
 #include <bsl_vector.h>
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
+#include <bslma_default.h>
 #include <bsls_assert.h>
 #include <bsls_types.h>
 
@@ -81,24 +83,26 @@ bool isValidSequenceNumber(bsl::ostream& error, const bsl::string& seqNumStr)
     return success;
 }
 
+/// Record types constants
+const bsl::string_view k_ALL_TYPE          = "all";
+const bsl::string_view k_MESSAGE_TYPE      = "message";
+const bsl::string_view k_QUEUEOP_TYPE      = "queue-op";
+const bsl::string_view k_JOURNALOP_TYPE    = "journal-op";
+const bsl::string_view k_CSL_ALL_TYPE      = "all";
+const bsl::string_view k_CSL_SNAPSHOT_TYPE = "snapshot";
+const bsl::string_view k_CSL_UPDATE_TYPE   = "update";
+const bsl::string_view k_CSL_COMMIT_TYPE   = "commit";
+const bsl::string_view k_CSL_ACK_TYPE      = "ack";
+/// Print modes constants
+const bsl::string_view k_HUMAN_MODE       = "human";
+const bsl::string_view k_JSON_PRETTY_MODE = "json-pretty";
+const bsl::string_view k_JSON_LINE_MODE   = "json-line";
+
 }  // close unnamed namespace
 
 // ==========================
 // class CommandLineArguments
 // ==========================
-
-const char* CommandLineArguments::k_ALL_TYPE          = "all";
-const char* CommandLineArguments::k_MESSAGE_TYPE      = "message";
-const char* CommandLineArguments::k_QUEUEOP_TYPE      = "queue-op";
-const char* CommandLineArguments::k_JOURNALOP_TYPE    = "journal-op";
-const char* CommandLineArguments::k_CSL_ALL_TYPE      = "all";
-const char* CommandLineArguments::k_CSL_SNAPSHOT_TYPE = "snapshot";
-const char* CommandLineArguments::k_CSL_UPDATE_TYPE   = "update";
-const char* CommandLineArguments::k_CSL_COMMIT_TYPE   = "commit";
-const char* CommandLineArguments::k_CSL_ACK_TYPE      = "ack";
-const char* CommandLineArguments::k_HUMAN_MODE        = "human";
-const char* CommandLineArguments::k_JSON_PRETTY_MODE  = "json-pretty";
-const char* CommandLineArguments::k_JSON_LINE_MODE    = "json-line";
 
 CommandLineArguments::CommandLineArguments(bslma::Allocator* allocator)
 : d_recordType(allocator)
@@ -129,14 +133,14 @@ CommandLineArguments::CommandLineArguments(bslma::Allocator* allocator)
 , d_partiallyConfirmed(false)
 , d_minRecordsPerQueue(0)
 , d_cslSummaryQueuesLimit(0)
+, d_allocator_p(bslma::Default::allocator(allocator))
 {
     // NOTHING
 }
 
-bool CommandLineArguments::validate(bsl::string*      error_p,
-                                    bslma::Allocator* allocator)
+bool CommandLineArguments::validate(bsl::string* error_p)
 {
-    bmqu::MemOutStream ss(allocator);
+    bmqu::MemOutStream ss(d_allocator_p);
 
     // Determine the mode: journal or CSL iteration.
     bool validMode = true;
@@ -149,10 +153,10 @@ bool CommandLineArguments::validate(bsl::string*      error_p,
     if (validMode) {
         if (!d_cslFile.empty() &&
             (d_journalPath.empty() && d_journalFile.empty())) {
-            validateCslModeArgs(ss, allocator);
+            validateCslModeArgs(ss);
         }
         else {
-            validateJournalModeArgs(ss, allocator);
+            validateJournalModeArgs(ss);
         }
     }
 
@@ -160,8 +164,7 @@ bool CommandLineArguments::validate(bsl::string*      error_p,
     return error_p->empty();
 }
 
-void CommandLineArguments::validateCslModeArgs(bsl::ostream&     stream,
-                                               bslma::Allocator* allocator)
+void CommandLineArguments::validateCslModeArgs(bsl::ostream& stream)
 {
     // Validate record types
     if (d_cslRecordType.size() > 4) {
@@ -174,7 +177,7 @@ void CommandLineArguments::validateCslModeArgs(bsl::ostream&     stream,
                   "passed.\n";
     }
 
-    const bool rangeArgPresent = validateRangeArgs(stream, allocator);
+    const bool rangeArgPresent = validateRangeArgs(stream);
 
     // Validate options compatibility
     if (!d_seqNum.empty() &&
@@ -194,7 +197,7 @@ void CommandLineArguments::validateCslModeArgs(bsl::ostream&     stream,
                "specific enough to find a particular record\n";
     }
     if (!d_seqNum.empty()) {
-        bmqu::MemOutStream errorDescr(allocator);
+        bmqu::MemOutStream errorDescr(d_allocator_p);
         for (bsl::vector<bsl::string>::const_iterator cit = d_seqNum.begin();
              cit != d_seqNum.end();
              ++cit) {
@@ -247,8 +250,7 @@ void CommandLineArguments::validateCslModeArgs(bsl::ostream&     stream,
                   "than zero.\n";
 }
 
-void CommandLineArguments::validateJournalModeArgs(bsl::ostream&     stream,
-                                                   bslma::Allocator* allocator)
+void CommandLineArguments::validateJournalModeArgs(bsl::ostream& stream)
 {
     // Validate record types
     if (d_recordType.size() > 3) {
@@ -316,7 +318,7 @@ void CommandLineArguments::validateJournalModeArgs(bsl::ostream&     stream,
                   "specified\n";
     }
 
-    const bool rangeArgPresent = validateRangeArgs(stream, allocator);
+    const bool rangeArgPresent = validateRangeArgs(stream);
 
     // Validate options compatibility
     if (!d_guid.empty() &&
@@ -346,7 +348,7 @@ void CommandLineArguments::validateJournalModeArgs(bsl::ostream&     stream,
                "specific enough to find a particular message\n";
     }
     if (!d_seqNum.empty()) {
-        bmqu::MemOutStream errorDescr(allocator);
+        bmqu::MemOutStream errorDescr(d_allocator_p);
         for (bsl::vector<bsl::string>::const_iterator cit = d_seqNum.begin();
              cit != d_seqNum.end();
              ++cit) {
@@ -400,8 +402,7 @@ void CommandLineArguments::validateJournalModeArgs(bsl::ostream&     stream,
         stream << "Dump limit must be positive value greater than zero.\n";
 }
 
-bool CommandLineArguments::validateRangeArgs(bsl::ostream&     error,
-                                             bslma::Allocator* allocator) const
+bool CommandLineArguments::validateRangeArgs(bsl::ostream& error) const
 {
     if (d_timestampLt < 0 || d_timestampGt < 0 ||
         (d_timestampLt > 0 && d_timestampGt >= d_timestampLt)) {
@@ -409,7 +410,7 @@ bool CommandLineArguments::validateRangeArgs(bsl::ostream&     error,
     }
 
     if (!d_seqNumLt.empty() || !d_seqNumGt.empty()) {
-        bmqu::MemOutStream      errorDescr(allocator);
+        bmqu::MemOutStream      errorDescr(d_allocator_p);
         CompositeSequenceNumber seqNumLt, seqNumGt;
         bool                    successLt = false;
         if (!d_seqNumLt.empty()) {
@@ -593,6 +594,7 @@ Parameters::Parameters(const CommandLineArguments& arguments,
 , d_confirmed(arguments.d_confirmed)
 , d_partiallyConfirmed(arguments.d_partiallyConfirmed)
 , d_cslSummaryQueuesLimit(arguments.d_cslSummaryQueuesLimit)
+, d_allocator_p(bslma::Default::allocator(allocator))
 {
     // Determine processing mode: process Journal or CSL file
     if (!arguments.d_cslFile.empty() &&
@@ -601,10 +603,10 @@ Parameters::Parameters(const CommandLineArguments& arguments,
     }
 
     // Check print mode
-    if (arguments.d_printMode == CommandLineArguments::k_JSON_PRETTY_MODE) {
+    if (arguments.d_printMode == k_JSON_PRETTY_MODE) {
         d_printMode = e_JSON_PRETTY;
     }
-    else if (arguments.d_printMode == CommandLineArguments::k_JSON_LINE_MODE) {
+    else if (arguments.d_printMode == k_JSON_LINE_MODE) {
         d_printMode = e_JSON_LINE;
     }
     // Set record types to process
@@ -618,19 +620,19 @@ Parameters::Parameters(const CommandLineArguments& arguments,
                      arguments.d_cslRecordType.begin();
                  cit != arguments.d_cslRecordType.end();
                  ++cit) {
-                if (*cit == CommandLineArguments::k_CSL_ALL_TYPE) {
+                if (*cit == k_CSL_ALL_TYPE) {
                     d_processCslRecordTypes.setAll();
                 }
-                else if (*cit == CommandLineArguments::k_CSL_SNAPSHOT_TYPE) {
+                else if (*cit == k_CSL_SNAPSHOT_TYPE) {
                     d_processCslRecordTypes.d_snapshot = true;
                 }
-                else if (*cit == CommandLineArguments::k_CSL_UPDATE_TYPE) {
+                else if (*cit == k_CSL_UPDATE_TYPE) {
                     d_processCslRecordTypes.d_update = true;
                 }
-                else if (*cit == CommandLineArguments::k_CSL_COMMIT_TYPE) {
+                else if (*cit == k_CSL_COMMIT_TYPE) {
                     d_processCslRecordTypes.d_commit = true;
                 }
-                else if (*cit == CommandLineArguments::k_CSL_ACK_TYPE) {
+                else if (*cit == k_CSL_ACK_TYPE) {
                     d_processCslRecordTypes.d_ack = true;
                 }
                 else {
@@ -649,17 +651,17 @@ Parameters::Parameters(const CommandLineArguments& arguments,
                      arguments.d_recordType.begin();
                  cit != arguments.d_recordType.end();
                  ++cit) {
-                if (*cit == CommandLineArguments::k_ALL_TYPE) {
+                if (*cit == k_ALL_TYPE) {
                     d_processRecordTypes.setAll();
                     break;  // BREAK
                 }
-                else if (*cit == CommandLineArguments::k_MESSAGE_TYPE) {
+                else if (*cit == k_MESSAGE_TYPE) {
                     d_processRecordTypes.d_message = true;
                 }
-                else if (*cit == CommandLineArguments::k_QUEUEOP_TYPE) {
+                else if (*cit == k_QUEUEOP_TYPE) {
                     d_processRecordTypes.d_queueOp = true;
                 }
-                else if (*cit == CommandLineArguments::k_JOURNALOP_TYPE) {
+                else if (*cit == k_JOURNALOP_TYPE) {
                     d_processRecordTypes.d_journalOp = true;
                 }
                 else {
@@ -730,10 +732,10 @@ Parameters::Parameters(const CommandLineArguments& arguments,
     }
 }
 
-void Parameters::validateQueueNames(bslma::Allocator* allocator) const
+void Parameters::validateQueueNames() const
 {
     // Validate given queue names agains existing in csl file
-    bmqu::MemOutStream                       ss(allocator);
+    bmqu::MemOutStream                       ss(d_allocator_p);
     bsl::vector<bsl::string>::const_iterator it = d_queueName.cbegin();
     for (; it != d_queueName.cend(); ++it) {
         if (!d_queueMap.findKeyByUri(*it).has_value()) {

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_parameters.h
@@ -29,21 +29,14 @@
 #include <m_bmqstoragetool_compositesequencenumber.h>
 #include <m_bmqstoragetool_queuemap.h>
 
-// MQB
-#include <mqbs_datafileiterator.h>
-#include <mqbs_filestoreprotocol.h>
-#include <mqbs_journalfileiterator.h>
-#include <mqbs_mappedfiledescriptor.h>
-
-// BMQ
-#include <bmqu_stringutil.h>
-
 // BDE
 #include <bsl_iosfwd.h>
 #include <bsl_optional.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_types.h>
 
 namespace BloombergLP {
@@ -58,20 +51,6 @@ class CommandLineArguments {
   public:
     // PUBLIC DATA
 
-    /// Record types constants
-    static const char* k_ALL_TYPE;
-    static const char* k_MESSAGE_TYPE;
-    static const char* k_QUEUEOP_TYPE;
-    static const char* k_JOURNALOP_TYPE;
-    static const char* k_CSL_ALL_TYPE;
-    static const char* k_CSL_SNAPSHOT_TYPE;
-    static const char* k_CSL_UPDATE_TYPE;
-    static const char* k_CSL_COMMIT_TYPE;
-    static const char* k_CSL_ACK_TYPE;
-    /// Print modes constants
-    static const char* k_HUMAN_MODE;
-    static const char* k_JSON_PRETTY_MODE;
-    static const char* k_JSON_LINE_MODE;
     /// List of record types to process (message, journalOp, queueOp)
     bsl::vector<bsl::string> d_recordType;
     /// List of CSL record types to process (snapshot, update, commit, ack)
@@ -131,30 +110,37 @@ class CommandLineArguments {
     int d_cslSummaryQueuesLimit;
 
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(CommandLineArguments,
+                                   bslma::UsesBslmaAllocator)
+
     explicit CommandLineArguments(bslma::Allocator* allocator = 0);
 
     // MANIPULATORS
     /// Validate the consistency of all settings.
-    bool validate(bsl::string* error, bslma::Allocator* allocator = 0);
+    bool validate(bsl::string* error);
 
   private:
+    // PRIVATE DATA
+
+    /// Allocator used inside the class.
+    bslma::Allocator* d_allocator_p;
+
     // PRIVATE MANIPULATORS
 
     /// Validate journal mode arguments. Write validation error into the
     /// specified `stream`.
-    void validateJournalModeArgs(bsl::ostream&     stream,
-                                 bslma::Allocator* allocator = 0);
+    void validateJournalModeArgs(bsl::ostream& stream);
 
     // PRIVATE ACCESSORS
 
     /// Validate CSL mode arguments. Write validation error into the specified
     /// `stream`.
-    void validateCslModeArgs(bsl::ostream&     stream,
-                             bslma::Allocator* allocator = 0);
+    void validateCslModeArgs(bsl::ostream& stream);
     /// Validate range args. Return true if at least one range argument passed,
     /// false otherwise.
-    bool validateRangeArgs(bsl::ostream&     error,
-                           bslma::Allocator* allocator) const;
+    bool validateRangeArgs(bsl::ostream& error) const;
 
   public:
     // CLASS METHODS
@@ -298,13 +284,19 @@ struct Parameters {
     bsl::optional<bsls::Types::Uint64> d_minRecordsPerQueue;
     /// Limit number of queues to display in CSL file summary
     unsigned int d_cslSummaryQueuesLimit;
+    /// Allocator used inside the class.
+    bslma::Allocator* d_allocator_p;
 
     // CREATORS
+
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(Parameters, bslma::UsesBslmaAllocator)
+
     /// Constructor from the specified 'aruments'
     explicit Parameters(const CommandLineArguments& aruments,
                         bslma::Allocator*           allocator = 0);
 
-    void validateQueueNames(bslma::Allocator* allocator = 0) const;
+    void validateQueueNames() const;
 };
 
 }  // close package namespace

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
@@ -23,8 +23,10 @@
 #include <bmqu_jsonprinter.h>
 
 // MQB
+#include <mqbs_datafileiterator.h>
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_filestoreprotocolprinter.h>
+#include <mqbs_journalfileiterator.h>
 
 // BDE
 #include <bsl_algorithm.h>

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
@@ -27,6 +27,10 @@
 #include <m_bmqstoragetool_messagedetails.h>
 #include <m_bmqstoragetool_parameters.h>
 
+// MQB
+#include <mqbs_datafileiterator.h>
+#include <mqbs_journalfileiterator.h>
+
 // BMQ
 #include <bmqt_messageguid.h>
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.h
@@ -27,10 +27,6 @@
 #include <m_bmqstoragetool_messagedetails.h>
 #include <m_bmqstoragetool_parameters.h>
 
-// MQB
-#include <mqbs_datafileiterator.h>
-#include <mqbs_journalfileiterator.h>
-
 // BMQ
 #include <bmqt_messageguid.h>
 
@@ -43,6 +39,12 @@
 #include <bslma_managedptr.h>
 
 namespace BloombergLP {
+
+// FORWARD DECLARATIONS
+namespace mqbs {
+class DataFileIterator;
+class JournalFileIterator;
+}
 
 namespace m_bmqstoragetool {
 

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.cpp
@@ -20,8 +20,10 @@
 #include <m_bmqstoragetool_searchresult.h>
 
 // MQB
+#include <mqbs_datafileiterator.h>
 #include <mqbs_filestoreprotocolprinter.h>
 #include <mqbs_filestoreprotocolutil.h>
+#include <mqbs_journalfileiterator.h>
 
 // BMQ
 #include <bmqu_alignedprinter.h>

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -61,7 +61,9 @@
 #include <m_bmqstoragetool_printer.h>
 
 // MQB
+#include <mqbs_datafileiterator.h>
 #include <mqbs_filestoreprotocolprinter.h>
+#include <mqbs_journalfileiterator.h>
 
 // BDE
 #include <bsl_iostream.h>

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -60,10 +60,7 @@
 #include <m_bmqstoragetool_payloaddumper.h>
 #include <m_bmqstoragetool_printer.h>
 
-// MQB
-#include <mqbs_datafileiterator.h>
 #include <mqbs_filestoreprotocolprinter.h>
-#include <mqbs_journalfileiterator.h>
 
 // BDE
 #include <bsl_iostream.h>
@@ -79,7 +76,12 @@
 #include <bsls_keyword.h>
 
 namespace BloombergLP {
-namespace m_bmqstoragetool {
+
+// FORWARD DECLARATIONS
+namespace mqbs {
+class DataFileIterator;
+class JournalFileIterator;
+}
 
 // ==================
 // class SearchResult

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_searchresult.h
@@ -83,6 +83,8 @@ class DataFileIterator;
 class JournalFileIterator;
 }
 
+namespace m_bmqstoragetool {
+
 // ==================
 // class SearchResult
 // ==================


### PR DESCRIPTION
Closes #1507

- Remove unused includes from the header and add direct includes to printer.h and searchresult.h
- Move record-type and print-mode constants into an unnamed namespace in the .cpp as bsl::string_view
- Add allocator traits to CommandLineArguments and Parameters
- Store d_allocator_p in each class and remove allocator argument used in other functions

@678098 could you take a look when you have a moment? Thanks!