### PR TITLE
Build: fetch_git bde last in `build_deps.sh`

### DIFF
--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -64,10 +64,10 @@ fetch_git() {
 }
 
 fetch_deps() {
-    fetch_git bloomberg bde-tools 4.38.0.0
-    fetch_git bloomberg bde 4.38.0.0
     fetch_git bloomberg ntf-core 2.6.12
     fetch_git google googletest v1.8.x
+    fetch_git bloomberg bde-tools 4.38.0.0
+    fetch_git bloomberg bde 4.38.0.0
 }
 
 configure() {


### PR DESCRIPTION
`bde` repo clone might take more time than the other repos, make sure to clone it last.