### PR TITLE
CI: Avoid linting fuzz tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -216,6 +216,7 @@ jobs:
           lines-changed-only: diff
           version: '21'
           database: build/blazingmq
+          ignore: '.github|src/standalones/s_bmqfuzz'
       - name: Fail fast?!
         if: steps.linter.outputs.checks-failed > 0
         run: exit 1


### PR DESCRIPTION
Our fuzztests in `src/standalones/s_bmqfuzz` need to be build with clang and libfuzzer to work, and need to be build with the fuzztest install target; their CMakeLists file enforces these two conditions:

```cmake
if(NOT BMQ_TARGET_FUZZTESTS_NEEDED OR NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
  return()
endif()
```

For building locally and in CI, this is fine.  However, the C++ linter check in CI configures a build using GCC (through the default `gh-build-ubuntu-latest-cpp23` preset) and without the fuzztest install target set.  Fixing these, especially using clang rather than GCC, would require bigger changes to our CI infrastructure, and the downside of not linting the simple fuzztests is fairly low.

This patch simply ignores the fuzz test executables under `src/standalones/s_bmqfuzz`.  By default, this action ignores anything under `.github`, so we maintain that default behavior (even though it does not affect us).
