### PR TITLE
Misc[mqbs::FileStore]: Add logging for record writes

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -3756,6 +3756,12 @@ void FileStore::writeQueueOpRecordImpl(DataStoreRecordHandle*  handle,
                                       bmqp::StorageMessageType::e_QUEUE_OP,
                                       RecordType::e_QUEUE_OP,
                                       recordOffset);
+
+    BALL_LOG_INFO << partitionDesc() << "Wrote QueueOpRecord to journal"
+                  << " [queueKey: " << queueKey << ", appKey: " << appKey
+                  << ", type: " << queueOpFlag
+                  << ", PSN: " << printPSN(d_primaryLeaseId, sequenceNumber())
+                  << ", journal offset: " << recordOffset << "]";
 }
 
 void FileStore::writeRolledOverRecord(DataStoreRecord*    record,
@@ -4964,6 +4970,15 @@ int FileStore::writeJournalRecord(const bmqp::StorageHeader& header,
         }
     }
 
+    if (bmqp::StorageMessageType::e_CONFIRM != messageType &&
+        bmqp::StorageMessageType::e_DELETION != messageType) {
+        BALL_LOG_INFO << partitionDesc() << "Wrote JournalRecord to journal"
+                      << " [type: " << messageType << ", PSN: "
+                      << printPSN(recHeader.primaryLeaseId(),
+                                  recHeader.sequenceNumber())
+                      << ", journal offset: " << recordOffset << "]";
+    }
+
     return rc_SUCCESS;
 }
 
@@ -5230,7 +5245,7 @@ void FileStore::aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
     OffsetPtr<const DataHeader> dataHeader(
         activeFileSet->d_data.d_file.block(),
         record.d_messageOffset);
-    const unsigned int          dataHdrSize = dataHeader->headerWords() *
+    const unsigned int dataHdrSize = dataHeader->headerWords() *
                                      bmqp::Protocol::k_WORD_SIZE;
     const bsls::Types::Uint64 optionsOffset = record.d_messageOffset +
                                               dataHdrSize;
@@ -6042,6 +6057,15 @@ int FileStore::writeQueueCreationRecord(DataStoreRecordHandle*  handle,
         activeFileSet->d_qlist.d_outstandingBytes += qlistRecTotalLength;
     }
 
+    BALL_LOG_INFO << partitionDesc() << "Wrote QueueCreationRecord to journal"
+                  << " [queueUri: " << queueUri << ", queueKey: " << queueKey
+                  << ", isNewQueue: " << isNewQueue << ", appIdKeyPairs: "
+                  << bmqu::Printer<AppInfos>(&appIdKeyPairs)
+                  << ", timestamp: " << timestamp
+                  << ", PSN: " << printPSN(d_primaryLeaseId, sequenceNumber())
+                  << ", journal offset: " << recordOffset
+                  << ", qlist offset: " << qlistOffset << "]";
+
     return rc_SUCCESS;
 }
 
@@ -6246,6 +6270,7 @@ int FileStore::writeSyncPointRecord(const bmqp_ctrlmsg::SyncPoint& syncPoint,
     BSLS_ASSERT_SAFE(journal.fileSize() >=
                      (journalPos + FileStoreProtocol::k_JOURNAL_RECORD_SIZE));
 
+    const bsls::Types::Uint64  recordOffset = journalPos;
     OffsetPtr<JournalOpRecord> journalOpRec(journal.block(), journalPos);
     new (journalOpRec.get())
         JournalOpRecord(JournalOpType::e_SYNCPOINT,
@@ -6265,6 +6290,11 @@ int FileStore::writeSyncPointRecord(const bmqp_ctrlmsg::SyncPoint& syncPoint,
 
     // Don't update outstanding journal bytes because it is a SyncPt, and we
     // don't rollover SyncPts.
+
+    BALL_LOG_INFO << partitionDesc() << "Wrote SyncPointRecord to journal"
+                  << " [type: " << type << ", syncPoint: " << syncPoint
+                  << ", PSN: " << printPSN(d_primaryLeaseId, sequenceNumber())
+                  << ", journal offset: " << recordOffset << "]";
 
     return rc_SUCCESS;
 }

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -1734,9 +1734,14 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
     }
 
     BALL_LOG_INFO << " Partition [" << partitionId
-                  << "]: " << "Received QueueCreationRecord of " << "type ["
-                  << queueRec->type() << "] for " << "queueKey ["
-                  << queueRec->queueKey() << "]" << queueUriAppsStr.str();
+                  << "]: Wrote QueueCreationRecord of type ["
+                  << queueRec->type() << "] for queueKey ["
+                  << queueRec->queueKey()
+                  << "], queueUri: " << queueUriAppsStr.str() << ", PSN ["
+                  << queueRec->header().primaryLeaseId() << ", "
+                  << queueRec->header().sequenceNumber()
+                  << "], journal offset: " << recordOffset
+                  << ", qlist offset: " << qlistOffset;
 
     return rc_SUCCESS;
 }


### PR DESCRIPTION
## Summary
  - Add INFO-level logging to the record-write methods in `mqbs::FileStore` to improve observability of storage operations on both the primary and replica paths.
  - Only journal/queue-op-style records are logged. High-frequency **message-related** records (MessageRecord, ConfirmRecord, DeletionRecord) are intentionally **not** logged at all to avoid flooding logs — no throttling mechanism is introduced.
  - Each log line consistently carries PSN (primary lease id + sequence number), journal offset, and record-type-specific fields (queueKey, appKey, guid, type, etc.).
  - Extend the existing log in `FileStoreUtil::writeQueueCreationRecordImpl` to include PSN and file offsets.