### PR TITLE
CI: Make clang-tidy checks not fail the lint pipeline

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -217,6 +217,4 @@ jobs:
           version: '21'
           database: build/blazingmq
           ignore: '.github|src/standalones/s_bmqfuzz'
-      - name: Fail fast?!
-        if: steps.linter.outputs.checks-failed > 0
-        run: exit 1
+        continue-on-error: true


### PR DESCRIPTION
This makes the noisy clang-tidy checks not cause the CI pipeline to turn red while we're still figuring out how to use it effectively.
