### PR TITLE
Refactor[mqbc::PStateTable]: Delay replica heal until PUSH from primary

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -526,7 +526,7 @@ class PartitionStateTableActions {
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
-    void do_closeRecoveryFileSet_attemptOpenStorage_sendDataToPrimary(
+    void do_sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
@@ -858,7 +858,7 @@ class PartitionStateTable
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,
                 REPLICA_DATA_RQST_PULL,
-                closeRecoveryFileSet_attemptOpenStorage_sendDataToPrimary,
+                sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage,
                 REPLICA_HEALING);
         PST_CFG(
             REPLICA_HEALING,
@@ -1177,13 +1177,13 @@ PartitionStateTableActions::do_resetReceiveDataCtx_closeRecoveryFileSet(
 }
 
 inline void PartitionStateTableActions::
-    do_closeRecoveryFileSet_attemptOpenStorage_sendDataToPrimary(
+    do_sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData)
 {
+    do_sendDataToPrimary(eventType, eventData);
     do_closeRecoveryFileSet(eventType, eventData);
     do_attemptOpenStorage(eventType, eventData);
-    do_sendDataToPrimary(eventType, eventData);
 }
 
 inline void PartitionStateTableActions::

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -526,10 +526,6 @@ class PartitionStateTableActions {
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
-    void do_sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage(
-        PartitionStateTableEvent::Enum eventType,
-        const PartitionFSMEventData&   eventData);
-
     void
     do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
@@ -559,11 +555,6 @@ class PartitionStateTableActions {
         const PartitionFSMEventData&   eventData);
 
     void do_replicaStateResponse_storePrimarySeq(
-        PartitionStateTableEvent::Enum eventType,
-        const PartitionFSMEventData&   eventData);
-
-    void
-    do_replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
@@ -858,13 +849,12 @@ class PartitionStateTable
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,
                 REPLICA_DATA_RQST_PULL,
-                sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage,
+                sendDataToPrimary,
                 REPLICA_HEALING);
-        PST_CFG(
-            REPLICA_HEALING,
-            DONE_SENDING_DATA_CHUNKS,
-            replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog,
-            REPLICA_HEALED);
+        PST_CFG(REPLICA_HEALING,
+                DONE_SENDING_DATA_CHUNKS,
+                replicaDataResponsePull,
+                REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,
                 ERROR_SENDING_DATA_CHUNKS,
                 failureReplicaDataResponsePull_reapplyDetectSelfReplica,
@@ -1177,16 +1167,6 @@ PartitionStateTableActions::do_resetReceiveDataCtx_closeRecoveryFileSet(
 }
 
 inline void PartitionStateTableActions::
-    do_sendDataToPrimary_closeRecoveryFileSet_attemptOpenStorage(
-        PartitionStateTableEvent::Enum eventType,
-        const PartitionFSMEventData&   eventData)
-{
-    do_sendDataToPrimary(eventType, eventData);
-    do_closeRecoveryFileSet(eventType, eventData);
-    do_attemptOpenStorage(eventType, eventData);
-}
-
-inline void PartitionStateTableActions::
     do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData)
@@ -1258,17 +1238,6 @@ PartitionStateTableActions::do_replicaStateResponse_storePrimarySeq(
 {
     do_replicaStateResponse(eventType, eventData);
     do_storePrimarySeq(eventType, eventData);
-}
-
-inline void PartitionStateTableActions::
-    do_replicaDataResponsePull_processBufferedLiveData_processBufferedPrimaryStatusAdvisories_stopWatchdog(
-        PartitionStateTableEvent::Enum eventType,
-        const PartitionFSMEventData&   eventData)
-{
-    do_replicaDataResponsePull(eventType, eventData);
-    do_processBufferedLiveData(eventType, eventData);
-    do_processBufferedPrimaryStatusAdvisories(eventType, eventData);
-    do_stopWatchdog(eventType, eventData);
 }
 
 inline void PartitionStateTableActions::

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -280,7 +280,10 @@ int RecoveryManager::processSendDataChunks(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(destination);
     BSLS_ASSERT_SAFE(fs.inDispatcherThread());
-    BSLS_ASSERT_SAFE(fs.isOpen());
+    // Either the FileStore is open, or the recovery file set is open.
+    BSLS_ASSERT_SAFE(
+        fs.isOpen() ||
+        d_recoveryContextVec[partitionId].d_mappedJournalFd.isValid());
 
     enum RcEnum {
         // Value for the various RC error categories
@@ -302,7 +305,12 @@ int RecoveryManager::processSendDataChunks(
                   << ". Peer: " << destination->nodeDescription() << ".";
 
     mqbs::FileStoreSet fileSet;
-    fs.loadCurrentFiles(&fileSet);
+    if (fs.isOpen()) {
+        fs.loadCurrentFiles(&fileSet);
+    }
+    else {
+        fileSet = d_recoveryContextVec[partitionId].d_recoveryFileSet;
+    }
 
     bsl::shared_ptr<mqbs::MappedFileDescriptor> mappedJournalFd =
         bsl::make_shared<mqbs::MappedFileDescriptor>();
@@ -1579,6 +1587,47 @@ int RecoveryManager::recoverPSN(bmqp_ctrlmsg::PartitionSequenceNumber* psn,
                       << mqbs::printPSN(0, 0) << " as self PSN.";
 
         psn->reset();
+    }
+
+    return rc_SUCCESS;
+}
+
+int RecoveryManager::loadHighestSeqNums(
+    mqbs::FileStore::LeaseIdToSeqNumMap* out,
+    int                                  partitionId)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with 'partitionId'
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(out);
+    validatePartitionId(partitionId);
+
+    enum RcEnum {
+        // Value for the various RC error categories
+        rc_SUCCESS               = 0,
+        rc_FILE_ITERATOR_FAILURE = -1
+    };
+
+    RecoveryContext& recoveryCtx = d_recoveryContextVec[partitionId];
+    BSLS_ASSERT_SAFE(recoveryCtx.d_mappedJournalFd.isValid());
+
+    mqbs::JournalFileIterator journalIt;
+    int                       rc = journalIt.reset(
+        &recoveryCtx.d_mappedJournalFd,
+        mqbs::FileStoreProtocolUtil::bmqHeader(recoveryCtx.d_mappedJournalFd));
+    if (0 != rc) {
+        BALL_LOG_ERROR << d_clusterData.identity().description()
+                       << " Partition [" << partitionId << "]: "
+                       << "While loading highest sequence numbers, failed to "
+                       << "reset journal iterator, rc: " << rc;
+        return 10 * rc + rc_FILE_ITERATOR_FAILURE;  // RETURN
+    }
+
+    // Journal records are laid out in ascending PSN order, so the last
+    // sequence number seen for each lease id is the highest one.
+    while (1 == journalIt.nextRecord()) {
+        const mqbs::RecordHeader& recHeader = journalIt.recordHeader();
+        (*out)[recHeader.primaryLeaseId()]  = recHeader.sequenceNumber();
     }
 
     return rc_SUCCESS;

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.h
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.h
@@ -392,6 +392,19 @@ class RecoveryManager {
                    int                                    partitionId,
                    bool firstSyncPointAfterRolllover = false);
 
+    /// Load into the specified `out` the map of primaryLeaseId to highest
+    /// sequence number observed, by scanning the recovery journal file set
+    /// of the specified `partitionId`.  Return 0 on success and non-zero
+    /// otherwise.  This provides the same information as
+    /// @bbref{mqbs::FileStore::highestSeqNums} when the FileStore is not
+    /// yet open.  The behavior is undefined unless the recovery file set for
+    /// `partitionId` is open.
+    ///
+    /// THREAD: Executed in the dispatcher thread associated with the
+    /// specified `partitionId`.
+    int loadHighestSeqNums(mqbs::FileStore::LeaseIdToSeqNumMap* out,
+                           int                                  partitionId);
+
     /// Set the live data source of the specified 'partitionId' to the
     /// specified 'source', and clear any existing buffered storage events.
     ///

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2751,9 +2751,6 @@ void StorageManager::do_sendDataToPrimary(
                      PartitionFSM::Event::e_REPLICA_DATA_RQST_PULL);
     BSLS_ASSERT_SAFE(d_partitionFSMVec.at(partitionId)->isSelfReplica());
 
-    const mqbs::FileStore& fs = fileStore(partitionId);
-    BSLS_ASSERT_SAFE(fs.isOpen());
-
     mqbnet::ClusterNode* selfNode = d_clusterData_p->membership().selfNode();
 
     mqbnet::ClusterNode* const destNode = eventData.source();
@@ -2783,8 +2780,26 @@ void StorageManager::do_sendDataToPrimary(
 
     // Check if the primary's PSN (beginSeqNum) is irreconcilable with
     // replica's known highest PSNs.
-    const mqbs::FileStore::LeaseIdToSeqNumMap& highestPSNs =
-        fs.highestSeqNums();
+    mqbs::FileStore::LeaseIdToSeqNumMap highestPSNs;
+    const mqbs::FileStore&              fs = fileStore(partitionId);
+    if (fs.isOpen()) {
+        highestPSNs = fs.highestSeqNums();
+    }
+    else {
+        const int rc = d_recoveryManager_mp->loadHighestSeqNums(&highestPSNs,
+                                                                partitionId);
+        if (rc != 0) {
+            BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                           << " Partition [" << partitionId << "]: "
+                           << "Failed to load highest sequence numbers from "
+                           << "recovery file set, rc = " << rc;
+
+            enqueuePartitionFSMEvent(
+                PartitionFSM::Event::e_ERROR_SENDING_DATA_CHUNKS,
+                sendPartitionFSMEventData);
+            return;  // RETURN
+        }
+    }
     mqbs::FileStore::LeaseIdToSeqNumMapCIter PSNCit = highestPSNs.find(
         beginSeqNum.primaryLeaseId());
     if (PSNCit != highestPSNs.end() &&

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -2496,8 +2496,6 @@ static void test15_replicaWaitingReceivesReplicaDataRqstPull()
 
     helper.startStorageManager(&storageManager, primaryNode);
 
-    mqbs::FileStore& fs = storageManager.fileStore(k_PARTITION_ID);
-
     BSLS_ASSERT_OPT(storageManager.partitionHealthState(k_PARTITION_ID) ==
                     mqbc::PartitionFSM::State::e_REPLICA_WAITING);
 
@@ -2575,9 +2573,6 @@ static void test15_replicaWaitingReceivesReplicaDataRqstPull()
     replicaDataRequest.endSequenceNumber()   = selfSeqNum;
 
     storageManager.processReplicaDataRequest(requestMessage, primaryNode);
-
-    BSLS_ASSERT_OPT(fs.primaryLeaseId() == selfSeqNum.primaryLeaseId());
-    BSLS_ASSERT_OPT(fs.sequenceNumber() == selfSeqNum.sequenceNumber());
 
     // Verify that Replica sends data chunks followed by
     // ReplicaDataRspnPull.


### PR DESCRIPTION
  ## Summary
  - Groundwork for the upcoming "primary conforms its journal to the CSL"
    work: a healing replica that the primary pulls from must be able to
    receive post-pull corrections back from the primary.
  - Previously a replica that received a `ReplicaDataRequestPull` opened its
    real storage and transitioned straight to `REPLICA_HEALED` once it
    finished sending. That gave the primary no window to push corrections
    back to the most up-to-date replica.
  - This PR keeps the pulled-from replica in `REPLICA_HEALING` after it
    finishes sending, with its recovery file set still open, so it heals
    through the push path (`DONE_RECEIVING_DATA_CHUNKS`) like any other
    replica — an empty push today, a corrections-carrying push in a
    follow-up PR.
  - To make this possible, sending data chunks to the primary no longer
    requires the replica's `FileStore` to be open.