### PR TITLE
Cleanup[mqbc::PStateTable]: Refresh self PSN after opening storage

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -527,7 +527,7 @@ class PartitionStateTableActions {
         const PartitionFSMEventData&   eventData);
 
     void
-    do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+    do_closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
@@ -546,7 +546,7 @@ class PartitionStateTableActions {
         const PartitionFSMEventData&   eventData);
 
     void
-    do_resetReceiveDataCtx_storeSelfSeq_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+    do_resetReceiveDataCtx_closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
@@ -676,7 +676,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG1,
             SELF_HIGHEST_SEQ,
-            closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn,
+            closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn,
             PRIMARY_HEALING_STG2);
         PST_CFG(
             PRIMARY_HEALING_STG1,
@@ -747,7 +747,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALING_STG2,
             REPLICA_DATA_RSPN_PULL,
-            resetReceiveDataCtx_storeSelfSeq_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn,
+            resetReceiveDataCtx_closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn,
             PRIMARY_HEALING_STG2);
         PST_CFG(PRIMARY_HEALING_STG2,
                 REPLICA_DATA_RSPN_PUSH,
@@ -1167,12 +1167,13 @@ PartitionStateTableActions::do_resetReceiveDataCtx_closeRecoveryFileSet(
 }
 
 inline void PartitionStateTableActions::
-    do_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+    do_closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData)
 {
     do_closeRecoveryFileSet(eventType, eventData);
     do_attemptOpenStorage(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
     do_sendDataToReplicas(eventType, eventData);
     do_incrementNumRplcaDataRspn(eventType, eventData);
     do_checkQuorumRplcaDataRspn(eventType, eventData);
@@ -1209,14 +1210,14 @@ PartitionStateTableActions::do_setExpectedDataChunkRange_clearBufferedLiveData(
 }
 
 inline void PartitionStateTableActions::
-    do_resetReceiveDataCtx_storeSelfSeq_closeRecoveryFileSet_attemptOpenStorage_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
+    do_resetReceiveDataCtx_closeRecoveryFileSet_attemptOpenStorage_storeSelfSeq_sendDataToReplicas_incrementNumRplcaDataRspn_checkQuorumRplcaDataRspn(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData)
 {
     do_resetReceiveDataCtx(eventType, eventData);
-    do_storeSelfSeq(eventType, eventData);
     do_closeRecoveryFileSet(eventType, eventData);
     do_attemptOpenStorage(eventType, eventData);
+    do_storeSelfSeq(eventType, eventData);
     do_sendDataToReplicas(eventType, eventData);
     do_incrementNumRplcaDataRspn(eventType, eventData);
     do_checkQuorumRplcaDataRspn(eventType, eventData);


### PR DESCRIPTION
## Summary
  - Groundwork for the upcoming primary CSL-conform work (Internal Ticket 183514192), where the primary writes corrective records while opening its FileStore during healing.
  - The primary cached self's partition sequence number (PSN) *before* `attemptOpenStorage`. That is fine today but goes stale-low once opening advances the PSN, causing the correction PUSH to replicas to omit those very records.
  - Moves the `storeSelfSeq` bookkeeping to run *after* `attemptOpenStorage` in both healing transitions, so the cached self PSN always reflects the open store. No behavioral change today.