### PR TITLE
Fix: Memory leak in ZLib::writeOutput

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -255,6 +255,7 @@ int ZLib::writeOutput(bdlbb::Blob*              output,
                      "Error processing stream",
                      result,
                      stream->msg);
+            zlibEndMethod(stream);
             return rc_STREAM_PROCESS_FAILURE;  // RETURN
         }
     }


### PR DESCRIPTION
When the PutMessageIterator calls Parse with the compression algorithm type flag set to ZLib, decompressZLib is eventually called, which calls ZLib::writeOutput. If the scope on line 252 in bmqp_compression.cpp (shown in the file changes tab in this PR) is entered, the method returns before calling zlibEndMethod, which causes the memory leak. 

See this gist for more details about how the bug was found by libfuzzer. Code for how to reproduce it is also included in the gist and was used to test this change by viewing the memory usage of the broker before and after sending specific PUT messages.
