### PR TITLE
CI: Add clang-tidy review comment permission

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,7 @@ name: Lint
 
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   pull_request:


### PR DESCRIPTION
This is a necessary permission for using the `thread-comments` feature in `cpp_linter_checks`
