### PR TITLE
Feat: Support incoming TLS connections

### DIFF
--- a/bin/gen-tls-certs.sh
+++ b/bin/gen-tls-certs.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+#
+#
+# This scripts generates:
+#  - root CA certificate
+#  - server certificate and keystore
+#  - client keys
+#
+# Based off of
+#   https://github.com/confluentinc/librdkafka/blob/master/tests/gen-ssl-certs.sh
+
+OP="$1"
+CA_CERT="$2"
+PFX="$3"
+HOST="$4"
+
+C=NN
+ST=NN
+L=NN
+O=NN
+OU=NN
+CN="$HOST"
+ 
+
+# Password
+PASS="secret"
+
+# Cert validity, in days
+VALIDITY=10000
+
+set -e
+
+export LC_ALL=C
+
+if [[ $OP == "ca" && -n "$CA_CERT" && -n "$3" ]]; then
+    CN="$3"
+    openssl req -new -x509 -keyout "${CA_CERT}.key" -out "${CA_CERT}" -days $VALIDITY -passin "pass:$PASS" -passout "pass:$PASS" <<EOF
+${C}
+${ST}
+${L}
+${O}
+${OU}
+${CN}
+$USER@${CN}
+.
+.
+EOF
+
+
+
+elif [[ $OP == "server" && -n "$CA_CERT" && -n "$PFX" && -n "$CN" ]]; then
+    HOST_CERT_CONFIG_PATH="${PFX}host_cert.cnf"
+    HOST_PRIVATE_RSA_KEY_PATH="${PFX}host_private_key_rsa.pem"
+    HOST_PRIVATE_KEY_PATH="${PFX}private_key.pem"
+    HOST_CSR_PATH="${PFX}host_csr.pem"
+    HOST_CERT_PATH="${PFX}host_cert.pem"
+    HOST_CERT_CHAIN_PATH="${PFX}client_${CN}.pem"
+
+    # Create the CA cert config file
+    echo "Setting up host certs..."
+
+    cat <<EOF > "${HOST_CERT_CONFIG_PATH}"
+[req]
+default_bits        = 2048
+distinguished_name  = req_distinguished_name
+req_extensions      = v3_req
+prompt              = no
+[req_distinguished_name]
+C   = ${C}
+ST  = ${ST}
+L   = ${L}
+O   = ${O}
+CN  = ${CN}
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1  = ${CN}
+DNS.2  = localhost.
+EOF
+
+    #Step 1
+    echo "############ Generating key"
+    openssl genrsa -out "${HOST_PRIVATE_RSA_KEY_PATH}" 2048
+    openssl pkcs8 -nocrypt -topk8 -v1 PBE-SHA1-RC4-128 -inform pem -outform pem -in "${HOST_PRIVATE_RSA_KEY_PATH}" -out "${HOST_PRIVATE_KEY_PATH}"
+	
+    #Step 2
+    echo "############ Generate the CSR"
+    openssl req -nodes -new -extensions v3_req -sha256 -config "${HOST_CERT_CONFIG_PATH}" -key "${HOST_PRIVATE_KEY_PATH}" -out "${HOST_CSR_PATH}"
+    
+    #Step 3
+    echo "############ Generate the cert"
+    openssl x509 -req -in "${HOST_CSR_PATH}" -CA "${CA_CERT}" -CAkey "${CA_CERT}.key" -CAcreateserial -out "${HOST_CERT_PATH}" -days ${VALIDITY} -sha256 -extensions v3_req -extfile "${HOST_CERT_CONFIG_PATH}" -passin "pass:${PASS}"
+    
+    cat "${HOST_CERT_PATH}" > "${HOST_CERT_CHAIN_PATH}"
+
+
+elif [[ $OP == "client" && -n "$CA_CERT" && -n "$PFX" && -n "$CN" ]]; then
+
+# Standard OpenSSL keys
+	echo "############ Generating key"
+	openssl genrsa -nodes -passout "pass:${PASS}" -out "${PFX}client.key" 2048 
+	
+	echo "############ Generating request"
+	openssl req -passin "pass:${PASS}" -passout "pass:${PASS}" -key "${PFX}client.key" -new -out "${PFX}client.req" \
+		<<EOF
+$C
+$ST
+$L
+$O
+$OU
+$CN
+.
+$PASS
+.
+EOF
+
+	echo "########### Signing key"
+	openssl x509 -req -passin "pass:${PASS}" -in "${PFX}client.req" -CA "${CA_CERT}" -CAkey "${CA_CERT}.key" -CAcreateserial -out "${PFX}client.pem" -days ${VALIDITY}
+
+
+else
+    echo "Usage: $0 ca <ca-cert-file> <CN>"
+    echo "       $0 server|client <ca-cert-file> <file_prefix> <hostname>"
+    echo ""
+    exit 1
+fi
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,10 +52,19 @@ FROM docker.io/ubuntu:24.04
 
 COPY --from=builder /bmq /usr/local
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    openssl
+
 RUN groupadd bmq \
     && useradd bmq --home /var/local/bmq --system --gid bmq --shell /usr/bin/bash
 USER bmq
 WORKDIR /var/local/bmq
-RUN mkdir -p logs storage/archive
+COPY bin/gen-tls-certs.sh gen-tls-certs.sh
+
+RUN mkdir -p logs storage/archive certs && \
+    cd certs && \
+    ../gen-tls-certs.sh ca ca-cert dummy && \
+    ../gen-tls-certs.sh server ca-cert broker_ dummy
 
 CMD [ "/bin/bash" ]

--- a/docker/cluster/config/bmqbrkrcfg.json
+++ b/docker/cluster/config/bmqbrkrcfg.json
@@ -86,11 +86,27 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    },
+                    {
+                        "name": "TLSListener",
+                        "port": 30115,
+                        "tls": true
+                    }
             }
         },
         "bmqconfConfig": {
             "cacheTTLSeconds": 30
+        },
+        "tlsConfig": {
+            "certificateAuthority": "/var/local/bmq/certs/ca-cert",
+            "certificate": "/var/local/bmq/certs/broker_host_cert.pem",
+            "key": "/var/local/bmq/certs/broker_private_key.pem"
         }
     }
 }

--- a/docker/single-node/config/bmqbrkrcfg.json
+++ b/docker/single-node/config/bmqbrkrcfg.json
@@ -86,11 +86,28 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    },
+                    {
+                        "name": "TLSListener",
+                        "port": 30115,
+                        "tls": true
+                    }
+                ]
             }
         },
         "bmqconfConfig": {
             "cacheTTLSeconds": 30
+        },
+        "tlsConfig": {
+            "certificateAuthority": "/var/local/bmq/certs/ca-cert",
+            "certificate": "/var/local/bmq/certs/broker_host_cert.pem",
+            "key": "/var/local/bmq/certs/broker_private_key.pem"
         }
     }
 }

--- a/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
+++ b/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
@@ -86,7 +86,14 @@
                 "highWatermark": 1073741824,
                 "nodeLowWatermark": 5242880,
                 "nodeHighWatermark": 10485760,
-                "heartbeatIntervalMs": 3000
+                "heartbeatIntervalMs": 3000,
+                "listeners": [
+                    {
+                        "name": "TCPListener",
+                        "port": 30114,
+                        "tls": false
+                    }
+                ]
             }
         },
         "bmqconfConfig": {

--- a/src/applications/bmqtool/bmqtool.m.cpp
+++ b/src/applications/bmqtool/bmqtool.m.cpp
@@ -202,6 +202,18 @@ static bool parseArgs(Parameters* parameters, int argc, const char* argv[])
          "address and port of the broker",
          balcl::TypeInfo(&params.broker()),
          balcl::OccurrenceInfo(params.broker())},
+        {"tls-authority",
+         "tlsAuthority",
+         "Path to the certificate authority FILE for TLS mode."
+         "The empty string value means that TLS is disabled, "
+         "non-empty string value means that TLS is enabled",
+         balcl::TypeInfo(&params.tlsAuthority()),
+         balcl::OccurrenceInfo(params.tlsAuthority())},
+        {"tls-versions",
+         "tlsVersions",
+         "TLS protocol versions, has effect only in TLS mode",
+         balcl::TypeInfo(&params.tlsVersions()),
+         balcl::OccurrenceInfo(params.tlsVersions())},
         {"q|queueuri",
          "uri",
          "URI of the queue (for auto/syschk modes)",

--- a/src/applications/bmqtool/m_bmqtool_application.cpp
+++ b/src/applications/bmqtool/m_bmqtool_application.cpp
@@ -487,6 +487,11 @@ int Application::initialize()
                                     d_parameters.authnData()));
     }
 
+    if (!d_parameters.tlsAuthority().empty()) {
+        options.configureTls(d_parameters.tlsAuthority(),
+                             d_parameters.tlsVersions());
+    }
+
     // Create the session
     if (d_parameters.noSessionEventHandler()) {
         d_session_mp.load(new (*d_allocator_p)

--- a/src/applications/bmqtool/m_bmqtool_parameters.cpp
+++ b/src/applications/bmqtool/m_bmqtool_parameters.cpp
@@ -276,18 +276,39 @@ bool ParametersLatency::isValid(const bsl::string* str, bsl::ostream& stream)
 // ================
 
 Parameters::Parameters(bslma::Allocator* allocator)
-: d_broker(allocator)
+: d_mode(ParametersMode::Value::e_CLI)
+, d_broker(allocator)
 , d_queueUri(allocator)
 , d_qlistFilePath(allocator)
 , d_journalFilePath(allocator)
 , d_dataFilePath(allocator)
+, d_sequentialMessagePattern(allocator)
+, d_queueFlags(0)
+, d_latency(ParametersLatency::e_NONE)
 , d_latencyReportPath(allocator)
 , d_logFilePath(allocator)
+, d_dumpMsg(false)
+, d_confirmMsg(false)
+, d_eventSize(0)
+, d_msgSize(0)
+, d_postRate(0)
+, d_postInterval(0)
+, d_eventsCount(0)
+, d_maxUnconfirmedMsgs(0)
+, d_maxUnconfirmedBytes(0)
+, d_verbosity(ParametersVerbosity::e_INFO)
+, d_logFormat(allocator)
+, d_numProcessingThreads(0)
+, d_shutdownGrace(0)
+, d_noSessionEventHandler(false)
+, d_memoryDebug(false)
 , d_messageProperties(allocator)
 , d_subscriptions(allocator)
 , d_autoIncrementedField(allocator)
 , d_authnMechanism(allocator)
 , d_authnData(allocator)
+, d_tlsAuthority(allocator)
+, d_tlsVersions(allocator)
 {
     CommandLineParameters params(allocator);
     const bool            rc = from(bsl::cerr, params);
@@ -334,6 +355,8 @@ Parameters::print(bsl::ostream& stream, int level, int spacesPerLevel) const
     printer.printAttribute("messageProperties", d_messageProperties);
     printer.printAttribute("subscriptions", d_subscriptions);
     printer.printAttribute("timeout", d_timeout);
+    printer.printAttribute("tlsAuthority", d_tlsAuthority);
+    printer.printAttribute("tlsVersions", d_tlsVersions);
     printer.end();
 
     return stream;
@@ -445,6 +468,8 @@ bool Parameters::from(bsl::ostream&                stream,
     setTimeout(timeout);
     setAuthnMechanism(params.authnMechanism());
     setAuthnData(params.authnData());
+    setTlsAuthority(params.tlsAuthority());
+    setTlsVersions(params.tlsVersions());
 
     return true;
 }

--- a/src/applications/bmqtool/m_bmqtool_parameters.h
+++ b/src/applications/bmqtool/m_bmqtool_parameters.h
@@ -284,7 +284,14 @@ class Parameters {
     // authentication callback is set.
 
     bsl::string d_authnData;
+
     // Authentication data/credentials string.
+    /// A path to the FILE, containing concatenation of known certificates
+    /// the client can use to reference as its certificate store.
+    bsl::string d_tlsAuthority;
+
+    /// A string with a comma-separated list of supported TLS versions.
+    bsl::string d_tlsVersions;
 
   public:
     // CREATORS
@@ -325,6 +332,8 @@ class Parameters {
     Parameters& setTimeout(const bsls::TimeInterval& value);
     Parameters& setAuthnMechanism(const bsl::string& value);
     Parameters& setAuthnData(const bsl::string& value);
+    Parameters& setTlsAuthority(const bsl::string& value);
+    Parameters& setTlsVersions(const bsl::string& value);
 
     // Set the corresponding member to the specified 'value' and return a
     // reference offering modifiable access to this object.
@@ -389,6 +398,8 @@ class Parameters {
     const bsl::string&                  authnData() const;
 
     const char* autoPubSubPropertyName() const;
+    const bsl::string& tlsAuthority() const;
+    const bsl::string& tlsVersions() const;
 };
 
 // FREE OPERATORS
@@ -608,7 +619,18 @@ inline Parameters& Parameters::setAutoPubSubModulo(int autoPubSubModulo)
 inline Parameters& Parameters::setTimeout(const bsls::TimeInterval& value)
 {
     d_timeout = value;
+    return *this;
+}
 
+inline Parameters& Parameters::setTlsAuthority(const bsl::string& value)
+{
+    d_tlsAuthority = value;
+    return *this;
+}
+
+inline Parameters& Parameters::setTlsVersions(const bsl::string& value)
+{
+    d_tlsVersions = value;
     return *this;
 }
 
@@ -789,6 +811,16 @@ inline const bsl::string& Parameters::authnMechanism() const
 inline const bsl::string& Parameters::authnData() const
 {
     return d_authnData;
+}
+
+inline const bsl::string& Parameters::tlsAuthority() const
+{
+    return d_tlsAuthority;
+}
+
+inline const bsl::string& Parameters::tlsVersions() const
+{
+    return d_tlsVersions;
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqimp/bmqimp_application.cpp
+++ b/src/groups/bmq/bmqimp/bmqimp_application.cpp
@@ -15,7 +15,6 @@
 
 #include <bmqimp_application.h>
 
-#include <bmqscm_version.h>
 // BMQ
 #include <bmqex_executionpolicy.h>
 #include <bmqex_systemexecutor.h>
@@ -37,11 +36,15 @@
 #include <bmqst_statvalue.h>
 #include <bmqst_tableutil.h>
 #include <bmqt_resultcode.h>
+#include <bmqt_sessionoptions.h>
+#include <bmqt_tlsprotocolversion.h>
 #include <bmqt_uri.h>
 #include <bmqu_blob.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
+#include <bmqu_stringutil.h>
 #include <bmqu_time.h>
+#include <bmqvt_valueorerror.h>
 
 // BDE
 #include <ball_log.h>
@@ -58,6 +61,8 @@
 #include <bsl_limits.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
+#include <bsla_unreachable.h>
+#include <bsla_unused.h>
 #include <bslma_allocator.h>
 #include <bslma_managedptr.h>
 #include <bslmf_movableref.h>
@@ -143,6 +148,45 @@ ntcCreateInterfaceConfig(const bmqt::SessionOptions& sessionOptions,
     config.setKeepHalfOpen(false);
 
     return config;
+}
+
+/// Convert a `bmqt::ProtocolVersion::Value` into its equivalent
+/// `ntca::EncryptionMethod::Value` value.
+///
+/// @param version A TLS protocol version value
+ntca::EncryptionMethod::Value
+toNtcEncryptionMethod(bmqt::TlsProtocolVersion::Value version)
+{
+    switch (version) {
+    case bmqt::TlsProtocolVersion::e_TLS1_3: {
+        return ntca::EncryptionMethod::e_TLS_V1_3;
+    } break;
+    default:
+        BSLS_ASSERT_OPT(false && "Missing conversion case");
+        BSLA_UNREACHABLE;
+    }
+}
+
+/// Get the minimum TLS version specified in the set of specified TLS
+/// versions.
+///
+/// Currently, only `TLSv1.3` is supported, and the empty set results
+/// in an error.
+///
+/// @param versions A set of versions to find the minimum in
+///
+/// @returns The minimum version found or bsl::nullopt if the set is empty
+bsl::optional<bmqt::TlsProtocolVersion::Value> findMinTlsVersion(
+    const bsl::unordered_set<bmqt::TlsProtocolVersion::Value>& versions)
+{
+    bsl::optional<bmqt::TlsProtocolVersion::Value> result;
+    if (versions.empty()) {
+        return result;
+    }
+
+    // We only support TLS v1.3
+    result.emplace(bmqt::TlsProtocolVersion::e_TLS1_3);
+    return result;
 }
 
 bslma::ManagedPtr<bmqio::ChannelFactoryPipeline> makeChannelFactoryPipeline(
@@ -232,9 +276,26 @@ bslma::ManagedPtr<bmqio::ChannelFactoryPipeline> makeChannelFactoryPipeline(
             blobBufferFactory,
             allocator);
 
+    // Check if we should use TLS sessions or not
+    if (sessionOptions.isTlsSession()) {
+        ntca::EncryptionClientOptions                  options;
+        bsl::optional<bmqt::TlsProtocolVersion::Value> minTlsVersion =
+            findMinTlsVersion(sessionOptions.protocolVersions());
+
+        BSLS_ASSERT(minTlsVersion.has_value());
+
+        options.setMinMethod(toNtcEncryptionMethod(minTlsVersion.value()));
+        options.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+        options.setAuthentication(ntca::EncryptionAuthentication::e_VERIFY);
+        options.addAuthorityFile(sessionOptions.certificateAuthority());
+
+        channelFactory->configureEncryptionClient(options);
+    }
+
     using bdlf::PlaceHolders::_1;
     bmqio::ChannelFactoryPipeline::Config builder(channelFactory, allocator);
-    builder
+
+    builder.add(channelFactory)
         .addWith(bdlf::BindUtil::bind(Builders::resolvingChannelFactory,
                                       allocator,
                                       _1))

--- a/src/groups/bmq/bmqio/bmqio_connectoptions.h
+++ b/src/groups/bmq/bmqio/bmqio_connectoptions.h
@@ -48,20 +48,24 @@ namespace bmqio {
 class ConnectOptions {
   private:
     // DATA
-    bsl::string d_endpoint;  // implementation-defined endpoint to
-                             // connect to
 
-    int d_numAttempts;  // number of connection attempts to
-                        // make before failing the connection
+    /// implementation-defined endpoint to connect to
+    bsl::string d_endpoint;
 
+    /// number of connection attempts to make before failing the connection
+    int d_numAttempts;
+
+    /// time to wait between successive connection attempts
     bsls::TimeInterval d_attemptInterval;
-    // time to wait between successive
-    // connection attempts
 
-    bool d_autoReconnect;  // should this connection be
-                           // auto-reconnected when it goes down
+    /// should this connection be auto-reconnected when it goes down
+    bool d_autoReconnect;
 
-    bmqvt::PropertyBag d_properties;  // additional properties
+    /// should this connection be upgraded to TLS
+    bool d_isTls;
+
+    /// additional properties
+    bmqvt::PropertyBag d_properties;
 
   public:
     // TRAITS
@@ -101,6 +105,10 @@ class ConnectOptions {
     /// established.  By default, this is `false`.
     ConnectOptions& setAutoReconnect(bool value);
 
+    /// Set whether this connection should be upgraded to a TLS connection once
+    /// established.  By default, this is `false`.
+    ConnectOptions& setIsTls(bool value);
+
     /// Return a reference providing modifiable access to the `properties`
     /// property of this object.
     bmqvt::PropertyBag& properties();
@@ -120,6 +128,9 @@ class ConnectOptions {
 
     /// Return the `autoReconnect` property of this object.
     bool autoReconnect() const;
+
+    /// Return the `isTls` property of this object.
+    bool isTls() const;
 
     /// Return a reference providing const access to the `properties`
     /// property of this object.
@@ -199,6 +210,12 @@ inline ConnectOptions& ConnectOptions::setAutoReconnect(bool value)
     return *this;
 }
 
+inline ConnectOptions& ConnectOptions::setIsTls(bool value)
+{
+    d_isTls = value;
+    return *this;
+}
+
 inline bmqvt::PropertyBag& ConnectOptions::properties()
 {
     return d_properties;
@@ -223,6 +240,11 @@ inline const bsls::TimeInterval& ConnectOptions::attemptInterval() const
 inline bool ConnectOptions::autoReconnect() const
 {
     return d_autoReconnect;
+}
+
+inline bool ConnectOptions::isTls() const
+{
+    return d_isTls;
 }
 
 inline const bmqvt::PropertyBag& ConnectOptions::properties() const

--- a/src/groups/bmq/bmqio/bmqio_listenoptions.h
+++ b/src/groups/bmq/bmqio/bmqio_listenoptions.h
@@ -47,8 +47,12 @@ namespace bmqio {
 class ListenOptions {
   private:
     // DATA
-    bsl::string d_endpoint;  // implementation-defined endpoint
-                             // to listen on
+
+    /// implementation-defined endpoint to listen on
+    bsl::string d_endpoint;
+
+    /// TLS mode
+    bool d_isTls;
 
     bmqvt::PropertyBag d_properties;  // additional properties
 
@@ -74,6 +78,10 @@ class ListenOptions {
     /// providing modifiable access to this object.
     ListenOptions& setEndpoint(const bslstl::StringRef& value);
 
+    /// Set the `isTls` property of this object and return a reference
+    /// providing modifiable access to this object.
+    ListenOptions& setIsTls(bool value);
+
     /// Return a reference providing modifiable access to the `properties`
     /// property of this object.
     bmqvt::PropertyBag& properties();
@@ -83,6 +91,10 @@ class ListenOptions {
     /// Return a reference providing const access to the `endpoint` property
     /// of this object.
     const bsl::string& endpoint() const;
+
+    /// Return a reference providing const access to the `isTls` property
+    /// of this object.
+    bool isTls() const;
 
     /// Return a reference providing const access to the `properties`
     /// property of this object.
@@ -118,6 +130,7 @@ bsl::ostream& operator<<(bsl::ostream& stream, const ListenOptions& obj);
 // CREATORS
 inline ListenOptions::ListenOptions(bslma::Allocator* basicAllocator)
 : d_endpoint(basicAllocator)
+, d_isTls(false)
 , d_properties(basicAllocator)
 {
 }
@@ -125,6 +138,7 @@ inline ListenOptions::ListenOptions(bslma::Allocator* basicAllocator)
 inline ListenOptions::ListenOptions(const ListenOptions& original,
                                     bslma::Allocator*    basicAllocator)
 : d_endpoint(original.d_endpoint, basicAllocator)
+, d_isTls(false)
 , d_properties(original.d_properties, basicAllocator)
 {
 }
@@ -137,6 +151,12 @@ ListenOptions::setEndpoint(const bslstl::StringRef& value)
     return *this;
 }
 
+inline ListenOptions& ListenOptions::setIsTls(bool value)
+{
+    d_isTls = value;
+    return *this;
+}
+
 inline bmqvt::PropertyBag& ListenOptions::properties()
 {
     return d_properties;
@@ -146,6 +166,11 @@ inline bmqvt::PropertyBag& ListenOptions::properties()
 inline const bsl::string& ListenOptions::endpoint() const
 {
     return d_endpoint;
+}
+
+inline bool ListenOptions::isTls() const
+{
+    return d_isTls;
 }
 
 inline const bmqvt::PropertyBag& ListenOptions::properties() const

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
@@ -33,11 +33,13 @@
 #include <bsl_iomanip.h>
 #include <bsl_ios.h>
 #include <bsl_iostream.h>
+#include <bsl_memory.h>
+#include <bsla_unused.h>
 #include <bslma_allocator.h>
 #include <bslma_default.h>
+#include <bslmf_allocatorargt.h>
 #include <bslmt_lockguard.h>
 #include <bsls_assert.h>
-#include <bsls_platform.h>
 
 namespace BloombergLP {
 namespace bmqio {
@@ -1320,6 +1322,88 @@ void NtcChannel::setWriteQueueHighWatermark(int highWatermark)
     }
 }
 
+void NtcChannel::processUpgrade(
+    const bsl::shared_ptr<ntci::Upgradable>& upgradable,
+    const ntca::UpgradeEvent&                upgradeEvent,
+    const ntci::UpgradeFunction&             cb)
+{
+    BSLS_ASSERT(cb);
+
+    BALL_LOG_DEBUG << d_peerUri
+                   << ": received upgrade event: " << upgradeEvent;
+
+    cb(upgradable, upgradeEvent);
+}
+
+void NtcChannel::upgrade(
+    bmqio::Status*                                 status,
+    const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
+    const ntca::UpgradeOptions&                    options,
+    const ntci::UpgradeFunction&                   upgradeCallback)
+{
+    BSLS_ASSERT(encryptionServer);
+    BSLS_ASSERT(d_streamSocket_sp);
+
+    if (status) {
+        status->reset();
+    }
+
+    BALL_LOG_INFO << d_peerUri << ": upgrading server connection";
+
+    ntsa::Error error = d_streamSocket_sp->upgrade(
+        encryptionServer,
+        options,
+        d_streamSocket_sp->createUpgradeCallback(
+            bdlf::BindUtil::bind(&NtcChannel::processUpgrade,
+                                 this,
+                                 bdlf::PlaceHolders::_1,
+                                 bdlf::PlaceHolders::_2,
+                                 upgradeCallback),
+            d_allocator_p));
+
+    if (error) {
+        NtcChannelUtil::fail(status,
+                             bmqio::StatusCategory::e_CONNECTION,
+                             "upgrade",
+                             error);
+    }
+}
+
+void NtcChannel::upgrade(
+    bmqio::Status*                                 status,
+    const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
+    const ntca::UpgradeOptions&                    options,
+    const ntci::UpgradeFunction&                   upgradeCallback)
+{
+    BSLS_ASSERT(encryptionClient);
+    BSLS_ASSERT(d_streamSocket_sp);
+
+    if (status) {
+        status->reset();
+    }
+
+    BALL_LOG_INFO << d_peerUri << ": upgrading client connection";
+
+    ntsa::Error error = d_streamSocket_sp->upgrade(
+        encryptionClient,
+        options,
+        d_streamSocket_sp->createUpgradeCallback(
+            bdlf::BindUtil::bindS(d_allocator_p,
+                                  &NtcChannel::processUpgrade,
+                                  this,
+                                  bdlf::PlaceHolders::_1,
+                                  bdlf::PlaceHolders::_2,
+                                  upgradeCallback),
+            d_allocator_p));
+
+    if (error) {
+        NtcChannelUtil::fail(status,
+                             bmqio::StatusCategory::e_CONNECTION,
+                             "upgrade",
+                             error);
+    }
+}
+
 // ACCESSORS
 int NtcChannel::channelId() const
 {
@@ -1534,7 +1618,7 @@ int NtcListener::listen(bmqio::Status*              status,
         return 1;
     }
 
-    int backlog;
+    int backlog = 0;
     if (!options.properties().load(&backlog,
                                    NtcListenerUtil::listenBacklogProperty())) {
         // The magic number 0 means the backlog will be the maximum allowed by

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.h
@@ -33,8 +33,8 @@
 #include <bmqvt_propertybag.h>
 
 // NTC
-#include <ntcf_system.h>
-#include <ntci_streamsocket.h>
+#include <ntca_upgradeoptions.h>
+#include <ntci_interface.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -46,6 +46,7 @@
 #include <bsl_list.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_keyword.h>
@@ -286,6 +287,11 @@ class NtcChannel : public bmqio::Channel,
     /// Notify using the specified `status` and remove each existing reader.
     void drainReaders(const bmqio::Status& status);
 
+    /// @brief Process the upgradeServer of this socket to TLS
+    void processUpgrade(const bsl::shared_ptr<ntci::Upgradable>& upgradable,
+                        const ntca::UpgradeEvent&                upgradeEvent,
+                        const ntci::UpgradeFunction&             cb);
+
   public:
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(NtcChannel, bslma::UsesBslmaAllocator)
@@ -409,6 +415,24 @@ class NtcChannel : public bmqio::Channel,
 
     /// Set the write queue high watermark to the specified `highWatermark`.
     void setWriteQueueHighWatermark(int highWatermark) BSLS_KEYWORD_OVERRIDE;
+
+    /// Assume the TLS server role and begin upgrading the socket from
+    /// being unencrypted to being encrypted with TLS. Invoke the specified
+    /// `upgradeCallback` when the socket has completed upgrading to TLS.
+    void
+    upgrade(bmqio::Status*                                 status,
+            const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer,
+            const ntca::UpgradeOptions&                    options,
+            const ntci::UpgradeFunction&                   upgradeCallback);
+
+    /// Assume the TLS client role and begin upgrading the socket from
+    /// being unencrypted to being encrypted with TLS. Invoke the specified
+    /// `upgradeCallback` when the socket has completed upgrading to TLS.
+    void
+    upgrade(bmqio::Status*                                 status,
+            const bsl::shared_ptr<ntci::EncryptionClient>& encryptionClient,
+            const ntca::UpgradeOptions&                    options,
+            const ntci::UpgradeFunction&                   upgradeCallback);
 
     // ACCESSORS
 

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.cpp
@@ -13,13 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bmqu_atomicvalidator.h"
 #include <bmqio_ntcchannelfactory.h>
 
 #include <bmqscm_version.h>
+
+// BMQ
+#include <bmqu_atomicvalidator.h>
+
 // NTF
 #include <ntcf_system.h>
-#include <ntsf_system.h>
 
 // BDE
 #include <ball_log.h>
@@ -82,6 +84,7 @@ void NtcChannelFactory::processListenerResult(
     bmqio::ChannelFactoryEvent::Enum             event,
     const bmqio::Status&                         status,
     const bsl::shared_ptr<bmqio::Channel>&       channel,
+    bool                                         shouldUpgrade,
     const bmqio::ChannelFactory::ResultCallback& callback)
 {
     BALL_LOG_TRACE << "NTC factory event " << event << " status " << status
@@ -107,6 +110,29 @@ void NtcChannelFactory::processListenerResult(
                                << AddressFormatter(alias.get()) << " to "
                                << alias->peerUri() << " registered"
                                << BALL_LOG_END;
+
+                // Check if we need to upgrade the connection to TLS
+                if (shouldUpgrade) {
+                    BSLS_ASSERT(d_encryptionServer_sp != NULL);
+                    bmqio::Status upgradeStatus;
+                    alias->upgrade(&upgradeStatus,
+                                   d_encryptionServer_sp,
+                                   ntca::UpgradeOptions(),
+                                   bdlf::BindUtil::bind(
+                                       &NtcChannelFactory::processUpgrade,
+                                       this,
+                                       event,
+                                       status,
+                                       alias,
+                                       bdlf::PlaceHolders::_1,  // upgradable
+                                       bdlf::PlaceHolders::_2,  // upgradeEvent
+                                       callback));
+
+                    if (!upgradeStatus) {
+                        callback(event, upgradeStatus, channel);
+                    }
+                    return;  // RETURN
+                }
             }
         }
     }
@@ -118,8 +144,10 @@ void NtcChannelFactory::processChannelResult(
     bmqio::ChannelFactoryEvent::Enum             event,
     const bmqio::Status&                         status,
     const bsl::shared_ptr<bmqio::Channel>&       channel,
+    bool                                         shouldUpgrade,
     const bmqio::ChannelFactory::ResultCallback& callback)
 {
+    // Result callback for connect
     BALL_LOG_TRACE << "NTC factory event " << event << " status " << status
                    << BALL_LOG_END;
 
@@ -130,8 +158,56 @@ void NtcChannelFactory::processChannelResult(
             if (alias) {
                 d_createSignaler(alias, alias);
             }
+
+            // Check if we need to upgrade the connection to TLS
+            if (shouldUpgrade) {
+                BSLS_ASSERT(d_encryptionClient_sp);
+                bmqio::Status upgradeStatus;
+                alias->upgrade(&upgradeStatus,
+                               d_encryptionClient_sp,
+                               d_upgradeOptions,
+                               bdlf::BindUtil::bind(
+                                   &NtcChannelFactory::processUpgrade,
+                                   this,
+                                   event,
+                                   status,
+                                   alias,
+                                   bdlf::PlaceHolders::_1,  // upgradable
+                                   bdlf::PlaceHolders::_2,  // upgradeEvent
+                                   callback));
+                if (!upgradeStatus) {
+                    callback(event, upgradeStatus, channel);
+                }
+
+                return;  // RETURN
+            }
         }
     }
+
+    callback(event, status, channel);
+}
+
+void NtcChannelFactory::processUpgrade(
+    bmqio::ChannelFactoryEvent::Enum             event,
+    const bmqio::Status&                         status,
+    const bsl::shared_ptr<bmqio::NtcChannel>&    channel,
+    const bsl::shared_ptr<ntci::Upgradable>&     upgradable,
+    const ntca::UpgradeEvent&                    upgradeEvent,
+    const bmqio::ChannelFactory::ResultCallback& callback)
+{
+    if (upgradeEvent.isError()) {
+        BALL_LOG_ERROR << "Received error during TLS negotiation: "
+                       << upgradeEvent;
+        bmqio::Status st(bmqio::StatusCategory::e_GENERIC_ERROR);
+        channel->close(st);
+        callback(ChannelFactoryEvent::e_CONNECT_FAILED, st, channel);
+        return;  // RETURN
+    }
+
+    // Note: the `upgradable` object is the channel's underlying stream socket.
+    // This signaler is the only way that we can communicate to observers what
+    // the status of the upgrade is.
+    d_upgradeSignaler(channel, upgradable, upgradeEvent);
 
     callback(event, status, channel);
 }
@@ -150,6 +226,10 @@ NtcChannelFactory::NtcChannelFactory(
 , d_validator(false)
 , d_resourceMonitor(false)
 , d_isInterfaceStarted(false)
+, d_encryptionServer_sp()
+, d_encryptionClient_sp()
+, d_upgradeSignaler(basicAllocator)
+, d_upgradeOptions()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
 }
@@ -167,6 +247,10 @@ NtcChannelFactory::NtcChannelFactory(
 , d_validator(false)
 , d_resourceMonitor(false)
 , d_isInterfaceStarted(false)
+, d_encryptionServer_sp()
+, d_encryptionClient_sp()
+, d_upgradeSignaler(basicAllocator)
+, d_upgradeOptions()
 , d_allocator_p(bslma::Default::allocator(basicAllocator))
 {
     bsl::shared_ptr<bdlbb::BlobBufferFactory> blobBufferFactory_sp(
@@ -194,7 +278,7 @@ NtcChannelFactory::~NtcChannelFactory()
     BSLS_ASSERT_OPT(d_channels.length() == 0);
     BSLS_ASSERT_OPT(d_createSignaler.slotCount() == 0);
     BSLS_ASSERT_OPT(d_limitSignaler.slotCount() == 0);
-    BSLS_ASSERT_OPT(!d_interface_sp);
+    BSLS_ASSERT_OPT(d_upgradeSignaler.slotCount() == 0);
 }
 
 // MANIPULATORS
@@ -256,6 +340,7 @@ void NtcChannelFactory::stop()
 
     d_createSignaler.disconnectAllSlots();
     d_limitSignaler.disconnectAllSlots();
+    d_upgradeSignaler.disconnectAllSlots();
 
     BALL_LOG_TRACE << "NTC factory has stopped" << BALL_LOG_END;
 }
@@ -292,6 +377,7 @@ void NtcChannelFactory::listen(Status*                      status,
         bdlf::PlaceHolders::_1,
         bdlf::PlaceHolders::_2,
         bdlf::PlaceHolders::_3,
+        options.isTls(),
         cb);
 
     bsl::shared_ptr<bmqio::NtcListener> listener;
@@ -360,6 +446,7 @@ void NtcChannelFactory::connect(Status*                      status,
         bdlf::PlaceHolders::_1,
         bdlf::PlaceHolders::_2,
         bdlf::PlaceHolders::_3,
+        options.isTls(),
         cb);
 
     bsl::shared_ptr<bmqio::NtcChannel> channel;
@@ -409,9 +496,14 @@ bdlmt::SignalerConnection NtcChannelFactory::onLimit(const LimitFn& cb)
     return d_limitSignaler.connect(cb);
 }
 
+bdlmt::SignalerConnection NtcChannelFactory::onUpgrade(const UpgradeFn& cb)
+{
+    return d_upgradeSignaler.connect(cb);
+}
+
 int NtcChannelFactory::lookupChannel(
     bsl::shared_ptr<bmqio::NtcChannel>* result,
-    int                                 channelId)
+    int                                 channelId) const
 {
     return d_channels.find(channelId, result);
 }
@@ -452,6 +544,72 @@ int NtcChannelFactory::addChannel(
 {
     d_resourceMonitor.acquire();
     return d_channels.add(channel);
+}
+
+void NtcChannelFactory::setEncryptionServer(
+    const EncryptionServerSp& encryptionServer)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_encryptionServer_sp = encryptionServer;
+}
+
+ntsa::Error NtcChannelFactory::configureEncryptionServer(
+    const ntca::EncryptionServerOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_interface_sp->createEncryptionServer(&d_encryptionServer_sp,
+                                                  options,
+                                                  d_allocator_p);
+}
+
+void NtcChannelFactory::setEncryptionClient(
+    const EncryptionClientSp& encryptionClient)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_encryptionClient_sp = encryptionClient;
+}
+
+ntsa::Error NtcChannelFactory::configureEncryptionClient(
+    const ntca::EncryptionClientOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_interface_sp->createEncryptionClient(&d_encryptionClient_sp,
+                                                  options,
+                                                  d_allocator_p);
+}
+
+void NtcChannelFactory::setUpgradeOptions(const ntca::UpgradeOptions& options)
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    d_upgradeOptions = options;
+}
+
+// ACCESSORS
+
+const ntci::EncryptionServer& NtcChannelFactory::encryptionServer() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return *d_encryptionServer_sp;
+}
+
+const ntci::EncryptionClient& NtcChannelFactory::encryptionClient() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return *d_encryptionClient_sp;
+}
+
+const ntca::UpgradeOptions& NtcChannelFactory::upgradeOptions() const
+{
+    BSLS_ASSERT(!d_isInterfaceStarted);
+
+    return d_upgradeOptions;
 }
 
 // ----------------------------

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.h
@@ -37,6 +37,7 @@
 // NTF
 #include <ntca_interfaceconfig.h>
 #include <ntci_interface.h>
+#include <ntci_upgradecallback.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -79,6 +80,21 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// been reached.
     typedef bsl::function<LimitFnType> LimitFn;
 
+    /// This typedef defines the signature of a function invoked when a
+    /// channel has been upgraded
+    typedef void
+    UpgradeFnType(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                  const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                  const ntca::UpgradeEvent&                 event);
+
+    /// This typedef defines a function invoked when a channel has been
+    /// upgraded.
+    typedef bsl::function<UpgradeFnType> UpgradeFn;
+
+    typedef bsl::shared_ptr<ntci::EncryptionServer> EncryptionServerSp;
+
+    typedef bsl::shared_ptr<ntci::EncryptionClient> EncryptionClientSp;
+
   private:
     // PRIVATE TYPES
 
@@ -110,6 +126,10 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     bmqu::AtomicValidator            d_validator;
     bmqu::AtomicValidator            d_resourceMonitor;
     bsls::AtomicBool                 d_isInterfaceStarted;
+    EncryptionServerSp               d_encryptionServer_sp;
+    EncryptionClientSp               d_encryptionClient_sp;
+    bdlmt::Signaler<UpgradeFnType>   d_upgradeSignaler;
+    ntca::UpgradeOptions             d_upgradeOptions;
     bslma::Allocator*                d_allocator_p;
 
   private:
@@ -127,6 +147,7 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
         bmqio::ChannelFactoryEvent::Enum             event,
         const bmqio::Status&                         status,
         const bsl::shared_ptr<bmqio::Channel>&       channel,
+        bool                                         shouldUpgrade,
         const bmqio::ChannelFactory::ResultCallback& callback);
 
     /// Process the specified `event` having the specified `status` for
@@ -135,6 +156,7 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
         bmqio::ChannelFactoryEvent::Enum             event,
         const bmqio::Status&                         status,
         const bsl::shared_ptr<bmqio::Channel>&       channel,
+        bool                                         shouldUpgrade,
         const bmqio::ChannelFactory::ResultCallback& callback);
 
     /// @brief Remove the listener identified by the specified @p handle
@@ -162,6 +184,14 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// @param channel Shared pointer to the channel to add.
     /// @return Catalog handle for the added channel.
     int addChannel(const bsl::shared_ptr<bmqio::NtcChannel>& channel);
+
+    /// Process a TLS upgrade
+    void processUpgrade(bmqio::ChannelFactoryEvent::Enum          event,
+                        const bmqio::Status&                      status,
+                        const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                        const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                        const ntca::UpgradeEvent&                 upgradeEvent,
+                        const bmqio::ChannelFactory::ResultCallback& callback);
 
   public:
     // PUBLIC TYPES
@@ -212,6 +242,9 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// this operation.  Return `e_SUCCESS` on success or a failure
     /// StatusCategory on error, populating the optionally-specified
     /// `status` with more detailed error information.
+    ///
+    /// If `encryptionServer()` is not null, the listener will use it to
+    /// upgrade to a TLS connection.
     void listen(Status*                      status,
                 bslma::ManagedPtr<OpHandle>* handle,
                 const ListenOptions&         options,
@@ -231,6 +264,9 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// `options.autoReconnect()` is `true` and the implementing
     /// `ChannelFactory` doesn't provide this behavior, it must fail the
     /// connection immediately.
+    ///
+    /// If `encryptionClient()` is not null, the connection will use it to
+    /// upgrade to a TLS connection.
     void connect(Status*                      status,
                  bslma::ManagedPtr<OpHandle>* handle,
                  const ConnectOptions&        options,
@@ -246,18 +282,72 @@ class NtcChannelFactory : public bmqio::ChannelFactory {
     /// used to unregister the callback.
     bdlmt::SignalerConnection onLimit(const LimitFn& cb);
 
+    /// Register the specified `cb` to be invoked when a channel is
+    /// upgraded. Return a `bdlmt::SignalerConnection` object than can be
+    /// used to unregister the callback.
+    bdlmt::SignalerConnection onUpgrade(const UpgradeFn& cb);
+
     /// Load into the specified `result` the channel having the specified
     /// `channelId`. Return 0 on success and a non-zero value otherwise.
     int lookupChannel(bsl::shared_ptr<bmqio::NtcChannel>* result,
-                      int                                 channelId);
+                      int                                 channelId) const;
 
     /// Invoke the specified `visitor` once for every currently active
     /// channel managed by this object.  The `visitor` will be invoked with
-    /// a single argument, `const bsl::shared_ptr<bmqio::NtzChannel>&`.
+    /// a single argument, `const bsl::shared_ptr<bmqio::NtcChannel>&`.
     /// Note that it is unspecified whether channels created or closed
     /// during the execution of this function will be included.
     template <typename VISITOR>
     void visitChannels(VISITOR& visitor);
+
+    /// @brief Modify the factory's encryption server.
+    ///
+    /// The behavior is undefined unless this channel factory
+    /// is stopped.
+    void setEncryptionServer(const EncryptionServerSp& encryptionServer);
+
+    /// @brief Initailze this factory's encryption server using `options`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    ntsa::Error
+    configureEncryptionServer(const ntca::EncryptionServerOptions& options);
+
+    /// @brief Modify this factory's encryption client.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    void setEncryptionClient(const EncryptionClientSp& encryptionClient);
+
+    /// @brief Initailze this factory's encryption server using `options`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    ntsa::Error
+    configureEncryptionClient(const ntca::EncryptionClientOptions& options);
+
+    /// @brief Modify the upgrade options used for listener and connect
+    /// operations. The default value is the default initialized
+    /// `ntca::UpgradeOptions`.
+    ///
+    /// The behavior is undefined unless this channel factory is stopped.
+    void setUpgradeOptions(const ntca::UpgradeOptions& options);
+
+    // ACCESSORS
+
+    /// @brief Access the factory's encryption server.
+    ///
+    /// The behavior of is undefined unless the encryption client was
+    /// initialized with either `configureEncryptionServer` or
+    /// `setEncryptionServer`.
+    const ntci::EncryptionServer& encryptionServer() const;
+
+    /// @brief Access this factory's encryption client.
+    ///
+    /// The behavior of is undefined unless the encryption client was
+    /// initialized with either `configureEncryptionClient` or
+    /// `setEncryptionClient`.
+    const ntci::EncryptionClient& encryptionClient() const;
+
+    /// @brief Access this factory's upgrade options.
+    const ntca::UpgradeOptions& upgradeOptions() const;
 };
 
 // ============================

--- a/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannelfactory.t.cpp
@@ -15,11 +15,15 @@
 
 #include <bmqio_ntcchannelfactory.h>
 
-#include <bmqu_blob.h>
-
+// NTC
+#include <ntca_upgradeevent.h>
+#include <ntca_upgradeoptions.h>
 #include <ntcf_system.h>
-#include <ntsf_system.h>
+#include <ntci_interface.h>
+#include <ntci_upgradable.h>
+#include <ntsa_distinguishedname.h>
 
+// BDE
 #include <ball_filteringobserver.h>
 #include <ball_loggermanager.h>
 #include <ball_testobserver.h>
@@ -31,13 +35,18 @@
 #include <bdlf_bind.h>
 #include <bsl_deque.h>
 #include <bsl_memory.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
 #include <bsla_annotations.h>
+#include <bslma_allocator.h>
 #include <bslmt_latch.h>
 #include <bslmt_threadutil.h>
 #include <bsls_timeutil.h>
 #include <bsls_types.h>
 
+// BMQ
 #include <bmqtst_testhelper.h>
+#include <bmqu_blob.h>
 #include <bsl_iostream.h>
 #include <bsl_map.h>
 
@@ -77,6 +86,110 @@ static bool ballFilter(const bsl::string&      messageSubstring,
     return !bdlb::StringRefUtil::strstr(record.fixedFields().messageRef(),
                                         messageSubstring)
                 .isEmpty();
+}
+
+namespace {
+
+// ==========================
+// class Tester_UpgradeCbInfo
+// ==========================
+
+/// Arguments used in a call to a `NtcChannelFactory::onUpgrade` handler.
+struct UpgradeCbInfo {
+    // DATA
+    bsl::shared_ptr<ntci::Upgradable> d_upgradable;
+    ntca::UpgradeEvent                d_event;
+
+    typedef bsl::allocator<> allocator_type;
+
+    // CREATORS
+    UpgradeCbInfo(allocator_type allocator)
+    : d_upgradable()
+    , d_event(bslma::AllocatorUtil::adapt(allocator))
+    {
+        // NOTHING
+    }
+
+    UpgradeCbInfo(BSLA_MAYBE_UNUSED const UpgradeCbInfo& original,
+                  allocator_type                         allocator)
+    : d_upgradable()
+    , d_event(bslma::AllocatorUtil::adapt(allocator))
+    {
+        // NOTHING
+    }
+};
+
+///
+class ChannelUpgradeHandler {
+  public:
+    typedef bsl::map<int, UpgradeCbInfo> ChannelMap;
+    typedef bsl::allocator<>             allocator_type;
+
+  private:
+    mutable bslmt::Mutex d_mutex;
+    ChannelMap           d_channelMap;
+
+  public:
+    explicit ChannelUpgradeHandler(allocator_type allocator)
+    : d_mutex()
+    , d_channelMap(allocator)
+    {
+    }
+
+    /// Record the upgrade event and associate it with a channel based on its
+    /// ID.
+    void onUpgrade(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                   const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                   const ntca::UpgradeEvent&                 event)
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        BMQTST_ASSERT_D("Channel was attempted to upgrade multiple times",
+                        !d_channelMap.contains(channel->channelId()));
+
+        UpgradeCbInfo& upgradeInfo = d_channelMap[channel->channelId()];
+        upgradeInfo.d_upgradable   = upgradable;
+        upgradeInfo.d_event        = event;
+    }
+
+    /// Check that each upgrade was successful. Otherwise, fail the test.
+    void checkAll() const
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);
+
+        bsl::for_each(d_channelMap.cbegin(),
+                      d_channelMap.cend(),
+                      ChannelUpgradeHandler::checkChannelMapEntry);
+    }
+
+    /// Return the number of upgrade events
+    bsl::size_t upgradeCounts() const { return d_channelMap.size(); }
+
+    /// Create a callback function that references this handler
+    bsl::function<void(const bsl::shared_ptr<bmqio::NtcChannel>&,
+                       const bsl::shared_ptr<ntci::Upgradable>&,
+                       const ntca::UpgradeEvent&)>
+    makeOnUpgradeCb()
+    {
+        return bdlf::BindUtil::bindS(
+            bslma::AllocatorUtil::adapt(d_channelMap.get_allocator()),
+            &ChannelUpgradeHandler::onUpgrade,
+            this,
+            bdlf::PlaceHolders::_1,
+            bdlf::PlaceHolders::_2,
+            bdlf::PlaceHolders::_3);
+    }
+
+  private:
+    /// Check if the upgrade event contained in `value` was completed,
+    /// otherwise fail the test.
+    static void checkChannelMapEntry(const ChannelMap::value_type& value)
+    {
+        BMQTST_ASSERT_D("Channel upgrade failed",
+                        value.second.d_event.isComplete());
+    }
+};
+
 }
 
 // CONSTANTS
@@ -193,6 +306,7 @@ struct Tester_HandleInfo {
     bsl::shared_ptr<ChannelFactory::OpHandle> d_handle;
     bsl::deque<Tester_ResultCbInfo>           d_resultCbCalls;
     int                                       d_listenPort;
+    bsl::deque<UpgradeCbInfo>                 d_upgradeCbCalls;
 
     // TRAITS
     BSLMF_NESTED_TRAIT_DECLARATION(Tester_HandleInfo,
@@ -203,6 +317,7 @@ struct Tester_HandleInfo {
     : d_handle()
     , d_resultCbCalls(basicAllocator)
     , d_listenPort(-1)
+    , d_upgradeCbCalls(basicAllocator)
     {
         // NOTHING
     }
@@ -212,6 +327,7 @@ struct Tester_HandleInfo {
     : d_handle(original.d_handle)
     , d_resultCbCalls(original.d_resultCbCalls, basicAllocator)
     , d_listenPort(original.d_listenPort)
+    , d_upgradeCbCalls(original.d_upgradeCbCalls, basicAllocator)
     {
         // NOTHING
     }
@@ -256,16 +372,25 @@ class Tester {
     typedef bsl::shared_ptr<NtcChannel>        NtcChannelPtr;
     typedef bsl::deque<NtcChannelPtr>          PreCreateCbCallList;
 
+  private:
     // DATA
-    bslma::Allocator*                    d_allocator_p;
-    bdlbb::PooledBlobBufferFactory       d_blobBufferFactory;
-    bsl::shared_ptr<ball::TestObserver>  d_ballObserver;
-    ChannelMap                           d_channelMap;
-    HandleMap                            d_handleMap;
-    PreCreateCbCallList                  d_preCreateCbCalls;
-    bool                                 d_setPreCreateCb;
-    bslma::ManagedPtr<NtcChannelFactory> d_object;
-    bslmt::Mutex                         d_mutex;
+    bslma::Allocator*                            d_allocator_p;
+    bdlbb::PooledBlobBufferFactory               d_blobBufferFactory;
+    bsl::shared_ptr<ball::TestObserver>          d_ballObserver;
+    ChannelMap                                   d_channelMap;
+    HandleMap                                    d_handleMap;
+    PreCreateCbCallList                          d_preCreateCbCalls;
+    bool                                         d_setPreCreateCb;
+    bool                                         d_setEncryptionServer;
+    bool                                         d_setEncryptionClient;
+    bslma::ManagedPtr<NtcChannelFactory>         d_object;
+    bslmt::Mutex                                 d_mutex;
+    bsl::shared_ptr<ntci::Interface>             d_interface;
+    bsl::shared_ptr<ntci::EncryptionCertificate> d_authorityCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         d_authorityPrivateKey;
+    bsl::shared_ptr<ntci::EncryptionCertificate> d_serverCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         d_serverPrivateKey;
+    bsl::shared_ptr<ntci::EncryptionClient>      d_encryptionClient;
 
     // PRIVATE MANIPULATORS
 
@@ -274,6 +399,11 @@ class Tester {
                   ChannelFactoryEvent::Enum       event,
                   const Status&                   status,
                   const bsl::shared_ptr<Channel>& channel);
+
+    /// Push an upgrade event onto the list of observed upgrade events
+    void recordUpgrade(const bsl::shared_ptr<bmqio::NtcChannel>& channel,
+                       const bsl::shared_ptr<ntci::Upgradable>&  upgradable,
+                       const ntca::UpgradeEvent&                 event);
 
     /// `channelPreCreationCb` passed to the NtcChannelFactory, if we're
     /// asked to pass one
@@ -301,6 +431,17 @@ class Tester {
     /// Destroy the object being tested and reset all supporting objects.
     void destroy();
 
+    /// Initialize the root authority certificate for the server and client.
+    void initEncryptionAuthority();
+
+    /// Initialize the server certificate and private key and configure the
+    /// channel factory to use it for upgrading listeners.
+    void initEncryptionServer();
+
+    /// Initialize the client encryption settings and configure the
+    /// channel factory to use it for upgrading connections.
+    void initEncryptionClient();
+
     // NOT IMPLEMENTED
     Tester(const Tester&);
     Tester& operator=(const Tester&);
@@ -319,6 +460,16 @@ class Tester {
     /// the next time `init` is called to the specified `value`.  By default
     /// this is `false`.
     void setPreCreateCb(bool value);
+
+    /// Set whether an `encryptionServer` will be set on the
+    /// `NtcChannelFactory` the next time `init` is called to the specified
+    /// `value`.  By default this is `false`.
+    void setEncryptionServer(bool value);
+
+    /// Set whether an `encryptionClient` will be set on the
+    /// `NtcChannelFactory` the next time `init` is called to the specified
+    /// `value`.  By default this is `false`.
+    void setEncryptionClient(bool value);
 
     /// Find and return a free port by opening and dropping a handle.
     /// Note that the found port might become occupied in an unlikely event of
@@ -551,6 +702,12 @@ void Tester::channelWatermarkCb(const bsl::string&         channelName,
 
 void Tester::destroy()
 {
+    d_serverPrivateKey.reset();
+    d_serverCertificate.reset();
+    d_authorityPrivateKey.reset();
+    d_authorityCertificate.reset();
+
+    d_interface.reset();
     d_preCreateCbCalls.clear();
 
     if (d_object) {
@@ -570,12 +727,20 @@ void Tester::destroy()
 Tester::Tester(bslma::Allocator* basicAllocator)
 : d_allocator_p(bslma::Default::allocator(basicAllocator))
 , d_blobBufferFactory(0xFFFF, basicAllocator)
+, d_ballObserver()
 , d_channelMap(basicAllocator)
 , d_handleMap(basicAllocator)
 , d_preCreateCbCalls(basicAllocator)
 , d_setPreCreateCb(false)
+, d_setEncryptionServer(false)
+, d_setEncryptionClient(false)
 , d_object()
 , d_mutex()
+, d_interface()
+, d_authorityCertificate()
+, d_authorityPrivateKey()
+, d_serverCertificate()
+, d_serverPrivateKey()
 {
 }
 
@@ -588,6 +753,16 @@ Tester::~Tester()
 void Tester::setPreCreateCb(bool value)
 {
     d_setPreCreateCb = value;
+}
+
+void Tester::setEncryptionServer(bool value)
+{
+    d_setEncryptionServer = value;
+}
+
+void Tester::setEncryptionClient(bool value)
+{
+    d_setEncryptionClient = value;
 }
 
 int Tester::findFreeEphemeralPort()
@@ -608,6 +783,138 @@ int Tester::findFreeEphemeralPort()
     return port;
 }
 
+void Tester::initEncryptionAuthority()
+{
+    if (d_authorityCertificate && d_authorityPrivateKey) {
+        // Authority root has already been initialized, no need to set it again
+        return;
+    }
+
+    bsl::shared_ptr<ntci::EncryptionCertificate> authorityCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         authorityPrivateKey;
+
+    // Generate the certificate and private key of a trusted authority.
+
+    ntsa::DistinguishedName authorityIdentity(d_allocator_p);
+    authorityIdentity["CN"] = "Authority";
+    authorityIdentity["O"]  = "Bloomberg LP";
+
+    ntsa::Error error = d_interface->generateKey(&authorityPrivateKey,
+                                                 ntca::EncryptionKeyOptions(),
+                                                 d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    ntca::EncryptionCertificateOptions authorityCertificateOptions;
+    authorityCertificateOptions.setAuthority(true);
+
+    error = d_interface->generateCertificate(&authorityCertificate,
+                                             authorityIdentity,
+                                             authorityPrivateKey,
+                                             authorityCertificateOptions,
+                                             d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    d_authorityCertificate.swap(authorityCertificate);
+    d_authorityPrivateKey.swap(authorityPrivateKey);
+}
+
+void Tester::initEncryptionServer()
+{
+    if (d_serverCertificate && d_serverPrivateKey) {
+        // Authority root has already been initialized, no need to set it again
+        return;
+    }
+
+    // Ensure the authority is initialized as its our root of trust
+    initEncryptionAuthority();
+
+    // Create an encryption server and configure the encryption server to
+    // accept upgrades to TLS 1.3 and higher, to cryptographically identify
+    // itself using the server certificate previously generated, to encrypt
+    // data using the server private key previously generated, and to not
+    // require identification from the client.
+    bsl::shared_ptr<ntci::EncryptionCertificate> serverCertificate;
+    bsl::shared_ptr<ntci::EncryptionKey>         serverPrivateKey;
+
+    // Generate the certificate and private key of the server, signed
+    // by the trusted authority.
+
+    ntsa::DistinguishedName serverIdentity(d_allocator_p);
+    serverIdentity["CN"] = "Server";
+    serverIdentity["O"]  = "Bloomberg LP";
+
+    ntsa::Error error = d_interface->generateKey(&serverPrivateKey,
+                                                 ntca::EncryptionKeyOptions(),
+                                                 d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    error = d_interface->generateCertificate(
+        &serverCertificate,
+        serverIdentity,
+        serverPrivateKey,
+        d_authorityCertificate,
+        d_authorityPrivateKey,
+        ntca::EncryptionCertificateOptions(),
+        d_allocator_p);
+    BMQTST_ASSERT(!error);
+
+    ntca::EncryptionServerOptions encryptionServerOptions;
+    encryptionServerOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionServerOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    encryptionServerOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_NONE);
+
+    {
+        bsl::vector<char> identityData(d_allocator_p);
+        serverCertificate->encode(&identityData);
+        encryptionServerOptions.setIdentityData(identityData);
+    }
+
+    {
+        bsl::vector<char> privateKeyData(d_allocator_p);
+        serverPrivateKey->encode(&privateKeyData);
+        encryptionServerOptions.setPrivateKeyData(privateKeyData);
+    }
+
+    // Let the channel factory use the certificate for upgrading incoming
+    // connections
+    error = object().configureEncryptionServer(encryptionServerOptions);
+
+    d_serverCertificate.swap(serverCertificate);
+    d_serverPrivateKey.swap(serverPrivateKey);
+
+    BMQTST_ASSERT(!error);
+}
+
+void Tester::initEncryptionClient()
+{
+    ntsa::Error error;
+
+    initEncryptionAuthority();
+
+    // Create an encryption client and configure the encryption client to
+    // request upgrades using TLS 1.2 require identification from the
+    // server, and to trust the certificate authority previously generated
+    // to verify the authenticity of the server.
+    ntca::EncryptionClientOptions encryptionClientOptions;
+    encryptionClientOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionClientOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    encryptionClientOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_VERIFY);
+
+    {
+        bsl::vector<char> authorityData(d_allocator_p);
+        d_authorityCertificate->encode(&authorityData);
+        encryptionClientOptions.addAuthorityData(authorityData);
+    }
+
+    // Let the channel factory use the certificate for upgrading outgoing
+    // connections
+    error = object().configureEncryptionClient(encryptionClientOptions);
+
+    BMQTST_ASSERT(!error);
+}
+
 void Tester::init(int line)
 {
     destroy();
@@ -615,9 +922,17 @@ void Tester::init(int line)
     ntca::InterfaceConfig interfaceConfig;
     interfaceConfig.setThreadName("test");
 
-    d_object.load(new (*d_allocator_p) NtcChannelFactory(interfaceConfig,
-                                                         &d_blobBufferFactory,
-                                                         d_allocator_p),
+    bsl::shared_ptr<bdlbb::BlobBufferFactory> blobBufferFactory_sp(
+        &d_blobBufferFactory,
+        bslstl::SharedPtrNilDeleter(),
+        d_allocator_p);
+
+    d_interface = ntcf::System::createInterface(interfaceConfig,
+                                                blobBufferFactory_sp,
+                                                d_allocator_p);
+
+    d_object.load(new (*d_allocator_p)
+                      NtcChannelFactory(d_interface, d_allocator_p),
                   d_allocator_p);
 
     if (d_setPreCreateCb) {
@@ -625,6 +940,12 @@ void Tester::init(int line)
                                                 this,
                                                 bdlf::PlaceHolders::_1,
                                                 bdlf::PlaceHolders::_2));
+    }
+    if (d_setEncryptionServer) {
+        initEncryptionServer();
+    }
+    if (d_setEncryptionClient) {
+        initEncryptionClient();
     }
 
     int ret = d_object->start();
@@ -1101,6 +1422,106 @@ NtcChannelFactory& Tester::object()
 // ============================================================================
 //                                    TESTS
 // ----------------------------------------------------------------------------
+
+static void test9_tlsClientFailsOnPlaintextServer()
+// ------------------------------------------------------------------------
+// PRE CREATION CB TEST
+//
+// Concerns:
+//  a) An attempt to connect to a plaintext server with a TLS channel will fail
+//  b) An attempt to connect to a TLS server with a plaintext channel will fail
+//  c) A failed attempt to connect from a plaintext client doesn't cause a TLS
+//  listener to close
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("Upgrade Channel Cb Test");
+
+    Tester t(bmqtst::TestHelperUtil::allocator());
+
+    // Use TLS for both connections and listeners
+    t.setEncryptionServer(true);
+
+    // Concern 'a'
+    t.init(L_);
+
+    {
+        ChannelUpgradeHandler upgradeCounter(
+            bmqtst::TestHelperUtil::allocator());
+
+        // Register a way to record upgrade events
+        t.object().onUpgrade(upgradeCounter.makeOnUpgradeCb());
+
+        // Shorten the timeout interval
+        ntca::UpgradeOptions upgradeOptions;
+        bsls::TimeInterval   deadline = bdlt::CurrentTime::now();
+        // 5ms doesn't seem to interfere with the success test case, so this
+        // should be sufficient enough
+        deadline.addMilliseconds(5);
+        upgradeOptions.setDeadline(deadline);
+        t.object().setUpgradeOptions(upgradeOptions);
+
+        BMQTST_ASSERT_EQ(0, t.object().start());
+    }
+
+    t.listen(L_, "listenHandle0", "127.0.0.1:5001", StatusCategory::e_SUCCESS);
+    t.connect(L_,
+              "connectHandle0",
+              "listenHandle0",
+              StatusCategory::e_SUCCESS);
+
+    t.checkResultCallback(L_,
+                          "listenHandle0",
+                          ChannelFactoryEvent::e_CONNECT_FAILED,
+                          StatusCategory::e_GENERIC_ERROR);
+    t.checkNoResultCallback(L_, "channelHandle0");
+}
+
+static void test8_upgradeChannelTest()
+// ------------------------------------------------------------------------
+// PRE CREATION CB TEST
+//
+// Concerns:
+//  a) 'upgradeChannelCb' is called for every channel upgraded
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("Upgrade Channel Cb Test");
+
+    Tester t(bmqtst::TestHelperUtil::allocator());
+
+    // Use TLS for both connections and listeners
+    t.setEncryptionServer(true);
+    t.setEncryptionClient(true);
+
+    // Concern 'a'
+    t.init(L_);
+
+    ChannelUpgradeHandler upgradeCounter(bmqtst::TestHelperUtil::allocator());
+
+    // Register a way to record upgrade events
+    t.object().onUpgrade(upgradeCounter.makeOnUpgradeCb());
+
+    // Create a TLS channel
+    t.listen(L_, "listenHandle", "127.0.0.1:5001", StatusCategory::e_SUCCESS);
+    t.connect(L_, "connectHandle", "listenHandle", StatusCategory::e_SUCCESS);
+    t.connect(L_, "connectHandle2", "listenHandle", StatusCategory::e_SUCCESS);
+
+    // Confirm the channel was successfully created
+    t.checkResultCallback(L_, "listenHandle", "listenChannel");
+    t.checkResultCallback(L_, "connectHandle", "connectChannel");
+    t.checkResultCallback(L_, "connectHandle2", "connectChannel2");
+
+    // We expect each connect/listen pair to have received a successful
+    // upgrade event
+    upgradeCounter.checkAll();
+    BMQTST_ASSERT_EQ_D("Unexpected number of channel upgrades",
+                       4UL,
+                       upgradeCounter.upgradeCounts());
+
+    // Confirm the upgrade didn't mess up the received message
+    t.writeChannel(L_, "listenChannel", "abcdef");
+    t.readChannel(L_, "connectChannel", "abcdef");
+}
+
 static void test7_checkMultithreadListen()
 {
     bmqtst::TestHelper::printTestName("Check Multithread Listen Test");
@@ -1389,7 +1810,7 @@ static void test1_breathingTest()
     t.init(L_);
 
     // Listen and connect work
-    t.listen(L_, "listenHandle", "127.0.0.1:0");
+    t.listen(L_, "listenHandle", "127.0.0.1:5001");
     t.connect(L_, "connectHandle", "listenHandle");
 
     t.checkResultCallback(L_, "listenHandle", "listenChannel");
@@ -1424,9 +1845,10 @@ static void test1_breathingTest()
 
 int main(int argc, char* argv[])
 {
+    bmqtst::TestHelperUtil::verbosityLevel() = 1;
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
-    // ntcf::System::initialize();
+    ntcf::SystemGuard systemGuard(ntscfg::Signal::e_PIPE);
 
     switch (_testCase) {
     case 0:
@@ -1437,13 +1859,13 @@ int main(int argc, char* argv[])
     case 5: test5_visitChannelsTest(); break;
     case 6: test6_preCreationCbTest(); break;
     case 7: test7_checkMultithreadListen(); break;
+    case 8: test8_upgradeChannelTest(); break;
+    case 9: test9_tlsClientFailsOnPlaintextServer(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }
-
-    // ntcf::System::exit();
 
     TEST_EPILOG(0);
 }

--- a/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
+++ b/src/groups/bmq/bmqio/bmqio_reconnectingchannelfactory.cpp
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "bmqu_atomicvalidator.h"
 #include <bmqio_reconnectingchannelfactory.h>
 
 #include <bmqscm_version.h>
 
 #include <bmqio_resolveutil.h>
+#include <bmqu_atomicvalidator.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
 #include <bmqu_time.h>
@@ -518,6 +518,8 @@ void ReconnectingChannelFactory::cancelAllHandles()
          ++iter) {
         iter->second->cancel();
     }
+
+    d_config.d_base_p->stop();
 }
 
 void ReconnectingChannelFactory::disableReconnect()

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
@@ -17,8 +17,13 @@
 
 #include <bmqscm_version.h>
 // BDE
+#include <bdlb_string.h>
+#include <bdls_filesystemutil.h>
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
+
+// BMQ
+#include <bmqu_stringutil.h>
 
 namespace BloombergLP {
 namespace bmqt {
@@ -28,6 +33,8 @@ namespace bmqt {
 // --------------------
 
 const char SessionOptions::k_BROKER_DEFAULT_URI[] = "tcp://localhost:30114";
+
+const char SessionOptions::k_DEFAULT_TLS_PROTOCOL_VERSIONS[] = "TLSv1.3";
 
 SessionOptions::SessionOptions(bslma::Allocator* allocator)
 : d_brokerUri(k_BROKER_DEFAULT_URI, allocator)
@@ -45,6 +52,8 @@ SessionOptions::SessionOptions(bslma::Allocator* allocator)
 , d_eventQueueHighWatermark(2 * 1000)
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
 , d_authnCredentialCb()
+, d_certificateAuthority(allocator)
+, d_protocolVersions(allocator)
 , d_hostHealthMonitor_sp()
 , d_dtContext_sp()
 , d_dtTracer_sp()
@@ -71,6 +80,8 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 , d_eventQueueHighWatermark(other.eventQueueHighWatermark())
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
 , d_authnCredentialCb(other.authnCredentialCb())
+, d_certificateAuthority(other.certificateAuthority(), allocator)
+, d_protocolVersions(other.protocolVersions(), allocator)
 , d_hostHealthMonitor_sp(other.hostHealthMonitor())
 , d_dtContext_sp(other.traceContext())
 , d_dtTracer_sp(other.tracer())
@@ -78,6 +89,44 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 , d_channelWriteTimeout(other.d_channelWriteTimeout)
 {
     // NOTHING
+}
+
+SessionOptions&
+SessionOptions::configureTls(bsl::string_view certificateAuthority,
+                             bsl::string_view versions)
+{
+    d_certificateAuthority = certificateAuthority;
+    d_protocolVersions.clear();
+
+    bsl::vector<bsl::string_view> vs =
+        bmqu::StringUtil::strTokenizeRef(versions, ", \t");
+    for (bsl::vector<bsl::string_view>::const_iterator it  = vs.cbegin(),
+                                                       end = vs.cend();
+         it != end;
+         ++it) {
+        TlsProtocolVersion::Value version;
+
+        if (TlsProtocolVersion::fromAscii(&version, *it)) {
+            d_protocolVersions.insert(version);
+        }
+        else {
+            BSLS_ASSERT_OPT(false && "Unrecognized protocol version");
+        }
+    }
+
+    // TODO(tfoxhall): Asserts are a terrible way to do validation here but
+    // this seems to be the approach taken for the entire SessionOptions class.
+    BSLS_ASSERT_OPT(bdls::FilesystemUtil::exists(d_certificateAuthority));
+    BSLS_ASSERT_OPT(!d_protocolVersions.empty() &&
+                    "At least one TLS protocol version must be specified");
+
+    return *this;
+}
+
+SessionOptions&
+SessionOptions::configureTls(bsl::string_view certificateAuthority)
+{
+    return configureTls(certificateAuthority, k_DEFAULT_TLS_PROTOCOL_VERSIONS);
 }
 
 bsl::ostream& SessionOptions::print(bsl::ostream& stream,
@@ -116,6 +165,10 @@ bsl::ostream& SessionOptions::print(bsl::ostream& stream,
                            d_hostHealthMonitor_sp != NULL);
     printer.printAttribute("hasDistributedTracing", d_dtTracer_sp != NULL);
     printer.printAttribute("userAgentPrefix", d_userAgentPrefix);
+    printer.printAttribute("certificateAuthority", d_certificateAuthority);
+    printer.printAttribute("protocolVersions",
+                           d_protocolVersions.cbegin(),
+                           d_protocolVersions.cend());
     printer.end();
 
     return stream;

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -130,6 +130,7 @@
 
 // BMQ
 #include <bmqt_authncredential.h>
+#include <bmqt_tlsprotocolversion.h>
 
 // BDE
 #include <bdlb_chartype.h>
@@ -140,6 +141,7 @@
 #include <bsl_memory.h>
 #include <bsl_optional.h>
 #include <bsl_string.h>
+#include <bsl_unordered_set.h>
 #include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
@@ -195,6 +197,9 @@ class SessionOptions {
 
     static const unsigned int k_CHANNEL_WRITE_DEFAULT_TIMEOUT_SEC = 5;
 
+    /// Default supported TLS versions in this client.
+    static const char k_DEFAULT_TLS_PROTOCOL_VERSIONS[];
+
   private:
     // DATA
 
@@ -242,6 +247,12 @@ class SessionOptions {
     /// data) for authenticating with the broker. If not set, the session will
     /// not authenticate with the broker.
     AuthnCredentialCb d_authnCredentialCb;
+
+    /// Path of the certificate authority
+    bsl::string d_certificateAuthority;
+
+    /// Supported TLS versions
+    bsl::unordered_set<TlsProtocolVersion::Value> d_protocolVersions;
 
     bsl::shared_ptr<bmqpi::HostHealthMonitor> d_hostHealthMonitor_sp;
 
@@ -357,6 +368,20 @@ class SessionOptions {
     /// Zero means no blocking.
     SessionOptions& setChannelWriteTimeout(const bsls::TimeInterval& value);
 
+    /// Set the TLS certificate authority to the specified
+    /// 'certificateAuthority'. Set the TLS protocol versions to the specified
+    /// 'versions'. Return this SessionOptions object reference.
+    ///
+    /// @pre The `versions` string must contain at least one TLS version.
+    SessionOptions& configureTls(bsl::string_view certificateAuthority,
+                                 bsl::string_view versions);
+
+    /// Set the TLS certificate authority to the specified
+    /// 'certificateAuthority'. Set the supported TLS protocol versions to the
+    /// default supported TLS versions. Return this SessionOptions object
+    /// reference.
+    SessionOptions& configureTls(bsl::string_view certificateAuthority);
+
     // ACCESSORS
 
     /// Get the broker URI.
@@ -405,6 +430,16 @@ class SessionOptions {
 
     int eventQueueLowWatermark() const;
     int eventQueueHighWatermark() const;
+
+    /// @brief Get the configured certificate authority file path.
+    const bsl::string& certificateAuthority() const;
+
+    /// @brief Get the configured supported TLS protocol versions.
+    const bsl::unordered_set<TlsProtocolVersion::Value>&
+    protocolVersions() const;
+
+    /// @brief Return true if this session will be configured for TLS.
+    bool isTlsSession() const;
 
     /// DEPRECATED: This parameter is no longer relevant and will be removed
     /// in future release of libbmq.
@@ -696,6 +731,22 @@ inline int SessionOptions::eventQueueHighWatermark() const
     return d_eventQueueHighWatermark;
 }
 
+inline const bsl::string& SessionOptions::certificateAuthority() const
+{
+    return d_certificateAuthority;
+}
+
+inline const bsl::unordered_set<TlsProtocolVersion::Value>&
+SessionOptions::protocolVersions() const
+{
+    return d_protocolVersions;
+}
+
+inline bool SessionOptions::isTlsSession() const
+{
+    return !protocolVersions().empty();
+}
+
 inline int SessionOptions::eventQueueSize() const
 {
     return d_eventQueueSize;
@@ -734,7 +785,9 @@ inline bool bmqt::operator==(const bmqt::SessionOptions& lhs,
            lhs.hostHealthMonitor() == rhs.hostHealthMonitor() &&
            lhs.traceContext() == rhs.traceContext() &&
            lhs.tracer() == rhs.tracer() &&
-           lhs.userAgentPrefix() == rhs.userAgentPrefix();
+           lhs.userAgentPrefix() == rhs.userAgentPrefix() &&
+           lhs.certificateAuthority() == rhs.certificateAuthority() &&
+           lhs.protocolVersions() == rhs.protocolVersions();
 }
 
 inline bool bmqt::operator!=(const bmqt::SessionOptions& lhs,
@@ -754,7 +807,9 @@ inline bool bmqt::operator!=(const bmqt::SessionOptions& lhs,
            lhs.hostHealthMonitor() != rhs.hostHealthMonitor() ||
            lhs.traceContext() != rhs.traceContext() ||
            lhs.tracer() != rhs.tracer() ||
-           lhs.userAgentPrefix() != rhs.userAgentPrefix();
+           lhs.userAgentPrefix() != rhs.userAgentPrefix() ||
+           lhs.certificateAuthority() != rhs.certificateAuthority() ||
+           lhs.protocolVersions() != rhs.protocolVersions();
 }
 
 inline bsl::ostream& bmqt::operator<<(bsl::ostream&               stream,

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
@@ -25,6 +25,7 @@
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
+#include <bslstl_unorderedset.h>
 
 // CONVENIENCE
 using namespace BloombergLP;
@@ -65,7 +66,8 @@ static void test2_printTest()
         "closeQueueTimeout = 300 eventQueueLowWatermark = 50 "
         "eventQueueHighWatermark = 2000 hasAuthnCredentialCb = false "
         "hasHostHealthMonitor = false hasDistributedTracing = false "
-        "userAgentPrefix = \"\" ]";
+        "userAgentPrefix = \"\" certificateAuthority = \"\" protocolVersions "
+        "= [ ] ]";
     bmqtst::TestHelper::printTestName("PRINT");
     PV("Testing print");
     bmqu::MemOutStream stream(bmqtst::TestHelperUtil::allocator());
@@ -83,10 +85,15 @@ static void test2_printTest()
 
 static void test3_setterGetterAndCopyTest()
 {
+    bslma::Allocator* allocator = bmqtst::TestHelperUtil::allocator();
     bmqtst::TestHelper::printTestName("SETTER GETTER");
+    // Default allocator use is actually pretty normal
+    // Used in configureTls
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
     PVV("Setter getter test");
     // Create default sessionOptions
-    bmqt::SessionOptions obj(bmqtst::TestHelperUtil::allocator());
+    bmqt::SessionOptions obj(allocator);
 
     PVV("Checking setter and getter for brokerUri");
     const char* const brokerUri = "tcp://localhost:30115";
@@ -170,6 +177,19 @@ static void test3_setterGetterAndCopyTest()
     obj.setUserAgentPrefix(userAgentPrefix);
     BMQTST_ASSERT_EQ(obj.userAgentPrefix(), userAgentPrefix);
 
+    PVV("Checking setter and getter for configureTls");
+    BMQTST_ASSERT(!obj.isTlsSession());
+    BMQTST_ASSERT(obj.certificateAuthority().empty());
+    BMQTST_ASSERT(obj.protocolVersions().empty());
+    const char* const certificatePath = "/tmp/test";
+    const char* const tlsVersions     = "TLSv1.3";
+    bsl::unordered_set<bmqt::TlsProtocolVersion::Value> expectedVersions(
+        allocator);
+    expectedVersions.insert(bmqt::TlsProtocolVersion::e_TLS1_3);
+    obj.configureTls(certificatePath, tlsVersions);
+    BMQTST_ASSERT_EQ(obj.certificateAuthority(), certificatePath);
+    BMQTST_ASSERT_EQ(obj.protocolVersions(), expectedVersions);
+
     PVV("Copy constructor test");
     bmqt::SessionOptions objCopy(obj, bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(objCopy.brokerUri(), brokerUri);
@@ -185,6 +205,8 @@ static void test3_setterGetterAndCopyTest()
     BMQTST_ASSERT_EQ(objCopy.eventQueueHighWatermark(),
                      eventQueueHighWatermark);
     BMQTST_ASSERT_EQ(objCopy.userAgentPrefix(), userAgentPrefix);
+    BMQTST_ASSERT_EQ(objCopy.certificateAuthority(), certificatePath);
+    BMQTST_ASSERT_EQ(objCopy.protocolVersions(), expectedVersions);
 }
 // ============================================================================
 //                                 MAIN PROGRAM

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.cpp
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.cpp
@@ -1,0 +1,110 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_sessionoptions.cpp                                            -*-C++-*-
+#include <bmqt_tlsprotocolversion.h>
+
+// BMQ
+#include <bmqscm_version.h>
+#include <bmqt_resultcode.h>
+#include <bmqu_stringutil.h>
+
+// BDE
+#include <bdlb_string.h>
+#include <bdls_filesystemutil.h>
+#include <bslim_printer.h>
+#include <bslma_allocator.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// =========================
+// struct TlsProtocolVersion
+// =========================
+
+bsl::ostream& TlsProtocolVersion::print(bsl::ostream&             stream,
+                                        TlsProtocolVersion::Value value,
+                                        int                       level,
+                                        int spacesPerLevel)
+{
+    if (stream.bad()) {
+        return stream;  // RETURN
+    }
+
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+    printer.printValue(TlsProtocolVersion::toAscii(value));
+    printer.end();
+
+    return stream;
+}
+
+const char* TlsProtocolVersion::toAscii(TlsProtocolVersion::Value value)
+{
+    // Use openssl compatible string representation
+    switch (value) {
+    case e_TLS1_3: return "TLSv1.3";
+    default: return "(* UNKNOWN *)";
+    }
+}
+
+bool TlsProtocolVersion::fromAscii(TlsProtocolVersion::Value* out,
+                                   const bslstl::StringRef&   str)
+{
+#define CHECKVALUE(M)                                                         \
+    if (bdlb::String::areEqualCaseless(toAscii(TlsProtocolVersion::e_##M),    \
+                                       str.data(),                            \
+                                       str.length())) {                       \
+        *out = TlsProtocolVersion::e_##M;                                     \
+        return true;                                                          \
+    }
+
+    CHECKVALUE(TLS1_3);
+
+    // Invalid string
+    return false;
+
+#undef CHECKVALUE
+}
+
+// =============================
+// struct TlsProtocolVersionUtil
+// =============================
+
+GenericResult::Enum TlsProtocolVersionUtil::parseMinTlsVersion(
+    TlsProtocolVersion::Value* outMinVersion,
+    const bsl::string&         versions)
+{
+    BSLS_ASSERT(outMinVersion);
+
+    bsl::vector<bslstl::StringRef> vs =
+        bmqu::StringUtil::strTokenizeRef(versions, ", \t");
+    for (size_t i = 0; i < vs.size(); i++) {
+        bmqt::TlsProtocolVersion::Value version;
+
+        if (TlsProtocolVersion::fromAscii(&version, vs[i])) {
+            // We only support TLS v1.3
+            if (version == TlsProtocolVersion::e_TLS1_3) {
+                *outMinVersion = version;
+                return GenericResult::e_SUCCESS;
+            }
+        }
+    }
+
+    return GenericResult::e_INVALID_ARGUMENT;
+}
+
+}
+}

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.g.cpp
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.g.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqt_tlsprotocolversion.h>
+
+// BMQ
+#include <bmqt_resultcode.h>
+#include <bmqu_memoutstream.h>
+
+// BDE
+#include <bsl_algorithm.h>
+
+// TEST_DRIVER
+#include <bmqtst_testhelper.h>
+#include <bslstl_iterator.h>
+#include <gtest/gtest.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+
+namespace {
+}
+
+TEST(TlsProtocolVersion, printRepresentation)
+{
+    struct TestCase {
+        bmqt::TlsProtocolVersion::Value d_input;
+        const char*                     d_expected;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqu::MemOutStream out(bmqtst::TestHelperUtil::allocator());
+            bmqt::TlsProtocolVersion::print(out, testCase.d_input, 0, -1);
+            bsl::string printed(out.str(),
+                                bmqtst::TestHelperUtil::allocator());
+            EXPECT_STREQ(testCase.d_expected, printed.c_str());
+        }
+    };
+
+    TestCase k_DATA[] = {
+        {bmqt::TlsProtocolVersion::e_TLS1_3, "[ \"TLSv1.3\" ]"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, fromAsciiInvertsToAscii)
+{
+    struct TestCase {
+        bmqt::TlsProtocolVersion::Value d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value converted;
+            bool result = bmqt::TlsProtocolVersion::fromAscii(
+                &converted,
+                bmqt::TlsProtocolVersion::toAscii(testCase.d_input));
+            EXPECT_TRUE(result);
+            EXPECT_EQ(testCase.d_input, converted);
+        }
+    };
+
+    TestCase k_DATA[] = {{bmqt::TlsProtocolVersion::e_TLS1_3}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, toAsciiInvertsFromAscii)
+{
+    struct TestCase {
+        const char* d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value converted;
+            EXPECT_TRUE(bmqt::TlsProtocolVersion::fromAscii(&converted,
+                                                            testCase.d_input));
+            EXPECT_STREQ(testCase.d_input,
+                         bmqt::TlsProtocolVersion::toAscii(converted));
+        }
+    };
+
+    TestCase k_DATA[] = {{"TLSv1.3"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersion, badAsciiGivesErrorCode)
+{
+    bmqt::TlsProtocolVersion::Value out;
+    bool result = bmqt::TlsProtocolVersion::fromAscii(&out, "garbage");
+    EXPECT_FALSE(result);
+}
+
+TEST(TlsProtocolVersionUtil, parsesMinTlsVersion)
+{
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    struct TestCase {
+        const char*                     d_input;
+        bmqt::TlsProtocolVersion::Value d_expected;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value out;
+            bmqt::TlsProtocolVersionUtil::parseMinTlsVersion(&out,
+                                                             testCase.d_input);
+            EXPECT_EQ(testCase.d_expected, out);
+        }
+    };
+
+    TestCase k_DATA[] = {
+        {"TLSv1.3", bmqt::TlsProtocolVersion::e_TLS1_3},
+        {"TLSv1.3,TLSv1.3", bmqt::TlsProtocolVersion::e_TLS1_3},
+        {"garbage,TLSv.13", bmqt::TlsProtocolVersion::e_TLS1_3}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+
+TEST(TlsProtocolVersionUtil, badVersionStringGivesErrorCode)
+{
+    struct TestCase {
+        const char* d_input;
+    };
+
+    struct Locals {
+        static void check(const TestCase& testCase)
+        {
+            bmqt::TlsProtocolVersion::Value out;
+            int rc = bmqt::TlsProtocolVersionUtil::parseMinTlsVersion(
+                &out,
+                testCase.d_input);
+            EXPECT_NE(0, rc)
+                << "Value parsed successfully: " << testCase.d_input;
+        }
+    };
+
+    TestCase k_DATA[] = {{"garbage"}, {""}, {",,,"}};
+    bsl::for_each(bsl::cbegin(k_DATA), bsl::cend(k_DATA), Locals::check);
+}
+// ========================================================================
+//                                  MAIN
+// ========================================================================
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    ::testing::InitGoogleTest(&argc, argv);
+
+    bmqtst::TestHelperUtil::testStatus() = RUN_ALL_TESTS();
+
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_DEF_GBL_ALLOC);
+}

--- a/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.h
+++ b/src/groups/bmq/bmqt/bmqt_tlsprotocolversion.h
@@ -1,0 +1,92 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// bmqt_tlsprotocol_version.h                                        -*-C++-*-
+#ifndef INCLUDED_BMQT_TLSPROTOCOLVERSION
+#define INCLUDED_BMQT_TLSPROTOCOLVERSION
+
+///@PURPOSE: Provide a set of helpers for parsing TLS related config values.
+///
+///@CLASSES:
+///  bmqu::TlsProtocolVersion: Struct containing enums representing TLS
+///  protocol versions.
+//
+//   bmqu::TlsProtocolVersionUtil: Utility struct for processing TLS protocol
+///  config values.
+///
+///@DESCRIPTION: 'bmqt::TlsProtocolVersion'
+///
+/// Functionality
+/// -------------
+/// TBD: Comment about Default vs Initial value -- assert vs safe mode
+///
+/// Usage
+/// -----
+/// This section illustrates the intended use of this component.
+///
+//// Example 1: TBD:
+////- - - - - - - -
+/// TBD:
+
+#include <bmqt_resultcode.h>
+
+namespace BloombergLP {
+namespace bmqt {
+
+// ======================
+// struct TlsProtocolVersion
+// ======================
+
+struct TlsProtocolVersion {
+    enum Value { e_TLS1_3 };
+
+    // CLASS METHODS
+    static bsl::ostream& print(bsl::ostream&             stream,
+                               TlsProtocolVersion::Value value,
+                               int                       level          = 0,
+                               int                       spacesPerLevel = 4);
+
+    static const char* toAscii(TlsProtocolVersion::Value value);
+
+    static bool fromAscii(TlsProtocolVersion::Value* out,
+                          const bslstl::StringRef&   str);
+};
+
+// ============================
+// class TlsProtocolVersionUtil
+// ============================
+
+/// Helper struct for parsing TLS config values.
+struct TlsProtocolVersionUtil {
+    /// Parse the minimum TLS version specified in the TLS config string.
+    ///
+    /// TLS version strings are comma separated values of TLS versions.
+    /// Currently, only `TLSv1.3` is supported. Invalid values are ignored,
+    /// and the empty string results in an error.
+    ///
+    /// @param[out] outMinVersion The location to store the minimum version
+    /// parsed
+    /// @param versions A comma separated string of versions
+    ///
+    /// @returns Zero on success
+    static GenericResult::Enum
+    parseMinTlsVersion(TlsProtocolVersion::Value* outMinVersion,
+                       const bsl::string&         versions);
+};
+
+}
+}
+
+#endif

--- a/src/groups/bmq/bmqt/package/bmqt.mem
+++ b/src/groups/bmq/bmqt/package/bmqt.mem
@@ -12,5 +12,6 @@ bmqt_resultcode
 bmqt_sessioneventtype
 bmqt_sessionoptions
 bmqt_subscription
+bmqt_tlsprotocolversion
 bmqt_uri
 bmqt_version

--- a/src/groups/bmq/bmqtst/bmqtst_testhelper.h
+++ b/src/groups/bmq/bmqtst/bmqtst_testhelper.h
@@ -684,7 +684,7 @@
         static void run()                                                     \
         {                                                                     \
             FIXTURE##NAME test;                                               \
-            bmqtst::TestHelper::printTestName(#NAME);                         \
+            bmqtst::TestHelper::printTestName(#FIXTURE "::" #NAME);           \
             test.SetUp();                                                     \
             test.body();                                                      \
             test.TearDown();                                                  \

--- a/src/groups/bmq/bmqu/bmqu_stringutil.cpp
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.cpp
@@ -22,6 +22,7 @@
 #include <bsl_cctype.h>
 #include <bsl_climits.h>
 #include <bsl_functional.h>
+#include <bsl_iterator.h>
 #include <bsls_assert.h>
 
 namespace BloombergLP {
@@ -141,14 +142,36 @@ bsl::vector<bslstl::StringRef>
 StringUtil::strTokenizeRef(const bsl::string&       str,
                            const bslstl::StringRef& delims)
 {
+    bsl::vector<bsl::string_view> tokenized =
+        strTokenizeRef(bsl::string_view(str), bsl::string_view(delims));
+
+    struct Locals {
+        static bslstl::StringRef convert(bsl::string_view str)
+        {
+            return bslstl::StringRef(str);
+        }
+    };
+
     bsl::vector<bslstl::StringRef> res;
+    res.reserve(tokenized.size());
+    bsl::transform(tokenized.cbegin(),
+                   tokenized.cend(),
+                   bsl::back_inserter(res),
+                   Locals::convert);
+    return res;
+}
+
+bsl::vector<bsl::string_view>
+StringUtil::strTokenizeRef(bsl::string_view str, bsl::string_view delims)
+{
+    bsl::vector<bsl::string_view> res;
 
     if (str.empty()) {
         return res;  // RETURN
     }
 
     if (delims.length() == 0) {
-        res.push_back(bslstl::StringRef(str.c_str(), str.length()));
+        res.push_back(str);
         return res;  // RETURN
     }
 
@@ -156,22 +179,21 @@ StringUtil::strTokenizeRef(const bsl::string&       str,
 
     while ((delimIdx = str.find_first_of(delims, idx)) != bsl::string::npos) {
         if ((len = delimIdx - idx) != 0) {
-            res.push_back(bslstl::StringRef(str.c_str() + idx, len));
+            res.emplace_back(str.cbegin() + idx, len);
         }
         else {
             // Put an empty ""
-            res.push_back(bslstl::StringRef(str.c_str() + idx, 0));
+            res.emplace_back(str.cbegin() + idx, 0);
         }
         idx = delimIdx + 1;
     }
 
     if (idx != str.length()) {
-        res.push_back(
-            bslstl::StringRef(str.c_str() + idx, str.length() - idx));
+        res.emplace_back(str.cbegin() + idx, str.length() - idx);
     }
     else {
         // Put an empty ""
-        res.push_back(bslstl::StringRef(str.c_str() + idx, 0));
+        res.emplace_back(str.cbegin() + idx, 0);
     }
 
     return res;

--- a/src/groups/bmq/bmqu/bmqu_stringutil.h
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.h
@@ -81,6 +81,9 @@ struct StringUtil {
     static bsl::vector<bslstl::StringRef>
     strTokenizeRef(const bsl::string& str, const bslstl::StringRef& delims);
 
+    static bsl::vector<bsl::string_view>
+    strTokenizeRef(bsl::string_view str, bsl::string_view delims);
+
     /// Return true if the specified string `str` matches the specified
     /// `pattern`.  `pattern` may include Unix file matching wildcards `*`
     /// and `?`, representing respectively 0 to n characters and exactly 1

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -59,15 +59,18 @@
 #include <bmqp_heartbeatmonitor.h>
 #include <bmqp_protocol.h>
 #include <bmqp_protocolutil.h>
-#include <bmqst_statcontext.h>
+#include <bmqt_sessionoptions.h>
+#include <bmqt_tlsprotocolversion.h>
 #include <bmqu_blob.h>
 #include <bmqu_memoutstream.h>
 #include <bmqu_printutil.h>
+#include <bmqu_stringutil.h>
 #include <bmqu_time.h>
 #include <bmqu_weakmemfn.h>
 
 // BDE
 #include <ball_log.h>
+#include <bdlb_pairutil.h>
 #include <bdlb_scopeexit.h>
 #include <bdlb_string.h>
 #include <bdlbb_blobutil.h>
@@ -98,6 +101,7 @@
 #include <bsls_types.h>
 
 // NTC
+#include <ntca_encryptionmethod.h>
 #include <ntcf_system.h>
 #include <ntsa_error.h>
 #include <ntsa_ipaddress.h>
@@ -290,6 +294,22 @@ struct ChannelFactoryBuilders {
         factory->onCreate(bdlf::BindUtil::bind(&ntcChannelPreCreation,
                                                bdlf::PlaceHolders::_1,
                                                bdlf::PlaceHolders::_2));
+        return factory;
+    }
+
+    static bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory(
+        bslma::Allocator*                              allocator,
+        const ntca::InterfaceConfig&                   interfaceConfig,
+        bdlbb::BlobBufferFactory*                      blobBufferFactory,
+        const bsl::shared_ptr<ntci::EncryptionServer>& encryptionServer)
+    {
+        BSLS_ASSERT(encryptionServer);
+        bsl::shared_ptr<bmqio::NtcChannelFactory> factory =
+            ChannelFactoryBuilders::ntcChannelFactory(allocator,
+                                                      interfaceConfig,
+                                                      blobBufferFactory);
+        factory->setEncryptionServer(encryptionServer);
+
         return factory;
     }
 
@@ -913,12 +933,12 @@ void TCPSessionFactory::onClose(const bsl::shared_ptr<bmqio::Channel>& channel,
             if (channelInfo->d_monitor_mp->isHearbeatEnabled() &&
                 d_heartbeatSchedulerActive) {
                 // NOTE: When shutting down, we don't care about heartbeat
-                //       verifying the channel, therefore, as an optimization
-                //       to avoid the one-by-one disable for each channel (as
-                //       they all will get closed at this time), the 'stop()'
-                //       sequence cancels the recurring event and wait before
-                //       closing the channels, so we don't need to
-                //       'disableHeartbeat' in this case.
+                //       verifying the channel, therefore, as an
+                //       optimization to avoid the one-by-one disable for
+                //       each channel (as they all will get closed at this
+                //       time), the 'stop()' sequence cancels the recurring
+                //       event and wait before closing the channels, so we
+                //       don't need to 'disableHeartbeat' in this case.
                 d_scheduler_p->scheduleEvent(
                     bsls::SystemTime::nowMonotonicClock(),
                     bdlf::BindUtil::bind(
@@ -930,13 +950,14 @@ void TCPSessionFactory::onClose(const bsl::shared_ptr<bmqio::Channel>& channel,
         }
 
         d_ports.onDeleteChannelContext(port);
-    }  // close mutex lock guard                                      // UNLOCK
+    }  // close mutex lock guard
+       // UNLOCK
 
     if (!channelInfo) {
         // We register to the close event as soon as the channel is up;
         // however, we insert in the d_channels only upon successful
-        // negotiation; therefore a failed to negotiate channel (like during
-        // intrusion testing) would trigger this trace.
+        // negotiation; therefore a failed to negotiate channel (like
+        // during intrusion testing) would trigger this trace.
         BALL_LOG_INFO << "#TCP_UNEXPECTED_STATE " << d_name
                       << ": onClose channel for an unknown channel '"
                       << channel.get() << "', " << d_nbActiveChannels
@@ -1072,6 +1093,40 @@ int TCPSessionFactory::validateTcpInterfaces() const
     return validator(*d_config_mp);
 }
 
+int TCPSessionFactory::initEncryptionServer(const mqbcfg::TlsConfig& tlsConfig)
+{
+    // We only support TLS 1.3
+    bsl::vector<bslstl::StringRef> vs =
+        bmqu::StringUtil::strTokenizeRef(tlsConfig.versions(), ", \t");
+    for (size_t i = 0; i < vs.size(); i++) {
+        bmqt::TlsProtocolVersion::Value version =
+            bmqt::TlsProtocolVersion::e_TLS1_3;
+
+        if (bmqt::TlsProtocolVersion::fromAscii(&version, vs[i])) {
+            if (version != bmqt::TlsProtocolVersion::e_TLS1_3) {
+                return ntsa::Error::e_NOT_IMPLEMENTED;
+            }
+        }
+    }
+
+    ntca::EncryptionServerOptions encryptionServerOptions;
+    // Set the minimum version to TLS 1.3
+    encryptionServerOptions.setMinMethod(ntca::EncryptionMethod::e_TLS_V1_3);
+    encryptionServerOptions.setMaxMethod(ntca::EncryptionMethod::e_DEFAULT);
+    // Disable client side authentication (mTLS)
+    encryptionServerOptions.setAuthentication(
+        ntca::EncryptionAuthentication::e_NONE);
+
+    encryptionServerOptions.setIdentityFile(tlsConfig.certificate());
+    encryptionServerOptions.setPrivateKeyFile(tlsConfig.key());
+    encryptionServerOptions.addAuthorityFile(tlsConfig.certificateAuthority());
+
+    return ntcf::System::createEncryptionServer(&d_encryptionServer_sp,
+                                                encryptionServerOptions,
+                                                d_allocator_p)
+        .code();
+}
+
 void TCPSessionFactory::reauthnOnAuthenticationEvent(
     const bmqp::Event& event,
     const ChannelInfo* channelInfo) const
@@ -1170,6 +1225,7 @@ TCPSessionFactory::TCPSessionFactory(
 , d_isListening(false)
 , d_listenContexts(allocator)
 , d_timestampMap(allocator)
+, d_encryptionServer_sp()
 , d_allocator_p(allocator)
 {
     // PRECONDITIONS
@@ -1265,21 +1321,37 @@ int TCPSessionFactory::start(bsl::ostream& errorDescription)
     typedef bmqio::ChannelFactoryPipeline::Config::ChannelFactoryBuilder
         ChannelFactoryBuilder;
 
-    bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory =
-        ChannelFactoryBuilders::ntcChannelFactory(d_allocator_p,
-                                                  interfaceConfig,
-                                                  d_blobBufferFactory_p);
+    // Initialize encryption if TLS is configured
+    bsl::shared_ptr<bmqio::NtcChannelFactory> ntcChannelFactory;
+    const mqbcfg::AppConfig& appConfig = mqbcfg::BrokerConfig::get();
+    if (appConfig.tlsConfig().has_value()) {
+        initEncryptionServer(appConfig.tlsConfig().value());
+        ntcChannelFactory = ChannelFactoryBuilders::ntcChannelFactory(
+            d_allocator_p,
+            interfaceConfig,
+            d_blobBufferFactory_p,
+            d_encryptionServer_sp);
+    }
+    else {
+        ntcChannelFactory = ChannelFactoryBuilders::ntcChannelFactory(
+            d_allocator_p,
+            interfaceConfig,
+            d_blobBufferFactory_p);
+    }
+
     ChannelFactoryBuilder resolvingChannelFactoryBuilder =
         bdlf::BindUtil::bind(ChannelFactoryBuilders::resolvingChannelFactory,
                              d_allocator_p,
                              bdlf::PlaceHolders::_1,
                              d_resolutionContext_sp);
+
     ChannelFactoryBuilder reconnectingChannelFactoryBuilder =
         bdlf::BindUtil::bind(
             ChannelFactoryBuilders::reconnectingChannelFactory,
             d_allocator_p,
             bdlf::PlaceHolders::_1,
             d_scheduler_p);
+
     ChannelFactoryBuilder statChannelFactoryBuilder = bdlf::BindUtil::bind(
         ChannelFactoryBuilders::statChannelFactory,
         d_allocator_p,
@@ -1386,8 +1458,13 @@ void TCPSessionFactory::stopListening()
     }
     d_isListening = false;
 
-    if (d_reconnectingChannelFactory_mp) {
-        d_reconnectingChannelFactory_mp->disableReconnect();
+    // TODO(tfoxhall): Since this is now shared across two channel factory
+    // pipelines this shoudn't be called twice, but it feels bad to have to
+    // guard against that
+    bmqio::ReconnectingChannelFactory* reconnectingChannelFactory_p =
+        d_channelFactoryPipeline_mp->get<bmqio::ReconnectingChannelFactory>();
+    if (reconnectingChannelFactory_p != NULL) {
+        reconnectingChannelFactory_p->disableReconnect();
     }
 
     cancelListeners();
@@ -1431,7 +1508,8 @@ void TCPSessionFactory::closeClients()
         BALL_LOG_ERROR << d_name << ": timed out while waiting for clients to "
                        << "close, remaining clients: " << d_nbOpenClients;
 
-        // Invalidate the remaining sessions before stopping all Dispatchers.
+        // Invalidate the remaining sessions before stopping all
+        // Dispatchers.
 
         for (size_t i = 0; i < clients.size(); ++i) {
             bsl::shared_ptr<Session> session = clients[i].lock();
@@ -1455,9 +1533,10 @@ void TCPSessionFactory::stop()
                   << " active channels, " << d_nbSessions
                   << " alive sessions]";
 
-    // NOTE: We don't need to manually call 'teardown' on any active session in
-    //       the 'd_channels' map: calling 'stop' on the channel factory will
-    //       invoke the 'onClose' for every sessions.
+    // NOTE: We don't need to manually call 'teardown' on any active
+    // session in
+    //       the 'd_channels' map: calling 'stop' on the channel factory
+    //       will invoke the 'onClose' for every sessions.
 
     // STOP
     d_resolutionContext_sp->stop();
@@ -1481,9 +1560,10 @@ void TCPSessionFactory::stop()
             bmqu::WeakMemFnUtil::weakMemFn(&TCPSessionFactory::stopHeartbeats,
                                            d_self.acquireWeak()));
 
-        // No need to wait for 'stopHeartbeats' because 'd_heartbeatChannels'
-        // keep counted reference to sessions ('ChannelInfo::d_session_sp') and
-        // the code below waits for sessions destruction.
+        // No need to wait for 'stopHeartbeats' because
+        // 'd_heartbeatChannels' keep counted reference to sessions
+        // ('ChannelInfo::d_session_sp') and the code below waits for
+        // sessions destruction.
     }
 
     if (d_nbSessions != 0) {
@@ -1510,6 +1590,8 @@ void TCPSessionFactory::stop()
     d_mutex.unlock();
 
     // DESTROY
+    // We destroy the channel factories here for symmetry since they're
+    // created in 'start'.
     d_channelFactoryPipeline_mp.reset();
 
     BALL_LOG_INFO << d_name << ": stopped";
@@ -1526,8 +1608,8 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
 
     // Maintain ownership of 'OperationContext' instead of passing it to
     // 'ChannelFactory::listen' because it may delete the context
-    // (on stopListening) while operation (readCallback / negotiation) is in
-    // progress.
+    // (on stopListening) while operation (readCallback / negotiation) is
+    // in progress.
     bsl::shared_ptr<OperationContext> context =
         bsl::allocate_shared<OperationContext>(d_allocator_p);
     d_listenContexts.emplace(port, context);
@@ -1540,10 +1622,12 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
     bmqu::MemOutStream                  endpoint(&localAlloc);
     endpoint << listener.address() << ":" << listener.port();
     bmqio::ListenOptions listenOptions;
-    listenOptions.setEndpoint(endpoint.str());
+    listenOptions.setEndpoint(endpoint.str()).setIsTls(listener.tls());
 
     bslma::ManagedPtr<bmqio::ChannelFactory::OpHandle> listeningHandle_mp;
     bmqio::Status                                      status;
+    BSLS_ASSERT_OPT(d_channelFactoryPipeline_mp != NULL);
+
     d_channelFactoryPipeline_mp->listen(
         &status,
         &listeningHandle_mp,
@@ -1733,7 +1817,8 @@ TCPSessionFactory::PortManager::addChannelContext(bmqst::StatContext* parent,
 
 void TCPSessionFactory::PortManager::onDeleteChannelContext(bsl::uint16_t port)
 {
-    // Lookup the port's StatContext and remove it from the internal containers
+    // Lookup the port's StatContext and remove it from the internal
+    // containers
     PortMap::iterator it = d_portMap.find(port);
     if (it != d_portMap.end() && --it->second.d_numChannels == 0) {
         d_portMap.erase(it);

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -78,10 +78,14 @@
 
 // MQB
 
+// BMQ
 #include <bmqio_channel.h>
 #include <bmqio_channelfactory.h>
 #include <bmqio_status.h>
 #include <bmqu_sharedresource.h>
+
+// NTF
+#include <ntci_encryptionserver.h>
 
 // BDE
 #include <bdlbb_blob.h>
@@ -107,6 +111,7 @@ namespace BloombergLP {
 namespace mqbcfg {
 class TcpInterfaceConfig;
 class TcpInterfaceListener;
+class TlsConfig;
 }
 
 namespace bmqex {
@@ -365,11 +370,6 @@ class TCPSessionFactory {
     bslma::ManagedPtr<bmqio::ChannelFactoryPipeline>
         d_channelFactoryPipeline_mp;
 
-    bslma::ManagedPtr<bmqio::ReconnectingChannelFactory>
-        d_reconnectingChannelFactory_mp;
-
-    bslma::ManagedPtr<bmqio::StatChannelFactory> d_statChannelFactory_mp;
-
     /// Cache of shared pointers to @bbref{mqbnet::InitialConnectionContext} to
     /// preserve their lifetime while an initial connection
     /// (authentication/negotiation) is in progress.  Each context is added by
@@ -443,6 +443,9 @@ class TCPSessionFactory {
 
     /// Map of HiRes timestamp of the session beginning per channel.
     TimestampMap d_timestampMap;
+
+    /// The encryption server used to authenticate incoming connections
+    bsl::shared_ptr<ntci::EncryptionServer> d_encryptionServer_sp;
 
     /// Allocator to use
     bslma::Allocator* d_allocator_p;
@@ -571,6 +574,13 @@ class TCPSessionFactory {
     /// in the specified `channelInfo`.
     void reauthnOnAuthenticationEvent(const bmqp::Event& event,
                                       const ChannelInfo* channelInfo) const;
+
+    /// Initialize this class's internal encryption server using the
+    /// application TLS config.
+    ///
+    /// @returns 0 on success, and a non-zero error code if `tlsConfig`
+    /// contains an invalid setting.
+    int initEncryptionServer(const mqbcfg::TlsConfig& tlsConfig);
 
   private:
     // NOT IMPLEMENTED

--- a/src/integration-tests/pytest.ini
+++ b/src/integration-tests/pytest.ini
@@ -19,3 +19,5 @@ markers =
     flakey
     eventual_consistency
     strong_consistency
+    tls
+certificate_generator = ../../bin/gen-tls-certs.sh

--- a/src/integration-tests/test_admin_client.py
+++ b/src/integration-tests/test_admin_client.py
@@ -168,7 +168,11 @@ def test_breathing(
     broker_config_str = admin.send_admin("brokerconfig dump")
     broker_config = json.loads(broker_config_str)
 
-    assert broker_config["networkInterfaces"]["tcpInterface"]["port"] == port
+    listeners = broker_config["networkInterfaces"]["tcpInterface"].get("listeners")
+    if listeners is not None:
+        assert listeners[0]["port"] == port
+    else:
+        assert broker_config["networkInterfaces"]["tcpInterface"]["port"] == port
 
     # Stop the admin session
     admin.stop()

--- a/src/integration-tests/test_breathing.py
+++ b/src/integration-tests/test_breathing.py
@@ -239,21 +239,33 @@ def test_broker_user_agent(multi_node: Cluster):
     assert node.capture("bmqbrkr:\\d+.\\d+.\\d+")
 
 
-def test_verify_priority(cluster: Cluster, domain_urls: tc.DomainUrls):
+# cluster = cluster + tls_cluster
+def test_verify_priority(
+    plain_and_tls_cluster: Cluster,
+    domain_urls: tc.DomainUrls,
+):
     uri_priority = domain_urls.uri_priority
-    proxies = cluster.proxy_cycle()
+    proxies = plain_and_tls_cluster.proxy_cycle()
 
     # 1: Setup producers and consumers
     # Proxy in same datacenter as leader/primary
     proxy1 = next(proxies)
 
-    producer1 = proxy1.create_client("producer1")
+    producer1 = proxy1.create_client(
+        "producer1",
+    )
     assert (
-        producer1.open(uri_priority, flags=["write", "ack"], block=True)
+        producer1.open(
+            uri_priority,
+            flags=["write", "ack"],
+            block=True,
+        )
         == Client.e_SUCCESS
     )
 
-    consumer1 = proxy1.create_client("consumer1")
+    consumer1 = proxy1.create_client(
+        "consumer1",
+    )
     assert (
         consumer1.open(uri_priority, flags=["read"], consumer_priority=2, block=True)
         == Client.e_SUCCESS
@@ -713,9 +725,9 @@ def test_multi_interface_connect(multi_interface: Cluster, domain_urls: tc.Domai
     brokers = cluster.nodes() + cluster.proxies()
     for broker in brokers:
         for i, listener in enumerate(broker.config.listeners):
-            port = listener.port
-            producer = broker.create_client(f"producer{i}", port=port)
-            consumer = broker.create_client(f"consumer{i}", port=port)
+            endpoint = listener.name
+            producer = broker.create_client(f"producer{i}", endpoint=endpoint)
+            consumer = broker.create_client(f"consumer{i}", endpoint=endpoint)
             producer.open(uri_priority, flags=["write", "ack"], succeed=True)
             consumer.open(
                 uri_priority,
@@ -741,8 +753,8 @@ def test_multi_interface_share_queues(
     cluster = multi_interface
     broker = next(cluster.proxy_cycle())
     [listener1, listener2] = broker.config.listeners
-    producer = broker.create_client("producer", port=listener1.port)
-    consumer = broker.create_client("consumer", port=listener2.port)
+    producer = broker.create_client("producer", endpoint=listener1.name)
+    consumer = broker.create_client("consumer", endpoint=listener2.name)
     producer.open(uri_priority, flags=["write", "ack"], succeed=True)
     consumer.open(
         uri_priority,

--- a/src/integration-tests/test_connection_loss.py
+++ b/src/integration-tests/test_connection_loss.py
@@ -19,7 +19,7 @@ This suite of test cases exercises connection losses.
 
 import re
 from time import sleep
-from typing import Dict
+from typing import Dict, List
 
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
@@ -185,7 +185,7 @@ def test_force_leader_primary_divergence(
         res = admin.send_admin(
             f"CLUSTERS CLUSTER {cluster.config.name} STORAGE SUMMARY"
         )
-        primaries: [str] = []
+        primaries: List[str] = []
         try:
             for line in res.splitlines():
                 mm = re.search(r"Primary Node.*\[(.+), \d+\]", line)

--- a/src/integration-tests/test_graceful_shutdown.py
+++ b/src/integration-tests/test_graceful_shutdown.py
@@ -42,7 +42,10 @@ def multi_cluster_config(
         "otherCluster",
         nodes=[
             configurator.broker(
-                "localhost", next(port_allocator), f"{dc}{i}", data_center=dc
+                name=f"{dc}{i}",
+                tcp_host="localhost",
+                tcp_port=next(port_allocator),
+                data_center=dc,
             )
             for dc in ("east", "west")
             for i in (3, 4)

--- a/src/python/blazingmq/dev/it/fixtures.py
+++ b/src/python/blazingmq/dev/it/fixtures.py
@@ -39,6 +39,9 @@ import tempfile
 from enum import IntEnum
 from pathlib import Path
 from typing import Callable, Iterator, List, Optional, Tuple
+from dataclasses import dataclass
+import subprocess
+
 import psutil
 
 import pytest
@@ -51,7 +54,7 @@ import blazingmq.util.logging as bul
 from blazingmq.dev.it.cluster import Cluster
 from blazingmq.dev.it.tweaks import tweak  # pylint: disable=unused-import
 from blazingmq.dev.it.tweaks import TWEAK_ATTRIBUTE, Tweak
-from blazingmq.dev.it.util import internal_use
+from blazingmq.dev.it.util import internal_use, chdir
 from blazingmq.dev.paths import paths
 from blazingmq.dev.pytest import PYTEST_LOG_SPEC_VAR
 from blazingmq.dev.reserveport import reserve_port, reserve_port_pool
@@ -246,7 +249,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
                 ):
                     try:
                         log_file_path.unlink()
-                    except:
+                    except FileNotFoundError:
                         pass
 
             on_exit.callback(remove_log_file_handler)
@@ -445,7 +448,7 @@ def cluster_fixture(request, configure) -> Iterator[Cluster]:
 
                     try:
                         cluster.stop()
-                    except:
+                    except RuntimeError:
                         if not get_option_ini(
                             request.config, "bmq_tolerate_dirty_shutdown"
                         ):
@@ -519,6 +522,30 @@ class ForwardProxyConnection(ProxyConnection):
 WorkspaceConfigurator = Callable[..., None]
 
 
+class Tls(IntEnum):
+    NONE = 0
+    HOST = 1
+
+    @property
+    def suffix(self) -> str:
+        return ["", "_tls"][self]
+
+    @property
+    def marks(self):
+        return [
+            [],
+            # TODO(tfoxhall): Figure out how to add a new mark
+            [pytest.mark.tls],
+        ][self]
+
+
+@dataclass(frozen=True)
+class CertificateBundle:
+    certificate_authority: Path
+    host_certificate: Path
+    host_key: Path
+
+
 ###############################################################################
 # single node cluster
 
@@ -543,16 +570,43 @@ def add_test_domains(cluster: cfg.Cluster):
             )
 
 
+def app_tls_config(certificate_bundle: CertificateBundle) -> mqbcfg.TlsConfig:
+    return mqbcfg.TlsConfig(
+        certificate_authority=str(certificate_bundle.certificate_authority),
+        certificate=str(certificate_bundle.host_certificate),
+        key=str(certificate_bundle.host_key),
+    )
+
+
 def single_node_cluster_config(
-    configurator: cfg.Configurator, port_allocator: Iterator[int], mode: Mode
+    configurator: cfg.Configurator,
+    port_allocator: Iterator[int],
+    mode: Mode,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ):
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is None:
+        raise ValueError("A TLS config is required when TLS is enabled")
+
     mode.tweak(configurator.proto.cluster)
+    if is_tls_enabled:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     broker = configurator.broker(
         name="single",
-        tcp_host="localhost",
-        tcp_port=next(port_allocator),
         data_center="single_node",
+        listeners=[
+            mqbcfg.TcpInterfaceListener(
+                name="localhost",
+                port=next(port_allocator),
+                tls=is_tls_enabled,
+                address="localhost",
+            ),
+        ],
+        tls_config=tls_config,
     )
 
     cluster = configurator.cluster(name="itCluster", nodes=[broker])
@@ -588,17 +642,41 @@ def multi_node_cluster_config(
     configurator: cfg.Configurator,
     port_allocator: Iterator[int],
     mode: Mode,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ) -> None:
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is None:
+        raise ValueError("A TLS config is required when TLS is enabled")
+
     mode.tweak(configurator.proto.cluster)
+    if is_tls_enabled:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
-                tcp_port=next(port_allocator),
                 data_center=data_center,
+                listeners=[
+                    mqbcfg.TcpInterfaceListener(
+                        name="localhost",
+                        port=next(port_allocator),
+                        tls=is_tls_enabled,
+                        address="localhost",
+                    ),
+                    mqbcfg.TcpInterfaceListener(
+                        name="BROKER",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
+                ],
+                tls_config=tls_config,
+                inter_broker_listener="BROKER",
             )
             for data_center in ("east", "west")
             for broker in ("1", "2")
@@ -610,9 +688,16 @@ def multi_node_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
-            tcp_port=next(port_allocator),
+            listeners=[
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
+            ],
             data_center=data_center,
+            tls_config=tls_config,
         ).proxy(cluster)
 
 
@@ -721,7 +806,8 @@ def multi_interface_cluster_config(
     configurator: cfg.Configurator,
     port_allocator: Iterator[int],
     mode: Mode,
-    listener_count: int,
+    tls: Tls = Tls.NONE,
+    certificate_bundle: Optional[CertificateBundle] = None,
 ) -> None:
     """A factory for cluster configurations containing multiple open TCP interfaces.
 
@@ -740,22 +826,34 @@ def multi_interface_cluster_config(
             minimum number of listeners is 1.
     """
     mode.tweak(configurator.proto.cluster)
-
-    assert listener_count > 0
+    is_tls_enabled = tls != Tls.NONE
+    if is_tls_enabled and certificate_bundle is not None:
+        tls_config = app_tls_config(certificate_bundle)
+    else:
+        tls_config = None
 
     cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
-                tcp_port=-1,
-                listeners=[("BROKER", next(port_allocator))]
-                + [
-                    (f"listener{i}", next(port_allocator))
-                    for i in range(listener_count - 1)
+                listeners=[
+                    mqbcfg.TcpInterfaceListener(
+                        name="localhost",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
+                    mqbcfg.TcpInterfaceListener(
+                        name="BROKER",
+                        port=next(port_allocator),
+                        tls=False,
+                        address="localhost",
+                    ),
                 ],
                 data_center=data_center,
+                tls_config=tls_config,
+                inter_broker_listener="BROKER",
             )
             for data_center in ("east", "west")
             for broker in ("1", "2")
@@ -767,18 +865,28 @@ def multi_interface_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
-            tcp_port=-1,
             listeners=[
-                (f"listener{i}", next(port_allocator)) for i in range(listener_count)
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost1",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
+                mqbcfg.TcpInterfaceListener(
+                    name="localhost2",
+                    port=next(port_allocator),
+                    tls=is_tls_enabled,
+                    address="localhost",
+                ),
             ],
             data_center=data_center,
+            tls_config=tls_config,
         ).proxy(cluster)
 
 
 multi_interface_cluster_params = [
     pytest.param(
-        functools.partial(multi_interface_cluster_config, mode=mode, listener_count=2),
+        functools.partial(multi_interface_cluster_config, mode=mode),
         id=f"multi_interface{mode.suffix}",
         marks=[
             pytest.mark.integrationtest,
@@ -815,13 +923,14 @@ def virtual_cluster_config(
     mode: Mode,
 ) -> None:
     mode.tweak(configurator.proto.cluster)
+    tcp_host = "localhost"
 
     final_cluster = configurator.cluster(
         name="itCluster",
         nodes=[
             configurator.broker(
                 name=f"{data_center}{broker}",
-                tcp_host="localhost",
+                tcp_host=tcp_host,
                 tcp_port=next(port_allocator),
                 data_center=data_center,
             )
@@ -836,7 +945,7 @@ def virtual_cluster_config(
         nodes=[
             configurator.broker(
                 name=f"{data_center}v",
-                tcp_host="localhost",
+                tcp_host=tcp_host,
                 tcp_port=next(port_allocator),
                 data_center=data_center,
             )
@@ -848,7 +957,7 @@ def virtual_cluster_config(
     for data_center in ("east", "west"):
         configurator.broker(
             name=f"{data_center}p",
-            tcp_host="localhost",
+            tcp_host=tcp_host,
             tcp_port=next(port_allocator),
             data_center=data_center,
         ).proxy(cluster)
@@ -977,3 +1086,127 @@ def fsm_cluster(request):
 @pytest.fixture(params=fsm_multi_cluster_params)
 def fsm_multi_cluster(request):
     yield from cluster_fixture(request, request.param)
+
+
+###############################################################################
+# TLS Cluster Config
+
+
+def generate_certificate_bundle(
+    generator: Path,
+    ca_cert: str,
+    prefix: str,
+    host: str,
+    path: Path,
+) -> CertificateBundle:
+    """Generate a certificate authority and a host certificate in the current directory.
+
+    Args:
+        generator: A path to an executable program that can generate certificates and
+            CAs. See gen-tls-certs.sh for more information on the interface.
+        ca_cert: The name of the certificate authority.
+        prefix: A prefix used to for naming the generated files
+        host: The hostname for the host certificate to use.
+
+    Returns:
+        A CertificateBundle object containing the paths to the generate certificate
+        authority and host certificate.
+    """
+    with chdir(path):
+        subprocess.run([generator, "ca", ca_cert, prefix], check=True)
+        subprocess.run([generator, "server", ca_cert, prefix, host], check=True)
+        return CertificateBundle(
+            certificate_authority=path / ca_cert,
+            host_certificate=path / f"{prefix}host_cert.pem",
+            host_key=path / f"{prefix}private_key.pem",
+        )
+
+
+@pytest.fixture()
+def certificate_bundle(tmp_path, request):
+    """Provide a certificate bundle for use in the current test session.
+
+    This fixture depends on a certificate generator script to be available, which can be
+    specified with the --certificate-generator option.
+    """
+    cert_generator = Path(request.config.getini("certificate_generator")).resolve()
+    return generate_certificate_bundle(
+        cert_generator,
+        ca_cert="ca-cert",
+        prefix="broker_",
+        host="dummy",
+        path=tmp_path,
+    )
+
+
+tls_single_cluster_params = [
+    pytest.param(
+        functools.partial(single_node_cluster_config, mode=mode, tls=Tls.HOST),
+        id=f"single_node_tls{mode.suffix}",
+        marks=[
+            pytest.mark.integrationtest,
+            pytest.mark.pr_integrationtest,
+            pytest.mark.single,
+            pytest.mark.tls,
+            *Mode.FSM.marks,
+        ],
+    )
+    for mode in Mode.__members__.values()
+]
+
+
+@pytest.fixture(params=tls_single_cluster_params)
+def tls_single_cluster(request, certificate_bundle):
+    print("Certificate bundle:", certificate_bundle)
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=certificate_bundle)
+    )
+
+
+tls_multi_cluster_params = [
+    pytest.param(
+        functools.partial(multi_node_cluster_config, mode=mode, tls=Tls.HOST),
+        id=f"multi_node_tls{mode.suffix}",
+        marks=[
+            pytest.mark.integrationtest,
+            pytest.mark.pr_integrationtest,
+            pytest.mark.multi,
+            pytest.mark.tls,
+            *Mode.FSM.marks,
+        ],
+    )
+    for mode in Mode.__members__.values()
+]
+
+
+@pytest.fixture(params=tls_multi_cluster_params)
+def tls_multi_cluster(request):
+    yield from cluster_fixture(request, request.param)
+
+
+@pytest.fixture(params=tls_single_cluster_params + tls_multi_cluster_params)
+def tls_cluster(request, certificate_bundle):
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=certificate_bundle)
+    )
+
+
+def pytest_addoption(parser):
+    help_ = "script for generating certificates"
+    parser.addini("certificate_generator", help_, type="string", default=".")
+
+
+@pytest.fixture(
+    params=single_node_cluster_params
+    + multi_node_cluster_params
+    + tls_single_cluster_params
+    + tls_multi_cluster_params
+)
+def plain_and_tls_cluster(request, certificate_bundle):
+    if request.param.keywords.get("tls", Tls.NONE) != Tls.NONE:
+        bundle = certificate_bundle
+    else:
+        bundle = None
+    yield from cluster_fixture(
+        request, functools.partial(request.param, certificate_bundle=bundle)
+    )

--- a/src/python/blazingmq/dev/it/process/client.py
+++ b/src/python/blazingmq/dev/it/process/client.py
@@ -27,12 +27,16 @@ import json
 import re
 import subprocess
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, List, NamedTuple
+from typing import Any, Callable, Dict, Optional, List, NamedTuple, Tuple
 
 from blazingmq.dev.it.process import bmqproc
 from blazingmq.dev.it.process.bmqproc import BMQProcess
 
-from blazingmq.dev.it.testconstants import *
+from blazingmq.dev.it.testconstants import (
+    URI_BROADCAST,
+    URI_FANOUT,
+    URI_PRIORITY,
+)
 from blazingmq.dev.it.util import internal_use, ListContextManager, Queue
 
 Message = namedtuple("Message", "guid, uri, correlationId, payload")
@@ -98,10 +102,10 @@ class Client(BMQProcess):
     def __init__(
         self,
         name,
-        broker: (str, int),
+        broker: Tuple[str, int],
         tool_path: Path,
-        options=None,
-        dump_messages=True,
+        options: Optional[str] = None,
+        dump_messages: bool = True,
         **kwargs,
     ):
         if options is None:

--- a/src/python/blazingmq/dev/it/util.py
+++ b/src/python/blazingmq/dev/it/util.py
@@ -25,6 +25,7 @@ import logging
 import random
 import string
 import time
+import os
 
 from typing import List, Optional, TypeVar
 from typing import TYPE_CHECKING
@@ -170,3 +171,20 @@ class ListContextManager(List[_T]):
     def __exit__(self, *args):
         for item in self.__reversed__():
             item.__exit__(*args)
+
+
+class chdir(contextlib.AbstractContextManager):
+    """Non thread-safe context manager to change the current working directory."""
+
+    # Backported from upstream python
+
+    def __init__(self, path):
+        self.path = path
+        self._old_cwd = []
+
+    def __enter__(self):
+        self._old_cwd.append(os.getcwd())
+        os.chdir(self.path)
+
+    def __exit__(self, *excinfo):
+        os.chdir(self._old_cwd.pop())


### PR DESCRIPTION
Added
=====

- TLS options for NtcChannel
- Loading certificates and authority data specified from bmqbrkrcfg.json
- SessionOptions to bmq package for configuring client sessions
- `--tls-authority` and `--tls-version` options to bmqtool to configure
  session options
- Client sessions will now require broker TLS sessions when TLS protocol
  versions are specified
- Integration tests for TLS

We're so back #549 