### PR TITLE
Fix: Widen contract of `mqba::ClientSession::processEvent`

### DIFF
--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -2504,8 +2504,13 @@ void ClientSession::processEvent(const bmqp::Event& event,
 {
     // executed by the *IO* thread
 
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!event.isAuthenticationEvent());
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(event.isAuthenticationEvent())) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        BALL_LOG_ERROR << "#CLIENT_IMPROPER_BEHAVIOR " << description()
+                       << ": Dropping unexpected AuthenticationEvent in "
+                       << "processEvent: " << event;
+        return;  // RETURN
+    }
 
     if (event.isControlEvent()) {
         bdlma::LocalSequentialAllocator<2048> localAllocator(

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -603,8 +603,8 @@ class ClientSession : public mqbnet::Session,
 
     /// Process the specified `event` received from the optionally specified
     /// `source` node.  Note that this method is the entry point for all
-    /// incoming events coming from the remote peer.  The behavior is undefined
-    /// unless `event` is not `AuthenticationEvent`.
+    /// incoming events coming from the remote peer.  If the specified `event`
+    /// is an `AuthenticationEvent`, it is dropped and an error is logged.
     void processEvent(const bmqp::Event&   event,
                       mqbnet::ClusterNode* source = 0) BSLS_KEYWORD_OVERRIDE;
 


### PR DESCRIPTION
This patch widens the contract of `mqba::ClientSession::processEvent` to accept authentication events and log an error if they are received. Currently, we check the existing precondition at the call site, but this is somewhat brittle, and a simple code refactoring could open up the opportunity for a broker crash here on protocol input.  Instead, we choose to make this a little more robust.