### PR TITLE
Fix[mqbs::FileStore]: Conform journal to cluster state (extra queues)

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -319,7 +319,7 @@ void StorageManager::onPartitionRecovery(
                                        : "**NA**")
                       << ", and will now be opened.";
 
-        int rc = fs->open(0);
+        int rc = fs->open(0, pinfo.primaryLeaseId());
         if (0 != rc) {
             BMQTSK_ALARMLOG_ALARM("FILE_IO")
                 << d_clusterData_p->identity().description()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3247,7 +3247,8 @@ void StorageManager::do_attemptOpenStorage(
         return;  // RETURN
     }
 
-    const int rc = fs->open(d_queueKeyInfoMapVec.at(partitionId).get());
+    const int rc = fs->open(d_queueKeyInfoMapVec.at(partitionId).get(),
+                            d_partitionInfoVec[partitionId].primaryLeaseId());
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
             << d_clusterData_p->identity().description() << " Partition ["

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3275,7 +3275,16 @@ void StorageManager::do_attemptOpenStorage(
         return;  // RETURN
     }
 
-    const int rc = fs->open(d_queueKeyInfoMapVec.at(partitionId).get(),
+    // Hand over the cluster state only when self is the primary.
+    QueueKeyInfoMap* const queueKeyInfoMap =
+        d_partitionFSMVec.at(partitionId)->isSelfPrimary()
+            ? d_queueKeyInfoMapVec.at(partitionId).get()
+            : 0;
+
+    // Conform may append unreplicated corrective records; they reach replicas
+    // only because storeSelfSeq and sendDataToReplicas run right after this
+    // action in the primary transitions.  Keep that order.
+    const int rc = fs->open(queueKeyInfoMap,
                             d_partitionInfoVec[partitionId].primaryLeaseId());
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3275,7 +3275,8 @@ void StorageManager::do_attemptOpenStorage(
         return;  // RETURN
     }
 
-    const int rc = fs->open(d_queueKeyInfoMapVec.at(partitionId).get());
+    const int rc = fs->open(d_queueKeyInfoMapVec.at(partitionId).get(),
+                            d_partitionInfoVec[partitionId].primaryLeaseId());
     if (0 != rc) {
         BMQTSK_ALARMLOG_ALARM("FILE_IO")
             << d_clusterData_p->identity().description() << " Partition ["

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -931,14 +931,16 @@ struct TestHelper {
 
         dynamic_cast<mqbnet::MockCluster&>(d_cluster_mp->netCluster())
             ._setDisableBroadcast(true);
-        fs.open(0);
+
+        const unsigned int k_PRIMARY_LEASE_ID = 1U;
+        fs.open(0, k_PRIMARY_LEASE_ID);
         // TODO: clean this up since its a hack to set replica node as primary!
         // had to explicitly setActivePrimary for fileStore because of the
         // assert in writeRecords which allows writes only if current node is
         // primary for the fileStore.
         // TODO: set primary to self but also correct it to the right node
         // after writing 'numRecords' records.
-        fs.setActivePrimary(selfNode, 1U);
+        fs.setActivePrimary(selfNode, k_PRIMARY_LEASE_ID);
 
         const mqbu::StorageKey& queueKey =
             writeQueueCreationRecord(handle, &fs, k_PARTITION_ID);
@@ -951,7 +953,7 @@ struct TestHelper {
             ._setDisableBroadcast(false);
 
         if (selfSeqNum) {
-            selfSeqNum->primaryLeaseId() = 1U;
+            selfSeqNum->primaryLeaseId() = k_PRIMARY_LEASE_ID;
 
             // One sync point, one queue creation record, and 'numRecords'
             // message records

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -1018,14 +1018,16 @@ struct TestHelper {
 
         dynamic_cast<mqbnet::MockCluster&>(d_cluster_mp->netCluster())
             ._setDisableBroadcast(true);
-        fs.open(0);
+
+        const unsigned int k_PRIMARY_LEASE_ID = 1U;
+        fs.open(0, k_PRIMARY_LEASE_ID);
         // TODO: clean this up since its a hack to set replica node as primary!
         // had to explicitly setActivePrimary for fileStore because of the
         // assert in writeRecords which allows writes only if current node is
         // primary for the fileStore.
         // TODO: set primary to self but also correct it to the right node
         // after writing 'numRecords' records.
-        fs.setActivePrimary(selfNode, 1U);
+        fs.setActivePrimary(selfNode, k_PRIMARY_LEASE_ID);
 
         const mqbu::StorageKey& queueKey =
             writeQueueCreationRecord(handle, &fs, k_PARTITION_ID);
@@ -1038,7 +1040,7 @@ struct TestHelper {
             ._setDisableBroadcast(false);
 
         if (selfSeqNum) {
-            selfSeqNum->primaryLeaseId() = 1U;
+            selfSeqNum->primaryLeaseId() = k_PRIMARY_LEASE_ID;
 
             // One sync point, one queue creation record, and 'numRecords'
             // message records

--- a/src/groups/mqb/mqbs/mqbs_datastore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datastore.cpp
@@ -37,14 +37,14 @@ BSLMF_ASSERT(sizeof(DataStoreRecordHandle) ==
 
 void DataStoreConfigQueueInfo::addAppInfo(const bsl::string&      appId,
                                           const mqbu::StorageKey& appKey,
-                                          bool                    withCSL)
+                                          bool withClusterState)
 {
     // Comparing ages of Apps and messages relies on chronological order
     // (hence 'OrderedHashMap'.
     // The Legacy mode recreates Apps by reverse iterating Journal (w/ QList)
     // The FSM node recreates Apps in chronological order.
 
-    if (withCSL) {
+    if (withClusterState) {
         d_appIdKeyPairs.insert(bsl::make_pair(appKey, appId));
     }
     else {

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -333,7 +333,7 @@ class DataStoreConfigQueueInfo {
     /// Apps.
     void addAppInfo(const bsl::string&      appId,
                     const mqbu::StorageKey& appKey,
-                    bool                    withCSL);
+                    bool                    withClusterState);
 
     /// Cache the Purge interval from the specified `start` to the specified
     /// `end` for the specified `key` unless the `key` was specified in a

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -590,8 +590,10 @@ class DataStore : public mqbi::DispatcherClient {
     // MANIPULATORS
 
     /// Open this instance using the optionally specified `queueKeyInfoMap`.
+    /// The specified `primaryLeaseId` is the leaseId of current primary.
     /// Return zero on success, non-zero value otherwise.
-    virtual int open(QueueKeyInfoMap* queueKeyInfoMap) = 0;
+    virtual int open(QueueKeyInfoMap* queueKeyInfoMap,
+                     unsigned int     primaryLeaseId) = 0;
 
     /// Close this instance.  If the optional `flush` flag is true, flush
     /// the data store to the backup storage (e.g., disk) if applicable.

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -589,9 +589,11 @@ class DataStore : public mqbi::DispatcherClient {
 
     // MANIPULATORS
 
-    /// Open this instance using the optionally specified `queueKeyInfoMap`.
-    /// The specified `primaryLeaseId` is the leaseId of current primary.
-    /// Return zero on success, non-zero value otherwise.
+    /// Open this instance using the optionally specified `queueKeyInfoMap`,
+    /// which must be supplied only when self is the primary.  The specified
+    /// `primaryLeaseId` is the leaseId of the current primary; it is unused
+    /// when `queueKeyInfoMap` is null.  Return zero on success, non-zero value
+    /// otherwise.
     virtual int open(QueueKeyInfoMap* queueKeyInfoMap,
                      unsigned int     primaryLeaseId) = 0;
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -391,7 +391,10 @@ class MockDataStore : public mqbs::DataStore {
         return d_description;
     }
 
-    int open(QueueKeyInfoMap*) BSLS_KEYWORD_OVERRIDE { return 0; }
+    int open(QueueKeyInfoMap*, unsigned int) BSLS_KEYWORD_OVERRIDE
+    {
+        return 0;
+    }
 
     int close(bool, bool) BSLS_KEYWORD_OVERRIDE { return 0; }
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -392,7 +392,10 @@ class MockDataStore : public mqbs::DataStore {
         return d_description;
     }
 
-    int open(QueueKeyInfoMap*) BSLS_KEYWORD_OVERRIDE { return 0; }
+    int open(QueueKeyInfoMap*, unsigned int) BSLS_KEYWORD_OVERRIDE
+    {
+        return 0;
+    }
 
     int close(bool, bool) BSLS_KEYWORD_OVERRIDE { return 0; }
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -343,7 +343,8 @@ int FileStore::openInNonRecoveryMode()
 }
 
 int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
-                                  QueueKeyInfoMap* queueKeyInfoMap)
+                                  QueueKeyInfoMap* queueKeyInfoMap,
+                                  unsigned int     primaryLeaseId)
 {
     // executed by the *DISPATCHER* thread
 
@@ -1032,11 +1033,21 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
     BSLS_ASSERT_SAFE(d_config.recoveredQueuesCb());
     d_config.recoveredQueuesCb()(d_config.partitionId(), queueKeyInfoMap);
 
-    // Conform the journal to the cluster state.  Each "extra" queueKey found
-    // during recovery (present in the journal but absent from the cluster
-    // state) must be removed.
-    if (!extraQueueKeys.empty()) {
+    // Conform the journal to the cluster state.
+    const bool needsConform = !extraQueueKeys.empty();
+    if (needsConform) {
         BSLS_ASSERT_SAFE(asPrimary);
+        BSLS_ASSERT_SAFE(0 != primaryLeaseId);
+        BSLS_ASSERT_SAFE(primaryLeaseId >= d_writeHeadLeaseId);
+
+        if (primaryLeaseId > d_writeHeadLeaseId) {
+            setWriteHead(primaryLeaseId, 0);
+        }
+    }
+
+    // Each "extra" queueKey found during recovery (present in the journal but
+    // absent from the cluster state) must be removed.
+    if (!extraQueueKeys.empty()) {
         const bsls::Types::Uint64 timestamp =
             bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc());
 
@@ -5565,7 +5576,8 @@ FileStore::~FileStore()
 }
 
 // MANIPULATORS
-int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap)
+int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap,
+                    unsigned int     primaryLeaseId)
 {
     // executed by the *DISPATCHER* thread
 
@@ -5603,7 +5615,9 @@ int FileStore::open(QueueKeyInfoMap* queueKeyInfoMap)
     }
 
     bmqu::MemOutStream errorDescription;
-    int rc = openInRecoveryMode(errorDescription, queueKeyInfoMap);
+    int                rc = openInRecoveryMode(errorDescription,
+                                queueKeyInfoMap,
+                                primaryLeaseId);
     if (rc == 0) {
         d_isOpen = true;
     }

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -364,7 +364,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         rc_PARTITION_FULL                      = -8,
         rc_CLOSE_FAILURE                       = -9,
         rc_OPEN_FAILURE                        = -10,
-        rc_SYNC_POINT_FAILURE                  = -11
+        rc_SYNC_POINT_FAILURE                  = -11,
+        rc_CONFORM_FAILURE                     = -12
     };
 
     MappedFileDescriptor journalFd;
@@ -816,6 +817,10 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         asPrimary       = false;
         queueKeyInfoMap = &temp;
     }
+
+    // As primary, collect extra queueKeys (present in the journal but absent
+    // from cluster state).
+    StorageKeys extraQueueKeys(d_allocator_p);
     BALL_LOG_INFO << partitionDesc()
                   << "Attempting to recover messages from the local storage "
                   << (asPrimary ? "as primary." : "as replica.");
@@ -829,6 +834,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
                          &jit,
                          &qit,
                          &dit,
+                         asPrimary ? &extraQueueKeys : 0,
                          asPrimary);
     if (0 != rc) {
         BALL_LOG_ERROR << partitionDesc() << "Failed to recover messages from"
@@ -1021,23 +1027,80 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
         }
     }
 
-    if (d_qListAware) {
-        BALL_LOG_INFO << partitionDesc()
-                      << "JOURNAL, QLIST and DATA files will be"
-                      << " written to at these offsets respectively: "
-                      << journalFileOffset << ", " << qlistFileOffset << ", "
-                      << dataFileOffset;
-    }
-    else {
-        BALL_LOG_INFO << partitionDesc() << "JOURNAL and DATA files will be"
-                      << " written to at these offsets respectively: "
-                      << journalFileOffset << ", " << dataFileOffset;
-    }
-
     // Hand over recovered queues to the storage manager *after* files have
     // been successfully opened.
     BSLS_ASSERT_SAFE(d_config.recoveredQueuesCb());
     d_config.recoveredQueuesCb()(d_config.partitionId(), queueKeyInfoMap);
+
+    // Conform the journal to the cluster state.  Each "extra" queueKey found
+    // during recovery (present in the journal but absent from the cluster
+    // state) must be removed.
+    if (!extraQueueKeys.empty()) {
+        BSLS_ASSERT_SAFE(asPrimary);
+        const bsls::Types::Uint64 timestamp =
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc());
+
+        FileSet* activeFileSet = d_fileSets[0].get();
+
+        // Space to append one corrective DELETION per extra queue.
+        const bsls::Types::Uint64 requiredSpace =
+            extraQueueKeys.size() * FileStoreProtocol::k_JOURNAL_RECORD_SIZE +
+            k_RESERVED2_PURGE_SIZE;
+
+        if (needRollover(activeFileSet->d_journal.d_file,
+                         activeFileSet->d_journal.d_filePosition,
+                         requiredSpace)) {
+            BALL_LOG_INFO
+                << partitionDesc()
+                << "Conforming journal to cluster state: rolling over "
+                << "to compact away " << extraQueueKeys.size()
+                << " extra queue(s).";
+            rc = rolloverDuringRecovery(timestamp);
+            if (0 != rc) {
+                BALL_LOG_ERROR << partitionDesc()
+                               << "Failed to roll over while conforming "
+                                  "journal to cluster "
+                               << "state, rc: " << rc;
+                return 100 * rc + rc_CONFORM_FAILURE;  // RETURN
+            }
+        }
+        else {
+            for (StorageKeys::const_iterator it = extraQueueKeys.begin();
+                 it != extraQueueKeys.end();
+                 ++it) {
+                BALL_LOG_WARN
+                    << partitionDesc()
+                    << "Conforming journal to cluster state: writing a "
+                    << "corrective QueueOp.DELETION for extra queueKey "
+                    << "[" << *it << "].";
+                rc = writeCorrectiveQueueDeletionDuringRecovery(*it,
+                                                                timestamp);
+                if (0 != rc) {
+                    BALL_LOG_ERROR
+                        << partitionDesc()
+                        << "Failed to write corrective QueueOp.DELETION for "
+                        << "extra queueKey [" << *it << "], rc: " << rc;
+                    return 100 * rc + rc_CONFORM_FAILURE;  // RETURN
+                }
+            }
+        }
+    }
+
+    const FileSet* activeFileSet = d_fileSets[0].get();
+    if (d_qListAware) {
+        BALL_LOG_INFO << partitionDesc()
+                      << "JOURNAL, QLIST and DATA files will be"
+                      << " written to at these offsets respectively: "
+                      << activeFileSet->d_journal.d_filePosition << ", "
+                      << activeFileSet->d_qlist.d_filePosition << ", "
+                      << activeFileSet->d_data.d_filePosition;
+    }
+    else {
+        BALL_LOG_INFO << partitionDesc() << "JOURNAL and DATA files will be"
+                      << " written to at these offsets respectively: "
+                      << activeFileSet->d_journal.d_filePosition << ", "
+                      << activeFileSet->d_data.d_filePosition;
+    }
 
     return rc_SUCCESS;
 }
@@ -1049,11 +1112,15 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                JournalFileIterator* jit,
                                QlistFileIterator*   qit,
                                DataFileIterator*    dit,
-                               bool                 withCSL)
+                               StorageKeys*         extraQueueKeys,
+                               bool                 withClusterState)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(queueKeyInfoMap);
-    if (!withCSL) {
+    if (withClusterState) {
+        BSLS_ASSERT_SAFE(extraQueueKeys);
+    }
+    else {
         BSLS_ASSERT_SAFE(queueKeyInfoMap->empty());
     }
     BSLS_ASSERT_SAFE(journalOffset);
@@ -1116,9 +1183,13 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
     typedef StorageKeysOffsets::const_iterator StorageKeysOffsetsConstIter;
     typedef bsl::pair<StorageKeysOffsetsIter, bool> StorageKeysOffsetsInsertRc;
 
-    typedef bsl::unordered_set<mqbu::StorageKey,
-                               bslh::Hash<mqbu::StorageKeyHashAlgo> >
-        StorageKeys;
+    // Sentinel deletion-record offset used to mark an extra queueKey as
+    // deleted.  Because no real record offset can equal this value, every one
+    // of the extra queue's records compares as "before the deletion" and is
+    // therefore skipped in the second pass, exactly like a genuinely-deleted
+    // queue.
+    const bsls::Types::Uint64 k_EXTRA_QUEUE_SENTINEL_OFFSET =
+        bsl::numeric_limits<bsls::Types::Uint64>::max();
 
     StorageKeysOffsets  deletedQueueKeysOffsets;
     StorageKeysOffsets  deletedAppKeysOffsets;
@@ -1187,7 +1258,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
         }
 
         if (QueueOpType::e_DELETION == queueOpType) {
-            if (withCSL) {
+            if (withClusterState) {
                 if (appKey.isNull() && queueKeyInfoMap->end() !=
                                            queueKeyInfoMap->find(queueKey)) {
                     BALL_LOG_ERROR
@@ -1324,20 +1395,26 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 continue;  // CONTINUE
             }
 
-            if (withCSL) {
+            if (withClusterState) {
                 if (queueKeyInfoMap->end() ==
                     queueKeyInfoMap->find(queueKey)) {
-                    BALL_LOG_ERROR
+                    BALL_LOG_WARN
                         << partitionDesc()
-                        << "Encountered a QueueOp.ADDITION record "
-                        << "for queueKey [" << queueKey
-                        << "] during 1st pass reverse iteration, "
-                        << "but the queueKey is not present in "
-                        << "cluster state.  Record offset: "
-                        << journalIt.recordOffset()
+                        << "Encountered "
+                           "a "
+                        << "QueueOp.ADDITION record for queueKey [" << queueKey
+                        << "] during 1st pass reverse iteration, but the "
+                        << "queueKey is not present in cluster state.  Will "
+                        << "remember this extra queue.  "
+                           "Record "
+                        << "offset: " << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
-                    return rc_INVALID_QUEUE_KEY;  // RETURN
+                    deletedQueueKeysOffsets.insert(
+                        bsl::make_pair(queueKey,
+                                       k_EXTRA_QUEUE_SENTINEL_OFFSET));
+                    extraQueueKeys->insert(queueKey);
+                    continue;  // CONTINUE
                 }
             }
             else if (queueKeyInfoMap->end() !=
@@ -1385,20 +1462,26 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 continue;  // CONTINUE
             }
 
-            if (withCSL) {
+            if (withClusterState) {
                 if (queueKeyInfoMap->end() ==
                     queueKeyInfoMap->find(queueKey)) {
-                    BALL_LOG_ERROR
+                    BALL_LOG_WARN
                         << partitionDesc()
-                        << "Encountered a QueueOp.CREATION record "
-                        << "for queueKey [" << queueKey
-                        << "] during 1st pass reverse iteration, "
-                        << "but the queueKey is not present in "
-                        << "cluster state.  Record offset: "
-                        << journalIt.recordOffset()
+                        << "Encountered "
+                           "a "
+                        << "QueueOp.CREATION record for queueKey [" << queueKey
+                        << "] during 1st pass reverse iteration, but the "
+                        << "queueKey is not present in cluster state.  Will "
+                        << "remember this extra queue.  "
+                           "Record "
+                        << "offset: " << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
-                    return rc_INVALID_QUEUE_KEY;  // RETURN
+                    deletedQueueKeysOffsets.insert(
+                        bsl::make_pair(queueKey,
+                                       k_EXTRA_QUEUE_SENTINEL_OFFSET));
+                    extraQueueKeys->insert(queueKey);
+                    continue;  // CONTINUE
                 }
             }
             else {
@@ -1791,15 +1874,24 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     queueKey);
 
                 if (iter == queueKeyInfoMap->end()) {
-                    if (withCSL) {
-                        BALL_LOG_ERROR
+                    if (withClusterState) {
+                        // An "extra" queue (present in the journal but absent
+                        // from the cluster state) is tracked as deleted in the
+                        // 1st pass and skipped above.  Reaching here means an
+                        // orphan record: the queueKey is absent from the
+                        // cluster state and had no QueueOp.CREATION record in
+                        // the 1st pass.
+                        BMQTSK_ALARMLOG_ALARM("RECOVERY")
                             << partitionDesc()
-                            << "Encountered a QueueOp.PURGE record for "
+                            << "Encountered an orphan QueueOp.PURGE record "
+                               "for "
                             << "queueKey [" << queueKey
                             << "], offset: " << jit->recordOffset()
                             << ", index: " << jit->recordIndex()
-                            << ", but the queueKey is not present in cluster "
-                            << "state.";
+                            << ": the queueKey is not present in the cluster "
+                            << "state and had no QueueOp.CREATION record in "
+                               "the "
+                            << "first pass." << BMQTSK_ALARMLOG_END;
                         continue;  // CONTINUE
                     }
                     else {
@@ -2015,7 +2107,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 QueueKeyInfoMap::iterator iter = queueKeyInfoMap->find(
                     queueKey);
 
-                if (!withCSL && QueueOpType::e_ADDITION == queueOpType &&
+                if (!withClusterState &&
+                    QueueOpType::e_ADDITION == queueOpType &&
                     iter == queueKeyInfoMap->end()) {
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
@@ -2077,7 +2170,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                           paddedUriLen -
                                               uriBegin[paddedUriLen - 1]);
 
-                    if (withCSL) {
+                    if (withClusterState) {
                         BSLS_ASSERT_SAFE(!qinfo.canonicalQueueUri().empty());
                         if (qinfo.canonicalQueueUri() != uri) {
                             BMQTSK_ALARMLOG_ALARM("RECOVERY")
@@ -2146,7 +2239,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                          cit != appIdKeyPairs.cend();
                          ++cit) {
                         if (0 == deletedAppKeysOffsets.count(cit->second)) {
-                            if (withCSL) {
+                            if (withClusterState) {
                                 DataStoreConfigQueueInfo::AppInfos::
                                     const_iterator qinfoAppCit =
                                         qinfo.appIdKeyPairs().find(
@@ -2198,7 +2291,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
 
                                 qinfo.addAppInfo(cit->first,
                                                  cit->second,
-                                                 withCSL);
+                                                 withClusterState);
                             }
                             BALL_LOG_INFO << partitionDesc()
                                           << "Recovered appId/appKey pair ['"
@@ -2275,15 +2368,23 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             }
 
             if (0 == queueKeyInfoMap->count(rec.queueKey())) {
-                if (withCSL) {
-                    BALL_LOG_ERROR
+                if (withClusterState) {
+                    // An "extra" queue (present in the journal but absent from
+                    // the cluster state) is tracked as deleted in the 1st pass
+                    // and skipped above.  Reaching here means an orphan
+                    // record: the queueKey is absent from the cluster state
+                    // and had no QueueOp.CREATION record in the 1st pass.
+                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
-                        << "Encountered a DELETION record for queueKey ["
+                        << "Encountered an orphan DELETION record for "
+                           "queueKey ["
                         << rec.queueKey()
                         << "], offset: " << jit->recordOffset()
                         << ", index: " << jit->recordIndex()
-                        << ", but the queueKey is not present in cluster "
-                        << "state.";
+                        << ": the queueKey is not present in the cluster "
+                           "state "
+                        << "and had no QueueOp.CREATION record in the first "
+                        << "pass." << BMQTSK_ALARMLOG_END;
                 }
                 else {
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
@@ -2354,15 +2455,23 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             }
 
             if (0 == queueKeyInfoMap->count(rec.queueKey())) {
-                if (withCSL) {
-                    BALL_LOG_ERROR
+                if (withClusterState) {
+                    // An "extra" queue (present in the journal but absent from
+                    // the cluster state) is tracked as deleted in the 1st pass
+                    // and skipped above.  Reaching here means an orphan
+                    // record: the queueKey is absent from the cluster state
+                    // and had no QueueOp.CREATION record in the 1st pass.
+                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
-                        << "Encountered a CONFIRM record for queueKey ["
+                        << "Encountered an orphan CONFIRM record for queueKey "
+                           "["
                         << rec.queueKey()
                         << "], offset: " << jit->recordOffset()
                         << ", index: " << jit->recordIndex()
-                        << ", but the queueKey is not "
-                        << "present in cluster state.";
+                        << ": the queueKey is not present in the cluster "
+                           "state "
+                        << "and had no QueueOp.CREATION record in the first "
+                        << "pass." << BMQTSK_ALARMLOG_END;
                     continue;  // CONTINUE
                 }
                 else {
@@ -2575,16 +2684,25 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             }
 
             if (0 == queueKeyInfoMap->count(rec.queueKey())) {
-                if (withCSL) {
-                    BALL_LOG_ERROR
+                if (withClusterState) {
+                    // An "extra" queue (present in the journal but absent from
+                    // the cluster state) is tracked as deleted in the 1st pass
+                    // and skipped above.  Reaching here means an orphan
+                    // record: the queueKey is absent from the cluster state
+                    // and had no QueueOp.CREATION record in the 1st pass.
+                    // Tolerate it defensively rather than failing recovery.
+                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
-                        << "Encountered a MESSAGE record for queueKey ["
+                        << "Encountered an orphan MESSAGE record for queueKey "
+                           "["
                         << rec.queueKey()
                         << "], offset: " << jit->recordOffset()
                         << ", index: " << jit->recordIndex()
-                        << ", but the queueKey is not "
-                        << "present in cluster state.";
-                    return rc_INVALID_QUEUE_KEY;  // RETURN
+                        << ": the queueKey is not present in the cluster "
+                           "state "
+                        << "and had no QueueOp.CREATION record in the first "
+                        << "pass." << BMQTSK_ALARMLOG_END;
+                    continue;  // CONTINUE
                 }
                 else {
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
@@ -3017,6 +3135,54 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
     return 0;
 }
 
+int FileStore::rolloverDuringRecovery(bsls::Types::Uint64 timestamp)
+{
+    enum {
+        rc_SUCCESS            = 0,
+        rc_SYNC_POINT_FAILURE = -1,
+        rc_ROLLOVER_FAILURE   = -2
+    };
+
+    FileSet* activeFileSet = d_fileSets[0].get();
+    BSLS_ASSERT_SAFE(activeFileSet);
+
+    const bsls::Types::Int64 journalPos = static_cast<bsls::Types::Int64>(
+        activeFileSet->d_journal.d_filePosition);
+    const bsls::Types::Int64 journalCap = static_cast<bsls::Types::Int64>(
+        activeFileSet->d_journal.d_file.fileSize());
+    BALL_LOG_INFO << partitionDesc()
+                  << "Rollover required during conformation: JOURNAL file ["
+                  << activeFileSet->d_journal.d_fileName
+                  << "] reaching capacity. Current size: "
+                  << bmqu::PrintUtil::prettyNumber(journalPos)
+                  << ", capacity: "
+                  << bmqu::PrintUtil::prettyNumber(journalCap) << ".";
+
+    bmqp_ctrlmsg::SyncPoint syncPt;
+    syncPt.primaryLeaseId()       = d_writeHeadLeaseId;
+    syncPt.sequenceNum()          = writeHeadSeqNum() + 1;
+    syncPt.dataFileOffsetDwords() = activeFileSet->d_data.d_filePosition /
+                                    bmqp::Protocol::k_DWORD_SIZE;
+    syncPt.qlistFileOffsetWords() =
+        d_qListAware ? activeFileSet->d_qlist.d_filePosition /
+                           bmqp::Protocol::k_WORD_SIZE
+                     : 0;
+
+    int rc = issueSyncPointInternal(SyncPointType::e_ROLLOVER,
+                                    syncPt,
+                                    false);  // replicate
+    if (0 != rc) {
+        return 10 * rc + rc_SYNC_POINT_FAILURE;  // RETURN
+    }
+
+    rc = rolloverImpl(timestamp);
+    if (0 != rc) {
+        return 10 * rc + rc_ROLLOVER_FAILURE;  // RETURN
+    }
+
+    return rc_SUCCESS;
+}
+
 int FileStore::rolloverIfNeeded(FileType::Enum           fileType,
                                 const FileSet::FileInfo& fileInfo,
                                 bsls::Types::Uint64      requestedSpace)
@@ -3277,7 +3443,7 @@ int FileStore::rollover()
 
     BALL_LOG_INFO << partitionDesc() << "Start rollover.";
 
-    // Issue sync point first.
+    // Issue an e_ROLLOVER sync point.
 
     bmqp_ctrlmsg::SyncPoint syncPt;
     syncPt.primaryLeaseId()       = d_writeHeadLeaseId;
@@ -3752,6 +3918,43 @@ void FileStore::writeQueueOpRecordImpl(DataStoreRecordHandle*  handle,
                   << ", journal offset: " << recordOffset << "]";
 }
 
+int FileStore::writeCorrectiveQueueDeletionDuringRecovery(
+    const mqbu::StorageKey& queueKey,
+    bsls::Types::Uint64     timestamp)
+{
+    enum { rc_SUCCESS = 0, rc_JOURNAL_FULL = -1 };
+
+    FileSet* activeFileSet = d_fileSets[0].get();
+    BSLS_ASSERT_SAFE(activeFileSet);
+
+    MappedFileDescriptor& journal    = activeFileSet->d_journal.d_file;
+    bsls::Types::Uint64&  journalPos = activeFileSet->d_journal.d_filePosition;
+
+    if (needRollover(journal, journalPos, k_REQUESTED_JOURNAL_SPACE)) {
+        BALL_LOG_ERROR
+            << partitionDesc()
+            << "Cannot write corrective QueueOp.DELETION for queueKey ["
+            << queueKey << "]: JOURNAL is full (position: " << journalPos
+            << ", size: " << journal.fileSize()
+            << ", required: " << k_REQUESTED_JOURNAL_SPACE << ").";
+        return rc_JOURNAL_FULL;  // RETURN
+    }
+
+    OffsetPtr<QueueOpRecord> qRec(journal.block(), journalPos);
+    new (qRec.get()) QueueOpRecord();
+    qRec->header()
+        .setPrimaryLeaseId(d_writeHeadLeaseId)
+        .setSequenceNumber(incrementWriteHeadSeqNum())
+        .setTimestamp(timestamp);
+    qRec->setQueueKey(queueKey).setType(QueueOpType::e_DELETION);
+    qRec->setStartSequenceNumber(0);
+    qRec->setStartPrimaryLeaseId(0);
+    qRec->setMagic(RecordHeader::k_MAGIC);
+    journalPos += FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
+
+    return rc_SUCCESS;
+}
+
 void FileStore::writeRolledOverRecord(DataStoreRecord*    record,
                                       QueueKeyCounterMap* queueKeyCounterMap,
                                       FileSet*            oldFileSet,
@@ -4097,7 +4300,8 @@ void FileStore::issueSyncPointIfNeeded()
 }
 
 int FileStore::issueSyncPointInternal(SyncPointType::Enum            type,
-                                      const bmqp_ctrlmsg::SyncPoint& syncPoint)
+                                      const bmqp_ctrlmsg::SyncPoint& syncPoint,
+                                      bool                           replicate)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(inDispatcherThread());
@@ -4141,10 +4345,11 @@ int FileStore::issueSyncPointInternal(SyncPointType::Enum            type,
 
     d_syncPoints.push_back(spoPair);
 
-    // Let replicas know about it.
-    replicateRecord(bmqp::StorageMessageType::e_JOURNAL_OP,
-                    syncPointJournalOffset,
-                    true /* immediateFlush */);
+    if (replicate) {
+        replicateRecord(bmqp::StorageMessageType::e_JOURNAL_OP,
+                        syncPointJournalOffset,
+                        true /* immediateFlush */);
+    }
 
     // Report cluster's partition stats
     d_partitionStats_sp->setPartitionBytes(fs->d_data.d_outstandingBytes,

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2384,14 +2384,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
                         << "Encountered an orphan DELETION record for "
-                           "queueKey ["
-                        << rec.queueKey()
+                        << "queueKey [" << rec.queueKey()
                         << "], offset: " << jit->recordOffset()
                         << ", index: " << jit->recordIndex()
                         << ": the queueKey is not present in the cluster "
-                           "state "
-                        << "and had no QueueOp.CREATION record in the first "
-                        << "pass." << BMQTSK_ALARMLOG_END;
+                        << "state and had no QueueOp.CREATION record in the "
+                        << "first pass." << BMQTSK_ALARMLOG_END;
                 }
                 else {
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
@@ -2471,14 +2469,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     BMQTSK_ALARMLOG_ALARM("RECOVERY")
                         << partitionDesc()
                         << "Encountered an orphan CONFIRM record for queueKey "
-                           "["
-                        << rec.queueKey()
+                        << "[" << rec.queueKey()
                         << "], offset: " << jit->recordOffset()
                         << ", index: " << jit->recordIndex()
                         << ": the queueKey is not present in the cluster "
-                           "state "
-                        << "and had no QueueOp.CREATION record in the first "
-                        << "pass." << BMQTSK_ALARMLOG_END;
+                        << "state and had no QueueOp.CREATION record in the "
+                        << "first pass." << BMQTSK_ALARMLOG_END;
                     continue;  // CONTINUE
                 }
                 else {

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1410,15 +1410,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 if (queueKeyInfoMap->end() ==
                     queueKeyInfoMap->find(queueKey)) {
                     BALL_LOG_WARN
-                        << partitionDesc()
-                        << "Encountered "
-                           "a "
+                        << partitionDesc() << "Encountered a "
                         << "QueueOp.ADDITION record for queueKey [" << queueKey
                         << "] during 1st pass reverse iteration, but the "
                         << "queueKey is not present in cluster state.  Will "
-                        << "remember this extra queue.  "
-                           "Record "
-                        << "offset: " << journalIt.recordOffset()
+                        << "remember this extra queue."
+                        << "  Record offset: " << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
                     deletedQueueKeysOffsets.insert(
@@ -1477,15 +1474,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 if (queueKeyInfoMap->end() ==
                     queueKeyInfoMap->find(queueKey)) {
                     BALL_LOG_WARN
-                        << partitionDesc()
-                        << "Encountered "
-                           "a "
+                        << partitionDesc() << "Encountered a "
                         << "QueueOp.CREATION record for queueKey [" << queueKey
                         << "] during 1st pass reverse iteration, but the "
                         << "queueKey is not present in cluster state.  Will "
-                        << "remember this extra queue.  "
-                           "Record "
-                        << "offset: " << journalIt.recordOffset()
+                        << "remember this extra queue."
+                        << "  Record offset: " << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
                     deletedQueueKeysOffsets.insert(
@@ -1895,14 +1889,12 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         BMQTSK_ALARMLOG_ALARM("RECOVERY")
                             << partitionDesc()
                             << "Encountered an orphan QueueOp.PURGE record "
-                               "for "
-                            << "queueKey [" << queueKey
+                            << "for queueKey [" << queueKey
                             << "], offset: " << jit->recordOffset()
                             << ", index: " << jit->recordIndex()
                             << ": the queueKey is not present in the cluster "
                             << "state and had no QueueOp.CREATION record in "
-                               "the "
-                            << "first pass." << BMQTSK_ALARMLOG_END;
+                            << "the first pass." << BMQTSK_ALARMLOG_END;
                         continue;  // CONTINUE
                     }
                     else {

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1036,6 +1036,7 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
     // Conform the journal to the cluster state.
     const bool needsConform = !extraQueueKeys.empty();
     if (needsConform) {
+        BSLS_ASSERT_SAFE(d_isFSMWorkflow);
         BSLS_ASSERT_SAFE(asPrimary);
         BSLS_ASSERT_SAFE(0 != primaryLeaseId);
         BSLS_ASSERT_SAFE(primaryLeaseId >= d_writeHeadLeaseId);
@@ -1048,6 +1049,9 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
     // Each "extra" queueKey found during recovery (present in the journal but
     // absent from the cluster state) must be removed.
     if (!extraQueueKeys.empty()) {
+        // Corrective records are written straight to the journal,
+        // unreplicated; the caller propagates them by shipping the delta up to
+        // the write head advanced here.
         const bsls::Types::Uint64 timestamp =
             bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc());
 
@@ -1414,8 +1418,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         << "QueueOp.ADDITION record for queueKey [" << queueKey
                         << "] during 1st pass reverse iteration, but the "
                         << "queueKey is not present in cluster state.  Will "
-                        << "remember this extra queue."
-                        << "  Record offset: " << journalIt.recordOffset()
+                        << "remember this extra queue.  Record offset: "
+                        << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
                     deletedQueueKeysOffsets.insert(
@@ -1478,8 +1482,8 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         << "QueueOp.CREATION record for queueKey [" << queueKey
                         << "] during 1st pass reverse iteration, but the "
                         << "queueKey is not present in cluster state.  Will "
-                        << "remember this extra queue."
-                        << "  Record offset: " << journalIt.recordOffset()
+                        << "remember this extra queue.  Record offset: "
+                        << journalIt.recordOffset()
                         << ", record index: " << journalIt.recordIndex();
 
                     deletedQueueKeysOffsets.insert(
@@ -2687,38 +2691,14 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
             }
 
             if (0 == queueKeyInfoMap->count(rec.queueKey())) {
-                if (withClusterState) {
-                    // An "extra" queue (present in the journal but absent from
-                    // the cluster state) is tracked as deleted in the 1st pass
-                    // and skipped above.  Reaching here means an orphan
-                    // record: the queueKey is absent from the cluster state
-                    // and had no QueueOp.CREATION record in the 1st pass.
-                    // Tolerate it defensively rather than failing recovery.
-                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
-                        << partitionDesc()
-                        << "Encountered an orphan MESSAGE record for queueKey "
-                           "["
-                        << rec.queueKey()
-                        << "], offset: " << jit->recordOffset()
-                        << ", index: " << jit->recordIndex()
-                        << ": the queueKey is not present in the cluster "
-                           "state "
-                        << "and had no QueueOp.CREATION record in the first "
-                        << "pass." << BMQTSK_ALARMLOG_END;
-                    continue;  // CONTINUE
-                }
-                else {
-                    BMQTSK_ALARMLOG_ALARM("RECOVERY")
-                        << partitionDesc()
-                        << "Encountered a MESSAGE record for queueKey ["
-                        << rec.queueKey()
-                        << "], offset: " << jit->recordOffset()
-                        << ", index: " << jit->recordIndex()
-                        << ", for which a "
-                        << "QueueOp.CREATION record was not seen in first "
-                        << "pass." << BMQTSK_ALARMLOG_END;
-                    return rc_INVALID_QUEUE_KEY;  // RETURN
-                }
+                BMQTSK_ALARMLOG_ALARM("RECOVERY")
+                    << partitionDesc()
+                    << "Encountered a MESSAGE record for queueKey ["
+                    << rec.queueKey() << "], offset: " << jit->recordOffset()
+                    << ", index: " << jit->recordIndex() << ", for which a "
+                    << "QueueOp.CREATION record was not seen in first "
+                    << "pass." << BMQTSK_ALARMLOG_END;
+                return rc_INVALID_QUEUE_KEY;  // RETURN
             }
 
             bsls::Types::Uint64 appDataOffset = dataHeaderOffset + headerSize +

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1322,6 +1322,10 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                         bsl::make_pair(queueKey, journalIt.recordOffset()));
 
                 if (!irc.second) {
+                    if (k_EXTRA_QUEUE_SENTINEL_OFFSET == irc.first->second) {
+                        continue;  // CONTINUE
+                    }
+
                     const OffsetPtr<const QueueOpRecord> originalRec(
                         MemoryBlock(
                             journalIt.mappedFileDescriptor()->mapping(),

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -77,6 +77,7 @@
 #include <bsl_cstring.h>
 #include <bsl_iomanip.h>
 #include <bsl_iostream.h>
+#include <bsl_limits.h>
 #include <bsl_map.h>
 #include <bsl_unordered_set.h>
 #include <bsl_utility.h>

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -70,6 +70,7 @@
 #include <bsl_ostream.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
+#include <bsl_unordered_set.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
 #include <bslh_hash.h>
@@ -187,6 +188,10 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
     typedef DataStoreConfig::QueueKeyInfoMapConstIter QueueKeyInfoMapConstIter;
     typedef DataStoreConfig::QueueKeyInfoMapInsertRc  QueueKeyInfoMapInsertRc;
+
+    typedef bsl::unordered_set<mqbu::StorageKey,
+                               bslh::Hash<mqbu::StorageKeyHashAlgo> >
+        StorageKeys;
 
     typedef mqbi::Storage::AppInfos AppInfos;
 
@@ -467,9 +472,14 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// iteration.
     ///
     /// - First pass: Retrieve the list of non-deleted queues from `jit`.  If
-    /// the specified `withCSL` is `false`, populate `queueKeyInfoMap` with
-    /// that list; otherwise, use information from `queueKeyInfoMap` already
-    /// populated by the CSL to validate against that list.
+    /// the specified `withClusterState` is `false`, populate `queueKeyInfoMap`
+    /// with that list.  Otherwise, validate that list against the cluster
+    /// state already populated in `queueKeyInfoMap`: a queueKey found in the
+    /// journal but absent from the cluster state is an "extra" queue whose
+    /// records are all ignored and whose queueKey is collected into
+    /// `extraQueueKeys` (which must be non-null), so the caller can conform
+    /// the journal to the cluster state by writing a corrective
+    /// `QueueOp.DELETION` for it.
     ///
     /// - Second pass: Iterate over jit`, `dit`, and optionally `qit` if
     /// `d_qListAware` is true, and retrieve outstanding records for all those
@@ -489,7 +499,8 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                         JournalFileIterator* jit,
                         QlistFileIterator*   qit,
                         DataFileIterator*    dit,
-                        bool                 withCSL);
+                        StorageKeys*         extraQueueKeys,
+                        bool                 withClusterState);
 
     /// Rollover the outstanding messages belonging to the storages mapped
     /// to this file store, from active file set into the rollover file set,
@@ -497,6 +508,12 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// on success, non-zero value otherwise.  Note that in its *current*
     /// implementation, this routine has no side-effect in case of failure.
     int rolloverImpl(bsls::Types::Uint64 timestamp);
+
+    /// Rollover during recovery (while conforming the journal to the cluster
+    /// state), using the specified `timestamp`.  Unlike the live `rollover()`,
+    /// this writes the `e_ROLLOVER` sync point record without network
+    /// replication.  Return zero on success, non-zero value otherwise.
+    int rolloverDuringRecovery(bsls::Types::Uint64 timestamp);
 
     /// If the specified `fileInfo` cannot accommodate the specified
     /// `requestedSpace`, roll over.  Return zero on success, non-zero value
@@ -531,6 +548,17 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                                 bsls::Types::Uint64     timestamp,
                                 unsigned int            startPrimaryLeaseId,
                                 bsls::Types::Uint64     startSequenceNum);
+
+    /// Directly append a `QueueOp.DELETION` record for the specified
+    /// `queueKey` with the specified `timestamp` to the journal during
+    /// recovery, in order to conform the journal to the cluster state.  Return
+    /// zero on success, non-zero value otherwise.  The caller must ensure the
+    /// record fits without rolling over; a full journal is reported as an
+    /// error.  Behavior is undefined unless the active file set is open in
+    /// write mode.
+    int writeCorrectiveQueueDeletionDuringRecovery(
+        const mqbu::StorageKey& queueKey,
+        bsls::Types::Uint64     timestamp);
 
     /// Rollover over the specified `record` from `oldFileSet` to the
     /// `newFileSet`, and if it is a message record, update the counter of
@@ -569,9 +597,11 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     void issueSyncPointIfNeeded();
 
     /// Write the specified `syncPoint` of the specified `type` to the
-    /// journal, replicate it to followers, and record it in `d_syncPoints`.
+    /// journal and record it in `d_syncPoints`.  If the specified `replicate`
+    /// is true, also replicate it to followers.
     int issueSyncPointInternal(SyncPointType::Enum            type,
-                               const bmqp_ctrlmsg::SyncPoint& syncPoint);
+                               const bmqp_ctrlmsg::SyncPoint& syncPoint,
+                               bool replicate = true);
 
     int writeMessageRecord(const bmqp::StorageHeader&          header,
                            const mqbs::RecordHeader&           recHeader,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -459,14 +459,16 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     int openInNonRecoveryMode();
 
     /// Open this instance in recovery mode using the specified
-    /// `queueKeyInfoMap`.  Return zero on success and a non-zero value
-    /// otherwise.  Note that return value of `1` indicates no files were
-    /// found to recover messages from.  All other failure conditions should
-    /// be treated as fatal.  Also note that file store will attempt to
-    /// recover any outstanding messages from the files found at the
-    /// location indicated by the configuration of this instance.
+    /// `queueKeyInfoMap`.  The specified `primaryLeaseId` is the leaseId of
+    /// current primary.  Return zero on success and a non-zero value
+    /// otherwise.  Note that return value of `1` indicates no files were found
+    /// to recover messages from.  All other failure conditions should be
+    /// treated as fatal.  Also note that file store will attempt to recover
+    /// any outstanding messages from the files found at the location indicated
+    /// by the configuration of this instance. `queueKeyInfoMap`.
     int openInRecoveryMode(bsl::ostream&    errorDescription,
-                           QueueKeyInfoMap* queueKeyInfoMap);
+                           QueueKeyInfoMap* queueKeyInfoMap,
+                           unsigned int     primaryLeaseId);
 
     /// Make two passes over the journal file iterator `jit` in reverse
     /// iteration.
@@ -795,8 +797,10 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     // MANIPULATORS
 
     /// Open this instance using the optionally specified `queueKeyInfoMap`.
+    /// The specified `primaryLeaseId` is the leaseId of current primary.
     /// Return zero on success, non-zero value otherwise.
-    int open(QueueKeyInfoMap* queueKeyInfoMap) BSLS_KEYWORD_OVERRIDE;
+    int open(QueueKeyInfoMap* queueKeyInfoMap,
+             unsigned int     primaryLeaseId) BSLS_KEYWORD_OVERRIDE;
 
     /// Close this instance.  If the optional `flush` flag is true, flush
     /// the data store to disk.  If the optional `archive` flag is true,

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -459,13 +459,14 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     int openInNonRecoveryMode();
 
     /// Open this instance in recovery mode using the specified
-    /// `queueKeyInfoMap`.  The specified `primaryLeaseId` is the leaseId of
-    /// current primary.  Return zero on success and a non-zero value
-    /// otherwise.  Note that return value of `1` indicates no files were found
-    /// to recover messages from.  All other failure conditions should be
-    /// treated as fatal.  Also note that file store will attempt to recover
-    /// any outstanding messages from the files found at the location indicated
-    /// by the configuration of this instance. `queueKeyInfoMap`.
+    /// `queueKeyInfoMap`, which is non-null only when self is the primary.
+    /// The specified `primaryLeaseId` is the leaseId of the current primary,
+    /// under which any corrective record is stamped.  Return zero on success
+    /// and a non-zero value otherwise.  Note that return value of `1`
+    /// indicates no files were found to recover messages from.  All other
+    /// failure conditions should be treated as fatal.  Also note that file
+    /// store will attempt to recover any outstanding messages from the files
+    /// found at the location indicated by the configuration of this instance.
     int openInRecoveryMode(bsl::ostream&    errorDescription,
                            QueueKeyInfoMap* queueKeyInfoMap,
                            unsigned int     primaryLeaseId);
@@ -511,10 +512,13 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// implementation, this routine has no side-effect in case of failure.
     int rolloverImpl(bsls::Types::Uint64 timestamp);
 
-    /// Rollover during recovery (while conforming the journal to the cluster
-    /// state), using the specified `timestamp`.  Unlike the live `rollover()`,
-    /// this writes the `e_ROLLOVER` sync point record without network
-    /// replication.  Return zero on success, non-zero value otherwise.
+    /// @brief Rollover while conforming the journal to the cluster state.
+    ///
+    /// @details Unlike the live `rollover()`, this writes the `e_ROLLOVER`
+    /// sync point record without network replication.
+    ///
+    /// @param timestamp Timestamp to stamp on the sync point record.
+    /// @return Zero on success, a non-zero value otherwise.
     int rolloverDuringRecovery(bsls::Types::Uint64 timestamp);
 
     /// If the specified `fileInfo` cannot accommodate the specified
@@ -551,13 +555,18 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                                 unsigned int            startPrimaryLeaseId,
                                 bsls::Types::Uint64     startSequenceNum);
 
-    /// Directly append a `QueueOp.DELETION` record for the specified
-    /// `queueKey` with the specified `timestamp` to the journal during
-    /// recovery, in order to conform the journal to the cluster state.  Return
-    /// zero on success, non-zero value otherwise.  The caller must ensure the
-    /// record fits without rolling over; a full journal is reported as an
-    /// error.  Behavior is undefined unless the active file set is open in
-    /// write mode.
+    /// @brief Append a corrective `QueueOp.DELETION` record during recovery.
+    ///
+    /// @details Marks an "extra" queue -- present in the journal but absent
+    /// from the cluster state -- as deleted, so that the journal conforms to
+    /// the cluster state.  The record is written directly to the journal,
+    /// without network replication.  The caller must ensure the record fits
+    /// without rolling over; a full journal is reported as an error.
+    /// Behavior is undefined unless the active file set is open in write mode.
+    ///
+    /// @param queueKey  Key of the extra queue to mark deleted.
+    /// @param timestamp Timestamp to stamp on the record.
+    /// @return Zero on success, a non-zero value otherwise.
     int writeCorrectiveQueueDeletionDuringRecovery(
         const mqbu::StorageKey& queueKey,
         bsls::Types::Uint64     timestamp);
@@ -713,7 +722,7 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// specified `position` in the file, false otherwise.
     bool needRollover(const MappedFileDescriptor& file,
                       bsls::Types::Uint64         position,
-                      unsigned int                length) const;
+                      bsls::Types::Uint64         length) const;
 
     void aliasMessage(bsl::shared_ptr<bdlbb::Blob>* appData,
                       bsl::shared_ptr<bdlbb::Blob>* options,
@@ -796,9 +805,11 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
 
     // MANIPULATORS
 
-    /// Open this instance using the optionally specified `queueKeyInfoMap`.
-    /// The specified `primaryLeaseId` is the leaseId of current primary.
-    /// Return zero on success, non-zero value otherwise.
+    /// Open this instance using the optionally specified `queueKeyInfoMap`,
+    /// which must be supplied only when self is the primary.  The specified
+    /// `primaryLeaseId` is the leaseId of the current primary; it is unused
+    /// when `queueKeyInfoMap` is null.  Return zero on success, non-zero value
+    /// otherwise.
     int open(QueueKeyInfoMap* queueKeyInfoMap,
              unsigned int     primaryLeaseId) BSLS_KEYWORD_OVERRIDE;
 
@@ -1253,7 +1264,7 @@ inline const bsl::string& FileStore::partitionDesc() const
 
 inline bool FileStore::needRollover(const MappedFileDescriptor& file,
                                     bsls::Types::Uint64         position,
-                                    unsigned int                length) const
+                                    bsls::Types::Uint64         length) const
 {
     BSLS_ASSERT_SAFE(position <= file.fileSize());
     return file.fileSize() < (position + length);

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -28,6 +28,10 @@
 #include <mqbs_filestoreprotocol.h>
 #include <mqbs_filestoreset.h>
 #include <mqbs_filestoretestutil.h>
+#include <mqbs_filestoreutil.h>
+#include <mqbs_filesystemutil.h>
+#include <mqbs_journalfileiterator.h>
+#include <mqbs_mappedfiledescriptor.h>
 #include <mqbstat_clusterstats.h>
 #include <mqbu_messageguidutil.h>
 #include <mqbu_storagekey.h>
@@ -163,6 +167,81 @@ void recoveredQueuesCb(
     static_cast<void>(queueKeyInfoMap);
 }
 
+/// Return true if the journal file at the specified `journalFilePath` holds at
+/// least one sync point record of the specified `subtype`.
+static bool journalHasSyncPoint(const bsl::string&        journalFilePath,
+                                mqbs::SyncPointType::Enum subtype)
+{
+    mqbs::FileStoreSet fileSet(bmqtst::TestHelperUtil::allocator());
+    fileSet.setJournalFile(journalFilePath)
+        .setJournalFileSize(
+            bdls::FilesystemUtil::getFileSize(journalFilePath));
+
+    mqbs::MappedFileDescriptor journalFd;
+    bmqu::MemOutStream         errDesc(bmqtst::TestHelperUtil::allocator());
+    int rc = mqbs::FileStoreUtil::openFileSetReadMode(errDesc,
+                                                      fileSet,
+                                                      &journalFd);
+    BMQTST_ASSERT_EQ(0, rc);
+    if (0 != rc) {
+        return false;  // RETURN
+    }
+
+    mqbs::JournalFileIterator jit;
+    rc = mqbs::FileStoreUtil::loadIterators(errDesc, fileSet, &jit, journalFd);
+    BMQTST_ASSERT_EQ(0, rc);
+
+    bool found = false;
+    while (1 == jit.nextRecord()) {
+        if (mqbs::RecordType::e_JOURNAL_OP == jit.recordType()) {
+            const mqbs::JournalOpRecord& rec = jit.asJournalOpRecord();
+            if (mqbs::JournalOpType::e_SYNCPOINT == rec.type() &&
+                subtype == rec.syncPointType()) {
+                found = true;
+                break;
+            }
+        }
+    }
+
+    mqbs::FileSystemUtil::close(&journalFd);
+    return found;
+}
+
+/// Return the number of QueueOp.DELETION records in the journal file at the
+/// specified `journalFilePath`, or -1 if it could not be opened.
+static int journalDeletionCount(const bsl::string& journalFilePath)
+{
+    mqbs::FileStoreSet fileSet(bmqtst::TestHelperUtil::allocator());
+    fileSet.setJournalFile(journalFilePath)
+        .setJournalFileSize(
+            bdls::FilesystemUtil::getFileSize(journalFilePath));
+
+    mqbs::MappedFileDescriptor journalFd;
+    bmqu::MemOutStream         errDesc(bmqtst::TestHelperUtil::allocator());
+    int rc = mqbs::FileStoreUtil::openFileSetReadMode(errDesc,
+                                                      fileSet,
+                                                      &journalFd);
+    BMQTST_ASSERT_EQ(0, rc);
+    if (0 != rc) {
+        return -1;  // RETURN
+    }
+
+    mqbs::JournalFileIterator jit;
+    rc = mqbs::FileStoreUtil::loadIterators(errDesc, fileSet, &jit, journalFd);
+    BMQTST_ASSERT_EQ(0, rc);
+
+    int count = 0;
+    while (1 == jit.nextRecord()) {
+        if (mqbs::RecordType::e_QUEUE_OP == jit.recordType() &&
+            mqbs::QueueOpType::e_DELETION == jit.asQueueOpRecord().type()) {
+            ++count;
+        }
+    }
+
+    mqbs::FileSystemUtil::close(&journalFd);
+    return count;
+}
+
 /// Build a storage event carrying a single regular SyncPt journal record with
 /// the specified `leaseId`, `seqNum`, `journalOffsetWords`, `dataOffsetDwords`
 /// and `qlistOffsetWords`, and apply it to the specified `fs` as a
@@ -254,7 +333,8 @@ class Tester {
 
   public:
     // CREATORS
-    explicit Tester(bsl::string_view location)
+    explicit Tester(bsl::string_view    location,
+                    bsls::Types::Uint64 maxJournalFileSize = 1 * 1024 * 1024)
     : d_allocator_p(bmqtst::TestHelperUtil::allocator())
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, d_allocator_p)
     , d_bufferFactory(1024, d_allocator_p)
@@ -294,7 +374,7 @@ class Tester {
         d_partitionCfg.maxDataFileSize()     = 100 * 1024 * 1024;
         d_partitionCfg.maxQlistFileSize()    = 1 * 1024 * 1024;
         d_partitionCfg.maxCSLFileSize()      = 1 * 1024 * 1024;
-        d_partitionCfg.maxJournalFileSize()  = 1 * 1024 * 1024;
+        d_partitionCfg.maxJournalFileSize()  = maxJournalFileSize;
         d_partitionCfg.location()            = d_clusterLocation;
         d_partitionCfg.archiveLocation()     = d_clusterArchiveLocation;
         d_partitionCfg.numPartitions()       = 1;
@@ -374,7 +454,7 @@ class Tester {
     bool writeRecords(mqbs::FileStore*               fs,
                       bsl::vector<HandleRecordPair>* records,
                       SyncPointOffsetPairs*          spOffsetPairs,
-                      unsigned int*                  leaseId,
+                      unsigned int                   leaseId,
                       bsls::Types::Uint64*           seqNum,
                       bsls::Types::Uint64*           numRecordsWritten,
                       bsls::Types::Uint64            numRecords)
@@ -703,7 +783,7 @@ class Tester {
                 rec.d_journalOpType = mqbs::JournalOpType::e_SYNCPOINT;
                 rec.d_syncPtType    = mqbs::SyncPointType::e_REGULAR;
 
-                rec.d_syncPoint.primaryLeaseId() = *leaseId;
+                rec.d_syncPoint.primaryLeaseId() = leaseId;
                 rec.d_syncPoint.sequenceNum()    = ++(*seqNum);
                 rec.d_syncPoint.dataFileOffsetDwords() =
                     fileSet.dataFileSize() / bmqp::Protocol::k_DWORD_SIZE;
@@ -848,6 +928,8 @@ class Tester {
     mqbmock::Dispatcher& dispatcher() { return d_dispatcher; }
 
     bdlmt::EventScheduler& scheduler() { return d_scheduler; }
+
+    bdlbb::BlobBufferFactory& bufferFactory() { return d_bufferFactory; }
 };
 
 // ============================================================================
@@ -867,10 +949,11 @@ static void test1_breathingTest()
 {
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
-    Tester           tester("./test-cluster123-1");
-    mqbs::FileStore& fs = tester.fileStore();
+    Tester             tester("./test-cluster123-1");
+    mqbs::FileStore&   fs             = tester.fileStore();
+    const unsigned int primaryLeaseId = 1U;
 
-    int rc = fs.open(0);
+    int rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     if (rc) {
         cout << "Failed to open partition, rc: " << rc << endl;
@@ -894,12 +977,9 @@ static void test1_breathingTest()
             bslmf::NestedTraitDeclaration<Record, bslma::UsesBslmaAllocator> >(
             dummy));
 
-    // Set primary.
-    unsigned int        primaryLeaseId = 1;
-    bsls::Types::Uint64 seqNum         = 1;
-
     fs.setActivePrimary(tester.node(), primaryLeaseId);
 
+    bsls::Types::Uint64 seqNum = 1;
     BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(seqNum, fs.writeHeadSeqNum());
     BMQTST_ASSERT_EQ(tester.node(), fs.primaryNode());
@@ -946,7 +1026,7 @@ static void test1_breathingTest()
     bool                success           = tester.writeRecords(&fs,
                                        &records,
                                        &spOffsetPairs,
-                                       &primaryLeaseId,
+                                       primaryLeaseId,
                                        &seqNum,
                                        &numRecordsWritten,
                                        k_NUM_RECORDS);
@@ -998,13 +1078,12 @@ static void test2_printTest()
 
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
-    Tester           tester("./test-cluster123-2");
-    mqbs::FileStore& fs = tester.fileStore();
-    BSLS_ASSERT_OPT(fs.open(0) == 0);
+    Tester             tester("./test-cluster123-2");
+    mqbs::FileStore&   fs             = tester.fileStore();
+    const unsigned int primaryLeaseId = 1;
 
-    // Set primary.
-    unsigned int        primaryLeaseId = 1;
-    bsls::Types::Uint64 seqNum         = 1;
+    int rc = fs.open(0, primaryLeaseId);
+    BSLS_ASSERT_OPT(rc == 0);
     fs.setActivePrimary(tester.node(), primaryLeaseId);
 
     // Write various records to the partition.
@@ -1013,17 +1092,18 @@ static void test2_printTest()
 
     const size_t        k_NUM_RECORDS     = 10;
     bsls::Types::Uint64 numRecordsWritten = 0;
+    bsls::Types::Uint64 seqNum            = 1;
     BSLS_ASSERT_OPT(tester.writeRecords(&fs,
                                         &records,
                                         &spOffsetPairs,
-                                        &primaryLeaseId,
+                                        primaryLeaseId,
                                         &seqNum,
                                         &numRecordsWritten,
                                         k_NUM_RECORDS));
 
     bdlpcre::RegEx expectedOut(bmqtst::TestHelperUtil::allocator());
     bsl::string    errorMessage(bmqtst::TestHelperUtil::allocator());
-    size_t         errorOffset;
+    size_t         errorOffset = 0;
     expectedOut.prepare(
         &errorMessage,
         &errorOffset,
@@ -1074,7 +1154,7 @@ static void test2_printTest()
     stream << fsIt;
     BMQTST_ASSERT_EQ(stream.str(), "INVALID");
 
-    const int rc = fs.close();
+    rc = fs.close();
     BMQTST_ASSERT_EQ(0, rc);
 }
 
@@ -1094,22 +1174,21 @@ static void test3_partitionFullAlarm()
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     Tester           tester("./test-cluster123-3");
-    mqbs::FileStore& fs = tester.fileStore();
+    mqbs::FileStore& fs             = tester.fileStore();
+    unsigned int     primaryLeaseId = 1;
 
     // Disable in-place callback execution in mock dispatcher to prevent
     // thread races between the main thread (that modifies FileStore) and
     // scheduler thread (that performs gc on FileStore).
     tester.dispatcher().setEnqueueOnly(true);
 
-    int rc = fs.open(0);
+    int rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     if (rc) {
         cout << "Failed to open partition, rc: " << rc << endl;
         return;  // RETURN
     }
 
-    // Set primary.
-    unsigned int primaryLeaseId = 1;
     fs.setActivePrimary(tester.node(), primaryLeaseId);
 
     // Create a storage and register it with the FileStore.
@@ -1208,7 +1287,7 @@ static void test3_partitionFullAlarm()
     fs.close();
     BMQTST_ASSERT_EQ(false, fs.isOpen());
 
-    rc = fs.open(0);
+    rc = fs.open(0, 2);
     BMQTST_ASSERT_EQ(0, rc);
     BMQTST_ASSERT_EQ(true, fs.isOpen());
 
@@ -1241,22 +1320,21 @@ static void test4_recoverMessagesAcrossLeaseIds()
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     Tester           tester("./test-cluster123-4");
-    mqbs::FileStore& fs = tester.fileStore();
+    mqbs::FileStore& fs             = tester.fileStore();
+    unsigned int     primaryLeaseId = 1;
 
     // Disable in-place callback execution in mock dispatcher to prevent
     // thread races between the main thread (that modifies FileStore) and
     // scheduler thread (that performs gc on FileStore).
     tester.dispatcher().setEnqueueOnly(true);
 
-    int rc = fs.open(0);
+    int rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     if (rc) {
         cout << "Failed to open partition, rc: " << rc << endl;
         return;  // RETURN
     }
 
-    // Set primary with leaseId 1.
-    unsigned int primaryLeaseId = 1;
     fs.setActivePrimary(tester.node(), primaryLeaseId);
 
     // Create a storage and register it with the FileStore.
@@ -1331,7 +1409,7 @@ static void test4_recoverMessagesAcrossLeaseIds()
     fs.close();
     BMQTST_ASSERT_EQ(false, fs.isOpen());
 
-    rc = fs.open(0);
+    rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     BMQTST_ASSERT_EQ(true, fs.isOpen());
 
@@ -1358,9 +1436,10 @@ static void test5_writeHeadFollowsAppliedLease()
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     Tester           tester("./test-cluster123-5");
-    mqbs::FileStore& fs = tester.fileStore();
+    mqbs::FileStore& fs             = tester.fileStore();
+    unsigned int     primaryLeaseId = 1;
 
-    int rc = fs.open(0);
+    int rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
 
     bdlbb::PooledBlobBufferFactory bufferFactory(
@@ -1383,7 +1462,7 @@ static void test5_writeHeadFollowsAppliedLease()
         mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE /
         bmqp::Protocol::k_WORD_SIZE;
 
-    fs.setActivePrimary(tester.node(), 1);
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
     // A sync point is issued -> [1, 1]
     journalOffsetWords += k_RECORD_WORDS;
     BMQTST_ASSERT_EQ(1U, fs.writeHeadLeaseId());
@@ -1394,38 +1473,39 @@ static void test5_writeHeadFollowsAppliedLease()
                              &bufferFactory,
                              tester.node(),
                              k_PARTITION_ID,
-                             1,  // leaseId
+                             primaryLeaseId,
                              2,  // seqNum
                              journalOffsetWords,
                              dataOffsetDwords,
                              qlistOffsetWords,
                              bmqtst::TestHelperUtil::allocator());
     journalOffsetWords += k_RECORD_WORDS;
-    BMQTST_ASSERT_EQ(1U, fs.writeHeadLeaseId());
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(2ULL, fs.writeHeadSeqNum());
 
+    primaryLeaseId = 2;
     for (bsls::Types::Uint64 seqNum = 1; seqNum <= 4; ++seqNum) {
         applyReplicatedSyncPoint(&fs,
                                  blobSpPool.get(),
                                  &bufferFactory,
                                  tester.node(),
                                  k_PARTITION_ID,
-                                 2,  // leaseId
+                                 primaryLeaseId,
                                  seqNum,
                                  journalOffsetWords,
                                  dataOffsetDwords,
                                  qlistOffsetWords,
                                  bmqtst::TestHelperUtil::allocator());
         journalOffsetWords += k_RECORD_WORDS;
-        BMQTST_ASSERT_EQ(2U, fs.writeHeadLeaseId());
+        BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
         BMQTST_ASSERT_EQ(seqNum, fs.writeHeadSeqNum());
     }
 
     // The delayed 'setActivePrimary' for leaseId 2 now arrives.  Verify it
     // does not reset the sequence number of leaseId 2 back to zero.
-    fs.setActivePrimary(tester.node(), 2);
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
     // A sync point is issued -> [2, 5]
-    BMQTST_ASSERT_EQ(2U, fs.writeHeadLeaseId());
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_GE(5ULL, fs.writeHeadSeqNum());
     BMQTST_ASSERT_EQ(tester.node(), fs.primaryNode());
 
@@ -1451,14 +1531,15 @@ static void test6_leaseTransitionWithoutSeal()
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     Tester           tester("./test-cluster123-6");
-    mqbs::FileStore& fs = tester.fileStore();
+    mqbs::FileStore& fs             = tester.fileStore();
+    unsigned int     primaryLeaseId = 1;
 
-    int rc = fs.open(0);
+    int rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
 
     // Set primary with leaseId 1; a sync point is issued -> [1, 1].
-    fs.setActivePrimary(tester.node(), 1);
-    BMQTST_ASSERT_EQ(1U, fs.writeHeadLeaseId());
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(1ULL, fs.writeHeadSeqNum());
 
     // Create a storage and register it with the FileStore.
@@ -1515,15 +1596,16 @@ static void test6_leaseTransitionWithoutSeal()
 
     // Bump the primary leaseId to 2.  A single sync point [2, 1] is issued for
     // the new lease.
-    fs.setActivePrimary(tester.node(), 2);
-    BMQTST_ASSERT_EQ(2U, fs.writeHeadLeaseId());
+    primaryLeaseId = 2;
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(1ULL, fs.writeHeadSeqNum());
 
     // Write a few more message records under leaseId 2.
     for (size_t i = 0; i < 3; ++i) {
         BMQTST_ASSERT_EQ(poster.postMessage(), mqbi::StorageResult::e_SUCCESS);
     }
-    BMQTST_ASSERT_EQ(2U, fs.writeHeadLeaseId());
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
 
     const bsls::Types::Uint64 numRecords = fs.numRecords();
     BMQTST_ASSERT_D("records should exist before reopen", numRecords > 0);
@@ -1532,12 +1614,260 @@ static void test6_leaseTransitionWithoutSeal()
     rc = fs.close();
     BMQTST_ASSERT_EQ(0, rc);
 
-    rc = fs.open(0);
+    rc = fs.open(0, primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     BMQTST_ASSERT_EQ(true, fs.isOpen());
 
     // Every record from both leaseIds should have been recovered.
     BMQTST_ASSERT_EQ(fs.numRecords(), numRecords);
+
+    rc = fs.close();
+    BMQTST_ASSERT_EQ(0, rc);
+}
+
+static void test7_conformExtraQueueWithoutRollover()
+// ------------------------------------------------------------------------
+// CONFORM EXTRA QUEUE WITHOUT ROLLOVER
+//
+// Concerns:
+//   When the primary conforms its journal to the cluster state and the
+//   corrective QueueOp.DELETION fits without rolling over, it is appended in
+//   place (no rollover) to mark the extra queue deleted.
+//
+// Testing:
+//   Corrective QueueOp.DELETION during conform without rollover
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CONFORM EXTRA QUEUE WITHOUT ROLLOVER");
+
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-6";
+
+    Tester           tester(k_FILE_STORE_LOCATION);
+    mqbs::FileStore& fs = tester.fileStore();
+
+    const unsigned int k_OLD_LEASE = 1;
+
+    // --- Phase 1: write a journal containing queue 'extraQ'.
+    int rc = fs.open(0, k_OLD_LEASE);
+    BMQTST_ASSERT_EQ(0, rc);
+    BMQTST_ASSERT_EQ(true, fs.isOpen());
+
+    fs.setActivePrimary(tester.node(), k_OLD_LEASE);
+
+    const bmqt::Uri        queueUri("bmq://si.amw.bmq.stats/extraQ",
+                             bmqtst::TestHelperUtil::allocator());
+    const mqbu::StorageKey queueKey(mqbu::StorageKey::BinaryRepresentation(),
+                                    "ABCDE");
+    mqbs::DataStoreRecordHandle queueHandle;
+    BMQTST_ASSERT_EQ(
+        0,
+        fs.writeQueueCreationRecord(
+            &queueHandle,
+            queueUri,
+            queueKey,
+            AppInfos(),
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
+            true));  // isNewQueue
+
+    mqbs::FileStoreSet fileSet(bmqtst::TestHelperUtil::allocator());
+    fs.loadCurrentFiles(&fileSet);
+    const bsl::string journalFileBefore(fileSet.journalFile(),
+                                        bmqtst::TestHelperUtil::allocator());
+
+    rc = fs.close();
+    BMQTST_ASSERT_EQ(0, rc);
+    BMQTST_ASSERT_EQ(false, fs.isOpen());
+
+    // --- Phase 2: reopen as the new primary with an empty cluster state.
+    // 'extraQ' is extra and the corrective QueueOp.DELETION fits, so it is
+    // appended in place without rolling over.
+    const unsigned int                     k_NEW_LEASE = k_OLD_LEASE + 1;
+    mqbs::DataStoreConfig::QueueKeyInfoMap clusterState(
+        bmqtst::TestHelperUtil::allocator());
+    BMQTST_ASSERT_EQ(0, fs.open(&clusterState, k_NEW_LEASE));
+    BMQTST_ASSERT_EQ(true, fs.isOpen());
+
+    fs.loadCurrentFiles(&fileSet);
+
+    // No rollover: same journal file.
+    BMQTST_ASSERT_EQ(journalFileBefore, fileSet.journalFile());
+
+    // Exactly one corrective QueueOp.DELETION was appended.
+    BMQTST_ASSERT_EQ(1, journalDeletionCount(fileSet.journalFile()));
+
+    // Write head reflects the new lease at (2, 1).
+    BMQTST_ASSERT_EQ(k_NEW_LEASE, fs.writeHeadLeaseId());
+    BMQTST_ASSERT_EQ(1ULL, fs.writeHeadSeqNum());
+
+    rc = fs.close();
+    BMQTST_ASSERT_EQ(0, rc);
+}
+
+static void test8_conformExtraQueueCausesRollover()
+// ------------------------------------------------------------------------
+// CONFORM EXTRA QUEUE CAUSES ROLLOVER
+//
+// Concerns:
+//   When the primary conforms its journal to the cluster state and the
+//   corrective QueueOp.DELETIONs do not fit on a near-full journal, conform
+//   rolls over once.  Rollover compacts away every extra queue, so no
+//   corrective DELETION is written.
+//
+// Testing:
+//   Corrective QueueOp.DELETION during conform causes rollover
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CONFORM EXTRA QUEUE CAUSES ROLLOVER");
+
+    bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
+
+    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-4";
+
+    const bsls::Types::Uint64 k_MAX_JOURNAL = 8 * 1024;
+
+    const bsls::Types::Uint64 k_REQUESTED_JOURNAL_SPACE =
+        static_cast<bsls::Types::Uint64>(
+            mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE) *
+        (1 + 2 + 16);
+
+    Tester           tester(k_FILE_STORE_LOCATION, k_MAX_JOURNAL);
+    mqbs::FileStore& fs = tester.fileStore();
+    tester.dispatcher().setEnqueueOnly(true);
+
+    const unsigned int k_OLD_LEASE = 1;
+
+    // --- Phase 1: build a near-full journal containing queues 'extraQ' and
+    // 'extraQ2'.
+    int rc = fs.open(0, k_OLD_LEASE);
+    BMQTST_ASSERT_EQ(0, rc);
+    BMQTST_ASSERT_EQ(true, fs.isOpen());
+
+    fs.setActivePrimary(tester.node(), k_OLD_LEASE);
+
+    const bmqt::Uri        queueUri("bmq://si.amw.bmq.stats/extraQ",
+                             bmqtst::TestHelperUtil::allocator());
+    const mqbu::StorageKey queueKey(mqbu::StorageKey::BinaryRepresentation(),
+                                    "ABCDE");
+    mqbs::DataStoreRecordHandle queueHandle;
+    BMQTST_ASSERT_EQ(
+        0,
+        fs.writeQueueCreationRecord(
+            &queueHandle,
+            queueUri,
+            queueKey,
+            AppInfos(),
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
+            true));  // isNewQueue
+
+    // A second extra queue: both extra queues are compacted away together by
+    // the single rollover, so neither yields a corrective DELETION.
+    const bmqt::Uri        queueUri2("bmq://si.amw.bmq.stats/extraQ2",
+                              bmqtst::TestHelperUtil::allocator());
+    const mqbu::StorageKey queueKey2(mqbu::StorageKey::BinaryRepresentation(),
+                                     "FGHIJ");
+    mqbs::DataStoreRecordHandle queueHandle2;
+    BMQTST_ASSERT_EQ(
+        0,
+        fs.writeQueueCreationRecord(
+            &queueHandle2,
+            queueUri2,
+            queueKey2,
+            AppInfos(),
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
+            true));  // isNewQueue
+
+    mqbs::FileStoreSet fileSet(bmqtst::TestHelperUtil::allocator());
+    fs.loadCurrentFiles(&fileSet);
+    const bsl::string journalFileBefore(fileSet.journalFile(),
+                                        bmqtst::TestHelperUtil::allocator());
+
+    // Fill with message records until the journal's near-full.
+    const bsls::Types::Uint64 k_FILL_UNTIL_POS = k_MAX_JOURNAL -
+                                                 k_REQUESTED_JOURNAL_SPACE;
+
+    bsl::size_t guard = 0;
+    while (true) {
+        BSLS_ASSERT_OPT(++guard < 100000);
+        fs.loadCurrentFiles(&fileSet);
+        if (fileSet.journalFileSize() >= k_FILL_UNTIL_POS) {
+            break;
+        }
+
+        mqbs::DataStoreRecordHandle msgHandle;
+        bmqt::MessageGUID           guid;
+        mqbu::MessageGUIDUtil::generateGUID(&guid);
+
+        bsl::shared_ptr<bdlbb::Blob> appData;
+        appData.createInplace(bmqtst::TestHelperUtil::allocator(),
+                              &tester.bufferFactory(),
+                              bmqtst::TestHelperUtil::allocator());
+        bdlbb::BlobUtil::append(appData.get(), "x", 1);
+        bsl::shared_ptr<bdlbb::Blob> options;
+
+        mqbi::StorageMessageAttributes attributes(
+            bdlt::EpochUtil::convertToTimeT64(bdlt::CurrentTime::utc()),
+            1,  // refCount
+            static_cast<unsigned int>(appData->length()),
+            bmqp::MessagePropertiesInfo(),
+            bmqt::CompressionAlgorithmType::e_NONE,
+            0U);  // crc32c
+
+        rc = fs.writeMessageRecord(&attributes,
+                                   &msgHandle,
+                                   guid,
+                                   appData,
+                                   options,
+                                   queueKey);
+        BMQTST_ASSERT_EQ(0, rc);
+        if (0 != rc) {
+            fs.close();
+            return;  // RETURN
+        }
+    }
+
+    // Phase 1 must not have rolled over: same journal file, near-full.
+    fs.loadCurrentFiles(&fileSet);
+    BMQTST_ASSERT_EQ(journalFileBefore, fileSet.journalFile());
+    BMQTST_ASSERT_GE(fileSet.journalFileSize(), k_FILL_UNTIL_POS);
+    const bsls::Types::Uint64 nearFullPos = fileSet.journalFileSize();
+
+    rc = fs.close();
+    BMQTST_ASSERT_EQ(0, rc);
+    BMQTST_ASSERT_EQ(false, fs.isOpen());
+
+    // --- Phase 2: reopen as primary with an empty cluster state, so both
+    // 'extraQ' and 'extraQ2' are extra queues.  The corrective DELETIONs do
+    // not fit on the near-full journal, so conform rolls over once.  Rollover
+    // compacts away both extra queues (their records are never outstanding),
+    // so NO corrective DELETION is written.
+    const unsigned int                     k_NEW_LEASE = 2;
+    mqbs::DataStoreConfig::QueueKeyInfoMap clusterState(
+        bmqtst::TestHelperUtil::allocator());
+    BMQTST_ASSERT_EQ(0, fs.open(&clusterState, k_NEW_LEASE));
+    BMQTST_ASSERT_EQ(true, fs.isOpen());
+
+    fs.loadCurrentFiles(&fileSet);
+
+    // Conform rolled the journal over to a fresh, smaller file.
+    BMQTST_ASSERT_NE(journalFileBefore, fileSet.journalFile());
+    BMQTST_ASSERT_LT(fileSet.journalFileSize(), nearFullPos);
+    BMQTST_ASSERT_LT(fileSet.journalFileSize(), k_FILL_UNTIL_POS);
+
+    // The rollover produced a well-formed new journal: it begins with an
+    // e_REGULAR sync point.
+    BMQTST_ASSERT(journalHasSyncPoint(fileSet.journalFile(),
+                                      mqbs::SyncPointType::e_REGULAR));
+
+    // The extra queues were compacted away by the rollover, so no corrective
+    // QueueOp.DELETION was written.
+    BMQTST_ASSERT_EQ(0, journalDeletionCount(fileSet.journalFile()));
+
+    // The rollover sync point is stamped under the NEW lease at (2, 1), so the
+    // write head reflects the new lease.
+    BMQTST_ASSERT_EQ(k_NEW_LEASE, fs.writeHeadLeaseId());
+    BMQTST_ASSERT_EQ(1ULL, fs.writeHeadSeqNum());
 
     rc = fs.close();
     BMQTST_ASSERT_EQ(0, rc);
@@ -1557,6 +1887,8 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 8: test8_conformExtraQueueCausesRollover(); break;
+    case 7: test7_conformExtraQueueWithoutRollover(); break;
     case 6: test6_leaseTransitionWithoutSeal(); break;
     case 5: test5_writeHeadFollowsAppliedLease(); break;
     case 4: test4_recoverMessagesAcrossLeaseIds(); break;

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -1721,6 +1721,8 @@ static void test8_conformExtraQueueCausesRollover()
 
     const bsls::Types::Uint64 k_MAX_JOURNAL = 8 * 1024;
 
+    // Mirrors the file-local 'k_REQUESTED_JOURNAL_SPACE' of
+    // mqbs_filestore.cpp.  Keep in sync with that constant.
     const bsls::Types::Uint64 k_REQUESTED_JOURNAL_SPACE =
         static_cast<bsls::Types::Uint64>(
             mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE) *

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -183,9 +183,6 @@ static bool journalHasSyncPoint(const bsl::string&        journalFilePath,
                                                       fileSet,
                                                       &journalFd);
     BMQTST_ASSERT_EQ(0, rc);
-    if (0 != rc) {
-        return false;  // RETURN
-    }
 
     mqbs::JournalFileIterator jit;
     rc = mqbs::FileStoreUtil::loadIterators(errDesc, fileSet, &jit, journalFd);
@@ -222,9 +219,6 @@ static int journalDeletionCount(const bsl::string& journalFilePath)
                                                       fileSet,
                                                       &journalFd);
     BMQTST_ASSERT_EQ(0, rc);
-    if (0 != rc) {
-        return -1;  // RETURN
-    }
 
     mqbs::JournalFileIterator jit;
     rc = mqbs::FileStoreUtil::loadIterators(errDesc, fileSet, &jit, journalFd);
@@ -1079,12 +1073,12 @@ static void test2_printTest()
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
     Tester             tester("./test-cluster123-2");
-    mqbs::FileStore&   fs             = tester.fileStore();
-    const unsigned int primaryLeaseId = 1;
+    mqbs::FileStore&   fs                 = tester.fileStore();
+    const unsigned int k_INITIAL_LEASE_ID = 1;
 
-    int rc = fs.open(0, primaryLeaseId);
+    int rc = fs.open(0, k_INITIAL_LEASE_ID);
     BSLS_ASSERT_OPT(rc == 0);
-    fs.setActivePrimary(tester.node(), primaryLeaseId);
+    fs.setActivePrimary(tester.node(), k_INITIAL_LEASE_ID);
 
     // Write various records to the partition.
     SyncPointOffsetPairs spOffsetPairs(bmqtst::TestHelperUtil::allocator());
@@ -1096,7 +1090,7 @@ static void test2_printTest()
     BSLS_ASSERT_OPT(tester.writeRecords(&fs,
                                         &records,
                                         &spOffsetPairs,
-                                        primaryLeaseId,
+                                        k_INITIAL_LEASE_ID,
                                         &seqNum,
                                         &numRecordsWritten,
                                         k_NUM_RECORDS));
@@ -1287,13 +1281,13 @@ static void test3_partitionFullAlarm()
     fs.close();
     BMQTST_ASSERT_EQ(false, fs.isOpen());
 
-    rc = fs.open(0, 2);
+    rc = fs.open(0, ++primaryLeaseId);
     BMQTST_ASSERT_EQ(0, rc);
     BMQTST_ASSERT_EQ(true, fs.isOpen());
 
     // 8. Verify writes succeed after reopen.
     fs.registerStorage(storage_sp.get());
-    fs.setActivePrimary(tester.node(), ++primaryLeaseId);
+    fs.setActivePrimary(tester.node(), primaryLeaseId);
     BMQTST_ASSERT_D("write after reopen should succeed",
                     poster.postMessage() == mqbi::StorageResult::e_SUCCESS);
 
@@ -1483,7 +1477,7 @@ static void test5_writeHeadFollowsAppliedLease()
     BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(2ULL, fs.writeHeadSeqNum());
 
-    primaryLeaseId = 2;
+    primaryLeaseId = fs.writeHeadLeaseId() + 1;
     for (bsls::Types::Uint64 seqNum = 1; seqNum <= 4; ++seqNum) {
         applyReplicatedSyncPoint(&fs,
                                  blobSpPool.get(),
@@ -1642,7 +1636,7 @@ static void test7_conformExtraQueueWithoutRollover()
 
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
-    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-6";
+    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-7";
 
     Tester           tester(k_FILE_STORE_LOCATION);
     mqbs::FileStore& fs = tester.fileStore();
@@ -1723,7 +1717,7 @@ static void test8_conformExtraQueueCausesRollover()
 
     bmqtst::TestHelperUtil::ignoreCheckDefAlloc() = true;
 
-    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-4";
+    const char k_FILE_STORE_LOCATION[] = "./test-cluster123-8";
 
     const bsls::Types::Uint64 k_MAX_JOURNAL = 8 * 1024;
 

--- a/src/integration-tests/test_fsm_partition_sync.py
+++ b/src/integration-tests/test_fsm_partition_sync.py
@@ -780,3 +780,104 @@ def test_sync_after_primary_extra_records(
     # Check that primary and replicas' journal files are equal
     for replica in cluster.nodes(exclude=leader):
         stop_cluster_and_compare_journal_files(leader.name, replica.name, cluster)
+
+
+def test_sync_after_primary_missed_queue_deletion(
+    fsm_multi_cluster: Cluster,
+    domain_urls: tc.DomainUrls,
+) -> None:
+    """
+    Test that when the primary's journal references a queue that the CSL has
+    deleted (an "extra queue" -- e.g. the queue's QueueOp.DELETION never made it
+    into this primary's journal), the primary conforms its journal to the CSL
+    by writing a corrective QueueOp.DELETION during recovery.
+    - Start cluster
+    - Open a queue and put 2 messages
+    - Snapshot every node's partition files (journal/data/qlist) while the queue
+      is alive
+    - Empty and delete the queue.  The CSL now records the queue as deleted.
+    - Stop all nodes
+    - Restore the snapshot partition files over every node's storage, leaving
+      the up-to-date CSL intact.  Every node's journal now has the queue's
+      CREATION (plus 2 outstanding messages) but no deletion, while the CSL says
+      the queue is gone -- i.e. an extra queue.
+    - Start all nodes
+    - Verify the new primary conforms its journal to the CSL and becomes available
+    - Verify that all nodes are synchronized by examining storage files
+    """
+    cluster: Cluster = fsm_multi_cluster
+    uri_priority = domain_urls.uri_priority
+
+    leader = cluster.last_known_leader
+    proxy = next(cluster.proxy_cycle())
+
+    producer = proxy.create_client("producer")
+    producer.open(uri_priority, flags=["write,ack"], succeed=True)
+
+    consumer = proxy.create_client("consumer")
+    consumer.open(uri_priority, flags=["read"], succeed=True)
+
+    # Put 2 messages
+    for i in range(1, 3):
+        producer.post(uri_priority, [f"msg{i}"], succeed=True, wait_ack=True)
+
+    # Snapshot every node's partition files while the queue is still alive.
+    partition_patterns = ["*.bmq_journal", "*.bmq_data", "*.bmq_qlist"]
+    snapshots = {}  # node.name -> temp dir holding its partition files
+    for node in cluster.nodes():
+        storage_dir = str(cluster.work_dir.joinpath(node.name, "storage"))
+        tmp_dir = tempfile.mkdtemp()
+        for pattern in partition_patterns:
+            for f in glob.glob(os.path.join(storage_dir, pattern)):
+                shutil.copy2(f, tmp_dir)
+        snapshots[node.name] = tmp_dir
+
+    # Empty and delete the queue so the CSL records its deletion.
+    consumer.wait_push_event()
+    consumer.confirm(uri_priority, "*", succeed=True)
+    consumer.close(uri_priority, succeed=True)
+    producer.close(uri_priority, succeed=True)
+    leader.force_gc_queues(succeed=True)
+
+    # Stop all nodes
+    cluster.stop_nodes()
+    for node in cluster.nodes():
+        cluster.make_sure_node_stopped(node)
+        node.drain()
+
+    # Restore the snapshot partition files (queue alive, no deletion) over every
+    # node's storage, leaving the up-to-date CSL intact.
+    for node in cluster.nodes():
+        storage_dir = str(cluster.work_dir.joinpath(node.name, "storage"))
+        for pattern in partition_patterns:
+            for f in glob.glob(os.path.join(storage_dir, pattern)):
+                os.remove(f)
+        tmp_dir = snapshots[node.name]
+        for f in os.listdir(tmp_dir):
+            shutil.copy2(os.path.join(tmp_dir, f), storage_dir)
+        shutil.rmtree(tmp_dir)
+
+    # Start all nodes.
+    cluster.start_nodes(wait_leader=True, wait_ready=False)
+    new_primary = cluster.last_known_leader
+
+    # Verify the new primary conforms its journal to the CSL for the extra
+    # queue and becomes available.
+    matches = new_primary.capture_n(
+        [
+            r"Conforming journal to cluster state: writing a corrective QueueOp.DELETION for extra queueKey",
+            r"Cluster \(itCluster\) is available",
+        ],
+        2,
+        timeout=10,
+    )
+    assert matches[0] is not None, (
+        f"New primary {new_primary} did not conform its journal to the CSL for the extra queue"
+    )
+    assert matches[1] is not None, (
+        f"New primary {new_primary} did not output 'Cluster (itCluster) is available'"
+    )
+
+    # Verify that all nodes are synchronized by examining storage files.
+    for replica in cluster.nodes(exclude=new_primary):
+        stop_cluster_and_compare_journal_files(new_primary.name, replica.name, cluster)


### PR DESCRIPTION
  ## Summary
  - During Partition-FSM recovery the primary validates its journal against the cluster state. If the journal referenced a queue **absent** from the cluster state — an "extra" queue, e.g. a `QueueOp.CREATION` whose matching deletion never reached this journal — recovery previously failed and the broker terminated (`RECOVERY_FAILURE`), so the primary could not heal.
  - This PR makes the primary treat the cluster state as the source of truth and **conform** its journal instead of erroring: during `open()` it writes a corrective `QueueOp.DELETION` for each extra queue. If the near-full journal can't fit the correctives, conform rolls over once (which compacts the extra queues away, so no DELETION is needed).
  - Corrective records are stamped under the **new primary leaseId**, not the old lease. Continuing the old lease's sequence (e.g. write head `(2,5)` → `(2,6),(2,7)`) risks a cluster-wide PSN collision: a replica that advanced the old lease in a prior term may hold *different* records at those same PSNs. Stamping under the new lease (`(3,1),(3,2)`) makes the primary unambiguously ahead, so its corrections supersede the replica's stale records when pushed. The leaseId is threaded through `DataStore::open` / `FileStore::openInRecoveryMode` (sentinel `0` = replica/legacy, no conform).
  - The corrective writes advance the PSN and are captured by `do_storeSelfSeq` after `open()`, so the existing FSM push path replicates them to replicas automatically — **no FSM state-table changes**. Builds on #1594 (refresh cached self-PSN after opening storage).
  - Scope is limited to **extra** queues (journal has it, cluster state doesn't). The reverse "missing" case (cluster state has it, journal doesn't) is benign at recovery and left for a follow-up; the new-lease bump is structured (a `needsConform` guard) so that follow-up inherits it.