### PR TITLE
Refactor[mqbnet]: void* -> NegotiationUserData protocol

### DIFF
--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -912,14 +912,14 @@ int SessionNegotiator::negotiateOutbound(
     BSLS_ASSERT_SAFE(!context_p->isIncoming());
 
     const mqbblp::ClusterCatalog::NegotiationUserData* userData =
-        reinterpret_cast<mqbblp::ClusterCatalog::NegotiationUserData*>(
-            context_p->userData());
+        dynamic_cast<const mqbblp::ClusterCatalog::NegotiationUserData*>(
+            context_p->userData().get());
 
     BSLS_ASSERT_SAFE(userData);
 
-    context_p->negotiationContext()->setClusterName(userData->d_clusterName);
+    context_p->negotiationContext()->setClusterName(userData->clusterName());
     context_p->negotiationContext()->setConnectionType(
-        d_clusterCatalog_p->isMemberOf(userData->d_clusterName)
+        d_clusterCatalog_p->isMemberOf(userData->clusterName())
             ? mqbnet::ConnectionType::e_CLUSTER_MEMBER
             : mqbnet::ConnectionType::e_CLUSTER_PROXY);
 

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.cpp
@@ -51,6 +51,21 @@
 namespace BloombergLP {
 namespace mqbblp {
 
+// -----------------------------------------
+// class ClusterCatalog::NegotiationUserData
+// -----------------------------------------
+
+ClusterCatalog::NegotiationUserData::NegotiationUserData(
+    bsl::string_view  clusterName,
+    bslma::Allocator* allocator)
+: d_clusterName(clusterName, allocator)
+{
+}
+
+ClusterCatalog::NegotiationUserData::~NegotiationUserData()
+{
+}
+
 // --------------------
 // class ClusterCatalog
 // --------------------
@@ -73,18 +88,15 @@ int ClusterCatalog::createNetCluster(
         connectionMode = mqbnet::TransportManager::e_CONNECT_ALL;
     }
 
-    NegotiationUserData* userData = new (*d_allocator_p) NegotiationUserData;
-    userData->d_clusterName       = name;
-    userData->d_myNodeId          = -1;  // Unused when not reversed connection
-
-    bslma::ManagedPtr<void> userDataMp(userData, d_allocator_p);
+    bsl::shared_ptr<mqbnet::NegotiationUserData> userData =
+        bsl::allocate_shared<NegotiationUserData>(d_allocator_p, name);
 
     return d_transportManager_p->createCluster(errorDescription,
                                                out,
                                                name,
                                                nodes,
                                                connectionMode,
-                                               &userDataMp);
+                                               userData);
 }
 
 struct Named {

--- a/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
+++ b/src/groups/mqb/mqbblp/mqbblp_clustercatalog.h
@@ -36,6 +36,7 @@
 #include <mqbcfg_messages.h>
 #include <mqbi_cluster.h>
 #include <mqbi_domain.h>
+#include <mqbnet_initialconnectioncontext.h>
 #include <mqbnet_multirequestmanager.h>
 #include <mqbnet_session.h>
 
@@ -49,6 +50,7 @@
 #include <bsl_memory.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bsl_unordered_map.h>
 #include <bsl_unordered_set.h>
 #include <bsl_vector.h>
@@ -60,6 +62,7 @@
 #include <bslmt_mutex.h>
 #include <bsls_assert.h>
 #include <bsls_cpp11.h>
+#include <bsls_keyword.h>
 
 namespace BloombergLP {
 
@@ -104,15 +107,40 @@ class ClusterCatalog {
   public:
     // TYPES
 
-    /// Struct holding some context state used during negotiation: refer to the
-    /// @bbref{ mqba::SessionNegotiator} for usage of that struct.  This
+    /// Class holding some context state used during negotiation: refer to the
+    /// @bbref{ mqba::SessionNegotiator} for usage of that class.  This
     /// `userData` is created here, passed to `mqbnet` to hold on to it and
-    /// deliver it back to the `Negotiator` ~ this hackery mechanism is needed
-    /// in order to avoid dependency cycles and keep `mqbnet` layer abstracted
-    /// away from this logic.
-    struct NegotiationUserData {
-        bsl::string d_clusterName;
-        int         d_myNodeId;
+    /// deliver it back to the `Negotiator`, which recovers the concrete type
+    /// by downcasting.  Implementing the @bbref{mqbnet::NegotiationUserData}
+    /// protocol keeps the `mqbnet` layer abstracted away from this logic and
+    /// avoids dependency cycles.
+    class NegotiationUserData : public mqbnet::NegotiationUserData {
+      private:
+        // DATA
+
+        /// Name of the cluster to negotiate the connection with.
+        const bsl::string d_clusterName;
+
+      public:
+        // TRAITS
+        BSLMF_NESTED_TRAIT_DECLARATION(NegotiationUserData,
+                                       bslma::UsesBslmaAllocator)
+
+        // CREATORS
+
+        /// Create a `NegotiationUserData` holding the specified `clusterName`.
+        /// Use the optionally specified `allocator` to supply memory; if
+        /// `allocator` is 0, use the currently installed default allocator.
+        explicit NegotiationUserData(bsl::string_view  clusterName,
+                                     bslma::Allocator* allocator = 0);
+
+        /// Destroy this object.
+        ~NegotiationUserData() BSLS_KEYWORD_OVERRIDE;
+
+        // ACCESSORS
+
+        /// Return the name of the cluster to negotiate the connection with.
+        const bsl::string& clusterName() const;
     };
 
     typedef bmqp::RequestManager<bmqp_ctrlmsg::ControlMessage,
@@ -359,6 +387,17 @@ class ClusterCatalog {
 // ============================================================================
 //                             INLINE DEFINITIONS
 // ============================================================================
+
+// ----------------------------------------
+// class ClusterCatalog::NegotiationUserData
+// ----------------------------------------
+
+// ACCESSORS
+inline const bsl::string&
+ClusterCatalog::NegotiationUserData::clusterName() const
+{
+    return d_clusterName;
+}
 
 // --------------------
 // class ClusterCatalog

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -184,26 +184,35 @@ bool InitialConnectionEvent::fromAscii(InitialConnectionEvent::Enum* out,
 #undef CHECKVALUE
 }
 
+// -------------------------
+// class NegotiationUserData
+// -------------------------
+
+NegotiationUserData::~NegotiationUserData()
+{
+    // NOTHING: Pure interface
+}
+
 // ------------------------------
 // class InitialConnectionContext
 // ------------------------------
 
 // CREATORS
 InitialConnectionContext::InitialConnectionContext(
-    bool                                   isIncoming,
-    mqbnet::Authenticator*                 authenticator,
-    mqbnet::Negotiator*                    negotiator,
-    void*                                  userData,
-    void*                                  resultState,
-    const bsl::shared_ptr<bmqio::Channel>& channel,
-    const InitialConnectionCompleteCb&     initialConnectionCompleteCb,
-    bslma::Allocator*                      allocator)
+    bool                                        isIncoming,
+    mqbnet::Authenticator*                      authenticator,
+    mqbnet::Negotiator*                         negotiator,
+    const bsl::shared_ptr<NegotiationUserData>& userData,
+    void*                                       resultState,
+    const bsl::shared_ptr<bmqio::Channel>&      channel,
+    const InitialConnectionCompleteCb&          initialConnectionCompleteCb,
+    bslma::Allocator*                           allocator)
 : d_allocator_p(allocator)
 , d_mutex()
 , d_authenticator_p(authenticator)
 , d_negotiator_p(negotiator)
 , d_resultState_p(resultState)
-, d_userData_p(userData)
+, d_userData_sp(userData)
 , d_channelSp(channel)
 , d_authenticationCtxSp()
 , d_negotiationCtxSp()
@@ -708,9 +717,10 @@ bool InitialConnectionContext::isIncoming() const
     return d_isIncoming;
 }
 
-void* InitialConnectionContext::userData() const
+const bsl::shared_ptr<NegotiationUserData>&
+InitialConnectionContext::userData() const
 {
-    return d_userData_p;
+    return d_userData_sp;
 }
 
 void* InitialConnectionContext::resultState() const

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -196,6 +196,23 @@ struct InitialConnectionEvent {
 bsl::ostream& operator<<(bsl::ostream&                stream,
                          InitialConnectionEvent::Enum value);
 
+// =========================
+// class NegotiationUserData
+// =========================
+
+/// Protocol for a caller-supplied, opaque piece of data carried through the
+/// negotiation of a session and handed back to the negotiator implementation.
+/// The `mqbnet` layer holds an instance purely as an owned lifetime handle and
+/// never interprets its contents; the concrete type is defined and recovered
+/// by the application layer.
+class NegotiationUserData {
+  public:
+    // CREATORS
+
+    /// Destroy this object.
+    virtual ~NegotiationUserData();
+};
+
 // ==============================
 // class InitialConnectionContext
 // ==============================
@@ -247,21 +264,18 @@ class InitialConnectionContext {
     /// data).
     void* d_resultState_p;
 
-    /// Raw pointer, held not owned, to some user data
-    /// the InitialConnectionContext can use
-    /// while negotiating the session.  This may or may
-    /// not be set by the caller, during
-    /// 'TcpSessionFactory::handleInitialConnection()';
-    /// and should not be changed during negotiation (this data is not
-    /// used by the session factory, so changing it will
-    /// have no effect).  This is used to bind high
-    /// level data (from application layer) to the
-    /// application layer (the negotiator concrete
-    /// implementation) (typically for the case of
-    /// 'connect' sessions to provide information to use
-    /// for negotiating the session with the remote
-    /// peer).
-    void* d_userData_p;
+    /// Shared pointer to caller-supplied user data the
+    /// InitialConnectionContext carries while negotiating
+    /// the session.  This may or may not be set by the
+    /// caller, during
+    /// 'TcpSessionFactory::handleInitialConnection()'.
+    /// This is used to bind high level data (from
+    /// application layer) to the application layer (the
+    /// negotiator concrete implementation) (typically for
+    /// the case of 'connect' sessions to provide
+    /// information to use for negotiating the session with
+    /// the remote peer).
+    bsl::shared_ptr<NegotiationUserData> d_userData_sp;
 
     /// The channel to use for the initial connection.
     bsl::shared_ptr<bmqio::Channel> d_channelSp;
@@ -310,14 +324,14 @@ class InitialConnectionContext {
 
     /// Create a new object having the specified `isIncoming` value.
     InitialConnectionContext(
-        bool                                   isIncoming,
-        mqbnet::Authenticator*                 authenticator,
-        mqbnet::Negotiator*                    negotiator,
-        void*                                  userData,
-        void*                                  resultState,
-        const bsl::shared_ptr<bmqio::Channel>& channel,
-        const InitialConnectionCompleteCb&     initialConnectionCompleteCb,
-        bslma::Allocator*                      allocator = 0);
+        bool                                        isIncoming,
+        mqbnet::Authenticator*                      authenticator,
+        mqbnet::Negotiator*                         negotiator,
+        const bsl::shared_ptr<NegotiationUserData>& userData,
+        void*                                       resultState,
+        const bsl::shared_ptr<bmqio::Channel>&      channel,
+        const InitialConnectionCompleteCb& initialConnectionCompleteCb,
+        bslma::Allocator*                  allocator = 0);
 
     ~InitialConnectionContext();
 
@@ -408,10 +422,10 @@ class InitialConnectionContext {
     // ACCESSORS
 
     /// Return the value of the corresponding field.
-    bool                                   isIncoming() const;
-    void*                                  userData() const;
-    void*                                  resultState() const;
-    const bsl::shared_ptr<bmqio::Channel>& channel() const;
+    bool                                        isIncoming() const;
+    const bsl::shared_ptr<NegotiationUserData>& userData() const;
+    void*                                       resultState() const;
+    const bsl::shared_ptr<bmqio::Channel>&      channel() const;
     bmqp::EncodingType::Enum               authenticationEncodingType() const;
     const bsl::shared_ptr<AuthenticationContext>&
                                                authenticationContext() const;

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -136,28 +136,31 @@ static void test1_initialConnectionContext()
     bmqtst::TestHelper::printTestName("test1_basicConstruction");
     {
         PV("Constructor");
-        mqbnet::InitialConnectionContext obj1(false,
-                                              authenticator.get(),
-                                              negotiator.get(),
-                                              static_cast<void*>(0),
-                                              static_cast<void*>(0),
-                                              channel,
-                                              completeCb);
+        mqbnet::InitialConnectionContext obj1(
+            false,
+            authenticator.get(),
+            negotiator.get(),
+            bsl::shared_ptr<mqbnet::NegotiationUserData>(),
+            static_cast<void*>(0),
+            channel,
+            completeCb);
         BMQTST_ASSERT_EQ(obj1.isIncoming(), false);
         BMQTST_ASSERT_EQ(obj1.resultState(), static_cast<void*>(0));
-        BMQTST_ASSERT_EQ(obj1.userData(), static_cast<void*>(0));
+        BMQTST_ASSERT_EQ(obj1.userData(),
+                         bsl::shared_ptr<mqbnet::NegotiationUserData>());
     }
 
     {
         PV("Manipulators/Accessors");
 
-        mqbnet::InitialConnectionContext obj(true,
-                                             authenticator.get(),
-                                             negotiator.get(),
-                                             static_cast<void*>(0),
-                                             static_cast<void*>(0),
-                                             channel,
-                                             completeCb);
+        mqbnet::InitialConnectionContext obj(
+            true,
+            authenticator.get(),
+            negotiator.get(),
+            bsl::shared_ptr<mqbnet::NegotiationUserData>(),
+            static_cast<void*>(0),
+            channel,
+            completeCb);
 
         {  // ResultState
             int value = 9;

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -361,7 +361,7 @@ struct TCPSessionFactory_OperationContext {
     // session (i.e., associated to a 'connect'
     // operation).
 
-    bsl::shared_ptr<void> d_negotiationUserData_sp;
+    bsl::shared_ptr<NegotiationUserData> d_negotiationUserData_sp;
     // The negotiation user data, if any, provided by
     // the caller (for the 'connect' operation); unused
     // for a 'listen' operation.  This is the user data
@@ -441,7 +441,7 @@ void TCPSessionFactory::handleInitialConnection(
             context->d_isIncoming,
             d_authenticator_p,
             d_negotiator_p,
-            context->d_negotiationUserData_sp.get(),
+            context->d_negotiationUserData_sp,
             context->d_resultState_p,
             channel,
             bdlf::BindUtil::bindS(
@@ -1573,21 +1573,19 @@ int TCPSessionFactory::listen(const mqbcfg::TcpInterfaceListener& listener,
     return 0;
 }
 
-int TCPSessionFactory::connect(bsl::string_view         endpoint,
-                               const ResultCallback&    resultCallback,
-                               bslma::ManagedPtr<void>* negotiationUserData,
-                               void*                    resultState,
-                               bool                     shouldAutoReconnect)
+int TCPSessionFactory::connect(
+    bsl::string_view                            endpoint,
+    const ResultCallback&                       resultCallback,
+    const bsl::shared_ptr<NegotiationUserData>& negotiationUserData,
+    void*                                       resultState,
+    bool                                        shouldAutoReconnect)
 {
     bsl::shared_ptr<OperationContext> context;
     context.createInplace(d_allocator_p);
-    context->d_resultCb      = resultCallback;
-    context->d_isIncoming    = false;
-    context->d_resultState_p = resultState;
-
-    if (negotiationUserData) {
-        context->d_negotiationUserData_sp = *negotiationUserData;
-    }
+    context->d_resultCb               = resultCallback;
+    context->d_isIncoming             = false;
+    context->d_resultState_p          = resultState;
+    context->d_negotiationUserData_sp = negotiationUserData;
 
     bsl::string                         endpointStr(endpoint, d_allocator_p);
     bmqio::TCPEndpoint                  tcpEndpoint(endpointStr);

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.h
@@ -142,6 +142,7 @@ namespace mqbnet {
 class AuthenticationContext;
 class Cluster;
 class InitialConnectionContext;
+class NegotiationUserData;
 class Session;
 class SessionEventProcessor;
 class TCPSessionFactoryIterator;
@@ -640,7 +641,7 @@ class TCPSessionFactory {
     /// the connection has successfully been started; with the result being
     /// provided by a call to the specified `resultCallback`; or return a
     /// non-zero code on error, in which case `resultCallback` will never be
-    /// invoked.  The optionally specified `negotiationUserData` will be
+    /// invoked.  The specified `negotiationUserData` will be
     /// passed in to the `handleInitialConnection` method (through the
     /// InitialConnectionContext).  The optionally specified `resultState` will
     /// be used to set the initial value of the corresponding member of the
@@ -649,11 +650,12 @@ class TCPSessionFactory {
     /// callback method.  The optionally specified `shouldAutoReconnect` will
     /// be used to determine if the factory should attempt to reconnect upon
     /// loss of connection.
-    int connect(bsl::string_view         endpoint,
-                const ResultCallback&    resultCallback,
-                bslma::ManagedPtr<void>* negotiationUserData = 0,
-                void*                    resultState         = 0,
-                bool                     shouldAutoReconnect = false);
+    int
+    connect(bsl::string_view                            endpoint,
+            const ResultCallback&                       resultCallback,
+            const bsl::shared_ptr<NegotiationUserData>& negotiationUserData,
+            void*                                       resultState = 0,
+            bool shouldAutoReconnect                                = false);
 
     /// Set the write queue low and high watermarks for the specified
     /// `session` to the configured `nodeLowWatermark` and

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -24,6 +24,7 @@
 #include <mqbcfg_messages.h>
 #include <mqbnet_cluster.h>
 #include <mqbnet_clusterimp.h>
+#include <mqbnet_initialconnectioncontext.h>
 #include <mqbnet_session.h>
 #include <mqbnet_tcpsessionfactory.h>
 
@@ -251,8 +252,6 @@ int TransportManager::connectLocked(ConnectionState* state)
                     // The mutex lock is necessary to ensure the 'state'
                     // doesn't get invalidated while processing this method.
 
-    bslma::ManagedPtr<void> negotiationUserData =
-        state->d_userData_sp.managedPtr();
     return d_tcpSessionFactory_mp->connect(
         state->d_endpoint,
         bdlf::BindUtil::bind(&TransportManager::sessionResult,
@@ -264,7 +263,7 @@ int TransportManager::connectLocked(ConnectionState* state)
                              bdlf::PlaceHolders::_5,  // resultState
                              bdlf::PlaceHolders::_6,  // readCb
                              false),                  // isListen
-        &negotiationUserData,
+        state->d_userData_sp,
         state,
         true);  // shouldAutoReconnect
 }
@@ -467,12 +466,12 @@ void TransportManager::stop()
 }
 
 int TransportManager::createCluster(
-    bsl::ostream&                           errorDescription,
-    bslma::ManagedPtr<mqbnet::Cluster>*     out,
-    const bsl::string&                      name,
-    const bsl::vector<mqbcfg::ClusterNode>& nodes,
-    ConnectionMode                          connectionMode,
-    bslma::ManagedPtr<void>*                userData)
+    bsl::ostream&                               errorDescription,
+    bslma::ManagedPtr<mqbnet::Cluster>*         out,
+    const bsl::string&                          name,
+    const bsl::vector<mqbcfg::ClusterNode>&     nodes,
+    ConnectionMode                              connectionMode,
+    const bsl::shared_ptr<NegotiationUserData>& userData)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(out);
@@ -499,12 +498,6 @@ int TransportManager::createCluster(
                                << " and config: ";
         bmqu::Printer<bsl::vector<mqbcfg::ClusterNode> > printer(&nodes);
         BALL_LOG_OUTPUT_STREAM << printer;
-    }
-
-    // Create a shared pointer to hold the user data, if any
-    bsl::shared_ptr<void> userDataSp;
-    if (userData) {
-        userDataSp = *userData;
     }
 
     bslma::Allocator*          alloc = d_allocators.get(name);
@@ -546,7 +539,7 @@ int TransportManager::createCluster(
 
         connectionState->d_endpoint    = tcpConfig.endpoint();
         connectionState->d_node_p      = node;
-        connectionState->d_userData_sp = userDataSp;
+        connectionState->d_userData_sp = userData;
 
         d_connectionsState[connectionState.get()] = connectionState;
 

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.h
@@ -92,6 +92,7 @@ namespace mqbnet {
 // FORWARD DECLARATION
 class Cluster;
 class ClusterNode;
+class NegotiationUserData;
 class Negotiator;
 class Session;
 class SessionEventProcessor;
@@ -149,7 +150,7 @@ class TransportManager {
         // is invalidated when the cluster is
         // destroyed.
 
-        bsl::shared_ptr<void> d_userData_sp;
+        bsl::shared_ptr<NegotiationUserData> d_userData_sp;
         // The user data, if any, provided
         // to the 'createCluster' method.
         // This correspond to the negotiator
@@ -346,7 +347,7 @@ class TransportManager {
     ///   the other end will be connecting to us; this is to prevent
     ///   double connections); this is the case when the node is part of a
     ///   cluster.
-    /// The optionally specified `userData` will be passed in to the
+    /// The specified `userData` will be passed in to the
     /// `negotiate` method of the negotiator (through the
     /// InitialConnectionContext) for any connections being established
     /// as a result of this cluster creation.  Return 0 on success, or a
@@ -357,7 +358,7 @@ class TransportManager {
                       const bsl::string&                      name,
                       const bsl::vector<mqbcfg::ClusterNode>& nodes,
                       ConnectionMode                          connectionMode,
-                      bslma::ManagedPtr<void>*                userData = 0);
+                      const bsl::shared_ptr<NegotiationUserData>& userData);
 
     /// Return the raw pointer `cookie handle` to the internal state
     /// associated to the specified `nodeId` in the specified `clusterName`,


### PR DESCRIPTION
Replace the opaque `void*` negotiation-user-data cookie in the initial-connection/negotiation
path with a typed `mqbnet::NegotiationUserData` protocol, held end-to-end as a `bsl::shared_ptr`.

- `InitialConnectionContext`, `TransportManager`, `TCPSessionFactory: void*/ManagedPtr<void>` -> `shared_ptr<NegotiationUserData>`.
- `mqbblp::ClusterCatalog::NegotiationUserData` implements the protocol.
- Consumer in `mqba::SessionNegotiator` uses a checked `dynamic_cast`.
- Remove dead `d_myNodeId `field.
