### PR TITLE
IT: fix not found regex

### DIFF
--- a/src/integration-tests/test_app_subscriptions.py
+++ b/src/integration-tests/test_app_subscriptions.py
@@ -456,7 +456,7 @@ class TestAppSubscriptions:
 
         for node in cluster.nodes():
             if node != self.leader:
-                node.capture(r"Received QueueOpRecord of type DELETION")
+                assert node.capture(r"Received QueueOpRecord of type \[DELETION\]")
 
         all_partition_id = -1  # use -1 to rollover all partitions
         self.leader.trigger_rollover(all_partition_id)


### PR DESCRIPTION
This IT is very slow: `425.06s call     test_app_subscriptions.py::TestAppSubscriptions::test_app_subscription_fanout_all_negative[multi_node-strong_consistency]`
It looks that the regex line that we search is incorrect and we waste `3*120s=360s` of failing regex searches for 3 replicas.

Note that the logged line has `[]` around operation type:

https://github.com/bloomberg/blazingmq/blob/11c01d78a64dba398fea8628dce12050f5dd3e54/src/groups/mqb/mqbs/mqbs_filestore.cpp#L4903-L4907

These `[]` are what we are missing

Run time reduced to ~30s:
`28.02s call     test_app_subscriptions.py::TestAppSubscriptions::test_app_subscription_fanout_all_negative[multi_node-strong_consistency]`