### PR TITLE
UT[mqbc_clusterstatemanager]: TSAN failure with scheduler

### DIFF
--- a/src/groups/bmq/bmqtst/bmqtst_schedulerlockguard.cpp
+++ b/src/groups/bmq/bmqtst/bmqtst_schedulerlockguard.cpp
@@ -1,0 +1,131 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <bmqtst_schedulerlockguard.h>
+
+#include <bmqscm_version.h>
+
+// BDE
+#include <bdlf_bind.h>
+#include <bdlmt_eventscheduler.h>
+#include <bslma_default.h>
+#include <bslmt_semaphore.h>
+#include <bsls_assert.h>
+
+namespace BloombergLP {
+namespace bmqtst {
+
+// ---------------------------------
+// struct SchedulerLockGuard_Context
+// ---------------------------------
+
+/// Context shared between the pause callback (which runs on the scheduler
+/// dispatcher thread) and the `SchedulerLockGuard` that owns it.  Co-owned via
+/// `shared_ptr` so it outlives whichever of the two ends last.  Defined at
+/// package scope (not in the unnamed namespace) to match its forward
+/// declaration in the header.
+struct SchedulerLockGuard_Context {
+    // DATA
+
+    /// Posted by the dispatcher thread once it has entered the pause callback.
+    bslmt::Semaphore d_enteredSem;
+
+    /// Latch on which the parked dispatcher thread blocks; posted to release
+    /// it.
+    bslmt::Semaphore d_releaseSem;
+};
+
+namespace {
+
+/// Post on the specified `sem_p`.
+void postSemaphore(bslmt::Semaphore* sem_p)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(sem_p);
+
+    sem_p->post();
+}
+
+/// Functor scheduled by `SchedulerLockGuard` to park the scheduler's
+/// dispatcher thread.  Co-owns the shared context via a `shared_ptr` so it
+/// stays alive for the callback's lifetime.
+class SchedulerPauseFunctor {
+  private:
+    // DATA
+    bsl::shared_ptr<SchedulerLockGuard_Context> d_context_sp;
+
+  public:
+    // CREATORS
+    explicit SchedulerPauseFunctor(
+        const bsl::shared_ptr<SchedulerLockGuard_Context>& context)
+    : d_context_sp(context)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_SAFE(d_context_sp);
+    }
+
+    // ACCESSORS
+
+    /// Run on the scheduler dispatcher thread: signal that the dispatcher is
+    /// parked, then block on the release latch until the owning guard is
+    /// destroyed.  The scheduler's internal mutex is *not* held while this
+    /// runs, so other threads may still (re)schedule events; those events
+    /// simply will not fire until this returns.
+    void operator()() const
+    {
+        d_context_sp->d_enteredSem.post();
+        d_context_sp->d_releaseSem.wait();
+    }
+};
+
+}  // close unnamed namespace
+
+// ------------------------
+// class SchedulerLockGuard
+// ------------------------
+
+SchedulerLockGuard::SchedulerLockGuard(bdlmt::EventScheduler* scheduler,
+                                       bslma::Allocator*      basicAllocator)
+: d_scheduler_p(scheduler)
+, d_context_sp(
+      bsl::allocate_shared<SchedulerLockGuard_Context>(basicAllocator))
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_scheduler_p);
+
+    // Schedule a callback which parks the scheduler's dispatcher thread, and
+    // block until that thread confirms it is parked.  Once parked, no other
+    // scheduled event can fire until this guard is destroyed.
+    d_scheduler_p->scheduleEvent(d_scheduler_p->now(),
+                                 SchedulerPauseFunctor(d_context_sp));
+    d_context_sp->d_enteredSem.wait();
+}
+
+SchedulerLockGuard::~SchedulerLockGuard()
+{
+    // Release the parked dispatcher thread, then wait until the scheduler has
+    // drained all now-due events (including any event that became due while
+    // the scheduler was paused).
+    d_context_sp->d_releaseSem.post();
+
+    bslmt::Semaphore drainSem;
+    d_scheduler_p->scheduleEvent(d_scheduler_p->now(),
+                                 bdlf::BindUtil::bind(&postSemaphore,
+                                                      &drainSem));
+    drainSem.wait();
+}
+
+}  // close package namespace
+}  // close enterprise namespace

--- a/src/groups/bmq/bmqtst/bmqtst_schedulerlockguard.h
+++ b/src/groups/bmq/bmqtst/bmqtst_schedulerlockguard.h
@@ -1,0 +1,128 @@
+// Copyright 2024 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef INCLUDED_BMQTST_SCHEDULERLOCKGUARD
+#define INCLUDED_BMQTST_SCHEDULERLOCKGUARD
+
+//@PURPOSE: Provide an RAII guard that pauses a 'bdlmt::EventScheduler'.
+//
+//@CLASSES:
+//   bmqtst::SchedulerLockGuard: RAII guard pausing a 'bdlmt::EventScheduler'
+//
+//@DESCRIPTION: 'bmqtst::SchedulerLockGuard' provides an RAII mechanism that
+// pauses a 'bdlmt::EventScheduler' for the lifetime of the guard.  While the
+// guard is alive, the scheduler's dispatcher thread is parked inside a
+// callback so that no scheduled event (timer, watchdog, gc, ...) can fire; the
+// thread holding the guard may therefore inspect or mutate state shared with
+// scheduler callbacks without racing the scheduler thread.  On destruction the
+// scheduler is resumed and all now-due events are drained before the
+// destructor returns.
+//
+// This is primarily useful in tests that drive an object on the main thread
+// while a real 'bdlmt::EventScheduler' runs background callbacks that touch
+// the same state.
+//
+/// Thread Safety
+///-------------
+// A single guard instance is not thread safe; it is intended to be created and
+// destroyed by the same thread.  The scheduler supplied at construction must
+// be running.
+//
+/// Warning
+///-------
+// Do *not* advance a test time source (e.g. via
+// 'bdlmt::EventSchedulerTestTimeSource::advanceTime') while a guard is active:
+// 'advanceTime' blocks until the dispatcher thread processes the change, but
+// that thread is parked, so the call would deadlock.
+//
+/// Usage Example
+///-------------
+// The following example illustrates typical intended usage of this component.
+//
+//..
+//  {
+//      bmqtst::SchedulerLockGuard guard(scheduler_p);
+//
+//      // The scheduler is paused here; inspect or mutate state shared with
+//      // scheduler callbacks without racing the scheduler thread.
+//  }
+//  // The scheduler has been resumed and all now-due events drained.
+//..
+
+// BDE
+#include <bsl_memory.h>
+#include <bsls_keyword.h>
+
+namespace BloombergLP {
+
+// FORWARD DECLARATION
+namespace bdlmt {
+class EventScheduler;
+}
+namespace bslma {
+class Allocator;
+}
+
+namespace bmqtst {
+
+// FORWARD DECLARATION
+
+/// Component-private context shared between the pause callback and the
+/// `SchedulerLockGuard` that owns it.  Defined in the `.cpp`.
+struct SchedulerLockGuard_Context;
+
+// ========================
+// class SchedulerLockGuard
+// ========================
+
+/// RAII guard that keeps a `bdlmt::EventScheduler` paused for its lifetime.
+class SchedulerLockGuard {
+  private:
+    // DATA
+
+    /// Scheduler paused by this guard.
+    bdlmt::EventScheduler* d_scheduler_p;
+
+    /// Context shared with the pause callback; used to release the parked
+    /// dispatcher thread on destruction.
+    bsl::shared_ptr<SchedulerLockGuard_Context> d_context_sp;
+
+  private:
+    // NOT IMPLEMENTED
+    SchedulerLockGuard(const SchedulerLockGuard&) BSLS_KEYWORD_DELETED;
+    SchedulerLockGuard&
+    operator=(const SchedulerLockGuard&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // CREATORS
+
+    /// Pause the specified `scheduler` and create a guard that keeps it paused
+    /// until this object is destroyed, blocking until the scheduler's
+    /// dispatcher thread is parked.  Optionally specify a `basicAllocator`
+    /// used to supply memory; if `basicAllocator` is 0, the currently
+    /// installed default allocator is used.  The behavior is undefined unless
+    /// `scheduler` is running.
+    explicit SchedulerLockGuard(bdlmt::EventScheduler* scheduler,
+                                bslma::Allocator*      basicAllocator = 0);
+
+    /// Resume the scheduler and drain all now-due events, then destroy this
+    /// object.
+    ~SchedulerLockGuard();
+};
+
+}  // close package namespace
+}  // close enterprise namespace
+
+#endif

--- a/src/groups/bmq/bmqtst/doc/bmqtst.txt
+++ b/src/groups/bmq/bmqtst/doc/bmqtst.txt
@@ -9,12 +9,14 @@ writing test drivers.
 
 /Hierarchical Synopsis
 /---------------------
- The bmqtst' package currently has 5 components having 1 level of physical
+ The bmqtst' package currently has 7 components having 1 level of physical
  dependency.  The list below shows the hierarchical ordering of the components.
 ..
   1. bmqtst_blobtestutil
      bmqtst_mocktime
+     bmqtst_schedulerlockguard
      bmqtst_scopedlogobserver
+     bmqtst_table
      bmqtst_tempfile
      bmqtst_testhelper
 ..
@@ -25,8 +27,12 @@ writing test drivers.
 :      Provide blob utilities for use in test drivers.
 : 'bmqtst_mocktime':
 :      Provide a mock of the time accessors usable with 'bmqu::Time'.
+: 'bmqtst_schedulerlockguard':
+:      Provide an RAII guard that pauses a 'bdlmt::EventScheduler'.
 : 'bmqtst_scopedlogobserver':
 :      Provide a scoped tester implementation of the log observer protocol.
+: 'bmqtst_table':
+:      Provide a utility for pretty-printing tabular data.
 : 'bmqtst_tempfile':
 :      Provide a guard for creating a temporary file.
 : 'bmqtst_testhelper':

--- a/src/groups/bmq/bmqtst/package/bmqtst.mem
+++ b/src/groups/bmq/bmqtst/package/bmqtst.mem
@@ -1,5 +1,6 @@
 bmqtst_blobtestutil
 bmqtst_mocktime
+bmqtst_schedulerlockguard
 bmqtst_scopedlogobserver
 bmqtst_table
 bmqtst_tempfile

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -33,6 +33,7 @@
 #include <bmqio_testchannel.h>
 #include <bmqp_crc32c.h>
 #include <bmqp_ctrlmsg_messages.h>
+#include <bmqtst_schedulerlockguard.h>
 
 #include <bmqu_memoutstream.h>
 #include <bmqu_tempdirectory.h>
@@ -1491,18 +1492,27 @@ static void test14_leaderCSLCommitFailure()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_LDR_HEALING_STG2);
 
-    // 2. Invoke failure commit callback at the CSL
-    tester.d_clusterStateLedger_p->_commitAdvisories(
-        mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
+    // 2. Invoke failure commit callback at the CSL.
+    //
+    // CSL_CMT_FAIL reschedules the watchdog to fire immediately, and the
+    // scheduler would run it (mutating the Cluster FSM) on its own thread,
+    // racing this thread's `healthState()` reads.  Pause the scheduler so the
+    // watchdog cannot fire while we inspect the FSM state; destroying the
+    // guard resumes the scheduler and drains the now-due watchdog.
+    {
+        bmqtst::SchedulerLockGuard schedulerGuard(
+            &tester.d_cluster_mp->_scheduler());
 
-    // CSL_CMT_FAIL triggers the watchdog (reschedules to now) but stays in
-    // LDR_HEALING_STG2.  Advance time so the triggered watchdog fires.
-    // The e_WATCHDOG transition goes to UNKNOWN, which re-applies
-    // SLCT_LDR, landing in LDR_HEALING_STG1.
-    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_LDR_HEALING_STG2);
-    tester.d_cluster_mp->advanceTime(1);
-    tester.d_cluster_mp->waitForScheduler();
+        tester.d_clusterStateLedger_p->_commitAdvisories(
+            mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
+
+        // The commit failure itself does not change the FSM state.
+        BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                        mqbc::ClusterStateTableState::e_LDR_HEALING_STG2);
+    }
+    // Guard destroyed: the triggered watchdog fires and is drained.  The
+    // e_WATCHDOG transition goes to UNKNOWN, which re-applies SLCT_LDR,
+    // landing in LDR_HEALING_STG1.
 
     // Verify that self restarts healing
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
@@ -1541,18 +1551,27 @@ static void test15_followerCSLCommitFailure()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_FOL_HEALING);
 
-    // 2. Invoke failure commit callback at the CSL
-    tester.d_clusterStateLedger_p->_commitAdvisories(
-        mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
+    // 2. Invoke failure commit callback at the CSL.
+    //
+    // CSL_CMT_FAIL reschedules the watchdog to fire immediately, and the
+    // scheduler would run it (mutating the Cluster FSM) on its own thread,
+    // racing this thread's `healthState()` reads.  Pause the scheduler so the
+    // watchdog cannot fire while we inspect the FSM state; destroying the
+    // guard resumes the scheduler and drains the now-due watchdog.
+    {
+        bmqtst::SchedulerLockGuard schedulerGuard(
+            &tester.d_cluster_mp->_scheduler());
 
-    // CSL_CMT_FAIL triggers the watchdog (reschedules to now) but stays in
-    // FOL_HEALING.  Advance time so the triggered watchdog fires.
-    // The e_WATCHDOG transition goes to UNKNOWN, which re-applies
-    // SLCT_FOL, landing back in FOL_HEALING.
-    BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
-    tester.d_cluster_mp->advanceTime(1);
-    tester.d_cluster_mp->waitForScheduler();
+        tester.d_clusterStateLedger_p->_commitAdvisories(
+            mqbc::ClusterStateLedgerCommitStatus::e_CANCELED);
+
+        // The commit failure itself does not change the FSM state.
+        BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
+                        mqbc::ClusterStateTableState::e_FOL_HEALING);
+    }
+    // Guard destroyed: the triggered watchdog fires and is drained.  The
+    // e_WATCHDOG transition goes to UNKNOWN, which re-applies SLCT_FOL,
+    // landing back in FOL_HEALING.
 
     // Verify that self restarts healing
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),

--- a/src/groups/mqb/mqbmock/mqbmock_cluster.h
+++ b/src/groups/mqb/mqbmock/mqbmock_cluster.h
@@ -64,7 +64,7 @@
 #include <bslma_managedptr.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
-#include <bsls_cpp11.h>
+#include <bsls_keyword.h>
 #include <bsls_timeinterval.h>
 #include <bsls_types.h>
 
@@ -246,8 +246,8 @@ class Cluster : public mqbi::Cluster {
 
   private:
     // NOT IMPLEMENTED
-    Cluster(const Cluster&) BSLS_CPP11_DELETED;
-    Cluster& operator=(const Cluster&) BSLS_CPP11_DELETED;
+    Cluster(const Cluster&) BSLS_KEYWORD_DELETED;
+    Cluster& operator=(const Cluster&) BSLS_KEYWORD_DELETED;
 
   private:
     // PRIVATE MANIPULATORS


### PR DESCRIPTION
Fix a TSAN data race in `mqbc_clusterstatemanager.t` cases 14/15: on CSL commit failure the watchdog fires on the scheduler thread and (via the mock dispatcher's inline execution) mutates the Cluster FSM state while the main thread reads it via `healthState()`. Test-only race — in production FSM access is serialized on the dispatcher thread.

Changes:
- Add reusable `bmqtst::SchedulerLockGuard`: parks a `bdlmt::EventScheduler`'s dispatcher thread for the guard's lifetime, resumes and drains now-due events on destruction.
- `mqbc_clusterstatemanager.t` cases 14/15: pause the scheduler around the commit-failure assertion, then let guard destruction fire and drain the watchdog.

Fixes the following TSAN issue:

```
[23:44:22] CASE 14: FAILURE (rc 66)
TEST /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp CASE 14

10JUL2026_23:44:21.791 2869:140221294554880 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1194 MQBC.CLUSTERSTATEMANAGER Cluster (testCluster): Failed to commit advisory: [ rId = NULL choice = [ clusterMessage = [ choice = [ leaderAdvisory = [ sequenceNumber = [ electorTerm = 2 sequenceNumber = 1 ] partitions = [ [ partitionId = 0 primaryNodeId = 1 primaryLeaseId = 1 ] [ partitionId = 1 primaryNodeId = 1 primaryLeaseId = 1 ] [ partitionId = 2 primaryNodeId = 1 primaryLeaseId = 1 ] [ partitionId = 3 primaryNodeId = 1 primaryLeaseId = 1 ] ] queues = [ ] ] ] ] ] ], with status 'CANCELED' 

10JUL2026_23:44:21.791 2869:140221133878976 ERROR /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1322 MQBC.CLUSTERSTATEMANAGER ALARM [RECOVERY] Cluster (testCluster): Watchdog triggered because cluster startup healing sequence was not completed in the configured time of 300 seconds. Retries remaining: 5 of 5 ALARM
==================
WARNING: ThreadSanitizer: data race (pid=2869)
  Write of size 4 at 0x728400004ce8 by thread T5:
    #0 BloombergLP::mqbc::ClusterFSM::processEvent(bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEventMetadata> const&) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterfsm.cpp:63:13 (mqbc_clusterstatemanager.t+0x885c2d) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #1 BloombergLP::mqbc::ClusterFSM::enqueueEvent(bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEventMetadata> const&) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterfsm.cpp:152:9 (mqbc_clusterstatemanager.t+0x886827) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #2 BloombergLP::mqbc::ClusterStateManager::applyFSMEvent(BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEventMetadata const&) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1237:18 (mqbc_clusterstatemanager.t+0x846057) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #3 BloombergLP::mqbc::ClusterStateManager::onWatchdogDispatched(int) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1331:9 (mqbc_clusterstatemanager.t+0x85333e) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #4 void BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)>::operator()<BloombergLP::mqbc::ClusterStateManager*>(BloombergLP::mqbc::ClusterStateManager* const&, int) const /opt/bb/include/bdlf_memfn.h:568:16 (mqbc_clusterstatemanager.t+0x87adcc) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #5 void BloombergLP::bdlf::Bind_Invoker<void, 2>::invoke<BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)> const, BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int> const, BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)> const*, BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int> const*, BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:8635:9 (mqbc_clusterstatemanager.t+0x87aca9) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #6 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::invokeImpl<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&, BloombergLP::bslmf::Tag<0u>) const /opt/bb/include/bdlf_bind.h:5950:24 (mqbc_clusterstatemanager.t+0x87abdc) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #7 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::invoke<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:6014:16 (mqbc_clusterstatemanager.t+0x87ab59) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #8 BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::operator()() const /opt/bb/include/bdlf_bind.h:6023:16 (mqbc_clusterstatemanager.t+0x87aade) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #9 BloombergLP::bslstl::Function_InvokerUtil_Dispatch<4, void (), BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>>::invoke(BloombergLP::bslstl::Function_Rep const*) /opt/bb/include/bslstl_function_invokerutil.h:951:12 (mqbc_clusterstatemanager.t+0x87aa62) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #10 BloombergLP::bslstl::Function_Variadic<void ()>::operator()() const /opt/bb/include/bslstl_function.h:1545:12 (mqbc_clusterstatemanager.t+0xc3bc90) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #11 BloombergLP::mqbmock::Dispatcher::processQueue() /blazingmq/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp:154:9 (mqbc_clusterstatemanager.t+0x12687c0) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #12 BloombergLP::mqbmock::Dispatcher::_execute(bsl::function<void ()> const&) /blazingmq/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp:133:9 (mqbc_clusterstatemanager.t+0x126853c) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #13 BloombergLP::mqbmock::Dispatcher::execute(bsl::function<void ()> const&, BloombergLP::mqbi::DispatcherClient*, BloombergLP::mqbi::DispatcherEventType::Enum) /blazingmq/src/groups/mqb/mqbmock/mqbmock_dispatcher.cpp:98:5 (mqbc_clusterstatemanager.t+0x126846a) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #14 BloombergLP::mqbc::ClusterStateManager::onWatchdog(int) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1292:19 (mqbc_clusterstatemanager.t+0x843de9) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #15 void BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)>::operator()<BloombergLP::mqbc::ClusterStateManager*>(BloombergLP::mqbc::ClusterStateManager* const&, int) const /opt/bb/include/bdlf_memfn.h:568:16 (mqbc_clusterstatemanager.t+0x87adcc) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #16 void BloombergLP::bdlf::Bind_Invoker<void, 2>::invoke<BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)> const, BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int> const, BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::MemFn<void (BloombergLP::mqbc::ClusterStateManager::*)(int)> const*, BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int> const*, BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:8635:9 (mqbc_clusterstatemanager.t+0x87aca9) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #17 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::invokeImpl<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&, BloombergLP::bslmf::Tag<0u>) const /opt/bb/include/bdlf_bind.h:5950:24 (mqbc_clusterstatemanager.t+0x87abdc) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #18 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::invoke<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&) const /opt/bb/include/bdlf_bind.h:6014:16 (mqbc_clusterstatemanager.t+0x87ab59) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #19 BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>::operator()() const /opt/bb/include/bdlf_bind.h:6023:16 (mqbc_clusterstatemanager.t+0x87aade) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #20 BloombergLP::bslstl::Function_InvokerUtil_Dispatch<4, void (), BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (BloombergLP::mqbc::ClusterStateManager::*)(int), BloombergLP::bdlf::Bind_BoundTuple2<BloombergLP::mqbc::ClusterStateManager*, int>>>::invoke(BloombergLP::bslstl::Function_Rep const*) /opt/bb/include/bslstl_function_invokerutil.h:951:12 (mqbc_clusterstatemanager.t+0x87aa62) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #21 BloombergLP::bslstl::Function_Variadic<void ()>::operator()() const /opt/bb/include/bslstl_function.h:1545:12 (mqbc_clusterstatemanager.t+0xc3bc90) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #22 BloombergLP::defaultDispatcherFunction(bsl::function<void ()> const&) /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp:106:5 (mqbc_clusterstatemanager.t+0xfa28b5) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #23 BloombergLP::bslstl::Function_InvokerUtil_Dispatch<1, void (bsl::function<void ()> const&), void (*)(bsl::function<void ()> const&)>::invoke(BloombergLP::bslstl::Function_Rep const*, bsl::function<void ()> const&) /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_function_invokerutil.h:807:12 (mqbc_clusterstatemanager.t+0xfb87d2) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #24 BloombergLP::bslstl::Function_Variadic<void (bsl::function<void ()> const&)>::operator()(bsl::function<void ()> const&) const /blazingmq/deps/srcs/bde/groups/bsl/bslstl/bslstl_function.h:1545:12 (mqbc_clusterstatemanager.t+0xfabe00) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #25 BloombergLP::bdlmt::EventScheduler::dispatchEvents() /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp:395:21 (mqbc_clusterstatemanager.t+0xfa110d) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #26 void BloombergLP::bdlf::MemFn<void (BloombergLP::bdlmt::EventScheduler::*)()>::operator()<BloombergLP::bdlmt::EventScheduler*>(BloombergLP::bdlmt::EventScheduler* const&) const /blazingmq/deps/srcs/bde/groups/bdl/bdlf/bdlf_memfn.h:557:16 (mqbc_clusterstatemanager.t+0xfc3660) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #27 void BloombergLP::bdlf::Bind_Invoker<void, 1>::invoke<BloombergLP::bdlf::MemFn<void (BloombergLP::bdlmt::EventScheduler::*)()> const, BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*> const, BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::MemFn<void (BloombergLP::bdlmt::EventScheduler::*)()> const*, BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*> const*, BloombergLP::bdlf::Bind_ArgTuple0&) const /blazingmq/deps/srcs/bde/groups/bdl/bdlf/bdlf_bind.h:8610:9 (mqbc_clusterstatemanager.t+0xfc3541) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #28 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>>::invokeImpl<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&, BloombergLP::bslmf::Tag<0u>) const /blazingmq/deps/srcs/bde/groups/bdl/bdlf/bdlf_bind.h:5950:24 (mqbc_clusterstatemanager.t+0xfc34ac) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #29 void BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>>::invoke<BloombergLP::bdlf::Bind_ArgTuple0>(BloombergLP::bdlf::Bind_ArgTuple0&) const /blazingmq/deps/srcs/bde/groups/bdl/bdlf/bdlf_bind.h:6014:16 (mqbc_clusterstatemanager.t+0xfc3429) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #30 BloombergLP::bdlf::Bind_ImplExplicit<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>>::operator()() const /blazingmq/deps/srcs/bde/groups/bdl/bdlf/bdlf_bind.h:6023:16 (mqbc_clusterstatemanager.t+0xfc[323](https://github.com/bloomberg/blazingmq/actions/runs/29127130203/job/86481578742#step:5:324)e) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #31 BloombergLP::bslmt::EntryPointFunctorAdapter<BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>>>::invokerFunction(void*) /blazingmq/deps/srcs/bde/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.h:324:5 (mqbc_clusterstatemanager.t+0xfc2fa4) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #32 bslmt_EntryPointFunctorAdapter_invoker /blazingmq/deps/srcs/bde/groups/bsl/bslmt/bslmt_entrypointfunctoradapter.cpp:15:5 (mqbc_clusterstatemanager.t+0x1050a43) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)

  Previous read of size 4 at 0x728400004ce8 by main thread:
    #0 BloombergLP::mqbc::ClusterFSM::state() const /blazingmq/src/groups/mqb/mqbc/mqbc_clusterfsm.h:486:12 (mqbc_clusterstatemanager.t+0x7fe4d0) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #1 BloombergLP::mqbc::ClusterStateManager::healthState() const /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h:698:25 (mqbc_clusterstatemanager.t+0x7f904c) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #2 test14_leaderCSLCommitFailure() /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:1502:5 (mqbc_clusterstatemanager.t+0x7e839c) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #3 main /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:2959:14 (mqbc_clusterstatemanager.t+0x7de886) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)

  Location is heap block of size 4720 at 0x728400003c00 allocated by main thread:
    #0 malloc <null> (mqbc_clusterstatemanager.t+0x7579b4) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #1 BloombergLP::bslma::MallocFreeAllocator::allocate(unsigned long) /blazingmq/deps/srcs/bde/groups/bsl/bslma/bslma_mallocfreeallocator.cpp:112:20 (mqbc_clusterstatemanager.t+0x1048172) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #2 BloombergLP::bslma::TestAllocator::allocate(unsigned long) /blazingmq/deps/srcs/bde/groups/bsl/bslma/bslma_testallocator.cpp:468:58 (mqbc_clusterstatemanager.t+0x104dc2c) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #3 operator new(unsigned long, BloombergLP::bslma::Allocator&) /opt/bb/include/bslma_allocator.h:772:27 (mqbc_clusterstatemanager.t+0x7f9c4e) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #4 (anonymous namespace)::Tester::Tester(bool, int, long long) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:190:13 (mqbc_clusterstatemanager.t+0x7ee7f5) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #5 test14_leaderCSLCommitFailure() /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:1449:12 (mqbc_clusterstatemanager.t+0x7e7e7f) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #6 main /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:2959:14 (mqbc_clusterstatemanager.t+0x7de886) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)

  Thread T5 'bdl.EventSched' (tid=2875, running) created by main thread at:
    #0 pthread_create <null> (mqbc_clusterstatemanager.t+0x759cee) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #1 BloombergLP::bslmt::ThreadUtilImpl<BloombergLP::bslmt::Platform::PosixThreads>::create(unsigned long*, BloombergLP::bslmt::ThreadAttributes const&, void* (*)(void*), void*) /blazingmq/deps/srcs/bde/groups/bsl/bslmt/bslmt_threadutilimpl_pthread.cpp:231:10 (mqbc_clusterstatemanager.t+0x105838d) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #2 int BloombergLP::bslmt::ThreadUtil::createWithAllocator<BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>>>(unsigned long*, BloombergLP::bslmt::ThreadAttributes const&, BloombergLP::bdlf::Bind<BloombergLP::bslmf::Nil, void (BloombergLP::bdlmt::EventScheduler::*)(), BloombergLP::bdlf::Bind_BoundTuple1<BloombergLP::bdlmt::EventScheduler*>> const&, BloombergLP::bslma::Allocator*) /blazingmq/deps/srcs/bde/groups/bsl/bslmt/bslmt_threadutil.h:863:14 (mqbc_clusterstatemanager.t+0xfad811) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #3 BloombergLP::bdlmt::EventScheduler::start(BloombergLP::bslmt::ThreadAttributes const&) /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp:1301:9 (mqbc_clusterstatemanager.t+0xfa9a92) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #4 BloombergLP::bdlmt::EventScheduler::start() /blazingmq/deps/srcs/bde/groups/bdl/bdlmt/bdlmt_eventscheduler.cpp:1272:12 (mqbc_clusterstatemanager.t+0xfa967f) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #5 BloombergLP::mqbmock::Cluster::start(std::__1::basic_ostream<char, std::__1::char_traits<char>>&) /blazingmq/src/groups/mqb/mqbmock/mqbmock_cluster.cpp:342:17 (mqbc_clusterstatemanager.t+0x109b423) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #6 (anonymous namespace)::Tester::Tester(bool, int, long long) /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:209:47 (mqbc_clusterstatemanager.t+0x7eea3d) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #7 test14_leaderCSLCommitFailure() /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:1449:12 (mqbc_clusterstatemanager.t+0x7e7e7f) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)
    #8 main /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp:2959:14 (mqbc_clusterstatemanager.t+0x7de886) (BuildId: 1615f301ea4979adf9bdd1cdf1674746a99c4340)

SUMMARY: ThreadSanitizer: data race /blazingmq/src/groups/mqb/mqbc/mqbc_clusterfsm.cpp:63:13 in BloombergLP::mqbc::ClusterFSM::processEvent(bsl::pair<BloombergLP::mqbc::ClusterStateTableEvent::Enum, BloombergLP::mqbc::ClusterFSMEventMetadata> const&)
==================

10JUL2026_23:44:22.031 2869:140221294554880 WARN /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1359 MQBC.CLUSTERSTATEMANAGER Cluster (testCluster): Received failed follower LSN response [ rId = 4 choice = [ status = [ category = E_CANCELED code = -10 message = "Cancellation by Cluster FSM" ] ] ] from [W2, 4]. Skipping this node's response. 

10JUL2026_23:44:22.031 2869:140221294554880 WARN /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1359 MQBC.CLUSTERSTATEMANAGER Cluster (testCluster): Received failed follower LSN response [ rId = 5 choice = [ status = [ category = E_CANCELED code = -10 message = "Cancellation by Cluster FSM" ] ] ] from [W1, 3]. Skipping this node's response. 

10JUL2026_23:44:22.032 2869:140221294554880 WARN /blazingmq/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp:1359 MQBC.CLUSTERSTATEMANAGER Cluster (testCluster): Received failed follower LSN response [ rId = 6 choice = [ status = [ category = E_CANCELED code = -10 message = "Cancellation by Cluster FSM" ] ] ] from [E2, 2]. Skipping this node's response. 
ThreadSanitizer: reported 1 warnings
```