### PR TITLE
Fix[mqbc::ClusterStateLedgerUtil]: Prevent recordSize overflow

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.cpp
@@ -102,8 +102,16 @@ const int ClusterStateRecordHeader::k_RECORD_TYPE_MASK =
     bdlb::BitMaskUtil::one(ClusterStateRecordHeader::k_RECORD_TYPE_START_IDX,
                            ClusterStateRecordHeader::k_RECORD_TYPE_NUM_BITS);
 
+const int ClusterStateRecordHeader::k_LEADER_ADVISORY_WORDS_MASK =
+    bdlb::BitMaskUtil::one(
+        ClusterStateRecordHeader::k_LEADER_ADVISORY_WORDS_START_IDX,
+        ClusterStateRecordHeader::k_LEADER_ADVISORY_WORDS_NUM_BITS);
+
 const unsigned int ClusterStateRecordHeader::k_HEADER_NUM_WORDS =
     sizeof(ClusterStateRecordHeader) / bmqp::Protocol::k_WORD_SIZE;
+
+const unsigned int ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS =
+    (1U << ClusterStateRecordHeader::k_LEADER_ADVISORY_WORDS_NUM_BITS) - 1;
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
@@ -235,7 +235,7 @@ bsl::ostream& operator<<(bsl::ostream&                stream,
 /// +---------------+---------------+---------------+---------------+
 /// |   HW  |  RT   |                   Reserved                    |
 /// +---------------+---------------+---------------+---------------+
-/// |                       LeaderAdvisoryWords                     |
+/// |Reservd|                  LeaderAdvisoryWords                  |
 /// +---------------+---------------+---------------+---------------+
 /// |                    Elector Term Upper Bits                    |
 /// +---------------+---------------+---------------+---------------+
@@ -272,14 +272,17 @@ bsl::ostream& operator<<(bsl::ostream&                stream,
 struct ClusterStateRecordHeader {
   private:
     // PRIVATE CONSTANTS
-    static const int k_HEADER_WORDS_NUM_BITS = 4;
-    static const int k_RECORD_TYPE_NUM_BITS  = 4;
+    static const int k_HEADER_WORDS_NUM_BITS          = 4;
+    static const int k_RECORD_TYPE_NUM_BITS           = 4;
+    static const int k_LEADER_ADVISORY_WORDS_NUM_BITS = 28;
 
-    static const int k_HEADER_WORDS_START_IDX = 4;
-    static const int k_RECORD_TYPE_START_IDX  = 0;
+    static const int k_HEADER_WORDS_START_IDX          = 4;
+    static const int k_RECORD_TYPE_START_IDX           = 0;
+    static const int k_LEADER_ADVISORY_WORDS_START_IDX = 0;
 
     static const int k_HEADER_WORDS_MASK;
     static const int k_RECORD_TYPE_MASK;
+    static const int k_LEADER_ADVISORY_WORDS_MASK;
 
   private:
     // DATA
@@ -326,6 +329,9 @@ struct ClusterStateRecordHeader {
     /// sufficient to capture header words).  This value should *never*
     /// change.
     static const int k_MIN_HEADER_SIZE = 1;
+
+    /// Maximum value of `leaderAdvisoryWords`.
+    static const unsigned int k_MAX_LEADER_ADVISORY_WORDS;
 
   public:
     // CREATORS
@@ -475,7 +481,7 @@ inline ClusterStateRecordHeader&
 ClusterStateRecordHeader::setHeaderWords(unsigned int value)
 {
     // PRECONDITIONS: protect against overflow
-    BSLS_ASSERT_SAFE(value <= (1 << k_HEADER_WORDS_NUM_BITS) - 1);
+    BSLS_ASSERT_SAFE(value <= (1U << k_HEADER_WORDS_NUM_BITS) - 1);
 
     d_headerWordsAndRecordType = static_cast<unsigned char>(
         (d_headerWordsAndRecordType & k_RECORD_TYPE_MASK) |
@@ -497,6 +503,9 @@ ClusterStateRecordHeader::setRecordType(ClusterStateRecordType::Enum value)
 inline ClusterStateRecordHeader&
 ClusterStateRecordHeader::setLeaderAdvisoryWords(unsigned int value)
 {
+    // PRECONDITIONS: protect against overflow
+    BSLS_ASSERT_SAFE(value <= k_MAX_LEADER_ADVISORY_WORDS);
+
     d_leaderAdvisoryWords = value;
     return *this;
 }
@@ -541,7 +550,8 @@ ClusterStateRecordHeader::recordType() const
 
 inline unsigned int ClusterStateRecordHeader::leaderAdvisoryWords() const
 {
-    return d_leaderAdvisoryWords;
+    return (d_leaderAdvisoryWords & k_LEADER_ADVISORY_WORDS_MASK) >>
+           k_LEADER_ADVISORY_WORDS_START_IDX;
 }
 
 inline bsls::Types::Uint64 ClusterStateRecordHeader::electorTerm() const

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.h
@@ -344,7 +344,8 @@ struct ClusterStateRecordHeader {
 
     /// Set the total size (in words) of this header to the specified
     /// `value` and return a reference offering modifiable access to this
-    /// object.
+    /// object.  The behavior is undefined unless `value` fits in
+    /// `k_HEADER_WORDS_NUM_BITS` bits (i.e. `value <= 15`).
     ClusterStateRecordHeader& setHeaderWords(unsigned int value);
 
     /// Set the record type to the specified `value` and return a reference
@@ -354,7 +355,8 @@ struct ClusterStateRecordHeader {
 
     /// Set the total size (in words) of the leader advisory to the
     /// specified `value` and return a reference offering modifiable access
-    /// to this object.
+    /// to this object.  The behavior is undefined unless
+    /// `value <= k_MAX_LEADER_ADVISORY_WORDS`.
     ClusterStateRecordHeader& setLeaderAdvisoryWords(unsigned int value);
 
     /// Set the leader elector term to the specified `value` and return a

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
@@ -18,6 +18,7 @@
 #include <bmqu_memoutstream.h>
 
 // BDE
+#include <bsl_cstring.h>
 #include <bsl_limits.h>
 #include <bsls_assert.h>
 
@@ -32,9 +33,6 @@ using namespace bsl;
 //                            TEST HELPERS UTILITY
 // ----------------------------------------------------------------------------
 namespace {
-
-const unsigned int k_UNSIGNED_INT_MAX =
-    bsl::numeric_limits<unsigned int>::max();
 
 const bsls::Types::Uint64 k_UINT64_MAX =
     bsl::numeric_limits<bsls::Types::Uint64>::max();
@@ -112,14 +110,17 @@ static void test1_breathingTest()
         ClusterStateRecordHeader fh2;
         fh2.setHeaderWords(15)
             .setRecordType(ClusterStateRecordType::e_COMMIT)
-            .setLeaderAdvisoryWords(k_UNSIGNED_INT_MAX)
+            .setLeaderAdvisoryWords(
+                ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS)
             .setElectorTerm(k_UINT64_MAX)
             .setSequenceNumber(k_UINT64_MAX)
             .setTimestamp(k_UINT64_MAX);
 
         BMQTST_ASSERT_EQ(fh2.headerWords(), 15U);
         BMQTST_ASSERT_EQ(fh2.recordType(), ClusterStateRecordType::e_COMMIT);
-        BMQTST_ASSERT_EQ(fh2.leaderAdvisoryWords(), k_UNSIGNED_INT_MAX);
+        BMQTST_ASSERT_EQ(
+            fh2.leaderAdvisoryWords(),
+            ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS);
         BMQTST_ASSERT_EQ(fh2.electorTerm(), k_UINT64_MAX);
         BMQTST_ASSERT_EQ(fh2.sequenceNumber(), k_UINT64_MAX);
         BMQTST_ASSERT_EQ(fh2.timestamp(), k_UINT64_MAX);
@@ -201,6 +202,41 @@ static void test2_enumPrint()
     }
 }
 
+static void test3_leaderAdvisoryWordsBound()
+// --------------------------------------------------------------------
+// LEADER ADVISORY WORDS BOUND
+//
+// Concerns:
+//   'ClusterStateRecordHeader::leaderAdvisoryWords' is bounded to
+//   'k_LEADER_ADVISORY_WORDS_NUM_BITS' bits so that record-size and
+//   message-length computations cannot overflow.
+//
+// Plan:
+//   1. The setter rejects any value above the maximum.
+//   2. The accessor masks the reserved top bits, so a corrupt/forged record
+//      with those bits set reads back as the bounded maximum.
+//
+// Testing:
+//   ClusterStateRecordHeader::setLeaderAdvisoryWords
+//   ClusterStateRecordHeader::leaderAdvisoryWords
+// --------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("LEADER ADVISORY WORDS BOUND");
+
+    using namespace mqbc;
+
+    // 1. Setter
+    ClusterStateRecordHeader header;
+    BMQTST_ASSERT_SAFE_FAIL(header.setLeaderAdvisoryWords(
+        ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS + 1));
+
+    // 2. Accessor
+    ClusterStateRecordHeader forged;
+    bsl::memset(&forged, 0xFF, sizeof(forged));
+    BMQTST_ASSERT_EQ(forged.leaderAdvisoryWords(),
+                     ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS);
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -211,6 +247,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 3: test3_leaderAdvisoryWordsBound(); break;
     case 2: test2_enumPrint(); break;
     case 1: test1_breathingTest(); break;
     default: {

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerprotocol.t.cpp
@@ -106,9 +106,10 @@ static void test1_breathingTest()
         BMQTST_ASSERT_EQ(fh.sequenceNumber(), 0ULL);
         BMQTST_ASSERT_EQ(fh.timestamp(), 0ULL);
 
-        // Create ClusterStateRecordHeader, set fields, assert fields
+        // Create ClusterStateRecordHeader, set fields, assert fields.
+        const unsigned int       k_HEADER_WORDS = 15;
         ClusterStateRecordHeader fh2;
-        fh2.setHeaderWords(15)
+        fh2.setHeaderWords(k_HEADER_WORDS)
             .setRecordType(ClusterStateRecordType::e_COMMIT)
             .setLeaderAdvisoryWords(
                 ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS)
@@ -116,7 +117,7 @@ static void test1_breathingTest()
             .setSequenceNumber(k_UINT64_MAX)
             .setTimestamp(k_UINT64_MAX);
 
-        BMQTST_ASSERT_EQ(fh2.headerWords(), 15U);
+        BMQTST_ASSERT_EQ(fh2.headerWords(), k_HEADER_WORDS);
         BMQTST_ASSERT_EQ(fh2.recordType(), ClusterStateRecordType::e_COMMIT);
         BMQTST_ASSERT_EQ(
             fh2.leaderAdvisoryWords(),

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.cpp
@@ -288,10 +288,9 @@ int ClusterStateLedgerUtil::validateLog(mqbsi::Log::Offset* offset,
         }
 
         // Validate CRC32-C on header + payload
-        const bsls::Types::Int64 recordSize =
-            ClusterStateLedgerUtil::recordSize(*recHeader);
+        const int recordSize = ClusterStateLedgerUtil::recordSize(*recHeader);
         bdlbb::Blob blob;
-        rc = log->alias(&blob, static_cast<int>(recordSize), currOffset);
+        rc = log->alias(&blob, recordSize, currOffset);
         if (rc != 0) {
             BALL_LOG_ERROR << "Unable to read header and record in log '"
                            << log->logConfig().location() << "' at offset "

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.h
@@ -261,9 +261,8 @@ struct ClusterStateLedgerUtil {
                                   const bdlbb::Blob&            record,
                                   int                           offset = 0);
 
-    /// Return the size in bytes of the specified `header`.
-    static bsls::Types::Int64
-    recordSize(const ClusterStateRecordHeader& header);
+    /// Return the size in bytes of the record described by `header`.
+    static int recordSize(const ClusterStateRecordHeader& header);
 };
 
 // ============================================================================
@@ -274,7 +273,7 @@ struct ClusterStateLedgerUtil {
 // struct ClusterStateLedgerUtil
 // -----------------------------
 
-inline bsls::Types::Int64
+inline int
 ClusterStateLedgerUtil::recordSize(const ClusterStateRecordHeader& header)
 {
     return (header.headerWords() + header.leaderAdvisoryWords()) *

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
@@ -833,19 +833,37 @@ static void test10_recordSize()
 {
     bmqtst::TestHelper::printTestName("RECORD SIZE");
 
+    const int k_LEADER_ADVISORY_WORDS = 17;
+
     mqbc::ClusterStateRecordHeader header;
     header.setHeaderWords(mqbc::ClusterStateRecordHeader::k_HEADER_NUM_WORDS)
         .setRecordType(mqbc::ClusterStateRecordType::e_SNAPSHOT)
-        .setLeaderAdvisoryWords(17)
+        .setLeaderAdvisoryWords(k_LEADER_ADVISORY_WORDS)
         .setElectorTerm(3)
         .setSequenceNumber(100)
         .setTimestamp(123456U);
 
-    bsls::Types::Int64 expectedRecordSize =
-        (mqbc::ClusterStateRecordHeader::k_HEADER_NUM_WORDS + 17) *
+    const int expectedRecordSize =
+        (mqbc::ClusterStateRecordHeader::k_HEADER_NUM_WORDS +
+         k_LEADER_ADVISORY_WORDS) *
         bmqp::Protocol::k_WORD_SIZE;
     BMQTST_ASSERT_EQ(mqbc::ClusterStateLedgerUtil::recordSize(header),
                      expectedRecordSize);
+
+    // Integer overflow prevention: exercise 'recordSize' at the maximum of
+    // both its inputs.
+    const unsigned int k_MAX_HEADER_WORDS = 15;  // 4-bit field
+    const unsigned int maxLeaderAdvisoryWords =
+        mqbc::ClusterStateRecordHeader::k_MAX_LEADER_ADVISORY_WORDS;
+    header.setHeaderWords(k_MAX_HEADER_WORDS)
+        .setLeaderAdvisoryWords(maxLeaderAdvisoryWords);
+
+    const int expectedMaxRecordSize = (k_MAX_HEADER_WORDS +
+                                       maxLeaderAdvisoryWords) *
+                                      bmqp::Protocol::k_WORD_SIZE;
+    BMQTST_ASSERT_EQ(mqbc::ClusterStateLedgerUtil::recordSize(header),
+                     expectedMaxRecordSize);
+    BMQTST_ASSERT_GT(mqbc::ClusterStateLedgerUtil::recordSize(header), 0);
 }
 
 // ============================================================================

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledgerutil.t.cpp
@@ -838,15 +838,12 @@ static void test10_recordSize()
     mqbc::ClusterStateRecordHeader header;
     header.setHeaderWords(mqbc::ClusterStateRecordHeader::k_HEADER_NUM_WORDS)
         .setRecordType(mqbc::ClusterStateRecordType::e_SNAPSHOT)
-        .setLeaderAdvisoryWords(k_LEADER_ADVISORY_WORDS)
-        .setElectorTerm(3)
-        .setSequenceNumber(100)
-        .setTimestamp(123456U);
+        .setLeaderAdvisoryWords(k_LEADER_ADVISORY_WORDS);
 
-    const int expectedRecordSize =
+    const int expectedRecordSize = static_cast<int>(
         (mqbc::ClusterStateRecordHeader::k_HEADER_NUM_WORDS +
          k_LEADER_ADVISORY_WORDS) *
-        bmqp::Protocol::k_WORD_SIZE;
+        bmqp::Protocol::k_WORD_SIZE);
     BMQTST_ASSERT_EQ(mqbc::ClusterStateLedgerUtil::recordSize(header),
                      expectedRecordSize);
 
@@ -858,9 +855,9 @@ static void test10_recordSize()
     header.setHeaderWords(k_MAX_HEADER_WORDS)
         .setLeaderAdvisoryWords(maxLeaderAdvisoryWords);
 
-    const int expectedMaxRecordSize = (k_MAX_HEADER_WORDS +
-                                       maxLeaderAdvisoryWords) *
-                                      bmqp::Protocol::k_WORD_SIZE;
+    const int expectedMaxRecordSize = static_cast<int>(
+        (k_MAX_HEADER_WORDS + maxLeaderAdvisoryWords) *
+        bmqp::Protocol::k_WORD_SIZE);
     BMQTST_ASSERT_EQ(mqbc::ClusterStateLedgerUtil::recordSize(header),
                      expectedMaxRecordSize);
     BMQTST_ASSERT_GT(mqbc::ClusterStateLedgerUtil::recordSize(header), 0);

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledgeriterator.cpp
@@ -93,7 +93,9 @@ int IncoreClusterStateLedgerIterator::next()
         /// Invalid record header
         rc_INVALID_RECORD_HEADER = -3,
         /// An offset outside of the ledger's range is reached
-        rc_OUT_OF_LEDGER_RANGE = -4
+        rc_OUT_OF_LEDGER_RANGE = -4,
+        /// Invalid record size
+        rc_INVALID_RECORD_SIZE = -5
     };
 
     bdlb::ScopeExitAny guard(bdlf::BindUtil::bind(onInvalidNext, &d_isValid));
@@ -122,8 +124,13 @@ int IncoreClusterStateLedgerIterator::next()
         incrementOffset(fh->headerWords() * bmqp::Protocol::k_WORD_SIZE);
     }
     else {
-        incrementOffset(
-            ClusterStateLedgerUtil::recordSize(*d_currRecordHeader_p));
+        const int recordSize = ClusterStateLedgerUtil::recordSize(
+            *d_currRecordHeader_p);
+        if (recordSize <= 0) {
+            return rc_INVALID_RECORD_SIZE;  // RETURN
+        }
+
+        incrementOffset(recordSize);
     }
 
     if (d_currRecordId.offset() ==


### PR DESCRIPTION
## Summary
  - Hardens CSL record header handling against integer overflow when a record's `leaderAdvisoryWords` field holds an unexpectedly large value (e.g. from a corrupt or malformed record).
  - `ClusterStateLedgerUtil::recordSize()` computed `(headerWords + leaderAdvisoryWords) * k_WORD_SIZE` in 32-bit arithmetic. For certain `leaderAdvisoryWords` values the product wrapped: it could wrap to `0` (the incore ledger iterator then calls `incrementOffset(0)` and stops advancing), or to a small value (causing CRC to be validated over an incorrectly sized window).
  - Additionally, a secondary overflow in `loadClusterMessage()` yields a negative length: `msgLen = leaderAdvisoryWords * k_WORD_SIZE` is computed into a signed `int` and goes negative for large values. `validateRecordHeader()` only rejects `leaderAdvisoryWords == 0`, so other out-of-range values were not caught before reaching these paths.
  - Fix: structurally bound `leaderAdvisoryWords` so downstream size arithmetic cannot overflow, rather than relying on callers to validate first.