### PR TITLE
Fix[bmqio]: data race on d_streamSocket_sp in NtcChannel

### DIFF
--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.cpp
@@ -1308,6 +1308,7 @@ void NtcChannel::setChannelId(int channelId)
 
 void NtcChannel::setWriteQueueLowWatermark(int lowWatermark)
 {
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
     if (d_streamSocket_sp) {
         d_streamSocket_sp->setWriteQueueLowWatermark(lowWatermark);
     }
@@ -1315,6 +1316,7 @@ void NtcChannel::setWriteQueueLowWatermark(int lowWatermark)
 
 void NtcChannel::setWriteQueueHighWatermark(int highWatermark)
 {
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
     if (d_streamSocket_sp) {
         d_streamSocket_sp->setWriteQueueHighWatermark(highWatermark);
     }
@@ -1328,12 +1330,14 @@ int NtcChannel::channelId() const
 
 ntsa::Endpoint NtcChannel::peerEndpoint() const
 {
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
     return d_streamSocket_sp ? d_streamSocket_sp->remoteEndpoint()
                              : ntsa::Endpoint();
 }
 
 ntsa::Endpoint NtcChannel::sourceEndpoint() const
 {
+    bslmt::LockGuard<bslmt::Mutex> lock(&d_mutex);
     return d_streamSocket_sp ? d_streamSocket_sp->sourceEndpoint()
                              : ntsa::Endpoint();
 }

--- a/src/groups/bmq/bmqio/bmqio_ntcchannel.h
+++ b/src/groups/bmq/bmqio/bmqio_ntcchannel.h
@@ -197,7 +197,7 @@ class NtcChannel : public bmqio::Channel,
     };
 
     // INSTANCE DATA
-    bslmt::Mutex                          d_mutex;
+    mutable bslmt::Mutex                  d_mutex;
     bsl::shared_ptr<ntci::Interface>      d_interface_sp;
     bsl::shared_ptr<ntci::StreamSocket>   d_streamSocket_sp;
     bmqio::NtcReadQueue                   d_readQueue;


### PR DESCRIPTION
Closes #1611

`processClose` resets `d_streamSocket_sp` under `d_mutex`, but `setWriteQueueLowWatermark`, `setWriteQueueHighWatermark`, `peerEndpoint`, and `sourceEndpoint` read and dereference it without the lock. Acquire `d_mutex` in the four unprotected methods and mark it `mutable` for the const accessors.

`peerUri` fix to follow in a separate PR.

