### PR TITLE
Fix[mqbc::StorageMgr]: Drop cross-thread primary assert

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -4364,7 +4364,6 @@ void StorageManager::detectPrimaryLossInPFSM(int partitionId)
     BSLS_ASSERT_SAFE(d_clusterData_p->cluster().inDispatcherThread());
     BSLS_ASSERT_SAFE(0 <= partitionId &&
                      partitionId < static_cast<int>(d_fileStores.size()));
-    BSLS_ASSERT_SAFE(d_partitionInfoVec[partitionId].primary());
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId << "]: "


### PR DESCRIPTION
As noted in [`the definition of d_partitionInfoVec`](https://github.com/bloomberg/blazingmq/blob/269426049d742a5f4fe970b6aa195b39cd75fac0/src/groups/mqb/mqbc/mqbc_storagemanager.h#L325-L330), this variable should only be accessed in the queue dispatcher thread. Hence, I am removing assert on it in the cluster dispatcher thread.

This fixes the crash described in Internal Ticket 185164739.
