### PR TITLE
Fix[bmqp]: cap PUT decompression for v1 msg properties

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_compression.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.cpp
@@ -114,16 +114,20 @@ struct ZLib {
 
     /// Apply the operation given by the specified `zlibMethod` and
     /// `zlibEndMethod` on the specified `input` using the specified
-    /// `stream`, and write the result to the specified `output`.  Return 0
-    /// on success and non-zero otherwise, in which case a message is
-    /// written to the specified `errorStream` if it is non-zero.
+    /// `stream`, and write the result to the specified `output`.  If the
+    /// specified `maxOutputSize` is non-zero, fail as soon as the
+    /// accumulated output would exceed `maxOutputSize` bytes; a value
+    /// of 0 means no limit is enforced.  Return 0 on success and
+    /// non-zero otherwise, in which case a message is written to the
+    /// specified `errorStream` if it is non-zero.
     static int writeOutput(bdlbb::Blob*              output,
                            bdlbb::BlobBufferFactory* factory,
                            z_stream*                 stream,
                            bsl::ostream*             errorStream,
                            const bdlbb::Blob&        input,
                            ZlibStreamMethod          zlibMethod,
-                           ZlibEndStreamMethod       zlibEndMethod);
+                           ZlibEndStreamMethod       zlibEndMethod,
+                           bsls::Types::Uint64       maxOutputSize);
 };
 
 // ===========
@@ -226,13 +230,15 @@ int ZLib::writeOutput(bdlbb::Blob*              output,
                       bsl::ostream*             errorStream,
                       const bdlbb::Blob&        input,
                       ZlibStreamMethod          zlibMethod,
-                      ZlibEndStreamMethod       zlibEndMethod)
+                      ZlibEndStreamMethod       zlibEndMethod,
+                      bsls::Types::Uint64       maxOutputSize)
 {
     enum RcEnum {
         rc_SUCCESS                = 0,
         rc_STREAM_INIT_FAILURE    = -1,
         rc_STREAM_PROCESS_FAILURE = -2,
-        rc_STREAM_END_FAILURE     = -3
+        rc_STREAM_END_FAILURE     = -3,
+        rc_MAX_SIZE_EXCEEDED      = -4
     };
 
     bdlbb::BlobBuffer inBuffer;
@@ -258,6 +264,20 @@ int ZLib::writeOutput(bdlbb::Blob*              output,
             zlibEndMethod(stream);
             return rc_STREAM_PROCESS_FAILURE;  // RETURN
         }
+
+        // Fail if the accumulated output would exceed the cap. The current
+        // 'outBuffer' has not been appended to 'output' yet, so account
+        // for the bytes already written into it.
+        if (maxOutputSize != 0 &&
+            static_cast<bsls::Types::Uint64>(output->length()) +
+                    (outBuffer.size() - stream->avail_out) >
+                maxOutputSize) {
+            setError(errorStream,
+                     "Decompressed output exceeds maximum size",
+                     0);
+            zlibEndMethod(stream);
+            return rc_MAX_SIZE_EXCEEDED;  // RETURN
+        }
     }
 
     // Continue to write output data until the stream reaches its end, or the
@@ -269,6 +289,19 @@ int ZLib::writeOutput(bdlbb::Blob*              output,
         advanceOutput(output, &outBuffer, factory, stream);
         lastSize = stream->avail_out;
         result   = zlibMethod(stream, Z_FINISH);
+
+        // Fail closed if the accumulated output would exceed the cap (see the
+        // explanation above).
+        if (maxOutputSize != 0 &&
+            static_cast<bsls::Types::Uint64>(output->length()) +
+                    (outBuffer.size() - stream->avail_out) >
+                maxOutputSize) {
+            setError(errorStream,
+                     "Decompressed output exceeds maximum size",
+                     0);
+            zlibEndMethod(stream);
+            return rc_MAX_SIZE_EXCEEDED;  // RETURN
+        }
     } while ((Z_BUF_ERROR == result || Z_OK == result) &&
              lastSize != stream->avail_out);
 
@@ -386,6 +419,7 @@ int Compression::decompress(bdlbb::Blob*                         output,
                             bdlbb::BlobBufferFactory*            factory,
                             bmqt::CompressionAlgorithmType::Enum algorithm,
                             const bdlbb::Blob&                   input,
+                            bsls::Types::Uint64                  maxOutputSize,
                             bsl::ostream*                        errorStream,
                             bslma::Allocator*                    allocator)
 {
@@ -396,6 +430,7 @@ int Compression::decompress(bdlbb::Blob*                         output,
         return Compression_Impl::decompressZlib(output,
                                                 factory,
                                                 input,
+                                                maxOutputSize,
                                                 errorStream,
                                                 allocator);  // RETURN
     case bmqt::CompressionAlgorithmType::e_NONE:
@@ -449,12 +484,14 @@ int Compression_Impl::compressZlib(bdlbb::Blob*              output,
                              errorStream,
                              input,
                              &::deflate,
-                             &::deflateEnd);
+                             &::deflateEnd,
+                             0);  // no output cap for compression
 }
 
 int Compression_Impl::decompressZlib(bdlbb::Blob*              output,
                                      bdlbb::BlobBufferFactory* factory,
                                      const bdlbb::Blob&        input,
+                                     bsls::Types::Uint64       maxOutputSize,
                                      bsl::ostream*             errorStream,
                                      bslma::Allocator*         allocator)
 {
@@ -481,7 +518,8 @@ int Compression_Impl::decompressZlib(bdlbb::Blob*              output,
                              errorStream,
                              input,
                              &::inflate,
-                             &::inflateEnd);
+                             &::inflateEnd,
+                             maxOutputSize);
 }
 
 }  // close package namespace

--- a/src/groups/bmq/bmqp/bmqp_compression.h
+++ b/src/groups/bmq/bmqp/bmqp_compression.h
@@ -37,6 +37,7 @@
 #include <bdlbb_blob.h>
 #include <bsl_ostream.h>
 #include <bslma_allocator.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 
@@ -88,16 +89,21 @@ struct Compression {
     /// specified `algorithm`, and load the uncompressed data into specified
     /// `output`, using the specified `factory` to supply the needed data
     /// buffers. Return 0 on success, and non-zero otherwise. Optionally
-    /// specify an `errorStream` to record details on any errors that may
-    /// occur during this operation. Also, optionally specify `allocator`
-    /// which will be used to supply memory.  Also note, that any existing
-    /// data in the specified `output` will be preserved.
+    /// specify a `maxOutputSize`, in bytes, beyond which decompression fails
+    /// closed with a non-zero return code rather than continuing to allocate
+    /// output buffers; a value of 0 (the default) means no limit is enforced.
+    /// This bounds the memory consumed when decompressing highly-compressible
+    /// input. Optionally specify an `errorStream` to record details
+    /// on any errors that may occur during this operation. Also, optionally
+    /// specify `allocator` which will be used to supply memory.  Also note,
+    /// that any existing data in the specified `output` will be preserved.
     static int decompress(bdlbb::Blob*                         output,
                           bdlbb::BlobBufferFactory*            factory,
                           bmqt::CompressionAlgorithmType::Enum algorithm,
                           const bdlbb::Blob&                   input,
-                          bsl::ostream*                        errorStream = 0,
-                          bslma::Allocator*                    allocator = 0);
+                          bsls::Types::Uint64 maxOutputSize = 0,
+                          bsl::ostream*       errorStream   = 0,
+                          bslma::Allocator*   allocator     = 0);
 };
 
 // ======================
@@ -131,13 +137,17 @@ struct Compression_Impl {
     /// Decompress the data within the specified `input` as according to the
     /// Zlib algorithm, and load the uncompressed data into the specified
     /// `output` blob, using the specified `factory` to supply needed data
-    /// buffers. Return 0 on success, and non-zero otherwise. Specify an
-    /// `errorStream` to record details on any errors that may occur during
-    /// this operation. Also, specify `allocator` which will be used to
-    /// supply memory. Return 0 on success, and non-zero otherwise.
+    /// buffers. Return 0 on success, and non-zero otherwise. Optionally
+    /// specify a `maxOutputSize`, in bytes, beyond which decompression fails
+    /// closed with a non-zero return code rather than continuing to allocate
+    /// output buffers; a value of 0 (the default) means no limit is enforced.
+    /// Specify an `errorStream` to record details on any errors that may
+    /// occur during this operation. Also, specify `allocator` which will be
+    /// used to supply memory. Return 0 on success, and non-zero otherwise.
     static int decompressZlib(bdlbb::Blob*              output,
                               bdlbb::BlobBufferFactory* factory,
                               const bdlbb::Blob&        input,
+                              bsls::Types::Uint64       maxOutputSize,
                               bsl::ostream*             errorStream,
                               bslma::Allocator*         allocator);
 };

--- a/src/groups/bmq/bmqp/bmqp_compression.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_compression.t.cpp
@@ -293,6 +293,7 @@ static void eZlibCompressDecompressHelper(
                                        &bufferFactory,
                                        algorithm,
                                        compressed,
+                                       0,  // no output cap
                                        &error,
                                        bmqtst::TestHelperUtil::allocator());
     *decompressionTime = bsls::TimeUtil::getTimer() - startTime;
@@ -336,6 +337,7 @@ eZlibCompressDecompressHelper(bsls::Types::Int64* compressionTime,
         &decompressed,
         &bufferFactory,
         compressed,
+        0,  // no output cap
         &error,
         bmqtst::TestHelperUtil::allocator());
     *decompressionTime = bsls::TimeUtil::getTimer() - startTime;
@@ -377,6 +379,7 @@ static void eZlibCompressionRatioHelper(bsls::Types::Int64* inputSize,
         &decompressed,
         &bufferFactory,
         compressed,
+        0,  // no output cap
         &error,
         bmqtst::TestHelperUtil::allocator());
     BMQTST_ASSERT_EQ(rc, 0);
@@ -544,6 +547,7 @@ static void test1_breathingTest()
             &decompressed,
             &bufferFactory,
             compressed,
+            0,  // no output cap
             &error,
             bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(rc, 0);
@@ -613,6 +617,7 @@ static void test1_breathingTest()
             &decompressed,
             &bufferFactory,
             compressed,
+            0,  // no output cap
             &error,
             bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(rc, 0);
@@ -692,6 +697,7 @@ static void test2_compression_cluster_message()
             &decompressed,
             &bufferFactory,
             compressed,
+            0,  // no output cap
             &error,
             bmqtst::TestHelperUtil::allocator());
         BMQTST_ASSERT_EQ(rc, 0);
@@ -749,6 +755,116 @@ static void test3_compression_decompression_none()
                 test.d_expected,
                 bmqt::CompressionAlgorithmType::e_NONE);
         }
+    }
+}
+
+static void test4_decompressionSizeLimit()
+// ------------------------------------------------------------------------
+// DECOMPRESSION OUTPUT SIZE LIMIT
+//
+// Concerns:
+//   A highly-compressible input must not be allowed to expand without
+//   bound.  When a maximum output size is supplied, decompression must fail
+//   closed once the accumulated output would exceed the cap, rather than
+//   continuing to allocate memory.
+//
+// Plan:
+//   - Compress a large run of zero bytes (which zlib shrinks dramatically).
+//   - Decompress with no cap and confirm the full round-trip (control).
+//   - Decompress with a cap below the true output size and confirm it fails
+//     with a non-zero code while producing output bounded near the cap (not
+//     the full expansion).
+//   - Decompress with a cap above the true output size and confirm success.
+//
+// Testing:
+//   bmqp::Compression::decompress with a non-zero maxOutputSize
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("DECOMPRESSION SIZE LIMIT TEST");
+
+    // Use small blob buffers so the enforced cap is tight (the overrun beyond
+    // the cap is bounded by a single buffer).
+    bdlbb::PooledBlobBufferFactory bufferFactory(
+        1024,
+        bmqtst::TestHelperUtil::allocator());
+
+    bmqu::MemOutStream error(bmqtst::TestHelperUtil::allocator());
+
+    // Build a large, highly-compressible input (all zero bytes) that expands
+    // far beyond the cap we will impose.
+    const int   k_INPUT_SIZE = 8 * 1024 * 1024;  // 8 MB
+    bsl::string zeros(k_INPUT_SIZE, '\0', bmqtst::TestHelperUtil::allocator());
+
+    bdlbb::Blob input(&bufferFactory, bmqtst::TestHelperUtil::allocator());
+    bdlbb::BlobUtil::append(&input, zeros.data(), k_INPUT_SIZE);
+
+    bdlbb::Blob compressed(&bufferFactory,
+                           bmqtst::TestHelperUtil::allocator());
+    int         rc = bmqp::Compression::compress(
+        &compressed,
+        &bufferFactory,
+        bmqt::CompressionAlgorithmType::e_ZLIB,
+        input,
+        &error,
+        bmqtst::TestHelperUtil::allocator());
+    BMQTST_ASSERT_EQ(rc, 0);
+    // Highly-compressible: compressed form is a tiny fraction of the input.
+    BMQTST_ASSERT_LT(compressed.length(), k_INPUT_SIZE);
+
+    {
+        PVV("Control: no cap decompresses fully");
+        bdlbb::Blob decompressed(&bufferFactory,
+                                 bmqtst::TestHelperUtil::allocator());
+        rc = bmqp::Compression::decompress(
+            &decompressed,
+            &bufferFactory,
+            bmqt::CompressionAlgorithmType::e_ZLIB,
+            compressed,
+            0,  // no cap
+            &error,
+            bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(rc, 0);
+        BMQTST_ASSERT_EQ(decompressed.length(), k_INPUT_SIZE);
+    }
+
+    {
+        PVV("Cap below decompressed size fails closed");
+        const bsls::Types::Uint64 k_CAP = 1024 * 1024;  // 1 MB < 8 MB
+        bdlbb::Blob               decompressed(&bufferFactory,
+                                 bmqtst::TestHelperUtil::allocator());
+        rc = bmqp::Compression::decompress(
+            &decompressed,
+            &bufferFactory,
+            bmqt::CompressionAlgorithmType::e_ZLIB,
+            compressed,
+            k_CAP,
+            &error,
+            bmqtst::TestHelperUtil::allocator());
+        // Fails with a non-zero code ...
+        BMQTST_ASSERT_NE(rc, 0);
+        // ... and stops well short of fully expanding the input, bounded
+        // near the cap rather than the full 8 MB.
+        BMQTST_ASSERT_LT(decompressed.length(), k_INPUT_SIZE);
+        BMQTST_ASSERT_LE(
+            static_cast<bsls::Types::Uint64>(decompressed.length()),
+            k_CAP + 1024);
+    }
+
+    {
+        PVV("Cap above decompressed size succeeds");
+        const bsls::Types::Uint64 k_CAP = 64 * 1024 * 1024;  // 64 MB > 8 MB
+        bdlbb::Blob               decompressed(&bufferFactory,
+                                 bmqtst::TestHelperUtil::allocator());
+        rc = bmqp::Compression::decompress(
+            &decompressed,
+            &bufferFactory,
+            bmqt::CompressionAlgorithmType::e_ZLIB,
+            compressed,
+            k_CAP,
+            &error,
+            bmqtst::TestHelperUtil::allocator());
+        BMQTST_ASSERT_EQ(rc, 0);
+        BMQTST_ASSERT_EQ(decompressed.length(), k_INPUT_SIZE);
     }
 }
 
@@ -1113,6 +1229,7 @@ int main(int argc, char* argv[])
     case 1: test1_breathingTest(); break;
     case 2: test2_compression_cluster_message(); break;
     case 3: test3_compression_decompression_none(); break;
+    case 4: test4_decompressionSizeLimit(); break;
     case -1:
         BMQTST_BENCHMARK_WITH_ARGS(
             testN1_performanceCompressionDecompressionDefault,

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.cpp
@@ -457,6 +457,7 @@ int ProtocolUtil::convertToOld(bdlbb::Blob*                         dst,
                                            factory,
                                            cat,
                                            compressed,
+                                           0,  // no output cap
                                            &error,
                                            allocator);
     }
@@ -518,7 +519,8 @@ int ProtocolUtil::parse(bdlbb::Blob*              messagePropertiesOutput,
                         bool                      haveNewMessageProperties,
                         bmqt::CompressionAlgorithmType::Enum cat,
                         bdlbb::BlobBufferFactory*            blobBufferFactory,
-                        bslma::Allocator*                    allocator)
+                        bslma::Allocator*                    allocator,
+                        bsls::Types::Uint64 maxDecompressedSize)
 {
     // This is to capture parsing and de-compressing MessageProperties in a
     // single place.
@@ -619,6 +621,7 @@ int ProtocolUtil::parse(bdlbb::Blob*              messagePropertiesOutput,
                                        blobBufferFactory,
                                        cat,
                                        bufferCompressed,
+                                       maxDecompressedSize,
                                        &error,
                                        allocator);
 

--- a/src/groups/bmq/bmqp/bmqp_protocolutil.h
+++ b/src/groups/bmq/bmqp/bmqp_protocolutil.h
@@ -65,6 +65,7 @@
 #include <bslma_allocator.h>
 #include <bsls_assert.h>
 #include <bsls_performancehint.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 
@@ -279,7 +280,12 @@ struct ProtocolUtil {
     /// input is compressed and the specified `decompressFlag` is `false` in
     /// which case parsing of MessageProperties succeeds only if
     /// `haveNewMessageProperties` is `true` (un-compressed) and parsing of
-    /// data does not succeed.  Return negative code on failure.
+    /// data does not succeed.  Return negative code on failure.  If the
+    /// optionally specified `maxDecompressedSize` is non-zero, fail (with a
+    /// negative code) rather than decompressing `input` into more than
+    /// `maxDecompressedSize` bytes; a value of `0` (the default) means no
+    /// limit is enforced.  This bounds the memory consumed when decompressing
+    /// highly-compressible input.
     static int parse(bdlbb::Blob*              messagePropertiesOutput,
                      int*                      messagePropertiesSize,
                      bdlbb::Blob*              dataOutput,
@@ -291,7 +297,8 @@ struct ProtocolUtil {
                      bool                      haveNewMessageProperties,
                      bmqt::CompressionAlgorithmType::Enum cat,
                      bdlbb::BlobBufferFactory*            blobBufferFactory,
-                     bslma::Allocator*                    allocator);
+                     bslma::Allocator*                    allocator,
+                     bsls::Types::Uint64 maxDecompressedSize = 0);
 };
 
 // ============================================================================

--- a/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_putmessageiterator.cpp
@@ -32,11 +32,23 @@
 #include <bsl_iostream.h>
 #include <bsla_annotations.h>
 #include <bsls_performancehint.h>
+#include <bsls_types.h>
 
 namespace BloombergLP {
 namespace bmqp {
 
 namespace {
+
+/// Maximum size, in bytes, that a PUT message's application data (message
+/// properties plus payload) may occupy after decompression.  Compressed PUT
+/// payloads are bounded on the wire by `PutHeader::k_MAX_PAYLOAD_SIZE_SOFT`
+/// (64 MB), but zlib can expand highly-compressible input by roughly 1000x,
+/// so this cap (8x the wire limit) bounds the memory used to decompress a
+/// message before any queue-id validation or permission checks occur.
+///
+/// Temporary; shall remove once old-style (v1) message properties are no
+/// longer supported.
+const bsls::Types::Uint64 k_MAX_DECOMPRESSED_SIZE = 512ULL * 1024 * 1024;
 
 inline bool isValidWordPaddingByte(char value)
 {
@@ -646,7 +658,8 @@ int PutMessageIterator::next()
                              haveNewMPs,
                              cat,
                              d_bufferFactory_p,
-                             d_allocator_p);
+                             d_allocator_p,
+                             k_MAX_DECOMPRESSED_SIZE);
 
     if (rc < 0) {
         d_applicationDataPosition = bmqu::BlobPosition();

--- a/src/groups/bmq/bmqp/bmqp_puttester.cpp
+++ b/src/groups/bmq/bmqp/bmqp_puttester.cpp
@@ -156,6 +156,7 @@ void PutTester::populateBlob(bdlbb::Blob*              blob,
                                               bufferFactory,
                                               cat,
                                               compressed,
+                                              0,  // no output cap
                                               &error,
                                               allocator);
                 BSLA_MAYBE_UNUSED int compare =


### PR DESCRIPTION
An anonymous client could send a PUT event with ZLIB-compressed old-style message properties that expands pathologically when decompressed.

Add an optional caller-supplied size limit to Compression::Decompress, and enforce the limit in the broker until message properties v1 are fully removed. Other decompression paths (SDK, PUSH processing) remain uncapped.

bmqp_compression.t tests validate the change.