### PR TITLE
Fix[mqbmock::CSL]: Append uncommitted advisory to 'd_records'

### DIFF
--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.cpp
@@ -39,6 +39,7 @@ int ClusterStateLedger::applyAdvisoryInternal(
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_clusterData_p->cluster().inDispatcherThread());
 
+    d_records.emplace_back(clusterMessage);
     d_uncommittedAdvisories.emplace_back(clusterMessage);
 
     return 0;
@@ -230,9 +231,6 @@ void ClusterStateLedger::_commitAdvisories(
          cit != d_uncommittedAdvisories.cend();
          ++cit) {
         if (status == mqbc::ClusterStateLedgerCommitStatus::e_SUCCESS) {
-            // Store the record and its commit
-            d_records.emplace_back(*cit);
-
             bmqp_ctrlmsg::ClusterMessage        commitRecord;
             bmqp_ctrlmsg::LeaderAdvisoryCommit& commit =
                 commitRecord.choice().makeLeaderAdvisoryCommit();

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
@@ -86,7 +86,7 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
     // Cluster's transient state.
 
     LedgerRecords d_records;
-    // List of records stored in this ledger.
+    // List of records stored in this ledger, including uncommitted ones.
 
     Advisories d_uncommittedAdvisories;
     // List of uncommitted (but not canceled) advisories.


### PR DESCRIPTION
`mqbmock::ClusterStateLedger` is the test double for `mqbc::IncoreClusterStateLedger`.  This PR moves the point at which an advisory record is inserted into the mock's backing store `d_records` from commit time to apply time, so the mock mirrors the real ledger.

How the real ledger behaves: in `IncoreClusterStateLedger::applyRecordInternalImpl`, the advisory record is written to the ledger (`d_ledger_mp->writeRecord`) at apply time, and only then is its LSN inserted into the in-memory `d_uncommittedAdvisories index`.  The later `LeaderAdvisoryCommit` writes a separate commit record and erases the index entry.  The record therefore lives in the ledger throughout its uncommitted lifetime, and `getIterator()` returns applied-but-uncommitted records.

Previous mock divergence: the mock pushed into `d_records` only inside `_commitAdvisories()` -- at commit time.  Between apply and commit, the mock's `d_records` (and thus `getIterator()`) did not contain the record, unlike production.  Any test that inspects the mock's ledger while an advisory is uncommitted saw behavior that could not occur with the real ledger -- a latent test-double fidelity bug.

Change:
- `applyAdvisoryInternal()`: append to d_records on apply, alongside the existing `d_uncommittedAdvisories` insert.
- `_commitAdvisories()`: drop the now-redundant `d_records.emplace_back`; the advisory is already recorded, and the commit record is still appended.

Net: the mock's ledger contains applied advisories immediately, matching the real ledger's write-ahead semantics.  No production code changes -- test infrastructure only.
