### PR TITLE
Refactor[mqbc::ClusterStateLedger]: Add uncommittedAdvisories accessor

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.h
@@ -325,6 +325,13 @@ class ClusterStateLedger {
     ///         dispatcher thread.
     virtual bool isOpen() const = 0;
 
+    /// Load into the specified `out` the list of uncommitted advisories as
+    /// const references.
+    ///
+    /// THREAD: This method can be invoked only in the associated cluster's
+    ///         dispatcher thread.
+    virtual void uncommittedAdvisories(ClusterMessageCRefList* out) const = 0;
+
     /// Return an iterator to this ledger.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's

--- a/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstateledger.t.cpp
@@ -106,14 +106,20 @@ struct ClusterStateLedgerTestImp
         return markDone();
     }
 
-    // ACCESSORS
     void
     setCommitCb(BSLA_MAYBE_UNUSED const CommitCb& value) BSLS_KEYWORD_OVERRIDE
     {
         markDone();
     }
 
+    // ACCESSORS
     bool isOpen() const BSLS_KEYWORD_OVERRIDE { return markDone(); }
+
+    void
+    uncommittedAdvisories(ClusterMessageCRefList*) const BSLS_KEYWORD_OVERRIDE
+    {
+        markDone();
+    }
 
     bslma::ManagedPtr<mqbc::ClusterStateLedgerIterator>
     getIterator() const BSLS_KEYWORD_OVERRIDE
@@ -201,6 +207,11 @@ static void test1_clusterStateLedger_protocol()
             testObj,
             setCommitCb(mqbc::ClusterStateLedger::CommitCb()));
         BSLS_PROTOCOLTEST_ASSERT(testObj, isOpen());
+        BSLS_PROTOCOLTEST_ASSERT(
+            testObj,
+            uncommittedAdvisories(
+                static_cast<mqbc::ClusterStateLedger::ClusterMessageCRefList*>(
+                    0)));
         BSLS_PROTOCOLTEST_ASSERT(testObj, getIterator());
     }
 

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -1241,7 +1241,7 @@ static void test11_leaderHighestLeaderHealed()
 
     // Verify that a cluster state snapshot is applied to the CSL
     ClusterMessageCRefList advisories;
-    tester.d_clusterStateLedger_p->_uncommittedAdvisories(&advisories);
+    tester.d_clusterStateLedger_p->uncommittedAdvisories(&advisories);
     BMQTST_ASSERT_EQ(advisories.size(), 1U);
     BMQTST_ASSERT(advisories.front().get().choice().isLeaderAdvisoryValue());
 
@@ -1366,7 +1366,7 @@ static void test12_followerHighestLeaderHealed()
 
     // Verify that a cluster state snapshot is applied to the CSL
     ClusterMessageCRefList advisories;
-    tester.d_clusterStateLedger_p->_uncommittedAdvisories(&advisories);
+    tester.d_clusterStateLedger_p->uncommittedAdvisories(&advisories);
     BMQTST_ASSERT_EQ(advisories.size(), 1U);
     BMQTST_ASSERT(advisories.front().get().choice().isLeaderAdvisoryValue());
 
@@ -1671,7 +1671,7 @@ static void test16_followerClusterStateRespFailureLeaderNext()
     //
     // Verify that a cluster state snapshot is applied to the CSL
     ClusterMessageCRefList advisories;
-    tester.d_clusterStateLedger_p->_uncommittedAdvisories(&advisories);
+    tester.d_clusterStateLedger_p->uncommittedAdvisories(&advisories);
     BMQTST_ASSERT_EQ(advisories.size(), 1U);
     BMQTST_ASSERT(advisories.front().get().choice().isLeaderAdvisoryValue());
 
@@ -1822,7 +1822,7 @@ static void test17_followerClusterStateRespFailureFollowerNext()
 
     // Verify that a cluster state snapshot is applied to the CSL
     ClusterMessageCRefList advisories;
-    tester.d_clusterStateLedger_p->_uncommittedAdvisories(&advisories);
+    tester.d_clusterStateLedger_p->uncommittedAdvisories(&advisories);
     BMQTST_ASSERT_EQ(advisories.size(), 1U);
     BMQTST_ASSERT(advisories.front().get().choice().isLeaderAdvisoryValue());
 

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -1535,6 +1535,24 @@ int IncoreClusterStateLedger::apply(const bdlbb::Blob&   event,
 
 // ACCESSORS
 //   (virtual mqbc::ClusterStateLedger)
+void IncoreClusterStateLedger::uncommittedAdvisories(
+    ClusterMessageCRefList* out) const
+{
+    // executed by the *CLUSTER DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_clusterData_p->cluster().inDispatcherThread());
+    BSLS_ASSERT_SAFE(out);
+
+    out->clear();
+    out->reserve(d_uncommittedAdvisories.size());
+    for (AdvisoriesMapCIter it = d_uncommittedAdvisories.cbegin();
+         it != d_uncommittedAdvisories.cend();
+         ++it) {
+        out->emplace_back(bsl::cref(it->second.d_clusterMessage));
+    }
+}
+
 bslma::ManagedPtr<ClusterStateLedgerIterator>
 IncoreClusterStateLedger::getIterator() const
 {

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -389,6 +389,14 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     ///         dispatcher thread.
     bool isOpen() const BSLS_KEYWORD_OVERRIDE;
 
+    /// Load into the specified `out` the list of uncommitted advisories as
+    /// const references.
+    ///
+    /// THREAD: This method can be invoked only in the associated cluster's
+    ///         dispatcher thread.
+    void uncommittedAdvisories(ClusterMessageCRefList* out) const
+        BSLS_KEYWORD_OVERRIDE;
+
     /// Return an iterator to this ledger.
     ///
     /// THREAD: This method is invoked in the associated cluster's

--- a/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
+++ b/src/groups/mqb/mqbmock/mqbmock_clusterstateledger.h
@@ -69,27 +69,28 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
 
   private:
     // DATA
+
+    /// Allocator used to supply memory.
     bslma::Allocator* d_allocator_p;
-    // Allocator used to supply memory.
 
+    /// Flag to indicate open/close status of this object.
     bool d_isOpen;
-    // Flag to indicate open/close status of this object.
 
+    /// Flag to indicate whether to pause commit callback.
     bool d_pauseCommitCb;
-    // Flag to indicate whether to pause commit callback.
 
+    /// Callback invoked when the status of a commit
+    /// operation becomes available.
     CommitCb d_commitCb;
-    // Callback invoked when the status of a commit
-    // operation becomes available.
 
+    /// Cluster's transient state.
     mqbc::ClusterData* d_clusterData_p;
-    // Cluster's transient state.
 
+    /// List of records stored in this ledger, including uncommitted ones.
     LedgerRecords d_records;
-    // List of records stored in this ledger, including uncommitted ones.
 
+    /// List of uncommitted (but not canceled) advisories.
     Advisories d_uncommittedAdvisories;
-    // List of uncommitted (but not canceled) advisories.
 
   private:
     // PRIVATE MANIPULATORS
@@ -213,18 +214,20 @@ class ClusterStateLedger : public mqbc::ClusterStateLedger {
     ///         dispatcher thread.
     bool isOpen() const BSLS_KEYWORD_OVERRIDE;
 
+    /// Load into the specified `out` the list of uncommitted advisories as
+    /// const references.
+    ///
+    /// THREAD: This method can be invoked only in the associated cluster's
+    ///         dispatcher thread.
+    void uncommittedAdvisories(ClusterMessageCRefList* out) const
+        BSLS_KEYWORD_OVERRIDE;
+
     /// Return an iterator to this ledger.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's
     ///         dispatcher thread.
     bslma::ManagedPtr<mqbc::ClusterStateLedgerIterator>
     getIterator() const BSLS_KEYWORD_OVERRIDE;
-
-    /// Load into `out` the list of uncommitted advisories as const references.
-    ///
-    /// THREAD: This method can be invoked only in the associated cluster's
-    ///         dispatcher thread.
-    void _uncommittedAdvisories(ClusterMessageCRefList* out) const;
 };
 
 // ============================================================================
@@ -277,7 +280,7 @@ inline bool ClusterStateLedger::isOpen() const
 }
 
 inline void
-ClusterStateLedger::_uncommittedAdvisories(ClusterMessageCRefList* out) const
+ClusterStateLedger::uncommittedAdvisories(ClusterMessageCRefList* out) const
 {
     // executed by the *CLUSTER DISPATCHER* thread
 
@@ -285,6 +288,7 @@ ClusterStateLedger::_uncommittedAdvisories(ClusterMessageCRefList* out) const
     BSLS_ASSERT_SAFE(d_clusterData_p->cluster().inDispatcherThread());
     BSLS_ASSERT_SAFE(out);
 
+    out->clear();
     out->assign(d_uncommittedAdvisories.begin(),
                 d_uncommittedAdvisories.end());
 }


### PR DESCRIPTION
Expose the applied-but-not-yet-committed advisories as a read-only accessor on the ClusterStateLedger interface:

    virtual void uncommittedAdvisories(ClusterMessageCRefList* out) const;

Previously this set was purely private state inside IncoreClusterStateLedger (d_uncommittedAdvisories).  Surfacing a read-only view lets callers (e.g. ClusterStateManager) inspect the in-flight advisories without waiting for them to commit.

This is a pure-exposure change: no runtime behavior is altered.  The IncoreClusterStateLedger implementation copies const references out of d_uncommittedAdvisories; the mqbmock test double renames its existing _uncommittedAdvisories() helper to the now-public uncommittedAdvisories() override; and the affected unit tests are updated to the new name.