### PR TITLE
Fix[mqbc::ClusterStateTable]: Prevent double-heal (e_FOL_WAITING)

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_clusterfsm.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterfsm.cpp
@@ -100,6 +100,7 @@ void ClusterFSM::processEvent(const EventWithMetadata& event)
             BSLS_ASSERT_SAFE(false && "Code unreachable by design");
             break;  // BREAK
         }
+        case State::e_FOL_WAITING: BSLA_FALLTHROUGH;
         case State::e_FOL_HEALING: BSLA_FALLTHROUGH;
         case State::e_LDR_HEALING_STG1: BSLA_FALLTHROUGH;
         case State::e_LDR_HEALING_STG2: BSLA_FALLTHROUGH;

--- a/src/groups/mqb/mqbc/mqbc_clusterfsm.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterfsm.h
@@ -495,7 +495,8 @@ inline bool ClusterFSM::isSelfLeader() const
 
 inline bool ClusterFSM::isSelfFollower() const
 {
-    return d_state == State::e_FOL_HEALING || d_state == State::e_FOL_HEALED;
+    return d_state == State::e_FOL_WAITING ||
+           d_state == State::e_FOL_HEALING || d_state == State::e_FOL_HEALED;
 }
 
 inline bool ClusterFSM::isSelfHealed() const

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.cpp
@@ -500,20 +500,40 @@ void ClusterStateManager::do_sendFailureFollowerLSNResponse(
     const InputMessage&            inputMessage = metadata.inputMessage();
 
     bmqp_ctrlmsg::ControlMessage controlMsg;
-    controlMsg.rId() = inputMessage.requestId();
-
+    controlMsg.rId()               = inputMessage.requestId();
     bmqp_ctrlmsg::Status& response = controlMsg.choice().makeStatus();
-    response.category()            = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
-    response.code()                = mqbi::ClusterErrorCode::e_NOT_FOLLOWER;
-    response.message()             = "Not a follower";
+
+    if (!d_clusterFSM.isSelfFollower()) {
+        response.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        response.code()     = mqbi::ClusterErrorCode::e_NOT_FOLLOWER;
+        response.message()  = "Not a follower";
+
+        BALL_LOG_INFO
+            << d_clusterData_p->identity().description()
+            << ": Self not follower! Sent failure response " << controlMsg
+            << " to FollowerLSNRequest from node claiming to be leader: "
+            << inputMessage.source()->nodeDescription() << ".";
+    }
+    else {
+        BSLS_ASSERT_SAFE(d_clusterFSM.state() ==
+                         ClusterFSM::State::e_FOL_WAITING);
+        BSLS_ASSERT_SAFE(d_clusterData_p->electorInfo().leaderNode());
+
+        response.category() = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        response.code()     = mqbi::ClusterErrorCode::e_FOLLOWER_WAITING;
+        response.message()  = "Self follower waiting for RegistrationResponse";
+
+        BALL_LOG_INFO << d_clusterData_p->identity().description()
+                      << ": Self is waiting for RegistrationResponse, and "
+                      << "**must** reject the FollowerLSNRequest to prevent "
+                      << "the leader from healing self twice in a row, "
+                      << "leading to duplicate work.  Sent failure response "
+                      << controlMsg << " to FollowerLSNRequest from node "
+                      << inputMessage.source()->nodeDescription() << ".";
+    }
 
     d_clusterData_p->messageTransmitter().sendMessage(controlMsg,
                                                       inputMessage.source());
-
-    BALL_LOG_INFO << d_clusterData_p->identity().description()
-                  << ": Sent failure response " << controlMsg
-                  << " to follower LSN request from "
-                  << inputMessage.source()->nodeDescription();
 }
 
 void ClusterStateManager::do_findHighestLSN(
@@ -1028,6 +1048,51 @@ void ClusterStateManager::do_logFailFollowerClusterStateResponse(
                       << " for request with rId = "
                       << inputMessage.requestId();
     }
+}
+
+void ClusterStateManager::do_logUnexpectedRegistrationResponse(
+    const EventWithMetadata& event)
+{
+    // executed by the cluster *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
+    BSLS_ASSERT_SAFE(!d_clusterData_p->cluster().isLocal());
+
+    const mqbnet::ClusterNode* source = event.second.inputMessage().source();
+    BSLS_ASSERT_SAFE(source);
+
+    BSLS_ASSERT_SAFE(d_clusterFSM.state() != ClusterFSM::State::e_FOL_WAITING);
+
+    BALL_LOG_WARN << d_clusterData_p->identity().description()
+                  << ": Received unexpected RegistrationResponse from node "
+                  << source->nodeDescription() << ", while self is in "
+                  << d_clusterFSM.state()
+                  << " state.  Self should only receive RegistrationResponse "
+                  << "when in FOL_WAITING state.";
+}
+
+void ClusterStateManager::do_logUnexpectedFailureRegistrationResponse(
+    const EventWithMetadata& event)
+{
+    // executed by the cluster *DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
+    BSLS_ASSERT_SAFE(!d_clusterData_p->cluster().isLocal());
+
+    const mqbnet::ClusterNode* source = event.second.inputMessage().source();
+    BSLS_ASSERT_SAFE(source);
+
+    BSLS_ASSERT_SAFE(d_clusterFSM.state() != ClusterFSM::State::e_FOL_WAITING);
+
+    BALL_LOG_WARN
+        << d_clusterData_p->identity().description()
+        << ": Received unexpected failure RegistrationResponse from node "
+        << source->nodeDescription() << ", while self is in "
+        << d_clusterFSM.state()
+        << " state.  Self should only receive failure RegistrationResponse "
+        << "when in FOL_WAITING state.";
 }
 
 void ClusterStateManager::do_logFailRegistrationResponse(

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.h
@@ -247,6 +247,12 @@ class ClusterStateManager BSLS_KEYWORD_FINAL
     void do_logFailRegistrationResponse(const EventWithMetadata& event)
         BSLS_KEYWORD_OVERRIDE;
 
+    void do_logUnexpectedRegistrationResponse(const EventWithMetadata& event)
+        BSLS_KEYWORD_OVERRIDE;
+
+    void do_logUnexpectedFailureRegistrationResponse(
+        const EventWithMetadata& event) BSLS_KEYWORD_OVERRIDE;
+
     void do_reapplyEvent(const EventWithMetadata& event) BSLS_KEYWORD_OVERRIDE;
 
     void do_reapplySelectLeader(const EventWithMetadata& event)

--- a/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatemanager.t.cpp
@@ -296,6 +296,28 @@ struct Tester {
         }
     }
 
+    void advanceToFolHealing(int rId = 1)
+    {
+        // Simulate a successful RegistrationResponse to advance the follower
+        // from FOL_WAITING to FOL_HEALING.
+        BSLS_ASSERT_OPT(d_clusterStateManager_mp->healthState() ==
+                        mqbc::ClusterStateTableState::e_FOL_WAITING);
+
+        bmqp_ctrlmsg::ControlMessage response;
+        response.rId() = rId;
+        response.choice()
+            .makeClusterMessage()
+            .choice()
+            .makeClusterStateFSMMessage()
+            .choice()
+            .makeRegistrationResponse();
+
+        d_cluster_mp->requestManager().processResponse(response);
+
+        BSLS_ASSERT_OPT(d_clusterStateManager_mp->healthState() ==
+                        mqbc::ClusterStateTableState::e_FOL_HEALING);
+    }
+
     // ACCESSORS
     bsls::TimeInterval nowMonotonicClock() const
     {
@@ -658,7 +680,7 @@ static void test2_breathingTestFollower()
     tester.electLeader(2U);
 
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
     BMQTST_ASSERT(tester.d_clusterStateManager_mp->nodeToLSNMap().empty());
 
     tester.verifyRegistrationRequestSent(selfLSN);
@@ -813,8 +835,9 @@ static void test5_followerLSNRequestHandlingFollower()
 
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
+    tester.advanceToFolHealing();
     tester.clearChannels();
 
     // 1. Receives a follower LSN request from leader
@@ -1149,8 +1172,9 @@ static void test10_followerClusterStateRequestHandlingFollower()
 
     tester.electLeader();
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
+    tester.advanceToFolHealing();
     tester.clearChannels();
 
     // 1. Receives a follower cluster state request from leader
@@ -1411,7 +1435,8 @@ static void test13_followerHealed()
 
     tester.electLeader();
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
+    tester.advanceToFolHealing();
 
     // 1. Receive CSL advisory from leader.  Apply it.
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
@@ -1540,7 +1565,8 @@ static void test15_followerCSLCommitFailure()
 
     tester.electLeader(4U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
+    tester.advanceToFolHealing();
 
     // 1. Receive CSL advisory from leader.  Apply it.
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
@@ -1575,7 +1601,7 @@ static void test15_followerCSLCommitFailure()
 
     // Verify that self restarts healing
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
 }
 
 static void test16_followerClusterStateRespFailureLeaderNext()
@@ -1980,7 +2006,7 @@ static void test19_stopNode()
 
     tester2.electLeader();
     BSLS_ASSERT_OPT(tester2.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
 
     tester2.d_clusterStateManager_mp->stop();
 
@@ -1993,6 +2019,7 @@ static void test19_stopNode()
                     mqbc::ClusterStateTableState::e_UNKNOWN);
 
     tester3.electLeader(3U);
+    tester3.advanceToFolHealing();
 
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
     cslAdvisory.sequenceNumber().electorTerm()    = 2U;
@@ -2244,10 +2271,10 @@ static void test21_resetUnknownFollower()
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
                     mqbc::ClusterStateTableState::e_UNKNOWN);
 
-    // 1.a.) Self transitions to Follower Healing
+    // 1.a.) Self transitions to Follower Waiting
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
 
     // 1.b.) Upon leader loss, verify that self goes back to UNKNOWN state
     tester.d_cluster_mp->_clusterData()->electorInfo().setElectorInfo(
@@ -2261,6 +2288,7 @@ static void test21_resetUnknownFollower()
 
     // 2.a.) Self transitions to Follower Healed, upon CSL commit success
     tester.electLeader(3U);
+    tester.advanceToFolHealing(2);
 
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
     cslAdvisory.sequenceNumber().electorTerm()    = 3U;
@@ -2324,7 +2352,7 @@ static void test22_selectFollowerFromLeader()
     tester.transitionToNewLeader(newLeader, 3U);
 
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
 
     tester.verifyRegistrationRequestSent(selfLSN);
 
@@ -2375,7 +2403,7 @@ static void test22_selectFollowerFromLeader()
     tester2.transitionToNewLeader(newLeader, 3U);
 
     BMQTST_ASSERT_EQ(tester2.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
 
     tester2.verifyRegistrationRequestSent(selfLSN);
 
@@ -2414,7 +2442,7 @@ static void test22_selectFollowerFromLeader()
     tester3.transitionToNewLeader(newLeader, 3U);
 
     BMQTST_ASSERT_EQ(tester3.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
 
     // Current self LSN should be (2,2) after becoming healed leader earlier
     bmqp_ctrlmsg::LeaderMessageSequence currentSelfLSN;
@@ -2451,7 +2479,7 @@ static void test23_selectLeaderFromFollower()
     tester.setSelfLedgerLSN(selfLSN);
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
@@ -2473,6 +2501,7 @@ static void test23_selectLeaderFromFollower()
     tester2.setSelfLedgerLSN(selfLSN);
     tester2.electLeader(2U);
     tester2.verifyRegistrationRequestSent(selfLSN);
+    tester2.advanceToFolHealing();
 
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
     cslAdvisory.sequenceNumber().electorTerm()    = 2U;
@@ -2690,7 +2719,7 @@ static void test25_watchdogFollower()
     // Transition to Follower Healing
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
@@ -2709,7 +2738,7 @@ static void test25_watchdogFollower()
     // Verify that the watchdog triggers re-transition to Follower Healing.
     // where we send registration request again.
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
@@ -2722,6 +2751,8 @@ static void test25_watchdogFollower()
                      true);
 
     // Transition to Follower Healed
+    tester.advanceToFolHealing(
+        2);  // rId=2: second RegistrationRequest after watchdog re-entry
     bmqp_ctrlmsg::LeaderAdvisory cslAdvisory;
     cslAdvisory.sequenceNumber().electorTerm()    = 2U;
     cslAdvisory.sequenceNumber().sequenceNumber() = 1U;
@@ -2847,7 +2878,7 @@ static void test27_watchdogFollowerRetryExhaustion()
     // 1.) Transition to Follower Healing
     tester.electLeader(2U);
     BSLS_ASSERT_OPT(tester.d_clusterStateManager_mp->healthState() ==
-                    mqbc::ClusterStateTableState::e_FOL_HEALING);
+                    mqbc::ClusterStateTableState::e_FOL_WAITING);
     tester.verifyRegistrationRequestSent(selfLSN);
     tester.clearChannels();
 
@@ -2855,7 +2886,7 @@ static void test27_watchdogFollowerRetryExhaustion()
     tester.d_cluster_mp->advanceTime(k_WATCHDOG_TIMEOUT_DURATION_SHORT);
     tester.d_cluster_mp->waitForScheduler();
     BMQTST_ASSERT_EQ(tester.d_clusterStateManager_mp->healthState(),
-                     mqbc::ClusterStateTableState::e_FOL_HEALING);
+                     mqbc::ClusterStateTableState::e_FOL_WAITING);
     BMQTST_ASSERT_EQ(
         tester.d_clusterStateManager_mp->watchdogRetriesRemaining(),
         0);

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.cpp
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.cpp
@@ -53,6 +53,7 @@ const char* ClusterStateTableState::toAscii(ClusterStateTableState::Enum value)
 
     switch (value) {
         CASE(UNKNOWN)
+        CASE(FOL_WAITING)
         CASE(FOL_HEALING)
         CASE(LDR_HEALING_STG1)
         CASE(LDR_HEALING_STG2)
@@ -79,6 +80,7 @@ bool ClusterStateTableState::fromAscii(ClusterStateTableState::Enum* out,
     }
 
     CHECKVALUE(UNKNOWN)
+    CHECKVALUE(FOL_WAITING)
     CHECKVALUE(FOL_HEALING)
     CHECKVALUE(LDR_HEALING_STG1)
     CHECKVALUE(LDR_HEALING_STG2)

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -521,6 +521,10 @@ class ClusterStateTable
                 logFailRegistrationResponse,
                 FOL_HEALING);
         CST_CFG(FOL_WAITING,
+                FOL_CSL_RQST,
+                sendFailureFollowerClusterStateResponse,
+                FOL_WAITING);
+        CST_CFG(FOL_WAITING,
                 CSL_CMT_SUCCESS,
                 stopWatchdog_updatePrimaryInPFSMs,
                 FOL_HEALED);

--- a/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_clusterstatetable.h
@@ -53,30 +53,36 @@ struct ClusterStateTableState {
         /// The leader is unknown.
         e_UNKNOWN = 0,
 
+        /// Self is follower, waiting for either success or failure
+        /// RegistrationResponse.  It **must** reject the FollowerLSNRequest
+        /// to prevent the leader from healing self twice in a row, leading
+        /// to duplicate work.
+        e_FOL_WAITING = 1,
+
         /// Self is follower, healing its CSL.
-        e_FOL_HEALING = 1,
+        e_FOL_HEALING = 2,
 
         /// Self is leader, exchanging LSNs with followers to determine who
         /// has the most up-to-date CSL.
-        e_LDR_HEALING_STG1 = 2,
+        e_LDR_HEALING_STG1 = 3,
 
         /// Self is leader, healing its CSL and the followers' CSLs.  It will
         /// apply a CSL leader advisory to heal everyone.
-        e_LDR_HEALING_STG2 = 3,
+        e_LDR_HEALING_STG2 = 4,
 
         /// Self is follower, and its CSL is healed.
-        e_FOL_HEALED = 4,
+        e_FOL_HEALED = 5,
 
         /// Self is leader, and its CSL is healed.
-        e_LDR_HEALED = 5,
+        e_LDR_HEALED = 6,
 
         /// Self is stopping.  Self could be either leader or follower, or
         /// leader might be unknown.
-        e_STOPPED = 6,
+        e_STOPPED = 7,
 
         /// **NOT A VALID STATE**.  This is an artificial enum value to
         /// represent the number of states.
-        e_NUM_STATES = 7
+        e_NUM_STATES = 8
     };
 
     // CLASS METHODS
@@ -340,6 +346,11 @@ class ClusterStateTableActions {
 
     virtual void do_logFailRegistrationResponse(const ARGS& args) = 0;
 
+    virtual void do_logUnexpectedRegistrationResponse(const ARGS& args) = 0;
+
+    virtual void
+    do_logUnexpectedFailureRegistrationResponse(const ARGS& args) = 0;
+
     virtual void do_reapplyEvent(const ARGS& args) = 0;
 
     virtual void do_reapplySelectLeader(const ARGS& args) = 0;
@@ -448,11 +459,11 @@ class ClusterStateTable
         CST_CFG(UNKNOWN,
                 SLCT_FOL,
                 startWatchdog_sendRegistrationRequest,
-                FOL_HEALING);
+                FOL_WAITING);
         CST_CFG(UNKNOWN,
                 REAPPLY_FOL,
                 startWatchdog_sendRegistrationRequest,
-                FOL_HEALING);
+                FOL_WAITING);
         CST_CFG(UNKNOWN,
                 FOL_LSN_RQST,
                 sendFailureFollowerLSNResponse,
@@ -480,6 +491,50 @@ class ClusterStateTable
                 UNKNOWN);
         CST_CFG(UNKNOWN, STOP_NODE, stopPFSMs, STOPPED);
         CST_CFG(UNKNOWN, RST_PRIMARY, updatePrimaryInPFSMs, UNKNOWN);
+        CST_CFG(FOL_WAITING,
+                SLCT_LDR,
+                stopWatchdog_cancelRequests_reapplyEvent,
+                UNKNOWN);
+        CST_CFG(FOL_WAITING,
+                SLCT_FOL,
+                stopWatchdog_cancelRequests_reapplyEvent,
+                UNKNOWN);
+        CST_CFG(FOL_WAITING,
+                REAPPLY_FOL,
+                cancelRequests_reapplyEvent,
+                UNKNOWN);
+        CST_CFG(FOL_WAITING,
+                FOL_LSN_RQST,
+                sendFailureFollowerLSNResponse,
+                FOL_WAITING);
+        CST_CFG(FOL_WAITING,
+                FOL_LSN_RSPN,
+                logStaleFollowerLSNResponse,
+                FOL_WAITING);
+        CST_CFG(FOL_WAITING,
+                REGISTRATION_RQST,
+                sendFailureRegistrationResponse,
+                FOL_WAITING);
+        CST_CFG(FOL_WAITING, REGISTRATION_RSPN, none, FOL_HEALING);
+        CST_CFG(FOL_WAITING,
+                FAIL_REGISTRATION_RSPN,
+                logFailRegistrationResponse,
+                FOL_HEALING);
+        CST_CFG(FOL_WAITING,
+                CSL_CMT_SUCCESS,
+                stopWatchdog_updatePrimaryInPFSMs,
+                FOL_HEALED);
+        CST_CFG(FOL_WAITING, CSL_CMT_FAIL, triggerWatchdog, FOL_WAITING);
+        CST_CFG(FOL_WAITING,
+                RST_UNKNOWN,
+                stopWatchdog_cancelRequests,
+                UNKNOWN);
+        CST_CFG(FOL_WAITING, RST_PRIMARY, updatePrimaryInPFSMs, FOL_WAITING);
+        CST_CFG(FOL_WAITING, WATCHDOG, reapplySelectFollower, FOL_WAITING);
+        CST_CFG(FOL_WAITING,
+                STOP_NODE,
+                stopPFSMs_stopWatchdog_cancelRequests,
+                STOPPED);
         CST_CFG(FOL_HEALING,
                 SLCT_LDR,
                 stopWatchdog_cancelRequests_reapplyEvent,
@@ -505,8 +560,12 @@ class ClusterStateTable
                 sendFailureRegistrationResponse,
                 FOL_HEALING);
         CST_CFG(FOL_HEALING,
+                REGISTRATION_RSPN,
+                logUnexpectedRegistrationResponse,
+                FOL_HEALING);
+        CST_CFG(FOL_HEALING,
                 FAIL_REGISTRATION_RSPN,
-                logFailRegistrationResponse,
+                logUnexpectedFailureRegistrationResponse,
                 FOL_HEALING);
         CST_CFG(FOL_HEALING,
                 FOL_CSL_RQST,

--- a/src/groups/mqb/mqbi/mqbi_cluster.cpp
+++ b/src/groups/mqb/mqbi/mqbi_cluster.cpp
@@ -68,6 +68,7 @@ const char* ClusterErrorCode::toAscii(ClusterErrorCode::Enum value)
         CASE(SOURCE_NOT_LEADER)
         CASE(SOURCE_NOT_PRIMARY)
         CASE(IRRECONCILABLE_DATA)
+        CASE(FOLLOWER_WAITING)
     default: return "(* UNKNOWN *)";
     }
 
@@ -102,7 +103,7 @@ bool ClusterErrorCode::fromAscii(ClusterErrorCode::Enum*  out,
     CHECKVALUE(SOURCE_NOT_LEADER)
     CHECKVALUE(SOURCE_NOT_PRIMARY)
     CHECKVALUE(IRRECONCILABLE_DATA)
-
+    CHECKVALUE(FOLLOWER_WAITING)
     // Invalid string
     return false;
 

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -163,7 +163,12 @@ struct ClusterErrorCode {
         e_SOURCE_NOT_PRIMARY = -212,
         /// The node's storage has irreconcilable data
         /// with respect to a peer
-        e_IRRECONCILABLE_DATA = -213
+        e_IRRECONCILABLE_DATA = -213,
+        /// Self is follower waiting for either success or failure
+        /// RegistrationResponse, and **must** reject the FollowerLSNRequest
+        /// to prevent the leader from healing self twice in a row, leading
+        /// to duplicate work.
+        e_FOLLOWER_WAITING = -214
     };
 
     // CLASS METHODS


### PR DESCRIPTION
  ## Summary
  - Introduce a new Cluster FSM follower state, `e_FOL_WAITING`, sitting between `UNKNOWN` and `FOL_HEALING`: a follower that has sent a `RegistrationRequest` now waits in `FOL_WAITING` for the `RegistrationResponse` before entering `FOL_HEALING`. This is analogous to the `e_REPLICA_WAITING ` introduced in the Partition FSM.
  - This prevents a **follower double-heal**: the follower's LSN reaches the leader via the `RegistrationRequest` (which carries `sequenceNumber`), so while waiting the follower must reject `FollowerLSNRequest`s — otherwise the leader would receive the same LSN twice (once via `RegistrationRequest`, once via `FollowerLSNResponse`) and heal the follower twice, doing duplicate work.
  - Split out of #1505 (follower-side piece); independent of the leader-side STG3 work. Depends only on already-merged pieces.