### PR TITLE
Fix[mqbc::IncoreCSL]: Gate e_UPDATE until a snapshot is applied

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -1080,13 +1080,14 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         }
 
         if (recordHeader->recordType() == ClusterStateRecordType::e_UPDATE &&
-            !d_hasAppliedSnapshot) {
+            lsn.electorTerm() != d_appliedSnapshotTerm) {
             BALL_LOG_WARN << description()
                           << ": Ignoring e_UPDATE record with LSN = "
                           << printLSN(lsn) << " from '"
                           << source->nodeDescription()
-                          << "' because self follower has not yet applied a "
-                             "snapshot.";
+                          << "' because self follower has not applied a "
+                             "snapshot for term "
+                          << lsn.electorTerm() << ".";
             d_gatedUpdateLsns.insert(lsn);
             return rc_UPDATE_BEFORE_SNAPSHOT;  // RETURN
         }
@@ -1255,7 +1256,14 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
     }
 
     if (recordHeader->recordType() == ClusterStateRecordType::e_SNAPSHOT) {
-        d_hasAppliedSnapshot = true;
+        d_appliedSnapshotTerm = lsn.electorTerm();
+
+        // Drop gated updates from earlier terms.
+        bmqp_ctrlmsg::LeaderMessageSequence termFloor;
+        termFloor.electorTerm()    = lsn.electorTerm();
+        termFloor.sequenceNumber() = 0;
+        d_gatedUpdateLsns.erase(d_gatedUpdateLsns.begin(),
+                                d_gatedUpdateLsns.lower_bound(termFloor));
     }
 
     return rc_SUCCESS;
@@ -1279,7 +1287,7 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
 , d_ledger_mp(0)
 , d_uncommittedAdvisories(allocator)
 , d_gatedUpdateLsns(allocator)
-, d_hasAppliedSnapshot(false)
+, d_appliedSnapshotTerm(0)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(clusterState);
@@ -1420,7 +1428,7 @@ int IncoreClusterStateLedger::close()
     cancelUncommittedAdvisories();
 
     d_gatedUpdateLsns.clear();
-    d_hasAppliedSnapshot = false;
+    d_appliedSnapshotTerm = 0;
 
     int rc = d_ledger_mp->close();
     if (rc != 0) {

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.cpp
@@ -493,10 +493,6 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
             return rc * 10 + rc_WRITE_FAILURE;  // RETURN
         }
 
-        if (!isSelfLeader()) {
-            d_clusterData_p->electorInfo().setLeaderMessageSequence(lsn);
-        }
-
         mqbsi::LedgerRecordId recordId;
         rc = d_ledger_mp->writeRecord(&recordId,
                                       record,
@@ -508,6 +504,10 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
                            << "failure, record type: " << recordType
                            << ", rc: " << rc << "]";
             return rc * 10 + rc_WRITE_FAILURE;  // RETURN
+        }
+
+        if (!isSelfLeader()) {
+            d_clusterData_p->electorInfo().setLeaderMessageSequence(lsn);
         }
         d_clusterData_p->stats().addCslOffsetBytes(record.length() -
                                                    recordOffset);
@@ -612,9 +612,6 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
             BSLS_ASSERT_SAFE(
                 lsn == d_clusterData_p->electorInfo().leaderMessageSequence());
         }
-        else {
-            d_clusterData_p->electorInfo().setLeaderMessageSequence(lsn);
-        }
 
         const bmqp_ctrlmsg::LeaderAdvisoryCommit& commit =
             clusterMessage.choice().leaderAdvisoryCommit();
@@ -622,6 +619,17 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
         AdvisoriesMapIter iter = d_uncommittedAdvisories.find(
             commit.sequenceNumberCommitted());
         if (iter == d_uncommittedAdvisories.end()) {
+            GatedUpdateLsnsIter git = d_gatedUpdateLsns.find(
+                commit.sequenceNumberCommitted());
+            if (git != d_gatedUpdateLsns.end()) {
+                BALL_LOG_INFO
+                    << description()
+                    << ": Ignoring 'LeaderAdvisoryCommit': " << commit
+                    << ". Reason: it commits an e_UPDATE that was ignored "
+                       "while self follower was not healed.";
+                d_gatedUpdateLsns.erase(git);
+                return rc_SUCCESS;  // RETURN
+            }
             BALL_LOG_ERROR << description()
                            << ": Failed to apply 'LeaderAdvisoryCommit': "
                            << commit
@@ -641,6 +649,10 @@ int IncoreClusterStateLedger::applyRecordInternalImpl(
                            << "failure, record type: " << recordType
                            << ", rc: " << rc << "]";
             return rc * 10 + rc_WRITE_FAILURE;  // RETURN
+        }
+
+        if (!isSelfLeader()) {
+            d_clusterData_p->electorInfo().setLeaderMessageSequence(lsn);
         }
         d_clusterData_p->stats().addCslOffsetBytes(record.length() -
                                                    recordOffset);
@@ -908,16 +920,19 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         rc_INVALID_HEADER = -3,
         /// Unexpected record type
         rc_UNEXPECTED_RECORD_TYPE = -4,
+        /// Record is of type e_UPDATE received before self follower applied
+        /// a snapshot
+        rc_UPDATE_BEFORE_SNAPSHOT = -5,
         /// Record was already applied
-        rc_RECORD_ALREADY_APPLIED = -5,
+        rc_RECORD_ALREADY_APPLIED = -6,
         /// Record is stale
-        rc_RECORD_STALE = -6,
+        rc_RECORD_STALE = -7,
         /// Fail to load cluster message
-        rc_LOAD_MESSAGE_FAILURE = -7,
+        rc_LOAD_MESSAGE_FAILURE = -8,
         /// Advisory is invalid, as determined by type-specific validation
-        rc_ADVISORY_INVALID = -8,
+        rc_ADVISORY_INVALID = -9,
         /// Fail to apply record
-        rc_APPLY_RECORD_FAILURE = -9
+        rc_APPLY_RECORD_FAILURE = -10
     };
 
     BALL_LOG_INFO << "Applying cluster state record event from node '"
@@ -1062,6 +1077,18 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
                        d_clusterData_p->electorInfo().leaderMessageSequence())
                 << "].";
             return rc_RECORD_STALE;  // RETURN
+        }
+
+        if (recordHeader->recordType() == ClusterStateRecordType::e_UPDATE &&
+            !d_hasAppliedSnapshot) {
+            BALL_LOG_WARN << description()
+                          << ": Ignoring e_UPDATE record with LSN = "
+                          << printLSN(lsn) << " from '"
+                          << source->nodeDescription()
+                          << "' because self follower has not yet applied a "
+                             "snapshot.";
+            d_gatedUpdateLsns.insert(lsn);
+            return rc_UPDATE_BEFORE_SNAPSHOT;  // RETURN
         }
     }
 
@@ -1227,6 +1254,10 @@ int IncoreClusterStateLedger::applyImpl(const bdlbb::Blob&   event,
         return rc * 10 + rc_APPLY_RECORD_FAILURE;  // RETURN
     }
 
+    if (recordHeader->recordType() == ClusterStateRecordType::e_SNAPSHOT) {
+        d_hasAppliedSnapshot = true;
+    }
+
     return rc_SUCCESS;
 }
 
@@ -1247,6 +1278,8 @@ IncoreClusterStateLedger::IncoreClusterStateLedger(
 , d_ledgerConfig(allocator)
 , d_ledger_mp(0)
 , d_uncommittedAdvisories(allocator)
+, d_gatedUpdateLsns(allocator)
+, d_hasAppliedSnapshot(false)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(clusterState);
@@ -1385,6 +1418,9 @@ int IncoreClusterStateLedger::close()
     }
 
     cancelUncommittedAdvisories();
+
+    d_gatedUpdateLsns.clear();
+    d_hasAppliedSnapshot = false;
 
     int rc = d_ledger_mp->close();
     if (rc != 0) {

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -61,6 +61,7 @@
 // BDE
 #include <ball_log.h>
 #include <bdlbb_blob.h>
+#include <bsl_set.h>
 #include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bslma_allocator.h>
@@ -153,6 +154,11 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     typedef AdvisoriesMap::const_iterator AdvisoriesMapCIter;
     typedef AdvisoriesMap::iterator       AdvisoriesMapIter;
 
+    /// Set of LSN of `e_UPDATE` records ignored by self follower who is not
+    /// healed.
+    typedef bsl::set<bmqp_ctrlmsg::LeaderMessageSequence> GatedUpdateLsns;
+    typedef GatedUpdateLsns::iterator                     GatedUpdateLsnsIter;
+
   private:
     // CLASS-SCOPE CATEGORY
     BALL_LOG_SET_CLASS_CATEGORY("MQBC.INCORECLUSTERSTATELEDGER");
@@ -194,6 +200,14 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     /// Map of uncommitted (but not canceled) advisories and associated record
     /// id from LSN.
     AdvisoriesMap d_uncommittedAdvisories;
+
+    /// LSNs of `e_UPDATE` records ignored by self follower who has not yet
+    /// applied a snapshot.  An entry is erased when its matching commit
+    /// arrives.
+    GatedUpdateLsns d_gatedUpdateLsns;
+
+    /// True once self follower has applied a snapshot.
+    bool d_hasAppliedSnapshot;
 
   private:
     // NOT IMPLEMENTED
@@ -262,8 +276,7 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     int applyCommit(const bmqp_ctrlmsg::LeaderMessageSequence& lsn,
                     unsigned int                               ackQuorum);
 
-    /// Cancel all uncommitted advisories.  Called upon new leader or term,
-    /// or when this ledger is closed.
+    /// Cancel all uncommitted advisories.
     ///
     /// THREAD: This method can be invoked only in the associated cluster's
     ///         dispatcher thread.

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -206,8 +206,9 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     /// arrives.
     GatedUpdateLsns d_gatedUpdateLsns;
 
-    /// True once self follower has applied a snapshot.
-    bool d_hasAppliedSnapshot;
+    /// Elector term of the last snapshot self follower applied (0 if none).
+    /// An e_UPDATE whose term differs is gated, re-arming the gate each term.
+    bsls::Types::Uint64 d_appliedSnapshotTerm;
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.h
@@ -154,8 +154,8 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     typedef AdvisoriesMap::const_iterator AdvisoriesMapCIter;
     typedef AdvisoriesMap::iterator       AdvisoriesMapIter;
 
-    /// Set of LSN of `e_UPDATE` records ignored by self follower who is not
-    /// healed.
+    /// Set of LSNs of gated `e_UPDATE` records, dropped because self follower
+    /// had not applied a snapshot for their term.
     typedef bsl::set<bmqp_ctrlmsg::LeaderMessageSequence> GatedUpdateLsns;
     typedef GatedUpdateLsns::iterator                     GatedUpdateLsnsIter;
 
@@ -201,9 +201,9 @@ class IncoreClusterStateLedger BSLS_KEYWORD_FINAL : public ClusterStateLedger {
     /// id from LSN.
     AdvisoriesMap d_uncommittedAdvisories;
 
-    /// LSNs of `e_UPDATE` records ignored by self follower who has not yet
-    /// applied a snapshot.  An entry is erased when its matching commit
-    /// arrives.
+    /// LSNs of `e_UPDATE` records gated because self follower had not applied
+    /// a snapshot for their term.  An entry is erased when its matching commit
+    /// arrives, or when a later snapshot supersedes its term.
     GatedUpdateLsns d_gatedUpdateLsns;
 
     /// Elector term of the last snapshot self follower applied (0 if none).

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -324,6 +324,31 @@ struct Tester {
         }
     }
 
+    /// Apply a minimal snapshot record so self follower has a valid base
+    /// state and will accept subsequent `e_UPDATE` records.  Uses the lowest
+    /// LSN so it does not disturb the LSNs of records applied afterwards.
+    void applyPrimingSnapshot()
+    {
+        bmqp_ctrlmsg::LeaderAdvisory snapshot;
+        snapshot.sequenceNumber().electorTerm()    = 1U;
+        snapshot.sequenceNumber().sequenceNumber() = 1U;
+
+        bmqp_ctrlmsg::ClusterMessage message;
+        message.choice().makeLeaderAdvisory(snapshot);
+
+        bdlbb::Blob event(d_cluster_mp->bufferFactory(),
+                          bmqtst::TestHelperUtil::allocator());
+        constructEventBlob(&event,
+                           message,
+                           snapshot.sequenceNumber(),
+                           1U,  // timestamp
+                           mqbc::ClusterStateRecordType::e_SNAPSHOT);
+        BSLS_ASSERT_OPT(d_clusterStateLedger_mp->apply(
+                            event,
+                            d_cluster_mp->netCluster().lookupNode(
+                                mqbmock::Cluster::k_LEADER_NODE_ID)) == 0);
+    }
+
     /// Load into the specified `event` a bmqp::Event of type
     /// `e_CLUSTER_STATE` containing a ledger record of the specified
     /// `clusterMessage` having the specified `sequenceNumber`, `timestamp`
@@ -882,55 +907,13 @@ static void test7_apply_ClusterStateRecord()
     mqbc::IncoreClusterStateLedger* obj = tester.d_clusterStateLedger_mp.get();
     BSLS_ASSERT_OPT(obj->open() == 0);
 
-    // Create an update record
     bmqp_ctrlmsg::PartitionPrimaryInfo pinfo;
     pinfo.primaryNodeId()  = mqbmock::Cluster::k_LEADER_NODE_ID;
     pinfo.partitionId()    = 1U;
     pinfo.primaryLeaseId() = 2U;
 
-    bmqp_ctrlmsg::PartitionPrimaryAdvisory pmAdvisory;
-    pmAdvisory.partitions().push_back(pinfo);
-
-    tester.d_cluster_mp->_clusterData()
-        ->electorInfo()
-        .nextLeaderMessageSequence(&pmAdvisory.sequenceNumber());
-
-    bmqp_ctrlmsg::ClusterMessage updateMessage;
-    updateMessage.choice().makePartitionPrimaryAdvisory(pmAdvisory);
-
-    bdlbb::Blob updateEvent(tester.d_cluster_mp->bufferFactory(),
-                            bmqtst::TestHelperUtil::allocator());
-    tester.constructEventBlob(&updateEvent,
-                              updateMessage,
-                              pmAdvisory.sequenceNumber(),
-                              123456,
-                              mqbc::ClusterStateRecordType::e_UPDATE);
-
-    // Apply the update record
-    BMQTST_ASSERT_EQ(obj->apply(updateEvent,
-                                tester.d_cluster_mp->netCluster().lookupNode(
-                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
-                     0);
-    BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
-    BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
-
-    // Verify that the underlying ledger contains the update record
-    bslma::ManagedPtr<mqbc::ClusterStateLedgerIterator> cslIter =
-        obj->getIterator();
-    BMQTST_ASSERT_EQ(cslIter->next(), 0);
-    BMQTST_ASSERT(cslIter->isValid());
-    verifyRecordHeader(*cslIter,
-                       mqbc::ClusterStateRecordType::e_UPDATE,
-                       pmAdvisory.sequenceNumber());
-    BMQTST_ASSERT_EQ(cslIter->header().timestamp(), 123456U);
-
-    bmqp_ctrlmsg::ClusterMessage msg;
-    int                          rc = cslIter->loadClusterMessage(&msg);
-    BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT(msg.choice().isPartitionPrimaryAdvisoryValue());
-    BMQTST_ASSERT_EQ(msg.choice().partitionPrimaryAdvisory(), pmAdvisory);
-
-    // 2. Create a snapshot record
+    // 1. Create and apply a snapshot record first: a follower must have a
+    //    snapshot base before it will accept e_UPDATE records.
     bmqp_ctrlmsg::QueueInfo qinfo;
     qinfo.uri()         = "bmq://bmq.test.mmap.priority/q1";
     qinfo.partitionId() = 1U;
@@ -951,10 +934,9 @@ static void test7_apply_ClusterStateRecord()
     tester.constructEventBlob(&snapshotEvent,
                               snapshotMessage,
                               leaderAdvisory.sequenceNumber(),
-                              123567,
+                              123456,
                               mqbc::ClusterStateRecordType::e_SNAPSHOT);
 
-    // Apply the snapshot record
     BMQTST_ASSERT_EQ(obj->apply(snapshotEvent,
                                 tester.d_cluster_mp->netCluster().lookupNode(
                                     mqbmock::Cluster::k_LEADER_NODE_ID)),
@@ -962,20 +944,203 @@ static void test7_apply_ClusterStateRecord()
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(1));
 
+    // Verify that the underlying ledger contains the snapshot record
+    bslma::ManagedPtr<mqbc::ClusterStateLedgerIterator> cslIter =
+        obj->getIterator();
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
     BMQTST_ASSERT(cslIter->isValid());
     verifyRecordHeader(*cslIter,
                        mqbc::ClusterStateRecordType::e_SNAPSHOT,
                        leaderAdvisory.sequenceNumber());
+    BMQTST_ASSERT_EQ(cslIter->header().timestamp(), 123456U);
+
+    bmqp_ctrlmsg::ClusterMessage msg;
+    int                          rc = cslIter->loadClusterMessage(&msg);
+    BMQTST_ASSERT_EQ(rc, 0);
+    BMQTST_ASSERT(msg.choice().isLeaderAdvisoryValue());
+    BMQTST_ASSERT_EQ(msg.choice().leaderAdvisory(), leaderAdvisory);
+
+    // 2. Create and apply an update record on top of the snapshot
+    bmqp_ctrlmsg::PartitionPrimaryAdvisory pmAdvisory;
+    pmAdvisory.partitions().push_back(pinfo);
+
+    tester.d_cluster_mp->_clusterData()
+        ->electorInfo()
+        .nextLeaderMessageSequence(&pmAdvisory.sequenceNumber());
+
+    bmqp_ctrlmsg::ClusterMessage updateMessage;
+    updateMessage.choice().makePartitionPrimaryAdvisory(pmAdvisory);
+
+    bdlbb::Blob updateEvent(tester.d_cluster_mp->bufferFactory(),
+                            bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&updateEvent,
+                              updateMessage,
+                              pmAdvisory.sequenceNumber(),
+                              123567,
+                              mqbc::ClusterStateRecordType::e_UPDATE);
+
+    BMQTST_ASSERT_EQ(obj->apply(updateEvent,
+                                tester.d_cluster_mp->netCluster().lookupNode(
+                                    mqbmock::Cluster::k_LEADER_NODE_ID)),
+                     0);
+    BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
+    BMQTST_ASSERT(tester.hasSentMessagesToLeader(2));
+
+    BMQTST_ASSERT_EQ(cslIter->next(), 0);
+    BMQTST_ASSERT(cslIter->isValid());
+    verifyRecordHeader(*cslIter,
+                       mqbc::ClusterStateRecordType::e_UPDATE,
+                       pmAdvisory.sequenceNumber());
     BMQTST_ASSERT_EQ(cslIter->header().timestamp(), 123567U);
 
     rc = cslIter->loadClusterMessage(&msg);
     BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT(msg.choice().isLeaderAdvisoryValue());
-    BMQTST_ASSERT_EQ(msg.choice().leaderAdvisory(), leaderAdvisory);
+    BMQTST_ASSERT(msg.choice().isPartitionPrimaryAdvisoryValue());
+    BMQTST_ASSERT_EQ(msg.choice().partitionPrimaryAdvisory(), pmAdvisory);
 }
 
-static void test8_apply_ClusterStateRecordCommit()
+static void test8_followerGatesUpdatesUntilSnapshot()
+// ------------------------------------------------------------------------
+// FOLLOWER GATES UPDATES UNTIL SNAPSHOT
+//
+// Concerns:
+//   - Before self follower has applied a snapshot, applying an e_UPDATE
+//     record from the leader is rejected: it has no valid base state onto
+//     which to apply an increment, so the record is ignored.
+//   - The commit of such a gated e_UPDATE is skipped: apply() succeeds, no
+//     commit callback fires, and self LSN is not advanced.
+//   - After self follower has applied a snapshot, applying a subsequent
+//     e_UPDATE record (with an LSN above the snapshot) succeeds.
+//
+// Testing:
+//   int apply(const bdlbb::Blob& record, mqbnet::ClusterNode* source)
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "APPLY - FOLLOWER GATES UPDATES UNTIL SNAPSHOT");
+
+    Tester                          tester(false);  // isLeader
+    mqbc::IncoreClusterStateLedger* obj = tester.d_clusterStateLedger_mp.get();
+    BSLS_ASSERT_OPT(obj->open() == 0);
+
+    mqbnet::ClusterNode* leaderNode =
+        tester.d_cluster_mp->netCluster().lookupNode(
+            mqbmock::Cluster::k_LEADER_NODE_ID);
+    const bsls::Types::Uint64 arbitraryTimestamp = 123456;
+
+    // 1. An e_UPDATE received before any snapshot is applied is gated, as self
+    //    follower has no valid base state to apply it onto.
+    bmqp_ctrlmsg::QueueInfo qinfo;
+    qinfo.uri()         = "bmq://bmq.test.mmap.priority/q1";
+    qinfo.partitionId() = 1U;
+    mqbu::StorageKey key(mqbu::StorageKey::BinaryRepresentation(), "7777");
+    key.loadBinary(&qinfo.key());
+
+    bmqp_ctrlmsg::QueueAssignmentAdvisory qadvisory;
+    tester.d_cluster_mp->_clusterData()
+        ->electorInfo()
+        .nextLeaderMessageSequence(&qadvisory.sequenceNumber());
+    qadvisory.queues().push_back(qinfo);
+
+    bmqp_ctrlmsg::ClusterMessage updateMessage;
+    updateMessage.choice().makeQueueAssignmentAdvisory(qadvisory);
+
+    bdlbb::Blob updateEvent(tester.d_cluster_mp->bufferFactory(),
+                            bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&updateEvent,
+                              updateMessage,
+                              qadvisory.sequenceNumber(),
+                              arbitraryTimestamp,
+                              mqbc::ClusterStateRecordType::e_UPDATE);
+
+    // Apply the update record — should fail (gated)
+    BMQTST_ASSERT_NE(obj->apply(updateEvent, leaderNode), 0);
+
+    // No ack was sent (record was not written)
+    BMQTST_ASSERT(tester.hasSentMessagesToLeader(0));
+
+    // 2. The commit of such a gated e_UPDATE is skipped: apply() succeeds, no
+    //    commit callback fires, and self LSN is not advanced.
+    bmqp_ctrlmsg::LeaderAdvisoryCommit gatedCommit;
+    tester.d_cluster_mp->_clusterData()
+        ->electorInfo()
+        .nextLeaderMessageSequence(&gatedCommit.sequenceNumber());
+    gatedCommit.sequenceNumberCommitted() = qadvisory.sequenceNumber();
+
+    bmqp_ctrlmsg::ClusterMessage gatedCommitMessage;
+    gatedCommitMessage.choice().makeLeaderAdvisoryCommit(gatedCommit);
+
+    bdlbb::Blob gatedCommitEvent(tester.d_cluster_mp->bufferFactory(),
+                                 bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&gatedCommitEvent,
+                              gatedCommitMessage,
+                              gatedCommit.sequenceNumber(),
+                              arbitraryTimestamp + 1,
+                              mqbc::ClusterStateRecordType::e_COMMIT);
+
+    const bmqp_ctrlmsg::LeaderMessageSequence lsnBeforeCommit =
+        tester.d_cluster_mp->_clusterData()
+            ->electorInfo()
+            .leaderMessageSequence();
+
+    BMQTST_ASSERT_EQ(obj->apply(gatedCommitEvent, leaderNode), 0);
+
+    // Commit was skipped: nothing committed and self LSN unchanged.
+    BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 0U);
+    BMQTST_ASSERT_EQ(tester.d_cluster_mp->_clusterData()
+                         ->electorInfo()
+                         .leaderMessageSequence(),
+                     lsnBeforeCommit);
+
+    // 3. Apply the healing snapshot (e_SNAPSHOT); self follower now has a
+    //    valid base state.
+    bmqp_ctrlmsg::PartitionPrimaryInfo pinfo;
+    pinfo.primaryNodeId()  = mqbmock::Cluster::k_LEADER_NODE_ID;
+    pinfo.partitionId()    = 1U;
+    pinfo.primaryLeaseId() = 2U;
+
+    bmqp_ctrlmsg::LeaderAdvisory leaderAdvisory;
+    leaderAdvisory.partitions().push_back(pinfo);
+    tester.d_cluster_mp->_clusterData()
+        ->electorInfo()
+        .nextLeaderMessageSequence(&leaderAdvisory.sequenceNumber());
+
+    bmqp_ctrlmsg::ClusterMessage snapshotMessage;
+    snapshotMessage.choice().makeLeaderAdvisory(leaderAdvisory);
+
+    bdlbb::Blob snapshotEvent(tester.d_cluster_mp->bufferFactory(),
+                              bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&snapshotEvent,
+                              snapshotMessage,
+                              leaderAdvisory.sequenceNumber(),
+                              arbitraryTimestamp + 2,
+                              mqbc::ClusterStateRecordType::e_SNAPSHOT);
+
+    BMQTST_ASSERT_EQ(obj->apply(snapshotEvent, leaderNode), 0);
+
+    // 4. A subsequent e_UPDATE (LSN above the snapshot) is now accepted.
+    tester.d_cluster_mp->_clusterData()
+        ->electorInfo()
+        .nextLeaderMessageSequence(&qadvisory.sequenceNumber());
+    updateMessage.choice().makeQueueAssignmentAdvisory(qadvisory);
+
+    bdlbb::Blob postSnapshotUpdate(tester.d_cluster_mp->bufferFactory(),
+                                   bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&postSnapshotUpdate,
+                              updateMessage,
+                              qadvisory.sequenceNumber(),
+                              arbitraryTimestamp + 3,
+                              mqbc::ClusterStateRecordType::e_UPDATE);
+
+    BMQTST_ASSERT_EQ(obj->apply(postSnapshotUpdate, leaderNode), 0);
+
+    // Acks were sent for the snapshot and the post-snapshot update.
+    BMQTST_ASSERT(tester.hasSentMessagesToLeader(2));
+
+    BMQTST_ASSERT_EQ(obj->close(), 0);
+}
+
+static void test9_apply_ClusterStateRecordCommit()
 // ------------------------------------------------------------------------
 // CLUSTER STATE RECORD COMMIT
 //
@@ -995,6 +1160,9 @@ static void test8_apply_ClusterStateRecordCommit()
     Tester                          tester(false);  // isLeader
     mqbc::IncoreClusterStateLedger* obj = tester.d_clusterStateLedger_mp.get();
     BSLS_ASSERT_OPT(obj->open() == 0);
+
+    // Prime self follower with a snapshot so it accepts e_UPDATE records.
+    tester.applyPrimingSnapshot();
 
     // Apply 'PartitionPrimaryAdvisory'
     bmqp_ctrlmsg::PartitionPrimaryInfo pinfo;
@@ -1088,10 +1256,10 @@ static void test8_apply_ClusterStateRecordCommit()
     BMQTST_ASSERT_EQ(tester.numCommittedMessages(), 1U);
 
     BSLS_ASSERT_OPT(obj->close() == 0);
-    BMQTST_ASSERT(tester.hasNoMoreBroadcastedMessages(1));
+    BMQTST_ASSERT(tester.hasNoMoreBroadcastedMessages(2));
 }
 
-static void test9_persistanceLeader()
+static void test10_persistanceLeader()
 // ------------------------------------------------------------------------
 // PERSISTENCE LEADER
 //
@@ -1314,7 +1482,7 @@ static void test9_persistanceLeader()
     BMQTST_ASSERT(!cslIter->isValid());
 }
 
-static void test10_persistanceFollower()
+static void test11_persistanceFollower()
 // ------------------------------------------------------------------------
 // PERSISTENCE FOLLOWER
 //
@@ -1336,6 +1504,9 @@ static void test10_persistanceFollower()
     Tester                          tester(false);  // isLeader
     mqbc::IncoreClusterStateLedger* obj = tester.d_clusterStateLedger_mp.get();
     BSLS_ASSERT_OPT(obj->open() == 0);
+
+    // Prime self follower with a snapshot so it accepts e_UPDATE records.
+    tester.applyPrimingSnapshot();
 
     // 1. Apply advisories of different types
 
@@ -1527,6 +1698,10 @@ static void test10_persistanceFollower()
 
     // 4. Iterate through the records and verify that they are as expected
 
+    // The first record is the priming snapshot applied during setup; skip it.
+    BMQTST_ASSERT_EQ(cslIter->next(), 0);
+    BMQTST_ASSERT(cslIter->isValid());
+
     // Verify 'PartitionPrimaryAdvisory'
     BMQTST_ASSERT_EQ(cslIter->next(), 0);
     BMQTST_ASSERT(cslIter->isValid());
@@ -1605,7 +1780,7 @@ static void test10_persistanceFollower()
 }
 
 BSLA_MAYBE_UNUSED
-static void test11_persistanceAcrossRolloverLeader()
+static void test12_persistanceAcrossRolloverLeader()
 // ------------------------------------------------------------------------
 // PERSISTENCE ACROSS ROLLOVER LEADER
 //
@@ -2021,7 +2196,7 @@ static void test11_persistanceAcrossRolloverLeader()
     BSLS_ASSERT_OPT(obj->close() == 0);
 }
 
-static void test12_quorumChangeCb()
+static void test13_quorumChangeCb()
 // ------------------------------------------------------------------------
 // QUORUM CHANGE CALLBACK
 //
@@ -2106,15 +2281,16 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 12: test12_quorumChangeCb(); break;
+    case 13: test13_quorumChangeCb(); break;
     // @TODO RENABLE AND FIX THIS TEST
     //
     // The following test consistently fails in CI.  It should be fixed,
     // but until then we want to avoid the noise.
-    //    case 11: test11_persistanceAcrossRolloverLeader(); break;
-    case 10: test10_persistanceFollower(); break;
-    case 9: test9_persistanceLeader(); break;
-    case 8: test8_apply_ClusterStateRecordCommit(); break;
+    //    case 12: test11_persistanceAcrossRolloverLeader(); break;
+    case 11: test11_persistanceFollower(); break;
+    case 10: test10_persistanceLeader(); break;
+    case 9: test9_apply_ClusterStateRecordCommit(); break;
+    case 8: test8_followerGatesUpdatesUntilSnapshot(); break;
     case 7: test7_apply_ClusterStateRecord(); break;
     case 6: test6_apply_LeaderAdvisory(); break;
     case 5: test5_apply_QueueUpdateAdvisory(); break;
@@ -2123,7 +2299,7 @@ int main(int argc, char* argv[])
     case 2: test2_apply_PartitionPrimaryAdvisory(); break;
     case 1: test1_breathingTest(); break;
     default: {
-        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND.\n";
         bmqtst::TestHelperUtil::testStatus() = -1;
     } break;
     }

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -435,9 +435,9 @@ struct Tester {
         return true;
     }
 
-    /// Return true if we the follower has sent `number` messages to the
-    /// leader, false otherwise.  Behavior is undefined unless the caller is a
-    /// follower node.
+    /// Return true if we the follower has sent at least `number` messages to
+    /// the leader, false otherwise.  Behavior is undefined unless the caller
+    /// is a follower node.
     bool hasSentMessagesToLeader(size_t number) const
     {
         // PRECONDITIONS
@@ -460,6 +460,22 @@ struct Tester {
         }
 
         return true;
+    }
+
+    /// Return the total number of messages self node has written to peers.
+    size_t numMessagesSent() const
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_OPT(d_cluster_mp->_channels().size() > 0);
+
+        size_t count = 0;
+        for (TestChannelMapCIter citer = d_cluster_mp->_channels().cbegin();
+             citer != d_cluster_mp->_channels().cend();
+             ++citer) {
+            count += citer->second->numWriteCalls();
+        }
+
+        return count;
     }
 
     /// Return true if we the leader has at least `number` broadcast messages,
@@ -1056,8 +1072,8 @@ static void test8_followerGatesUpdatesUntilSnapshot()
     // Apply the update record — should fail (gated)
     BMQTST_ASSERT_NE(obj->apply(updateEvent, leaderNode), 0);
 
-    // No ack was sent (record was not written)
-    BMQTST_ASSERT(tester.hasSentMessagesToLeader(0));
+    // The gated record produced no output: no message was sent to any node.
+    BMQTST_ASSERT_EQ(tester.numMessagesSent(), 0U);
 
     // 2. The commit of such a gated e_UPDATE is skipped: apply() succeeds, no
     //    commit callback fires, and self LSN is not advanced.

--- a/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_incoreclusterstateledger.t.cpp
@@ -1027,6 +1027,8 @@ static void test8_followerGatesUpdatesUntilSnapshot()
 //     commit callback fires, and self LSN is not advanced.
 //   - After self follower has applied a snapshot, applying a subsequent
 //     e_UPDATE record (with an LSN above the snapshot) succeeds.
+//   - A new elector term re-arms the gate: an e_UPDATE from a later term is
+//     rejected until a snapshot for that term is applied.
 //
 // Testing:
 //   int apply(const bdlbb::Blob& record, mqbnet::ClusterNode* source)
@@ -1152,6 +1154,61 @@ static void test8_followerGatesUpdatesUntilSnapshot()
 
     // Acks were sent for the snapshot and the post-snapshot update.
     BMQTST_ASSERT(tester.hasSentMessagesToLeader(2));
+
+    // 5. A new elector term re-arms the gate: although self is healed for
+    //    term 1, an e_UPDATE from term 2 is gated until a term-2 snapshot.
+    bmqp_ctrlmsg::QueueInfo qinfo2;
+    qinfo2.uri()         = "bmq://bmq.test.mmap.priority/q2";
+    qinfo2.partitionId() = 1U;
+    mqbu::StorageKey key2(mqbu::StorageKey::BinaryRepresentation(), "8888");
+    key2.loadBinary(&qinfo2.key());
+
+    bmqp_ctrlmsg::QueueAssignmentAdvisory newTermUpdate;
+    newTermUpdate.sequenceNumber().electorTerm()    = 2U;
+    newTermUpdate.sequenceNumber().sequenceNumber() = 1U;
+    newTermUpdate.queues().push_back(qinfo2);
+    updateMessage.choice().makeQueueAssignmentAdvisory(newTermUpdate);
+
+    bdlbb::Blob newTermUpdateEvent(tester.d_cluster_mp->bufferFactory(),
+                                   bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&newTermUpdateEvent,
+                              updateMessage,
+                              newTermUpdate.sequenceNumber(),
+                              arbitraryTimestamp + 4,
+                              mqbc::ClusterStateRecordType::e_UPDATE);
+
+    BMQTST_ASSERT_NE(obj->apply(newTermUpdateEvent, leaderNode), 0);
+
+    // A term-2 snapshot re-establishes the base for term 2.
+    bmqp_ctrlmsg::LeaderAdvisory newTermSnapshot;
+    newTermSnapshot.partitions().push_back(pinfo);
+    newTermSnapshot.sequenceNumber().electorTerm()    = 2U;
+    newTermSnapshot.sequenceNumber().sequenceNumber() = 2U;
+    snapshotMessage.choice().makeLeaderAdvisory(newTermSnapshot);
+
+    bdlbb::Blob newTermSnapshotEvent(tester.d_cluster_mp->bufferFactory(),
+                                     bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&newTermSnapshotEvent,
+                              snapshotMessage,
+                              newTermSnapshot.sequenceNumber(),
+                              arbitraryTimestamp + 5,
+                              mqbc::ClusterStateRecordType::e_SNAPSHOT);
+
+    BMQTST_ASSERT_EQ(obj->apply(newTermSnapshotEvent, leaderNode), 0);
+
+    // Now a term-2 e_UPDATE is accepted.
+    newTermUpdate.sequenceNumber().sequenceNumber() = 3U;
+    updateMessage.choice().makeQueueAssignmentAdvisory(newTermUpdate);
+
+    bdlbb::Blob newTermUpdate2Event(tester.d_cluster_mp->bufferFactory(),
+                                    bmqtst::TestHelperUtil::allocator());
+    tester.constructEventBlob(&newTermUpdate2Event,
+                              updateMessage,
+                              newTermUpdate.sequenceNumber(),
+                              arbitraryTimestamp + 6,
+                              mqbc::ClusterStateRecordType::e_UPDATE);
+
+    BMQTST_ASSERT_EQ(obj->apply(newTermUpdate2Event, leaderNode), 0);
 
     BMQTST_ASSERT_EQ(obj->close(), 0);
 }


### PR DESCRIPTION
  ## Summary
  - Gate `e_UPDATE` records on a follower until it has applied a snapshot (`e_SNAPSHOT`). Before a snapshot there is no valid base state to apply an increment onto, and applying/committing an update could also prematurely mark the follower healed.
  - The gate keys off **snapshot-applied**, not **healed** (snapshot committed). This is the crucial distinction: by per-channel ordering, updates received *before* the snapshot have a lower LSN and are superseded (safe to drop), while updates *after* the snapshot are genuine increments that must be applied. Keying off "healed" would drop a post-snapshot update arriving before the snapshot's commit — losing it permanently, with no re-fetch path.
  - Split out of #1505; complements the follower `e_FOL_WAITING` state (#1633) — that's the state in which a rejoining/late follower is unhealed and can receive updates it must gate.