### PR TITLE
Refactor[mqbblp]: simplify RootQueueEngine

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_localqueue.cpp
@@ -158,10 +158,11 @@ int LocalQueue::configure(bsl::ostream& errorDescription, bool isReconfigure)
     // during update of a domain's configuration, this object already exists,
     // and should not be re-created.
     if (!d_queueEngine_mp) {
-        RootQueueEngine::create(&d_queueEngine_mp,
-                                d_state_p,
-                                *domainCfg,
-                                d_allocator_p);
+        d_queueEngine_mp =
+            bslma::ManagedPtrUtil::allocateManaged<RootQueueEngine>(
+                d_allocator_p,
+                d_state_p,
+                *domainCfg);
     }
 
     // Inform the storage about the queue.

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.cpp
@@ -36,7 +36,6 @@
 #include <bmqt_uri.h>
 
 #include <bmqu_memoutstream.h>
-#include <bmqu_time.h>
 
 // BDE
 #include <bdlb_string.h>
@@ -49,7 +48,6 @@
 #include <bsl_memory.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
-#include <bslmt_once.h>
 #include <bsls_types.h>
 #include <bslstl_stringref.h>
 
@@ -395,8 +393,6 @@ QueueEngineTester::QueueEngineTester(const mqbconfm::Domain& domainConfig,
 , d_messageCount(0)
 , d_allocator_p(allocator)
 {
-    oneTimeInit();
-
     mqbconfm::Domain config = domainConfig;
 
     config.deduplicationTimeMs() = 0;  // No history
@@ -421,18 +417,9 @@ QueueEngineTester::~QueueEngineTester()
     d_mockDomain_mp->unregisterQueue(queue);
 
     d_mockCluster_mp->stop();
-    oneTimeShutdown();
 }
 
 // PRIVATE MANIPULATORS
-void QueueEngineTester::oneTimeInit()
-{
-    BSLMT_ONCE_DO
-    {
-        bmqu::Time::initialize();
-    }
-}
-
 void QueueEngineTester::init(const mqbconfm::Domain& domainConfig,
                              bool                    startScheduler)
 {
@@ -625,14 +612,6 @@ void QueueEngineTester::init(const mqbconfm::Domain& domainConfig,
 
     const_cast<QueueHandleCatalog&>(d_queueState_mp->handleCatalog())
         .setHandleFactory(handleFactory_mp);
-}
-
-void QueueEngineTester::oneTimeShutdown()
-{
-    BSLMT_ONCE_DO
-    {
-        bmqu::Time::shutdown();
-    }
 }
 
 void QueueEngineTester::handleReleasedCallback(

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
@@ -642,12 +642,14 @@ inline T* QueueEngineTester::createQueueEngine()
 {
     // PRECONDITIONS
     BSLS_ASSERT_OPT(!d_queueEngine_mp && "'createQueueEngine()' was called");
-    T* result = new (*d_allocator_p)
-        T(d_queueState_mp.get(),
-          *d_queueState_mp->queue()->domain()->config(),
-          d_allocator_p);
+
     // Create and configure Queue Engine
-    d_queueEngine_mp.load(result, d_allocator_p);
+    d_queueEngine_mp = bslma::ManagedPtrUtil::allocateManaged<T>(
+        d_allocator_p,
+        d_queueState_mp.get(),
+        *d_queueState_mp->queue()->domain()->config());
+
+    T* result = static_cast<T*>(d_queueEngine_mp.get());
 
     createQueueEngineHelper(d_queueEngine_mp.get());
 

--- a/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
+++ b/src/groups/mqb/mqbblp/mqbblp_queueenginetester.h
@@ -257,17 +257,9 @@ class QueueEngineTester {
   private:
     // PRIVATE MANIPULATORS
 
-    /// Perform any initialization that needs to be done one time only in
-    /// the course of a program's execution (to enable thread-safety of some
-    /// component, etc.).
-    void oneTimeInit();
-
     /// Reset and recreate all objects using the currently set options and
     /// the specific `domainConfig`.
     void init(const mqbconfm::Domain& domainConfig, bool startScheduler);
-
-    /// Pendant operation of the `oneTimeInit` one.
-    void oneTimeShutdown();
 
     void
     handleReleasedCallback(int*  rc,

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.t.cpp
@@ -25,6 +25,7 @@
 #include <mqbstat_brokerstats.h>
 
 #include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
 
 // BMQ
 #include <bmqp_protocol.h>
@@ -2028,6 +2029,8 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
+    bmqu::Time::initialize(bmqtst::TestHelperUtil::allocator());
+
     {
         mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
         mqbcfg::BrokerConfig::set(brokerConfig);
@@ -2067,6 +2070,8 @@ int main(int argc, char* argv[])
         } break;
         }
     }
+
+    bmqu::Time::shutdown();
 
     // Default allocator check is disabled for all UTs:
     // `mqbblp::QueueEngine` and mocks from `mqbi` methods use ball logging

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -300,19 +300,6 @@ void RootQueueEngine::onHandleCreation(void* ptr, void* cookie)
                                                      hndlCreated);
 }
 
-void RootQueueEngine::create(bslma::ManagedPtr<mqbi::QueueEngine>* queueEngine,
-                             QueueState*                           queueState,
-                             const mqbconfm::Domain& domainConfig,
-                             bslma::Allocator*       allocator)
-{
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(queueEngine);
-
-    queueEngine->load(new (*allocator)
-                          RootQueueEngine(queueState, domainConfig, allocator),
-                      allocator);
-}
-
 void RootQueueEngine::FanoutConfiguration::loadRoutingConfiguration(
     bmqp_ctrlmsg::RoutingConfiguration* config)
 {

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.h
@@ -220,14 +220,6 @@ class RootQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// to a boolean flag indicating whether the handle was created or not.
     static void onHandleCreation(void* ptr, void* cookie);
 
-    /// Loads the specified `queueEngine` with a new `RootQueueEngine`
-    /// initialized using the specified `queueState`, `domainConfig`,
-    /// `scheduler` and `allocator`.
-    static void create(bslma::ManagedPtr<mqbi::QueueEngine>* queueEngine,
-                       QueueState*                           queueState,
-                       const mqbconfm::Domain&               domainConfig,
-                       bslma::Allocator*                     allocator);
-
     /// Loads the specified `config` with the appropriate values for
     /// fanout delivery mode.
     struct FanoutConfiguration {

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -41,6 +41,7 @@
 
 #include <bmqtst_scopedlogobserver.h>
 #include <bmqu_memoutstream.h>
+#include <bmqu_time.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -5122,6 +5123,8 @@ int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
 
+    bmqu::Time::initialize(bmqtst::TestHelperUtil::allocator());
+
     mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
     mqbcfg::BrokerConfig::set(brokerConfig);
 
@@ -5197,6 +5200,8 @@ int main(int argc, char* argv[])
         } break;
         }
     }
+
+    bmqu::Time::shutdown();
 
     // Default allocator check is disabled for all UTs:
     // `mqbblp::QueueEngine` and mocks from `mqbi` methods use ball logging

--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp
@@ -20,8 +20,6 @@
 #include <mqbblp_queueengineutil.h>
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
-#include <mqbi_queueengine.h>
-#include <mqbi_storage.h>
 #include <mqbmock_queuehandle.h>
 #include <mqbstat_brokerstats.h>
 
@@ -33,16 +31,12 @@
 // BDE
 #include <bdlb_bitutil.h>
 #include <bdlb_tokenizer.h>
-#include <bdlmt_eventscheduler.h>
 #include <bsl_iostream.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
 #include <bslma_allocator.h>
-#include <bslma_managedptr.h>
-#include <bslmf_assert.h>
-#include <bslmt_semaphore.h>
 #include <bsls_timeinterval.h>
 
 #include <bmqtst_scopedlogobserver.h>
@@ -50,9 +44,7 @@
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
-#include <bsl_algorithm.h>
 #include <bsl_functional.h>
-#include <bsl_ios.h>
 #include <bsl_limits.h>
 #include <bsl_map.h>
 
@@ -1367,18 +1359,22 @@ static void test8_priorityBreathingTest()
     tester.confirm("C3", tester.getMessages(C3->_messages(), "0"));
 }
 
-static void test9_priorityCreateAndConfigure()
+static void test9_createAndConfigure()
 // ------------------------------------------------------------------------
 // CREATE AND CONFIGURE
 //
 // Concerns:
 //   Ensure that creating the queue engine results in a functional queue
-//   engine that can be configured successfully.
+//   engine that can be configured successfully, for priority, fanout and
+//   broadcast modes.
 //
 // Plan:
-//  1. Create PriorityQueueEngine
-//  2. Verify that the created PriorityQueueEngine is functional by
-//     configuring it successfully
+//  1. Create a priority RootQueueEngine and verify it is functional by
+//     configuring it successfully.
+//  2. Create a fanout RootQueueEngine and verify it is functional by
+//     configuring it successfully.
+//  3. Create a broadcast RootQueueEngine and verify it is functional by
+//     configuring it successfully.
 //
 // Testing:
 //   create
@@ -1388,52 +1384,50 @@ static void test9_priorityCreateAndConfigure()
 {
     bmqtst::TestHelper::printTestName("CREATE AND CONFIGURE");
 
-    class PriorityQueueEngineTester : public mqbblp::QueueEngineTester {
-      public:
-        // CREATORS
-        PriorityQueueEngineTester(const mqbconfm::Domain& domainConfig,
-                                  bslma::Allocator*       allocator)
-        : mqbblp::QueueEngineTester(domainConfig, true, allocator)
-        {
-        }
+    // 'createQueueEngine' configures the engine and asserts that
+    // configuration succeeds.
 
-        // ACCESSORS
-        void create(bslma::ManagedPtr<mqbi::QueueEngine>* queueEngine,
-                    bslma::Allocator*                     allocator) const
-        {
-            mqbblp::RootQueueEngine::create(
-                queueEngine,
-                d_queueState_mp.get(),
-                *d_queueState_mp->domain()->config(),
-                allocator);
-        }
+    // 1. Priority
+    {
+        mqbconfm::Domain domainConfig;
+        domainConfig.mode().makePriority();
 
-        ~PriorityQueueEngineTester() {}
-    };
+        mqbblp::QueueEngineTester tester(domainConfig,
+                                         true,  // start scheduler
+                                         bmqtst::TestHelperUtil::allocator());
 
-    mqbconfm::Domain domainConfig;
-    domainConfig.mode().makePriority();
+        mqbblp::RootQueueEngine* queueEngine =
+            tester.createQueueEngine<mqbblp::RootQueueEngine>();
 
-    PriorityQueueEngineTester            tester(domainConfig,
-                                     bmqtst::TestHelperUtil::allocator());
-    bslma::ManagedPtr<mqbi::QueueEngine> queueEngineMp;
-    BSLS_ASSERT_OPT(!queueEngineMp);
+        BMQTST_ASSERT(queueEngine != 0);
+        BMQTST_ASSERT_EQ(queueEngine->messageReferenceCount(), 1U);
+    }
 
-    // 1. Create PriorityQueueEngine
-    tester.create(&queueEngineMp, bmqtst::TestHelperUtil::allocator());
+    // 2. Fanout
+    {
+        mqbblp::QueueEngineTester tester(fanoutConfig("a,b,c,d,e"),
+                                         true,  // start scheduler
+                                         bmqtst::TestHelperUtil::allocator());
 
-    BMQTST_ASSERT(queueEngineMp.get() != 0);
+        mqbblp::RootQueueEngine* queueEngine =
+            tester.createQueueEngine<mqbblp::RootQueueEngine>();
 
-    // 2. Verify that the created PriorityQueueEngine is functional by
-    //    configuring it successfully
-    bmqu::MemOutStream errorDescription(bmqtst::TestHelperUtil::allocator());
-    errorDescription.reset();
+        BMQTST_ASSERT(queueEngine != 0);
+        BMQTST_ASSERT_EQ(queueEngine->messageReferenceCount(), 5U);
+    }
 
-    int rc = queueEngineMp->configure(errorDescription, false);
+    // 3. Broadcast
+    {
+        mqbblp::QueueEngineTester tester(broadcastConfig(),
+                                         true,  // start scheduler
+                                         bmqtst::TestHelperUtil::allocator());
 
-    BMQTST_ASSERT_EQ(errorDescription.length(), 0U);
-    BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT_EQ(queueEngineMp->messageReferenceCount(), 1U);
+        mqbblp::RootQueueEngine* queueEngine =
+            tester.createQueueEngine<mqbblp::RootQueueEngine>();
+
+        BMQTST_ASSERT(queueEngine != 0);
+        BMQTST_ASSERT_EQ(queueEngine->messageReferenceCount(), 1U);
+    }
 }
 
 static void test10_priorityAggregateDownstream()
@@ -2572,70 +2566,6 @@ static void test21_breathingTest()
         BMQTST_ASSERT_EQ(C2->_appIds(), "");
         BMQTST_ASSERT_EQ(C3->_appIds(), "");
     }
-}
-
-static void test22_createAndConfigure()
-// ------------------------------------------------------------------------
-// CREATE AND CONFIGURE
-//
-// Concerns:
-//   Ensure that creating the queue engine results in a functional queue
-//   engine that can be configured successfully.
-//
-// Plan:
-//  1. Create FanoutQueueEngine
-//  2. Verify that the created FanoutQueueEngine is functional by
-//     configuring it successfully
-//
-// Testing:
-//   create
-//   configure
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("CREATE AND CONFIGURE");
-
-    class FanoutQueueEngineTester : public mqbblp::QueueEngineTester {
-      public:
-        // CREATORS
-        FanoutQueueEngineTester(const mqbconfm::Domain& domainConfig,
-                                bslma::Allocator*       allocator)
-        : mqbblp::QueueEngineTester(domainConfig, true, allocator)
-        {
-        }
-
-        // ACCESSORS
-        void create(bslma::ManagedPtr<mqbi::QueueEngine>* queueEngine,
-                    bslma::Allocator*                     allocator) const
-        {
-            mqbblp::RootQueueEngine::create(
-                queueEngine,
-                d_queueState_mp.get(),
-                *d_queueState_mp->domain()->config(),
-                allocator);
-        }
-
-        ~FanoutQueueEngineTester() {}
-    };
-
-    FanoutQueueEngineTester              tester(fanoutConfig("a,b,c,d,e"),
-                                   bmqtst::TestHelperUtil::allocator());
-    bslma::ManagedPtr<mqbi::QueueEngine> queueEngineMp;
-    BSLS_ASSERT_OPT(!queueEngineMp);
-
-    // 1. Create FanoutQueueEngine
-    tester.create(&queueEngineMp, bmqtst::TestHelperUtil::allocator());
-
-    BMQTST_ASSERT(queueEngineMp.get() != 0);
-
-    // 2. Verify that the created FanoutQueueEngine is functional by
-    //    configuring it successfully
-    bmqu::MemOutStream errorDescription(bmqtst::TestHelperUtil::allocator());
-    errorDescription.reset();
-    int rc = queueEngineMp->configure(errorDescription, false);
-
-    BMQTST_ASSERT_EQ(errorDescription.length(), 0U);
-    BMQTST_ASSERT_EQ(rc, 0);
-    BMQTST_ASSERT_EQ(queueEngineMp->messageReferenceCount(), 5U);
 }
 
 static void test23_loadRoutingConfiguration()
@@ -5230,7 +5160,7 @@ int main(int argc, char* argv[])
         case 25: test25_getHandleSameHandleMultipleAppIds(); break;
         case 24: test24_getHandleDuplicateAppId(); break;
         case 23: test23_loadRoutingConfiguration(); break;
-        case 22: test22_createAndConfigure(); break;
+        case 22: /* vacant */ break;
         case 21: test21_breathingTest(); break;
         case 20: test20_priorityRedeliverAfterGc(); break;
         case 19: test19_priorityReleaseHandle_isDeletedFlag(); break;
@@ -5249,7 +5179,7 @@ int main(int argc, char* argv[])
         case 12: test12_priorityCannotDeliver(); break;
         case 11: test11_priorityReconfigure(); break;
         case 10: test10_priorityAggregateDownstream(); break;
-        case 9: test9_priorityCreateAndConfigure(); break;
+        case 9: test9_createAndConfigure(); break;
         case 8: test8_priorityBreathingTest(); break;
         case 7: test7_broadcastPriorityFailover(); break;
         case 6: test6_broadcastDynamicPriorities(); break;


### PR DESCRIPTION
- Remove useless `RootQueueEngine::create`
- `QueueEngineTester`: use `allocateManaged`
- `src/groups/mqb/mqbblp/mqbblp_rootqueueengine.t.cpp`: simplify test cases, remove useless includes, add missing `broadcast` test case