### PR TITLE
Fix[mqbnet::InitialConnectionContext]: propagate close to authn

### DIFF
--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -84,6 +84,7 @@ int Authenticator::onAuthenticationRequest(
     bsl::shared_ptr<mqbnet::AuthenticationContext> authenticationContext =
         bsl::allocate_shared<mqbnet::AuthenticationContext>(
             d_allocator_p,
+            d_scheduler_p,
             context_p,  // initialConnectionContext
             authenticationMsg.authenticationRequest()
                 .mechanism(),   // mechanism
@@ -353,7 +354,6 @@ void Authenticator::authenticate(
     bmqu::MemOutStream scheduleErrStream;
     const int scheduleRc = context_sp->setAuthenticatedAndScheduleReauthn(
         scheduleErrStream,
-        d_scheduler_p,
         result->lifetimeMs(),
         channel);
     if (scheduleRc != 0) {

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
@@ -100,6 +100,7 @@ bool AuthenticationState::fromAscii(AuthenticationState::Enum* out,
 // ---------------------------
 
 AuthenticationContext::AuthenticationContext(
+    bdlmt::EventScheduler*                     scheduler,
     InitialConnectionContext*                  initialConnectionContext,
     bsl::string_view                           mechanism,
     const bmqp_ctrlmsg::AuthenticationMessage& authenticationMessage,
@@ -107,6 +108,7 @@ AuthenticationContext::AuthenticationContext(
     AuthenticationState::Enum                  state,
     bslma::Allocator*                          allocator)
 : d_allocator_p(allocator)
+, d_scheduler_p(scheduler)
 , d_self(this)  // use default allocator
 , d_mutex()
 , d_authenticationResultSp()
@@ -117,7 +119,8 @@ AuthenticationContext::AuthenticationContext(
 , d_authenticationMessage(authenticationMessage)
 , d_encodingType(authenticationEncodingType)
 {
-    // NOTHING
+    // PRECONDITION
+    BSLS_ASSERT_SAFE(d_scheduler_p);
 }
 
 void AuthenticationContext::setAuthenticationResult(
@@ -153,14 +156,12 @@ void AuthenticationContext::resetAuthenticationMessage()
 
 int AuthenticationContext::setAuthenticatedAndScheduleReauthn(
     bsl::ostream&                             errorDescription,
-    bdlmt::EventScheduler*                    scheduler_p,
     const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
     const bsl::shared_ptr<bmqio::Channel>&    channel_sp)
 {
     // executed by an *AUTHENTICATION* thread
 
     // PRECONDITION
-    BSLS_ASSERT_SAFE(scheduler_p);
     BSLS_ASSERT_SAFE(channel_sp);
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
@@ -175,14 +176,14 @@ int AuthenticationContext::setAuthenticatedAndScheduleReauthn(
 
     d_state = AuthenticationState::e_AUTHENTICATED;
 
-    scheduler_p->cancelEventAndWait(&d_timeoutHandle);
+    d_scheduler_p->cancelEventAndWait(&d_timeoutHandle);
 
     if (!lifetimeMs.has_value()) {
         return 0;
     }
     const bsls::Types::Uint64 lifetime = lifetimeMs.value();
 
-    scheduler_p->scheduleEvent(
+    d_scheduler_p->scheduleEvent(
         &d_timeoutHandle,
         bsls::TimeInterval(bmqu::Time::nowMonotonicClock())
             .addMilliseconds(lifetime),
@@ -250,12 +251,9 @@ void AuthenticationContext::onReauthenticationError(
     channel_sp->close(status);
 }
 
-void AuthenticationContext::onClose(bdlmt::EventScheduler* scheduler_p)
+void AuthenticationContext::onClose()
 {
     // executed by *ANY* thread
-
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(scheduler_p);
 
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED
 
@@ -264,7 +262,7 @@ void AuthenticationContext::onClose(bdlmt::EventScheduler* scheduler_p)
     }
     d_state = AuthenticationState::e_CLOSED;
 
-    scheduler_p->cancelEventAndWait(&d_timeoutHandle);
+    d_scheduler_p->cancelEventAndWait(&d_timeoutHandle);
 }
 
 bool AuthenticationContext::tryStartReauthentication()

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
@@ -127,6 +127,9 @@ class AuthenticationContext {
     /// Allocator to use.
     bslma::Allocator* d_allocator_p;
 
+    /// Scheduler used to schedule and cancel the reauthentication timer.
+    bdlmt::EventScheduler* d_scheduler_p;
+
     /// Used to make sure no callback is invoked on a destroyed object.
     bmqu::SharedResource<AuthenticationContext> d_self;
 
@@ -179,6 +182,7 @@ class AuthenticationContext {
                                    bslma::UsesBslmaAllocator)
     // CREATORS
     AuthenticationContext(
+        bdlmt::EventScheduler*                     scheduler,
         InitialConnectionContext*                  initialConnectionContext,
         bsl::string_view                           mechanism,
         const bmqp_ctrlmsg::AuthenticationMessage& authenticationMessage,
@@ -201,14 +205,13 @@ class AuthenticationContext {
 
     void resetAuthenticationMessage();
 
-    /// Schedule a reauthentication timer using the specified `scheduler_p`
-    /// with the specified `lifetimeMs`.  The specified `channel_sp` is used to
-    /// close the connection in case of reauthentication timeout or error.
-    /// Return 0 on success, and a non-zero value populating the specified
-    /// `errorDescription` with details on failure.
+    /// @brief Mark as authenticated and schedule a reauthentication timer.
+    /// @param[out] errorDescription Populated with details on failure.
+    /// @param lifetimeMs Duration after which reauthentication is required.
+    /// @param channel_sp Channel closed on reauthentication timeout or error.
+    /// @return 0 on success, and a non-zero value on failure.
     int setAuthenticatedAndScheduleReauthn(
         bsl::ostream&                             errorDescription,
-        bdlmt::EventScheduler*                    scheduler_p,
         const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
         const bsl::shared_ptr<bmqio::Channel>&    channel_sp);
 
@@ -226,9 +229,9 @@ class AuthenticationContext {
                             int                                    errorCode,
                             const bsl::string& errorDescription);
 
-    /// Called when a channel is closing.  Cancel any outstanding
-    /// reauthentication timer using the specified `scheduler_p`.
-    void onClose(bdlmt::EventScheduler* scheduler_p);
+    /// @brief Cancel any outstanding reauthentication timer when the channel
+    ///        is closing.
+    void onClose();
 
     /// Attempt to begin reauthentication by transitioning the state from
     /// AUTHENTICATED to AUTHENTICATING.

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.t.cpp
@@ -110,6 +110,7 @@ struct TestBench {
         bmqp_ctrlmsg::AuthenticationMessage authnMsg;
         return bsl::allocate_shared<mqbnet::AuthenticationContext>(
             d_allocator_p,
+            &d_scheduler,
             static_cast<mqbnet::InitialConnectionContext*>(0),
             "testMechanism",
             authnMsg,
@@ -150,12 +151,11 @@ static void test1_breathingTest()
     bsl::optional<bsls::Types::Uint64> noLifetime;
 
     int rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      noLifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
 
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 }
 
 static void test2_zeroLifetimeTimeout()
@@ -188,7 +188,6 @@ static void test2_zeroLifetimeTimeout()
 
     bmqu::MemOutStream errStream(alloc);
     int                rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      lifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
@@ -208,7 +207,7 @@ static void test2_zeroLifetimeTimeout()
         ".*Reauthentication timeout.*",
         alloc));
 
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 }
 
 static void test3_reauthenticationTimeout()
@@ -247,7 +246,6 @@ static void test3_reauthenticationTimeout()
 
     bmqu::MemOutStream errStream(alloc);
     int                rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      lifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
@@ -280,7 +278,7 @@ static void test3_reauthenticationTimeout()
         ".*Reauthentication timeout.*",
         alloc));
 
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 }
 
 static void test4_reauthenticationBeforeTimeout()
@@ -316,7 +314,6 @@ static void test4_reauthenticationBeforeTimeout()
 
     // 1) Initial authentication with lifetime
     int rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      lifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
@@ -338,7 +335,6 @@ static void test4_reauthenticationBeforeTimeout()
     bsl::optional<bsls::Types::Uint64> newLifetime(newLifetimeMs);
 
     rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                 &tb.d_scheduler,
                                                  newLifetime,
                                                  tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
@@ -353,7 +349,7 @@ static void test4_reauthenticationBeforeTimeout()
     // 7) Now the new timer fires and closes the channel
     BMQTST_ASSERT_EQ(tb.d_channel->numCloseCalls(), 1u);
 
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 }
 
 static void test5_noLifetimeNoTimer()
@@ -381,7 +377,6 @@ static void test5_noLifetimeNoTimer()
     bsl::optional<bsls::Types::Uint64> noLifetime;
 
     int rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      noLifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
@@ -391,7 +386,7 @@ static void test5_noLifetimeNoTimer()
 
     BMQTST_ASSERT_EQ(tb.d_channel->numCloseCalls(), 0u);
 
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 }
 
 static void test6_onCloseBeforeTimeout()
@@ -424,13 +419,12 @@ static void test6_onCloseBeforeTimeout()
 
     bmqu::MemOutStream errStream(alloc);
     int                rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                     &tb.d_scheduler,
                                                      lifetime,
                                                      tb.d_channel);
     BMQTST_ASSERT_EQ(rc, 0);
 
     // 2) Close before timeout
-    ctx->onClose(&tb.d_scheduler);
+    ctx->onClose();
 
     // 3) Advance time past the lifetime
     tb.d_testClock.d_timeSource.advanceTime(
@@ -471,7 +465,6 @@ static void test7_contextDestroyedBeforeTimeout()
 
         bmqu::MemOutStream errStream(alloc);
         int rc = ctx->setAuthenticatedAndScheduleReauthn(errStream,
-                                                         &tb.d_scheduler,
                                                          lifetime,
                                                          tb.d_channel);
         BMQTST_ASSERT_EQ(rc, 0);

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.cpp
@@ -213,9 +213,9 @@ InitialConnectionContext::InitialConnectionContext(
 , d_negotiator_p(negotiator)
 , d_resultState_p(resultState)
 , d_userData_sp(userData)
-, d_channelSp(channel)
-, d_authenticationCtxSp()
-, d_negotiationCtxSp()
+, d_channel_sp(channel)
+, d_authenticationCtx_sp()
+, d_negotiationCtx_sp()
 , d_initialConnectionCompleteCb(initialConnectionCompleteCb)
 , d_authenticationEncodingType(bmqp::EncodingType::e_BER)
 , d_state(InitialConnectionState::e_INITIAL)
@@ -236,7 +236,7 @@ void InitialConnectionContext::setState(InitialConnectionState::Enum value,
                                         InitialConnectionEvent::Enum event)
 {
     BALL_LOG_DEBUG << "State transition: " << d_state << " -> (" << event
-                   << ") -> " << value << " [peer: " << d_channelSp.get()
+                   << ") -> " << value << " [peer: " << d_channel_sp.get()
                    << "]";
     d_state = value;
 }
@@ -402,11 +402,11 @@ int InitialConnectionContext::decodeInitialConnectionMessage(
 
 void InitialConnectionContext::createNegotiationContext()
 {
-    if (d_negotiationCtxSp) {
+    if (d_negotiationCtx_sp) {
         return;  // RETURN
     }
 
-    d_negotiationCtxSp = bsl::allocate_shared<mqbnet::NegotiationContext>(
+    d_negotiationCtx_sp = bsl::allocate_shared<mqbnet::NegotiationContext>(
         d_allocator_p,
         this  // initialConnectionContext
     );
@@ -455,14 +455,19 @@ void InitialConnectionContext::setAuthenticationContext(
     const bsl::shared_ptr<AuthenticationContext>& value)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(!d_authenticationCtxSp);
+    BSLS_ASSERT_SAFE(!d_authenticationCtx_sp);
 
-    d_authenticationCtxSp = value;
+    d_authenticationCtx_sp = value;
 }
 
 void InitialConnectionContext::onClose()
 {
     d_isClosed = true;
+
+    // Propagate close
+    if (d_authenticationCtx_sp) {
+        d_authenticationCtx_sp->onClose();
+    }
 }
 
 void InitialConnectionContext::readCallback(const bmqio::Status& status,
@@ -539,7 +544,7 @@ void InitialConnectionContext::handleEvent(
 
     BALL_LOG_DEBUG << "Enter InitialConnectionContext::handleEvent: "
                    << "state = " << d_state << ", event = " << event
-                   << " [peer: " << d_channelSp.get() << "]";
+                   << " [peer: " << d_channel_sp.get() << "]";
 
     InitialConnectionState::Enum oldState = d_state;
 
@@ -731,7 +736,7 @@ void* InitialConnectionContext::resultState() const
 const bsl::shared_ptr<bmqio::Channel>&
 InitialConnectionContext::channel() const
 {
-    return d_channelSp;
+    return d_channel_sp;
 }
 
 bmqp::EncodingType::Enum
@@ -743,13 +748,13 @@ InitialConnectionContext::authenticationEncodingType() const
 const bsl::shared_ptr<AuthenticationContext>&
 InitialConnectionContext::authenticationContext() const
 {
-    return d_authenticationCtxSp;
+    return d_authenticationCtx_sp;
 }
 
 const bsl::shared_ptr<NegotiationContext>&
 InitialConnectionContext::negotiationContext() const
 {
-    return d_negotiationCtxSp;
+    return d_negotiationCtx_sp;
 }
 
 InitialConnectionState::Enum InitialConnectionContext::state() const

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.h
@@ -278,14 +278,14 @@ class InitialConnectionContext {
     bsl::shared_ptr<NegotiationUserData> d_userData_sp;
 
     /// The channel to use for the initial connection.
-    bsl::shared_ptr<bmqio::Channel> d_channelSp;
+    bsl::shared_ptr<bmqio::Channel> d_channel_sp;
 
     /// The AuthenticationContext updated upon receiving an
     /// authentication message.
-    bsl::shared_ptr<AuthenticationContext> d_authenticationCtxSp;
+    bsl::shared_ptr<AuthenticationContext> d_authenticationCtx_sp;
 
     /// The NegotiationContext updated upon receiving a negotiation message.
-    bsl::shared_ptr<NegotiationContext> d_negotiationCtxSp;
+    bsl::shared_ptr<NegotiationContext> d_negotiationCtx_sp;
 
     /// The callback to invoke to notify of the status of the initial
     /// connection.
@@ -394,7 +394,7 @@ class InitialConnectionContext {
     void setAuthenticationContext(
         const bsl::shared_ptr<AuthenticationContext>& value);
 
-    /// Called by the IO upon `onClose` signal
+    /// @brief Called by the IO upon `onClose` signal.
     void onClose();
 
     /// Read callback invoked when data is available on the channel.

--- a/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_initialconnectioncontext.t.cpp
@@ -169,10 +169,12 @@ static void test1_initialConnectionContext()
         }
 
         {  // AuthenticationContext
+            bdlmt::EventScheduler                          scheduler(alloc);
             bmqp_ctrlmsg::AuthenticationMessage            authnMsg;
             bsl::shared_ptr<mqbnet::AuthenticationContext> authnCtx =
                 bsl::allocate_shared<mqbnet::AuthenticationContext>(
                     alloc,
+                    &scheduler,
                     &obj,
                     "testMechanism",
                     authnMsg,

--- a/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_tcpsessionfactory.cpp
@@ -896,12 +896,10 @@ void TCPSessionFactory::onClose(const bsl::shared_ptr<bmqio::Channel>& channel,
 
         // set the 'isClosed' flag under lock to be checked under lock in
         // 'initialConnectionComplete'.
-        bsl::shared_ptr<InitialConnectionContext> initialConnectionContext_sp;
         InitialConnectionContextMp::iterator      iter =
             d_initialConnectionContextCache.find(channel.get());
         if (iter != d_initialConnectionContextCache.end()) {
-            initialConnectionContext_sp = iter->second;
-            initialConnectionContext_sp->onClose();
+            iter->second->onClose();
         }
 
         ChannelMap::const_iterator it = d_channels.find(channel.get());
@@ -951,7 +949,7 @@ void TCPSessionFactory::onClose(const bsl::shared_ptr<bmqio::Channel>& channel,
 
         // Disable reauthentication timer if there's any
         if (channelInfo->d_authenticationCtx_sp) {
-            channelInfo->d_authenticationCtx_sp->onClose(d_scheduler_p);
+            channelInfo->d_authenticationCtx_sp->onClose();
         }
 
         // TearDown the session


### PR DESCRIPTION
The channel might be in the middle of opening when the broker stops.
In this case, `InitialConnectionContext` and `AuthenticationContext` both exist for this channel, and we might have scheduled reuthn callback.
Bug: `InitialConnectionContext::onClose` doesn't propagate close to `AuthenticationContext`. As a result, we don't remove scheduled event for reauthn from scheduler, and this leads to shutdown crash.

Fixes:
https://github.com/bloomberg/blazingmq/actions/runs/30048572316/job/89347302563