### PR TITLE
Fix[bmqp]: Guard Storage/Recovery iterators against zero-progress loop

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.cpp
@@ -59,7 +59,9 @@ int RecoveryMessageIterator::next()
         rc_NO_RECOVERYHEADER = -2,
         /// The number of bytes in the blob is less than the header size OR
         /// payload size declared in the header
-        rc_NOT_ENOUGH_BYTES = -3
+        rc_NOT_ENOUGH_BYTES = -3,
+        /// The message declares a size smaller than its own header
+        rc_INVALID_MESSAGE_SIZE = -4
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -90,6 +92,12 @@ int RecoveryMessageIterator::next()
     }
 
     const int headerSize = d_header->headerWords() * Protocol::k_WORD_SIZE;
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+            headerSize < RecoveryHeader::k_MIN_HEADER_SIZE)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        d_advanceLength = -1;
+        return rc_NO_RECOVERYHEADER;  // RETURN
+    }
 
     d_header.resize(headerSize);
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!d_header.isSet())) {
@@ -99,6 +107,11 @@ int RecoveryMessageIterator::next()
     }
 
     const int messageSize = d_header->messageWords() * Protocol::k_WORD_SIZE;
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageSize < headerSize)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        d_advanceLength = -1;
+        return rc_INVALID_MESSAGE_SIZE;  // RETURN
+    }
 
     // Validation: make sure blob has enough data as indicated by
     // RecoveryHeader

--- a/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_recoverymessageiterator.t.cpp
@@ -600,6 +600,8 @@ static void test6_nextMethod()
     //       2.2. number of bytes in the blob is less than event header plus
     //            full size of message header.
     //       2.3. number of bytes in the blob not enough for expected payload.
+    //       2.4. the message declares a size smaller than its own header
+    //            (including zero), which would prevent forward progress.
     //
     // Plan:
     //   1. Create and init iterator by blob.
@@ -615,6 +617,9 @@ static void test6_nextMethod()
     //      second message payload.
     //   9. First time iterate successfully, then expect that second
     //      invocation of next method will return error code
+    //   10. Create and init iterator by a blob whose message header declares
+    //       a 'messageWords' smaller than 'headerWords' (as described in 2.4),
+    //       and expect that next method returns error code and stays invalid.
     //
     // Testing:
     //   int next();
@@ -726,6 +731,65 @@ static void test6_nextMethod()
         BMQTST_ASSERT(iter.isValid());
         BMQTST_ASSERT_LT(iter.next(), 0);  // rc_NOT_ENOUGH_BYTES
         BMQTST_ASSERT(!iter.isValid());
+    }
+
+    // Next method. Message smaller than its header (no forward progress).
+    {
+        PVV("MESSAGE SMALLER THAN HEADER - NO FORWARD PROGRESS");
+
+        const int k_HEADER_WORDS = sizeof(bmqp::RecoveryHeader) /
+                                   bmqp::Protocol::k_WORD_SIZE;
+
+        bsl::vector<int> malformedMessageWords(
+            bmqtst::TestHelperUtil::allocator());
+        malformedMessageWords.push_back(0);
+        malformedMessageWords.push_back(k_HEADER_WORDS - 1);
+
+        for (size_t i = 0; i < malformedMessageWords.size(); ++i) {
+            PVV("MESSAGE WORDS: " << malformedMessageWords[i]);
+
+            bdlbb::PooledBlobBufferFactory bufferFactory(
+                1024,
+                bmqtst::TestHelperUtil::allocator());
+            bdlbb::Blob blob(&bufferFactory,
+                             bmqtst::TestHelperUtil::allocator());
+
+            // EventHeader
+            bmqp::EventHeader eh;
+            eh.setType(bmqp::EventType::e_RECOVERY);
+            eh.setHeaderWords(sizeof(bmqp::EventHeader) /
+                              bmqp::Protocol::k_WORD_SIZE);
+            bdlbb::BlobUtil::append(&blob,
+                                    reinterpret_cast<const char*>(&eh),
+                                    eh.headerWords() *
+                                        bmqp::Protocol::k_WORD_SIZE);
+
+            // RecoveryHeader with a valid 'headerWords' but a 'messageWords'
+            // smaller than the header.
+            bmqp::RecoveryHeader rhdr;
+            rhdr.setHeaderWords(k_HEADER_WORDS)
+                .setPartitionId(0)
+                .setChunkSequenceNumber(1)
+                .setFileChunkType(bmqp::RecoveryFileChunkType::e_JOURNAL)
+                .setMessageWords(malformedMessageWords[i]);
+            bdlbb::BlobUtil::append(&blob,
+                                    reinterpret_cast<const char*>(&rhdr),
+                                    rhdr.headerWords() *
+                                        bmqp::Protocol::k_WORD_SIZE);
+
+            // Set EventHeader length
+            bmqp::EventHeader* e = reinterpret_cast<bmqp::EventHeader*>(
+                blob.buffer(0).data());
+            e->setLength(sizeof(bmqp::EventHeader) +
+                         sizeof(bmqp::RecoveryHeader));
+
+            bmqp::RecoveryMessageIterator iter(&blob, eh);
+            BMQTST_ASSERT(iter.isValid());
+            BMQTST_ASSERT_LT(iter.next(), 0);  // rc_INVALID_MESSAGE_SIZE
+            BMQTST_ASSERT(!iter.isValid());
+            BMQTST_ASSERT_LT(iter.next(), 0);  // stays invalid, does not loop
+            BMQTST_ASSERT(!iter.isValid());
+        }
     }
 }
 

--- a/src/groups/bmq/bmqp/bmqp_storagemessageiterator.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storagemessageiterator.cpp
@@ -58,7 +58,9 @@ int StorageMessageIterator::next()
         rc_NO_STORAGEHEADER = -2,
         /// The number of bytes in the blob is less than the header size OR
         /// payload size declared in the header
-        rc_NOT_ENOUGH_BYTES = -3
+        rc_NOT_ENOUGH_BYTES = -3,
+        /// The message declares a size smaller than its own header
+        rc_INVALID_MESSAGE_SIZE = -4
     };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!isValid())) {
@@ -89,6 +91,12 @@ int StorageMessageIterator::next()
     }
 
     const int headerSize = d_header->headerWords() * Protocol::k_WORD_SIZE;
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+            headerSize < StorageHeader::k_MIN_HEADER_SIZE)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        d_advanceLength = -1;
+        return rc_NO_STORAGEHEADER;  // RETURN
+    }
 
     d_header.resize(headerSize);
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(!d_header.isSet())) {
@@ -98,6 +106,11 @@ int StorageMessageIterator::next()
     }
 
     const int messageSize = d_header->messageWords() * Protocol::k_WORD_SIZE;
+    if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(messageSize < headerSize)) {
+        BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+        d_advanceLength = -1;
+        return rc_INVALID_MESSAGE_SIZE;  // RETURN
+    }
 
     // Validation: make sure blob has enough data as indicated by StorageHeader
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(d_blobIter.remaining() <

--- a/src/groups/bmq/bmqp/bmqp_storagemessageiterator.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_storagemessageiterator.t.cpp
@@ -570,7 +570,7 @@ static void test4_corruptedStorageEvent_part2()
 
     bdlbb::BlobUtil::append(&eventBlob, confirmRecord.c_str(), k_RECORD_SIZE);
 
-    // StorageHeader (invalid: missing a byte from the StorageHeader)
+    // StorageHeader (valid, but its declared payload is truncated below)
     bmqp::StorageHeader shd2;
     shd2.setFlags(2)
         .setHeaderWords(sizeof(bmqp::StorageHeader) /
@@ -648,7 +648,73 @@ static void test5_corruptedStorageEvent_part3()
         BMQTST_ASSERT(!iter.isValid());
     }
 }
-static void test6_resetMethod()
+
+static void test6_corruptedStorageEvent_part4()
+{
+    // ------------------------------------------------------------------------
+    // CORRUPTED STORAGE EVENT - PART 4
+    //
+    // Concerns:
+    //   Test iterating over a corrupted STORAGE event whose StorageHeader
+    //   declares a 'messageWords' smaller than 'headerWords'.
+    //
+    // Testing:
+    //   int next() rejects a StorageHeader whose 'messageWords' is smaller
+    //   than 'headerWords'.
+    // ------------------------------------------------------------------------
+    bmqtst::TestHelper::printTestName("CORRUPTED STORAGE EVENT - PART 4");
+
+    const int k_HEADER_WORDS = sizeof(bmqp::StorageHeader) /
+                               bmqp::Protocol::k_WORD_SIZE;
+
+    bsl::vector<int> malformedMessageWords(
+        bmqtst::TestHelperUtil::allocator());
+    malformedMessageWords.push_back(0);
+    malformedMessageWords.push_back(k_HEADER_WORDS - 1);
+
+    for (size_t i = 0; i < malformedMessageWords.size(); ++i) {
+        PVV("MESSAGE WORDS: " << malformedMessageWords[i]);
+
+        bdlbb::PooledBlobBufferFactory bufferFactory(
+            1024,
+            bmqtst::TestHelperUtil::allocator());
+        bdlbb::Blob eventBlob(&bufferFactory,
+                              bmqtst::TestHelperUtil::allocator());
+
+        // BUILD the event blob ...
+        // EventHeader
+        bmqp::EventHeader eh(bmqp::EventType::e_STORAGE);
+        eh.setLength(sizeof(bmqp::EventHeader) + sizeof(bmqp::StorageHeader));
+        bdlbb::BlobUtil::append(&eventBlob,
+                                reinterpret_cast<const char*>(&eh),
+                                sizeof(bmqp::EventHeader));
+
+        // StorageHeader with a valid 'headerWords' but a 'messageWords'
+        // smaller than the header.
+        bmqp::StorageHeader shd;
+        shd.setFlags(1)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setMessageType(bmqp::StorageMessageType::e_CONFIRM)
+            .setPartitionId(0)
+            .setMessageWords(malformedMessageWords[i]);
+
+        bdlbb::BlobUtil::append(&eventBlob,
+                                reinterpret_cast<const char*>(&shd),
+                                sizeof(bmqp::StorageHeader));
+
+        // Iterate and check that 'next()' rejects the message and stays
+        // invalid instead of returning 1.
+        bmqp::StorageMessageIterator iter(&eventBlob, eh);
+        BMQTST_ASSERT_EQ(true, iter.isValid());
+        BMQTST_ASSERT_LT(iter.next(), 0);
+        BMQTST_ASSERT_EQ(false, iter.isValid());
+        BMQTST_ASSERT_LT(iter.next(),
+                         0);  // successive calls keep returning invalid
+        BMQTST_ASSERT_EQ(false, iter.isValid());
+    }
+}
+
+static void test7_resetMethod()
 {
     // --------------------------------------------------------------------
     // RESET
@@ -698,7 +764,7 @@ static void test6_resetMethod()
     }
 }
 
-static void test7_dumpBlob()
+static void test8_dumpBlob()
 {
     // --------------------------------------------------------------------
     // DUMB BLOB
@@ -789,8 +855,9 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 7: test7_dumpBlob(); break;
-    case 6: test6_resetMethod(); break;
+    case 8: test8_dumpBlob(); break;
+    case 7: test7_resetMethod(); break;
+    case 6: test6_corruptedStorageEvent_part4(); break;
     case 5: test5_corruptedStorageEvent_part3(); break;
     case 4: test4_corruptedStorageEvent_part2(); break;
     case 3: test3_corruptedStorageEvent_part1(); break;


### PR DESCRIPTION
## Summary
  - Hardens `bmqp::StorageMessageIterator` and `bmqp::RecoveryMessageIterator` against malformed input by validating header/message sizes before advancing.
  - Previously `next()` derived the message size from the header and set the advance length without checking it. A message whose declared size (`messageWords`) is smaller than its own header — in particular zero — could leave the advance length at or below zero, so `while (iter.next() == 1)` loops would not make forward progress.
  - Brings these two iterators in line with the sibling PUT/PUSH/CONFIRM iterators, which already validate for forward progress.