### PR TITLE
Fix[mqbnet]: keep a weak ptr to a channel for reauthn

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.cpp
@@ -191,19 +191,22 @@ int AuthenticationContext::setAuthenticatedAndScheduleReauthn(
             bmqu::WeakMemFnUtil::weakMemFn(
                 &AuthenticationContext::onReauthenticationTimeout,
                 d_self.acquireWeak()),
-            channel_sp,  // channel_sp
-            lifetime     // timeoutMs
+            bsl::weak_ptr<bmqio::Channel>(channel_sp),  // channel_wp
+            lifetime                                    // timeoutMs
             ));
 
     return 0;
 }
 
 void AuthenticationContext::onReauthenticationTimeout(
-    const bsl::shared_ptr<bmqio::Channel>& channel_sp,
-    bsls::Types::Uint64                    timeoutMs)
+    const bsl::weak_ptr<bmqio::Channel>& channel_wp,
+    bsls::Types::Uint64                  timeoutMs)
 {
-    // PRECONDITIONS
-    BSLS_ASSERT_SAFE(channel_sp);
+    bsl::shared_ptr<bmqio::Channel> channel_sp = channel_wp.lock();
+    if (!channel_sp) {
+        // The channel has already been destroyed; nothing to close.
+        return;
+    }
 
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCKED

--- a/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
+++ b/src/groups/mqb/mqbnet/mqbnet_authenticationcontext.h
@@ -212,11 +212,19 @@ class AuthenticationContext {
         const bsl::optional<bsls::Types::Uint64>& lifetimeMs,
         const bsl::shared_ptr<bmqio::Channel>&    channel_sp);
 
-    /// Close the specified `channel_sp` indicating that reauthentication was
-    /// not received within the specified `timeoutMs` (in milliseconds).
-    void onReauthenticationTimeout(
-        const bsl::shared_ptr<bmqio::Channel>& channel_sp,
-        bsls::Types::Uint64                    timeoutMs);
+    /// @brief Close the channel on reauthentication timeout.
+    ///
+    /// Close the channel referenced by `channel_wp`, indicating that
+    /// reauthentication was not received in time.  A weak reference is held so
+    /// the pending timer does not extend the channel's lifetime; do nothing if
+    /// the channel has already been destroyed.
+    ///
+    /// @param channel_wp Weak reference to the channel to close.
+    /// @param timeoutMs  The reauthentication window, in milliseconds, that
+    ///                   elapsed without a reauthentication request.
+    void
+    onReauthenticationTimeout(const bsl::weak_ptr<bmqio::Channel>& channel_wp,
+                              bsls::Types::Uint64                  timeoutMs);
 
     /// Close the specified `channel_sp` with the specified `errorCode` and
     /// `errorDescription`, indicating a reauthentication error for the


### PR DESCRIPTION
It seems wrong to own a copy of a shared_ptr to a channel in timeout callback.

<img width="1935" height="912" alt="channel_lifetime" src="https://github.com/user-attachments/assets/a46de5e0-2a50-4d85-b5af-9d7fad73f970" />

