### PR TITLE
Doc: Update bmqu package documentation

### DIFF
--- a/src/groups/bmq/bmqu/README.dox
+++ b/src/groups/bmq/bmqu/README.dox
@@ -1,8 +1,8 @@
 /**
 @dir bmqu
 
-@brief The `BMQU` (BlazingMQ Utility) package provides
-value-semantic vocabulary types.
+@brief The `BMQU` (BlazingMQ Utility) package provides miscellaneous
+utility components.
 
 The ‘bmqu‘ package provides miscellaneous utility components to be
 reused through various applications.


### PR DESCRIPTION
This documentation looks like it was copied-and-pasted from bmqt, because what it says does not apply to bmqu.  This patch changes the doc’s brief so that it accurately describes the purpose of the package.