### PR TITLE
Doc: Use Markdown rather than Unicode quotes

### DIFF
--- a/src/groups/bmq/bmqt/README.dox
+++ b/src/groups/bmq/bmqt/README.dox
@@ -4,6 +4,6 @@
 @brief The `BMQT` (BlazingMQ (vocabulary) Types) package provides
 value-semantic vocabulary types.
 
-The ‘bmqt‘ package provides low level value-semantic vocabulary types for use
+The `bmqt` package provides low level value-semantic vocabulary types for use
 by the BlazingMQ SDK.
 */

--- a/src/groups/bmq/bmqu/README.dox
+++ b/src/groups/bmq/bmqu/README.dox
@@ -4,6 +4,6 @@
 @brief The `BMQU` (BlazingMQ Utility) package provides miscellaneous
 utility components.
 
-The ‘bmqu‘ package provides miscellaneous utility components to be
+The `bmqu` package provides miscellaneous utility components to be
 reused through various applications.
 */


### PR DESCRIPTION
In place of Markdown backticks in bmqt and bmqu’s package documentation, both of these files had Unicode quoting, meaning the packages would not be rendered in monospace.  This patch fixes these two instances of Unicode quotes.