### PR TITLE
Feat[mqb]: Bump min SDK versions

### DIFF
--- a/src/groups/mqb/mqbu/mqbu_sdkversionutil.cpp
+++ b/src/groups/mqb/mqbu/mqbu_sdkversionutil.cpp
@@ -32,9 +32,9 @@ namespace mqbu {
 namespace {
 
 // C++
-const int k_MINIMUM_SDK_VERSION_SUPPORTED_CPP = BMQ_MAKE_EXT_VERSION(1, 5, 0);
+const int k_MINIMUM_SDK_VERSION_SUPPORTED_CPP = BMQ_MAKE_EXT_VERSION(1, 12, 0);
 const int k_MINIMUM_SDK_VERSION_RECOMMENDED_CPP = BMQ_MAKE_EXT_VERSION(1,
-                                                                       9,
+                                                                       12,
                                                                        0);
 
 BSLMF_ASSERT(k_MINIMUM_SDK_VERSION_SUPPORTED_CPP <=

--- a/src/groups/mqb/mqbu/mqbu_sdkversionutil.cpp
+++ b/src/groups/mqb/mqbu/mqbu_sdkversionutil.cpp
@@ -41,10 +41,10 @@ BSLMF_ASSERT(k_MINIMUM_SDK_VERSION_SUPPORTED_CPP <=
              k_MINIMUM_SDK_VERSION_RECOMMENDED_CPP);
 
 // Java
-const int k_MINIMUM_SDK_VERSION_SUPPORTED_JAVA = BMQ_MAKE_EXT_VERSION(0, 0, 2);
+const int k_MINIMUM_SDK_VERSION_SUPPORTED_JAVA = BMQ_MAKE_EXT_VERSION(0, 0, 9);
 const int k_MINIMUM_SDK_VERSION_RECOMMENDED_JAVA = BMQ_MAKE_EXT_VERSION(0,
                                                                         0,
-                                                                        2);
+                                                                        9);
 BSLMF_ASSERT(k_MINIMUM_SDK_VERSION_SUPPORTED_JAVA <=
              k_MINIMUM_SDK_VERSION_RECOMMENDED_JAVA);
 


### PR DESCRIPTION
Update the minimum required SDK version, in preparation for cleaning up old protocols/features. There will be further bumps, but this begins the process.

Min SDK versions:
* C++:  `1.12.0`, previously `1.5.0`
* Java: `0.0.9`, previously `0.0.2`