### PR TITLE
Fix[mqbnet]: active-node PANIC alarms during shutdown

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_clusterproxy.cpp
@@ -138,8 +138,9 @@ void ClusterProxy::initiateShutdownDispatched(const VoidFunctor& callback)
 
     BALL_LOG_INFO << "Shutting down ClusterProxy: [name: '" << name() << "']";
 
-    // Mark self as stopping.
+    // Mark self as stopping and notify active node manager.
     d_isStopping = true;
+    d_activeNodeManager.onClusterStopping();
 
     d_queueHelper.requestToStopQueues();
     // 'checkUnconfirmedV2' serves as synchronization.

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.cpp
@@ -212,8 +212,9 @@ void ClusterActiveNodeManager::onNewActiveNode(ClusterNode* node)
     if (!node) {
         // No nodes are available, that is a major issue!  However, no need to
         // alarm in the case of single-node cluster, as this is bound to happen
-        // when that node bounces.
-        if (d_nodes.size() > 1) {
+        // when that node bounces; nor when the cluster is stopping, as all
+        // nodes are expected to go down during shutdown.
+        if (d_nodes.size() > 1 && !d_isStopping) {
             BMQTSK_ALARMLOG_PANIC("CLUSTER_ACTIVE_NODE")
                 << d_description << ": no node available !!!"
                 << BMQTSK_ALARMLOG_END;
@@ -244,6 +245,7 @@ ClusterActiveNodeManager::ClusterActiveNodeManager(
 , d_activeNodeIt(d_nodes.end())
 , d_ignoreDataCenter(false)
 , d_useExtendedSelection(false)
+, d_isStopping(false)
 {
     bool clusterHasNodeInLocalDC = false;
     for (mqbnet::Cluster::NodesList::const_iterator it = nodes.begin();

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.h
@@ -265,6 +265,10 @@ class ClusterActiveNodeManager {
     /// node.
     bool d_useExtendedSelection;
 
+    /// If true, the associated cluster is shutting down.  In this state,
+    /// it is okay to not have an active node.
+    bool d_isStopping;
+
   private:
     // PRIVATE MANIPULATORS
 
@@ -303,6 +307,11 @@ class ClusterActiveNodeManager {
     /// drop the `same DataCenter` requirement for all subsequent active
     /// node selections.
     void enableExtendedSelection();
+
+    /// Notify this object that the associated cluster is stopping (during
+    /// broker shutdown, when all clusters are stopped) and suppresses
+    /// alarms related to active node selection.
+    void onClusterStopping();
 
     /// Initialize this object.  Iterate sessions from the specified
     /// `transportManager` and update corresponding nodes status.
@@ -349,6 +358,11 @@ class ClusterActiveNodeManager {
 inline void ClusterActiveNodeManager::enableExtendedSelection()
 {
     d_useExtendedSelection = true;
+}
+
+inline void ClusterActiveNodeManager::onClusterStopping()
+{
+    d_isStopping = true;
 }
 
 inline mqbnet::ClusterNode* ClusterActiveNodeManager::activeNode() const

--- a/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusteractivenodemanager.t.cpp
@@ -316,6 +316,88 @@ static void test4_panicInExtendedMode()
     }
 }
 
+static void test5_noPanicWhenStopping()
+// Validate that once the cluster is marked as stopping, failing to select an
+// active node does NOT emit a PANIC log (all nodes are expected to go down
+// during shutdown).
+{
+    bmqtst::TestHelper::printTestName("NO PANIC WHEN STOPPING");
+
+    bmqtst::ScopedLogObserver logObserver(ball::Severity::e_ERROR,
+                                          bmqtst::TestHelperUtil::allocator());
+
+    // Set up mock cluster
+    mqbcfg::ClusterDefinition clusterConfig(
+        bmqtst::TestHelperUtil::allocator());
+    bdlbb::PooledBlobBufferFactory bufferFactory(
+        1024,
+        bmqtst::TestHelperUtil::allocator());
+    mqbnet::MockCluster mockCluster(clusterConfig,
+                                    &bufferFactory,
+                                    bmqtst::TestHelperUtil::allocator());
+
+    // Populate cluster nodes
+    // - 1 node in "east" data center
+    // - 1 node in "west" data center
+    mqbnet::Cluster::NodesList nodes(bmqtst::TestHelperUtil::allocator());
+    mqbcfg::ClusterNode clusterNodeConfig(bmqtst::TestHelperUtil::allocator());
+
+    clusterNodeConfig.dataCenter() = "east";
+    clusterNodeConfig.name()       = "east-1";
+    mqbnet::MockClusterNode east1(&mockCluster,
+                                  clusterNodeConfig,
+                                  &bufferFactory,
+                                  bmqtst::TestHelperUtil::allocator());
+    nodes.push_back(&east1);
+
+    clusterNodeConfig.dataCenter() = "west";
+    clusterNodeConfig.name()       = "west-1";
+    mqbnet::MockClusterNode west1(&mockCluster,
+                                  clusterNodeConfig,
+                                  &bufferFactory,
+                                  bmqtst::TestHelperUtil::allocator());
+    nodes.push_back(&west1);
+
+    // Create ClusterActiveNodeManager
+    bsl::string                      description = "dummy";
+    bsl::string                      dataCenter  = "east";
+    mqbnet::ClusterActiveNodeManager mgr =
+        mqbnet::ClusterActiveNodeManager(nodes, description, dataCenter);
+    BMQTST_ASSERT(!mgr.activeNode());
+
+    bmqp_ctrlmsg::NegotiationMessage negotiationMessage(
+        bmqtst::TestHelperUtil::allocator());
+    negotiationMessage.makeClientIdentity().hostName() = "dummyIdentity";
+
+    // Mark the cluster as stopping.
+    mgr.onClusterStopping();
+
+    // "east" node up, it should become active
+    {
+        int rc = mgr.onNodeUp(&east1, negotiationMessage.clientIdentity());
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NEW_ACTIVE);
+        BMQTST_ASSERT_EQ(mgr.activeNode(), &east1);
+    }
+
+    // "east" node down, no active node -- but NO PANIC because stopping
+    {
+        int rc = mgr.onNodeDown(&east1);
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_LOST_ACTIVE);
+        BMQTST_ASSERT(!mgr.activeNode());
+    }
+
+    // Refresh in extended mode with no available nodes -- still NO PANIC.
+    {
+        mgr.enableExtendedSelection();
+        int rc = mgr.refresh();
+        BMQTST_ASSERT_EQ(rc, mqbnet::ClusterActiveNodeManager::e_NO_CHANGE);
+        BMQTST_ASSERT(!mgr.activeNode());
+    }
+
+    // No PANIC (or any ERROR) should have been logged while stopping.
+    BMQTST_ASSERT(logObserver.records().empty());
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -326,6 +408,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 5: test5_noPanicWhenStopping(); break;
     case 4: test4_panicInExtendedMode(); break;
     case 3: test3_activeNodeOutsideDC(); break;
     case 2: test2_activeNodeWithinDC(); break;


### PR DESCRIPTION
**Describe your changes**
During shutdown, proxies often emit a false cluster availability alarm.

> ERROR mqbnet_clusteractivenodemanager.cpp PANIC [CLUSTER_ACTIVE_NODE] ClusterProxy (foo): no node available !!!

The root cause is shutdown ordering:

1. `initiateShutdown` runs and each `ClusterProxy` sets `d_isStopping`.
2. The broker stops `TransportManager` *before* the `ClusterCatalog`, so every cluster node channel gets closed while the proxy is still registered as a node state observer.
3. Each channel close triggers `ClusterActiveNodeManager::onNodeDown`. When the current active node drops it re-selects another node. The remaining nodes' down events are still queued and therefore still appear available.
4. This repeats until the last node drops, `onNewActiveNode(0)` finds no candidates and raises the PANIC alarm.
5. `ClusterProxy`'s `d_isStopping` guard logic sit below the alarm in `onActiveNodeUp` and `onActiveNodeDown`, so they suppress the reaction to the event but not the alarm itself.

To fix, make `ClusterActiveNodeManager` shutdown-aware.

- `ClusterProxy` tells the `ClusterActiveNodeManager` when it enters the stopping state (in `initiateShutdownDispatched`) so that no PANIC alarm is logged when the last node drops.
- Add unit test covering the shutdown case.

