### PR TITLE
Fix[bmqt] fix SessionOptions authn cb allocator usage

### DIFF
--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.cpp
@@ -19,6 +19,7 @@
 // BDE
 #include <bslim_printer.h>
 #include <bslma_allocator.h>
+#include <bslmf_allocatorargt.h>
 
 namespace BloombergLP {
 namespace bmqt {
@@ -44,7 +45,7 @@ SessionOptions::SessionOptions(bslma::Allocator* allocator)
 , d_eventQueueLowWatermark(50)
 , d_eventQueueHighWatermark(2 * 1000)
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
-, d_authnCredentialCb()
+, d_authnCredentialCb(bsl::allocator_arg, allocator)
 , d_hostHealthMonitor_sp()
 , d_dtContext_sp()
 , d_dtTracer_sp()
@@ -70,7 +71,7 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 , d_eventQueueLowWatermark(other.eventQueueLowWatermark())
 , d_eventQueueHighWatermark(other.eventQueueHighWatermark())
 , d_eventQueueSize(-1)  // DEPRECATED: will be removed in future release
-, d_authnCredentialCb(other.authnCredentialCb())
+, d_authnCredentialCb(bsl::allocator_arg, allocator, other.authnCredentialCb())
 , d_hostHealthMonitor_sp(other.hostHealthMonitor())
 , d_dtContext_sp(other.traceContext())
 , d_dtTracer_sp(other.tracer())
@@ -79,6 +80,43 @@ SessionOptions::SessionOptions(const SessionOptions& other,
 {
     // NOTHING
 }
+
+SessionOptions& SessionOptions::operator=(const SessionOptions& other)
+{
+    if (this != &other) {
+        d_brokerUri               = other.d_brokerUri;
+        d_processNameOverride     = other.d_processNameOverride;
+        d_numProcessingThreads    = other.d_numProcessingThreads;
+        d_blobBufferSize          = other.d_blobBufferSize;
+        d_channelHighWatermark    = other.d_channelHighWatermark;
+        d_statsDumpInterval       = other.d_statsDumpInterval;
+        d_connectTimeout          = other.d_connectTimeout;
+        d_disconnectTimeout       = other.d_disconnectTimeout;
+        d_openQueueTimeout        = other.d_openQueueTimeout;
+        d_configureQueueTimeout   = other.d_configureQueueTimeout;
+        d_closeQueueTimeout       = other.d_closeQueueTimeout;
+        d_eventQueueLowWatermark  = other.d_eventQueueLowWatermark;
+        d_eventQueueHighWatermark = other.d_eventQueueHighWatermark;
+        d_authnCredentialCb       = other.d_authnCredentialCb;
+        d_hostHealthMonitor_sp    = other.d_hostHealthMonitor_sp;
+        d_dtContext_sp            = other.d_dtContext_sp;
+        d_dtTracer_sp             = other.d_dtTracer_sp;
+        d_userAgentPrefix         = other.d_userAgentPrefix;
+        d_channelWriteTimeout     = other.d_channelWriteTimeout;
+
+        // DEPRECATED: preserve current behavior from constructors.
+        d_eventQueueSize = -1;
+    }
+
+    return *this;
+}
+
+SessionOptions::~SessionOptions()
+{
+    // NOTHING
+}
+
+// MANIPULATORS
 
 bsl::ostream& SessionOptions::print(bsl::ostream& stream,
                                     int           level,

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.h
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.h
@@ -143,6 +143,7 @@
 #include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
+#include <bslmf_movableref.h>
 #include <bslmf_nestedtraitdeclaration.h>
 #include <bsls_assert.h>
 #include <bsls_timeinterval.h>
@@ -272,6 +273,13 @@ class SessionOptions {
     /// `other`, using the optionally specified `allocator`.
     SessionOptions(const SessionOptions& other,
                    bslma::Allocator*     allocator = 0);
+
+    /// Assign to this object the value of the specified `other`, and return
+    /// a reference providing modifiable access to this object.
+    SessionOptions& operator=(const SessionOptions& other);
+
+    /// Destroy this object.
+    ~SessionOptions();
 
     // MANIPULATORS
 

--- a/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
+++ b/src/groups/bmq/bmqt/bmqt_sessionoptions.t.cpp
@@ -186,6 +186,70 @@ static void test3_setterGetterAndCopyTest()
                      eventQueueHighWatermark);
     BMQTST_ASSERT_EQ(objCopy.userAgentPrefix(), userAgentPrefix);
 }
+
+static void test4_copyAssignmentTest()
+{
+    bmqtst::TestHelper::printTestName("MOVE AND ASSIGNMENT");
+
+    const char* const        brokerUri            = "tcp://localhost:30116";
+    const char* const        processNameOverride  = "sessionoptions-test";
+    const int                numProcessingThreads = 7;
+    const int                blobBufferSize       = 16 * 1024;
+    const bsls::Types::Int64 channelHighWatermark = 512 * 1024 * 1024;
+    const bsls::TimeInterval statsDumpInterval(9 * 60.0);
+    const bsls::TimeInterval connectTimeout(77);
+    const bsls::TimeInterval disconnectTimeout(33);
+    const bsls::TimeInterval openQueueTimeout(
+        bmqt::SessionOptions::k_QUEUE_OPERATION_DEFAULT_TIMEOUT + 10);
+    const bsls::TimeInterval configureQueueTimeout(
+        bmqt::SessionOptions::k_QUEUE_OPERATION_DEFAULT_TIMEOUT + 11);
+    const bsls::TimeInterval closeQueueTimeout(
+        bmqt::SessionOptions::k_QUEUE_OPERATION_DEFAULT_TIMEOUT + 12);
+    const int                eventQueueLowWatermark  = 71;
+    const int                eventQueueHighWatermark = 3001;
+    const char* const        userAgentPrefix         = "wrapper-lib/1.2.3";
+    const bsls::TimeInterval channelWriteTimeout(8);
+
+    bmqt::SessionOptions source(bmqtst::TestHelperUtil::allocator());
+    source.setBrokerUri(brokerUri)
+        .setProcessNameOverride(processNameOverride)
+        .setNumProcessingThreads(numProcessingThreads)
+        .setBlobBufferSize(blobBufferSize)
+        .setChannelHighWatermark(channelHighWatermark)
+        .setStatsDumpInterval(statsDumpInterval)
+        .setConnectTimeout(connectTimeout)
+        .setDisconnectTimeout(disconnectTimeout)
+        .setOpenQueueTimeout(openQueueTimeout)
+        .setConfigureQueueTimeout(configureQueueTimeout)
+        .setCloseQueueTimeout(closeQueueTimeout)
+        .configureEventQueue(eventQueueLowWatermark, eventQueueHighWatermark)
+        .setUserAgentPrefix(userAgentPrefix)
+        .setChannelWriteTimeout(channelWriteTimeout);
+
+    PVV("Copy assignment");
+    bmqt::SessionOptions copyAssigned(bmqtst::TestHelperUtil::allocator());
+    copyAssigned = source;
+    BMQTST_ASSERT_EQ(copyAssigned.brokerUri(), brokerUri);
+    BMQTST_ASSERT_EQ(copyAssigned.processNameOverride(), processNameOverride);
+    BMQTST_ASSERT_EQ(copyAssigned.numProcessingThreads(),
+                     numProcessingThreads);
+    BMQTST_ASSERT_EQ(copyAssigned.blobBufferSize(), blobBufferSize);
+    BMQTST_ASSERT_EQ(copyAssigned.channelHighWatermark(),
+                     channelHighWatermark);
+    BMQTST_ASSERT_EQ(copyAssigned.statsDumpInterval(), statsDumpInterval);
+    BMQTST_ASSERT_EQ(copyAssigned.connectTimeout(), connectTimeout);
+    BMQTST_ASSERT_EQ(copyAssigned.disconnectTimeout(), disconnectTimeout);
+    BMQTST_ASSERT_EQ(copyAssigned.openQueueTimeout(), openQueueTimeout);
+    BMQTST_ASSERT_EQ(copyAssigned.configureQueueTimeout(),
+                     configureQueueTimeout);
+    BMQTST_ASSERT_EQ(copyAssigned.closeQueueTimeout(), closeQueueTimeout);
+    BMQTST_ASSERT_EQ(copyAssigned.eventQueueLowWatermark(),
+                     eventQueueLowWatermark);
+    BMQTST_ASSERT_EQ(copyAssigned.eventQueueHighWatermark(),
+                     eventQueueHighWatermark);
+    BMQTST_ASSERT_EQ(copyAssigned.userAgentPrefix(), userAgentPrefix);
+    BMQTST_ASSERT_EQ(copyAssigned.channelWriteTimeout(), channelWriteTimeout);
+}
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -196,6 +260,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 4: test4_copyAssignmentTest(); break;
     case 3: test3_setterGetterAndCopyTest(); break;
     case 2: test2_printTest(); break;
     case 1: test1_breathingTest(); break;


### PR DESCRIPTION
While looking at this with @hallfox, we stumbled into `SessionOptions` copying `shared_ptr` to non-const, but that's a problem for another day. For now, we're just going to fix the authn callback to ensure it has an allocator.