### PR TITLE
Refactor[mqbs::DataStore]: Rename primaryLeaseId to writeHeadLeaseId

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_recoverymanager.cpp
@@ -2010,7 +2010,7 @@ int RecoveryManager::syncPeerPartition(PrimarySyncContext* primarySyncCtx,
     int                    pid = fs->config().partitionId();
 
     bmqp_ctrlmsg::PartitionSequenceNumber selfSequenceNum;
-    selfSequenceNum.primaryLeaseId() = fs->primaryLeaseId();
+    selfSequenceNum.primaryLeaseId() = fs->writeHeadLeaseId();
     selfSequenceNum.sequenceNumber() = fs->sequenceNumber();
 
     const FileTransferInfo& fti = primarySyncCtx->fileTransferInfo();
@@ -4372,7 +4372,7 @@ void RecoveryManager::startPartitionPrimarySync(
     primarySyncCtx.setPartitionPrimarySyncCb(partitionPrimarySyncCb);
 
     bmqp_ctrlmsg::PartitionSequenceNumber tmp;
-    tmp.primaryLeaseId() = fs->primaryLeaseId();
+    tmp.primaryLeaseId() = fs->writeHeadLeaseId();
     tmp.sequenceNumber() = fs->sequenceNumber();
     primarySyncCtx.setSelfPartitionSequenceNum(tmp);
 
@@ -4468,7 +4468,7 @@ void RecoveryManager::processPartitionSyncStateRequest(
         clusterMsg.choice().makePartitionSyncStateQueryResponse();
 
     response.partitionId()    = req.partitionId();
-    response.primaryLeaseId() = fs->primaryLeaseId();
+    response.primaryLeaseId() = fs->writeHeadLeaseId();
     response.sequenceNum()    = fs->sequenceNumber();
     if (!fs->syncPoints().empty()) {
         response.lastSyncPointOffsetPair() = fs->syncPoints().back();
@@ -4577,7 +4577,7 @@ void RecoveryManager::processPartitionSyncDataRequest(
     requesterUptoPSN.sequenceNumber() = req.uptoSequenceNum();
 
     bmqp_ctrlmsg::PartitionSequenceNumber selfPSN;
-    selfPSN.primaryLeaseId() = fs->primaryLeaseId();
+    selfPSN.primaryLeaseId() = fs->writeHeadLeaseId();
     selfPSN.sequenceNumber() = fs->sequenceNumber();
 
     if (requesterUptoPSN <= requesterPSN) {

--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -138,7 +138,8 @@ void processPrimaryStatusAdvisoryDispatched(
         if (!isFSMWorkflow &&
             bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE == pinfo->primaryStatus()) {
             BSLS_ASSERT_SAFE(pinfo->primary() == fs->primaryNode());
-            BSLS_ASSERT_SAFE(pinfo->primaryLeaseId() == fs->primaryLeaseId());
+            BSLS_ASSERT_SAFE(pinfo->primaryLeaseId() ==
+                             fs->writeHeadLeaseId());
         }
     }
     else {
@@ -351,7 +352,8 @@ void StorageManager::onPartitionRecovery(
 
             // Get the latest PSN for this partition.
             if (fs->isOpen()) {
-                d_recoveredPrimaryLeaseIds[partitionId] = fs->primaryLeaseId();
+                d_recoveredPrimaryLeaseIds[partitionId] =
+                    fs->writeHeadLeaseId();
 
                 BALL_LOG_INFO
                     << d_clusterData_p->identity().description()
@@ -361,7 +363,7 @@ void StorageManager::onPartitionRecovery(
                     << (recoveryPeer ? recoveryPeer->nodeDescription()
                                      : "**none**")
                     << ", "
-                    << mqbs::printPSN(fs->primaryLeaseId(),
+                    << mqbs::printPSN(fs->writeHeadLeaseId(),
                                       fs->sequenceNumber())
                     << ")";
             }

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -230,7 +230,7 @@ void RecoveryManager::setExpectedDataChunkRange(
     receiveDataCtx.d_currPSN              = beginSeqNum;
     if (fs.isOpen()) {
         BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.primaryLeaseId() ==
-                         fs.primaryLeaseId());
+                         fs.writeHeadLeaseId());
         BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.sequenceNumber() ==
                          fs.sequenceNumber());
     }
@@ -644,13 +644,13 @@ int RecoveryManager::processReceiveDataChunks(
 
     if (fs->isOpen()) {
         BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.primaryLeaseId() ==
-                         fs->primaryLeaseId());
+                         fs->writeHeadLeaseId());
         BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.sequenceNumber() ==
                          fs->sequenceNumber());
 
         fs->processStorageEvent(blob, true /* isPartitionSyncEvent */, source);
 
-        receiveDataCtx.d_currPSN.primaryLeaseId() = fs->primaryLeaseId();
+        receiveDataCtx.d_currPSN.primaryLeaseId() = fs->writeHeadLeaseId();
         receiveDataCtx.d_currPSN.sequenceNumber() = fs->sequenceNumber();
 
         if (receiveDataCtx.d_currPSN == receiveDataCtx.d_endPSN) {

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1924,7 +1924,7 @@ void StorageManager::do_storeSelfSeq(
     mqbs::FileStore* fs = d_fileStores[partitionId].get();
     BSLS_ASSERT_SAFE(fs);
     if (fs->isOpen()) {
-        nodePSNCtx.d_PSN.primaryLeaseId() = fs->primaryLeaseId();
+        nodePSNCtx.d_PSN.primaryLeaseId() = fs->writeHeadLeaseId();
         nodePSNCtx.d_PSN.sequenceNumber() = fs->sequenceNumber();
     }
     else {

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -2922,7 +2922,7 @@ static void test18_primaryHealingWatchdogRetry()
                     1);
 
     const int k_PRIMARY_LEASE_ID =
-        storageManager.fileStore(k_PARTITION_ID).primaryLeaseId();
+        storageManager.fileStore(k_PARTITION_ID).writeHeadLeaseId();
     const int k_PRIMARY_SEQ_NUM =
         storageManager.fileStore(k_PARTITION_ID).sequenceNumber();
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3265,7 +3265,8 @@ void StorageUtil::processShutdownEventDispatched(ClusterData*     clusterData,
             // partition.
 
             BSLS_ASSERT_SAFE(fs->primaryNode() == pinfo->primary());
-            BSLS_ASSERT_SAFE(fs->primaryLeaseId() == pinfo->primaryLeaseId());
+            BSLS_ASSERT_SAFE(fs->writeHeadLeaseId() ==
+                             pinfo->primaryLeaseId());
 
             int rc = fs->issueSyncPoint();
             if (0 != rc) {
@@ -3708,7 +3709,7 @@ void StorageUtil::forceIssueAdvisoryAndSyncPt(mqbc::ClusterData*   clusterData,
     BSLS_ASSERT_SAFE(clusterData);
     BSLS_ASSERT_SAFE(pinfo.primary() == clusterData->membership().selfNode());
     BSLS_ASSERT_SAFE(pinfo.primary() == fs->primaryNode());
-    BSLS_ASSERT_SAFE(fs->primaryLeaseId() == pinfo.primaryLeaseId());
+    BSLS_ASSERT_SAFE(fs->writeHeadLeaseId() == pinfo.primaryLeaseId());
     BSLS_ASSERT_SAFE(pinfo.primaryStatus() ==
                      bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE);
 
@@ -3733,7 +3734,7 @@ void StorageUtil::forceIssueAdvisoryAndSyncPt(mqbc::ClusterData*   clusterData,
         BALL_LOG_INFO << clusterData->identity().description() << "Partition ["
                       << fs->config().partitionId()
                       << "]: successfully issued a forced SyncPt: "
-                      << mqbs::printPSN(fs->primaryLeaseId(),
+                      << mqbs::printPSN(fs->writeHeadLeaseId(),
                                         fs->sequenceNumber())
                       << ".";
     }
@@ -3742,7 +3743,7 @@ void StorageUtil::forceIssueAdvisoryAndSyncPt(mqbc::ClusterData*   clusterData,
                        << "Partition [" << fs->config().partitionId()
                        << "]: failed to force-issue SyncPt, rc: " << rc
                        << ", current PSN: "
-                       << mqbs::printPSN(fs->primaryLeaseId(),
+                       << mqbs::printPSN(fs->writeHeadLeaseId(),
                                          fs->sequenceNumber());
     }
 }

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -762,8 +762,9 @@ class DataStore : public mqbi::DispatcherClient {
     virtual unsigned int
     getMessageLenRaw(const DataStoreRecordHandle& handle) const = 0;
 
-    /// Return the current primary leaseId for this partition.
-    virtual unsigned int primaryLeaseId() const = 0;
+    /// Return the write-head leaseId for this partition: the lease id of the
+    /// next record this store writes or applies.
+    virtual unsigned int writeHeadLeaseId() const = 0;
 
     /// Return `true` if there was Replication Receipt for the specified
     /// `handle`.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.cpp
@@ -173,7 +173,7 @@ FileBackedStorage::get(bsl::shared_ptr<bdlbb::Blob>*   appData,
 
     d_store_p->loadMessageRaw(appData, options, attributes, handles[0]);
 
-    if (handles[0].primaryLeaseId() < d_store_p->primaryLeaseId()) {
+    if (handles[0].primaryLeaseId() < d_store_p->writeHeadLeaseId()) {
         // Consider this the past that needs translation
         bmqp::SchemaLearner& learner = queue()->schemaLearner();
 
@@ -201,7 +201,7 @@ FileBackedStorage::get(mqbi::StorageMessageAttributes* attributes,
     BSLS_ASSERT(!handles.empty());
     d_store_p->loadMessageAttributesRaw(attributes, handles[0]);
 
-    if (handles[0].primaryLeaseId() < d_store_p->primaryLeaseId()) {
+    if (handles[0].primaryLeaseId() < d_store_p->writeHeadLeaseId()) {
         // Consider this the past that needs translation
         bmqp::SchemaLearner& learner = queue()->schemaLearner();
 

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -526,7 +526,7 @@ class MockDataStore : public mqbs::DataStore {
         return sizeof(int);
     }
 
-    unsigned int primaryLeaseId() const BSLS_KEYWORD_OVERRIDE { return 0U; }
+    unsigned int writeHeadLeaseId() const BSLS_KEYWORD_OVERRIDE { return 0U; }
 
     bool
     hasReceipt(const mqbs::DataStoreRecordHandle&) const BSLS_KEYWORD_OVERRIDE

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -1029,8 +1029,9 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     /// Return the current primary node for this partition.
     mqbnet::ClusterNode* primaryNode() const;
 
-    /// Return the current primary leaseId for this partition.
-    unsigned int primaryLeaseId() const BSLS_KEYWORD_OVERRIDE;
+    /// Return the write-head leaseId for this partition: the lease id of the
+    /// next record this store writes or applies (see `d_writeHeadLeaseId`).
+    unsigned int writeHeadLeaseId() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return `true` if there was Replication Receipt for the specified
     /// `handle`.
@@ -1319,7 +1320,7 @@ inline mqbnet::ClusterNode* FileStore::primaryNode() const
     return d_primaryNode_p;
 }
 
-inline unsigned int FileStore::primaryLeaseId() const
+inline unsigned int FileStore::writeHeadLeaseId() const
 {
     return d_writeHeadLeaseId;
 }

--- a/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.t.cpp
@@ -817,7 +817,7 @@ static void test1_breathingTest()
     BMQTST_ASSERT_EQ(1U, fs.clusterSize());
     BMQTST_ASSERT_EQ(0ULL, fs.numRecords());
     BMQTST_ASSERT_EQ(true, fs.syncPoints().empty());
-    BMQTST_ASSERT_EQ(0U, fs.primaryLeaseId());
+    BMQTST_ASSERT_EQ(0U, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(0ULL, fs.sequenceNumber());
 
     // Temporary workaround to suppress the 'unused operator
@@ -836,7 +836,7 @@ static void test1_breathingTest()
 
     fs.setActivePrimary(tester.node(), primaryLeaseId);
 
-    BMQTST_ASSERT_EQ(primaryLeaseId, fs.primaryLeaseId());
+    BMQTST_ASSERT_EQ(primaryLeaseId, fs.writeHeadLeaseId());
     BMQTST_ASSERT_EQ(seqNum, fs.sequenceNumber());
     BMQTST_ASSERT_EQ(tester.node(), fs.primaryNode());
 


### PR DESCRIPTION
## Summary
  - Follow-up to #1660, which renamed the `mqbs::FileStore` member `d_primaryLeaseId` to `d_writeHeadLeaseId` but left the accessor still named `primaryLeaseId()` — reintroducing the exact "cluster-state primary lease id" misreading the member rename set out to remove.
  - Renames the accessor `DataStore::primaryLeaseId()` → `writeHeadLeaseId()` (base virtual + `FileStore` override) so the public API matches the member and states what the value actually is: the write-head lease id (the lease id of the next record this store writes or applies).
  - Pure rename + doc clarification — **no behavior change**.