### PR TITLE
Cleanup dead broker log categories

### DIFF
--- a/docker/cluster/config/bmqbrkrcfg.json
+++ b/docker/cluster/config/bmqbrkrcfg.json
@@ -13,9 +13,7 @@
             "categories": [
                 "BMQBRKR:INFO:green",
                 "BMQ*:INFO:green",
-                "MQB*:INFO:green",
-                "SIM*:INFO:gray",
-                "BAEA.PERFORMANCEMONITOR:INFO:white"
+                "MQB*:INFO:green"
             ],
             "syslog": {
                 "enabled": false,

--- a/docker/single-node/config/bmqbrkrcfg.json
+++ b/docker/single-node/config/bmqbrkrcfg.json
@@ -13,9 +13,7 @@
             "categories": [
                 "BMQBRKR:INFO:green",
                 "BMQ*:INFO:green",
-                "MQB*:INFO:green",
-                "SIM*:INFO:gray",
-                "BAEA.PERFORMANCEMONITOR:INFO:white"
+                "MQB*:INFO:green"
             ],
             "syslog": {
                 "enabled": false,

--- a/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
+++ b/src/applications/bmqbrkr/etc/bmqbrkrcfg.json
@@ -13,9 +13,7 @@
             "categories": [
                 "BMQBRKR:INFO:green",
                 "BMQ*:INFO:green",
-                "MQB*:INFO:green",
-                "SIM*:INFO:gray",
-                "BAEA.PERFORMANCEMONITOR:INFO:white"
+                "MQB*:INFO:green"
             ],
             "syslog": {
                 "enabled": false,

--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -338,8 +338,6 @@ class Proto:
                         "BMQBRKR:INFO:green",
                         "BMQ*:INFO:green",
                         "MQB*:INFO:green",
-                        "SIM*:INFO:gray",
-                        "BAEA.PERFORMANCEMONITOR:INFO:white",
                     ],
                     syslog=mqbcfg.SyslogConfig(
                         enabled=False,


### PR DESCRIPTION
SIM and BAEA are not used anymore, they can be removed.
