### PR TITLE
Fix[bmqc]: first clean and block queues, then unset d_started

### DIFF
--- a/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
+++ b/src/groups/bmq/bmqc/bmqc_multiqueuethreadpool.h
@@ -856,8 +856,6 @@ inline void MultiQueueThreadPool<TYPE>::stop()
 {
     BSLS_ASSERT_SAFE(isStarted() && "MQTP has not been started");
 
-    d_started = false;
-
     if (d_config.d_eventScheduler_p) {
         d_config.d_eventScheduler_p->cancelEventAndWait(
             &d_alarmMonitorEventHandle);
@@ -909,6 +907,8 @@ inline void MultiQueueThreadPool<TYPE>::stop()
 
         d_allocator_p->deleteObject(info.d_queue_p);
     }
+
+    d_started = false;
 
     d_queues.clear();
 }


### PR DESCRIPTION
`MQTP::stop` sets `d_started = false` first before stopping each dispatcher queue.
This leads to a thread race where dispatcher events being processed in its thread might try to enqueue another event through a dispatcher that is going to close. Since we've set `d_started = false`, enqueue attempt fails on assertion.

The fix is to set `d_started` flag only after we've disabled push to each dispatcher queue and cleared its contents. During stop, we just drop any events in queues, so disabling push is equivalent to just dropping a dispatcher event, which is fine at shutdown.

<img width="1240" height="712" alt="mqtp_crash_sequence" src="https://github.com/user-attachments/assets/1a07a7e7-16a8-43bf-b800-902408a7bfbd" />
