### PR TITLE
Fix[mqbblp::Domain]: unsafe `d_queues` access without mutex

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -577,6 +577,8 @@ int Domain::registerQueue(const bsl::shared_ptr<mqbi::Queue>& queueSp)
     // invoke 'Queue.configure' outside of the lock scope, and in case it
     // fails, we rollback.
 
+    size_t count = 0;
+
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
 
@@ -597,20 +599,22 @@ int Domain::registerQueue(const bsl::shared_ptr<mqbi::Queue>& queueSp)
         d_queues[queueSp->uri().queue()] = queueSp;
 
         d_numQueues.add(1);
+
+        count = d_queues.size();
     }
 
     BALL_LOG_INFO << "Registered queue to domain '" << d_name << "' "
                   << "[canonicalURI: " << queueSp->uri().canonical()
                   << ", qId: " << bmqp::QueueId::QueueIdInt(queueSp->id())
                   << "]. Total number of registered queues in the domain: "
-                  << d_queues.size() << ".";
+                  << count << ".";
 
     return rc_SUCCESS;
 }
 
 void Domain::unregisterQueue(mqbi::Queue* queue)
 {
-    // executed by the associated CLUSTER's DISPATCHER thread
+    // Thread: CLUSTER DISPATCHER
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_sp->inDispatcherThread());

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -211,6 +211,55 @@ int normalizeConfig(mqbconfm::Domain* defn,
     return updatedValues;
 }
 
+/// @brief Function object that reconfigures a snapshot of queues.
+class QueueReconfigureFunctor {
+  public:
+    // TYPES
+
+    /// Snapshot of queues held by weak pointer.
+    typedef bsl::vector<bsl::weak_ptr<mqbi::Queue> > QueueWeakPtrVector;
+
+  private:
+    // DATA
+
+    /// Shared snapshot of the queues to reconfigure.
+    bsl::shared_ptr<QueueWeakPtrVector> d_queues_sp;
+
+  public:
+    // CREATORS
+
+    /// @brief Create a functor owning the specified `queues_sp` snapshot.
+    ///
+    /// @param queues_sp The queues to reconfigure, held by weak pointer.
+    explicit QueueReconfigureFunctor(
+        const bsl::shared_ptr<QueueWeakPtrVector>& queues_sp)
+    : d_queues_sp(queues_sp)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT(queues_sp);
+    }
+
+    // ACCESSORS
+
+    /// @brief Reconfigure every queue in the snapshot that is still alive.
+    void operator()() const
+    {
+        // Thread: CLUSTER DISPATCHER
+
+        for (QueueWeakPtrVector::const_iterator it = d_queues_sp->begin();
+             it != d_queues_sp->end();
+             ++it) {
+            bsl::shared_ptr<mqbi::Queue> queue = it->lock();
+            if (queue) {
+                queue->configure(
+                    static_cast<bsl::ostream*>(0),  // errorDescription
+                    true,                           // isReconfigure
+                    false);                         // wait
+            }
+        }
+    }
+};
+
 }  // close unnamed namespace
 
 // ------------
@@ -224,7 +273,7 @@ void Domain::onOpenQueueResponse(
     const mqbi::OpenQueueConfirmationCookieSp& confirmationCookie,
     const mqbi::Domain::OpenQueueCallback&     callback)
 {
-    // executed by *ANY* thread
+    // Thread: CLUSTER DISPATCHER
 
     --d_pendingRequests;
     if (status.category() == bmqp_ctrlmsg::StatusCategory::E_SUCCESS) {
@@ -287,6 +336,8 @@ Domain::~Domain()
 int Domain::configure(bsl::ostream&           errorDescription,
                       const mqbconfm::Domain& newConfig)
 {
+    // Thread: ADMIN
+
     enum RcEnum {
         // Value for the various RC error categories
         rc_SUCCESS                  = 0,
@@ -358,6 +409,22 @@ int Domain::configure(bsl::ostream&           errorDescription,
         // any needed update-advisories to the CSL.
         d_cluster_sp->onDomainReconfigured(*this, *oldConfig, finalConfig);
 
+        // Make a snapshot of weak queue pointers for reconfigure.
+        bsl::shared_ptr<QueueReconfigureFunctor::QueueWeakPtrVector>
+            queues_sp = bsl::allocate_shared<
+                QueueReconfigureFunctor::QueueWeakPtrVector>(d_allocator_p);
+        {
+            bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+            queues_sp->reserve(d_queues.size());
+            for (QueueMapCIter it = d_queues.begin(); it != d_queues.end();
+                 ++it) {
+                queues_sp->push_back(it->second);
+            }
+        }
+
+        BALL_LOG_INFO << "Reconfiguring " << queues_sp->size()
+                      << " queues from domain " << d_name;
+
         // Note: Queues must only be reconfigured AFTER ensuring that virtual
         // storage has been created for any new AppIds. This is done by the
         // 'QueueEngine::afterAppIdRegistered' method, which is invoked on the
@@ -370,19 +437,7 @@ int Domain::configure(bsl::ostream&           errorDescription,
         //  that it happens after 'onDomainReconfigured'; since implementation
         //  of 'Queue::configure' dispatches to the Queue dispatcher thread, it
         //  will also happen after completion of 'afterAppIdRegistered' above.
-        BALL_LOG_INFO << "Reconfiguring " << d_queues.size()
-                      << " queues from domain " << d_name;
-
-        QueueMap::iterator it = d_queues.begin();
-        for (; it != d_queues.end(); it++) {
-            bsl::function<int()> reconfigureQueueFn = bdlf::BindUtil::bind(
-                &mqbi::Queue::configure,
-                it->second.get(),
-                static_cast<bsl::ostream*>(0),  // errorDescription_p
-                true,                           // isReconfigure
-                false);                         // wait
-            d_dispatcher_p->execute(reconfigureQueueFn, cluster());
-        }
+        d_dispatcher_p->execute(QueueReconfigureFunctor(queues_sp), cluster());
     }
     // 'wait==false', so the result of reconfiguration is not known
 
@@ -450,7 +505,7 @@ void Domain::openQueue(
     const bmqp_ctrlmsg::QueueHandleParameters&                handleParameters,
     const mqbi::Domain::OpenQueueCallback&                    callback)
 {
-    // will execute in DomainManager's IO requester thread
+    // Thread: DomainManager's IO requester thread
     // (TBD: for now, in client-session or cluster dispatcher thread)
 
     // PRECONDITIONS
@@ -502,7 +557,7 @@ void Domain::openQueue(
 
 int Domain::registerQueue(const bsl::shared_ptr<mqbi::Queue>& queueSp)
 {
-    // executed by the associated CLUSTER's DISPATCHER thread
+    // Thread: CLUSTER DISPATCHER
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_sp->inDispatcherThread());
@@ -875,7 +930,7 @@ void Domain::loadAllQueues(bsl::vector<bmqt::Uri>* out) const
 void Domain::loadRoutingConfiguration(
     bmqp_ctrlmsg::RoutingConfiguration* config) const
 {
-    // executed by the associated CLUSTER's DISPATCHER thread
+    // Thread: CLUSTER DISPATCHER
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_sp->inDispatcherThread());

--- a/src/groups/mqb/mqbblp/mqbblp_domain.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.cpp
@@ -652,7 +652,7 @@ void Domain::unregisterQueue(mqbi::Queue* queue)
 int Domain::processCommand(mqbcmd::DomainResult*        result,
                            const mqbcmd::DomainCommand& command)
 {
-    // executed by *any* thread
+    // Thread: ADMIN
 
     if (command.isPurgeValue()) {
         // Some queues might be inactive.  They don't have associated
@@ -717,10 +717,15 @@ int Domain::processCommand(mqbcmd::DomainResult*        result,
                                                 OrderedQueueMap;
         typedef OrderedQueueMap::const_iterator OrderedQueueMapCIter;
 
-        // sort by queue name
-        OrderedQueueMap      map(d_queues.cbegin(), d_queues.cend());
+        // Make a snapshot of queues.
+        OrderedQueueMap map(d_allocator_p);
+        {
+            bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // LOCK
+            map.insert(d_queues.cbegin(), d_queues.cend());
+        }
+
         OrderedQueueMapCIter cit;
-        domainInfo.queueUris().reserve(d_queues.size());
+        domainInfo.queueUris().reserve(map.size());
         for (cit = map.cbegin(); cit != map.cend(); ++cit) {
             domainInfo.queueUris().push_back(cit->second->uri().asString());
         }

--- a/src/groups/mqb/mqbblp/mqbblp_domain.h
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.h
@@ -1,4 +1,4 @@
-// Copyright 2015-2023 Bloomberg Finance L.P.
+// Copyright 2026 Bloomberg Finance L.P.
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/groups/mqb/mqbblp/mqbblp_domain.t.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_domain.t.cpp
@@ -1,0 +1,632 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// mqbblp_domain.t.cpp                                                -*-C++-*-
+#include <mqbblp_domain.h>
+
+// MQB
+#include <mqbc_clusterutil.h>
+#include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
+#include <mqbcmd_messages.h>
+#include <mqbconfm_messages.h>
+#include <mqbi_cluster.h>
+#include <mqbi_domain.h>
+#include <mqbi_queue.h>
+#include <mqbmock_cluster.h>
+#include <mqbmock_dispatcher.h>
+#include <mqbmock_queue.h>
+#include <mqbscm_version.h>
+#include <mqbstat_domainstats.h>
+
+// BMQ
+#include <bmqst_statcontext.h>
+#include <bmqt_uri.h>
+#include <bmqu_memoutstream.h>
+#include <bmqu_tempdirectory.h>
+
+// BDE
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bdlf_bind.h>
+#include <bsl_memory.h>
+#include <bsl_string.h>
+#include <bsl_string_view.h>
+#include <bsl_vector.h>
+#include <bslma_managedptr.h>
+#include <bslma_usesbslmaallocator.h>
+#include <bslmf_nestedtraitdeclaration.h>
+#include <bslmt_barrier.h>
+#include <bslmt_threadutil.h>
+#include <bsls_assert.h>
+#include <bsls_atomic.h>
+#include <bsls_timeinterval.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+namespace {
+
+/// A minimal `mqbi::Queue` (built on `mqbmock::Queue`) that reports a
+/// per-instance URI, so many of them can be registered under distinct names
+/// in a single domain.  `mqbmock::Queue` itself hard-codes a single URI,
+/// which is insufficient for this test.
+class TestQueue : public mqbmock::Queue {
+  private:
+    // DATA
+    bmqt::Uri d_uri;
+
+    /// Incremented on every call to `configure`.  Lets a test observe
+    /// whether the reconfigure functor actually reached this queue.
+    bsls::AtomicInt d_configureCalls;
+
+  private:
+    // NOT IMPLEMENTED
+    TestQueue(const TestQueue&) BSLS_KEYWORD_DELETED;
+    TestQueue& operator=(const TestQueue&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // TRAITS
+    BSLMF_NESTED_TRAIT_DECLARATION(TestQueue, bslma::UsesBslmaAllocator)
+
+    // CREATORS
+
+    /// @brief Create a `TestQueue` reporting the specified `uri`.
+    ///
+    /// @param uri       The URI this queue reports from `uri()`.
+    /// @param allocator The allocator to supply memory.
+    explicit TestQueue(bsl::string_view uri, bslma::Allocator* allocator)
+    : mqbmock::Queue(static_cast<mqbi::Domain*>(0), allocator)
+    , d_uri(uri, allocator)
+    , d_configureCalls(0)
+    {
+        BSLS_ASSERT_OPT(d_uri.isValid());
+    }
+
+    // MANIPULATORS
+
+    /// @brief Record the reconfigure and return success.
+    ///
+    /// @return 0 always.
+    int configure(BSLA_MAYBE_UNUSED bsl::ostream* errorDescription_p,
+                  BSLA_MAYBE_UNUSED bool          isReconfigure,
+                  BSLA_MAYBE_UNUSED bool          wait) BSLS_KEYWORD_OVERRIDE
+    {
+        ++d_configureCalls;
+        return 0;
+    }
+
+    // ACCESSORS
+
+    /// @brief Return the number of times `configure` has been called.
+    ///
+    /// @return The reconfigure call count.
+    int configureCounter() const { return d_configureCalls.load(); }
+
+    /// @brief Return the URI of this queue.
+    ///
+    /// @return The URI supplied at construction.
+    const bmqt::Uri& uri() const BSLS_KEYWORD_OVERRIDE { return d_uri; }
+};
+
+/// @brief Build a valid priority / in-memory domain configuration.
+///
+/// Varying `messagesLimit` yields a configuration that differs from a
+/// previous one, so `Domain::configure` does not early-return.
+///
+/// @param name          The domain name.
+/// @param messagesLimit The domain-wide message limit.
+/// @param allocator     The allocator to supply memory.
+///
+/// @return The constructed configuration.
+mqbconfm::Domain makeConfig(const bsl::string& name,
+                            bsls::Types::Int64 messagesLimit,
+                            bslma::Allocator*  allocator)
+{
+    mqbconfm::Domain config(allocator);
+    config.name() = name;
+    config.mode().makePriority();
+    config.consistency().makeEventual();
+    config.storage().config().makeInMemory();
+
+    mqbconfm::Limits& limits = config.storage().domainLimits();
+    limits.messages()        = messagesLimit;
+    limits.bytes()           = messagesLimit * 1024;
+    // Watermark ratios default to 0.8, which is valid.
+
+    return config;
+}
+
+/// @brief No-op teardown callback for `Domain::teardown`.
+///
+/// @param domainName The name of the domain being torn down (unused).
+void teardownCb(BSLA_MAYBE_UNUSED const bsl::string& domainName)
+{
+    // NOTHING
+}
+
+/// Test fixture owning a fully-constructed `mqbblp::Domain` and its
+/// dependencies, mirroring the wiring done by `mqba::DomainManager`.
+struct DomainTester {
+    // DATA
+    bslma::Allocator*                     d_allocator_p;
+    bmqu::TempDirectory                   d_tempDir;
+    bdlbb::PooledBlobBufferFactory        d_bufferFactory;
+    mqbmock::Dispatcher                   d_dispatcher;
+    bsl::shared_ptr<mqbmock::Cluster>     d_cluster_sp;
+    bsl::shared_ptr<bmqst::StatContext>   d_domainsStatContext_sp;
+    bslma::ManagedPtr<bmqst::StatContext> d_queuesStatContext_mp;
+    bslma::ManagedPtr<mqbblp::Domain>     d_domain_mp;
+
+    // CREATORS
+
+    /// @brief Build a `Domain` and its dependencies for testing.
+    ///
+    /// @param allocator The allocator to supply memory.
+    explicit DomainTester(bslma::Allocator* allocator)
+    : d_allocator_p(allocator)
+    , d_tempDir(allocator)
+    , d_bufferFactory(1024, allocator)
+    , d_dispatcher(allocator)
+    , d_cluster_sp(0)
+    , d_domainsStatContext_sp(0)
+    , d_queuesStatContext_mp(0)
+    , d_domain_mp(0)
+    {
+        // The Domain's dispatcher only needs to accept the reconfigure
+        // functors 'Domain::configure' posts; setting 'enqueueOnly' prevents
+        // it from ever invoking 'Queue::configure' on the mock queues.
+        d_dispatcher.setEnqueueOnly(true);
+
+        // Build a *member* cluster so that 'Domain' does not treat itself as
+        // remote (a remote domain skips the reconfigure path entirely).
+        mqbmock::Cluster::ClusterNodeDefs nodeDefs(d_allocator_p);
+        mqbc::ClusterUtil::appendClusterNode(
+            &nodeDefs,
+            "testNode1",
+            "US-EAST",
+            41234,
+            mqbmock::Cluster::k_LEADER_NODE_ID,
+            d_allocator_p);
+        mqbc::ClusterUtil::appendClusterNode(
+            &nodeDefs,
+            "testNode2",
+            "US-EAST",
+            41235,
+            mqbmock::Cluster::k_LEADER_NODE_ID + 1,
+            d_allocator_p);
+
+        d_cluster_sp.createInplace(d_allocator_p,
+                                   d_allocator_p,
+                                   true,   // isClusterMember
+                                   false,  // isLeader
+                                   false,  // isFSMWorkflow
+                                   false,  // doesFSMwriteQLIST
+                                   nodeDefs,
+                                   "testCluster",
+                                   d_tempDir.path());
+
+        // Allow dispatcher-thread checks (e.g. in 'registerQueue') to pass
+        // from any thread.
+        d_cluster_sp->setThreadId(mqbi::DispatcherClient::k_ANY_THREAD_ID);
+
+        d_domainsStatContext_sp =
+            mqbstat::DomainStatsUtil::initializeStatContext(1, d_allocator_p);
+
+        bmqst::StatContextConfiguration statCfg("domain-test", d_allocator_p);
+        d_queuesStatContext_mp = d_domainsStatContext_sp->addSubcontext(
+            statCfg);
+
+        bsl::shared_ptr<mqbi::Cluster> clusterBase = d_cluster_sp;
+
+        d_domain_mp.load(new (*d_allocator_p)
+                             mqbblp::Domain("domain-test",
+                                            &d_dispatcher,
+                                            &d_bufferFactory,
+                                            clusterBase,
+                                            d_domainsStatContext_sp.get(),
+                                            d_queuesStatContext_mp,
+                                            d_allocator_p),
+                         d_allocator_p);
+    }
+
+    ~DomainTester()
+    {
+        // Satisfy 'Domain::~Domain' precondition (must be torn down first).
+        d_domain_mp->teardown(&teardownCb);
+    }
+
+    /// @brief Return the domain under test.
+    ///
+    /// @return A reference to the owned `Domain`.
+    mqbblp::Domain& domain() { return *d_domain_mp; }
+
+    /// @brief Return the dispatcher wired to the domain under test.
+    ///
+    /// @return A reference to the owned mock dispatcher.
+    mqbmock::Dispatcher& dispatcher() { return d_dispatcher; }
+};
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_breathingTest()
+// ------------------------------------------------------------------------
+// BREATHING TEST
+//
+// Concerns:
+//   Exercise basic construction / configuration / teardown of a Domain.
+//
+// Plan:
+//   Construct a Domain, configure it once, reconfigure it, and let the
+//   fixture tear it down.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("BREATHING TEST");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    DomainTester tester(alloc);
+
+    bmqu::MemOutStream errorDescription(alloc);
+
+    // First-time configure.
+    int rc = tester.domain().configure(errorDescription,
+                                       makeConfig("domain-test", 1000, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Reconfigure with a different config (takes the reconfigure path).
+    rc = tester.domain().configure(errorDescription,
+                                   makeConfig("domain-test", 2000, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+}
+
+namespace {
+
+/// @brief Repeatedly reconfigure the domain until the stop flag is set.
+///
+/// Exercises `Domain::configure` concurrently with queue registration.
+/// Runs on a spawned thread.
+///
+/// @param domain    The domain to reconfigure.
+/// @param barrier   Barrier used to start in lock-step with the main thread.
+/// @param stop      Flag signalling the loop to terminate.
+/// @param allocator The allocator to supply memory.
+void reconfigureThread(mqbblp::Domain*   domain,
+                       bslmt::Barrier*   barrier,
+                       bsls::AtomicBool* stop,
+                       bslma::Allocator* allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_OPT(domain);
+    BSLS_ASSERT_OPT(barrier);
+    BSLS_ASSERT_OPT(stop);
+
+    const mqbconfm::Domain cfgA = makeConfig("domain-test", 1000, allocator);
+    const mqbconfm::Domain cfgB = makeConfig("domain-test", 2000, allocator);
+
+    bmqu::MemOutStream err(allocator);
+
+    barrier->wait();
+
+    bool toggle = false;
+    while (!stop->loadRelaxed()) {
+        domain->configure(err, toggle ? cfgA : cfgB);
+        toggle = !toggle;
+    }
+}
+
+}  // close unnamed namespace
+
+static void test2_concurrentConfigureAndRegisterQueue()
+// ------------------------------------------------------------------------
+// CONCURRENT CONFIGURE AND REGISTER-QUEUE
+//
+// Concerns:
+//   'Domain::configure' and 'Domain::registerQueue' must be safe to call
+//   concurrently: a 'DOMAINS RECONFIGURE' running on the admin thread may
+//   overlap queue open/close activity driving 'registerQueue' on the
+//   cluster dispatcher thread.  Concurrent access to the domain's internal
+//   queue map must be properly synchronized.
+//
+// Plan:
+//   Spawn one thread that continuously reconfigures the domain while the
+//   main thread continuously registers distinct queues.  The test must
+//   complete without data races or crashes.  Run under ThreadSanitizer to
+//   assert the concurrent accesses are correctly synchronized.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "CONCURRENT CONFIGURE AND REGISTER-QUEUE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    DomainTester tester(alloc);
+
+    bmqu::MemOutStream errorDescription(alloc);
+
+    // Establish an initial config so subsequent 'configure' calls take the
+    // reconfigure path.
+    int rc = tester.domain().configure(errorDescription,
+                                       makeConfig("domain-test", 500, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Pre-create a large number of distinct queues to register concurrently
+    // with the reconfigure loop.
+    const int                                k_NUM_QUEUES = 4000;
+    bsl::vector<bsl::shared_ptr<TestQueue> > queues(alloc);
+    queues.reserve(k_NUM_QUEUES);
+    for (int i = 0; i < k_NUM_QUEUES; ++i) {
+        bmqu::MemOutStream uri(alloc);
+        uri << "bmq://bmq.test.local/q" << i;
+        queues.push_back(bsl::allocate_shared<TestQueue>(alloc, uri.str()));
+    }
+
+    bslmt::Barrier   barrier(2);
+    bsls::AtomicBool stop(false);
+
+    bslmt::ThreadUtil::Handle handle;
+    rc = bslmt::ThreadUtil::create(&handle,
+                                   bdlf::BindUtil::bind(&reconfigureThread,
+                                                        &tester.domain(),
+                                                        &barrier,
+                                                        &stop,
+                                                        alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Start both threads roughly simultaneously, then hammer registrations.
+    barrier.wait();
+    for (int i = 0; i < k_NUM_QUEUES; ++i) {
+        bsl::shared_ptr<mqbi::Queue> queueBase = queues[i];
+        tester.domain().registerQueue(queueBase);
+    }
+
+    stop.storeRelaxed(true);
+    bslmt::ThreadUtil::join(handle);
+
+    // If we get here without a crash / sanitizer abort, the run completed.
+    BMQTST_ASSERT_EQ(static_cast<int>(queues.size()), k_NUM_QUEUES);
+}
+
+static void test3_reconfigureSkipsUnregisteredQueue()
+// ------------------------------------------------------------------------
+// RECONFIGURE SKIPS UNREGISTERED QUEUE
+//
+// Concerns:
+//   The queue reconfiguration that 'Domain::configure' dispatches must not
+//   access a queue that has been unregistered (and destroyed) after the
+//   reconfigure was posted but before it runs.  The dispatched work must
+//   hold no owning-or-raw reference that can outlive the queue: a queue
+//   gone by execution time must be safely skipped, while queues still
+//   alive must still be reconfigured.
+//
+// Plan:
+//   Drive the exact ordering deterministically using the mock dispatcher's
+//   'enqueueOnly' mode:
+//     1. Register two queues: one to survive, one to be destroyed.
+//     2. Reconfigure the domain.  This posts the reconfigure work but, in
+//        'enqueueOnly' mode, does not run it yet.
+//     3. Unregister the doomed queue and drop every strong reference to it,
+//        so it is actually destroyed while the reconfigure work is still
+//        queued.  Assert (via a 'weak_ptr') that it is gone.
+//     4. Run the queued work with 'processQueue'.
+//   The surviving queue must observe exactly one reconfigure and the run
+//   must complete cleanly.  Were the dispatched work holding a raw queue
+//   pointer, step 4 would dereference freed memory (a use-after-free that
+//   ThreadSanitizer / AddressSanitizer flags).
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("RECONFIGURE SKIPS UNREGISTERED QUEUE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    DomainTester tester(alloc);
+
+    bmqu::MemOutStream errorDescription(alloc);
+
+    // Establish an initial config so subsequent 'configure' calls take the
+    // reconfigure path.
+    int rc = tester.domain().configure(errorDescription,
+                                       makeConfig("domain-test", 500, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // A queue that will remain registered across the reconfigure.
+    bsl::shared_ptr<TestQueue> survivor = bsl::allocate_shared<TestQueue>(
+        alloc,
+        "bmq://bmq.test.local/survivor");
+
+    // A queue that will be unregistered and destroyed before the reconfigure
+    // work runs.
+    bsl::shared_ptr<TestQueue> doomed =
+        bsl::allocate_shared<TestQueue>(alloc, "bmq://bmq.test.local/doomed");
+
+    // Watch the doomed queue's lifetime without keeping it alive.
+    bsl::weak_ptr<TestQueue> doomedWatch = doomed;
+
+    {
+        bsl::shared_ptr<mqbi::Queue> survivorBase = survivor;
+        bsl::shared_ptr<mqbi::Queue> doomedBase   = doomed;
+        tester.domain().registerQueue(survivorBase);
+        tester.domain().registerQueue(doomedBase);
+    }
+
+    // Reconfigure: this snapshots the queues and *posts* the reconfigure work,
+    // but 'enqueueOnly' keeps it queued rather than running it now.
+    rc = tester.domain().configure(errorDescription,
+                                   makeConfig("domain-test", 1000, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Nothing has run yet.
+    BMQTST_ASSERT_EQ(survivor->configureCounter(), 0);
+
+    // Destroy the doomed queue while the reconfigure work is still queued.
+    tester.domain().unregisterQueue(doomed.get());
+    doomed.reset();
+
+    // The doomed queue is truly gone; any raw pointer to it now dangles.
+    BMQTST_ASSERT(doomedWatch.expired());
+
+    // Run the queued reconfigure work.  The destroyed queue must be skipped
+    // and the survivor must be reconfigured exactly once.
+    tester.dispatcher().processQueue();
+
+    BMQTST_ASSERT_EQ(survivor->configureCounter(), 1);
+
+    // Unregister the survivor so the fixture tears down cleanly.
+    tester.domain().unregisterQueue(survivor.get());
+}
+
+namespace {
+
+/// @brief Repeatedly issue a domain `INFO` command until the stop flag is set.
+///
+/// Exercises `Domain::processCommand` (which iterates the domain's queue map)
+/// concurrently with queue registration.  Runs on a spawned thread.
+///
+/// @param domain    The domain to query.
+/// @param barrier   Barrier used to start in lock-step with the main thread.
+/// @param stop      Flag signalling the loop to terminate.
+/// @param allocator The allocator to supply memory.
+void processInfoThread(mqbblp::Domain*   domain,
+                       bslmt::Barrier*   barrier,
+                       bsls::AtomicBool* stop,
+                       bslma::Allocator* allocator)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_OPT(domain);
+    BSLS_ASSERT_OPT(barrier);
+    BSLS_ASSERT_OPT(stop);
+
+    mqbcmd::DomainCommand command(allocator);
+    command.makeInfo();
+
+    barrier->wait();
+
+    while (!stop->loadRelaxed()) {
+        // The mock cluster returns an error for the nested cluster command,
+        // but the racy queue-map iteration in 'processCommand' happens before
+        // that, which is what this test exercises.
+        mqbcmd::DomainResult result(allocator);
+        domain->processCommand(&result, command);
+    }
+}
+
+}  // close unnamed namespace
+
+static void test4_concurrentProcessCommandAndRegisterQueue()
+// ------------------------------------------------------------------------
+// CONCURRENT PROCESS-COMMAND AND REGISTER-QUEUE
+//
+// Concerns:
+//   'Domain::processCommand' (handling a 'DOMAINS DOMAIN <name> INFOS'
+//   command) iterates the domain's internal queue map.  It runs on an admin
+//   ('ANY') thread and may overlap queue open activity driving
+//   'registerQueue' on the cluster dispatcher thread.  Access to the queue
+//   map must be properly synchronized.
+//
+// Plan:
+//   Spawn one thread that continuously issues 'INFO' commands while the main
+//   thread continuously registers distinct queues.  The test must complete
+//   without data races or crashes.  Run under ThreadSanitizer to assert the
+//   concurrent accesses are correctly synchronized.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "CONCURRENT PROCESS-COMMAND AND REGISTER-QUEUE");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    DomainTester tester(alloc);
+
+    bmqu::MemOutStream errorDescription(alloc);
+
+    int rc = tester.domain().configure(errorDescription,
+                                       makeConfig("domain-test", 500, alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Pre-create a large number of distinct queues to register concurrently
+    // with the 'INFO' loop.
+    const int                                k_NUM_QUEUES = 4000;
+    bsl::vector<bsl::shared_ptr<TestQueue> > queues(alloc);
+    queues.reserve(k_NUM_QUEUES);
+    for (int i = 0; i < k_NUM_QUEUES; ++i) {
+        bmqu::MemOutStream uri(alloc);
+        uri << "bmq://bmq.test.local/q" << i;
+        queues.push_back(bsl::allocate_shared<TestQueue>(alloc, uri.str()));
+    }
+
+    bslmt::Barrier   barrier(2);
+    bsls::AtomicBool stop(false);
+
+    bslmt::ThreadUtil::Handle handle;
+    rc = bslmt::ThreadUtil::create(&handle,
+                                   bdlf::BindUtil::bind(&processInfoThread,
+                                                        &tester.domain(),
+                                                        &barrier,
+                                                        &stop,
+                                                        alloc));
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    // Start both threads roughly simultaneously, then hammer registrations.
+    barrier.wait();
+    for (int i = 0; i < k_NUM_QUEUES; ++i) {
+        bsl::shared_ptr<mqbi::Queue> queueBase = queues[i];
+        tester.domain().registerQueue(queueBase);
+    }
+
+    stop.storeRelaxed(true);
+    bslmt::ThreadUtil::join(handle);
+
+    // If we get here without a crash / sanitizer abort, the run completed.
+    BMQTST_ASSERT_EQ(static_cast<int>(queues.size()), k_NUM_QUEUES);
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    {
+        mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
+        mqbcfg::BrokerConfig::set(brokerConfig);
+
+        switch (_testCase) {
+        case 4: test4_concurrentProcessCommandAndRegisterQueue(); break;
+        case 3: test3_reconfigureSkipsUnregisteredQueue(); break;
+        case 2: test2_concurrentConfigureAndRegisterQueue(); break;
+        case 1: test1_breathingTest(); break;
+        default: {
+            cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+            bmqtst::TestHelperUtil::testStatus() = -1;
+        } break;
+        }
+    }
+
+    TEST_EPILOG(bmqtst::TestHelper::e_DEFAULT);
+    // Can't ensure no global memory is allocated because
+    // 'bslmt::ThreadUtil::create()' uses the global allocator.
+}


### PR DESCRIPTION
# Problem

**Bug 1**:
`mqbblp::Domain::configure` iterated the `d_queues` map on the admin thread without holding `d_mutex`, while `registerQueue`/`unregisterQueue` mutate the same map (insert/erase) under `d_mutex` on the cluster dispatcher thread. A `DOMAINS RECONFIGURE` overlapping a queue open/close is a data race - a rehash on insert could invalidate the concurrent iterator (crash / garbage read).

**Bug 2**:
The reconfigure path also bound a raw `mqbi::Queue*` (`it->second.get()`) into an async dispatcher functor, opening a use-after-free window between enqueue and execution if the queue was unregistered in the meantime.

**Bug 3**:
`Domain::processCommand` makes a copy of `d_queues` without holding a mutex from ADMIN thread. `d_queues` might be changed or rehashed from the cluster dispatcher thread at the same time.

**Bug 4**:
`Domain::registerQueue` logs `d_queues.size()` without holding a mutex.

# Fix

In `Domain::configure`, snapshot the queues under `d_mutex` into a `shared_ptr<vector<weak_ptr<mqbi::Queue>>>`, then dispatch a single functor (`QueueReconfigureFunctor`) that owns the snapshot. On the cluster dispatcher thread it `lock()`s each weak pointer and reconfigures only the queues still alive — queues unregistered since the snapshot are safely skipped.

This closes both the iteration race (map is now only touched under the mutex) and the lifetime hazard (no raw pointers bound; `weak_ptr::lock()` gates every access).

# Tests

Add `mqbblp_domain.t.cpp` test driver:
- `test1_breathingTest` — construct / configure / reconfigure / teardown.
- `test2_concurrentConfigureAndRegisterQueue` — one thread reconfigures continuously while the main thread registers thousands of distinct queues, exercising the exact overlap.
- `test3_reconfigureSkipsUnregisteredQueue` — deterministically (via the mock dispatcher's enqueueOnly mode) unregisters and destroys a queue after the reconfigure is posted but before it runs, asserting the dispatched work skips the dead queue (weak_ptr gone) and reconfigures the survivor exactly once — proving no raw/owning reference outlives the queue.
- `test4_concurrentProcessCommandAndRegisterQueue` — one thread issues `INFO` commands continuously while the main thread register thousands of distinct queues, exercising the `processCommand` overlap.
