### PR TITLE
CI: fix prometheus concurrent restart

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -357,14 +357,17 @@ jobs:
           cmake --build --preset gh-prometheus-ubuntu-latest-cpp23
           echo "::remove-matcher owner=cpp-prometheus"
 
-      - name: Create prometheus dir
-        run:  mkdir -p prometheus_dir
+      - name: Create prometheus dirs
+        run:  mkdir -p prometheus_dir/pull prometheus_dir/push
 
       - name: Download Prometheus
         run:  curl -SL "https://github.com/prometheus/prometheus/releases/download/v2.45.1/prometheus-2.45.1.linux-amd64.tar.gz" | tar -xzC prometheus_dir/
 
-      - name: Run Prometheus
-        run:  ./prometheus_dir/prometheus-2.45.1.linux-amd64/prometheus --config.file=${{ github.workspace }}/src/plugins/bmqprometheus/tests/prometheus_localhost.yaml --web.enable-lifecycle --storage.tsdb.path=${{ github.workspace }}/prometheus_dir/data &
+      - name: Run Prometheus for "pull" mode
+        run:  ./prometheus_dir/prometheus-2.45.1.linux-amd64/prometheus --config.file=${{ github.workspace }}/.github/workflows/ext/prometheus_localhost_pull.yaml --web.listen-address=0.0.0.0:9090 --storage.tsdb.path=${{ github.workspace }}/prometheus_dir/pull &
+
+      - name: Run Prometheus for "push" mode
+        run:  ./prometheus_dir/prometheus-2.45.1.linux-amd64/prometheus --config.file=${{ github.workspace }}/.github/workflows/ext/prometheus_localhost_push.yaml --web.listen-address=0.0.0.0:9092 --storage.tsdb.path=${{ github.workspace }}/prometheus_dir/push &
 
       - name: Run Pushgateway
         run: |
@@ -372,17 +375,11 @@ jobs:
           docker pull prom/pushgateway@sha256:c835998819105d84d484918908df132807c78c05f3e0e649df0c0479c6780d98
           docker run -d -p 9091:9091 prom/pushgateway
 
-      - name: Run BMQPrometheus plugin integration test in "pull" mode
-        run: ${{ github.workspace }}/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p ${{ github.workspace }}/build/blazingmq -m pull --no-docker
+      - name: Prometheus plugin IT[pull]
+        run: ${{ github.workspace }}/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p ${{ github.workspace }}/build/blazingmq -m pull --no-docker --prometheus-host localhost:9090
 
-      - name: Clear Prometheus database and restart
-        run: |
-          curl -X POST "http://localhost:9090/-/quit"
-          rm -rf prometheus_dir/data
-          ./prometheus_dir/prometheus-2.45.1.linux-amd64/prometheus --config.file=${{ github.workspace }}/src/plugins/bmqprometheus/tests/prometheus_localhost.yaml --web.enable-lifecycle --storage.tsdb.path=${{ github.workspace }}/prometheus_dir/data &
-
-      - name: Run Prometheus plugin integration test in "push" mode
-        run: ${{ github.workspace }}/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p ${{ github.workspace }}/build/blazingmq -m push --no-docker
+      - name: Prometheus plugin IT[push]
+        run: ${{ github.workspace }}/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p ${{ github.workspace }}/build/blazingmq -m push --no-docker --prometheus-host localhost:9092
 
   documentation:
     name: "Documentation"

--- a/.github/workflows/ext/prometheus_localhost_pull.yaml
+++ b/.github/workflows/ext/prometheus_localhost_pull.yaml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval:     5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name:       'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name:       'bmq'
+    scrape_interval: 1s
+    static_configs:
+      - targets: ['localhost:8080']
+        labels:
+          group: 'bmq'

--- a/.github/workflows/ext/prometheus_localhost_push.yaml
+++ b/.github/workflows/ext/prometheus_localhost_push.yaml
@@ -5,7 +5,7 @@ global:
 scrape_configs:
   - job_name:       'prometheus'
     static_configs:
-      - targets: ['localhost:9090']
+      - targets: ['localhost:9092']
 
   - job_name:       'gateway'
     scrape_interval: 1s
@@ -14,9 +14,3 @@ scrape_configs:
       - targets: ['localhost:9091']
         labels:
           group: 'pushgateway'
-  - job_name:       'bmq'
-    scrape_interval: 1s
-    static_configs:
-      - targets: ['localhost:8080']
-        labels:
-          group: 'bmq'

--- a/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py
+++ b/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py
@@ -40,6 +40,8 @@ options:
   -m {all,pull,push}, --mode {all,pull,push}
                         prometheus mode
   --no-docker           don't run Prometheus in docker, assume it is running on localhost
+  --prometheus-host PROMETHEUS_HOST
+                        Prometheus server host:port to query (default: localhost:9090)
 
 """
 
@@ -99,6 +101,12 @@ def parse_arguments():
         "--no-docker",
         action="store_true",
         help="don't run Prometheus in docker, assume it is running on localhost",
+    )
+    parser.add_argument(
+        "--prometheus-host",
+        type=str,
+        default=PROMETHEUS_HOST,
+        help="Prometheus server host:port to query",
     )
 
     return parser.parse_args()
@@ -245,7 +253,7 @@ def main(args):
             plugin_path,
             broker_path,
             tool_path,
-            PROMETHEUS_HOST,
+            args.prometheus_host,
             prometheus_docker_file_path,
             mode,
         )


### PR DESCRIPTION
- Start 2 independent prometheus instances (push, pull)
- Move prometheus CI configs to CI folder

Fixes the following CI error
```
Run /home/runner/work/blazingmq/blazingmq/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py -p /home/runner/work/blazingmq/blazingmq/build/blazingmq -m push --no-docker
Traceback (most recent call last):
  File "/home/runner/work/blazingmq/blazingmq/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py", line 366, in <module>
    sys.exit(main(parse_arguments()))
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/blazingmq/blazingmq/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py", line 2[4](https://github.com/bloomberg/blazingmq/actions/runs/30564764931/job/90946514631?pr=1670#step:15:5)4, in main
    results[f"local_cluster_test_with_{mode}_mode"] = test_local_cluster(
                                                      ^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/blazingmq/blazingmq/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py", line 169, in test_local_cluster
    response = _make_request(
               ^^^^^^^^^^^^^^
  File "/home/runner/work/blazingmq/blazingmq/src/plugins/bmqprometheus/tests/bmqprometheus_prometheusstatconsumer_test.py", line 26[5](https://github.com/bloomberg/blazingmq/actions/runs/30564764931/job/90946514631?pr=1670#step:15:6), in _make_request
    conn.request("GET", url)
  File "/usr/lib/python3.12/http/client.py", line 1365, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 1411, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 13[6](https://github.com/bloomberg/blazingmq/actions/runs/30564764931/job/90946514631?pr=1670#step:15:7)0, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.12/http/client.py", line 1120, in _send_output
    self.send(msg)
  File "/usr/lib/python3.12/http/client.py", line 1064, in send
    self.connect()
  File "/usr/lib/python3.12/http/client.py", line 1030, in connect
    self.sock = self._create_connection(
                ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/socket.py", line 852, in create_connection
    raise exceptions[0]
  File "/usr/lib/python3.12/socket.py", line 83[7](https://github.com/bloomberg/blazingmq/actions/runs/30564764931/job/90946514631?pr=1670#step:15:8), in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
```