### PR TITLE
Fix[mqba::AdminSession]: handle in-flight events on teardown

### DIFF
--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -102,6 +102,20 @@ bmqp_ctrlmsg::ClientIdentity* extractClientIdentity(
     };
 }
 
+/// @brief Keep the specified `session` alive for the duration of a dispatcher
+/// event.
+///
+/// This function does nothing on its own; it exists only so that a keep-alive
+/// handle to the session can be bound into a dispatcher event, delaying the
+/// session's destruction until all events enqueued before it have been
+/// processed.
+///
+/// @param session A keep-alive handle to the session being torn down.
+void sessionHolderDummy(BSLA_MAYBE_UNUSED const bsl::shared_ptr<void>& session)
+{
+    // NOTHING
+}
+
 }  // close unnamed namespace
 
 // -------------------------
@@ -372,7 +386,8 @@ void AdminSession::processEvent(const bmqp::Event& event,
         this);
 }
 
-void AdminSession::tearDownImpl(bslmt::Semaphore* semaphore)
+void AdminSession::tearDownImpl(bslmt::Semaphore*            semaphore,
+                                const bsl::shared_ptr<void>& session)
 {
     // executed by the *CLIENT* dispatcher thread
     // PRECONDITIONS
@@ -380,34 +395,55 @@ void AdminSession::tearDownImpl(bslmt::Semaphore* semaphore)
 
     d_self.invalidate();
 
+    // An in-flight admin command completion may have acquired 'd_self' just
+    // before the 'invalidate' above and enqueued a 'finalizeAdminCommand'
+    // event onto this client's dispatcher queue.  Because 'invalidate' does
+    // not return until all such acquisitions have been released, any such
+    // event is now guaranteed to sit ahead of the event we enqueue next.
+    // Enqueue a final event holding the 'session' handle alive: only once it
+    // is processed is the client dispatcher queue guaranteed drained, and only
+    // then do we let the last reference to the session be released, so no
+    // callback ever runs on a destroyed session.
+    //
+    // NOTE: We use the e_DISPATCHER type because this Client is dying, and the
+    //       process of this event by the dispatcher should not add it to the
+    //       flush list.
+    dispatcher()->execute(bdlf::BindUtil::bind(&sessionHolderDummy, session),
+                          this,
+                          mqbi::DispatcherEventType::e_DISPATCHER);
+
     // We can now wake up the IO thread, and let the channel be destroyed
     semaphore->post();
 }
 
-void AdminSession::tearDown(
-    BSLA_MAYBE_UNUSED const bsl::shared_ptr<void>& session,
-    BSLA_MAYBE_UNUSED bool                         isBrokerShutdown)
+void AdminSession::tearDown(const bsl::shared_ptr<void>& session,
+                            BSLA_MAYBE_UNUSED bool       isBrokerShutdown)
 {
     // executed by the *IO* thread
 
     // Enqueue an event to the client dispatcher thread and wait for it to
     // finish; only after this will we have the guarantee that no method will
-    // try to use the channel.
+    // try to use the channel.  The 'session' handle is threaded through to
+    // 'tearDownImpl' so that it can keep the session alive until the client
+    // dispatcher queue has been fully drained.
     bslmt::Semaphore semaphore;
 
     // NOTE: We use the e_DISPATCHER type because this Client is dying, and the
     //       process of this event by the dispatcher should not add it to the
     //       flush list.
-    dispatcher()->execute(
-        bdlf::BindUtil::bind(&AdminSession::tearDownImpl, this, &semaphore),
-        this,
-        mqbi::DispatcherEventType::e_DISPATCHER);
+    dispatcher()->execute(bdlf::BindUtil::bind(&AdminSession::tearDownImpl,
+                                               this,
+                                               &semaphore,
+                                               session),
+                          this,
+                          mqbi::DispatcherEventType::e_DISPATCHER);
     semaphore.wait();
 
     // At this point, we are sure the client dispatcher thread has no pending
     // processing that could be using the channel, so we can return, which will
     // destroy the channel.  The session will die when all references to the
-    // 'session' go out of scope.
+    // 'session' go out of scope, including the one held by the final drain
+    // event enqueued in 'tearDownImpl'.
 }
 
 void AdminSession::initiateShutdown(const ShutdownCb& callback)

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -261,9 +261,20 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     void tearDown(const bsl::shared_ptr<void>& session,
                   bool isBrokerShutdown) BSLS_KEYWORD_OVERRIDE;
 
-    /// Implementation of the teardown process, posting on the specified
-    /// `semaphore` once processing is done.
-    void tearDownImpl(bslmt::Semaphore* semaphore);
+    /// @brief Implementation of the teardown process on the client dispatcher
+    /// thread.
+    ///
+    /// Invalidate the session so that no further asynchronous callback is
+    /// dispatched, then enqueue a final dispatcher event holding the specified
+    /// `session` alive so that any callback that was dispatched before
+    /// invalidation is processed before the session is destroyed, and post on
+    /// the specified `semaphore` once done.
+    ///
+    /// @param semaphore The semaphore to post once the teardown work is done.
+    /// @param session   A keep-alive handle to this session, kept alive until
+    ///                  the client dispatcher queue has been drained.
+    void tearDownImpl(bslmt::Semaphore*            semaphore,
+                      const bsl::shared_ptr<void>& session);
 
     // MANIPULATORS
     //   (virtual: mqbi::DispatcherClient)

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -18,6 +18,7 @@
 // MQB
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
+#include <mqbi_dispatcher.h>
 #include <mqbmock_dispatcher.h>
 #include <mqbu_messageguidutil.h>
 
@@ -39,10 +40,15 @@
 #include <bdlcc_objectpool.h>
 #include <bdlcc_sharedobjectpool.h>
 #include <bdlf_bind.h>
+#include <bdlmt_threadpool.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
+#include <bslmt_semaphore.h>
+#include <bslmt_threadutil.h>
+#include <bsls_atomic.h>
+#include <bsls_timeinterval.h>
 
 // TEST DRIVER
 #include <bmqtst_testhelper.h>
@@ -192,6 +198,117 @@ class TestBench {
     }
 };
 
+// ============================================================================
+//              HELPERS FOR THE CONCURRENT TEARDOWN TEST
+// ----------------------------------------------------------------------------
+
+/// Drives a `mqbmock::Dispatcher` (configured in `enqueueOnly` mode) from a
+/// dedicated thread, emulating the broker's single-threaded dispatcher
+/// processor.
+/// This ensures that dispatcher callbacks (such as `finalizeAdminCommand`,
+/// enqueued by `onProcessedAdminCommand` from the admin execution pool) run on
+/// a thread distinct from the one that tears down and destroys the
+/// `AdminSession`, as they do in the broker.
+class QueueProcessor {
+  private:
+    // DATA
+    mqbmock::Dispatcher*      d_dispatcher_p;
+    bsls::AtomicBool          d_running;
+    bslmt::ThreadUtil::Handle d_handle;
+
+    // NOT IMPLEMENTED
+    QueueProcessor(const QueueProcessor&);
+    QueueProcessor& operator=(const QueueProcessor&);
+
+  public:
+    // CREATORS
+
+    /// Create a processor draining the specified `dispatcher`.
+    explicit QueueProcessor(mqbmock::Dispatcher* dispatcher)
+    : d_dispatcher_p(dispatcher)
+    , d_running(true)
+    , d_handle(bslmt::ThreadUtil::invalidHandle())
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_OPT(d_dispatcher_p);
+    }
+
+    // MANIPULATORS
+
+    /// Spawn the processor thread.
+    void start()
+    {
+        int rc = bslmt::ThreadUtil::create(
+            &d_handle,
+            bdlf::BindUtil::bind(&QueueProcessor::run, this));
+        BMQTST_ASSERT_EQ(rc, 0);
+    }
+
+    /// Body of the processor thread: repeatedly drain the dispatcher queue
+    /// until stopped, then perform one final drain.
+    void run()
+    {
+        while (d_running.load()) {
+            d_dispatcher_p->processQueue();
+            bslmt::ThreadUtil::yield();
+        }
+        d_dispatcher_p->processQueue();
+    }
+
+    /// Signal the processor thread to stop and join it.
+    void stop()
+    {
+        d_running.store(false);
+        if (d_handle != bslmt::ThreadUtil::invalidHandle()) {
+            bslmt::ThreadUtil::join(d_handle);
+            d_handle = bslmt::ThreadUtil::invalidHandle();
+        }
+    }
+};
+
+/// Admin command enqueue callback that completes commands asynchronously on a
+/// separate thread pool.
+class AsyncAdminExecutor {
+  private:
+    // DATA
+    bdlmt::ThreadPool* d_pool_p;
+
+  public:
+    // CREATORS
+    explicit AsyncAdminExecutor(bdlmt::ThreadPool* pool)
+    : d_pool_p(pool)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_OPT(d_pool_p);
+    }
+
+    // MANIPULATORS
+
+    /// Post the completion of the specified `cmd` (with the specified
+    /// `onProcessedCb`) to the thread pool.
+    void enqueueCommand(
+        BSLA_MAYBE_UNUSED const bsl::string&            source,
+        const bsl::string&                              cmd,
+        const mqbnet::Session::AdminCommandProcessedCb& onProcessedCb)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_OPT(onProcessedCb);
+
+        d_pool_p->enqueueJob(bdlf::BindUtil::bind(&AsyncAdminExecutor::invoke,
+                                                  onProcessedCb,
+                                                  cmd));
+    }
+
+  private:
+    /// Invoke the specified `onProcessedCb` with the specified `cmd`.
+    static void
+    invoke(const mqbnet::Session::AdminCommandProcessedCb& onProcessedCb,
+           const bsl::string&                              cmd)
+    {
+        onProcessedCb(0, cmd);
+    }
+};
+
 }  // close unnamed namespace
 
 // ============================================================================
@@ -285,6 +402,141 @@ static void test1_watermark()
     BMQTST_ASSERT_EQ(response.choice().adminCommandResponse().text(), command);
 }
 
+static void test2_safeConcurrentTeardown()
+// ------------------------------------------------------------------------
+// SAFE CONCURRENT TEARDOWN
+//
+// Concerns:
+//   - An admin command submitted to an `AdminSession` is executed
+//     asynchronously (on the broker's admin execution pool), and its
+//     completion callback is delivered on a separate thread.  Tearing down
+//     and destroying the session concurrently with such an in-flight
+//     completion must be safe: the session must remain valid until every
+//     callback it has dispatched to the client dispatcher has been processed,
+//     so that no callback ever runs on a destroyed session.
+//
+// Plan:
+//   Faithfully emulate the broker's threading model:
+//     - a `mqbmock::Dispatcher` in `enqueueOnly` mode drained by a dedicated
+//       `QueueProcessor` thread (so dispatched callbacks run on a thread
+//       distinct from the destroying thread, as in the broker);
+//     - an `AsyncAdminExecutor` that completes admin commands on a thread pool
+//       (as `mqba::Application`'s admin execution pool does).
+//   For a number of iterations: create an `AdminSession`, submit an admin
+//   command (whose completion is delivered asynchronously), then tear down and
+//   release the session while the completion may still be in flight.  The
+//   session must be destroyed safely in every iteration.  Running under
+//   ThreadSanitizer or AddressSanitizer additionally verifies the absence of
+//   data races and invalid memory accesses.
+//
+// Testing:
+//   AdminSession::tearDown
+//   AdminSession::onProcessedAdminCommand
+//   AdminSession::finalizeAdminCommand
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("SAFE CONCURRENT TEARDOWN");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    // Number of teardown iterations to exercise.
+    const int k_NUM_ITERATIONS = 1000;
+
+    // Shared blob infrastructure.
+    bdlbb::PooledBlobBufferFactory bufferFactory(256, alloc);
+    BlobSpPool                     blobSpPool(bdlf::BindUtil::bind(&createBlob,
+                                               &bufferFactory,
+                                               bdlf::PlaceHolders::_1,
+                                               bdlf::PlaceHolders::_2),
+                          1024,
+                          alloc);
+
+    bdlmt::EventScheduler scheduler(bsls::SystemClockType::e_MONOTONIC, alloc);
+
+    // Dispatcher driven by a dedicated processor thread.
+    mqbmock::Dispatcher dispatcher(alloc);
+    dispatcher.setEnqueueOnly(true);
+    QueueProcessor processor(&dispatcher);
+    processor.start();
+
+    // Thread pool emulating the asynchronous admin execution pool.
+    bdlmt::ThreadPool pool(bslmt::ThreadAttributes(),
+                           1,  // minThreads
+                           2,  // maxThreads
+                           bsls::TimeInterval(120).totalMilliseconds(),
+                           alloc);
+    int               rc = pool.start();
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    AsyncAdminExecutor                     executor(&pool);
+    mqbnet::Session::AdminCommandEnqueueCb adminCb = bdlf::BindUtil::bind(
+        &AsyncAdminExecutor::enqueueCommand,
+        &executor,
+        bdlf::PlaceHolders::_1,   // source
+        bdlf::PlaceHolders::_2,   // cmd
+        bdlf::PlaceHolders::_3);  // onProcessedCb
+
+    // Build a single admin command event, reused across iterations.  The
+    // builder is kept alive for the whole loop so that `adminEvent`'s
+    // underlying blob remains valid.
+    bmqp_ctrlmsg::ControlMessage admin(alloc);
+    admin.rId() = 1;
+    admin.choice().makeAdminCommand();
+    admin.choice().adminCommand().command() = "sample command";
+
+    bmqp::SchemaEventBuilder builder(&blobSpPool,
+                                     bmqp::EncodingType::e_BER,
+                                     alloc);
+    rc = builder.setMessage(admin, bmqp::EventType::e_CONTROL);
+    BMQTST_ASSERT_EQ(rc, 0);
+
+    bmqp::Event adminEvent(builder.blob().get(), alloc);
+    const bmqp_ctrlmsg::NegotiationMessage negotiationMessage = client();
+    const bsl::string                      description("adminSession", alloc);
+
+    for (int i = 0; i < k_NUM_ITERATIONS; ++i) {
+        bsl::shared_ptr<bmqio::TestChannel> channel;
+        channel.createInplace(alloc, alloc);
+
+        bsl::shared_ptr<mqba::AdminSession> session =
+            bsl::allocate_shared<mqba::AdminSession>(alloc,
+                                                     channel,
+                                                     negotiationMessage,
+                                                     description,
+                                                     &dispatcher,
+                                                     &blobSpPool,
+                                                     &scheduler,
+                                                     adminCb);
+
+        // All dispatched callbacks may run on the processor thread; allow
+        // `inDispatcherThread()` preconditions to pass regardless of thread.
+        session->setThreadId(mqbi::DispatcherClient::k_ANY_THREAD_ID);
+        session->dispatcherClientData().setDispatcher(&dispatcher);
+
+        // Feed an admin command.  This enqueues `enqueueAdminCommand`, which
+        // the processor thread runs, invoking `adminCb`, which posts the
+        // completion to the pool.  The completion will call
+        // `onProcessedAdminCommand`, potentially concurrently with the
+        // teardown below.
+        session->processEvent(adminEvent);
+
+        // Tear the session down and release it while the asynchronous
+        // completion may still be in flight (or a callback it dispatched may
+        // still be pending on the processor).  This must be safe.
+        bsl::shared_ptr<void> handle = session;
+        session->tearDown(handle, false);
+        handle.reset();
+        session.reset();  // destroy the session
+    }
+
+    // Ensure no more completions are posted, then drain everything still in
+    // flight before tearing down the shared infrastructure.
+    pool.drain();
+    pool.stop();
+    processor.stop();
+    scheduler.stop();
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -302,6 +554,7 @@ int main(int argc, char* argv[])
         switch (_testCase) {
         case 0:
         case 1: test1_watermark(); break;
+        case 2: test2_safeConcurrentTeardown(); break;
         default: {
             cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
             bmqtst::TestHelperUtil::testStatus() = -1;


### PR DESCRIPTION
- Add a test driver that verifies if concurrent shutdown of mqba::AdminSession is safe with admin commands reaching the broker.
- Similar to `ClientSession`, keep the last reference to `AdminSession` on teardown.