### PR TITLE
Fix[mqbc::StorageManager]: Send ACTIVE advisory on PrimaryStateRequest

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -445,6 +445,10 @@ class PartitionStateTableActions {
                                  const PartitionFSMEventData&   eventData) = 0;
 
     virtual void
+    do_sendPrimaryStatusAdvisory(PartitionStateTableEvent::Enum eventType,
+                                 const PartitionFSMEventData&   eventData) = 0;
+
+    virtual void
     do_reapplyDetectSelfPrimary(PartitionStateTableEvent::Enum eventType,
                                 const PartitionFSMEventData&   eventData) = 0;
 
@@ -576,7 +580,7 @@ class PartitionStateTableActions {
         const PartitionFSMEventData&   eventData);
 
     void
-    do_storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
+    do_storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas_sendPrimaryStatusAdvisory(
         PartitionStateTableEvent::Enum eventType,
         const PartitionFSMEventData&   eventData);
 
@@ -952,7 +956,7 @@ class PartitionStateTable
         PST_CFG(
             PRIMARY_HEALED,
             PRIMARY_STATE_RQST,
-            storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas,
+            storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas_sendPrimaryStatusAdvisory,
             PRIMARY_HEALED);
         PST_CFG(PRIMARY_HEALED,
                 RST_UNKNOWN,
@@ -1283,16 +1287,11 @@ inline void PartitionStateTableActions::
     do_sendDataToReplicas(eventType, eventData);
 }
 
-inline void PartitionStateTableActions::
-    do_storeSelfSeq_storeReplicaSeq_primaryStateResponse_sendDataToReplicas(
-        PartitionStateTableEvent::Enum eventType,
-        const PartitionFSMEventData&   eventData)
-{
-    do_storeSelfSeq(eventType, eventData);
-    do_storeReplicaSeq(eventType, eventData);
-    do_primaryStateResponse(eventType, eventData);
-    do_sendDataToReplicas(eventType, eventData);
-}
+PST_COMPOSITE_5(storeSelfSeq,
+                storeReplicaSeq,
+                primaryStateResponse,
+                sendDataToReplicas,
+                sendPrimaryStatusAdvisory)
 
 inline void PartitionStateTableActions::do_storeReplicaSeq_sendDataToReplicas(
     PartitionStateTableEvent::Enum eventType,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3703,6 +3703,43 @@ void StorageManager::do_transitionToActivePrimary(
                                         0);  // status
 }
 
+void StorageManager::do_sendPrimaryStatusAdvisory(
+    BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
+    const PartitionFSMEventData&                     eventData)
+{
+    // executed by the *QUEUE DISPATCHER* thread associated with the
+    // partitionId contained in 'eventData'
+
+    const int partitionId = eventData.partitionId();
+    BSLS_ASSERT_SAFE(0 <= partitionId &&
+                     partitionId < static_cast<int>(d_fileStores.size()));
+    BSLS_ASSERT_SAFE(eventData.source());
+
+    const PartitionInfo& pinfo = d_partitionInfoVec[partitionId];
+    BSLS_ASSERT_SAFE(pinfo.primary() ==
+                     d_clusterData_p->membership().selfNode());
+    BSLS_ASSERT_SAFE(pinfo.primaryStatus() ==
+                     bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE);
+
+    bmqp_ctrlmsg::ControlMessage         controlMsg;
+    bmqp_ctrlmsg::PrimaryStatusAdvisory& primaryAdv =
+        controlMsg.choice()
+            .makeClusterMessage()
+            .choice()
+            .makePrimaryStatusAdvisory();
+    primaryAdv.partitionId()    = partitionId;
+    primaryAdv.primaryLeaseId() = pinfo.primaryLeaseId();
+    primaryAdv.status()         = bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE;
+
+    fileStore(partitionId).sendMessage(controlMsg, eventData.source());
+
+    BALL_LOG_INFO << d_clusterData_p->identity().description()
+                  << " Partition [" << partitionId
+                  << "]: sent primary status advisory " << controlMsg
+                  << " to replica node "
+                  << eventData.source()->nodeDescription() << ".";
+}
+
 void StorageManager::do_reapplyDetectSelfPrimary(
     BSLA_MAYBE_UNUSED PartitionStateTableEvent::Enum eventType,
     const PartitionFSMEventData&                     eventData)

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.h
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.h
@@ -800,6 +800,10 @@ class StorageManager BSLS_KEYWORD_FINAL : public mqbi::StorageManager,
                                       const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;
 
+    void do_sendPrimaryStatusAdvisory(PartitionStateTableEvent::Enum eventType,
+                                      const PartitionFSMEventData&   eventData)
+        BSLS_KEYWORD_OVERRIDE;
+
     void do_reapplyDetectSelfPrimary(PartitionStateTableEvent::Enum eventType,
                                      const PartitionFSMEventData&   eventData)
         BSLS_KEYWORD_OVERRIDE;


### PR DESCRIPTION
## Summary
  - In the FSM workflow, a healed (and therefore active) primary now sends an ACTIVE `PrimaryStatusAdvisory` to any replica that sends it a `PrimaryStateRequest`, in addition to the existing state response and data chunks.
  - This closes a latent gap: a replica that joins/heals **after** the primary has already broadcast its ACTIVE advisory would otherwise never learn the primary is active until it later announces its own status and the primary re-issues one. Between healing and that round-trip, the replica can be `REPLICA_HEALED` and processing live data without knowing the primary is active.
  - Groundwork for restoring the `E_ACTIVE` gate in `validateStorageEvent` for FSM (unifying it with the legacy workflow): once a replica is guaranteed to learn ACTIVE during the healing handshake, live data can once again be gated on the primary being perceived active. No user-visible behavior change.