### PR TITLE
Refactor: AlignedPrinter to accept string

### DIFF
--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslprinter.cpp
@@ -339,7 +339,7 @@ void HumanReadableCslPrinter::printSummaryResult(
             d_ostream << '\n'
                       << recordCount.d_updateCount
                       << " update record(s) found, including:" << '\n';
-            bsl::vector<const char*>           fields(d_allocator_p);
+            bsl::vector<bsl::string>           fields(d_allocator_p);
             bmqp_ctrlmsg::ClusterMessageChoice clusterMessageChoice(
                 d_allocator_p);
             for (CslUpdateChoiceMap::const_iterator it =
@@ -349,7 +349,7 @@ void HumanReadableCslPrinter::printSummaryResult(
                 clusterMessageChoice.makeSelection(it->first);
                 fields.push_back(clusterMessageChoice.selectionName());
             }
-            bmqu::AlignedPrinter printer(d_ostream, &fields);
+            bmqu::AlignedPrinter printer(d_ostream, fields);
             for (CslUpdateChoiceMap::const_iterator it =
                      updateChoiceMap.begin();
                  it != updateChoiceMap.end();

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_cslrecordprinter.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_cslrecordprinter.h
@@ -35,6 +35,7 @@
 // BDE
 #include <bdlt_epochutil.h>
 #include <bsl_ostream.h>
+#include <bsl_string.h>
 #include <bsl_unordered_map.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
@@ -93,7 +94,7 @@ template <typename PRINTER_TYPE>
 class CslRecordPrinter {
   private:
     bsl::ostream&                   d_ostream;
-    bsl::vector<const char*>        d_fields;
+    bsl::vector<bsl::string>        d_fields;
     bslma::ManagedPtr<PRINTER_TYPE> d_printer_mp;
     bslma::Allocator*               d_allocator_p;
 
@@ -150,10 +151,10 @@ void CslRecordPrinter<PRINTER_TYPE>::printRecordDetails(
     d_fields.push_back("LeaderAdvisoryWords");
     d_fields.push_back("Timestamp");
     d_fields.push_back("Epoch");
-    // It's ok to pass a vector by pointer and push elements after that as
+    // It's ok to pass a vector by reference and push elements after that as
     // we've reserved it's capacity in advance. Hense, no reallocations will
-    // happen and the pointer won't get invalidated.
-    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, &d_fields),
+    // happen and the reference remains valid.
+    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, d_fields),
                       d_allocator_p);
 
     *d_printer_mp << header.recordType() << recId.offset() << recId.logId()
@@ -197,10 +198,10 @@ void CslRecordPrinter<PRINTER_TYPE>::printRecordsSummary(
     d_fields.push_back("CommitRecords");
     d_fields.push_back("AckRecords");
 
-    // It's ok to pass a vector by pointer and push elements after that as
+    // It's ok to pass a vector by reference and push elements after that as
     // we've reserved it's capacity in advance. Hense, no reallocations will
-    // happen and the pointer won't get invalidated.
-    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, &d_fields),
+    // happen and the reference remains valid.
+    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, d_fields),
                       d_allocator_p);
 
     *d_printer_mp << recordCount.d_snapshotCount << recordCount.d_updateCount;

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_printer.cpp
@@ -93,10 +93,10 @@ void printDataFileMeta(bsl::ostream&                 ostream,
 {
     BSLS_ASSERT_SAFE(dataFile_p && dataFile_p->isValid());
 
-    const bsl::vector<const char*> fields = {"BlazingMQ File Header",
+    const bsl::vector<bsl::string> fields = {"BlazingMQ File Header",
                                              "Data File Header"};
 
-    PRINTER_TYPE1 printer(ostream, &fields);
+    PRINTER_TYPE1 printer(ostream, fields);
     {
         bmqu::MemOutStream s(allocator);
         s << '\n';
@@ -123,11 +123,11 @@ void printJournalFileMeta(bsl::ostream&                    ostream,
 {
     BSLS_ASSERT_SAFE(journalFile_p && journalFile_p->isValid());
 
-    const bsl::vector<const char*> fields = {"BlazingMQ File Header",
+    const bsl::vector<bsl::string> fields = {"BlazingMQ File Header",
                                              "Journal File Header",
                                              "Journal SyncPoint"};
 
-    PRINTER_TYPE1 printer(ostream, &fields);
+    PRINTER_TYPE1 printer(ostream, fields);
     {
         bmqu::MemOutStream s(allocator);
         s << '\n';
@@ -152,7 +152,7 @@ void printJournalFileMeta(bsl::ostream&                    ostream,
         s << '\n';
         {
             // Print journal-specific fields
-            bsl::vector<const char*> fieldsSyncPoint(allocator);
+            bsl::vector<bsl::string> fieldsSyncPoint(allocator);
             fieldsSyncPoint.reserve(12);
             fieldsSyncPoint.push_back("Last Valid Record Offset");
             fieldsSyncPoint.push_back("Record Type");
@@ -167,7 +167,7 @@ void printJournalFileMeta(bsl::ostream&                    ostream,
             fieldsSyncPoint.push_back("SyncPoint DataFileOffset (DWORDS)");
             fieldsSyncPoint.push_back("SyncPoint QlistFileOffset (WORDS)");
 
-            PRINTER_TYPE2       p(s, &fieldsSyncPoint);
+            PRINTER_TYPE2       p(s, fieldsSyncPoint);
             bsls::Types::Uint64 lastRecPos =
                 journalFile_p->lastRecordPosition();
             p << lastRecPos;
@@ -253,7 +253,7 @@ void printQueueDetails(bsl::ostream&          ostream,
         const bsl::size_t       appKeysCount = details.d_appDetailsMap.size();
 
         // Setup fields to be displayed
-        bsl::vector<const char*> fields(allocator);
+        bsl::vector<bsl::string> fields(allocator);
         fields.reserve(8);
         fields.push_back("Queue Key");
         if (!details.d_queueUri.empty()) {
@@ -269,7 +269,7 @@ void printQueueDetails(bsl::ostream&          ostream,
         fields.push_back("Num Delete Records");
 
         {
-            PRINTER_TYPE printer(ostream, &fields);
+            PRINTER_TYPE printer(ostream, fields);
 
             // Print Queue Key id: either Key or URI
             printer << queueKey;
@@ -576,13 +576,13 @@ void HumanReadablePrinter::printQueueOpSummary(
         d_ostream << "\nTotal number of queueOp records: "
                   << queueOpRecordsCount << '\n';
 
-        bsl::vector<const char*> fields(d_allocator_p);
+        bsl::vector<bsl::string> fields(d_allocator_p);
         fields.reserve(4);
         fields.push_back("Number of 'purge' operations");
         fields.push_back("Number of 'creation' operations");
         fields.push_back("Number of 'deletion' operations");
         fields.push_back("Number of 'addition' operations");
-        bmqu::AlignedPrinter printer(d_ostream, &fields);
+        bmqu::AlignedPrinter printer(d_ostream, fields);
         printer << queueOpCountsVec[mqbs::QueueOpType::e_PURGE]
                 << queueOpCountsVec[mqbs::QueueOpType::e_CREATION]
                 << queueOpCountsVec[mqbs::QueueOpType::e_DELETION]
@@ -899,7 +899,7 @@ void JsonPrinter::printQueueOpSummary(
 {
     BSLS_ASSERT_SAFE(queueOpCountsVec.size() > mqbs::QueueOpType::e_ADDITION);
     closeBraceIfOpen();
-    bsl::vector<const char*> fields(d_allocator_p);
+    bsl::vector<bsl::string> fields(d_allocator_p);
     fields.reserve(5);
     fields.push_back("TotalQueueOperationsNumber");
     fields.push_back("PurgeOperationsNumber");
@@ -907,7 +907,7 @@ void JsonPrinter::printQueueOpSummary(
     fields.push_back("DeletionOperationsNumber");
     fields.push_back("AdditionOperationsNumber");
 
-    bmqu::JsonPrinter<true, false, 0, 2> printer(d_ostream, &fields);
+    bmqu::JsonPrinter<true, false, 0, 2> printer(d_ostream, fields);
     printer << queueOpRecordsCount
             << queueOpCountsVec[mqbs::QueueOpType::e_PURGE]
             << queueOpCountsVec[mqbs::QueueOpType::e_CREATION]

--- a/src/applications/bmqstoragetool/m_bmqstoragetool_recordprinter.h
+++ b/src/applications/bmqstoragetool/m_bmqstoragetool_recordprinter.h
@@ -40,6 +40,7 @@
 
 // BDE
 #include <bsl_ostream.h>
+#include <bsl_string.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
@@ -65,7 +66,7 @@ template <typename PRINTER_TYPE>
 class RecordDetailsPrinter {
   private:
     bsl::ostream&                   d_ostream;
-    bsl::vector<const char*>        d_fields;
+    bsl::vector<bsl::string>        d_fields;
     bslma::ManagedPtr<PRINTER_TYPE> d_printer_mp;
     bslma::Allocator*               d_allocator_p;
 
@@ -180,10 +181,10 @@ void RecordDetailsPrinter<PRINTER_TYPE>::printCommonHeader(
     d_fields.push_back("Timestamp");
     d_fields.push_back("Epoch");
 
-    // It's ok to pass a vector by pointer and push elements after that as
+    // It's ok to pass a vector by reference and push elements after that as
     // we've reserved its capacity in advance. Hence, no reallocations will
-    // happen and the pointer won't get invalidated.
-    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, &d_fields),
+    // happen and the reference remains valid.
+    d_printer_mp.load(new (*d_allocator_p) PRINTER_TYPE(d_ostream, d_fields),
                       d_allocator_p);
 
     *d_printer_mp << details.d_record.header().type() << details.d_recordIndex

--- a/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
+++ b/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
@@ -464,7 +464,7 @@ void StorageInspector::processCommand(
 
             // Print journal-specific fields
             BALL_LOG_OUTPUT_STREAM << "Journal SyncPoint:\n";
-            bsl::vector<const char*> fields;
+            bsl::vector<bsl::string> fields;
             fields.push_back("Last Valid Record Offset");
             fields.push_back("Record Type");
             fields.push_back("Record Timestamp");
@@ -478,7 +478,7 @@ void StorageInspector::processCommand(
             fields.push_back("SyncPoint DataFileOffset (DWORDS)");
             fields.push_back("SyncPoint QlistFileOffset (WORDS)");
 
-            bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, &fields);
+            bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, fields);
             bsls::Types::Uint64  lastRecPos =
                 d_journalFileIter.lastRecordPosition();
             printer << lastRecPos;
@@ -577,12 +577,12 @@ void StorageInspector::processCommand(
             BALL_LOG_OUTPUT_STREAM << "Queue #" << qnum << "\n";
             const QueueRecord& qr = cit->second;
 
-            bsl::vector<const char*> fields;
+            bsl::vector<bsl::string> fields;
             fields.push_back("Queue URI");
             fields.push_back("QueueKey");
             fields.push_back("Number of AppIds");
 
-            bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, &fields);
+            bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, fields);
             printer << cit->first << qr.d_queueKey << qr.d_appIds.size();
 
             // 'printer' not to be used beyond this point
@@ -591,12 +591,12 @@ void StorageInspector::processCommand(
             for (unsigned int i = 0; i < appRecs.size(); ++i) {
                 const AppIdRecord& ar = appRecs[i];
                 BALL_LOG_OUTPUT_STREAM << "        AppId #" << i + 1 << "\n";
-                bsl::vector<const char*> f;
+                bsl::vector<bsl::string> f;
                 f.push_back("AppId");
                 f.push_back("AppKey");
 
                 const int            indent = 8;
-                bmqu::AlignedPrinter p(BALL_LOG_OUTPUT_STREAM, &f, indent);
+                bmqu::AlignedPrinter p(BALL_LOG_OUTPUT_STREAM, f, indent);
                 p << ar.d_appId << ar.d_appKey;
             }
 

--- a/src/groups/bmq/bmqu/bmqu_alignedprinter.h
+++ b/src/groups/bmq/bmqu/bmqu_alignedprinter.h
@@ -136,8 +136,8 @@ inline AlignedPrinter& AlignedPrinter::operator<<(const TYPE& value)
     BSLS_ASSERT_SAFE(d_counter < d_fields.size());
 
     d_ostream << bsl::setw(d_indent) << ' ' << d_fields[d_counter]
-              << bsl::setw(static_cast<int>(
-                     d_width - d_fields[d_counter].length()))
+              << bsl::setw(
+                     static_cast<int>(d_width - d_fields[d_counter].length()))
               << ": " << value << '\n';
 
     ++d_counter;

--- a/src/groups/bmq/bmqu/bmqu_alignedprinter.h
+++ b/src/groups/bmq/bmqu/bmqu_alignedprinter.h
@@ -28,7 +28,7 @@
 ///-----
 // First, specify field names for printer:
 //..
-//  bsl::vector<const char*> fields;
+//  bsl::vector<bsl::string> fields;
 //  fields.push_back("Queue URI");
 //  fields.push_back("QueueKey");
 //  fields.push_back("Number of AppIds");
@@ -38,7 +38,7 @@
 //..
 //  bsl::stringstream    output;
 //  const int            indent = 8;
-//  bmqu::AlignedPrinter printer(output, &fields, indent);
+//  bmqu::AlignedPrinter printer(output, fields, indent);
 //..
 //
 // Last, print field values accordingly:
@@ -51,7 +51,6 @@
 //
 
 // BDE
-#include <bsl_cstring.h>
 #include <bsl_iomanip.h>
 #include <bsl_ostream.h>
 #include <bsl_string.h>
@@ -70,7 +69,7 @@ class AlignedPrinter {
   private:
     // DATA
     bsl::ostream&                   d_ostream;
-    const bsl::vector<const char*>* d_fields_p;
+    const bsl::vector<bsl::string>& d_fields;
     int                             d_indent;
     int                             d_width;
     unsigned int                    d_counter;
@@ -88,7 +87,7 @@ class AlignedPrinter {
     /// is undefined unless `indent` >= 0 and at least one field is present
     /// in the `fields`.
     AlignedPrinter(bsl::ostream&                   stream,
-                   const bsl::vector<const char*>* fields,
+                   const bsl::vector<bsl::string>& fields,
                    int                             indent = 4);
 
     // MANIPULATORS
@@ -109,20 +108,20 @@ class AlignedPrinter {
 // --------------
 
 inline AlignedPrinter::AlignedPrinter(bsl::ostream&                   stream,
-                                      const bsl::vector<const char*>* fields,
+                                      const bsl::vector<bsl::string>& fields,
                                       int                             indent)
 : d_ostream(stream)
-, d_fields_p(fields)
+, d_fields(fields)
 , d_indent(indent)
 , d_width(0)
 , d_counter(0)
 {
     BSLS_ASSERT_SAFE(0 <= d_indent);
-    BSLS_ASSERT_SAFE(0 < d_fields_p->size());
+    BSLS_ASSERT_SAFE(0 < d_fields.size());
 
-    int maxLen = static_cast<int>(bsl::strlen((*d_fields_p)[0]));
-    for (unsigned int i = 1; i < d_fields_p->size(); ++i) {
-        int len = static_cast<int>(bsl::strlen((*d_fields_p)[i]));
+    int maxLen = static_cast<int>(d_fields[0].length());
+    for (unsigned int i = 1; i < d_fields.size(); ++i) {
+        int len = static_cast<int>(d_fields[i].length());
         if (maxLen < len) {
             maxLen = len;
         }
@@ -134,11 +133,11 @@ inline AlignedPrinter::AlignedPrinter(bsl::ostream&                   stream,
 template <typename TYPE>
 inline AlignedPrinter& AlignedPrinter::operator<<(const TYPE& value)
 {
-    BSLS_ASSERT_SAFE(d_counter < d_fields_p->size());
+    BSLS_ASSERT_SAFE(d_counter < d_fields.size());
 
-    d_ostream << bsl::setw(d_indent) << ' ' << (*d_fields_p)[d_counter]
+    d_ostream << bsl::setw(d_indent) << ' ' << d_fields[d_counter]
               << bsl::setw(static_cast<int>(
-                     d_width - bsl::strlen((*d_fields_p)[d_counter])))
+                     d_width - d_fields[d_counter].length()))
               << ": " << value << '\n';
 
     ++d_counter;

--- a/src/groups/bmq/bmqu/bmqu_jsonprinter.h
+++ b/src/groups/bmq/bmqu/bmqu_jsonprinter.h
@@ -28,16 +28,16 @@
 ///-----
 // First, specify field names for printer:
 //..
-//  bsl::vector<const char*> fields;
+//  bsl::vector<bsl::string> fields;
 //  fields.push_back("Queue URI");
 //  fields.push_back("QueueKey");
 //  fields.push_back("Number of AppIds");
 //..
 //
-// Next, create an instance of bmqu::AlignedPrinter:
+// Next, create an instance of bmqu::JsonPrinter:
 //..
 //  bsl::stringstream             output;
-//  bmqu::JsonPrinter<true, 0, 4> printer(output, &fields);
+//  bmqu::JsonPrinter<true, 0, 4> printer(output, fields);
 //..
 //
 // Last, print field values accordingly:
@@ -50,7 +50,6 @@
 //
 
 // BDE
-#include <bsl_cstring.h>
 #include <bsl_iomanip.h>
 #include <bsl_iostream.h>
 #include <bsl_ostream.h>
@@ -96,7 +95,7 @@ class JsonPrinter {
   private:
     // DATA
     bsl::ostream&                   d_ostream;
-    const bsl::vector<const char*>* d_fields_p;
+    const bsl::vector<bsl::string>& d_fields;
     unsigned int                    d_counter;
 
     // NOT IMPLEMENTED
@@ -110,7 +109,7 @@ class JsonPrinter {
     /// object with the specified `fields` with the optionally specified
     /// `indent`.  Behavior is undefined unless `indent` >= 0 and at least one
     /// field is present in the `fields`.
-    JsonPrinter(bsl::ostream& stream, const bsl::vector<const char*>* fields);
+    JsonPrinter(bsl::ostream& stream, const bsl::vector<bsl::string>& fields);
 
     ~JsonPrinter();
 
@@ -134,12 +133,12 @@ class JsonPrinter {
 template <bool pretty, bool braceNeeded, int braceIndent, int fieldIndent>
 inline JsonPrinter<pretty, braceNeeded, braceIndent, fieldIndent>::JsonPrinter(
     bsl::ostream&                   stream,
-    const bsl::vector<const char*>* fields)
+    const bsl::vector<bsl::string>& fields)
 : d_ostream(stream)
-, d_fields_p(fields)
+, d_fields(fields)
 , d_counter(0)
 {
-    BSLS_ASSERT_SAFE(0 < d_fields_p->size());
+    BSLS_ASSERT_SAFE(0 < d_fields.size());
     if (braceNeeded) {
         if (braceIndent > 0) {
             d_ostream << bsl::setw(braceIndent) << ' ';
@@ -172,7 +171,7 @@ inline JsonPrinter<pretty, braceNeeded, braceIndent, fieldIndent>&
 JsonPrinter<pretty, braceNeeded, braceIndent, fieldIndent>::operator<<(
     const TYPE& value)
 {
-    BSLS_ASSERT_SAFE(d_counter < d_fields_p->size());
+    BSLS_ASSERT_SAFE(d_counter < d_fields.size());
 
     if (d_counter != 0) {
         d_ostream << ',' << (pretty ? '\n' : ' ');
@@ -183,7 +182,7 @@ JsonPrinter<pretty, braceNeeded, braceIndent, fieldIndent>::operator<<(
     }
 
     const bool quotes = addQuotes(value);
-    d_ostream << '\"' << (*d_fields_p)[d_counter] << "\": ";
+    d_ostream << '\"' << d_fields[d_counter] << "\": ";
     if (quotes) {
         d_ostream << '\"';
     }

--- a/src/groups/bmq/bmqu/bmqu_jsonprinter.h
+++ b/src/groups/bmq/bmqu/bmqu_jsonprinter.h
@@ -50,6 +50,7 @@
 //
 
 // BDE
+#include <bsl_cstddef.h>
 #include <bsl_iomanip.h>
 #include <bsl_iostream.h>
 #include <bsl_ostream.h>

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.cpp
@@ -106,12 +106,12 @@ bsl::ostream& operator<<(bsl::ostream&               stream,
 bsl::ostream& operator<<(bsl::ostream&                stream,
                          const mqbs::QlistFileHeader& header)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.push_back("HeaderWords");
 
     stream << "Qlist File Header: \n";
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << static_cast<int>(header.headerWords());
     stream << '\n';
 
@@ -254,7 +254,7 @@ namespace FileStoreProtocolPrinter {
 
 void printRecord(bsl::ostream& stream, const mqbs::MessageRecord& rec)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.reserve(10);
     fields.push_back("PrimaryLeaseId");
     fields.push_back("SequenceNumber");
@@ -267,7 +267,7 @@ void printRecord(bsl::ostream& stream, const mqbs::MessageRecord& rec)
     fields.push_back("GUID");
     fields.push_back("Crc32c");
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << rec.header().primaryLeaseId() << rec.header().sequenceNumber();
 
     bsls::Types::Uint64 epochValue = rec.header().timestamp();
@@ -293,7 +293,7 @@ void printRecord(bsl::ostream& stream, const mqbs::MessageRecord& rec)
 
 void printRecord(bsl::ostream& stream, const mqbs::ConfirmRecord& rec)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.reserve(7);
     fields.push_back("PrimaryLeaseId");
     fields.push_back("SequenceNumber");
@@ -313,7 +313,7 @@ void printRecord(bsl::ostream& stream, const mqbs::ConfirmRecord& rec)
         appKeyStr << rec.appKey();
     }
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << rec.header().primaryLeaseId() << rec.header().sequenceNumber();
 
     bsls::Types::Uint64 epochValue = rec.header().timestamp();
@@ -332,7 +332,7 @@ void printRecord(bsl::ostream& stream, const mqbs::ConfirmRecord& rec)
 
 void printRecord(bsl::ostream& stream, const mqbs::DeletionRecord& rec)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.push_back("PrimaryLeaseId");
     fields.push_back("SequenceNumber");
     fields.push_back("Timestamp");
@@ -344,7 +344,7 @@ void printRecord(bsl::ostream& stream, const mqbs::DeletionRecord& rec)
     bmqu::MemOutStream queueKeyStr;
     queueKeyStr << rec.queueKey();
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << rec.header().primaryLeaseId() << rec.header().sequenceNumber();
 
     bsls::Types::Uint64 epochValue = rec.header().timestamp();
@@ -363,7 +363,7 @@ void printRecord(bsl::ostream& stream, const mqbs::DeletionRecord& rec)
 
 void printRecord(bsl::ostream& stream, const mqbs::QueueOpRecord& rec)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.reserve(8);
     fields.push_back("PrimaryLeaseId");
     fields.push_back("SequenceNumber");
@@ -389,7 +389,7 @@ void printRecord(bsl::ostream& stream, const mqbs::QueueOpRecord& rec)
         appKeyStr << rec.appKey();
     }
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << rec.header().primaryLeaseId() << rec.header().sequenceNumber();
 
     bsls::Types::Uint64 epochValue = rec.header().timestamp();
@@ -415,7 +415,7 @@ void printRecord(bsl::ostream& stream, const mqbs::QueueOpRecord& rec)
 
 void printRecord(bsl::ostream& stream, const mqbs::JournalOpRecord& rec)
 {
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.reserve(10);
     fields.push_back("PrimaryLeaseId");
     fields.push_back("SequenceNumber");
@@ -428,7 +428,7 @@ void printRecord(bsl::ostream& stream, const mqbs::JournalOpRecord& rec)
     fields.push_back("PrimaryNodeId");
     fields.push_back("DataFileOffsetDwords");
 
-    bmqu::AlignedPrinter printer(stream, &fields);
+    bmqu::AlignedPrinter printer(stream, fields);
     printer << rec.header().primaryLeaseId() << rec.header().sequenceNumber();
 
     bsls::Types::Uint64 epochValue = rec.header().timestamp();
@@ -608,7 +608,7 @@ void printIterator(mqbs::QlistFileIterator& it)
     it.loadAppIds(&appIdLenPairs);
     it.loadAppIdHashes(&appIdHashes);
 
-    bsl::vector<const char*> fields;
+    bsl::vector<bsl::string> fields;
     fields.reserve(3);
     fields.push_back("Queue URI");
     fields.push_back("QueueKey");
@@ -621,20 +621,20 @@ void printIterator(mqbs::QlistFileIterator& it)
                                << ", offset: " << it.recordOffset() << '\n'
                                << "QueueUriRecord:" << '\n';
 
-        bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, &fields);
+        bmqu::AlignedPrinter printer(BALL_LOG_OUTPUT_STREAM, fields);
         printer << bsl::string(uri, uriLen)
                 << mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
                                     queueKey)
                 << numAppIds;
 
         if (0 != numAppIds) {
-            bsl::vector<const char*> appIdsInfo;
+            bsl::vector<bsl::string> appIdsInfo;
             for (size_t n = 0; n < numAppIds; ++n) {
                 appIdsInfo.push_back("AppId");
                 appIdsInfo.push_back("AppKey");
             }
 
-            bmqu::AlignedPrinter p(BALL_LOG_OUTPUT_STREAM, &appIdsInfo);
+            bmqu::AlignedPrinter p(BALL_LOG_OUTPUT_STREAM, appIdsInfo);
             for (size_t n = 0; n < numAppIds; ++n) {
                 p << bsl::string(appIdLenPairs[n].first,
                                  appIdLenPairs[n].second)

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolprinter.h
@@ -99,7 +99,7 @@ void printFileHeader(bsl::ostream&                     stream,
                      const mqbs::MappedFileDescriptor& mfd,
                      bslma::Allocator*                 allocator = 0)
 {
-    bsl::vector<const char*> fields(allocator);
+    bsl::vector<bsl::string> fields(allocator);
     fields.reserve(5);
     fields.push_back("Protocol Version");
     fields.push_back("Bitness");
@@ -109,7 +109,7 @@ void printFileHeader(bsl::ostream&                     stream,
 
     const mqbs::FileHeader& fh = mqbs::FileStoreProtocolUtil::bmqHeader(mfd);
 
-    PRINTER_TYPE printer(stream, &fields);
+    PRINTER_TYPE printer(stream, fields);
     printer << static_cast<unsigned int>(fh.protocolVersion()) << fh.bitness()
             << fh.fileType() << static_cast<unsigned int>(fh.headerWords())
             << fh.partitionId();
@@ -123,7 +123,7 @@ void printJournalFileHeader(bsl::ostream&                     stream,
                             const mqbs::MappedFileDescriptor& journalFd,
                             bslma::Allocator*                 allocator = 0)
 {
-    bsl::vector<const char*> fields(allocator);
+    bsl::vector<bsl::string> fields(allocator);
     fields.reserve(10);
     fields.push_back("HeaderWords");
     fields.push_back("RecordWords");
@@ -139,7 +139,7 @@ void printJournalFileHeader(bsl::ostream&                     stream,
     bsls::Types::Uint64 offsetW =
         header.firstSyncPointAfterRollloverOffsetWords();
 
-    PRINTER_TYPE printer(stream, &fields);
+    PRINTER_TYPE printer(stream, fields);
     printer << static_cast<unsigned int>(header.headerWords())
             << static_cast<unsigned int>(header.recordWords()) << offsetW;
 
@@ -183,7 +183,7 @@ void printDataFileHeader(bsl::ostream&               stream,
                          const mqbs::DataFileHeader& header,
                          bslma::Allocator*           allocator = 0)
 {
-    bsl::vector<const char*> fields(allocator);
+    bsl::vector<bsl::string> fields(allocator);
     fields.reserve(2);
     fields.push_back("HeaderWords");
     fields.push_back("FileId (FileKey)");
@@ -191,7 +191,7 @@ void printDataFileHeader(bsl::ostream&               stream,
     bmqu::MemOutStream os;
     os << header.fileKey();
 
-    PRINTER_TYPE printer(stream, &fields);
+    PRINTER_TYPE printer(stream, fields);
     printer << static_cast<unsigned int>(header.headerWords()) << os.str();
 }
 


### PR DESCRIPTION
*Issue number of the reported bug or feature request: #564*

**Describe your changes**
Refactor bmqu::AlignedPrinter and bmqu::JsonPrinter so field names use bsl::string passed by const reference, instead of const char*. Update all call sites that used the old API.

**Testing performed**
Compiled the affected translation units locally in WSL (bmqu_alignedprinter, bmqu_jsonprinter, mqbs_filestoreprotocolprinter, bmqstoragetool printer/cslprinter, and bmqtool storageinspector). Compilation succeeded.

**Additional context**
Add any other context about your contribution here.
