### PR TITLE
Fix[mqbc::StorageUtil]: Require active primary for FSM storage events

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1652,8 +1652,7 @@ void StorageManager::processStorageEvent(const mqbevt::StorageEvent& event)
             pinfo.primaryNode(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm,
-            false)) {  // isFSMWorkflow
+            skipAlarm)) {
         return;        // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2886,8 +2886,7 @@ void StorageManager::do_bufferLiveData(
             pinfo.primary(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm,
-            true)) {  // isFSMWorkflow
+            skipAlarm)) {
         return;       // RETURN
     }
 
@@ -3043,8 +3042,7 @@ void StorageManager::do_processLiveData(
             pinfo.primary(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm,
-            true)) {  // isFSMWorkflow
+            skipAlarm)) {
         return;       // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1196,8 +1196,7 @@ bool StorageUtil::validateStorageEvent(
     const mqbnet::ClusterNode*           primary,
     bmqp_ctrlmsg::PrimaryStatus::Value   status,
     const bsl::string&                   clusterDescription,
-    bool                                 skipAlarm,
-    bool                                 isFSMWorkflow)
+    bool                                 skipAlarm)
 {
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId' or
     // by the *CLUSTER DISPATCHER* thread
@@ -1238,7 +1237,7 @@ bool StorageUtil::validateStorageEvent(
     }
 
     // Ensure that primary is perceived as active.
-    if (!isFSMWorkflow && bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE != status) {
+    if (bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE != status) {
         if (skipAlarm) {
             return false;  // RETURN
         }

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -497,9 +497,8 @@ struct StorageUtil {
     /// 'source' is the specified 'primary' with the specified 'status'
     /// which needs to be ACTIVE.  Use the specified 'clusterData' to help
     /// with validation.  The specified 'skipAlarm' flag determines whether
-    /// to skip alarming if 'source' is not active primary.  Use the
-    /// specified 'isFSMWorkflow' flag to help with validation.  Return true
-    /// if valid, false otherwise.
+    /// to skip alarming if 'source' is not active primary.  Return true if
+    /// valid, false otherwise.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread for the specified
     ///         `partitionId` or by the cluster dispatcher thread.
@@ -509,8 +508,7 @@ struct StorageUtil {
                                      const mqbnet::ClusterNode* primary,
                                      bmqp_ctrlmsg::PrimaryStatus::Value status,
                                      const bsl::string& clusterDescription,
-                                     bool               skipAlarm,
-                                     bool               isFSMWorkflow);
+                                     bool               skipAlarm);
 
     /// Validate that every partition sync message in the specified `event`
     /// have the same specified `partitionId`, and that ether self or the


### PR DESCRIPTION
## Summary
  - In the FSM workflow, a replica now only accepts steady-state (non partition-sync) storage events when it perceives the primary as `E_ACTIVE` — the same rule the legacy workflow already enforced. Previously FSM bypassed this check, so a replica could apply live records from a primary it hadn't yet confirmed active.
  - Unifies the two workflows: the `isFSMWorkflow` bypass in `StorageUtil::validateStorageEvent` is removed, and since the parameter no longer has any effect it is dropped entirely.
  - Safe because of the already-merged late-join advisory (a healed primary sends an ACTIVE `PrimaryStatusAdvisory` in response to a replica's `PrimaryStateRequest`): a replica reliably learns the primary is active during the healing handshake, before it starts processing live data.