### PR TITLE
Feat: Add authorization checks to session creation

### DIFF
--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -301,8 +301,8 @@ AdminSession::AdminSession(
               d_clientIdentity_p->features()),
           allocator)
 , d_scheduler_p(scheduler)
-, d_adminCb(adminCb)
 , d_authorizer_sp(authorizer)
+, d_adminCb(adminCb)
 {
     // Register this client to the dispatcher
     mqbi::Dispatcher::ProcessorHandle processor = dispatcher->registerClient(

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -304,6 +304,14 @@ AdminSession::AdminSession(
 , d_authorizer_sp(authorizer)
 , d_adminCb(adminCb)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(channel);
+    BSLS_ASSERT(dispatcher);
+    BSLS_ASSERT(blobSpPool);
+    BSLS_ASSERT(scheduler);
+    BSLS_ASSERT(adminCb);
+    BSLS_ASSERT(authorizer);
+
     // Register this client to the dispatcher
     mqbi::Dispatcher::ProcessorHandle processor = dispatcher->registerClient(
         this,

--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -288,6 +288,7 @@ AdminSession::AdminSession(
     AdminSessionState::BlobSpPool*                blobSpPool,
     bdlmt::EventScheduler*                        scheduler,
     const mqbnet::Session::AdminCommandEnqueueCb& adminCb,
+    const bsl::shared_ptr<mqbi::Authorizer>&      authorizer,
     bslma::Allocator*                             allocator)
 : d_self(this)  // use default allocator
 , d_running(true)
@@ -301,6 +302,7 @@ AdminSession::AdminSession(
           allocator)
 , d_scheduler_p(scheduler)
 , d_adminCb(adminCb)
+, d_authorizer_sp(authorizer)
 {
     // Register this client to the dispatcher
     mqbi::Dispatcher::ProcessorHandle processor = dispatcher->registerClient(

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -158,11 +158,11 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     /// Pointer to the event scheduler to use (held, not owned).
     bdlmt::EventScheduler* d_scheduler_p;
 
-    /// The callback to invoke on received admin command.
-    mqbnet::Session::AdminCommandEnqueueCb d_adminCb;
-
     /// The authorizer to use for this session
     bsl::shared_ptr<mqbi::Authorizer> d_authorizer_sp;
+
+    /// The callback to invoke on received admin command.
+    mqbnet::Session::AdminCommandEnqueueCb d_adminCb;
 
   private:
     // NOT IMPLEMENTED

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -61,6 +61,9 @@ class Semaphore;
 namespace bmqp {
 class Event;
 }
+namespace mqbi {
+class Authorizer;
+}
 
 namespace mqba {
 
@@ -158,6 +161,9 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     /// The callback to invoke on received admin command.
     mqbnet::Session::AdminCommandEnqueueCb d_adminCb;
 
+    /// The authorizer to use for this session
+    bsl::shared_ptr<mqbi::Authorizer> d_authorizer_sp;
+
   private:
     // NOT IMPLEMENTED
 
@@ -224,6 +230,7 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
                  AdminSessionState::BlobSpPool*          blobSpPool,
                  bdlmt::EventScheduler*                  scheduler,
                  const mqbnet::Session::AdminCommandEnqueueCb& adminEnqueueCb,
+                 const bsl::shared_ptr<mqbi::Authorizer>&      authorizer,
                  bslma::Allocator*                             allocator);
 
     /// Destructor

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -154,11 +154,11 @@ class TestBench {
     // DATA
     bdlbb::PooledBlobBufferFactory      d_bufferFactory;
     BlobSpPool                          d_blobSpPool;
-    bsl::shared_ptr<bmqio::TestChannel> d_channel;
+    bsl::shared_ptr<bmqio::TestChannel> d_channel_sp;
     mqbmock::Dispatcher                 d_mockDispatcher;
     bdlmt::EventScheduler               d_scheduler;
     TestClock                           d_testClock;
-    bsl::shared_ptr<TestAuthorizer>     d_authorizer;
+    bsl::shared_ptr<TestAuthorizer>     d_authorizer_sp;
     mqba::AdminSession                  d_as;
     bslma::Allocator*                   d_allocator_p;
 
@@ -176,19 +176,19 @@ class TestBench {
                                         bdlf::PlaceHolders::_2),  // alloc
                    1024,  // blob pool growth strategy
                    allocator)
-    , d_channel(new bmqio::TestChannel(allocator))
+    , d_channel_sp(new bmqio::TestChannel(allocator))
     , d_mockDispatcher(allocator)
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
     , d_testClock(d_scheduler)
-    , d_authorizer(bsl::allocate_shared<TestAuthorizer>(allocator))
-    , d_as(d_channel,
+    , d_authorizer_sp(bsl::allocate_shared<TestAuthorizer>(allocator))
+    , d_as(d_channel_sp,
            negotiationMessage,
            "sessionDescription",
            &d_mockDispatcher,
            &d_blobSpPool,
            &d_scheduler,
            adminEnqueueCb,
-           d_authorizer,
+           d_authorizer_sp,
            allocator)
     , d_allocator_p(allocator)
     {
@@ -392,20 +392,20 @@ static void test1_watermark()
     // Set high watermark status for the test channel
     bmqio::Status status;
     status.setCategory(bmqio::StatusCategory::e_LIMIT);
-    tb.d_channel->setWriteStatus(status);
+    tb.d_channel_sp->setWriteStatus(status);
 
     // Send the sample admin event multiple times to the admin session
     for (size_t i = 0; i < numMessages; i++) {
         tb.d_as.processEvent(adminEvent);
-        BSLS_ASSERT(tb.d_channel->waitFor(i + 1));
+        BSLS_ASSERT(tb.d_channel_sp->waitFor(i + 1));
     }
 
     // Check that we have the needed number of write calls after all admin
     // commands were sent.
-    BMQTST_ASSERT(tb.d_channel->waitFor(numMessages));
+    BMQTST_ASSERT(tb.d_channel_sp->waitFor(numMessages));
 
     bmqio::TestChannel::WriteCall writeCall;
-    BMQTST_ASSERT(tb.d_channel->getWriteCall(&writeCall, 0));
+    BMQTST_ASSERT(tb.d_channel_sp->getWriteCall(&writeCall, 0));
 
     // Sanity check for the first admin response
     bmqp::Event adminResponseEvent(&writeCall.d_blob,

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -13,11 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <bsla_maybeunused.h>
 #include <mqba_adminsession.h>
 
 // MQB
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
+#include <mqbi_authorizer.h>
 #include <mqbi_dispatcher.h>
 #include <mqbmock_dispatcher.h>
 #include <mqbu_messageguidutil.h>
@@ -132,6 +134,20 @@ struct TestAdminRetranslator {
     }
 };
 
+/// Authorizer for testing that allows all
+class TestAuthorizer : public mqbi::Authorizer {
+  public:
+    TestAuthorizer() {}
+
+    bool
+    authorize(BSLA_UNUSED const mqbact::Action& action,
+              BSLA_UNUSED const mqbplug::AuthenticationResult& authnResult)
+        BSLS_KEYWORD_OVERRIDE
+    {
+        return true;
+    }
+};
+
 /// The `TestBench` holds system components together.
 class TestBench {
   public:
@@ -142,6 +158,7 @@ class TestBench {
     mqbmock::Dispatcher                 d_mockDispatcher;
     bdlmt::EventScheduler               d_scheduler;
     TestClock                           d_testClock;
+    bsl::shared_ptr<TestAuthorizer>     d_authorizer;
     mqba::AdminSession                  d_as;
     bslma::Allocator*                   d_allocator_p;
 
@@ -163,6 +180,7 @@ class TestBench {
     , d_mockDispatcher(allocator)
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
     , d_testClock(d_scheduler)
+    , d_authorizer(bsl::allocate_shared<TestAuthorizer>(allocator))
     , d_as(d_channel,
            negotiationMessage,
            "sessionDescription",
@@ -170,6 +188,7 @@ class TestBench {
            &d_blobSpPool,
            &d_scheduler,
            adminEnqueueCb,
+           d_authorizer,
            allocator)
     , d_allocator_p(allocator)
     {
@@ -493,6 +512,8 @@ static void test2_safeConcurrentTeardown()
     bmqp::Event adminEvent(builder.blob().get(), alloc);
     const bmqp_ctrlmsg::NegotiationMessage negotiationMessage = client();
     const bsl::string                      description("adminSession", alloc);
+    bsl::shared_ptr<TestAuthorizer>        authorizer =
+        bsl::allocate_shared<TestAuthorizer>(alloc);
 
     for (int i = 0; i < k_NUM_ITERATIONS; ++i) {
         bsl::shared_ptr<bmqio::TestChannel> channel;
@@ -506,7 +527,8 @@ static void test2_safeConcurrentTeardown()
                                                      &dispatcher,
                                                      &blobSpPool,
                                                      &scheduler,
-                                                     adminCb);
+                                                     adminCb,
+                                                     authorizer);
 
         // All dispatched callbacks may run on the processor thread; allow
         // `inDispatcherThread()` preconditions to pass regardless of thread.

--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -350,10 +350,10 @@ int Application::start(bsl::ostream& errorDescription)
                                            d_allocators.get("Authenticator")),
         d_allocator_p);
 
-    bslma::ManagedPtr<mqbi::Authorizer> authorizer_mp(
-        bslma::ManagedPtrUtil::allocateManaged<mqba::Authorizer>(
+    bsl::shared_ptr<mqbi::Authorizer> authorizer_sp =
+        bsl::allocate_shared<mqba::Authorizer>(
             d_allocators.get("Authorizer"),
-            d_authorizationController_mp.get()));
+            d_authorizationController_mp.get());
 
     SessionNegotiator* sessionNegotiator = new (*d_allocator_p)
         SessionNegotiator(&d_bufferFactory,
@@ -371,7 +371,7 @@ int Application::start(bsl::ostream& errorDescription)
                                  bdlf::PlaceHolders::_2,   // cmd
                                  bdlf::PlaceHolders::_3,   // onProcessedCb
                                  bdlf::PlaceHolders::_4))  // fromReroute
-        .setAuthorizer(bslmf::MovableRefUtil::move(authorizer_mp));
+        .setAuthorizer(authorizer_sp);
 
     bslma::ManagedPtr<mqbnet::Negotiator> negotiatorMp(sessionNegotiator,
                                                        d_allocator_p);

--- a/src/groups/mqb/mqba/mqba_authenticator.cpp
+++ b/src/groups/mqb/mqba/mqba_authenticator.cpp
@@ -305,6 +305,10 @@ void Authenticator::authenticate(
         else {
             event.value() = InitialConnectionEvent::e_AUTHN_SUCCESS;
         }
+
+        // Set authentication result
+        context_sp->setAuthenticationResult(result);
+
         return;  // RETURN
     }
 

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -2460,6 +2460,16 @@ ClientSession::ClientSession(
 , d_shutdownChain(allocator)
 , d_authorizer_sp(authorizer)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(channel);
+    BSLS_ASSERT(dispatcher);
+    BSLS_ASSERT(domainFactory);
+    BSLS_ASSERT(clientStatContext);
+    BSLS_ASSERT(blobSpPool);
+    BSLS_ASSERT(bufferFactory);
+    BSLS_ASSERT(scheduler);
+    BSLS_ASSERT(authorizer);
+
     // Register this client to the dispatcher
     mqbi::Dispatcher::ProcessorHandle processor = dispatcher->registerClient(
         this,

--- a/src/groups/mqb/mqba/mqba_clientsession.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.cpp
@@ -147,6 +147,7 @@
 //     the 'd_operationState' is set to 'e_DISCONNECTED'.
 
 // MQB
+#include <mqbact_actions.h>
 #include <mqbblp_clustercatalog.h>
 #include <mqbblp_queueengineutil.h>
 #include <mqbcfg_brokerconfig.h>
@@ -156,6 +157,7 @@
 #include <mqbevt_pushevent.h>
 #include <mqbevt_putevent.h>
 #include <mqbevt_rejectevent.h>
+#include <mqbi_authorizer.h>
 #include <mqbi_cluster.h>
 #include <mqbi_queue.h>
 #include <mqbnet_tcpsessionfactory.h>
@@ -2417,17 +2419,18 @@ bool ClientSession::validatePutMessage(QueueState**   queueState,
 
 // CREATORS
 ClientSession::ClientSession(
-    const bsl::shared_ptr<bmqio::Channel>&     channel,
-    const bmqp_ctrlmsg::NegotiationMessage&    negotiationMessage,
-    const bsl::string&                         sessionDescription,
-    mqbi::Dispatcher*                          dispatcher,
-    mqbblp::ClusterCatalog*                    clusterCatalog,
-    mqbi::DomainFactory*                       domainFactory,
-    const bsl::shared_ptr<bmqst::StatContext>& clientStatContext,
-    ClientSessionState::BlobSpPool*            blobSpPool,
-    bdlbb::BlobBufferFactory*                  bufferFactory,
-    bdlmt::EventScheduler*                     scheduler,
-    bslma::Allocator*                          allocator)
+    const bsl::shared_ptr<bmqio::Channel>&         channel,
+    const bmqp_ctrlmsg::NegotiationMessage&        negotiationMessage,
+    const bsl::string&                             sessionDescription,
+    mqbi::Dispatcher*                              dispatcher,
+    mqbblp::ClusterCatalog*                        clusterCatalog,
+    mqbi::DomainFactory*                           domainFactory,
+    const bsl::shared_ptr<bmqst::StatContext>&     clientStatContext,
+    ClientSessionState::BlobSpPool*                blobSpPool,
+    bdlbb::BlobBufferFactory*                      bufferFactory,
+    bdlmt::EventScheduler*                         scheduler,
+    const bsl::shared_ptr<const mqbi::Authorizer>& authorizer,
+    bslma::Allocator*                              allocator)
 : d_self(this)  // use default allocator
 , d_operationState(e_RUNNING)
 , d_isDisconnecting(false)
@@ -2455,6 +2458,7 @@ ClientSession::ClientSession(
 , d_scheduler_p(scheduler)
 , d_periodicUnconfirmedCheckHandler()
 , d_shutdownChain(allocator)
+, d_authorizer_sp(authorizer)
 {
     // Register this client to the dispatcher
     mqbi::Dispatcher::ProcessorHandle processor = dispatcher->registerClient(

--- a/src/groups/mqb/mqba/mqba_clientsession.h
+++ b/src/groups/mqb/mqba/mqba_clientsession.h
@@ -85,6 +85,7 @@ class MessageGUID;
 }
 namespace mqbi {
 class QueueHandle;
+class Authorizer;
 }
 namespace mqbblp {
 class ClusterCatalog;
@@ -360,6 +361,9 @@ class ClientSession : public mqbnet::Session,
     /// execution of the queue handle deconfigure callbacks.
     bmqu::OperationChain d_shutdownChain;
 
+    /// Owned handle to the application's authorizer.
+    bsl::shared_ptr<const mqbi::Authorizer> d_authorizer_sp;
+
   private:
     // NOT IMPLEMENTED
 
@@ -593,7 +597,8 @@ class ClientSession : public mqbnet::Session,
                   ClientSessionState::BlobSpPool*            blobSpPool,
                   bdlbb::BlobBufferFactory*                  bufferFactory,
                   bdlmt::EventScheduler*                     scheduler,
-                  bslma::Allocator*                          allocator);
+                  const bsl::shared_ptr<const mqbi::Authorizer>& authorizer,
+                  bslma::Allocator*                              allocator);
 
     /// Destructor
     ~ClientSession() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -664,7 +664,7 @@ class TestBench {
     // DATA
     bdlbb::PooledBlobBufferFactory            d_bufferFactory;
     BlobSpPool                                d_blobSpPool;
-    bsl::shared_ptr<bmqio::TestChannel>       d_channel;
+    bsl::shared_ptr<bmqio::TestChannel>       d_channel_sp;
     mqbmock::Cluster                          d_cluster;
     mqbmock::Dispatcher                       d_mockDispatcher;
     MyMockDomain                              d_domain;
@@ -672,7 +672,7 @@ class TestBench {
     const bsl::shared_ptr<bmqst::StatContext> d_clientStatContext_sp;
     bdlmt::EventScheduler                     d_scheduler;
     TestClock                                 d_testClock;
-    bsl::shared_ptr<TestAuthorizer>           d_authorizer;
+    bsl::shared_ptr<TestAuthorizer>           d_authorizer_sp;
     mqba::ClientSession                       d_cs;
     bslma::Allocator*                         d_allocator_p;
 
@@ -692,7 +692,7 @@ class TestBench {
                                         bdlf::PlaceHolders::_2),  // alloc
                    1024,  // blob pool growth strategy
                    allocator)
-    , d_channel(new bmqio::TestChannel(allocator))
+    , d_channel_sp(new bmqio::TestChannel(allocator))
     , d_cluster(allocator)
     , d_mockDispatcher(allocator)
     , d_domain(&d_mockDispatcher, &d_cluster, atMostOnce, allocator)
@@ -701,8 +701,8 @@ class TestBench {
           mqbstat::QueueStatsUtil::initializeStatContextClients(10, allocator))
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
     , d_testClock(d_scheduler)
-    , d_authorizer(bsl::allocate_shared<TestAuthorizer>(allocator))
-    , d_cs(d_channel,
+    , d_authorizer_sp(bsl::allocate_shared<TestAuthorizer>(allocator))
+    , d_cs(d_channel_sp,
            negotiationMessage,
            "sessionDescription",
            &d_mockDispatcher,
@@ -712,7 +712,7 @@ class TestBench {
            &d_blobSpPool,
            &d_bufferFactory,
            &d_scheduler,
-           d_authorizer,
+           d_authorizer_sp,
            allocator)
     , d_allocator_p(allocator)
     {
@@ -953,7 +953,7 @@ class TestBench {
     void assertOpenQueueResponse()
     {
         bmqio::TestChannel::WriteCall openQueueCall;
-        BMQTST_ASSERT(d_channel->getWriteCall(&openQueueCall, 0));
+        BMQTST_ASSERT(d_channel_sp->getWriteCall(&openQueueCall, 0));
 
         bmqp::Event openQueueEvent(&openQueueCall.d_blob,
                                    bmqtst::TestHelperUtil::allocator());
@@ -975,8 +975,8 @@ class TestBench {
         if (ackResult == e_AckResultNone) {
             // If no ack expected we shouldn't have more events than
             // 'eventIndex'.
-            BMQTST_ASSERT(d_channel->waitFor(eventIndex));
-            BMQTST_ASSERT_EQ(d_channel->numWriteCalls(), eventIndex);
+            BMQTST_ASSERT(d_channel_sp->waitFor(eventIndex));
+            BMQTST_ASSERT_EQ(d_channel_sp->numWriteCalls(), eventIndex);
 
             return;  // RETURN
         }
@@ -990,7 +990,7 @@ class TestBench {
         // If we expect acks, then the event with corresponding number
         // should exist and be of type Ack.
         bmqio::TestChannel::WriteCall ackCall;
-        BMQTST_ASSERT(d_channel->getWriteCall(&ackCall, eventIndex));
+        BMQTST_ASSERT(d_channel_sp->getWriteCall(&ackCall, eventIndex));
 
         bmqp::Event ackEvent(&ackCall.d_blob,
                              bmqtst::TestHelperUtil::allocator());
@@ -1016,7 +1016,7 @@ class TestBench {
         BMQTST_ASSERT(!iter.isValid());
 
         if (isFinal) {
-            BMQTST_ASSERT_EQ(d_channel->numWriteCalls(), eventIndex + 1);
+            BMQTST_ASSERT_EQ(d_channel_sp->numWriteCalls(), eventIndex + 1);
         }
     }
 
@@ -1037,7 +1037,7 @@ class TestBench {
         d_cs.flush();
 
         bmqio::TestChannel::WriteCall writeCall;
-        BMQTST_ASSERT(d_channel->getWriteCall(&writeCall, pushIndex));
+        BMQTST_ASSERT(d_channel_sp->getWriteCall(&writeCall, pushIndex));
 
         bmqp::Event pushEvent(&writeCall.d_blob,
                               bmqtst::TestHelperUtil::allocator());
@@ -1802,7 +1802,7 @@ static void test7_oldStylePut()
     BMQTST_ASSERT(
         tb.validateData(*postMessages[0].d_appData, msgPropsAreaSize));
 
-    const size_t pushIndex = tb.d_channel->numWriteCalls();
+    const size_t pushIndex = tb.d_channel_sp->numWriteCalls();
 
     // Turn around and send PUSH
     tb.sendPush(queueId,
@@ -1887,7 +1887,7 @@ static void test8_oldStyleCompressedPut()
     BMQTST_ASSERT(
         tb.validateData(*postMessages[0].d_appData, msgPropsAreaSize));
 
-    const size_t pushIndex = tb.d_channel->numWriteCalls();
+    const size_t pushIndex = tb.d_channel_sp->numWriteCalls();
 
     // Turn around and send PUSH
     tb.sendPush(queueId,
@@ -2002,7 +2002,7 @@ static void test9_newStylePush()
     BMQTST_ASSERT(
         tb.validateData(*postMessages[0].d_appData, msgPropsAreaSize, 99));
 
-    const size_t pushIndex = tb.d_channel->numWriteCalls();
+    const size_t pushIndex = tb.d_channel_sp->numWriteCalls();
 
     // Turn around and send PUSH
     tb.sendPush(queueId,
@@ -2112,7 +2112,7 @@ static void test10_newStyleCompressedPush()
 
     // No payload validation, it is compressed.
 
-    const size_t pushIndex = tb.d_channel->numWriteCalls();
+    const size_t pushIndex = tb.d_channel_sp->numWriteCalls();
 
     // Turn around and send PUSH
     tb.sendPush(queueId,

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mqbi_authorizer.h"
 #include <mqba_clientsession.h>
 
 // MQB
@@ -643,13 +644,27 @@ T assertFail()
     return T();
 }
 
+/// Authorizer for testing that allows all
+class TestAuthorizer : public mqbi::Authorizer {
+  public:
+    TestAuthorizer() {}
+
+    bool
+    authorize(BSLA_UNUSED const mqbact::Action& action,
+              BSLA_UNUSED const mqbplug::AuthenticationResult& authnResult)
+        BSLS_KEYWORD_OVERRIDE
+    {
+        return true;
+    }
+};
+
 /// The `TestBench` holds system components together.
 class TestBench {
   public:
     // DATA
     bdlbb::PooledBlobBufferFactory            d_bufferFactory;
     BlobSpPool                                d_blobSpPool;
-    bsl::shared_ptr<bmqio::TestChannel>   d_channel;
+    bsl::shared_ptr<bmqio::TestChannel>       d_channel;
     mqbmock::Cluster                          d_cluster;
     mqbmock::Dispatcher                       d_mockDispatcher;
     MyMockDomain                              d_domain;
@@ -657,6 +672,7 @@ class TestBench {
     const bsl::shared_ptr<bmqst::StatContext> d_clientStatContext_sp;
     bdlmt::EventScheduler                     d_scheduler;
     TestClock                                 d_testClock;
+    bsl::shared_ptr<TestAuthorizer>           d_authorizer;
     mqba::ClientSession                       d_cs;
     bslma::Allocator*                         d_allocator_p;
 
@@ -685,6 +701,7 @@ class TestBench {
           mqbstat::QueueStatsUtil::initializeStatContextClients(10, allocator))
     , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
     , d_testClock(d_scheduler)
+    , d_authorizer(bsl::allocate_shared<TestAuthorizer>(allocator))
     , d_cs(d_channel,
            negotiationMessage,
            "sessionDescription",
@@ -695,6 +712,7 @@ class TestBench {
            &d_blobSpPool,
            &d_bufferFactory,
            &d_scheduler,
+           d_authorizer,
            allocator)
     , d_allocator_p(allocator)
     {
@@ -937,7 +955,7 @@ class TestBench {
         bmqio::TestChannel::WriteCall openQueueCall;
         BMQTST_ASSERT(d_channel->getWriteCall(&openQueueCall, 0));
 
-        bmqp::Event     openQueueEvent(&openQueueCall.d_blob,
+        bmqp::Event openQueueEvent(&openQueueCall.d_blob,
                                    bmqtst::TestHelperUtil::allocator());
         PVV("Event 1: " << openQueueEvent);
         BMQTST_ASSERT(openQueueEvent.isControlEvent());
@@ -974,7 +992,7 @@ class TestBench {
         bmqio::TestChannel::WriteCall ackCall;
         BMQTST_ASSERT(d_channel->getWriteCall(&ackCall, eventIndex));
 
-        bmqp::Event     ackEvent(&ackCall.d_blob,
+        bmqp::Event ackEvent(&ackCall.d_blob,
                              bmqtst::TestHelperUtil::allocator());
         PVV("Event " << eventIndex + 1 << ": " << ackEvent);
         BMQTST_ASSERT(ackEvent.isAckEvent());
@@ -1937,7 +1955,7 @@ static void test9_newStylePush()
 
     BMQTST_ASSERT_EQ(bmqt::EventBuilderResult::e_SUCCESS, rc);
 
-    bmqp::Event           rawEvent(peb.blob().get(),
+    bmqp::Event rawEvent(peb.blob().get(),
                          bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(rawEvent.isValid());
@@ -2052,7 +2070,7 @@ static void test10_newStyleCompressedPush()
 
     BMQTST_ASSERT_EQ(bmqt::EventBuilderResult::e_SUCCESS, rc);
 
-    bmqp::Event           rawEvent(peb.blob().get(),
+    bmqp::Event rawEvent(peb.blob().get(),
                          bmqtst::TestHelperUtil::allocator());
 
     BSLS_ASSERT(rawEvent.isValid());
@@ -2128,8 +2146,8 @@ static void test11_initiateShutdown()
     const bsl::string uri("bmq://my.domain/queue-foo-bar",
                           bmqtst::TestHelperUtil::allocator());
 
-    const int                queueId          = 4;  // A queue number
-    const bool                 isAtMostOnce     = false;
+    const int                  queueId      = 4;  // A queue number
+    const bool                 isAtMostOnce = false;
     bslmt::TimedSemaphore      semaphore;
     bmqp::Protocol::MsgGroupId msgGroupId(bmqtst::TestHelperUtil::allocator());
     const unsigned int         subscriptionId =

--- a/src/groups/mqb/mqba/mqba_clientsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_clientsession.t.cpp
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mqbi_authorizer.h"
 #include <mqba_clientsession.h>
 
 // MQB
@@ -22,6 +21,7 @@
 #include <mqbevt_ackevent.h>
 #include <mqbevt_pushevent.h>
 #include <mqbevt_putevent.h>
+#include <mqbi_authorizer.h>
 #include <mqbi_queue.h>
 #include <mqbmock_cluster.h>
 #include <mqbmock_dispatcher.h>

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -557,6 +557,10 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
         return NULL;  // RETURN
     }
 
+    if (!authorizeIncomingConnection(errorDescription, context_p)) {
+        return NULL;  // RETURN
+    }
+
     // Create the session.
     bsl::string description;
     loadSessionDescription(&description,
@@ -564,10 +568,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
                            *(context_p->channel().get()));
 
     bsl::shared_ptr<mqbnet::Session> session;
-    rc = createSession(&session, context_p, description);
-    if (rc != 0) {
-        return NULL;
-    }
+    createSession(&session, context_p, description);
 
     return session;
 }
@@ -619,12 +620,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onBrokerResponseMessage(
     }
 
     bsl::shared_ptr<mqbnet::Session> session;
-    {
-        const int rc = createSession(&session, context_p, description);
-        if (rc != 0) {
-            return NULL;  // RETURN
-        }
-    }
+    createSession(&session, context_p, description);
 
     return session;
 }
@@ -795,7 +791,62 @@ int SessionNegotiator::populateNegotiationContext(
     return rc_SUCCESS;
 }
 
-int SessionNegotiator::createSession(
+bool SessionNegotiator::authorizeIncomingConnection(
+    bsl::ostream&                     errorDescription,
+    mqbnet::InitialConnectionContext* context_p)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(context_p);
+    BSLS_ASSERT_SAFE(context_p->negotiationContext());
+    BSLS_ASSERT_SAFE(context_p->negotiationContext()->connectionType() !=
+                     mqbnet::ConnectionType::e_UNKNOWN);
+
+    const NegotiationContextSp& negotiationContext =
+        context_p->negotiationContext();
+
+    BSLS_ASSERT(context_p->authenticationContext() &&
+                context_p->authenticationContext()->authenticationResult());
+    const mqbplug::AuthenticationResult& authnResult =
+        *context_p->authenticationContext()->authenticationResult();
+
+    mqbact::Action action;
+    switch (negotiationContext->connectionType()) {
+    case mqbnet::ConnectionType::e_ADMIN: {
+        action.makeConnectAdmin();
+    } break;
+    case mqbnet::ConnectionType::e_CLIENT: {
+        action.makeConnectClient();
+    } break;
+    case mqbnet::ConnectionType::e_CLUSTER_MEMBER: {
+        action.makeConnectClusterNode().clusterName() =
+            negotiationContext->negotiationMessage()
+                .clientIdentity()
+                .clusterName();
+    } break;
+    // An incoming connection (this method's precondition) can never be of
+    // type 'e_CLUSTER_PROXY': it is only used for a broker's own outbound
+    // connections (see 'negotiateOutbound').
+    case mqbnet::ConnectionType::e_CLUSTER_PROXY:
+    case mqbnet::ConnectionType::e_UNKNOWN:
+    default: {
+        // Fail the connection and log an error (rather than assert).
+        BALL_LOG_ERROR << "#CONNECTION_UNEXPECTED Unexpected connection "
+                       << "type for an incoming connection: "
+                       << negotiationContext->connectionType();
+        errorDescription << "Unexpected connection type";
+        return false;  // RETURN
+    }
+    }
+
+    if (!d_authorizer_sp->authorize(action, authnResult)) {
+        errorDescription << "Connection not authorized";
+        return false;  // RETURN
+    }
+
+    return true;
+}
+
+void SessionNegotiator::createSession(
     bsl::shared_ptr<mqbnet::Session>* out,
     mqbnet::InitialConnectionContext* context_p,
     const bsl::string&                description)
@@ -810,11 +861,6 @@ int SessionNegotiator::createSession(
                           ->negotiationMessage()
                           .isUndefinedValue());
 
-    enum {
-        e_OK                    = 0,
-        e_AUTHORIZATION_FAILURE = 1,
-    };
-
     const NegotiationContextSp& negotiationContext =
         context_p->negotiationContext();
 
@@ -824,20 +870,6 @@ int SessionNegotiator::createSession(
 
     if (negotiationContext->connectionType() ==
         mqbnet::ConnectionType::e_ADMIN) {
-        // Authorize
-        if (context_p->isIncoming()) {
-            BSLS_ASSERT(
-                context_p->authenticationContext() &&
-                context_p->authenticationContext()->authenticationResult());
-            const mqbplug::AuthenticationResult& authnResult =
-                *context_p->authenticationContext()->authenticationResult();
-            mqbact::Action action;
-            action.makeConnectAdmin();
-            if (!d_authorizer_sp->authorize(action, authnResult)) {
-                return e_AUTHORIZATION_FAILURE;  // RETURN
-            }
-        }
-
         mqba::AdminSession* session = new (*d_allocator_p)
             AdminSession(channel,
                          negoMsg,
@@ -853,20 +885,6 @@ int SessionNegotiator::createSession(
     }
     else if (negotiationContext->connectionType() ==
              mqbnet::ConnectionType::e_CLIENT) {
-        // Authorize
-        if (context_p->isIncoming()) {
-            BSLS_ASSERT(
-                context_p->authenticationContext() &&
-                context_p->authenticationContext()->authenticationResult());
-            const mqbplug::AuthenticationResult& authnResult =
-                *context_p->authenticationContext()->authenticationResult();
-            mqbact::Action action;
-            action.makeConnectClient();
-            if (!d_authorizer_sp->authorize(action, authnResult)) {
-                return e_AUTHORIZATION_FAILURE;  // RETURN
-            }
-        }
-
         // Create a dedicated stats subcontext for this client
         bmqst::StatContextConfiguration statContextCfg(description);
         statContextCfg.storeExpiredSubcontextValues(true);
@@ -906,8 +924,6 @@ int SessionNegotiator::createSession(
                                                              d_allocator_p),
                    d_allocator_p);
     }
-
-    return e_OK;
 }
 
 bool SessionNegotiator::checkIsDeprecatedSdkVersion(

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -424,8 +424,6 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
                   << context_p->channel().get()
                   << "': " << logSafe(clientIdentity);
 
-    bsl::shared_ptr<mqbnet::Session> session;
-
     // Inject the hostName in the negotiation message if not provided by the
     // connecting peer.
     switch (clientIdentity.clientType()) {
@@ -441,7 +439,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
     default: {
         errorDescription << "Unknown ClientIdentity client type: "
                          << logSafe(clientIdentity);
-        return session;  // RETURN
+        return NULL;  // RETURN
     }
     }
 
@@ -539,7 +537,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
     // Populate the negotiation context based on the received client identity.
     int rc = populateNegotiationContext(errorDescription, context_p);
     if (rc != 0) {
-        return session;  // RETURN
+        return NULL;  // RETURN
     }
 
     // Communicate heartbeat settings.  Currently, only for SDK use
@@ -556,7 +554,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
                                 negotiationResponse,
                                 negotiationContext);
     if (rc != 0) {
-        return session;  // RETURN
+        return NULL;  // RETURN
     }
 
     // Create the session.
@@ -565,7 +563,11 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
                            clientIdentity,
                            *(context_p->channel().get()));
 
-    createSession(&session, context_p, description);
+    bsl::shared_ptr<mqbnet::Session> session;
+    rc = createSession(&session, context_p, description);
+    if (rc != 0) {
+        return NULL;
+    }
 
     return session;
 }
@@ -592,13 +594,11 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onBrokerResponseMessage(
                    << context_p->channel().get()
                    << "': " << logSafe(brokerResponse);
 
-    bsl::shared_ptr<mqbnet::Session> session;
-
     if (brokerResponse.result().category() !=
         bmqp_ctrlmsg::StatusCategory::E_SUCCESS) {
         errorDescription << "Failure broker's response ["
                          << logSafe(brokerResponse) << "]";
-        return session;  // RETURN
+        return NULL;  // RETURN
     }
 
     // Resolve 'hostName' of the brokerIdentity
@@ -611,11 +611,20 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onBrokerResponseMessage(
                            brokerResponse.brokerIdentity(),
                            *(context_p->channel().get()));
 
-    const int rc = populateNegotiationContext(errorDescription, context_p);
-    if (rc != 0) {
-        return session;  // RETURN
+    {
+        const int rc = populateNegotiationContext(errorDescription, context_p);
+        if (rc != 0) {
+            return NULL;  // RETURN
+        }
     }
-    createSession(&session, context_p, description);
+
+    bsl::shared_ptr<mqbnet::Session> session;
+    {
+        const int rc = createSession(&session, context_p, description);
+        if (rc != 0) {
+            return NULL;  // RETURN
+        }
+    }
 
     return session;
 }
@@ -786,7 +795,7 @@ int SessionNegotiator::populateNegotiationContext(
     return rc_SUCCESS;
 }
 
-void SessionNegotiator::createSession(
+int SessionNegotiator::createSession(
     bsl::shared_ptr<mqbnet::Session>* out,
     mqbnet::InitialConnectionContext* context_p,
     const bsl::string&                description)
@@ -801,6 +810,11 @@ void SessionNegotiator::createSession(
                           ->negotiationMessage()
                           .isUndefinedValue());
 
+    enum {
+        e_OK                    = 0,
+        e_AUTHORIZATION_FAILURE = 1,
+    };
+
     const NegotiationContextSp& negotiationContext =
         context_p->negotiationContext();
 
@@ -810,6 +824,20 @@ void SessionNegotiator::createSession(
 
     if (negotiationContext->connectionType() ==
         mqbnet::ConnectionType::e_ADMIN) {
+        // Authorize
+        if (context_p->isIncoming()) {
+            BSLS_ASSERT(
+                context_p->authenticationContext() &&
+                context_p->authenticationContext()->authenticationResult());
+            const mqbplug::AuthenticationResult& authnResult =
+                *context_p->authenticationContext()->authenticationResult();
+            mqbact::Action action;
+            action.makeConnectAdmin();
+            if (!d_authorizer_sp->authorize(action, authnResult)) {
+                return e_AUTHORIZATION_FAILURE;  // RETURN
+            }
+        }
+
         mqba::AdminSession* session = new (*d_allocator_p)
             AdminSession(channel,
                          negoMsg,
@@ -818,12 +846,27 @@ void SessionNegotiator::createSession(
                          d_blobSpPool_p,
                          d_scheduler_p,
                          d_adminCb,
+                         d_authorizer_sp,
                          d_allocator_p);
 
         out->reset(session, d_allocator_p);
     }
     else if (negotiationContext->connectionType() ==
              mqbnet::ConnectionType::e_CLIENT) {
+        // Authorize
+        if (context_p->isIncoming()) {
+            BSLS_ASSERT(
+                context_p->authenticationContext() &&
+                context_p->authenticationContext()->authenticationResult());
+            const mqbplug::AuthenticationResult& authnResult =
+                *context_p->authenticationContext()->authenticationResult();
+            mqbact::Action action;
+            action.makeConnectClient();
+            if (!d_authorizer_sp->authorize(action, authnResult)) {
+                return e_AUTHORIZATION_FAILURE;  // RETURN
+            }
+        }
+
         // Create a dedicated stats subcontext for this client
         bmqst::StatContextConfiguration statContextCfg(description);
         statContextCfg.storeExpiredSubcontextValues(true);
@@ -841,6 +884,7 @@ void SessionNegotiator::createSession(
                           d_blobSpPool_p,
                           d_bufferFactory_p,
                           d_scheduler_p,
+                          d_authorizer_sp,
                           d_allocator_p);
 
         out->reset(session, d_allocator_p);
@@ -862,6 +906,8 @@ void SessionNegotiator::createSession(
                                                              d_allocator_p),
                    d_allocator_p);
     }
+
+    return e_OK;
 }
 
 bool SessionNegotiator::checkIsDeprecatedSdkVersion(

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -48,6 +48,7 @@
 #include <bdlcc_sharedobjectpool.h>
 #include <bsl_memory.h>
 #include <bsl_ostream.h>
+#include <bsla_annotations.h>
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
@@ -97,8 +98,8 @@ class SessionNegotiator : public mqbnet::Negotiator {
     // PRIVATE TYPES
     typedef bsl::shared_ptr<mqbnet::NegotiationContext> NegotiationContextSp;
     typedef bsl::shared_ptr<mqbnet::InitialConnectionContext>
-                                                InitialConnectionContextSp;
-    typedef bslma::ManagedPtr<mqbi::Authorizer> AuthorizerMp;
+                                              InitialConnectionContextSp;
+    typedef bsl::shared_ptr<mqbi::Authorizer> AuthorizerSp;
 
   private:
     // DATA
@@ -134,7 +135,7 @@ class SessionNegotiator : public mqbnet::Negotiator {
     mqbnet::Session::AdminCommandEnqueueCb d_adminCb;
 
     /// The authorizer
-    AuthorizerMp d_authorizer_mp;
+    AuthorizerSp d_authorizer_sp;
 
   private:
     // NOT IMPLEMENTED
@@ -182,9 +183,10 @@ class SessionNegotiator : public mqbnet::Negotiator {
     /// specified `context_p` and `description`; or leave `out` untouched and
     /// populate the specified `errorDescription` with a description of the
     /// error in case of failure.
-    void createSession(bsl::shared_ptr<mqbnet::Session>* out,
-                       mqbnet::InitialConnectionContext* context_p,
-                       const bsl::string&                description);
+    BSLA_NODISCARD
+    int createSession(bsl::shared_ptr<mqbnet::Session>* out,
+                      mqbnet::InitialConnectionContext* context_p,
+                      const bsl::string&                description);
 
     /// Return true if the negotiation message in the specified `context` is
     /// for a client using a deprecated version of the libbmq SDK.
@@ -241,8 +243,7 @@ class SessionNegotiator : public mqbnet::Negotiator {
 
     /// Set the authorizer that will be used to authorize sessions and actions
     /// that can occur in those sessions.
-    SessionNegotiator&
-    setAuthorizer(bslmf::MovableRef<AuthorizerMp> authorizer);
+    SessionNegotiator& setAuthorizer(const AuthorizerSp& authorizer);
 
     // MANIPULATORS
     //   (virtual: mqbnet::Negotiator)
@@ -294,9 +295,9 @@ SessionNegotiator::setDomainFactory(mqbi::DomainFactory* value)
 }
 
 inline SessionNegotiator&
-SessionNegotiator::setAuthorizer(bslmf::MovableRef<AuthorizerMp> authorizer)
+SessionNegotiator::setAuthorizer(const AuthorizerSp& authorizer)
 {
-    d_authorizer_mp = bslmf::MovableRefUtil::move(authorizer);
+    d_authorizer_sp = authorizer;
     return *this;
 }
 

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -179,14 +179,20 @@ class SessionNegotiator : public mqbnet::Negotiator {
     populateNegotiationContext(bsl::ostream& errorDescription,
                                mqbnet::InitialConnectionContext* context_p);
 
-    /// Load into the specified `out` a new session created using the
-    /// specified `context_p` and `description`; or leave `out` untouched and
-    /// populate the specified `errorDescription` with a description of the
-    /// error in case of failure.
+    /// Authorize the incoming connection described by the specified
+    /// `context_p`, based on its connection type.  Return true if the
+    /// connection is authorized, or false otherwise and populate the
+    /// specified `errorDescription` with a description of the error.
     BSLA_NODISCARD
-    int createSession(bsl::shared_ptr<mqbnet::Session>* out,
-                      mqbnet::InitialConnectionContext* context_p,
-                      const bsl::string&                description);
+    bool
+    authorizeIncomingConnection(bsl::ostream& errorDescription,
+                                mqbnet::InitialConnectionContext* context_p);
+
+    /// Load into the specified `out` a new session created using the
+    /// specified `context_p` and `description`.
+    void createSession(bsl::shared_ptr<mqbnet::Session>* out,
+                       mqbnet::InitialConnectionContext* context_p,
+                       const bsl::string&                description);
 
     /// Return true if the negotiation message in the specified `context` is
     /// for a client using a deprecated version of the libbmq SDK.

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -52,6 +52,7 @@
 #include <bslma_allocator.h>
 #include <bslma_usesbslmaallocator.h>
 #include <bslmf_nestedtraitdeclaration.h>
+#include <bsls_assert.h>
 
 namespace BloombergLP {
 
@@ -289,6 +290,9 @@ inline SessionNegotiator& SessionNegotiator::setAdminCommandEnqueueCallback(
 inline SessionNegotiator&
 SessionNegotiator::setClusterCatalog(mqbblp::ClusterCatalog* value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(value);
+
     d_clusterCatalog_p = value;
     return *this;
 }
@@ -296,6 +300,9 @@ SessionNegotiator::setClusterCatalog(mqbblp::ClusterCatalog* value)
 inline SessionNegotiator&
 SessionNegotiator::setDomainFactory(mqbi::DomainFactory* value)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(value);
+
     d_domainFactory_p = value;
     return *this;
 }
@@ -303,6 +310,9 @@ SessionNegotiator::setDomainFactory(mqbi::DomainFactory* value)
 inline SessionNegotiator&
 SessionNegotiator::setAuthorizer(const AuthorizerSp& authorizer)
 {
+    // PRECONDITIONS
+    BSLS_ASSERT(authorizer);
+
     d_authorizer_sp = authorizer;
     return *this;
 }


### PR DESCRIPTION
This PR adds authorization checks for session negotiation. Client, admin, and cluster peer session creation now needs to be authorized in order to be established. In an upcoming PR both session objects will use the authorizer handle to authorize access to certain resources while the session is active.
