### PR TITLE
IT: Add log attributes to the log line format

### DIFF
--- a/src/python/blazingmq/dev/configurator/__init__.py
+++ b/src/python/blazingmq/dev/configurator/__init__.py
@@ -330,8 +330,8 @@ class Proto:
                     file_name="logs/logs.%T.%p",
                     file_max_age_days=10,
                     rotation_bytes=268435456,
-                    logfile_format="%d (%t) %s %F:%l %m\n\n",
-                    console_format="%d (%t) %s %F:%l %m\n",
+                    logfile_format="%d (%t) %s %F:%l %m %a\n\n",
+                    console_format="%d (%t) %s %F:%l %m %a\n",
                     logging_verbosity="INFO",
                     console_severity_threshold="INFO",
                     categories=[
@@ -342,7 +342,7 @@ class Proto:
                     syslog=mqbcfg.SyslogConfig(
                         enabled=False,
                         app_name="BMQ",
-                        log_format="%d (%t) %s %F:%l %m\n\n",
+                        log_format="%d (%t) %s %F:%l %m %a\n\n",
                         verbosity="",
                     ),
                 ),

--- a/src/python/blazingmq/dev/it/process/bmqproc.py
+++ b/src/python/blazingmq/dev/it/process/bmqproc.py
@@ -37,7 +37,7 @@ _LOG_FORMAT_DEFINITION = [
     ("%t", r"(\d+)"),  # thread
     ("%s", r"([A-Z]+)"),  # level
     ("%F:%l", r"(\w+(?:\.\w+)+):(\d+)"),  # file, line
-    ("%m", r"(.*)"),  # message
+    ("%m %a", r"(.*)"),  # message
 ]
 
 _LOG_FIELD_SEP = "~@~"


### PR DESCRIPTION
BlazingMQ is not configured for logging attributes in most places. This is a decently low risk way to start logging that information.