### PR TITLE
CI: enable MSAN memory origins, sanitize all ITs

### DIFF
--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: IT [c++,${{ github.job }}]
         if: ${{ matrix.fuzz == 'off' }}
         run: |
-          docker run --rm sanitizer-${{ github.job }} /blazingmq/cmake.bld/Linux/run-it.sh -k breathing --bmq-tolerate-dirty-shutdown
+          docker run --rm sanitizer-${{ github.job }} /blazingmq/cmake.bld/Linux/run-it.sh --bmq-tolerate-dirty-shutdown -n logical

--- a/docker/sanitizers/build_sanitizer.sh
+++ b/docker/sanitizers/build_sanitizer.sh
@@ -204,6 +204,11 @@ export DIR_SCRIPTS="${DIR_SCRIPTS}"
 
 TOOLCHAIN_PATH="${DIR_SCRIPTS}/clang-libcxx-sanitizer.cmake"
 export SANITIZER_NAME="${SANITIZER_NAME}"
+# Enable MemorySanitizer origin tracking (origins=2) so reports name where an
+# uninitialized value was created, not just where it was consumed.  The
+# toolchain only acts on this for 'msan' builds.  Override with
+# 'DEBUG_MEMORY_SANITIZER=0' to disable.
+export DEBUG_MEMORY_SANITIZER="${DEBUG_MEMORY_SANITIZER:-1}"
 export CC="clang"
 export CXX="clang++"
 if [ "${FUZZER}" == "on" ]; then

--- a/docker/sanitizers/clang-libcxx-sanitizer.cmake
+++ b/docker/sanitizers/clang-libcxx-sanitizer.cmake
@@ -118,7 +118,10 @@ elseif(SANITIZER_NAME STREQUAL "msan")
   set(MSAN_SUPPRESSION_LIST_PATH "$ENV{DIR_SRC_BMQ}/etc/msansup.txt")
   set(TOOLCHAIN_DEBUG_FLAGS "-fsanitize=memory -fsanitize-blacklist=${MSAN_SUPPRESSION_LIST_PATH} ")
   # Conditionally add flags helpful for debugging MemorySanitizer issues.
-  if (DEBUG_MEMORY_SANITIZER)
+  # Honor either a CMake cache variable or an environment variable so the same
+  # setting propagates to every build that shares this toolchain (BDE, NTF,
+  # BlazingMQ) without threading '-D' through each configure invocation.
+  if (DEBUG_MEMORY_SANITIZER OR "$ENV{DEBUG_MEMORY_SANITIZER}")
       string(CONCAT TOOLCHAIN_DEBUG_FLAGS
             "${TOOLCHAIN_DEBUG_FLAGS} "
             "-fsanitize-memory-track-origins=2 "


### PR DESCRIPTION
- Run all ITs in sanitizers CI
- Run sanitized ITs in parallel
- Enable MSAN memory origins