### PR TITLE
Refactor: Replace StringUtil with bdlb::StringViewUtil

### DIFF
--- a/src/applications/bmqtool/m_bmqtool_parameters.h
+++ b/src/applications/bmqtool/m_bmqtool_parameters.h
@@ -31,6 +31,7 @@
 #include <m_bmqtool_messages.h>
 
 // BDE
+#include <bdlb_stringviewutil.h>
 #include <bsl_iosfwd.h>
 #include <bsl_string.h>
 #include <bslma_allocator.h>
@@ -551,13 +552,13 @@ inline Parameters& Parameters::setStoragePath(const bsl::string& value)
             d_dataFilePath.assign(substr);
             d_dataFilePath.append(dataExt);
         }
-        else if (bmqu::StringUtil::endsWith(value, qlistExt)) {
+        else if (bdlb::StringViewUtil::endsWith(value, qlistExt)) {
             d_qlistFilePath = value;
         }
-        else if (bmqu::StringUtil::endsWith(value, journalExt)) {
+        else if (bdlb::StringViewUtil::endsWith(value, journalExt)) {
             d_journalFilePath = value;
         }
-        else if (bmqu::StringUtil::endsWith(value, dataExt)) {
+        else if (bdlb::StringViewUtil::endsWith(value, dataExt)) {
             d_dataFilePath = value;
         }
     }

--- a/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
+++ b/src/applications/bmqtool/m_bmqtool_storageinspector.cpp
@@ -38,6 +38,7 @@
 // BDE
 #include <ball_log.h>
 #include <bdlb_print.h>
+#include <bdlb_stringviewutil.h>
 #include <bdlbb_blob.h>
 #include <bdls_filesystemutil.h>
 #include <bdlt_datetime.h>
@@ -361,7 +362,7 @@ void StorageInspector::processCommand(const OpenStorageCommand& command)
                       << d_journalFile << "] Qlist file: [" << d_qlistFile
                       << "]";
     }
-    else if (bmqu::StringUtil::endsWith(
+    else if (bdlb::StringViewUtil::endsWith(
                  path,
                  mqbs::FileStoreProtocol::k_DATA_FILE_EXTENSION)) {
         if (!resetIterator(&d_dataFd, &d_dataFileIter, path.c_str())) {
@@ -370,7 +371,7 @@ void StorageInspector::processCommand(const OpenStorageCommand& command)
 
         d_dataFile = path;
     }
-    else if (bmqu::StringUtil::endsWith(
+    else if (bdlb::StringViewUtil::endsWith(
                  path,
                  mqbs::FileStoreProtocol::k_JOURNAL_FILE_EXTENSION)) {
         if (!resetIterator(&d_journalFd, &d_journalFileIter, path.c_str())) {
@@ -379,7 +380,7 @@ void StorageInspector::processCommand(const OpenStorageCommand& command)
 
         d_journalFile = path;
     }
-    else if (bmqu::StringUtil::endsWith(
+    else if (bdlb::StringViewUtil::endsWith(
                  path,
                  mqbs::FileStoreProtocol::k_QLIST_FILE_EXTENSION)) {
         if (!resetIterator(&d_qlistFd, &d_qlistFileIter, path.c_str())) {

--- a/src/groups/bmq/bmqio/bmqio_tcpendpoint.cpp
+++ b/src/groups/bmq/bmqio/bmqio_tcpendpoint.cpp
@@ -22,6 +22,7 @@
 
 // BDE
 #include <bdlb_print.h>
+#include <bdlb_stringviewutil.h>
 #include <bdlma_localsequentialallocator.h>
 #include <bsl_cstdlib.h>
 #include <bsl_ostream.h>
@@ -71,7 +72,7 @@ bool TCPEndpoint::fromUri(const bsl::string& uri)
     d_uri.clear();
 
     // Check 'uri' starts by the proper expected scheme
-    if (!bmqu::StringUtil::startsWith(uri, k_SCHEME)) {
+    if (!bdlb::StringViewUtil::startsWith(uri, k_SCHEME)) {
         return false;  // RETURN
     }
 

--- a/src/groups/bmq/bmqtsk/bmqtsk_alarmlogobserver.cpp
+++ b/src/groups/bmq/bmqtsk/bmqtsk_alarmlogobserver.cpp
@@ -22,6 +22,7 @@
 
 // BDE
 #include <ball_severity.h>
+#include <bdlb_stringviewutil.h>
 #include <bdlt_timeunitratio.h>
 #include <bsl_iostream.h>
 #include <bsla_annotations.h>
@@ -82,7 +83,7 @@ void AlarmLogObserver::publish(const ball::Record&     record,
     const bsl::string& alarmType = record.customFields()[0].theString();
 
     // Raw version used, no throttling
-    if (bmqu::StringUtil::startsWith(alarmType, "RAW_")) {
+    if (bdlb::StringViewUtil::startsWith(alarmType, "RAW_")) {
         // We are stripping out the 'RAW_' prefix from the alarm identification
         // string.
         const bslstl::StringRef categoryStr(alarmType.c_str() + 4,

--- a/src/groups/bmq/bmqu/bmqu_stringutil.cpp
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.cpp
@@ -18,7 +18,6 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlb_chartype.h>
-#include <bdlb_stringviewutil.h>
 #include <bsl_algorithm.h>
 #include <bsl_bitset.h>
 #include <bsl_cctype.h>

--- a/src/groups/bmq/bmqu/bmqu_stringutil.cpp
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.cpp
@@ -18,6 +18,7 @@
 #include <bmqscm_version.h>
 // BDE
 #include <bdlb_chartype.h>
+#include <bdlb_stringviewutil.h>
 #include <bsl_algorithm.h>
 #include <bsl_bitset.h>
 #include <bsl_cctype.h>
@@ -76,47 +77,6 @@ bool StringUtil::contains(const bsl::string&       str,
                           const bslstl::StringRef& substr)
 {
     return str.find(substr, 0) != bsl::string::npos;
-}
-
-bool StringUtil::startsWith(const bslstl::StringRef& str,
-                            const bslstl::StringRef& prefix,
-                            size_t                   offset)
-{
-    if (offset > str.length() || ((str.length() - offset) < prefix.length())) {
-        // There is not enough characters in 'str' after 'offset' to contain
-        // the full 'prefix' string.  Note that the first check is covered by
-        // the second, but needed due to unsigned operation.
-        return false;  // RETURN
-    }
-
-    size_t idx = 0;
-    while (idx < prefix.length()) {
-        if (str[offset++] != prefix[idx++]) {
-            return false;  // RETURN
-        }
-    }
-
-    return true;
-}
-
-bool StringUtil::endsWith(const bslstl::StringRef& str,
-                          const bslstl::StringRef& suffix)
-{
-    if (str.length() < suffix.length()) {
-        // There is not enough characters in 'str' to contain the full 'suffix'
-        // string.
-        return false;  // RETURN
-    }
-
-    int i = static_cast<int>(str.length() - 1);
-    int j = static_cast<int>(suffix.length() - 1);
-    while ((i >= 0) && (j >= 0)) {
-        if (str[i--] != suffix[j--]) {
-            return false;  // RETURN
-        }
-    }
-
-    return true;
 }
 
 bool StringUtil::isPrintable(const bslstl::StringRef& str)

--- a/src/groups/bmq/bmqu/bmqu_stringutil.h
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.h
@@ -45,18 +45,6 @@ struct StringUtil {
     static bool contains(const bsl::string&       str,
                          const bslstl::StringRef& substr);
 
-    /// Return `true` if the specified string `str` contains the specified
-    /// `prefix` substring starting from the optionally specified `offset`,
-    /// return `false` otherwise.
-    static bool startsWith(const bslstl::StringRef& str,
-                           const bslstl::StringRef& prefix,
-                           size_t                   offset = 0);
-
-    /// Return `true` if the specified string `str` ends with the specified
-    /// `suffix` string, return `false` otherwise.
-    static bool endsWith(const bslstl::StringRef& str,
-                         const bslstl::StringRef& suffix);
-
     /// Return `true` if every character in the specified string `str` is
     /// printable, and `false` otherwise.  An empty string is printable.
     static bool isPrintable(const bslstl::StringRef& str);

--- a/src/groups/bmq/bmqu/bmqu_stringutil.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_stringutil.t.cpp
@@ -71,105 +71,7 @@ static void test1_contains()
     }
 }
 
-static void test2_startsWith()
-// ------------------------------------------------------------------------
-// bmqu::StringUtil::startsWith
-//
-// Concerns:
-//   Ensure proper behavior of the 'startsWith' method.
-//
-// Plan:
-//   Test various strings, focusing on edge cases.
-//
-// Testing:
-//   Proper behavior of the 'startsWith(str, prefix, offset)' method.
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("startsWith");
-
-    struct Test {
-        int         d_line;
-        const char* d_str;
-        const char* d_prefix;
-        size_t      d_offset;
-        bool        d_result;
-    } k_DATA[] = {{L_, "", "", 0, true},
-                  {L_, "", "", 1, false},
-                  {L_, "", "a", 0, false},
-                  {L_, "", "a", 1, false},
-                  {L_, "a", "", 0, true},
-                  {L_, "a", "", 1, true},
-                  {L_, "abc", "ab", 0, true},
-                  {L_, "abc", "ab", 1, false},
-                  {L_, "abab", "ab", 1, false},
-                  {L_, "abab", "ab", 2, true},
-                  {L_, "abc", "abcd", 0, false},
-                  {L_, "abc", "abc", 0, true}};
-
-    const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
-
-    for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test& test = k_DATA[idx];
-
-        PVV(test.d_line << ": checking if '" << test.d_str << "' "
-                        << "starts with '" << test.d_prefix << "' "
-                        << "from offset " << test.d_offset);
-
-        BMQTST_ASSERT_EQ_D("line " << test.d_line,
-                           bmqu::StringUtil::startsWith(test.d_str,
-                                                        test.d_prefix,
-                                                        test.d_offset),
-                           test.d_result);
-    }
-}
-
-static void test3_endsWith()
-// ------------------------------------------------------------------------
-// bmqu::StringUtil::endsWith
-//
-// Concerns:
-//   Ensure proper behavior of the 'endsWith' method.
-//
-// Plan:
-//   Test various strings, focusing on edge cases.
-//
-// Testing:
-//   Proper behavior of the 'endsWith(str, suffix)' method.
-// ------------------------------------------------------------------------
-{
-    bmqtst::TestHelper::printTestName("endsWith");
-
-    struct Test {
-        int         d_line;
-        const char* d_str;
-        const char* d_suffix;
-        bool        d_result;
-    } k_DATA[] = {{L_, "", "", true},
-                  {L_, "", "a", false},
-                  {L_, "a", "", true},
-                  {L_, "abc", "bc", true},
-                  {L_, "abc", "ab", false},
-                  {L_, "abab", "ab", true},
-                  {L_, "abab", "ba", false},
-                  {L_, "abc", "abcd", false},
-                  {L_, "abc", "abc", true}};
-
-    const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
-
-    for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
-        const Test& test = k_DATA[idx];
-
-        PVV(test.d_line << ": checking if '" << test.d_str << "' "
-                        << "ends with '" << test.d_suffix << "'");
-
-        BMQTST_ASSERT_EQ_D("line " << test.d_line,
-                           bmqu::StringUtil::endsWith(test.d_str,
-                                                      test.d_suffix),
-                           test.d_result);
-    }
-}
-
-static void test4_trim()
+static void test2_trim()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::trim
 //
@@ -210,7 +112,7 @@ static void test4_trim()
     }
 }
 
-static void test5_ltrim()
+static void test3_ltrim()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::ltrim
 //
@@ -251,7 +153,7 @@ static void test5_ltrim()
     }
 }
 
-static void test6_rtrim()
+static void test4_rtrim()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::rtrim
 //
@@ -292,7 +194,7 @@ static void test6_rtrim()
     }
 }
 
-static void test7_strTokenizeRef()
+static void test5_strTokenizeRef()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::strTokenizeRef
 //
@@ -367,7 +269,7 @@ static void test7_strTokenizeRef()
     }
 }
 
-static void test8_match()
+static void test6_match()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::match
 //
@@ -470,7 +372,7 @@ static void test8_match()
     }
 }
 
-static void test9_squeeze()
+static void test7_squeeze()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::squeeze
 //
@@ -524,7 +426,7 @@ static void test9_squeeze()
     }
 }
 
-static void test10_isPrintable()
+static void test8_isPrintable()
 // ------------------------------------------------------------------------
 // bmqu::StringUtil::isPrintable
 //
@@ -588,15 +490,13 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 10: test10_isPrintable(); break;
-    case 9: test9_squeeze(); break;
-    case 8: test8_match(); break;
-    case 7: test7_strTokenizeRef(); break;
-    case 6: test6_rtrim(); break;
-    case 5: test5_ltrim(); break;
-    case 4: test4_trim(); break;
-    case 3: test3_endsWith(); break;
-    case 2: test2_startsWith(); break;
+    case 8: test8_isPrintable(); break;
+    case 7: test7_squeeze(); break;
+    case 6: test6_match(); break;
+    case 5: test5_strTokenizeRef(); break;
+    case 4: test4_rtrim(); break;
+    case 3: test3_ltrim(); break;
+    case 2: test2_trim(); break;
     case 1: test1_contains(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;

--- a/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_transportmanager.cpp
@@ -34,6 +34,7 @@
 #include <bmqu_time.h>
 
 // BDE
+#include <bdlb_stringviewutil.h>
 #include <bdlf_bind.h>
 #include <bdlf_placeholder.h>
 #include <bsl_functional.h>
@@ -626,7 +627,7 @@ void* TransportManager::getClusterNodeAndState(
 
 bool TransportManager::isEndpointLoopback(const bslstl::StringRef& uri) const
 {
-    if (bmqu::StringUtil::startsWith(uri, "tcp://")) {
+    if (bdlb::StringViewUtil::startsWith(uri, "tcp://")) {
         return d_tcpSessionFactory_mp &&
                d_tcpSessionFactory_mp->isEndpointLoopback(uri);  // RETURN
     }

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -37,6 +37,7 @@
 // BDE
 #include <bdlb_scopeexit.h>
 #include <bdlb_string.h>
+#include <bdlb_stringviewutil.h>
 #include <bdlf_bind.h>
 #include <bdls_filesystemutil.h>
 #include <bdlt_currenttime.h>
@@ -409,21 +410,21 @@ void FileStoreUtil::createQlistFileName(bsl::string*             filename,
 
 bool FileStoreUtil::hasDataFileExtension(const bsl::string& filename)
 {
-    return bmqu::StringUtil::endsWith(
+    return bdlb::StringViewUtil::endsWith(
         filename,
         FileStoreProtocol::k_DATA_FILE_EXTENSION);
 }
 
 bool FileStoreUtil::hasJournalFileExtension(const bsl::string& filename)
 {
-    return bmqu::StringUtil::endsWith(
+    return bdlb::StringViewUtil::endsWith(
         filename,
         FileStoreProtocol::k_JOURNAL_FILE_EXTENSION);
 }
 
 bool FileStoreUtil::hasQlistFileExtension(const bsl::string& filename)
 {
-    return bmqu::StringUtil::endsWith(
+    return bdlb::StringViewUtil::endsWith(
         filename,
         FileStoreProtocol::k_QLIST_FILE_EXTENSION);
 }


### PR DESCRIPTION
Remove custom `startsWith()` and `endsWith()` from `bmqu::StringUtil` and use BDE's implementation directly. Note the offset parameter in our implementation was unused.
