### PR TITLE
Revert "Fix[mqbc::StorageUtil]: Require active primary for FSM storage events"

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -1652,7 +1652,8 @@ void StorageManager::processStorageEvent(const mqbevt::StorageEvent& event)
             pinfo.primaryNode(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm)) {
+            skipAlarm,
+            false)) {  // isFSMWorkflow
         return;        // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2886,7 +2886,8 @@ void StorageManager::do_bufferLiveData(
             pinfo.primary(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm)) {
+            skipAlarm,
+            true)) {  // isFSMWorkflow
         return;       // RETURN
     }
 
@@ -3042,7 +3043,8 @@ void StorageManager::do_processLiveData(
             pinfo.primary(),
             pinfo.primaryStatus(),
             d_clusterData_p->identity().description(),
-            skipAlarm)) {
+            skipAlarm,
+            true)) {  // isFSMWorkflow
         return;       // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -1196,7 +1196,8 @@ bool StorageUtil::validateStorageEvent(
     const mqbnet::ClusterNode*           primary,
     bmqp_ctrlmsg::PrimaryStatus::Value   status,
     const bsl::string&                   clusterDescription,
-    bool                                 skipAlarm)
+    bool                                 skipAlarm,
+    bool                                 isFSMWorkflow)
 {
     // executed by *QUEUE_DISPATCHER* thread associated with 'partitionId' or
     // by the *CLUSTER DISPATCHER* thread
@@ -1237,7 +1238,7 @@ bool StorageUtil::validateStorageEvent(
     }
 
     // Ensure that primary is perceived as active.
-    if (bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE != status) {
+    if (!isFSMWorkflow && bmqp_ctrlmsg::PrimaryStatus::E_ACTIVE != status) {
         if (skipAlarm) {
             return false;  // RETURN
         }

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -497,8 +497,9 @@ struct StorageUtil {
     /// 'source' is the specified 'primary' with the specified 'status'
     /// which needs to be ACTIVE.  Use the specified 'clusterData' to help
     /// with validation.  The specified 'skipAlarm' flag determines whether
-    /// to skip alarming if 'source' is not active primary.  Return true if
-    /// valid, false otherwise.
+    /// to skip alarming if 'source' is not active primary.  Use the
+    /// specified 'isFSMWorkflow' flag to help with validation.  Return true
+    /// if valid, false otherwise.
     ///
     /// THREAD: Executed by the Queue's dispatcher thread for the specified
     ///         `partitionId` or by the cluster dispatcher thread.
@@ -508,7 +509,8 @@ struct StorageUtil {
                                      const mqbnet::ClusterNode* primary,
                                      bmqp_ctrlmsg::PrimaryStatus::Value status,
                                      const bsl::string& clusterDescription,
-                                     bool               skipAlarm);
+                                     bool               skipAlarm,
+                                     bool               isFSMWorkflow);
 
     /// Validate that every partition sync message in the specified `event`
     /// have the same specified `partitionId`, and that ether self or the


### PR DESCRIPTION
Our test cluster received errors of the form:
```
ERROR mqbc_storageutil.cpp:1245 ALARM [STORAGE] Cluster (clusterName): Received storage event for Partition [0] from:n[node, nodeId], which is perceived as non-active primary. Primary status: E_PASSIVE. Ignoring entire storage event.
```

Hence, the `if` condition check in #1688 was incorrect. Reverting.