### PR TITLE
Cleanup[mqba::SessionNegotiator]: require authorizer at construction

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -361,17 +361,17 @@ int Application::start(bsl::ostream& errorDescription)
                           d_statController_mp->clientsStatContext(),
                           &d_blobSpPool,
                           d_scheduler_p,
+                          authorizer_sp,
                           d_allocators.get("SessionNegotiator"));
 
     (*sessionNegotiator)
         .setAdminCommandEnqueueCallback(
             bdlf::BindUtil::bind(&Application::enqueueCommand,
                                  this,
-                                 bdlf::PlaceHolders::_1,   // source
-                                 bdlf::PlaceHolders::_2,   // cmd
-                                 bdlf::PlaceHolders::_3,   // onProcessedCb
-                                 bdlf::PlaceHolders::_4))  // fromReroute
-        .setAuthorizer(authorizer_sp);
+                                 bdlf::PlaceHolders::_1,    // source
+                                 bdlf::PlaceHolders::_2,    // cmd
+                                 bdlf::PlaceHolders::_3,    // onProcessedCb
+                                 bdlf::PlaceHolders::_4));  // fromReroute
 
     bslma::ManagedPtr<mqbnet::Negotiator> negotiatorMp(sessionNegotiator,
                                                        d_allocator_p);

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -1001,12 +1001,12 @@ SessionNegotiator::SessionNegotiator(bdlbb::BlobBufferFactory* bufferFactory,
 , d_authorizer_sp(authorizer)
 {
     // PRECONDITIONS
-    BSLS_ASSERT(bufferFactory);
-    BSLS_ASSERT(dispatcher);
-    BSLS_ASSERT(statContext);
-    BSLS_ASSERT(blobSpPool);
-    BSLS_ASSERT(scheduler);
-    BSLS_ASSERT(authorizer);
+    BSLS_ASSERT(d_bufferFactory_p);
+    BSLS_ASSERT(d_dispatcher_p);
+    BSLS_ASSERT(d_statContext_p);
+    BSLS_ASSERT(d_blobSpPool_p);
+    BSLS_ASSERT(d_scheduler_p);
+    BSLS_ASSERT(d_authorizer_sp);
 }
 
 SessionNegotiator::~SessionNegotiator()

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -988,6 +988,7 @@ SessionNegotiator::SessionNegotiator(bdlbb::BlobBufferFactory* bufferFactory,
                                      bmqst::StatContext*       statContext,
                                      BlobSpPool*               blobSpPool,
                                      bdlmt::EventScheduler*    scheduler,
+                                     const AuthorizerSp&       authorizer,
                                      bslma::Allocator*         allocator)
 : d_allocator_p(allocator)
 , d_bufferFactory_p(bufferFactory)
@@ -997,8 +998,15 @@ SessionNegotiator::SessionNegotiator(bdlbb::BlobBufferFactory* bufferFactory,
 , d_blobSpPool_p(blobSpPool)
 , d_clusterCatalog_p(0)
 , d_scheduler_p(scheduler)
+, d_authorizer_sp(authorizer)
 {
-    // NOTHING
+    // PRECONDITIONS
+    BSLS_ASSERT(bufferFactory);
+    BSLS_ASSERT(dispatcher);
+    BSLS_ASSERT(statContext);
+    BSLS_ASSERT(blobSpPool);
+    BSLS_ASSERT(scheduler);
+    BSLS_ASSERT(authorizer);
 }
 
 SessionNegotiator::~SessionNegotiator()

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -221,13 +221,15 @@ class SessionNegotiator : public mqbnet::Negotiator {
 
     /// Create a new `SessionNegotiator` using the specified
     /// `bufferFactory`, `dispatcher`, `statContext`, `scheduler` and
-    /// `blobSpPool` to inject in the negotiated sessions.  Use the
-    /// specified `allocator` for all memory allocations.
+    /// `blobSpPool` to inject in the negotiated sessions, and the specified
+    /// `authorizer` to authorize incoming connections.  Use the specified
+    /// `allocator` for all memory allocations.
     SessionNegotiator(bdlbb::BlobBufferFactory* bufferFactory,
                       mqbi::Dispatcher*         dispatcher,
                       bmqst::StatContext*       statContext,
                       BlobSpPool*               blobSpPool,
                       bdlmt::EventScheduler*    scheduler,
+                      const AuthorizerSp&       authorizer,
                       bslma::Allocator*         allocator);
 
     /// Destructor
@@ -247,10 +249,6 @@ class SessionNegotiator : public mqbnet::Negotiator {
     /// Set the domain factory to the specified `value` and return a
     /// reference offering modifiable access to this object.
     SessionNegotiator& setDomainFactory(mqbi::DomainFactory* value);
-
-    /// Set the authorizer that will be used to authorize sessions and actions
-    /// that can occur in those sessions.
-    SessionNegotiator& setAuthorizer(const AuthorizerSp& authorizer);
 
     // MANIPULATORS
     //   (virtual: mqbnet::Negotiator)
@@ -304,16 +302,6 @@ SessionNegotiator::setDomainFactory(mqbi::DomainFactory* value)
     BSLS_ASSERT(value);
 
     d_domainFactory_p = value;
-    return *this;
-}
-
-inline SessionNegotiator&
-SessionNegotiator::setAuthorizer(const AuthorizerSp& authorizer)
-{
-    // PRECONDITIONS
-    BSLS_ASSERT(authorizer);
-
-    d_authorizer_sp = authorizer;
     return *this;
 }
 


### PR DESCRIPTION
Provide Authorizer via SessionNegotiator constructor instead of via `setAuthorizer` as there is no ordering constraint for this field (unlike clusterCatalog/domainFactor).

Also add precondition checks to SessionNegotiator constructor for all mandatory fields.
