### PR TITLE
Fix[mqba::Application]: failed start() should not crash stop()

### DIFF
--- a/src/groups/mqb/mqba/mqba_application.cpp
+++ b/src/groups/mqb/mqba/mqba_application.cpp
@@ -475,29 +475,8 @@ int Application::start(bsl::ostream& errorDescription)
     return rc_SUCCESS;
 }
 
-void Application::stop()
+void Application::stopTransportAndClusters()
 {
-    BALL_LOG_INFO << bsl::endl
-                  << "========== ============================== =========="
-                  << bsl::endl
-                  << "                      Stopping                      "
-                  << bsl::endl
-                  << "========== ============================== ==========";
-
-    bsls::TimeInterval startTime = bdlt::CurrentTime::now();
-
-#define STOP_OBJ(OBJ, NAME)                                                   \
-    if (OBJ) {                                                                \
-        BALL_LOG_INFO << "Stopping " NAME "...";                              \
-        OBJ->stop();                                                          \
-    }
-
-#define DESTROY_OBJ(OBJ, NAME)                                                \
-    if (OBJ) {                                                                \
-        BALL_LOG_INFO << "Destroying " NAME "...";                            \
-        OBJ.reset();                                                          \
-    }
-
     // Stop listening so that any new connections are refused.
     BALL_LOG_INFO << "Stopping listening for new connections...";
 
@@ -549,6 +528,35 @@ void Application::stop()
     // and destructed, make sure that Dispatcher will not call `flush` for
     // any DispatcherClient that might be in the middle of its destruction.
     d_dispatcher_mp->disableFlushClients();
+}
+
+void Application::stop()
+{
+    BALL_LOG_INFO << bsl::endl
+                  << "========== ============================== =========="
+                  << bsl::endl
+                  << "                      Stopping                      "
+                  << bsl::endl
+                  << "========== ============================== ==========";
+
+    bsls::TimeInterval startTime = bdlt::CurrentTime::now();
+
+#define STOP_OBJ(OBJ, NAME)                                                   \
+    if (OBJ) {                                                                \
+        BALL_LOG_INFO << "Stopping " NAME "...";                              \
+        OBJ->stop();                                                          \
+    }
+
+#define DESTROY_OBJ(OBJ, NAME)                                                \
+    if (OBJ) {                                                                \
+        BALL_LOG_INFO << "Destroying " NAME "...";                            \
+        OBJ.reset();                                                          \
+    }
+
+    // Only if 'start()' got far enough to construct the transport manager.
+    if (d_transportManager_mp) {
+        stopTransportAndClusters();
+    }
 
     // 'Application::initiateShutdown' had closed all client sessions.
     // 'Cluster::initiateShutdown' had drained and closed all cluster nodes

--- a/src/groups/mqb/mqba/mqba_application.h
+++ b/src/groups/mqb/mqba/mqba_application.h
@@ -199,6 +199,12 @@ class Application {
                           const Sessions& brokers,
                           int             version);
 
+    /// Gracefully shut down the transport layer: stop listening, drain and
+    /// close client/proxy/cluster sessions, and stop the admin thread
+    /// pools.  Must only be called if `start()` succeeded far enough to
+    /// construct the transport manager.
+    void stopTransportAndClusters();
+
   private:
     // NOT IMPLEMENTED
     Application(const Application& other) BSLS_CPP11_DELETED;

--- a/src/groups/mqb/mqba/mqba_application.t.cpp
+++ b/src/groups/mqb/mqba/mqba_application.t.cpp
@@ -19,6 +19,9 @@
 #include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 
+// BMQ
+#include <bmqu_memoutstream.h>
+
 // BDE
 #include <bdlmt_eventscheduler.h>
 #include <bsls_systemclocktype.h>
@@ -68,6 +71,54 @@ static void test1_breathingTest()
     scheduler.stop();
 }
 
+static void test2_stopAfterStartFailure()
+// ------------------------------------------------------------------------
+// STOP AFTER START FAILURE
+//
+// Concerns:
+//   If 'start()' fails before the transport manager is constructed (e.g.
+//   a misconfigured authenticator plugin name), 'stop()' must not crash.
+//
+// Plan:
+//   Configure a nonexistent authenticator plugin name so 'start()' fails
+//   at the 'AuthenticationController' stage, before the transport manager
+//   is ever created.  Verify 'start()' fails and 'stop()' succeeds.
+// Testing:
+//   Application::start()/stop() on early startup failure
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("stop after start failure");
+
+    mqbcfg::AppConfig cfg(bmqtst::TestHelperUtil::allocator());
+    cfg.networkInterfaces().tcpInterface().makeValue();
+    cfg.stats().snapshotInterval() = 0;
+
+    mqbcfg::AuthenticatorPluginConfig authenticatorCfg(
+        bmqtst::TestHelperUtil::allocator());
+    authenticatorCfg.name() = "NonexistentAuthenticator";
+    cfg.authentication().authenticators().push_back(authenticatorCfg);
+
+    mqbcfg::BrokerConfig::set(cfg);
+
+    bdlmt::EventScheduler scheduler(bsls::SystemClockType::e_MONOTONIC,
+                                    bmqtst::TestHelperUtil::allocator());
+    scheduler.start();
+
+    {
+        mqba::Application obj(&scheduler,
+                              0,
+                              bmqtst::TestHelperUtil::allocator());
+
+        bmqu::MemOutStream error(bmqtst::TestHelperUtil::allocator());
+        int                rc = obj.start(error);
+        BMQTST_ASSERT_NE(rc, 0);
+
+        obj.stop();  // must not crash
+    }
+
+    scheduler.stop();
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -79,6 +130,7 @@ int main(int argc, char* argv[])
     switch (_testCase) {
     case 0:
     case 1: test1_breathingTest(); break;
+    case 2: test2_stopAfterStartFailure(); break;
     default: {
         cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
         bmqtst::TestHelperUtil::testStatus() = -1;


### PR DESCRIPTION
`stop()` dereferenced `d_transportManager_mp`, `d_clusterCatalog_mp`, and `d_dispatcher_mp` unconditionally, but these are null if `start()` fails early (e.g. a bad plugin name) so the function crashed.

Extract that shutdown code into `stopTransportAndClusters()` and only call it in `stop()` if `d_transportManager_mp` exists.

I came across this while testing bad plugin names; added a new unit test to cover a basic scenario.