### PR TITLE
Fix[mqbauthz::AuthorizationController]: validate authorizer plugin name

### DIFF
--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.cpp
@@ -59,6 +59,7 @@ AuthorizationController::AuthorizationController(
 void AuthorizationController::collectAvailablePluginFactories(
     PluginFactories*              pluginFactories,
     const mqbplug::PluginManager& pluginManager,
+    const PluginLibrary&          builtInPlugins,
     mqbplug::PluginType::Enum     type)
 {
     // PRECONDITIONS
@@ -68,7 +69,6 @@ void AuthorizationController::collectAvailablePluginFactories(
     pluginManager.get(pluginFactories, type);
 
     // Add built-in plugin factories
-    PluginLibrary                                    builtInPlugins;
     bsl::vector<mqbplug::PluginInfo>::const_iterator it =
         builtInPlugins.plugins().cbegin();
     for (; it != builtInPlugins.plugins().cend(); ++it) {
@@ -107,18 +107,31 @@ int AuthorizationController::createConfiguredAuthorizer(
                   << "'";
 
     // Try to create the authorizer for this plugin name
-    bsl::optional<mqbplug::AuthorizerPluginFactory*> factoryOpt =
-        mqbplug::PluginFactoryUtil::findType<mqbplug::AuthorizerPluginFactory>(
-            pluginFactories.cbegin(),
-            pluginFactories.cend());
-    if (!factoryOpt.has_value()) {
+    AuthorizerMp                    authorizer;
+    PluginFactories::const_iterator factoryIt = pluginFactories.cbegin();
+    for (; factoryIt != pluginFactories.cend(); ++factoryIt) {
+        mqbplug::AuthorizerPluginFactory* candidateFactory =
+            dynamic_cast<mqbplug::AuthorizerPluginFactory*>(*factoryIt);
+        if (!candidateFactory) {
+            continue;  // CONTINUE
+        }
+        AuthorizerMp candidate = candidateFactory->create(
+            allocator.mechanism());
+        if (candidate && candidate->name() == pluginName) {
+            authorizer = bslmf::MovableRefUtil::move(candidate);
+            break;  // BREAK
+        }
+    }
+
+    if (!authorizer) {
         errorDescription
             << "authorizer plugin '" << pluginName
             << "' not found. Ensure the plugin is either built-in or listed "
                "in plugins.enabled[], or its configuration is correct.";
         return rc_PLUGIN_NOT_FOUND;  // RETURN
     }
-    *result = (*factoryOpt)->create(allocator.mechanism());
+
+    *result = bslmf::MovableRefUtil::move(authorizer);
 
     return rc_SUCCESS;
 }
@@ -162,10 +175,14 @@ int AuthorizationController::allocateManaged(
 
     BALL_LOG_INFO << "Starting AuthorizationController";
 
-    // Step 1: Collect all available plugin factories (built-in + external)
+    // Step 1: Collect all available plugin factories (built-in + external).
+    // 'builtInPlugins' must outlive 'pluginFactories', which holds raw
+    // pointers into it.
+    PluginLibrary   builtInPlugins;
     PluginFactories pluginFactories;
     collectAvailablePluginFactories(&pluginFactories,
                                     pluginManager,
+                                    builtInPlugins,
                                     mqbplug::PluginType::e_AUTHORIZER);
 
     // Step 2: Create authorizers based on configuration

--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
@@ -54,6 +54,50 @@ TEST(AuthorizationController, breathingTest)
     EXPECT_TRUE(tam.isInUseSame());
 }
 
+TEST(AuthorizationController, configuredWithKnownNameSucceeds)
+{
+    bsl::allocator<> alloc = bmqtst::TestHelperUtil::allocator();
+    bslma::ManagedPtr<mqbauthz::AuthorizationController> controller_mp;
+    mqbplug::PluginManager   pluginManager(alloc.mechanism());
+    mqbcfg::AuthorizerConfig authzConfig;
+    bmqu::MemOutStream       errDesc;
+
+    authzConfig.authorizer().makeValue();
+    authzConfig.authorizer().value().name() = "BasicAuthorizer";
+
+    int rc = mqbauthz::AuthorizationController::allocateManaged(&controller_mp,
+                                                                errDesc,
+                                                                authzConfig,
+                                                                pluginManager,
+                                                                alloc);
+
+    EXPECT_EQ(0, rc);
+    ASSERT_TRUE(controller_mp);
+    EXPECT_EQ("BasicAuthorizer", controller_mp->authorizer().name());
+}
+
+TEST(AuthorizationController, configuredWithUnknownNameFails)
+{
+    bsl::allocator<> alloc = bmqtst::TestHelperUtil::allocator();
+    bslma::ManagedPtr<mqbauthz::AuthorizationController> controller_mp;
+    mqbplug::PluginManager   pluginManager(alloc.mechanism());
+    mqbcfg::AuthorizerConfig authzConfig;
+    bmqu::MemOutStream       errDesc;
+
+    authzConfig.authorizer().makeValue();
+    authzConfig.authorizer().value().name() = "NonexistentAuthorizer";
+
+    int rc = mqbauthz::AuthorizationController::allocateManaged(&controller_mp,
+                                                                errDesc,
+                                                                authzConfig,
+                                                                pluginManager,
+                                                                alloc);
+
+    EXPECT_NE(0, rc);
+    EXPECT_FALSE(controller_mp);
+    EXPECT_FALSE(errDesc.str().isEmpty());
+}
+
 // ========================================================================
 //                                  MAIN
 // ------------------------------------------------------------------------

--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.h
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.h
@@ -51,6 +51,9 @@ class AuthorizerConfig;
 
 namespace mqbauthz {
 
+// FORWARD DECLARATION
+class PluginLibrary;
+
 // =============================
 // class AuthorizationController
 // =============================
@@ -82,15 +85,19 @@ class AuthorizationController {
 
     /// Collect all available plugin factories of the specified `type`
     /// (built-in and external).  Load them into the specified
-    /// `pluginFactories` collection.
+    /// `pluginFactories` collection.  The specified `builtInPlugins` must
+    /// outlive any use of the collected factories.
     static void collectAvailablePluginFactories(
         PluginFactories*              pluginFactories,
         const mqbplug::PluginManager& pluginManager,
+        const PluginLibrary&          builtInPlugins,
         mqbplug::PluginType::Enum     type);
 
     /// Create authorizer based on configuration from the specified
-    /// `authorizerConfig` using the specified `pluginFactories`.
-    /// Return 0 on success, non-zero on error.
+    /// `authorizerConfig` using the specified `pluginFactories`.  A
+    /// candidate is only accepted if its constructed instance's name
+    /// matches the name configured in `authorizerConfig`.  Return 0 on
+    /// success, non-zero on error (including no name match).
     static int createConfiguredAuthorizer(
         AuthorizerMp*                   result,
         bsl::ostream&                   errorDescription,


### PR DESCRIPTION
`createConfiguredAuthorizer()` accepted any registered `AuthorizerPluginFactory` regardless of the configured name, so a typo'd or nonexistent plugin name silently defaulted to whatever factory was found first instead of failing.

Match `AuthenticationController` behavior which matches by `name()` to find the right factory and add tests for known/unknown plugin names.

Also fixes a lifetime issue for `builtInPlugins`.
