### PR TITLE
Fix[mqbnet]: return identity by value with mutex guard

### DIFF
--- a/src/groups/mqb/mqbnet/mqbnet_cluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.h
@@ -157,7 +157,7 @@ class ClusterNode {
     // ACCESSORS
 
     /// Return identity from the last received negotiation message.
-    virtual const bmqp_ctrlmsg::ClientIdentity& identity() const = 0;
+    virtual bmqp_ctrlmsg::ClientIdentity identity() const = 0;
 
     /// Return the id of this node.
     virtual int nodeId() const = 0;

--- a/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_cluster.t.cpp
@@ -88,9 +88,9 @@ struct ClusterNodeTestImp : bsls::ProtocolTestImp<mqbnet::ClusterNode> {
 
     mqbnet::Channel& channel() BSLS_KEYWORD_OVERRIDE { return markDoneRef(); }
 
-    const bmqp_ctrlmsg::ClientIdentity& identity() const BSLS_KEYWORD_OVERRIDE
+    bmqp_ctrlmsg::ClientIdentity identity() const BSLS_KEYWORD_OVERRIDE
     {
-        return markDoneRef();
+        return markDone();
     }
 
     int nodeId() const BSLS_KEYWORD_OVERRIDE { return markDone(); }

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.cpp
@@ -66,6 +66,12 @@ ClusterNodeImp::~ClusterNodeImp()
     // NOTHING: Needed due to inheritance
 }
 
+bmqp_ctrlmsg::ClientIdentity ClusterNodeImp::identity() const
+{
+    bslmt::LockGuard<bslmt::Mutex> guard(&d_identityMutex);
+    return d_identity;
+}
+
 ClusterNode*
 ClusterNodeImp::setChannel(const bsl::weak_ptr<bmqio::Channel>& value,
                            const bmqp_ctrlmsg::ClientIdentity&  identity,
@@ -74,7 +80,10 @@ ClusterNodeImp::setChannel(const bsl::weak_ptr<bmqio::Channel>& value,
     // Save the value
     d_readCb    = readCb;
     d_isReading = false;
-    d_identity  = identity;
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_identityMutex);
+        d_identity = identity;
+    }
 
     d_channel.setChannel(value);
 
@@ -129,7 +138,10 @@ ClusterNode* ClusterNodeImp::resetChannel(
     }
 
     d_isReading = false;
-    d_identity.reset();
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(&d_identityMutex);
+        d_identity.reset();
+    }
     d_readCb = bmqio::Channel::ReadCallback();
 
     // Notify the cluster of changes to this node

--- a/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
+++ b/src/groups/mqb/mqbnet/mqbnet_clusterimp.h
@@ -93,6 +93,8 @@ class ClusterNodeImp : public ClusterNode {
 
     bmqp_ctrlmsg::ClientIdentity d_identity;
 
+    mutable bslmt::Mutex d_identityMutex;
+
     bmqio::Channel::ReadCallback d_readCb;
 
     bsls::AtomicBool d_isReading;
@@ -155,7 +157,7 @@ class ClusterNodeImp : public ClusterNode {
           bmqp::EventType::Enum               type) BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
-    const bmqp_ctrlmsg::ClientIdentity& identity() const BSLS_KEYWORD_OVERRIDE;
+    bmqp_ctrlmsg::ClientIdentity identity() const BSLS_KEYWORD_OVERRIDE;
     // Return identity from the last received negotiation message.
 
     /// Return the id of this node.
@@ -352,11 +354,6 @@ class ClusterImp : public Cluster {
 inline Channel& ClusterNodeImp::channel()
 {
     return d_channel;
-}
-
-inline const bmqp_ctrlmsg::ClientIdentity& ClusterNodeImp::identity() const
-{
-    return d_identity;
 }
 
 inline int ClusterNodeImp::nodeId() const

--- a/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
+++ b/src/groups/mqb/mqbnet/mqbnet_mockcluster.h
@@ -143,7 +143,7 @@ class MockClusterNode : public ClusterNode {
     //   (virtual mqbnet::ClusterNode)
 
     /// Return identity from the last received negotiation message.
-    const bmqp_ctrlmsg::ClientIdentity& identity() const BSLS_KEYWORD_OVERRIDE;
+    bmqp_ctrlmsg::ClientIdentity identity() const BSLS_KEYWORD_OVERRIDE;
 
     /// Return the id of this node.
     int nodeId() const BSLS_KEYWORD_OVERRIDE;
@@ -338,7 +338,7 @@ inline Channel& MockClusterNode::channel()
     return d_channel;
 }
 
-inline const bmqp_ctrlmsg::ClientIdentity& MockClusterNode::identity() const
+inline bmqp_ctrlmsg::ClientIdentity MockClusterNode::identity() const
 {
     return d_identity;
 }


### PR DESCRIPTION
Closes #1652

`identity()` returned a const reference to `d_identity`, but `setChannel()` and `resetChannel()` write that member from the IO thread, so a caller on another thread could read a partially-written object. 

Return by value and guard the three access sites with a `mutable bslmt::Mutex`. The lock is scoped narrowly in `setChannel()` and `resetChannel()` and released before `notifyObserversOfNodeStateChange()` to avoid deadlock through the observer chain.


