### PR TITLE
Refactor[mqbauthz]: rename BasicAuthorizer to DefaultAuthorizer

### DIFF
--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.cpp
@@ -18,7 +18,7 @@
 #include <mqbscm_version.h>
 
 // MQB
-#include <mqbauthz_basicauthorizer.h>
+#include <mqbauthz_defaultauthorizer.h>
 #include <mqbauthz_pluginlibrary.h>
 #include <mqbcfg_messages.h>
 #include <mqbplug_authorizer.h>
@@ -148,13 +148,13 @@ void AuthorizationController::ensureDefaultAuthorizer(
         return;
     }
 
-    // If no authenticators are configured, use BasicAuthorizer for allow-all
+    // If no authenticators are configured, use DefaultAuthorizer for allow-all
     // authorization
     BALL_LOG_INFO << "No authorizer configured, using "
-                     "BasicAuthorizer as default";
+                     "DefaultAuthorizer as default";
 
-    BasicAuthorizerPluginFactory basicAuthzFactory;
-    *result = basicAuthzFactory.create(allocator.mechanism());
+    DefaultAuthorizerPluginFactory defaultAuthzFactory;
+    *result = defaultAuthzFactory.create(allocator.mechanism());
 }
 
 int AuthorizationController::allocateManaged(

--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
@@ -63,7 +63,7 @@ TEST(AuthorizationController, configuredWithKnownNameSucceeds)
     bmqu::MemOutStream       errDesc;
 
     authzConfig.authorizer().makeValue();
-    authzConfig.authorizer().value().name() = "BasicAuthorizer";
+    authzConfig.authorizer().value().name() = "DefaultAuthorizer";
 
     int rc = mqbauthz::AuthorizationController::allocateManaged(&controller_mp,
                                                                 errDesc,
@@ -73,7 +73,7 @@ TEST(AuthorizationController, configuredWithKnownNameSucceeds)
 
     EXPECT_EQ(0, rc);
     ASSERT_TRUE(controller_mp);
-    EXPECT_EQ("BasicAuthorizer", controller_mp->authorizer().name());
+    EXPECT_EQ("DefaultAuthorizer", controller_mp->authorizer().name());
 }
 
 TEST(AuthorizationController, configuredWithUnknownNameFails)

--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.h
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.h
@@ -106,7 +106,7 @@ class AuthorizationController {
         bsl::allocator<>                allocator);
 
     /// Ensure at least one authorizer is available for default
-    /// Authorization, adding default BasicAuthorizer if none are
+    /// Authorization, adding default DefaultAuthorizer if none are
     /// configured.
     static void ensureDefaultAuthorizer(AuthorizerMp*    result,
                                         bsl::allocator<> allocator);

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mqbauthz_basicauthorizer.h>
+#include <mqbauthz_defaultauthorizer.h>
 
 #include <mqbscm_version.h>
 
@@ -31,23 +31,23 @@
 namespace BloombergLP {
 namespace mqbauthz {
 
-bsl::string_view BasicAuthorizer::k_NAME = "BasicAuthorizer";
+bsl::string_view DefaultAuthorizer::k_NAME = "DefaultAuthorizer";
 
-// -------------------------------------
-// class BasicAuthorizerPluginFactory
-// -------------------------------------
+// -----------------------
+// class DefaultAuthorizer
+// -----------------------
 
-BasicAuthorizer::~BasicAuthorizer()
+DefaultAuthorizer::~DefaultAuthorizer()
 {
     // NOTHING
 }
 
-bsl::string_view BasicAuthorizer::name() const
+bsl::string_view DefaultAuthorizer::name() const
 {
     return k_NAME;
 }
 
-bool BasicAuthorizer::authorize(
+bool DefaultAuthorizer::authorize(
     const mqbact::Action&   action,
     BSLA_MAYBE_UNUSED const mqbplug::AuthenticationResult& authnResult)
 
@@ -56,22 +56,22 @@ bool BasicAuthorizer::authorize(
     return true;
 }
 
-// -------------------------------------
-// class BasicAuthorizerPluginFactory
-// -------------------------------------
+// ------------------------------------
+// class DefaultAuthorizerPluginFactory
+// ------------------------------------
 
-BasicAuthorizerPluginFactory::~BasicAuthorizerPluginFactory()
+DefaultAuthorizerPluginFactory::~DefaultAuthorizerPluginFactory()
 {
     // NOTHING
 }
 
 bslma::ManagedPtr<mqbplug::Authorizer>
-BasicAuthorizerPluginFactory::create(bslma::Allocator* allocator)
+DefaultAuthorizerPluginFactory::create(bslma::Allocator* allocator)
 {
-    bslma::ManagedPtr<BasicAuthorizer> basicAuthorizer =
-        bslma::ManagedPtrUtil::allocateManaged<BasicAuthorizer>(allocator);
+    bslma::ManagedPtr<DefaultAuthorizer> defaultAuthorizer =
+        bslma::ManagedPtrUtil::allocateManaged<DefaultAuthorizer>(allocator);
     bslma::ManagedPtr<mqbplug::Authorizer> authorizer(
-        bslmf::MovableRefUtil::move(basicAuthorizer));
+        bslmf::MovableRefUtil::move(defaultAuthorizer));
     return authorizer;
 }
 

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.g.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.g.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mqbauthz_basicauthorizer.h>
+#include <mqbauthz_defaultauthorizer.h>
 
 // MQB
 #include <mqbact_actions.h>
@@ -58,32 +58,32 @@ const bsl::optional<bsls::Types::Uint64>
 
 }
 
-class BasicAuthorizerTest : public ::testing::Test {
+class DefaultAuthorizerTest : public ::testing::Test {
   private:
-    mqbauthz::BasicAuthorizer d_authorizer;
+    mqbauthz::DefaultAuthorizer d_authorizer;
 
   protected:
-    BasicAuthorizerTest()
+    DefaultAuthorizerTest()
     : d_authorizer()
     {
     }
 
-    ~BasicAuthorizerTest() BSLS_KEYWORD_OVERRIDE;
+    ~DefaultAuthorizerTest() BSLS_KEYWORD_OVERRIDE;
 
-    mqbauthz::BasicAuthorizer& authorizer() { return d_authorizer; }
+    mqbauthz::DefaultAuthorizer& authorizer() { return d_authorizer; }
 };
 
-BasicAuthorizerTest::~BasicAuthorizerTest()
+DefaultAuthorizerTest::~DefaultAuthorizerTest()
 {
 }
 
-TEST_F(BasicAuthorizerTest, breathingTest)
+TEST_F(DefaultAuthorizerTest, breathingTest)
 {
     bsl::string name(authorizer().name());
-    EXPECT_STREQ("BasicAuthorizer", name.c_str());
+    EXPECT_STREQ("DefaultAuthorizer", name.c_str());
 }
 
-TEST_F(BasicAuthorizerTest, allActionsAreAllowed)
+TEST_F(DefaultAuthorizerTest, allActionsAreAllowed)
 {
     bslma::Allocator*        alloc = bmqtst::TestHelperUtil::allocator();
     TestAuthenticationResult authnResult;
@@ -132,10 +132,10 @@ TEST_F(BasicAuthorizerTest, allActionsAreAllowed)
     }
 }
 
-TEST(BasicAuthorizerFactory, factoryBreathingTest)
+TEST(DefaultAuthorizerFactory, factoryBreathingTest)
 {
-    mqbauthz::BasicAuthorizerPluginFactory factory;
-    bslma::ManagedPtr<mqbplug::Authorizer> authorizer = factory.create(
+    mqbauthz::DefaultAuthorizerPluginFactory factory;
+    bslma::ManagedPtr<mqbplug::Authorizer>   authorizer = factory.create(
         bmqtst::TestHelperUtil::allocator());
 }
 

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.h
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.h
@@ -13,20 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef INCLUDED_MQBAUTHN_BASICAUTHORIZER
-#define INCLUDED_MQBAUTHN_BASICAUTHORIZER
+#ifndef INCLUDED_MQBAUTHZ_DEFAULTAUTHORIZER
+#define INCLUDED_MQBAUTHZ_DEFAULTAUTHORIZER
 
-/// @file mqbauthn_basicauthorizer.h
+/// @file mqbauthz_defaultauthorizer.h
 ///
-/// @brief Provide a basic authorizer plugin that uses username and
-/// password.
+/// @brief Provide the built-in default authorizer plugin.
 ///
-/// @bbref{mqbauthn::BasicAuthorizer} provides a built-in authorizer
-/// plugin that authorizes all actions. It's designed to represent the current
-/// authorization policy, which allows all clients access.
+/// @bbref{mqbauthz::DefaultAuthorizer} provides the built-in default
+/// authorizer plugin that authorizes all actions. It's designed to
+/// represent the current authorization policy, which allows all access.
 ///
-/// @bbref{mqbauthn::BasicAuthorizerPluginFactory} is the corresponding factory
-/// classes for the Authorizer plugin.
+/// @bbref{mqbauthz::DefaultAuthorizerPluginFactory} is the corresponding
+/// factory class for the Authorizer plugin.
 
 // MQB
 #include <mqbplug_authenticator.h>
@@ -48,24 +47,24 @@ class Action;
 
 namespace mqbauthz {
 
-// ========================
-// class BasicAuthorizer
-// ========================
+// =======================
+// class DefaultAuthorizer
+// =======================
 
-class BasicAuthorizer : public mqbplug::Authorizer {
+class DefaultAuthorizer : public mqbplug::Authorizer {
   public:
     // CLASS DATA
     static bsl::string_view k_NAME;
 
   private:
     // CLASS-SCOPE CATEGORY
-    BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHN.BASICAUTHORIZER");
+    BALL_LOG_SET_CLASS_CATEGORY("MQBAUTHZ.DEFAULTAUTHORIZER");
 
   public:
     // CREATORS
 
     /// Destructor.
-    ~BasicAuthorizer() BSLS_KEYWORD_OVERRIDE;
+    ~DefaultAuthorizer() BSLS_KEYWORD_OVERRIDE;
 
     // ACCESSORS
 
@@ -83,18 +82,19 @@ class BasicAuthorizer : public mqbplug::Authorizer {
         BSLS_KEYWORD_OVERRIDE;
 };
 
-// =====================================
-// class BasicAuthorizerPluginFactory
-// =====================================
+// ====================================
+// class DefaultAuthorizerPluginFactory
+// ====================================
 
-class BasicAuthorizerPluginFactory : public mqbplug::AuthorizerPluginFactory {
+class DefaultAuthorizerPluginFactory
+: public mqbplug::AuthorizerPluginFactory {
   public:
     // CREATORS
-    ~BasicAuthorizerPluginFactory() BSLS_KEYWORD_OVERRIDE;
+    ~DefaultAuthorizerPluginFactory() BSLS_KEYWORD_OVERRIDE;
 
     // MANIPULATORS
 
-    /// Create a `BasicAuthorizer` using the supplied allocator.
+    /// Create a `DefaultAuthorizer` using the supplied allocator.
     bslma::ManagedPtr<mqbplug::Authorizer>
     create(bslma::Allocator* allocator) BSLS_KEYWORD_OVERRIDE;
 };

--- a/src/groups/mqb/mqbauthz/mqbauthz_pluginlibrary.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_pluginlibrary.cpp
@@ -18,7 +18,7 @@
 #include <mqbscm_version.h>
 
 // MQB
-#include <mqbauthz_basicauthorizer.h>
+#include <mqbauthz_defaultauthorizer.h>
 
 namespace BloombergLP {
 namespace mqbauthz {
@@ -30,13 +30,13 @@ namespace mqbauthz {
 PluginLibrary::PluginLibrary(const allocator_type& allocator)
 : d_plugins(allocator)
 {
-    // BasicAuthorizer
-    mqbplug::PluginInfo& basicPluginInfo = d_plugins.emplace_back(
+    // DefaultAuthorizer
+    mqbplug::PluginInfo& defaultPluginInfo = d_plugins.emplace_back(
         mqbplug::PluginType::e_AUTHORIZER,
-        mqbauthz::BasicAuthorizer::k_NAME);
-    basicPluginInfo.setFactory(
-        bsl::allocate_shared<BasicAuthorizerPluginFactory>(allocator));
-    basicPluginInfo.setDescription("Built-in Basic Allow-All Authorizer");
+        mqbauthz::DefaultAuthorizer::k_NAME);
+    defaultPluginInfo.setFactory(
+        bsl::allocate_shared<DefaultAuthorizerPluginFactory>(allocator));
+    defaultPluginInfo.setDescription("Built-in Default Allow-All Authorizer");
 }
 
 PluginLibrary::~PluginLibrary()

--- a/src/groups/mqb/mqbauthz/package/mqbauthz.mem
+++ b/src/groups/mqb/mqbauthz/package/mqbauthz.mem
@@ -1,3 +1,3 @@
 mqbauthz_authorizationcontroller
-mqbauthz_basicauthorizer
+mqbauthz_defaultauthorizer
 mqbauthz_pluginlibrary


### PR DESCRIPTION
Mechanical rename of this component. The new name better states the purpose of the authorizer in the system and reduces confusion with its relation to `BasicAuthenticator`.

Also fixes a `MQBAUTHN.*` log category typo, should be `MQBAUTHZ.*`.
