### PR TITLE
Fix: Resolve conversion warnings in mqbs iterators and mqbu load balancer

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_datafileiterator.cpp
+++ b/src/groups/mqb/mqbs/mqbs_datafileiterator.cpp
@@ -196,7 +196,7 @@ int DataFileIterator::nextRecord()
             // We don't have footers for our records and since they are
             // variable-sized, we can't navigate backwards safely, so we have
             // to navigate from the first record.
-            unsigned int position = firstRecordPosition();
+            bsls::Types::Uint64 position = firstRecordPosition();
             while (position < d_blockIter.position()) {
                 OffsetPtr<const DataHeader> header(*d_blockIter.block(),
                                                    position);
@@ -217,7 +217,7 @@ void DataFileIterator::flipDirection()
 {
     d_blockIter.flipDirection();
 
-    unsigned int firstRecordPos = firstRecordPosition();
+    bsls::Types::Uint64 firstRecordPos = firstRecordPosition();
     if (d_blockIter.position() < firstRecordPos) {
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbs/mqbs_qlistfileiterator.cpp
+++ b/src/groups/mqb/mqbs/mqbs_qlistfileiterator.cpp
@@ -211,8 +211,7 @@ int QlistFileIterator::nextRecord()
             // that this iterator remains valid, as well as
             // `hasRecordSizeRemaining` works correctly in reverse
             // iteration mode.
-            bsls::Types::Uint64 recSize =
-                bsl::numeric_limits<unsigned int>::max();
+            unsigned int recSize = bsl::numeric_limits<unsigned int>::max();
 
             while (position < d_blockIter.position()) {
                 OffsetPtr<const QueueRecordHeader> header(*d_blockIter.block(),
@@ -246,7 +245,7 @@ void QlistFileIterator::flipDirection()
 {
     d_blockIter.flipDirection();
 
-    unsigned int firstRecordPos = firstRecordPosition();
+    bsls::Types::Uint64 firstRecordPos = firstRecordPosition();
     if (d_blockIter.position() < firstRecordPos) {
         return;  // RETURN
     }

--- a/src/groups/mqb/mqbu/mqbu_loadbalancer.h
+++ b/src/groups/mqb/mqbu/mqbu_loadbalancer.h
@@ -63,6 +63,7 @@
 
 // BDE
 #include <bsl_algorithm.h>
+#include <bsl_limits.h>
 #include <bsl_unordered_map.h>
 #include <bsl_vector.h>
 #include <bslma_allocator.h>
@@ -176,10 +177,13 @@ int LoadBalancer<TYPE>::findSmallestCounterLocked() const
 {
     // PRECONDITIONS
     BSLMT_MUTEXASSERT_IS_LOCKED_SAFE(&d_mutex);  // d_mutex was LOCKED
+    BSLS_ASSERT_SAFE(d_counters.size() <=
+                     static_cast<bsl::vector<int>::size_type>(
+                         bsl::numeric_limits<int>::max()));
 
-    return bsl::distance(d_counters.begin(),
-                         bsl::min_element(d_counters.begin(),
-                                          d_counters.end()));
+    return static_cast<int>(
+        bsl::distance(d_counters.begin(),
+                      bsl::min_element(d_counters.begin(), d_counters.end())));
 }
 
 template <class TYPE>
@@ -251,14 +255,20 @@ void LoadBalancer<TYPE>::removeClient(const TYPE* client)
 template <class TYPE>
 int LoadBalancer<TYPE>::processorsCount() const
 {
-    return d_counters.size();
+    BSLS_ASSERT_SAFE(d_counters.size() <=
+                     static_cast<bsl::vector<int>::size_type>(
+                         bsl::numeric_limits<int>::max()));
+    return static_cast<int>(d_counters.size());
 }
 
 template <class TYPE>
 int LoadBalancer<TYPE>::clientsCount() const
 {
     bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // d_mutex LOCKED
-    return d_clients.size();
+    BSLS_ASSERT_SAFE(d_clients.size() <=
+                     static_cast<typename ClientMap::size_type>(
+                         bsl::numeric_limits<int>::max()));
+    return static_cast<int>(d_clients.size());
 }
 
 template <class TYPE>


### PR DESCRIPTION
Refs #87.

## Summary

- keep data-file and qlist iterator positions as `bsls::Types::Uint64`
- use the existing unsigned record-size representation in the qlist iterator
- check `LoadBalancer` container sizes before converting them to its existing `int` return type

This removes seven `-Wconversion` warnings without changing the public API or broadening the scope to unrelated warnings.

## Testing

- built `mqbs_datafileiterator.t`, `mqbs_qlistfileiterator.t`, and `mqbu_loadbalancer.t` with GCC 13.3, C++23, and SAFE assertions
- ran the three targeted CTest cases: 3 passed
- ran `git clang-format --diff HEAD` on the changed files
- ran `git diff --check`

The targeted build still reports existing conversion warnings in unrelated components and the iterator test drivers; those are intentionally outside this PR.
