### PR TITLE
Fix[bmqp::RequestManager]: unsafe read without mutex

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
@@ -33,6 +33,7 @@
 #include <bdlf_placeholder.h>
 #include <bdlmt_eventscheduler.h>
 #include <bsl_utility.h>
+#include <bsl_vector.h>
 #include <bsla_annotations.h>
 #include <bslma_managedptr.h>
 #include <bslmt_lockguard.h>
@@ -469,15 +470,19 @@ void RequestManager::cancelAllRequestsImpl(
     int                                 groupId,
     int                                 componentId)
 {
-    // Note that requests must be cancelled in the same order in which they
-    // were sent.
+    typedef bsl::vector<RequestSp> RequestVec;
 
-    // Create a new map so we can work on it outside the mutex
-    RequestMap requestsCopy(d_requests.bucket_count(),
-                            d_requests.get_allocator());
+    // Note that requests must be cancelled in the same order in which they
+    // were sent.  Since 'd_requests' is traversed in insertion order, simply
+    // appending to a sequence container preserves that order.
+
+    // Collect the requests to cancel so we can work on them outside the mutex
+    RequestVec requestsCopy(d_allocator_p);
 
     {
         bslmt::LockGuard<bslmt::Mutex> guard(&d_mutex);  // MUTEX LOCKED
+
+        requestsCopy.reserve(d_requests.size());
 
         RequestMapIter it = d_requests.begin();
         while (it != d_requests.end()) {
@@ -491,10 +496,7 @@ void RequestManager::cancelAllRequestsImpl(
             if (matchGroup && matchComponent) {
                 // Do not notify about timed out requests.
                 if (!it->second->d_haveTimeout) {
-                    BSLA_MAYBE_UNUSED bsl::pair<RequestMapIter, bool>
-                                      insertRC = requestsCopy.insert(
-                            bsl::make_pair(it->first, it->second));
-                    BSLS_ASSERT_SAFE(insertRC.second);
+                    requestsCopy.push_back(it->second);
                 }
                 d_requests.erase(it++);
             }
@@ -532,10 +534,10 @@ void RequestManager::cancelAllRequestsImpl(
         return;  // RETURN
     }
 
-    for (RequestMapConstIter it = requestsCopy.begin();
+    for (RequestVec::const_iterator it = requestsCopy.begin();
          it != requestsCopy.end();
          ++it) {
-        applyResponse(it->second, reason);
+        applyResponse(*it, reason);
     }
 }
 

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
@@ -118,11 +118,8 @@ void RequestManager::onRequestTimeout(int requestId)
     response.choice().status().code() = k_CODE_TIMEOUT_LOCAL;
     response.choice().status().message().assign(os.str().data(),
                                                 os.str().length());
-    reinterpret_cast<int&>(response.choice().status().category()) =
-        static_cast<int>(bmqt::GenericResult::e_TIMEOUT);
-    // Note that above reinterpret & static casts are needed to suppress
-    // compiler diagnostics, because this component does not include
-    // bmqp_ctrlmsg_messages.h on purpose.
+    response.choice().status().category() =
+        bmqp_ctrlmsg::StatusCategory::E_TIMEOUT;
 
     // The lateResponseMode assumes that 'onRequestTimeout' is serialized with
     // 'processResponse' and 'cancelAllRequests' (by using 'd_executor').

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -421,8 +421,6 @@ class RequestManager {
 
     typedef RequestMap::iterator RequestMapIter;
 
-    typedef RequestMap::const_iterator RequestMapConstIter;
-
     // DATA
     bslma::Allocator* d_allocator_p;
     // Allocator to use.

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.t.cpp
@@ -38,6 +38,7 @@
 #include <bsl_vector.h>
 #include <bslmt_barrier.h>
 #include <bslmt_threadgroup.h>
+#include <bsls_assert.h>
 #include <bsls_atomic.h>
 
 // TEST DRIVER
@@ -58,6 +59,7 @@ using namespace bsl;
 // - sendRequestTest
 // - processResponseTest
 // - cancelAllRequestsTest (by groupId and by componentId)
+// - cancelRequestsOrderTest
 //-----------------------------------------------------------------------------
 // ============================================================================
 //                            TEST HELPERS UTILITY
@@ -372,6 +374,44 @@ struct Caller {
     {
         *called = true;
         BMQTST_ASSERT_EQ(request->request(), (*expected)->request());
+    }
+};
+
+/// @brief Response callback recording the identifier of every request it is
+/// invoked for, in invocation order.
+///
+/// Note that this functor is declared at namespace scope because a local
+/// class may not be used as a template argument in C++03.
+class OrderRecorder {
+  private:
+    // DATA
+
+    /// Sequence of recorded identifiers, held not owned.
+    bsl::vector<int>* d_order_p;
+
+  public:
+    // CREATORS
+
+    /// @brief Create an object appending to the specified `order`.
+    ///
+    /// @param order The sequence to append recorded identifiers to.  Must
+    ///              remain valid for the lifetime of this object.
+    explicit OrderRecorder(bsl::vector<int>* order)
+    : d_order_p(order)
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_SAFE(d_order_p);
+    }
+
+    // ACCESSORS
+
+    /// @brief Append the identifier of the specified `request` to the
+    /// recorded sequence.
+    ///
+    /// @param request The request whose response callback is being invoked.
+    void operator()(const ReqSp& request) const
+    {
+        d_order_p->push_back(request->request().rId().value());
     }
 };
 
@@ -1131,6 +1171,111 @@ static void test8_requestSignalWaitTest()
     }
 }
 
+static void test9_cancelRequestsOrderTest()
+// ------------------------------------------------------------------------
+// Testing:
+//   Response callbacks of cancelled requests are invoked in the order in
+//   which the requests were sent, for each of the three cancellation
+//   flavors.  For the filtered flavors, the relative order of the matching
+//   requests is preserved.
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("CANCEL REQUESTS ORDER TEST");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    const bsl::size_t k_NUM_REQUESTS = 10;
+
+    // Note that in each scenario below 'order' is declared before the
+    // 'TestContext' on purpose: the context cancels every request still
+    // outstanding upon destruction, which invokes the recording callback
+    // once more, after the expectations have been checked.
+
+    {
+        // Cancel all requests
+        bsl::vector<int> order(alloc);
+        bsl::vector<int> expected(alloc);
+        TestContext      context(false, alloc);
+
+        for (bsl::size_t i = 0; i < k_NUM_REQUESTS; ++i) {
+            ReqSp request = context.createRequest();
+            context.populateRequest(request);
+            request->setResponseCb(OrderRecorder(&order));
+            context.sendChannelRequest(request);
+            expected.push_back(request->request().rId().value());
+        }
+
+        Mes reason = context.createResponseCancel();
+        context.manager().cancelAllRequests(reason);
+
+        BMQTST_ASSERT_EQ(order, expected);
+    }
+
+    {
+        // Cancel a group of requests: the cancelled subset keeps its
+        // relative order, and the requests of the other group are left
+        // untouched.
+        const int k_GROUP_CANCELED = 1;
+        const int k_GROUP_KEPT     = 2;
+
+        bsl::vector<int> order(alloc);
+        bsl::vector<int> expected(alloc);
+        TestContext      context(false, alloc);
+
+        for (bsl::size_t i = 0; i < k_NUM_REQUESTS; ++i) {
+            const int groupId = (i % 2 == 0) ? k_GROUP_CANCELED : k_GROUP_KEPT;
+
+            ReqSp request = context.createRequest();
+            context.populateRequest(request);
+            request->setGroupId(groupId);
+            request->setResponseCb(OrderRecorder(&order));
+            context.sendChannelRequest(request);
+            if (groupId == k_GROUP_CANCELED) {
+                expected.push_back(request->request().rId().value());
+            }
+        }
+
+        Mes reason = context.createResponseCancel();
+        context.manager().cancelGroupRequests(reason, k_GROUP_CANCELED);
+
+        BMQTST_ASSERT_EQ(order, expected);
+    }
+
+    {
+        // Cancel the requests of a component: the cancelled subset keeps
+        // its relative order, and the requests of the other component are
+        // left untouched.
+        const int k_COMPONENT_CANCELED =
+            bmqp::RequestManagerComponentId::k_CLUSTER_FSM;
+        const int k_COMPONENT_KEPT =
+            bmqp::RequestManagerComponentId::partitionFSM(0);
+
+        bsl::vector<int> order(alloc);
+        bsl::vector<int> expected(alloc);
+        TestContext      context(false, alloc);
+
+        for (bsl::size_t i = 0; i < k_NUM_REQUESTS; ++i) {
+            const int componentId = (i % 2 == 0) ? k_COMPONENT_CANCELED
+                                                 : k_COMPONENT_KEPT;
+
+            ReqSp request = context.createRequest();
+            context.populateRequest(request);
+            request->setComponentId(componentId);
+            request->setResponseCb(OrderRecorder(&order));
+            context.sendChannelRequest(request);
+            if (componentId == k_COMPONENT_CANCELED) {
+                expected.push_back(request->request().rId().value());
+            }
+        }
+
+        Mes reason = context.createResponseCancel();
+        context.manager().cancelComponentRequests(reason,
+                                                  k_COMPONENT_CANCELED);
+
+        BMQTST_ASSERT_EQ(order, expected);
+    }
+}
+
 // ============================================================================
 //                                MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -1143,6 +1288,7 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
+    case 9: test9_cancelRequestsOrderTest(); break;
     case 8: test8_requestSignalWaitTest(); break;
     case 7: test7_requestBreathingTest(); break;
     case 6: test6_cancelAllRequestsTest(); break;


### PR DESCRIPTION
- Remove `reinterpret_cast`
- Add a UT to verify request cancellation order
- Fix unsafe field access without mutex
- Use `vector`, not the `map`, to iterate through the requests that has to be cancelled