### PR TITLE
Fix[bmqp::RequestManager]: handle unset `rId` in response

### DIFF
--- a/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.cpp
@@ -404,6 +404,14 @@ int RequestManager::processResponse(
         rc_NOT_FOUND = -1
     };
 
+    if (response.rId().isNull()) {
+        // The response carries no correlator, so it cannot be matched to an
+        // outstanding request.
+        BALL_LOG_DEBUG << "Received a response without a request id"
+                       << ", dropping it";
+        return rc_NOT_FOUND;  // RETURN
+    }
+
     RequestSp request;
 
     {

--- a/src/groups/bmq/bmqp/bmqp_requestmanager.h
+++ b/src/groups/bmq/bmqp/bmqp_requestmanager.h
@@ -580,9 +580,13 @@ class RequestManager {
                                           const bsls::TimeInterval& timeout,
                                           bsl::string* errorDescription = 0);
 
-    /// Process the specified `response` and return 0 if the response is for
-    /// a valid request, or non-zero otherwise (for example if the request
-    /// has been removed due to timeout).
+    /// @brief Process the specified `response`.
+    ///
+    /// @param response The response to correlate to an outstanding request.
+    ///
+    /// @return 0 if the response is for a valid request, or a non-zero value
+    ///         otherwise; for example if the response carries no request
+    ///         identifier, or if the request has been removed due to timeout.
     int processResponse(const bmqp_ctrlmsg::ControlMessage& response);
 
     /// Cancel all outstanding requests with the specified `reason` response


### PR DESCRIPTION
Check for `rId` being not null before trying to perform lookup
`d_requests.find(response.rId().value());`.