### PR TITLE
Fix[mqbc]: perform queue storage lookup from purge thread

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storageutil.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.cpp
@@ -3496,6 +3496,52 @@ void StorageUtil::purgeQueueDispatched(
     queueDetails.numBytesPurged()    = numBytes;
 }
 
+void StorageUtil::purgeQueueByUriDispatched(
+    mqbcmd::PurgeQueueResult* purgedQueueResult,
+    bslmt::Semaphore*         purgeFinishedSemaphore,
+    StorageSpMap*             storageMap,
+    bslmt::Mutex*             storagesLock,
+    const mqbs::FileStore*    fileStore,
+    const bmqt::Uri&          uri,
+    const bsl::string&        appId)
+{
+    // executed by *QUEUE_DISPATCHER* thread with the specified 'fileStore'
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(fileStore && fileStore->inDispatcherThread());
+    BSLS_ASSERT_SAFE(purgedQueueResult);
+    BSLS_ASSERT_SAFE(storageMap);
+    BSLS_ASSERT_SAFE(storagesLock);
+
+    // Storages are registered and unregistered from this very thread, hence
+    // the storage found here cannot go away until this routine returns.
+
+    StorageSp storage;
+    {
+        bslmt::LockGuard<bslmt::Mutex> guard(storagesLock);  // LOCK
+
+        StorageSpMapIter it = storageMap->find(uri);
+        if (it != storageMap->end()) {
+            storage = it->second;
+        }
+    }
+
+    if (!storage) {
+        bmqu::MemOutStream errorMsg;
+        errorMsg << "Queue was not found in a storage '" << uri << "'";
+        purgedQueueResult->makeError().message() = errorMsg.str();
+
+        optionalSemaphorePost(purgeFinishedSemaphore);
+        return;  // RETURN
+    }
+
+    purgeQueueDispatched(purgedQueueResult,
+                         purgeFinishedSemaphore,
+                         storage.get(),
+                         fileStore,
+                         appId);
+}
+
 void StorageUtil::processCommand(
     mqbcmd::StorageResult*                       result,
     FileStores*                                  fileStores,
@@ -3633,18 +3679,21 @@ void StorageUtil::processCommand(
 
         BSLS_ASSERT_SAFE(uri.isCanonical());
 
-        mqbi::Storage* queueStorage = NULL;
+        // Only resolve the partition owning the queue here: a storage is
+        // destroyed by the dispatcher thread of its partition, so no storage
+        // must outlive the lock in this thread.  The lookup is repeated by
+        // 'purgeQueueByUriDispatched' from that dispatcher thread.
+        int partitionId = mqbi::Storage::k_INVALID_PARTITION_ID;
         for (size_t i = 0; i < storageMapVec->size(); ++i) {
             bslmt::LockGuard<bslmt::Mutex> guard(
                 (*storageLockVec)[i].get());  // LOCK
-            StorageSpMap::iterator storageIter = (*storageMapVec)[i].find(uri);
-            if (storageIter != (*storageMapVec)[i].end()) {
-                queueStorage = storageIter->second.get();
+            if ((*storageMapVec)[i].find(uri) != (*storageMapVec)[i].end()) {
+                partitionId = static_cast<int>(i);
                 break;  // BREAK
             }
         }
 
-        if (!queueStorage) {
+        if (mqbi::Storage::k_INVALID_PARTITION_ID == partitionId) {
             bdlma::LocalSequentialAllocator<256> localAllocator(allocator);
             bmqu::MemOutStream                   os(&localAllocator);
             os << "Queue was not found in a storage '" << uri << "'";
@@ -3658,17 +3707,19 @@ void StorageUtil::processCommand(
         const bsl::string& purgeAppId = command.queue().command().purgeAppId();
         bsl::string        appId      = (purgeAppId == "*") ? "" : purgeAppId;
 
-        const int    partitionId = queueStorage->partitionId();
-        FileStoreSp& fileStore   = (*fileStores)[partitionId];
+        FileStoreSp& fileStore = (*fileStores)[partitionId];
 
         mqbcmd::PurgeQueueResult purgedQueueResult;
         bslmt::Semaphore         purgeFinishedSemaphore;
-        fileStore->execute(bdlf::BindUtil::bind(&purgeQueueDispatched,
-                                                &purgedQueueResult,
-                                                &purgeFinishedSemaphore,
-                                                queueStorage,
-                                                fileStore.get(),
-                                                appId));
+        fileStore->execute(
+            bdlf::BindUtil::bind(&purgeQueueByUriDispatched,
+                                 &purgedQueueResult,
+                                 &purgeFinishedSemaphore,
+                                 &(*storageMapVec)[partitionId],
+                                 (*storageLockVec)[partitionId].get(),
+                                 fileStore.get(),
+                                 uri,
+                                 appId));
 
         purgeFinishedSemaphore.wait();
 

--- a/src/groups/mqb/mqbc/mqbc_storageutil.h
+++ b/src/groups/mqb/mqbc/mqbc_storageutil.h
@@ -382,6 +382,37 @@ struct StorageUtil {
     /// THREAD: Executed by the Queue's dispatcher thread for the specified
     ///         `fileStore`.
 
+    /// @brief Purge the queue with the specified `uri`, if it is registered.
+    ///
+    /// Look the queue up in the specified `storageMap` and purge it.  Load an
+    /// error into `purgedQueueResult` if the queue is not registered.  The
+    /// lookup is performed from the same thread which registers and
+    /// unregisters storages, so that the storage cannot be destroyed while it
+    /// is being purged.
+    ///
+    /// @param[out] purgedQueueResult The result of the operation.
+    /// @param purgeFinishedSemaphore Optional semaphore to notify the calling
+    ///                               thread that this operation has finished.
+    /// @param storageMap The storages of the partition owning the queue.
+    /// @param storagesLock The mutex controlling access to `storageMap`.
+    /// @param fileStore The FileStore of the partition owning the queue, used
+    ///                  to verify correctness and thread-safety of calling
+    ///                  this method.
+    /// @param uri The canonical URI of the queue to purge.
+    /// @param appId The appId to purge, or an empty string for the entire
+    ///              queue.
+    ///
+    /// THREAD: Executed by the Queue's dispatcher thread for the specified
+    ///         `fileStore`.
+    static void
+    purgeQueueByUriDispatched(mqbcmd::PurgeQueueResult* purgedQueueResult,
+                              bslmt::Semaphore*         purgeFinishedSemaphore,
+                              StorageSpMap*             storageMap,
+                              bslmt::Mutex*             storagesLock,
+                              const mqbs::FileStore*    fileStore,
+                              const bmqt::Uri&          uri,
+                              const bsl::string&        appId);
+
     /// Execute the specified `job` for each partition in the specified
     /// `fileStores`.  Each partition will receive its partitionId and a
     /// latch along with the `job`.  Each partition *must* call

--- a/src/integration-tests/test_admin_client.py
+++ b/src/integration-tests/test_admin_client.py
@@ -20,8 +20,10 @@ commands.
 
 import dataclasses
 import json
+import re
+import threading
 import time
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
@@ -615,6 +617,119 @@ def test_purge_breathing(single_node: Cluster, domain_urls: tc.DomainUrls) -> No
         assert "Purged 0 message(s)" in res
 
     # Stop the admin session
+    admin.stop()
+
+
+def test_purge_and_queue_operations_safety(
+    single_node: Cluster, domain_urls: tc.DomainUrls
+) -> None:
+    """
+    Test: purge a queue concurrently with queue operations on the very same
+    queue.
+
+    Preconditions:
+    - Establish several admin sessions with the cluster: one to drive the
+      queue garbage collection, the others to purge.
+
+    Stage 1, repeat N times:
+    - Open and immediately close a queue, so it is left empty and without
+      handles, which makes it eligible for garbage collection.
+    - Force queue garbage collection, so the queue gets unassigned and its
+      storage unregistered.
+    - Meanwhile, several admin sessions keep purging that very queue, so a
+      purge is always in flight while the queue is created and GCed.
+
+    Stage 2:
+    - Verify that the broker is still alive and that the storage of the queue
+      is functional, by posting messages and purging them.
+
+    Concerns:
+    - Purging a queue and registering/unregistering it are carried out by
+      different threads.  The broker stays healthy under any interleaving of
+      the two.
+    - A purge always yields a well-formed response, whether the queue is
+      registered at the time the purge is executed.
+    """
+    cluster: Cluster = single_node
+    du = domain_urls
+
+    num_purgers = 4
+    num_rounds = 1000
+
+    queue_name = "test_queue_purge_safety"
+    uri = f"bmq://{du.domain_priority}/{queue_name}"
+    purge_command = f"DOMAINS DOMAIN {du.domain_priority} QUEUE {queue_name} PURGE *"
+    gc_command = f"CLUSTERS CLUSTER {cluster.name} FORCE_GC_QUEUES"
+
+    # A purge either reports what it removed, or tells that the queue is not
+    # registered in the storage.  Anything else means the broker mishandled
+    # the command.
+    purge_response_re = re.compile(
+        r"Purged \d+ message\(s\)|Queue was not found in a storage"
+    )
+
+    proxy = next(cluster.proxy_cycle())
+    producer: Client = proxy.create_client("producer")
+
+    stop_purging = threading.Event()
+    failures: List[str] = []
+
+    def purge_until_stopped() -> None:
+        """
+        Purge the queue over a dedicated admin session until told to stop.
+        Record every unexpected response or error in 'failures'.
+        """
+        admin_purger = AdminClient()
+        admin_purger.connect(*cluster.admin_endpoint)
+        try:
+            while not stop_purging.is_set():
+                res = admin_purger.send_admin(purge_command)
+                if not isinstance(res, str) or not purge_response_re.search(res):
+                    failures.append(f"unexpected purge response: {res}")
+                    return
+        except Exception as err:  # pylint: disable=broad-except
+            # The broker went away, or answered something undecodable.
+            failures.append(f"{type(err).__name__}: {err}")
+        finally:
+            admin_purger.stop()
+
+    purgers = [
+        threading.Thread(target=purge_until_stopped, name=f"purger-{i}", daemon=True)
+        for i in range(num_purgers)
+    ]
+
+    admin = AdminClient()
+    admin.connect(*cluster.admin_endpoint)
+
+    for purger in purgers:
+        purger.start()
+
+    try:
+        # Stage 1: purge while the queue is registered and unregistered
+        for _ in range(num_rounds):
+            producer.open(uri, flags=["write,ack"], succeed=True)
+            producer.close(uri, succeed=True)
+
+            res = admin.send_admin(gc_command)
+            assert "SUCCESS" in res
+
+            if failures:
+                break
+    finally:
+        stop_purging.set()
+        for purger in purgers:
+            purger.join(timeout=60)
+
+    assert not failures, failures
+
+    # Stage 2: the broker is alive and its storage is still functional
+    cluster.check_processes()
+
+    post_n_msgs(producer, PostRecord(du.domain_priority, queue_name, num=3))
+
+    res = admin.send_admin(purge_command)
+    assert "Purged 3 message(s)" in res
+
     admin.stop()
 
 


### PR DESCRIPTION
- IT: add test for purge/queue gc concurrent safety
- Fix[mqbc]: perform queue storage lookup from the thread that performs purge, so this storage is guaranteed to be alive

In `main`, there might be a time window when purge event is enqueued for processing with a raw pointer to a storage, while this exact storage is already destructed.