### PR TITLE
Fix[MQB]: downgrade `RootQueueEngine` error log on ShutdownV2

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_rootqueueengine.cpp
@@ -1255,12 +1255,10 @@ void RootQueueEngine::releaseHandle(
                     // The handle has a valid consumer priority, meaning that a
                     // downstream client is attempting to release the handle
                     // without having first configured it to have null
-                    // streamParameters (i.e. invalid consumerPriority).  This
-                    // is not the expected flow since we expect an incoming
-                    // configureQueue with null streamParameters to precede a
-                    // 'releaseHandle' that releases the handle.
-                    BALL_LOG_ERROR
-                        << "#QUEUE_IMPROPER_BEHAVIOR "
+                    // streamParameters (i.e. invalid consumerPriority).
+                    // This is expected in shutdown V2 where we minimize the
+                    // number of requests.
+                    BMQ_LOGTHROTTLE_INFO
                         << "For queue [" << d_queueState_p->uri() << "],  "
                         << "received a 'releaseHandle' for the handle [id: "
                         << handle->id() << ", clientPtr: " << handle->client()


### PR DESCRIPTION
`RootQueueEngine::releaseHandle` logs `#QUEUE_IMPROPER_BEHAVIOR` at `ERROR` when a handle is released while still registered as a consumer. Under shutdown V2 this is the normal flow, not client misbehavior.

`Application::initiateShutdown` calls `ClientSession::initiateShutdown` on every downstream session, including proxies, which moves them out of the `e_RUNNING` state.  `ClientSession::tearDownImpl` then computes `doDeconfigure = (d_operationState == e_RUNNING)`, so `Queue::dropHandleDispatched` skips the null-`streamParameters` configure and goes straight to `releaseHandle`.  As a result, every shutdown of a proxy consumer handle emits this error once per consumer substream.

An identical log from `RelayQueueEngine` was fixed in #624 with the same reasoning; this makes the same change to `RootQueueEngine`.