### PR TITLE
Feat[mqbplug]: provide broker config to authorizer plugins

### DIFF
--- a/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_authorizationcontroller.g.cpp
@@ -17,6 +17,7 @@
 #include <mqbauthz_authorizationcontroller.h>
 
 // MQB
+#include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 #include <mqbplug_pluginmanager.h>
 
@@ -105,6 +106,12 @@ TEST(AuthorizationController, configuredWithUnknownNameFails)
 int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    // 'DefaultAuthorizerPluginFactory::create()' looks up its settings from
+    // the broker's global authorization configuration, so it must be set
+    // before any test constructs an authorizer.
+    mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
+    mqbcfg::BrokerConfig::set(brokerConfig);
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.cpp
@@ -19,6 +19,7 @@
 
 // MQB
 #include <mqbact_actions.h>
+#include <mqbcfg_messages.h>
 #include <mqbplug_authorizer.h>
 
 // BDE
@@ -36,6 +37,12 @@ bsl::string_view DefaultAuthorizer::k_NAME = "DefaultAuthorizer";
 // -----------------------
 // class DefaultAuthorizer
 // -----------------------
+
+DefaultAuthorizer::DefaultAuthorizer(
+    BSLA_MAYBE_UNUSED const mqbcfg::AuthorizerPluginConfig* config)
+{
+    // NOTHING
+}
 
 DefaultAuthorizer::~DefaultAuthorizer()
 {
@@ -68,8 +75,13 @@ DefaultAuthorizerPluginFactory::~DefaultAuthorizerPluginFactory()
 bslma::ManagedPtr<mqbplug::Authorizer>
 DefaultAuthorizerPluginFactory::create(bslma::Allocator* allocator)
 {
+    const mqbcfg::AuthorizerPluginConfig* config =
+        mqbplug::AuthorizerUtil::findAuthorizerConfig(
+            DefaultAuthorizer::k_NAME);
+
     bslma::ManagedPtr<DefaultAuthorizer> defaultAuthorizer =
-        bslma::ManagedPtrUtil::allocateManaged<DefaultAuthorizer>(allocator);
+        bslma::ManagedPtrUtil::allocateManaged<DefaultAuthorizer>(allocator,
+                                                                  config);
     bslma::ManagedPtr<mqbplug::Authorizer> authorizer(
         bslmf::MovableRefUtil::move(defaultAuthorizer));
     return authorizer;

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.g.cpp
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.g.cpp
@@ -17,6 +17,8 @@
 
 // MQB
 #include <mqbact_actions.h>
+#include <mqbcfg_brokerconfig.h>
+#include <mqbcfg_messages.h>
 #include <mqbplug_authenticator.h>
 #include <mqbplug_authorizer.h>
 
@@ -83,6 +85,29 @@ TEST_F(DefaultAuthorizerTest, breathingTest)
     EXPECT_STREQ("DefaultAuthorizer", name.c_str());
 }
 
+TEST(DefaultAuthorizer, acceptsPluginConfig)
+{
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    mqbcfg::PluginSettingKeyValue setting(alloc);
+    setting.key() = "exampleSetting";
+    setting.value().makeBoolVal(true);
+
+    mqbcfg::AuthorizerPluginConfig config(alloc);
+    config.name() = "DefaultAuthorizer";
+    config.settings().push_back(setting);
+
+    mqbauthz::DefaultAuthorizer authorizer(&config);
+
+    bsl::string name(authorizer.name());
+    EXPECT_STREQ("DefaultAuthorizer", name.c_str());
+
+    mqbact::Action connectClient;
+    connectClient.makeConnectClient();
+    TestAuthenticationResult authnResult;
+    EXPECT_TRUE(authorizer.authorize(connectClient, authnResult));
+}
+
 TEST_F(DefaultAuthorizerTest, allActionsAreAllowed)
 {
     bslma::Allocator*        alloc = bmqtst::TestHelperUtil::allocator();
@@ -146,6 +171,12 @@ TEST(DefaultAuthorizerFactory, factoryBreathingTest)
 int main(int argc, char* argv[])
 {
     TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    // 'DefaultAuthorizerPluginFactory::create()' looks up its settings from
+    // the broker's global authorization configuration, so it must be set
+    // before any test constructs an authorizer.
+    mqbcfg::AppConfig brokerConfig(bmqtst::TestHelperUtil::allocator());
+    mqbcfg::BrokerConfig::set(brokerConfig);
 
     ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.h
+++ b/src/groups/mqb/mqbauthz/mqbauthz_defaultauthorizer.h
@@ -45,6 +45,10 @@ namespace mqbact {
 class Action;
 }
 
+namespace mqbcfg {
+class AuthorizerPluginConfig;
+}
+
 namespace mqbauthz {
 
 // =======================
@@ -62,6 +66,11 @@ class DefaultAuthorizer : public mqbplug::Authorizer {
 
   public:
     // CREATORS
+
+    /// Create a `DefaultAuthorizer` using the optionally specified
+    /// `config`.
+    explicit DefaultAuthorizer(
+        const mqbcfg::AuthorizerPluginConfig* config = 0);
 
     /// Destructor.
     ~DefaultAuthorizer() BSLS_KEYWORD_OVERRIDE;

--- a/src/groups/mqb/mqbplug/mqbplug_authorizer.cpp
+++ b/src/groups/mqb/mqbplug/mqbplug_authorizer.cpp
@@ -18,9 +18,11 @@
 #include <mqbscm_version.h>
 
 // MQB
+#include <mqbcfg_brokerconfig.h>
 #include <mqbcfg_messages.h>
 
 // BDE
+#include <bdlb_nullablevalue.h>
 #include <bsl_string_view.h>
 #include <bsl_vector.h>
 
@@ -48,6 +50,22 @@ AuthorizerPluginFactory::AuthorizerPluginFactory()
 AuthorizerPluginFactory::~AuthorizerPluginFactory()
 {
     // NOTHING
+}
+
+// ---------------------
+// struct AuthorizerUtil
+// ---------------------
+
+const mqbcfg::AuthorizerPluginConfig*
+AuthorizerUtil::findAuthorizerConfig(bsl::string_view name)
+{
+    const bdlb::NullableValue<mqbcfg::AuthorizerPluginConfig>& authorizerCfg =
+        mqbcfg::BrokerConfig::get().authorization().authorizer();
+
+    if (!authorizerCfg.isNull() && authorizerCfg.value().name() == name) {
+        return &authorizerCfg.value();  // RETURN
+    }
+    return 0;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbplug/mqbplug_authorizer.h
+++ b/src/groups/mqb/mqbplug/mqbplug_authorizer.h
@@ -98,6 +98,18 @@ class AuthorizerPluginFactory : public PluginFactory {
     create(bslma::Allocator* allocator) = 0;
 };
 
+// =====================
+// struct AuthorizerUtil
+// =====================
+
+struct AuthorizerUtil {
+    // STATIC CLASS METHODS
+
+    /// Find the authorizer config with the specified `name`.
+    static const mqbcfg::AuthorizerPluginConfig*
+    findAuthorizerConfig(bsl::string_view name);
+};
+
 }  // close package namespace
 }  // close enterprise namespace
 


### PR DESCRIPTION
Add `AuthorizerUtil::findAuthorizerConfig`, which resolves an authorizer plugin's configuration from the broker's global authorization config by plugin name. This mirrors the existing `AuthenticatorUtil` and `StatConsumerUtil` helpers.

`DefaultAuthorizerPluginFactory::create()` now looks up its own config and hands it to the authorizer. `DefaultAuthorizer` accepts it but does not use it yet; a follow-up will add settings to deny specific actions.

Test drivers that create an authorizer through the factory must now set a broker configuration, since the lookup reads the global.