### PR TITLE
Fix[mqbc::StorageMgr]: Validate E_PUSH sender and partitionId

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1120,11 +1120,51 @@ void StorageManager::processReplicaDataRequestPush(
                      bmqp_ctrlmsg::ReplicaDataType::E_PUSH);
 
     const int partitionId = replicaDataRequest.partitionId();
-    BSLS_ASSERT_SAFE(0 <= partitionId &&
-                     partitionId < static_cast<int>(d_fileStores.size()));
-    BSLS_ASSERT_SAFE(
-        source->nodeId() ==
-        d_clusterState_p->partitionsInfo().at(partitionId).primaryNodeId());
+    if (partitionId < 0 ||
+        partitionId >= static_cast<int>(d_fileStores.size())) {
+        BALL_LOG_ERROR
+            << d_clusterData_p->identity().description()
+            << " Received ReplicaDataRequestPush: " << message << " from "
+            << source->nodeDescription()
+            << " with invalid partitionId.  Sending failure response.";
+
+        bmqp_ctrlmsg::ControlMessage controlMsg;
+        controlMsg.rId() = message.rId();
+
+        bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
+        status.category()            = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        status.code()                = mqbi::ClusterErrorCode::e_NO_PARTITION;
+        status.message()             = "Invalid partitionId";
+
+        d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg,
+                                                              source);
+        return;  // RETURN
+    }
+    if (source->nodeId() !=
+        d_clusterState_p->partitionsInfo().at(partitionId).primaryNodeId()) {
+        const mqbnet::ClusterNode* primaryNode =
+            d_clusterState_p->partitionsInfo().at(partitionId).primaryNode();
+        BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                       << " Partition [" << partitionId << "]: "
+                       << " Received ReplicaDataRequestPush: " << message
+                       << " from " << source->nodeDescription()
+                       << " but self's perceived primary is "
+                       << (primaryNode ? primaryNode->nodeDescription()
+                                       : " ** NULL **")
+                       << ".  Sending failure response.";
+
+        bmqp_ctrlmsg::ControlMessage controlMsg;
+        controlMsg.rId() = message.rId();
+
+        bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
+        status.category()            = bmqp_ctrlmsg::StatusCategory::E_REFUSED;
+        status.code()    = mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY;
+        status.message() = "Source node is not recognized as the primary";
+
+        d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg,
+                                                              source);
+        return;  // RETURN
+    }
 
     BALL_LOG_INFO << d_clusterData_p->identity().description()
                   << " Partition [" << partitionId << "]: "
@@ -1175,15 +1215,6 @@ void StorageManager::processReplicaDataRequestDrop(
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_cluster_p->inDispatcherThread());
-    BSLS_ASSERT_SAFE(message.choice().isClusterMessageValue());
-    BSLS_ASSERT_SAFE(
-        message.choice().clusterMessage().choice().isPartitionMessageValue());
-    BSLS_ASSERT_SAFE(message.choice()
-                         .clusterMessage()
-                         .choice()
-                         .partitionMessage()
-                         .choice()
-                         .isReplicaDataRequestValue());
 
     const bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
         message.choice()

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -1105,13 +1105,13 @@ struct TestHelper {
                 .choice()
                 .makePrimaryStateResponse();
 
-        bmqp_ctrlmsg::PartitionSequenceNumber PSN;
-        PSN.sequenceNumber() = 1U;
-        PSN.primaryLeaseId() = 1U;
+        bmqp_ctrlmsg::PartitionSequenceNumber psn;
+        psn.sequenceNumber() = 1U;
+        psn.primaryLeaseId() = 1U;
 
         primaryStateResponse.partitionId()          = partitionId;
         primaryStateResponse.primaryLeaseId()       = 1U;
-        primaryStateResponse.latestSequenceNumber() = PSN;
+        primaryStateResponse.latestSequenceNumber() = psn;
 
         d_cluster_mp->requestManager().processResponse(pstMessage);
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -727,6 +727,93 @@ struct TestHelper {
         }
     }
 
+    /// Verify that the node having the specified `sourceNodeId` was sent an
+    /// E_REFUSED response bearing the specified `requestId` and `errorCode`,
+    /// and that no other node in the cluster was written to.
+    void verifyRefusedResponse(int sourceNodeId, int requestId, int errorCode)
+    {
+        for (TestChannelMapCIter cit = d_cluster_mp->_channels().cbegin();
+             cit != d_cluster_mp->_channels().cend();
+             ++cit) {
+            if (cit->first->nodeId() == sourceNodeId) {
+                bmqio::TestChannel::WriteCall writeCall;
+                const bool hasWriteCall = cit->second->getWriteCall(&writeCall,
+                                                                    0);
+                BMQTST_ASSERT(hasWriteCall);
+
+                bmqp_ctrlmsg::ControlMessage response;
+                mqbc::ClusterUtil::extractMessage(
+                    &response,
+                    writeCall.d_blob,
+                    bmqtst::TestHelperUtil::allocator());
+
+                BMQTST_ASSERT_EQ(response.rId(), requestId);
+                BMQTST_ASSERT(response.choice().isStatusValue());
+
+                const bmqp_ctrlmsg::Status& status =
+                    response.choice().status();
+                BMQTST_ASSERT_EQ(status.category(),
+                                 bmqp_ctrlmsg::StatusCategory::E_REFUSED);
+                BMQTST_ASSERT_EQ(status.code(), errorCode);
+            }
+            else {
+                const bool wroteAnything = cit->second->waitFor(1);
+                BMQTST_ASSERT(!wroteAnything);
+            }
+        }
+    }
+
+    /// Send a storage event (PUT) for the specified `partitionId` from the
+    /// specified `source` to the specified `storageManager`, and verify that
+    /// it is buffered rather than processed.
+    void verifyLiveDataIsBuffered(mqbc::StorageManager* storageManager,
+                                  int                   partitionId,
+                                  mqbnet::ClusterNode*  source)
+    {
+        const bsls::Types::Uint64 seqNumBefore =
+            storageManager->fileStore(partitionId).writeHeadSeqNum();
+
+        bmqp::StorageEventBuilder seb(mqbs::FileStoreProtocol::k_VERSION,
+                                      bmqp::EventType::e_STORAGE,
+                                      d_cluster_mp->_blobSpPool(),
+                                      bmqtst::TestHelperUtil::allocator());
+
+        char journalBuf[mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE];
+        bsl::memset(journalBuf, 0, sizeof(journalBuf));
+        bsl::shared_ptr<char> journalSp(journalBuf,
+                                        bslstl::SharedPtrNilDeleter(),
+                                        bmqtst::TestHelperUtil::allocator());
+        bdlbb::BlobBuffer     journalBlobBuf(journalSp, sizeof(journalBuf));
+
+        char dataBuf[bmqp::Protocol::k_WORD_SIZE];
+        bsl::memset(dataBuf, 0, sizeof(dataBuf));
+        bsl::shared_ptr<char> dataSp(dataBuf,
+                                     bslstl::SharedPtrNilDeleter(),
+                                     bmqtst::TestHelperUtil::allocator());
+        bdlbb::BlobBuffer     dataBlobBuf(dataSp, sizeof(dataBuf));
+
+        const bmqt::EventBuilderResult::Enum rc = seb.packMessage(
+            bmqp::StorageMessageType::e_DATA,
+            partitionId,
+            0,     // flags
+            1000,  // journalOffsetWords (non-zero, required by builder)
+            journalBlobBuf,
+            dataBlobBuf);
+        BSLS_ASSERT_OPT(rc == bmqt::EventBuilderResult::e_SUCCESS);
+
+        mqbevt::StorageEvent storageEvent(bmqtst::TestHelperUtil::allocator());
+        storageEvent.setBlob(seb.blob());
+        storageEvent.setClusterNode(source);
+
+        storageManager->processStorageEvent(storageEvent);
+
+        // Sequence number has not advanced; this proves that we did not
+        // process the PUT.
+        BMQTST_ASSERT_EQ(
+            storageManager->fileStore(partitionId).writeHeadSeqNum(),
+            seqNumBefore);
+    }
+
     NodePSNPair
     getHighestSeqNumNodeDetails(mqbnet::ClusterNode*   selfNode,
                                 const NodeToPSNCtxMap& nodeToPSNCtxMap)
@@ -989,6 +1076,51 @@ struct TestHelper {
         }
     }
 
+    /// Start the specified `storageManager` with the specified `primaryNode`
+    /// and drive the specified `partitionId` from e_UNKNOWN through
+    /// e_REPLICA_WAITING to e_REPLICA_HEALING, by answering the emitted
+    /// PrimaryStateRequest with a success PrimaryStateResponse.  Leave all
+    /// test channels cleared.
+    void transitionReplicaToHealing(mqbc::StorageManager* storageManager,
+                                    mqbnet::ClusterNode*  primaryNode,
+                                    int                   partitionId)
+    {
+        startStorageManager(storageManager, primaryNode);
+
+        BSLS_ASSERT_OPT(storageManager->partitionHealthState(partitionId) ==
+                        mqbc::PartitionFSM::State::e_REPLICA_WAITING);
+
+        for (size_t pid = 0; pid < numPartitions(); ++pid) {
+            verifyReplicaSendsPrimaryStateRqst(primaryNode->nodeId());
+        }
+
+        static const int             k_PRIMARY_REQUEST_ID = 1;
+        bmqp_ctrlmsg::ControlMessage pstMessage;
+        pstMessage.rId() = k_PRIMARY_REQUEST_ID;
+        bmqp_ctrlmsg::PrimaryStateResponse& primaryStateResponse =
+            pstMessage.choice()
+                .makeClusterMessage()
+                .choice()
+                .makePartitionMessage()
+                .choice()
+                .makePrimaryStateResponse();
+
+        bmqp_ctrlmsg::PartitionSequenceNumber PSN;
+        PSN.sequenceNumber() = 1U;
+        PSN.primaryLeaseId() = 1U;
+
+        primaryStateResponse.partitionId()          = partitionId;
+        primaryStateResponse.primaryLeaseId()       = 1U;
+        primaryStateResponse.latestSequenceNumber() = PSN;
+
+        d_cluster_mp->requestManager().processResponse(pstMessage);
+
+        BSLS_ASSERT_OPT(storageManager->partitionHealthState(partitionId) ==
+                        mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+
+        clearChannels();
+    }
+
     /// Allow any thread to pass `inDispatcherThread` checks on the
     /// FileStores managed by the specified `storageManager`.  This is
     /// needed in tests that fire scheduler callbacks (e.g. watchdog)
@@ -1010,6 +1142,7 @@ struct TestHelper {
             .numPartitions();
     }
 };
+
 }  // close unnamed namespace
 
 // ============================================================================
@@ -3402,208 +3535,228 @@ static void test22_rstUnknownCancelsInFlightRequests()
     helper.d_cluster_mp->stop();
 }
 
-static void test23_replicaHealingReceivesReplicaDataRqstDropInvalidPid()
+static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
 // ------------------------------------------------------------------------
-// REPLICA HEALING RECEIVES REPLICA DATA REQUEST DROP WITH INVALID PID
+// REPLICA HEALING REFUSES INVALID REPLICA DATA REQUEST
 //
 // Concerns:
-//   When a replica in e_REPLICA_HEALING receives a ReplicaDataRequestDrop
-//   with an invalid partitionId, it must:
+//   When a replica in e_REPLICA_HEALING receives a ReplicaDataRequest with an
+//   invalid partitionId or from a non-primary node, it must:
 //     a) Send a failure response.
 //     b) Remain in e_REPLICA_HEALING.
 //     c) Continue to buffer incoming PUT messages.
 //
 // Plan:
-//  1) Transition to REPLICA_WAITING, then to REPLICA_HEALING.
-//  2) Send ReplicaDataRequestDrop with invalid partitionId (-1).
-//  3) Verify failure response sent to source.
-//  4) Verify state remains e_REPLICA_HEALING.
-//  5) Send a storage event (PUT) and verify it is buffered, not processed.
+//  For each row of the table below, on a fresh cluster:
+//   1) Transition to REPLICA_HEALING.
+//   2) Optionally clear the partition primary.
+//   3) Send the ReplicaDataRequest described by the row.
+//   4) Verify the expected failure response is sent to the source.
+//   5) Verify state remains e_REPLICA_HEALING.
+//   6) Verify a subsequent PUT is buffered, not processed.
 //
 // Testing:
-//   processReplicaDataRequestDrop invalid partition validation
+//   processReplicaDataRequestPush partition and source validation
+//   processReplicaDataRequestDrop partition and source validation
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName(
-        "REPLICA HEALING RECEIVES REPLICA DATA REQUEST DROP "
-        "WITH INVALID PARTITION ID");
-
-    TestHelper helper;
-
-    bmqp_ctrlmsg::PartitionSequenceNumber selfSeqNum;
-    mqbs::DataStoreRecordHandle           handle;
-    helper.initializeRecords(&handle, 1, &selfSeqNum);
-
-    mqbc::StorageManager storageManager(
-        helper.d_cluster_mp->_clusterDefinition(),
-        helper.d_cluster_mp.get(),
-        helper.d_cluster_mp->_clusterData(),
-        helper.d_cluster_mp->_state(),
-        helper.d_cluster_mp->_clusterData()->domainFactory(),
-        helper.d_cluster_mp->dispatcher(),
-        k_WATCHDOG_TIMEOUT_DURATION,
-        k_WATCHDOG_NUM_RETRIES,
-        mockOnRecoveryStatus,
-        mockOnPartitionPrimaryStatus,
-        bmqtst::TestHelperUtil::allocator());
+        "REPLICA HEALING REFUSES INVALID REPLICA DATA REQUEST");
 
     static const int k_PARTITION_ID = 0;
+    static const int k_REQUEST_ID   = 42;
 
-    BSLS_ASSERT_OPT(storageManager.partitionHealthState(k_PARTITION_ID) ==
-                    mqbc::PartitionFSM::State::e_UNKNOWN);
+    // Selects the partitionId to put on the wire.
+    enum PartitionSelector { e_VALID_PID, e_NEGATIVE_PID, e_TOO_LARGE_PID };
 
-    const int selfNodeId = helper.d_cluster_mp->_clusterData()
-                               ->membership()
-                               .netCluster()
-                               ->selfNodeId();
-    const int primaryNodeId = selfNodeId + 1;
+    struct Test {
+        /// Line of this row, reported when an assertion fails.
+        int d_line;
 
-    mqbnet::ClusterNode* primaryNode = helper.d_cluster_mp->_clusterData()
-                                           ->membership()
-                                           .netCluster()
-                                           ->lookupNode(primaryNodeId);
+        /// Scenario summary.
+        const char* d_description;
 
-    // 1. Transition to REPLICA_WAITING, then to REPLICA_HEALING.
-    helper.startStorageManager(&storageManager, primaryNode);
+        /// Type of the ReplicaDataRequest to send.
+        bmqp_ctrlmsg::ReplicaDataType::Value d_dataType;
 
-    BSLS_ASSERT_OPT(storageManager.partitionHealthState(k_PARTITION_ID) ==
-                    mqbc::PartitionFSM::State::e_REPLICA_WAITING);
+        /// Which partitionId to put in the request.
+        PartitionSelector d_partition;
 
-    for (size_t pid = 0; pid < helper.numPartitions(); ++pid) {
-        helper.verifyReplicaSendsPrimaryStateRqst(primaryNodeId);
-    }
-    helper.clearChannels();
+        /// Whether to send from the primary node, or from another replica.
+        bool d_fromPrimary;
 
-    static const int             k_PRIMARY_REQUEST_ID = 1;
-    bmqp_ctrlmsg::ControlMessage pstMessage;
-    pstMessage.rId() = k_PRIMARY_REQUEST_ID;
-    bmqp_ctrlmsg::PrimaryStateResponse& primaryStateResponse =
-        pstMessage.choice()
-            .makeClusterMessage()
-            .choice()
-            .makePartitionMessage()
-            .choice()
-            .makePrimaryStateResponse();
+        /// Whether to unassign the partition's primary before sending.
+        bool d_clearPrimary;
 
-    bmqp_ctrlmsg::PartitionSequenceNumber PSN;
-    PSN.sequenceNumber() = 1U;
-    PSN.primaryLeaseId() = 1U;
+        /// Expected 'mqbi::ClusterErrorCode' in the refusal response.
+        int d_expectedCode;
+    } k_DATA[] = {{L_,
+                   "DROP with negative partitionId",
+                   bmqp_ctrlmsg::ReplicaDataType::E_DROP,
+                   e_NEGATIVE_PID,
+                   true,
+                   false,
+                   mqbi::ClusterErrorCode::e_NO_PARTITION},
+                  {L_,
+                   "DROP with too large partitionId",
+                   bmqp_ctrlmsg::ReplicaDataType::E_DROP,
+                   e_TOO_LARGE_PID,
+                   true,
+                   false,
+                   mqbi::ClusterErrorCode::e_NO_PARTITION},
+                  {L_,
+                   "DROP from a node which is not the primary",
+                   bmqp_ctrlmsg::ReplicaDataType::E_DROP,
+                   e_VALID_PID,
+                   false,
+                   false,
+                   mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
+                  {L_,
+                   "DROP when the partition has no primary",
+                   bmqp_ctrlmsg::ReplicaDataType::E_DROP,
+                   e_VALID_PID,
+                   true,
+                   true,
+                   mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
+                  {L_,
+                   "PUSH with negative partitionId",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
+                   e_NEGATIVE_PID,
+                   true,
+                   false,
+                   mqbi::ClusterErrorCode::e_NO_PARTITION},
+                  {L_,
+                   "PUSH with too large partitionId",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
+                   e_TOO_LARGE_PID,
+                   true,
+                   false,
+                   mqbi::ClusterErrorCode::e_NO_PARTITION},
+                  {L_,
+                   "PUSH from a node which is not the primary",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
+                   e_VALID_PID,
+                   false,
+                   false,
+                   mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
+                  {L_,
+                   "PUSH when the partition has no primary",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
+                   e_VALID_PID,
+                   true,
+                   true,
+                   mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY}};
 
-    primaryStateResponse.partitionId()          = k_PARTITION_ID;
-    primaryStateResponse.primaryLeaseId()       = 1U;
-    primaryStateResponse.latestSequenceNumber() = PSN;
+    const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
 
-    helper.d_cluster_mp->requestManager().processResponse(pstMessage);
+    for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
+        const Test& test = k_DATA[idx];
 
-    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
-                     mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+        PVV(test.d_line << ": Testing: " << test.d_description);
 
-    helper.clearChannels();
+        TestHelper helper;
 
-    // 2. Send ReplicaDataRequestDrop with invalid partitionId
-    static const int             k_DROP_REQUEST_ID = 42;
-    static const int             k_INVALID_PID     = -1;
-    bmqp_ctrlmsg::ControlMessage dropMessage;
-    dropMessage.rId() = k_DROP_REQUEST_ID;
-    bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
-        dropMessage.choice()
-            .makeClusterMessage()
-            .choice()
-            .makePartitionMessage()
-            .choice()
-            .makeReplicaDataRequest();
+        mqbc::StorageManager storageManager(
+            helper.d_cluster_mp->_clusterDefinition(),
+            helper.d_cluster_mp.get(),
+            helper.d_cluster_mp->_clusterData(),
+            helper.d_cluster_mp->_state(),
+            helper.d_cluster_mp->_clusterData()->domainFactory(),
+            helper.d_cluster_mp->dispatcher(),
+            k_WATCHDOG_TIMEOUT_DURATION,
+            k_WATCHDOG_NUM_RETRIES,
+            mockOnRecoveryStatus,
+            mockOnPartitionPrimaryStatus,
+            bmqtst::TestHelperUtil::allocator());
+        BSLS_ASSERT_OPT(storageManager.partitionHealthState(k_PARTITION_ID) ==
+                        mqbc::PartitionFSM::State::e_UNKNOWN);
 
-    replicaDataRequest.replicaDataType() =
-        bmqp_ctrlmsg::ReplicaDataType::E_DROP;
-    replicaDataRequest.partitionId() = k_INVALID_PID;
+        const int selfNodeId = helper.d_cluster_mp->_clusterData()
+                                   ->membership()
+                                   .netCluster()
+                                   ->selfNodeId();
+        const int primaryNodeId    = selfNodeId + 1;
+        const int nonPrimaryNodeId = selfNodeId + 2;
 
-    storageManager.processReplicaDataRequest(dropMessage, primaryNode);
+        mqbnet::ClusterNode* primaryNode = helper.d_cluster_mp->_clusterData()
+                                               ->membership()
+                                               .netCluster()
+                                               ->lookupNode(primaryNodeId);
+        mqbnet::ClusterNode* otherNode = helper.d_cluster_mp->_clusterData()
+                                             ->membership()
+                                             .netCluster()
+                                             ->lookupNode(nonPrimaryNodeId);
+        BSLS_ASSERT_OPT(primaryNode);
+        BSLS_ASSERT_OPT(otherNode);
 
-    // 3. Verify failure response sent to source (primaryNode)
-    for (TestChannelMapCIter cit = helper.d_cluster_mp->_channels().cbegin();
-         cit != helper.d_cluster_mp->_channels().cend();
-         ++cit) {
-        if (cit->first->nodeId() == primaryNodeId) {
-            bmqio::TestChannel::WriteCall writeCall;
-            BMQTST_ASSERT(cit->second->getWriteCall(&writeCall, 0));
+        // 1. Transition to REPLICA_HEALING.
+        helper.transitionReplicaToHealing(&storageManager,
+                                          primaryNode,
+                                          k_PARTITION_ID);
 
-            bmqp_ctrlmsg::ControlMessage response;
-            mqbc::ClusterUtil::extractMessage(
-                &response,
-                writeCall.d_blob,
-                bmqtst::TestHelperUtil::allocator());
-
-            BMQTST_ASSERT_EQ(response.rId(), k_DROP_REQUEST_ID);
-            BMQTST_ASSERT(response.choice().isStatusValue());
-
-            const bmqp_ctrlmsg::Status& status = response.choice().status();
-            BMQTST_ASSERT_EQ(status.category(),
-                             bmqp_ctrlmsg::StatusCategory::E_REFUSED);
-            BMQTST_ASSERT_EQ(status.code(),
-                             mqbi::ClusterErrorCode::e_NO_PARTITION);
+        // 2. Optionally clear the partition primary.
+        if (test.d_clearPrimary) {
+            helper.d_cluster_mp->_state()->setPartitionPrimary(
+                k_PARTITION_ID,
+                1,   // primaryLeaseId
+                0);  // no primary
         }
-        else {
-            BMQTST_ASSERT(!cit->second->waitFor(1));
+
+        // 3. Send the ReplicaDataRequest described by this row.
+        int partitionId = k_PARTITION_ID;
+        if (test.d_partition == e_NEGATIVE_PID) {
+            partitionId = -1;
         }
+        else if (test.d_partition == e_TOO_LARGE_PID) {
+            partitionId = static_cast<int>(helper.numPartitions());
+        }
+
+        bmqp_ctrlmsg::ControlMessage message;
+        message.rId() = k_REQUEST_ID;
+        bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
+            message.choice()
+                .makeClusterMessage()
+                .choice()
+                .makePartitionMessage()
+                .choice()
+                .makeReplicaDataRequest();
+
+        replicaDataRequest.replicaDataType() = test.d_dataType;
+        replicaDataRequest.partitionId()     = partitionId;
+        replicaDataRequest.primaryLeaseId()  = 1U;
+
+        mqbnet::ClusterNode* const source = test.d_fromPrimary ? primaryNode
+                                                               : otherNode;
+        const int sourceNodeId            = test.d_fromPrimary ? primaryNodeId
+                                                               : nonPrimaryNodeId;
+
+        storageManager.processReplicaDataRequest(message, source);
+
+        // 4. Verify the expected failure response is sent to the source.
+        helper.verifyRefusedResponse(sourceNodeId,
+                                     k_REQUEST_ID,
+                                     test.d_expectedCode);
+
+        helper.clearChannels();
+
+        // 5. Verify state remains e_REPLICA_HEALING.
+        BMQTST_ASSERT_EQ_D(test.d_line,
+                           storageManager.partitionHealthState(k_PARTITION_ID),
+                           mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+
+        // 6. Verify a subsequent PUT is buffered, not processed.
+        helper.verifyLiveDataIsBuffered(&storageManager,
+                                        k_PARTITION_ID,
+                                        primaryNode);
+
+        BMQTST_ASSERT_EQ_D(test.d_line,
+                           storageManager.partitionHealthState(k_PARTITION_ID),
+                           mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+
+        storageManager.stopPFSMs();
+        storageManager.stop();
+        helper.d_cluster_mp->stop();
     }
-
-    // 4. Verify state remains e_REPLICA_HEALING
-    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
-                     mqbc::PartitionFSM::State::e_REPLICA_HEALING);
-
-    helper.clearChannels();
-
-    // 5. Send a storage event (PUT) and verify it is buffered, not processed
-    const bsls::Types::Uint64 seqNumBefore =
-        storageManager.fileStore(k_PARTITION_ID).writeHeadSeqNum();
-
-    bmqp::StorageEventBuilder seb(mqbs::FileStoreProtocol::k_VERSION,
-                                  bmqp::EventType::e_STORAGE,
-                                  helper.d_cluster_mp->_blobSpPool(),
-                                  bmqtst::TestHelperUtil::allocator());
-
-    char journalBuf[mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE];
-    bsl::memset(journalBuf, 0, sizeof(journalBuf));
-    bsl::shared_ptr<char> journalSp(journalBuf,
-                                    bslstl::SharedPtrNilDeleter(),
-                                    bmqtst::TestHelperUtil::allocator());
-    bdlbb::BlobBuffer     journalBlobBuf(journalSp, sizeof(journalBuf));
-
-    char dataBuf[bmqp::Protocol::k_WORD_SIZE];
-    bsl::memset(dataBuf, 0, sizeof(dataBuf));
-    bsl::shared_ptr<char> dataSp(dataBuf,
-                                 bslstl::SharedPtrNilDeleter(),
-                                 bmqtst::TestHelperUtil::allocator());
-    bdlbb::BlobBuffer     dataBlobBuf(dataSp, sizeof(dataBuf));
-
-    bmqt::EventBuilderResult::Enum rc = seb.packMessage(
-        bmqp::StorageMessageType::e_DATA,
-        k_PARTITION_ID,
-        0,     // flags
-        1000,  // journalOffsetWords (non-zero, required by builder)
-        journalBlobBuf,
-        dataBlobBuf);
-    BSLS_ASSERT_OPT(rc == bmqt::EventBuilderResult::e_SUCCESS);
-
-    mqbevt::StorageEvent storageEvent(bmqtst::TestHelperUtil::allocator());
-    storageEvent.setBlob(seb.blob());
-    storageEvent.setClusterNode(primaryNode);
-
-    storageManager.processStorageEvent(storageEvent);
-
-    // Sequence number has not advanced; this proves that we did not process
-    // the PUT.
-    BMQTST_ASSERT_EQ(
-        storageManager.fileStore(k_PARTITION_ID).writeHeadSeqNum(),
-        seqNumBefore);
-
-    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
-                     mqbc::PartitionFSM::State::e_REPLICA_HEALING);
-
-    // Cleanup
-    storageManager.stopPFSMs();
-    storageManager.stop();
-    helper.d_cluster_mp->stop();
 }
 
 // ============================================================================
@@ -3623,9 +3776,7 @@ int main(int argc, char* argv[])
         //      - test21_replicaHealingReceivesReplicaDataRqstDrop();
         //      - test20_replicaHealingReceivesReplicaDataRqstPush();
         //      - test19_primaryHealedSendsDataChunks();
-    case 23:
-        test23_replicaHealingReceivesReplicaDataRqstDropInvalidPid();
-        break;
+    case 23: test23_replicaHealingRefusesInvalidReplicaDataRequest(); break;
     case 22: test22_rstUnknownCancelsInFlightRequests(); break;
     case 21: test21_watchdogMultipleRetries(); break;
     case 20: test20_watchdogStopResetsState(); break;

--- a/src/integration-tests/test_replica_data_request.py
+++ b/src/integration-tests/test_replica_data_request.py
@@ -1,0 +1,268 @@
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression coverage for ReplicaDataRequest partition and sender validation.
+
+`E_PUSH` and `E_DROP` are only meaningful from the current primary of a
+partition, but any authorized cluster peer can put one on the wire with any
+partitionId.  Both must be refused at runtime, leaving the broker up.
+
+The tests establish a real authenticated `E_TCPBROKER` session over TCP.  A
+configured node is taken down first so that its identity can be claimed.
+"""
+
+import os
+import re
+import time
+
+import pytest
+
+from blazingmq.dev.it.fixtures import (
+    Cluster,
+    order,
+    start_cluster,
+)
+from blazingmq.dev.it.process.admin import AdminClient
+from blazingmq.dev.it.process.rawclient import RawClient
+
+pytestmark = order(99)
+
+PARTITION_ID = 0
+NEGOTIATION_ATTEMPTS = 30
+
+LOG_NAME = {"E_PUSH": "Push", "E_DROP": "Drop"}
+DATA_TYPES = ["E_PUSH", "E_DROP"]
+
+
+def _partition_primary(admin: AdminClient, cluster_name: str, partition_id: int):
+    """
+    Return the (name, id) of the primary of 'partition_id', or None if the
+    partition has no primary yet.
+    """
+
+    summary = admin.send_admin(f"CLUSTERS CLUSTER {cluster_name} STORAGE SUMMARY")
+
+    # The summary lists partitions in order, so pick the 'partition_id'-th
+    # primary it reports.
+    primaries = re.findall(r"Primary Node\s*:\s*\[([^,]+),\s*(\d+)\]", summary)
+    if len(primaries) <= partition_id:
+        return None
+
+    name, node_id = primaries[partition_id]
+    return name, int(node_id)
+
+
+def _wait_for_primary(
+    admin: AdminClient, cluster_name: str, partition_id: int, exclude_node_id=None
+):
+    """
+    Wait for 'partition_id' to have a primary other than the optionally
+    specified 'exclude_node_id', and return it as a (name, id) tuple.
+    """
+
+    for _ in range(30):
+        primary = _partition_primary(admin, cluster_name, partition_id)
+        if primary is not None and primary[1] != exclude_node_id:
+            return primary
+        time.sleep(1)
+
+    raise AssertionError(f"partition {partition_id} never got a usable primary")
+
+
+def _prepare_impersonation(cluster: Cluster):
+    """
+    Take down a non-leader node so its identity can be claimed, and wait for
+    PARTITION_ID to be led by someone else.  Return (victim, impostor, admin),
+    where 'admin' is connected to the live victim and owned by the caller.
+    """
+
+    leader = cluster.last_known_leader
+    assert leader is not None
+
+    others = cluster.nodes(exclude=leader)
+    impostor = others[0]
+    victim = others[1]
+
+    impostor.check_exit_code = False
+    impostor.kill()
+    impostor.wait()
+
+    admin = AdminClient()
+    admin.connect(victim.config.host, int(victim.config.port))
+
+    try:
+        _wait_for_primary(
+            admin,
+            cluster.config.name,
+            PARTITION_ID,
+            exclude_node_id=impostor.config.id,
+        )
+    except Exception:
+        admin.stop()
+        raise
+
+    return victim, impostor, admin
+
+
+def _connect_as_cluster_node(host, port, cluster_name, node_name, node_id):
+    """
+    Open an authenticated cluster-peer session to 'host:port' claiming the
+    identity of the configured node 'node_name' / 'node_id'.  Return the
+    connected `RawClient`.
+    """
+
+    last_result = None
+
+    for _ in range(NEGOTIATION_ATTEMPTS):
+        client = RawClient(verbose=True)
+        client.open_channel(host, port)
+
+        response = client.negotiate(
+            {
+                "clientType": "E_TCPBROKER",
+                "processName": "it-replica-data-request",
+                "pid": os.getpid(),
+                "hostName": node_name,
+                "clusterName": cluster_name,
+                "clusterNodeId": node_id,
+            }
+        )
+
+        last_result = response.get("brokerResponse", {}).get("result", {})
+        if last_result.get("code") == 0:
+            return client
+
+        # The victim has not dropped the impersonated node's channel yet.
+        client.stop()
+        time.sleep(1)
+
+    raise AssertionError(f"cluster-peer negotiation never succeeded: {last_result}")
+
+
+def _replica_data_request(request_id, partition_id, data_type):
+    return {
+        "rId": request_id,
+        "clusterMessage": {
+            "partitionMessage": {
+                "replicaDataRequest": {
+                    "partitionId": partition_id,
+                    "primaryLeaseId": 1,
+                    "replicaDataType": data_type,
+                    "beginSequenceNumber": {
+                        "primaryLeaseId": 1,
+                        "sequenceNumber": 0,
+                    },
+                    "endSequenceNumber": {
+                        "primaryLeaseId": 1,
+                        "sequenceNumber": 0,
+                    },
+                }
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize("data_type", DATA_TYPES)
+@start_cluster(True, True, True)
+def test_non_primary_replica_data_request_is_refused(
+    fsm_multi_cluster: Cluster, data_type: str
+):
+    """
+    An authorized cluster peer which is not the primary of a partition sends a
+    ReplicaDataRequest for it.  The broker must refuse the request and stay
+    alive.
+    """
+
+    cluster = fsm_multi_cluster
+    cluster_name = cluster.config.name
+
+    victim, impostor, admin = _prepare_impersonation(cluster)
+
+    try:
+        client = _connect_as_cluster_node(
+            victim.config.host,
+            int(victim.config.port),
+            cluster_name,
+            impostor.name,
+            impostor.config.id,
+        )
+
+        try:
+            client.send_control_message(
+                _replica_data_request(4242, PARTITION_ID, data_type)
+            )
+        finally:
+            client.stop()
+
+        # The victim must have refused the request rather than aborted.
+        assert victim.outputs_regex(
+            rf"Received ReplicaDataRequest{LOG_NAME[data_type]}.*"
+            r"but self's perceived primary is.*Sending failure response",
+            timeout=30,
+        )
+
+        assert victim.is_alive()
+
+        # And it must still serve admin traffic.
+        assert admin.send_admin(f"CLUSTERS CLUSTER {cluster_name} STORAGE SUMMARY")
+    finally:
+        admin.stop()
+
+
+@pytest.mark.parametrize("data_type", DATA_TYPES)
+@start_cluster(True, True, True)
+def test_replica_data_request_invalid_partition_is_refused(
+    fsm_multi_cluster: Cluster, data_type: str
+):
+    """
+    'partitionId' is peer-controlled.  An out-of-range value must be refused
+    rather than used to index partition state.
+    """
+
+    cluster = fsm_multi_cluster
+    cluster_name = cluster.config.name
+
+    victim, impostor, admin = _prepare_impersonation(cluster)
+
+    try:
+        num_partitions = cluster.config.definition.partition_config.num_partitions
+
+        client = _connect_as_cluster_node(
+            victim.config.host,
+            int(victim.config.port),
+            cluster_name,
+            impostor.name,
+            impostor.config.id,
+        )
+
+        try:
+            for invalid_partition_id in (-1, num_partitions):
+                client.send_control_message(
+                    _replica_data_request(4243, invalid_partition_id, data_type)
+                )
+        finally:
+            client.stop()
+
+        assert victim.outputs_regex(
+            rf"Received ReplicaDataRequest{LOG_NAME[data_type]}.*invalid partitionId",
+            timeout=30,
+        )
+
+        assert victim.is_alive()
+
+        assert admin.send_admin(f"CLUSTERS CLUSTER {cluster_name} STORAGE SUMMARY")
+    finally:
+        admin.stop()

--- a/src/integration-tests/test_replica_data_request.py
+++ b/src/integration-tests/test_replica_data_request.py
@@ -27,6 +27,7 @@ configured node is taken down first so that its identity can be claimed.
 import os
 import re
 import time
+from typing import Optional, Tuple
 
 import pytest
 
@@ -37,17 +38,22 @@ from blazingmq.dev.it.fixtures import (
 )
 from blazingmq.dev.it.process.admin import AdminClient
 from blazingmq.dev.it.process.rawclient import RawClient
+from blazingmq.dev.it.util import wait_until
 
-pytestmark = order(99)
+pytestmark = order(6)
 
 PARTITION_ID = 0
-NEGOTIATION_ATTEMPTS = 30
+PRIMARY_FAILOVER_SECONDS = 10
+NEGOTIATION_TIMEOUT_SECONDS = 10
+NEGOTIATION_INTERVAL_SECONDS = 0.5
 
 LOG_NAME = {"E_PUSH": "Push", "E_DROP": "Drop"}
 DATA_TYPES = ["E_PUSH", "E_DROP"]
 
 
-def _partition_primary(admin: AdminClient, cluster_name: str, partition_id: int):
+def _partition_primary(
+    admin: AdminClient, cluster_name: str, partition_id: int
+) -> Optional[Tuple[str, int]]:
     """
     Return the (name, id) of the primary of 'partition_id', or None if the
     partition has no primary yet.
@@ -66,20 +72,23 @@ def _partition_primary(admin: AdminClient, cluster_name: str, partition_id: int)
 
 
 def _wait_for_primary(
-    admin: AdminClient, cluster_name: str, partition_id: int, exclude_node_id=None
-):
+    admin: AdminClient,
+    cluster_name: str,
+    partition_id: int,
+    exclude_node_id: Optional[int] = None,
+) -> None:
     """
     Wait for 'partition_id' to have a primary other than the optionally
-    specified 'exclude_node_id', and return it as a (name, id) tuple.
+    specified 'exclude_node_id'.
     """
 
-    for _ in range(30):
+    def _has_usable_primary() -> bool:
         primary = _partition_primary(admin, cluster_name, partition_id)
-        if primary is not None and primary[1] != exclude_node_id:
-            return primary
-        time.sleep(1)
+        return primary is not None and primary[1] != exclude_node_id
 
-    raise AssertionError(f"partition {partition_id} never got a usable primary")
+    assert wait_until(_has_usable_primary, PRIMARY_FAILOVER_SECONDS), (
+        f"partition {partition_id} never got a usable primary"
+    )
 
 
 def _prepare_impersonation(cluster: Cluster):
@@ -126,7 +135,9 @@ def _connect_as_cluster_node(host, port, cluster_name, node_name, node_id):
 
     last_result = None
 
-    for _ in range(NEGOTIATION_ATTEMPTS):
+    attempts = int(NEGOTIATION_TIMEOUT_SECONDS / NEGOTIATION_INTERVAL_SECONDS)
+
+    for _ in range(attempts):
         client = RawClient(verbose=True)
         client.open_channel(host, port)
 
@@ -147,7 +158,7 @@ def _connect_as_cluster_node(host, port, cluster_name, node_name, node_id):
 
         # The victim has not dropped the impersonated node's channel yet.
         client.stop()
-        time.sleep(1)
+        time.sleep(NEGOTIATION_INTERVAL_SECONDS)
 
     raise AssertionError(f"cluster-peer negotiation never succeeded: {last_result}")
 

--- a/src/python/blazingmq/dev/it/process/rawclient.py
+++ b/src/python/blazingmq/dev/it/process/rawclient.py
@@ -20,6 +20,7 @@ blazingmq.dev.it.process.rawclient
 PURPOSE: Provide a BMQ raw client.
 """
 
+import copy
 import socket
 import json
 from typing import Optional, Tuple, Union
@@ -275,15 +276,23 @@ class RawClient:
         response = self.decode_event_bytes(response_header, response_body)
         return response
 
-    def negotiate(self) -> dict:
+    def send_control_message(self, payload: Union[str, dict]) -> None:
         """
-        Send a negotiation request to the broker.
+        Send the specified control 'payload' to the broker without waiting for a
+        response.
+        """
+        self._send_raw(self._wrap_control_event(payload))
+
+    def negotiate(self, identity: Optional[dict] = None) -> dict:
+        """
+        Send a negotiation request to the broker, overriding the default client
+        identity fields with the optionally specified 'identity'.
         Return the negotiation response from the broker.
         """
-        self._send_negotiation_request()
+        self._send_negotiation_request(identity)
         return self._receive_negotiation_response()
 
-    def _send_negotiation_request(self) -> None:
+    def _send_negotiation_request(self, identity: Optional[dict] = None) -> None:
         """
         Send a negotiation request to the broker without waiting for a response.
         Use this when you need to send the request asynchronously or when you want
@@ -291,8 +300,10 @@ class RawClient:
         """
         assert self._channel is not None
 
-        raw_client_identity = broker.CLIENT_IDENTITY_SCHEMA
+        raw_client_identity = copy.deepcopy(broker.CLIENT_IDENTITY_SCHEMA)
         raw_client_identity["clientIdentity"]["clientType"] = "E_TCPCLIENT"
+        if identity:
+            raw_client_identity["clientIdentity"].update(identity)
 
         self._send_raw(self._wrap_control_event(raw_client_identity))
 


### PR DESCRIPTION
  ## Summary
  - `StorageManager::processReplicaDataRequestPush` used `BSLS_ASSERT_SAFE` to enforce two conditions that depend on the contents of the received request: that `partitionId` is in range, and that the sender is the partition's current primary. A stale or out-of-date peer can legitimately send a request that fails either check — for example after a primary changeover — so the broker would abort in assert-enabled builds instead of handling it. Both are now runtime checks that return `E_REFUSED` with `e_NO_PARTITION` or `e_SOURCE_NOT_PRIMARY`.
  - The new checks mirror the adjacent `processReplicaDataRequestDrop`, which already validated both conditions this way; the two handlers now read identically. The "partition has no primary" case falls out of the same comparison, since `primaryNodeId()` is `k_INVALID_NODE_ID` while a partition is unassigned.