### PR TITLE
Fix[mqbs::FileStore]: terminate on replica write failure

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6505,8 +6505,10 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                 << printPSN(recHeader->primaryLeaseId(),
                             recHeader->sequenceNumber())
                 << "), journal offset words: " << header.journalOffsetWords()
-                << ", rc: " << rc << ". Ignoring this message."
+                << ", rc: " << rc << ". Aborting broker."
                 << BMQTSK_ALARMLOG_END;
+            mqbu::ExitUtil::terminate(mqbu::ExitCode::e_STORAGE_OUT_OF_SYNC);
+            // EXIT
         }
     } while (1 == iter.next());
 


### PR DESCRIPTION
Closes #1702

`processStorageEvent` continued iterating after a replica write failure, logging "Ignoring this message." Because the PSN was not bumped for the failed record, the next record failed the sequence number continuity check and terminated with `e_STORAGE_OUT_OF_SYNC`, attributing the failure to a PSN gap rather than the write error that caused it. If the failed record was the last in the event, the replica ran with a stale PSN until the next event arrived. We terminate directly on write failure, matching the severity of the existing PSN gap handler.