### PR TITLE
Fix[mqbblp]: remove ConfigureContext, report configure result from queue thread

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_queuehandle.cpp
@@ -1161,9 +1161,8 @@ void QueueHandle::deconfigureDispatched(
     BSLS_ASSERT_SAFE(d_queue_sp->inDispatcherThread());
     BSLS_ASSERT_SAFE(d_haveClient);
 
-    bsl::shared_ptr<DeconfigureContext> context(
-        new (*d_allocator_p) DeconfigureContext(deconfiguredCb),
-        d_allocator_p);
+    bsl::shared_ptr<DeconfigureContext> context;
+    context.createInplace(d_allocator_p, deconfiguredCb);
 
     mqbi::QueueHandle::SubStreams::const_iterator citer =
         d_subStreamInfos.begin();

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.cpp
@@ -55,6 +55,7 @@
 #include <bsl_limits.h>
 #include <bsl_sstream.h>
 #include <bsl_string.h>
+#include <bsl_string_view.h>
 #include <bsl_utility.h>
 #include <bsl_vector.h>
 #include <bsla_annotations.h>
@@ -262,6 +263,109 @@ bool isConfigureErrorPermanent(
     BSLA_UNREACHABLE;
 }
 
+// =======================
+// class ConfigureNotifier
+// =======================
+
+/// @brief Reports the outcome of a `configure-stream` request to the
+/// requester, once.
+///
+/// The callback is released as soon as an outcome is reported, so that a
+/// repeated report has no effect.  It can also be released to another
+/// routine, which then owes the report.  Destroying a notifier that still
+/// holds a callback is a precondition violation: every exit path of the
+/// operation owning a notifier is expected to either report an outcome or
+/// hand the callback over.
+class ConfigureNotifier {
+  private:
+    // DATA
+
+    /// Callback notifying the requester; empty once an outcome has been
+    /// reported.
+    mqbi::QueueHandle::HandleConfiguredCallback d_configuredCb;
+
+    /// Parameters mirrored back to the requester.
+    const bmqp_ctrlmsg::StreamParameters& d_streamParameters;
+
+    /// Allocator to use.
+    bslma::Allocator* d_allocator_p;
+
+  private:
+    // NOT IMPLEMENTED
+    ConfigureNotifier(const ConfigureNotifier&) BSLS_KEYWORD_DELETED;
+
+    /// Copy constructor and assignment operator removed.
+    ConfigureNotifier&
+    operator=(const ConfigureNotifier&) BSLS_KEYWORD_DELETED;
+
+  public:
+    // CREATORS
+
+    /// @brief Create a notifier reporting to the specified `configuredCb`.
+    ///
+    /// @param configuredCb Callback notifying the requester; may be empty,
+    ///                     in which case no outcome is reported.
+    /// @param streamParameters Parameters mirrored back to the requester;
+    ///                         must outlive this object.
+    /// @param allocator Allocator to use.
+    explicit ConfigureNotifier(
+        const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb,
+        const bmqp_ctrlmsg::StreamParameters&              streamParameters,
+        bslma::Allocator*                                  allocator = 0)
+    : d_configuredCb(configuredCb)
+    , d_streamParameters(streamParameters)
+    , d_allocator_p(allocator)
+    {
+        // NOTHING
+    }
+
+    ~ConfigureNotifier()
+    {
+        // PRECONDITIONS
+        BSLS_ASSERT_SAFE(!d_configuredCb &&
+                         "the outcome was never reported to the requester");
+    }
+
+    // MANIPULATORS
+
+    /// @brief Report the specified `status` to the requester and release
+    /// the callback.
+    void notify(const bmqp_ctrlmsg::Status& status)
+    {
+        if (d_configuredCb) {
+            d_configuredCb(status, d_streamParameters);
+
+            d_configuredCb = bsl::nullptr_t();
+        }
+    }
+
+    /// @brief Report a status built from the specified `category`, `code`
+    /// and `message` to the requester, and release the callback.
+    void notify(const bmqp_ctrlmsg::StatusCategory::Value& category,
+                int                                        code,
+                bsl::string_view                           message)
+    {
+        bmqp_ctrlmsg::Status status(d_allocator_p);
+        status.category() = category;
+        status.code()     = code;
+        status.message().assign(message.data(), message.length());
+
+        notify(status);
+    }
+
+    /// @brief Return the callback and release it, transferring the
+    /// obligation to report an outcome to the caller.
+    mqbi::QueueHandle::HandleConfiguredCallback releaseCb()
+    {
+        mqbi::QueueHandle::HandleConfiguredCallback configuredCb(
+            d_configuredCb);
+
+        d_configuredCb = bsl::nullptr_t();
+
+        return configuredCb;
+    }
+};
+
 }  // close unnamed namespace
 
 // ==================================
@@ -327,12 +431,13 @@ void RelayQueueEngine::onHandleCreation(void* ptr, void* cookie)
 
 // PRIVATE MANIPULATORS
 void RelayQueueEngine::onHandleConfigured(
-    const bsl::weak_ptr<RelayQueueEngine>&   self,
-    const bmqp_ctrlmsg::Status&              status,
-    const bmqp_ctrlmsg::StreamParameters&    upStreamParameters,
-    mqbi::QueueHandle*                       handle,
-    const bmqp_ctrlmsg::StreamParameters&    downStreamParameters,
-    const bsl::shared_ptr<ConfigureContext>& context)
+    const bsl::weak_ptr<RelayQueueEngine>&             self,
+    const bmqp_ctrlmsg::Status&                        status,
+    const bmqp_ctrlmsg::StreamParameters&              upStreamParameters,
+    mqbi::QueueHandle*                                 handle,
+    const bmqp_ctrlmsg::StreamParameters&              downStreamParameters,
+    const bsl::shared_ptr<Routers::AppContext>&        routing_sp,
+    const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb)
 {
     // executed by *ANY* thread
 
@@ -342,8 +447,7 @@ void RelayQueueEngine::onHandleConfigured(
     // lifetime) to reach the queue, and forward 'self' as-is instead of
     // re-deriving it from 'd_self'.  'onHandleConfiguredDispatched' performs
     // the liveness check, once truly running on the queue's dispatcher
-    // thread.  This also guarantees 'context' -- whose destructor invokes
-    // the completion callback -- is always destroyed on that same thread.
+    // thread, and invokes 'configuredCb' there.
 
     handle->queue()->dispatcher()->execute(
         bdlf::BindUtil::bind(&RelayQueueEngine::onHandleConfiguredDispatched,
@@ -353,12 +457,12 @@ void RelayQueueEngine::onHandleConfigured(
                              upStreamParameters,
                              handle,
                              downStreamParameters,
-                             context),
+                             routing_sp,
+                             configuredCb),
         handle->queue());
 
     // 'onHandleConfiguredDispatched' is now responsible for calling the
-    // callback: either 'ClusterQueueHelper::onHandleConfigured' or
-    // 'ClientSession::onHandleConfigured'.  Neither one requires queue thread.
+    // callback, on the queue's dispatcher thread.
 }
 
 void RelayQueueEngine::onHandleConfiguredDispatched(
@@ -366,20 +470,29 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
     const bmqp_ctrlmsg::Status&            status,
     BSLA_MAYBE_UNUSED const bmqp_ctrlmsg::StreamParameters& upStreamParameters,
     mqbi::QueueHandle*                                      handle,
-    const bmqp_ctrlmsg::StreamParameters&    downStreamParameters,
-    const bsl::shared_ptr<ConfigureContext>& context)
+    const bmqp_ctrlmsg::StreamParameters&              downStreamParameters,
+    const bsl::shared_ptr<Routers::AppContext>&        routing_sp,
+    const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb)
 {
     // executed by the *QUEUE DISPATCHER* thread
+
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(routing_sp);
+
+    // Every exit path below reports an outcome to the requester, from this
+    // thread.  Note that 'this' must not be dereferenced until 'self' has
+    // been locked, hence the notifier is left with the default allocator.
+    ConfigureNotifier notifier(configuredCb, downStreamParameters);
 
     bsl::shared_ptr<RelayQueueEngine> strongSelf = self.lock();
     if (!strongSelf) {
         // The engine was destroyed.
+        notifier.notify(bmqp_ctrlmsg::StatusCategory::E_SUCCESS, 0, "");
+
         return;  // RETURN
     }
 
-    // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->inDispatcherThread());
-    BSLS_ASSERT_SAFE(context);
 
     // Force re-delivery
     deliverMessages();
@@ -394,7 +507,7 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
             << Event(handle, d_queueState_p, isHandleKnown)
             << ", for parameters [" << downStreamParameters << "].";
 
-        context->setStatus(status);
+        notifier.notify(status);
 
         return;  // RETURN
     }
@@ -423,9 +536,9 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
             app.invalidate(handle);
         }
 
-        context->setStatus(bmqp_ctrlmsg::StatusCategory::E_UNKNOWN,
-                           -1,
-                           "Unknown handle.");
+        notifier.notify(bmqp_ctrlmsg::StatusCategory::E_UNKNOWN,
+                        -1,
+                        "Unknown handle.");
 
         return;  // RETURN
     }
@@ -454,8 +567,8 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
         app = findApp(upstreamSubQueueId);
         BSLS_ASSERT_SAFE(app);
 
-        // This also validates the context by checking for missing handles.
-        applyConfiguration(*app, *context);
+        // This also validates the routing by checking for missing handles.
+        applyConfiguration(*app, routing_sp);
 
         BALL_LOGTHROTTLE_INFO_BLOCK(k_MAX_INSTANT_MESSAGES, k_NS_PER_MESSAGE)
         {
@@ -481,7 +594,7 @@ void RelayQueueEngine::onHandleConfiguredDispatched(
     }
 
     // Invoke callback sending ConfigureQueue response before PUSHing.
-    context->invokeCallback();
+    notifier.notify(bmqp_ctrlmsg::StatusCategory::E_SUCCESS, 0, "");
 
     if (app) {
         processAppRedelivery(upstreamSubQueueId, app);
@@ -799,10 +912,10 @@ void RelayQueueEngine::processAppRedelivery(unsigned int upstreamSubQueueId,
 }
 
 void RelayQueueEngine::configureApp(
-    App_State&                               appState,
-    mqbi::QueueHandle*                       handle,
-    const bmqp_ctrlmsg::StreamParameters&    streamParameters,
-    const bsl::shared_ptr<ConfigureContext>& context)
+    App_State&                                         appState,
+    mqbi::QueueHandle*                                 handle,
+    const bmqp_ctrlmsg::StreamParameters&              streamParameters,
+    const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb)
 {
     // Update handle's 'upstream/outstanding' stream parameters.  Note that
     // self node has to send a configure request upstream.  RelayQueueEngine
@@ -811,6 +924,10 @@ void RelayQueueEngine::configureApp(
     // request will not fail.  So, we update the 'effective' stream parameters
     // before sending the request but update the stream parameters of the
     // specified 'handle' only in the response callback.
+
+    // Every exit path below either reports an outcome to the requester, or
+    // hands the callback over to the routine that will.
+    ConfigureNotifier notifier(configuredCb, streamParameters, d_allocator_p);
 
     App_State::CachedParametersMap::iterator itHandle(
         appState.d_cache.find(handle));
@@ -826,6 +943,8 @@ void RelayQueueEngine::configureApp(
             << "ones: " << streamParameters
             << ". Not sending configure-queue request upstream, but "
             << "returning success to downstream client.";
+
+        notifier.notify(bmqp_ctrlmsg::StatusCategory::E_SUCCESS, 0, "");
 
         return;  // RETURN
     }
@@ -848,7 +967,14 @@ void RelayQueueEngine::configureApp(
         << "', about to rebuild upstream state [current stream parameters: "
         << previousParameters << "]";
 
-    rebuildUpstreamState(context->d_routing_sp.get(),
+    // Routing data to advertise upstream (including Subscription Ids).  It
+    // becomes effective either right below, or once upstream has responded.
+    bsl::shared_ptr<Routers::AppContext> routing_sp =
+        bsl::allocate_shared<Routers::AppContext>(
+            d_allocator_p,
+            &d_queueState_p->routingContext());
+
+    rebuildUpstreamState(routing_sp.get(),
                          &appState,
                          upstreamSubQueueId,
                          streamParameters.appId());
@@ -875,9 +1001,13 @@ void RelayQueueEngine::configureApp(
         // Set the parameters and inform downstream client of success
         handle->setStreamParameters(streamParameters);
 
-        applyConfiguration(appState, *context);
+        applyConfiguration(appState, routing_sp);
+
+        notifier.notify(bmqp_ctrlmsg::StatusCategory::E_SUCCESS, 0, "");
+
         return;  // RETURN
     }
+
     const QueueHandle::HandleConfiguredCallback& callback =
         bdlf::BindUtil::bind(&RelayQueueEngine::onHandleConfigured,
                              this,
@@ -886,7 +1016,8 @@ void RelayQueueEngine::configureApp(
                              bdlf::PlaceHolders::_2,  // upStreamParameters
                              handle,
                              streamParameters,  // downStreamParameters
-                             context);
+                             routing_sp,
+                             notifier.releaseCb());
 
     // Send a configure stream request upstream.
     d_queueState_p->domain()->cluster()->configureQueue(
@@ -952,17 +1083,18 @@ void RelayQueueEngine::rebuildUpstreamState(Routers::AppContext* context,
         << upstreamParams << "]";
 }
 
-void RelayQueueEngine::applyConfiguration(App_State&        app,
-                                          ConfigureContext& context)
+void RelayQueueEngine::applyConfiguration(
+    App_State&                                  app,
+    const bsl::shared_ptr<Routers::AppContext>& routing_sp)
 {
     // executed by the *QUEUE DISPATCHER* thread
 
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->inDispatcherThread());
+    BSLS_ASSERT_SAFE(routing_sp);
 
     app.undoRouting();
-
-    app.routing() = context.d_routing_sp;
+    app.routing() = routing_sp;
 
     if (!d_queueState_p->isDeliverConsumerPriority()) {
         if (d_queueState_p->hasMultipleSubStreams()) {
@@ -1295,11 +1427,9 @@ void RelayQueueEngine::configureHandle(
     BSLS_ASSERT_SAFE(d_queueState_p->queue()->inDispatcherThread());
     BSLS_ASSERT_SAFE(handle);
 
-    // The 'context' will mirror streamParameters when calling 'configuredCb'
-    bsl::shared_ptr<ConfigureContext> context(
-        new (*d_allocator_p)
-            ConfigureContext(configuredCb, streamParameters, d_allocator_p),
-        d_allocator_p);
+    // Every exit path below either reports an outcome to the requester, or
+    // hands the callback over to the routine that will.
+    ConfigureNotifier notifier(configuredCb, streamParameters, d_allocator_p);
 
     // Verify handle exists
     if (!d_queueState_p->handleCatalog().hasHandle(handle)) {
@@ -1310,9 +1440,10 @@ void RelayQueueEngine::configureHandle(
             << "', stream params: " << streamParameters << ", handlePtr '"
             << handle << "'.";
 
-        context->setStatus(bmqp_ctrlmsg::StatusCategory::E_UNKNOWN,
-                           -1,
-                           "Attempting to configure unknown handle.");
+        notifier.notify(bmqp_ctrlmsg::StatusCategory::E_UNKNOWN,
+                        -1,
+                        "Attempting to configure unknown handle.");
+
         return;  // RETURN
     }
 
@@ -1328,10 +1459,11 @@ void RelayQueueEngine::configureHandle(
             << "', stream params: " << streamParameters << ", handlePtr '"
             << handle << "'.";
 
-        context->setStatus(
+        notifier.notify(
             bmqp_ctrlmsg::StatusCategory::E_UNKNOWN,
             -1,
             "Attempting to configure unknown substream for the handle.");
+
         return;  // RETURN
     }
 
@@ -1339,9 +1471,7 @@ void RelayQueueEngine::configureHandle(
     App_State*   app                = findApp(upstreamSubQueueId);
     BSLS_ASSERT_SAFE(app);
 
-    context->initializeRouting(d_queueState_p->routingContext());
-
-    configureApp(*app, handle, streamParameters, context);
+    configureApp(*app, handle, streamParameters, notifier.releaseCb());
 }
 
 void RelayQueueEngine::releaseHandle(

--- a/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
+++ b/src/groups/mqb/mqbblp/mqbblp_relayqueueengine.h
@@ -164,47 +164,6 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     /// Has to have access to private member variables.
     friend class AutoPurger;
 
-    /// This struct serves as multiplexor when sending configure request(s)
-    /// (plural in the case of wildcard) to upstream.  Once all responses
-    /// are collected (there are no more references), it calls the specified
-    /// callback
-    struct ConfigureContext {
-        // TRAITS
-        BSLMF_NESTED_TRAIT_DECLARATION(ConfigureContext,
-                                       bslma::UsesBslmaAllocator)
-
-        mqbi::QueueHandle::HandleConfiguredCallback d_configuredCb;
-        bmqp_ctrlmsg::Status                        d_status;
-        const bmqp_ctrlmsg::StreamParameters        d_streamParameters;
-
-        /// Routing data advertised upstream (including Subscription Ids).
-        /// Upon response from upstream, this becomes effective.
-        bsl::shared_ptr<Routers::AppContext> d_routing_sp;
-
-        bslma::Allocator* d_allocator_p;
-
-        ConfigureContext(
-            const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb,
-            const bmqp_ctrlmsg::StreamParameters& streamParameters,
-            bslma::Allocator*                     allocator);
-
-        ~ConfigureContext();
-
-        void setStatus(const bmqp_ctrlmsg::StatusCategory::Value& category,
-                       int                                        code,
-                       const bslstl::StringRef&                   message);
-
-        void setStatus(const bmqp_ctrlmsg::Status& status);
-
-        void invokeCallback();
-
-        void resetCallback();
-
-        void reset();
-
-        void initializeRouting(Routers::QueueRoutingContext& queueContext);
-    };
-
   private:
     // DATA
     QueueState* d_queueState_p;
@@ -251,40 +210,60 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
   private:
     // PRIVATE MANIPULATORS
 
-    /// Schedule processing of the stream configuration response from
-    /// upstream of the specified `handle` with the specified
-    /// `downStreamParameters` per the specified `status`.  The specified
-    /// `upStreamParameters` is the upstream view of the stream parameters
-    /// of this node.  When the specified `context` reference count drops to
-    /// zero, invoke associated callback. Note that the specified `self`
-    /// must be locked to ensure the engine is still alive at the time the
-    /// callback is invoked.
+    /// @brief Schedule processing of a `configure-stream` response from
+    /// upstream on the queue's dispatcher thread.
+    ///
+    /// @param self Weak reference to this engine, checked for liveness once
+    ///             running on the queue's dispatcher thread.
+    /// @param status Outcome reported by upstream.
+    /// @param upStreamParameters Upstream view of this node's stream
+    ///                           parameters.
+    /// @param handle The handle being configured.
+    /// @param downStreamParameters Stream parameters advertised downstream.
+    /// @param routing_sp Routing advertised upstream, to be made effective
+    ///                   by `onHandleConfiguredDispatched`.
+    /// @param configuredCb Callback notifying the requester of the outcome,
+    ///                     invoked by `onHandleConfiguredDispatched`; may be
+    ///                     empty.
     ///
     /// THREAD: This method is called from any thread.
     void onHandleConfigured(
-        const bsl::weak_ptr<RelayQueueEngine>&   self,
-        const bmqp_ctrlmsg::Status&              status,
-        const bmqp_ctrlmsg::StreamParameters&    upStreamParameters,
-        mqbi::QueueHandle*                       handle,
-        const bmqp_ctrlmsg::StreamParameters&    downStreamParameters,
-        const bsl::shared_ptr<ConfigureContext>& context);
+        const bsl::weak_ptr<RelayQueueEngine>&      self,
+        const bmqp_ctrlmsg::Status&                 status,
+        const bmqp_ctrlmsg::StreamParameters&       upStreamParameters,
+        mqbi::QueueHandle*                          handle,
+        const bmqp_ctrlmsg::StreamParameters&       downStreamParameters,
+        const bsl::shared_ptr<Routers::AppContext>& routing_sp,
+        const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb);
 
-    /// Process stream configuration response from upstream of the specified
-    /// `handle` with the specified `downStreamParameters` per the specified
-    /// `status`.  The specified `upStreamParameters` is the upstream view
-    /// of the stream parameters of this node.  When the specified `context`
-    /// reference count drops to zero, invoke associated callback.  Note
-    /// that the specified `self` must be locked to ensure the engine is
-    /// still alive at the time the callback is invoked.
+    /// @brief Process a `configure-stream` response from upstream and
+    /// notify the requester of the outcome.
+    ///
+    /// Apply the response to the routing of the specified `handle`, then
+    /// invoke the specified `configuredCb` on every exit path, so that it
+    /// always runs on this thread.
+    ///
+    /// @param self Weak reference to this engine; nothing but the callback
+    ///             is performed if the engine is no longer alive.
+    /// @param status Outcome reported by upstream.
+    /// @param upStreamParameters Upstream view of this node's stream
+    ///                           parameters.
+    /// @param handle The handle being configured.
+    /// @param downStreamParameters Stream parameters advertised downstream,
+    ///                             and mirrored back to the requester.
+    /// @param routing_sp Routing advertised upstream, made effective here.
+    /// @param configuredCb Callback notifying the requester of the outcome;
+    ///                     may be empty.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
     void onHandleConfiguredDispatched(
-        const bsl::weak_ptr<RelayQueueEngine>&   self,
-        const bmqp_ctrlmsg::Status&              status,
-        const bmqp_ctrlmsg::StreamParameters&    upStreamParameters,
-        mqbi::QueueHandle*                       handle,
-        const bmqp_ctrlmsg::StreamParameters&    downStreamParameters,
-        const bsl::shared_ptr<ConfigureContext>& context);
+        const bsl::weak_ptr<RelayQueueEngine>&      self,
+        const bmqp_ctrlmsg::Status&                 status,
+        const bmqp_ctrlmsg::StreamParameters&       upStreamParameters,
+        mqbi::QueueHandle*                          handle,
+        const bmqp_ctrlmsg::StreamParameters&       downStreamParameters,
+        const bsl::shared_ptr<Routers::AppContext>& routing_sp,
+        const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb);
 
     /// Schedule processing of the release response from upstream of the
     /// specified `handle` with the specified `handleParameters` per the
@@ -310,15 +289,21 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
     void deliverMessages();
     void processAppRedelivery(unsigned int upstreamSubQueueId, App_State* app);
 
-    /// Configure the specified `handle` with the specified
-    /// `streamParameters` for the specified `appState`.  When the specified
-    /// `context` reference count drops to zero, invoke associated callback.
+    /// @brief Configure the specified `handle` with the specified
+    /// `streamParameters` for the specified `appState`.
+    ///
+    /// Consult upstream if the newly advertised parameters differ from the
+    /// ones already in effect, in which case the specified `configuredCb`
+    /// is invoked upon the upstream response; otherwise complete the
+    /// request and invoke `configuredCb` before returning.  `configuredCb`
+    /// may be empty, in which case the outcome is not reported.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void configureApp(App_State&                            appState,
-                      mqbi::QueueHandle*                    handle,
-                      const bmqp_ctrlmsg::StreamParameters& streamParameters,
-                      const bsl::shared_ptr<ConfigureContext>& context);
+    void configureApp(
+        App_State&                                         appState,
+        mqbi::QueueHandle*                                 handle,
+        const bmqp_ctrlmsg::StreamParameters&              streamParameters,
+        const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb);
 
     void releaseHandleImpl(
         mqbi::QueueHandle*                                           handle,
@@ -336,11 +321,16 @@ class RelayQueueEngine BSLS_KEYWORD_FINAL : public mqbi::QueueEngine {
                               unsigned int         upstreamSubQueueId,
                               const bsl::string&   appId);
 
-    /// Make effective the previously built routing results containing
-    /// Subscription ids advertised upstream.
+    /// @brief Make the specified `routing_sp` the effective routing of the
+    /// specified `appState`.
+    ///
+    /// `routing_sp` holds the previously built routing results containing
+    /// the Subscription ids advertised upstream.
     ///
     /// THREAD: This method is called from the Queue's dispatcher thread.
-    void applyConfiguration(App_State& appState, ConfigureContext& context);
+    void
+    applyConfiguration(App_State&                                  appState,
+                       const bsl::shared_ptr<Routers::AppContext>& routing_sp);
 
     mqbi::Storage* storage() const;
 
@@ -606,65 +596,6 @@ inline RelayQueueEngine_AppState::CachedParameters::CachedParameters(
 , d_downstreamSubQueueId(downstreamSubQueueId)
 {
     // NOTHING
-}
-
-// -----------------------------------------
-// struct RelayQueueEngine::ConfigureContext
-// -----------------------------------------
-
-inline RelayQueueEngine::ConfigureContext::ConfigureContext(
-    const mqbi::QueueHandle::HandleConfiguredCallback& configuredCb,
-    const bmqp_ctrlmsg::StreamParameters&              streamParameters,
-    bslma::Allocator*                                  allocator)
-: d_configuredCb(configuredCb)
-, d_status()
-, d_streamParameters(streamParameters, allocator)
-, d_routing_sp()
-, d_allocator_p(allocator)
-{
-    d_status.category() = bmqp_ctrlmsg::StatusCategory::E_SUCCESS;
-    d_status.code()     = 0;
-}
-
-inline RelayQueueEngine::ConfigureContext::~ConfigureContext()
-{
-    invokeCallback();
-}
-
-inline void RelayQueueEngine::ConfigureContext::setStatus(
-    const bmqp_ctrlmsg::StatusCategory::Value& category,
-    int                                        code,
-    const bslstl::StringRef&                   message)
-{
-    d_status.category() = category;
-    d_status.code()     = code;
-    d_status.message()  = message;
-}
-
-inline void RelayQueueEngine::ConfigureContext::setStatus(
-    const bmqp_ctrlmsg::Status& status)
-{
-    d_status = status;
-}
-
-inline void RelayQueueEngine::ConfigureContext::invokeCallback()
-{
-    if (d_configuredCb) {
-        d_configuredCb(d_status, d_streamParameters);
-        resetCallback();
-    }
-}
-
-inline void RelayQueueEngine::ConfigureContext::resetCallback()
-{
-    d_configuredCb = bsl::nullptr_t();
-}
-
-inline void RelayQueueEngine::ConfigureContext::initializeRouting(
-    Routers::QueueRoutingContext& queueContext)
-{
-    d_routing_sp = bsl::allocate_shared<Routers::AppContext>(d_allocator_p,
-                                                             &queueContext);
 }
 
 // ----------------------

--- a/src/integration-tests/test_queue_close.py
+++ b/src/integration-tests/test_queue_close.py
@@ -17,6 +17,8 @@
 Integration test that tests closing a queue when the broker is down.
 """
 
+import time
+
 import blazingmq.dev.it.testconstants as tc
 from blazingmq.dev.it.fixtures import (
     Cluster,
@@ -192,3 +194,120 @@ def test_close_while_retrying_reopen(multi_node: Cluster, domain_urls: tc.Domain
 
     # verify new open
     consumer1.open(uri_priority, flags=["read"], succeed=True)
+
+
+@tweak.cluster.queue_operations.configure_timeout_ms(500)
+@tweak.cluster.queue_operations.close_timeout_ms(500)
+@tweak.cluster.queue_operations.keepalive_duration_ms(100)
+def test_upstream_replies_racing_client_teardown(
+    multi_node: Cluster, domain_urls: tc.DomainUrls
+):
+    """
+    A proxy answers its clients only once its upstream has answered it, so an
+    open-queue reply can arrive after the client that asked for it is already
+    gone.  Such a handle is rolled back as soon as it is created, which can
+    retire it -- and the queue holding it -- while the de-configure the proxy
+    issued for that same handle is still outstanding upstream.  The reply to
+    that de-configure then has nothing left to apply, and it arrives on the
+    thread that received it rather than on the one that owns the queue.
+    Applying it, or discarding it, is the queue dispatcher thread's job either
+    way.
+
+    Each round parks a batch of opens on an upstream that cannot answer, then
+    releases the batch at the same moment the clients that issued it are
+    destroyed, so the replies land while the proxy is dismantling their
+    handles.  Every broker must survive every round.
+    """
+    # The two things that have to overlap are a reply arriving and a client
+    # being torn down, and neither side can be pinned down exactly.  Rounds are
+    # cheap and each one throws a whole batch of replies into the window.
+    rounds = 6
+
+    # Clients destroyed together, so that later teardowns overlap the replies
+    # still owed to earlier ones.
+    clients_per_round = 3
+
+    # Opens each client leaves outstanding when it is destroyed.  The batch has
+    # to be long enough to still be arriving once teardown has started.
+    queues_per_client = 15
+
+    cluster = multi_node
+    du = domain_urls
+
+    proxies = cluster.proxy_cycle()
+    # pick the proxy in the data center opposite to the primary's
+    next(proxies)
+    proxy = next(proxies)
+
+    for rnd in range(rounds):
+        # Each round uses queues of its own, so a round's queues are retired
+        # while that round's replies may still be travelling.
+        def held(index, rnd=rnd):
+            return f"{du.uri_priority}r{rnd}h{index}"
+
+        def parked(client_index, index, rnd=rnd):
+            return f"{du.uri_priority}r{rnd}c{client_index}q{index}"
+
+        clients = []
+        for i in range(clients_per_round):
+            client = proxy.create_client(f"consumer{rnd}n{i}")
+            # An established handle, so that losing this client also leaves a
+            # de-configure outstanding upstream.
+            client.open(held(i), flags=["read"], succeed=True)
+            clients.append(client)
+
+        # The proxy names a session after the pid of its client, which is how
+        # this round tells its own teardowns from any other round's.
+        pids = [client.pid for client in clients]
+
+        active_node = cluster.process(proxy.get_active_node())
+
+        # Nothing the proxy forwards from here on can be answered.
+        active_node.suspend()
+
+        for i, client in enumerate(clients):
+            for q in range(queues_per_client):
+                client.open(parked(i, q), flags=["read"], block=False)
+
+        # Release the batch and lose the clients at the same time.  Which of
+        # the two lands first decides whether a reply meets a live handle, a
+        # retired one, or a queue that is already gone, so alternate the order.
+        if rnd % 2:
+            active_node.resume()
+            for client in clients:
+                client.force_stop()
+        else:
+            for client in clients:
+                client.force_stop()
+            active_node.resume()
+
+        # Every client of this round reached teardown.  Each session that goes
+        # away logs this line, and scanning consumes the output, so claim one
+        # line per client: a line left behind here would be matched by a later
+        # round, which would then be looking at a teardown that is not its own.
+        assert all(
+            proxy.capture_n(
+                [rf":{pid}\b.*Dropped \d+ queue handles" for pid in pids],
+                timeout=10,
+            )
+        )
+
+        if rnd == 0:
+            # The batch really did outlive its requesters: replies are being
+            # applied to handles nobody is waiting for any more.
+            assert proxy.capture(
+                r"OpenQueueConfirmationCookie released without", timeout=10
+            )
+
+        # Let the queues nobody holds any more be collected while the rest of
+        # the batch is still being digested.
+        time.sleep(1)
+
+        # The proxy digested the whole batch and still serves clients.
+        witness = proxy.create_client(f"witness{rnd}")
+        witness.open(held(0), flags=["write,ack"], succeed=True)
+        witness.stop()
+
+        assert proxy.is_alive()
+        for node in cluster.nodes():
+            assert node.is_alive()


### PR DESCRIPTION
- Remove ref-counted shared `ConfigureContext` (no need to share it)
- Introduce stack-scoped `ConfigureNotifier`. It allows to execute the stored callback at most once, and ensures that the callback is either called or passed next in the end.
- Build routing close to the place it is used first.
- Add an IT that fails in main with configure context destructed from a wrong thread.