### PR TITLE
Refactor[mqba]: simplify AdminSession, SessionNegotiator

### DIFF
--- a/src/groups/mqb/mqba/mqba_adminsession.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.cpp
@@ -286,7 +286,6 @@ AdminSession::AdminSession(
     const bsl::string&                            sessionDescription,
     mqbi::Dispatcher*                             dispatcher,
     AdminSessionState::BlobSpPool*                blobSpPool,
-    bdlmt::EventScheduler*                        scheduler,
     const mqbnet::Session::AdminCommandEnqueueCb& adminCb,
     const bsl::shared_ptr<mqbi::Authorizer>&      authorizer,
     bslma::Allocator*                             allocator)
@@ -300,7 +299,6 @@ AdminSession::AdminSession(
           bmqp::SchemaEventBuilderUtil::bestEncodingSupported(
               d_clientIdentity_p->features()),
           allocator)
-, d_scheduler_p(scheduler)
 , d_authorizer_sp(authorizer)
 , d_adminCb(adminCb)
 {
@@ -308,7 +306,6 @@ AdminSession::AdminSession(
     BSLS_ASSERT(channel);
     BSLS_ASSERT(dispatcher);
     BSLS_ASSERT(blobSpPool);
-    BSLS_ASSERT(scheduler);
     BSLS_ASSERT(adminCb);
     BSLS_ASSERT(authorizer);
 

--- a/src/groups/mqb/mqba/mqba_adminsession.h
+++ b/src/groups/mqb/mqba/mqba_adminsession.h
@@ -41,7 +41,6 @@
 #include <bdlbb_blob.h>
 #include <bdlcc_objectpool.h>
 #include <bdlcc_sharedobjectpool.h>
-#include <bdlmt_eventscheduler.h>
 #include <bsl_functional.h>
 #include <bsl_memory.h>
 #include <bsl_string.h>
@@ -155,9 +154,6 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
     /// The state associated to this session.
     AdminSessionState d_state;
 
-    /// Pointer to the event scheduler to use (held, not owned).
-    bdlmt::EventScheduler* d_scheduler_p;
-
     /// The authorizer to use for this session
     bsl::shared_ptr<mqbi::Authorizer> d_authorizer_sp;
 
@@ -228,7 +224,6 @@ class AdminSession : public mqbnet::Session, public mqbi::DispatcherClient {
                  const bsl::string&                      sessionDescription,
                  mqbi::Dispatcher*                       dispatcher,
                  AdminSessionState::BlobSpPool*          blobSpPool,
-                 bdlmt::EventScheduler*                  scheduler,
                  const mqbnet::Session::AdminCommandEnqueueCb& adminEnqueueCb,
                  const bsl::shared_ptr<mqbi::Authorizer>&      authorizer,
                  bslma::Allocator*                             allocator);

--- a/src/groups/mqb/mqba/mqba_adminsession.t.cpp
+++ b/src/groups/mqb/mqba/mqba_adminsession.t.cpp
@@ -70,32 +70,6 @@ typedef bdlcc::SharedObjectPool<
     bdlcc::ObjectPoolFunctors::RemoveAll<bdlbb::Blob> >
     BlobSpPool;
 
-/// Struct to initialize system time component
-struct TestClock {
-    // DATA
-    bdlmt::EventScheduler& d_scheduler;
-
-    bdlmt::EventSchedulerTestTimeSource d_timeSource;
-
-    // CREATORS
-    TestClock(bdlmt::EventScheduler& scheduler)
-    : d_scheduler(scheduler)
-    , d_timeSource(&scheduler)
-    {
-        // NOTHING
-    }
-
-    // MANIPULATORS
-    bsls::TimeInterval realtimeClock() { return d_timeSource.now(); }
-
-    bsls::TimeInterval monotonicClock() { return d_timeSource.now(); }
-
-    bsls::Types::Int64 highResTimer()
-    {
-        return d_timeSource.now().totalNanoseconds();
-    }
-};
-
 bmqp_ctrlmsg::NegotiationMessage client()
 // Create a 'NegotiationMessage' that represents a client configuration for
 // the specified 'clientType'.
@@ -156,8 +130,6 @@ class TestBench {
     BlobSpPool                          d_blobSpPool;
     bsl::shared_ptr<bmqio::TestChannel> d_channel_sp;
     mqbmock::Dispatcher                 d_mockDispatcher;
-    bdlmt::EventScheduler               d_scheduler;
-    TestClock                           d_testClock;
     bsl::shared_ptr<TestAuthorizer>     d_authorizer_sp;
     mqba::AdminSession                  d_as;
     bslma::Allocator*                   d_allocator_p;
@@ -178,15 +150,12 @@ class TestBench {
                    allocator)
     , d_channel_sp(new bmqio::TestChannel(allocator))
     , d_mockDispatcher(allocator)
-    , d_scheduler(bsls::SystemClockType::e_MONOTONIC, allocator)
-    , d_testClock(d_scheduler)
     , d_authorizer_sp(bsl::allocate_shared<TestAuthorizer>(allocator))
     , d_as(d_channel_sp,
            negotiationMessage,
            "sessionDescription",
            &d_mockDispatcher,
            &d_blobSpPool,
-           &d_scheduler,
            adminEnqueueCb,
            d_authorizer_sp,
            allocator)
@@ -195,26 +164,10 @@ class TestBench {
         // Typically done during 'Dispatcher::registerClient()'.
         d_as.dispatcherClientData().setDispatcher(&d_mockDispatcher);
         d_as.setThreadId(bslmt::ThreadUtil::selfId());
-
-        // Setup test time source
-        bmqu::Time::shutdown();
-        bmqu::Time::initialize(
-            bdlf::BindUtil::bind(&TestClock::realtimeClock, &d_testClock),
-            bdlf::BindUtil::bind(&TestClock::monotonicClock, &d_testClock),
-            bdlf::BindUtil::bind(&TestClock::highResTimer, &d_testClock),
-            d_allocator_p);
-
-        int rc = d_scheduler.start();
-        BMQTST_ASSERT_EQ(rc, 0);
     }
 
     /// Destructor
-    ~TestBench()
-    {
-        d_as.tearDown(bsl::shared_ptr<void>(), true);
-        d_scheduler.cancelAllEventsAndWait();
-        d_scheduler.stop();
-    }
+    ~TestBench() { d_as.tearDown(bsl::shared_ptr<void>(), true); }
 };
 
 // ============================================================================
@@ -470,8 +423,6 @@ static void test2_safeConcurrentTeardown()
                           1024,
                           alloc);
 
-    bdlmt::EventScheduler scheduler(bsls::SystemClockType::e_MONOTONIC, alloc);
-
     // Dispatcher driven by a dedicated processor thread.
     mqbmock::Dispatcher dispatcher(alloc);
     dispatcher.setEnqueueOnly(true);
@@ -526,7 +477,6 @@ static void test2_safeConcurrentTeardown()
                                                      description,
                                                      &dispatcher,
                                                      &blobSpPool,
-                                                     &scheduler,
                                                      adminCb,
                                                      authorizer);
 
@@ -556,7 +506,6 @@ static void test2_safeConcurrentTeardown()
     pool.drain();
     pool.stop();
     processor.stop();
-    scheduler.stop();
 }
 
 // ============================================================================

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -890,7 +890,6 @@ void SessionNegotiator::createSession(
                          description,
                          d_dispatcher_p,
                          d_blobSpPool_p,
-                         d_scheduler_p,
                          d_adminCb,
                          d_authorizer_sp,
                          d_allocator_p);

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.cpp
@@ -581,10 +581,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onClientIdentityMessage(
                            clientIdentity,
                            *(context_p->channel().get()));
 
-    bsl::shared_ptr<mqbnet::Session> session;
-    createSession(&session, context_p, description);
-
-    return session;
+    return createSession(context_p, description);
 }
 
 bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onBrokerResponseMessage(
@@ -633,10 +630,7 @@ bsl::shared_ptr<mqbnet::Session> SessionNegotiator::onBrokerResponseMessage(
         }
     }
 
-    bsl::shared_ptr<mqbnet::Session> session;
-    createSession(&session, context_p, description);
-
-    return session;
+    return createSession(context_p, description);
 }
 
 int SessionNegotiator::sendNegotiationMessage(
@@ -860,13 +854,11 @@ bool SessionNegotiator::authorizeIncomingConnection(
     return true;
 }
 
-void SessionNegotiator::createSession(
-    bsl::shared_ptr<mqbnet::Session>* out,
-    mqbnet::InitialConnectionContext* context_p,
-    const bsl::string&                description)
+bsl::shared_ptr<mqbnet::Session>
+SessionNegotiator::createSession(mqbnet::InitialConnectionContext* context_p,
+                                 const bsl::string&                description)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(out);
     BSLS_ASSERT_SAFE(context_p);
     BSLS_ASSERT_SAFE(context_p->negotiationContext());
     BSLS_ASSERT_SAFE(context_p->negotiationContext()->connectionType() !=
@@ -884,59 +876,54 @@ void SessionNegotiator::createSession(
 
     if (negotiationContext->connectionType() ==
         mqbnet::ConnectionType::e_ADMIN) {
-        mqba::AdminSession* session = new (*d_allocator_p)
-            AdminSession(channel,
-                         negoMsg,
-                         description,
-                         d_dispatcher_p,
-                         d_blobSpPool_p,
-                         d_adminCb,
-                         d_authorizer_sp,
-                         d_allocator_p);
-
-        out->reset(session, d_allocator_p);
+        return bsl::allocate_shared<AdminSession>(d_allocator_p,
+                                                  channel,
+                                                  negoMsg,
+                                                  description,
+                                                  d_dispatcher_p,
+                                                  d_blobSpPool_p,
+                                                  d_adminCb,
+                                                  d_authorizer_sp);  // RETURN
     }
-    else if (negotiationContext->connectionType() ==
-             mqbnet::ConnectionType::e_CLIENT) {
+
+    if (negotiationContext->connectionType() ==
+        mqbnet::ConnectionType::e_CLIENT) {
         // Create a dedicated stats subcontext for this client
         bmqst::StatContextConfiguration statContextCfg(description);
         statContextCfg.storeExpiredSubcontextValues(true);
-        bslma::ManagedPtr<bmqst::StatContext> statContext =
+        bslma::ManagedPtr<bmqst::StatContext> statContextMp =
             d_statContext_p->addSubcontext(statContextCfg);
+        bsl::shared_ptr<bmqst::StatContext> statContext(statContextMp,
+                                                        d_allocator_p);
 
-        mqba::ClientSession* session = new (*d_allocator_p)
-            ClientSession(channel,
-                          negoMsg,
-                          description,
-                          d_dispatcher_p,
-                          d_clusterCatalog_p,
-                          d_domainFactory_p,
-                          statContext,
-                          d_blobSpPool_p,
-                          d_bufferFactory_p,
-                          d_scheduler_p,
-                          d_authorizer_sp,
-                          d_allocator_p);
-
-        out->reset(session, d_allocator_p);
+        return bsl::allocate_shared<ClientSession>(d_allocator_p,
+                                                   channel,
+                                                   negoMsg,
+                                                   description,
+                                                   d_dispatcher_p,
+                                                   d_clusterCatalog_p,
+                                                   d_domainFactory_p,
+                                                   statContext,
+                                                   d_blobSpPool_p,
+                                                   d_bufferFactory_p,
+                                                   d_scheduler_p,
+                                                   d_authorizer_sp);  // RETURN
     }
-    else {
-        const bmqp_ctrlmsg::ClientIdentity& peerIdentity =
-            negoMsg.isClientIdentityValue()
-                ? negoMsg.clientIdentity()
-                : negoMsg.brokerResponse().brokerIdentity();
 
-        mqbnet::ClusterNode* clusterNode =
-            negotiationContext->cluster()->lookupNode(
-                peerIdentity.clusterNodeId());
+    const bmqp_ctrlmsg::ClientIdentity& peerIdentity =
+        negoMsg.isClientIdentityValue()
+            ? negoMsg.clientIdentity()
+            : negoMsg.brokerResponse().brokerIdentity();
 
-        out->reset(new (*d_allocator_p) mqbnet::DummySession(channel,
-                                                             negoMsg,
-                                                             clusterNode,
-                                                             description,
-                                                             d_allocator_p),
-                   d_allocator_p);
-    }
+    mqbnet::ClusterNode* clusterNode =
+        negotiationContext->cluster()->lookupNode(
+            peerIdentity.clusterNodeId());
+
+    return bsl::allocate_shared<mqbnet::DummySession>(d_allocator_p,
+                                                      channel,
+                                                      negoMsg,
+                                                      clusterNode,
+                                                      description);
 }
 
 bool SessionNegotiator::checkIsDeprecatedSdkVersion(

--- a/src/groups/mqb/mqba/mqba_sessionnegotiator.h
+++ b/src/groups/mqb/mqba/mqba_sessionnegotiator.h
@@ -189,11 +189,15 @@ class SessionNegotiator : public mqbnet::Negotiator {
     authorizeIncomingConnection(bsl::ostream& errorDescription,
                                 mqbnet::InitialConnectionContext* context_p);
 
-    /// Load into the specified `out` a new session created using the
-    /// specified `context_p` and `description`.
-    void createSession(bsl::shared_ptr<mqbnet::Session>* out,
-                       mqbnet::InitialConnectionContext* context_p,
-                       const bsl::string&                description);
+    /// @brief Create a new session for the specified `context_p`.
+    ///
+    /// @param context_p The initial connection context describing the peer.
+    /// @param description The short form description of the session.
+    ///
+    /// @return The newly created session.
+    bsl::shared_ptr<mqbnet::Session>
+    createSession(mqbnet::InitialConnectionContext* context_p,
+                  const bsl::string&                description);
 
     /// Return true if the negotiation message in the specified `context` is
     /// for a client using a deprecated version of the libbmq SDK.


### PR DESCRIPTION
- Remove `mqba::AdminSession::d_scheduler_p` field
- `mqba::SessionNegotiator::createSession`: return `bsl::shared_ptr` directly, not as an output arg