### PR TITLE
CI: check licenses in shell scripts

### DIFF
--- a/.github/workflows/ext/check_license.py
+++ b/.github/workflows/ext/check_license.py
@@ -74,6 +74,7 @@ def main() -> None:
         "*.c": "cxx_license_template.txt",
         "*.hpp": "cxx_license_template.txt",
         "*.py": "python_license_template.txt",
+        "*.sh": "shell_license_template.txt",
     }
 
     script_dir = Path(__file__).absolute().parent

--- a/.github/workflows/ext/shell_license_template.txt
+++ b/.github/workflows/ext/shell_license_template.txt
@@ -1,0 +1,14 @@
+# Copyright [\d-]+ Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 \(the "License"\);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -34,8 +34,6 @@ jobs:
     name: License Check
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: license check
         run: |
           python3 ${{ github.workspace }}/.github/workflows/ext/check_license.py --path=${{ github.workspace }} | tee missing_licenses.txt
@@ -46,8 +44,6 @@ jobs:
     name: PR Title Check
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
       - name: pr title check
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/bin/build-darwin.sh
+++ b/bin/build-darwin.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script builds BlazingMQ and all of its dependencies.
 #

--- a/bin/build-fuzz.sh
+++ b/bin/build-fuzz.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # :: Set some initial constants :::::::::::::::::::::::::::::::::::::::::::::::
 

--- a/bin/build-ubuntu.sh
+++ b/bin/build-ubuntu.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script builds BlazingMQ and all of its dependencies.
 

--- a/bin/codegen.sh
+++ b/bin/codegen.sh
@@ -1,4 +1,19 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This is a codegen script used to generate implementations of the schema format used in BlazingMQ.
 #
 # This script is not able to be run by non-Bloomberg developers as it relies on internal tooling.

--- a/docker/build_deps.sh
+++ b/docker/build_deps.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script downloads, builds, and installs the required build dependencies of BMQ
 # from github.com/bloomberg. Software packages are installed to the /opt/bb prefix.

--- a/docker/sanitizers/build_sanitizer.sh
+++ b/docker/sanitizers/build_sanitizer.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script can be used to build BlazingMQ, and all of its transitive
 # dependencies (up to and including the standard library) using:

--- a/src/plugins/bmqprometheus/build_prometheus_deps.sh
+++ b/src/plugins/bmqprometheus/build_prometheus_deps.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# Copyright 2026 Bloomberg Finance L.P.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # This script downloads, builds, and installs the required build dependencies of Prometheus plugin
 # from github.com. Software packages are installed to the /opt/bb prefix.
@@ -39,7 +53,7 @@ build_prometheus_cpp() {
 
     # fetch third-party dependencies
     git submodule init
-    git submodule update    
+    git submodule update
 
     mkdir -p build
 


### PR DESCRIPTION
- Add license checks for shell files
- Add missing licenses to shell files
- Avoid full repo checkout for simple workflow steps, making CI faster