### PR TITLE
Fix[mqbc::StorageMgr]: validate PSN range and report end PSN mismatch

### DIFF
--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.cpp
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.cpp
@@ -137,6 +137,7 @@ PartitionStateTableEvent::toAscii(PartitionStateTableEvent::Enum value)
         CASE(STOP_NODE)
         CASE(IRRECONCILABLE_DATA)
         CASE(IRRECONCILABLE_REPLICA_DATA_RSPN_PULL)
+        CASE(END_PSN_MISMATCH)
         CASE(NUM_EVENTS)
     default: return "(* UNKNOWN *)";
     }

--- a/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
+++ b/src/groups/mqb/mqbc/mqbc_partitionstatetable.h
@@ -196,9 +196,13 @@ struct PartitionStateTableEvent {
         /// up-to-date replica.
         e_IRRECONCILABLE_REPLICA_DATA_RSPN_PULL = 35,
 
+        /// Self replica detects that the end sequence number a primary asked
+        /// it to send data up to does not match its own.
+        e_END_PSN_MISMATCH = 36,
+
         /// **NOT A VALID STATE**.  This is an artificial enum value to
         /// represent the number of states.
-        e_NUM_EVENTS = 36
+        e_NUM_EVENTS = 37
     };
 
     // CLASS METHODS
@@ -865,6 +869,10 @@ class PartitionStateTable
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,
                 IRRECONCILABLE_DATA,
+                failureReplicaDataResponsePull,
+                REPLICA_HEALING);
+        PST_CFG(REPLICA_HEALING,
+                END_PSN_MISMATCH,
                 failureReplicaDataResponsePull,
                 REPLICA_HEALING);
         PST_CFG(REPLICA_HEALING,

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -1129,7 +1129,7 @@ void StorageManager::processReplicaDataRequestPull(
     BSLS_ASSERT_SAFE(replicaDataRequest.replicaDataType() ==
                      bmqp_ctrlmsg::ReplicaDataType::E_PULL);
 
-    int requestId;
+    int requestId = 0;
     if (!validateReplicaDataRequest(&requestId,
                                     replicaDataRequest,
                                     message.rId(),
@@ -1158,32 +1158,23 @@ void StorageManager::processReplicaDataRequestPull(
         return;  // RETURN
     }
 
-    mqbnet::ClusterNode* const selfNode =
-        d_clusterData_p->membership().selfNode();
-    const bmqp_ctrlmsg::PartitionSequenceNumber selfPSN =
-        d_nodeToPSNCtxMapVec.at(partitionId).at(selfNode).d_PSN;
-    if (replicaDataRequest.endSequenceNumber() != selfPSN) {
-        bmqp_ctrlmsg::ControlMessage controlMsg;
-        controlMsg.rId() = requestId;
+    if (replicaDataRequest.beginSequenceNumber() >=
+        replicaDataRequest.endSequenceNumber()) {
+        BALL_LOG_ERROR
+            << d_clusterData_p->identity().description() << " Partition ["
+            << partitionId << "]: "
+            << "Received ReplicaDataRequestPull from "
+            << source->nodeDescription() << " with begin PSN: "
+            << mqbs::printPSN(replicaDataRequest.beginSequenceNumber())
+            << " which is not below its end PSN: "
+            << mqbs::printPSN(replicaDataRequest.endSequenceNumber())
+            << ".  Sending failure response.";
 
-        bmqp_ctrlmsg::Status& status = controlMsg.choice().makeStatus();
-        status.category() = bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT;
-        status.code()     = mqbi::ClusterErrorCode::e_STORAGE_FAILURE;
-        status.message()  = "End PSN mismatch";
-
-        d_clusterData_p->messageTransmitter().sendMessageSafe(controlMsg,
-                                                              source);
-
-        BALL_LOG_ERROR << d_clusterData_p->identity().description()
-                       << " Partition [" << partitionId << "]: "
-                       << "Received ReplicaDataRequestPull from "
-                       << source->nodeDescription() << " with end PSN: "
-                       << mqbs::printPSN(
-                              replicaDataRequest.endSequenceNumber())
-                       << " that does not match self's current PSN: "
-                       << mqbs::printPSN(selfPSN)
-                       << ".  Sent a failure response " << controlMsg << ".";
-
+        sendFailureResponse(requestId,
+                            source,
+                            bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT,
+                            mqbi::ClusterErrorCode::e_STORAGE_FAILURE,
+                            "Invalid sequence number range");
         return;  // RETURN
     }
 
@@ -1224,7 +1215,7 @@ void StorageManager::processReplicaDataRequestPush(
     BSLS_ASSERT_SAFE(replicaDataRequest.replicaDataType() ==
                      bmqp_ctrlmsg::ReplicaDataType::E_PUSH);
 
-    int requestId;
+    int requestId = 0;
     if (!validateReplicaDataRequest(&requestId,
                                     replicaDataRequest,
                                     message.rId(),
@@ -1250,6 +1241,26 @@ void StorageManager::processReplicaDataRequestPush(
                             bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                             mqbi::ClusterErrorCode::e_STOPPING,
                             "Self node is stopping");
+        return;  // RETURN
+    }
+
+    if (replicaDataRequest.beginSequenceNumber() >
+        replicaDataRequest.endSequenceNumber()) {
+        BALL_LOG_ERROR
+            << d_clusterData_p->identity().description() << " Partition ["
+            << partitionId << "]: "
+            << "Received ReplicaDataRequestPush from "
+            << source->nodeDescription() << " with begin PSN: "
+            << mqbs::printPSN(replicaDataRequest.beginSequenceNumber())
+            << " which is above its end PSN: "
+            << mqbs::printPSN(replicaDataRequest.endSequenceNumber())
+            << ".  Sending failure response.";
+
+        sendFailureResponse(requestId,
+                            source,
+                            bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT,
+                            mqbi::ClusterErrorCode::e_STORAGE_FAILURE,
+                            "Invalid sequence number range");
         return;  // RETURN
     }
 
@@ -1290,7 +1301,7 @@ void StorageManager::processReplicaDataRequestDrop(
     BSLS_ASSERT_SAFE(replicaDataRequest.replicaDataType() ==
                      bmqp_ctrlmsg::ReplicaDataType::E_DROP);
 
-    int requestId;
+    int requestId = 0;
     if (!validateReplicaDataRequest(&requestId,
                                     replicaDataRequest,
                                     message.rId(),
@@ -2804,8 +2815,6 @@ void StorageManager::do_sendDataToPrimary(
     const bmqp_ctrlmsg::PartitionSequenceNumber endSeqNum =
         eventData.partitionSeqNumDataRange().second;
     BSLS_ASSERT_SAFE(beginSeqNum < endSeqNum);
-    BSLS_ASSERT_SAFE(endSeqNum ==
-                     d_nodeToPSNCtxMapVec[partitionId][selfNode].d_PSN);
 
     PartitionFSMEventData sendPartitionFSMEventData(
         destNode,
@@ -2813,6 +2822,38 @@ void StorageManager::do_sendDataToPrimary(
         partitionId,
         1,
         eventData.partitionSeqNumDataRange());
+
+    const NodeToPSNCtxMap& nodeToPSNCtxMap = d_nodeToPSNCtxMapVec.at(
+        partitionId);
+    const NodeToPSNCtxMapCIter selfCit = nodeToPSNCtxMap.find(selfNode);
+    if (selfCit == nodeToPSNCtxMap.cend()) {
+        BMQTSK_ALARMLOG_ALARM(PartitionFSM::k_PFSM_DEFECT_LOG_TAG)
+            << d_clusterData_p->identity().description() << " Partition ["
+            << partitionId << "]: " << "Self has no stored PSN while healing "
+            << "as a replica.  Please review Partition FSM logic."
+            << BMQTSK_ALARMLOG_END;
+
+        enqueuePartitionFSMEvent(
+            PartitionFSM::Event::e_ERROR_SENDING_DATA_CHUNKS,
+            sendPartitionFSMEventData);
+        return;  // RETURN
+    }
+
+    if (endSeqNum != selfCit->second.d_PSN) {
+        BALL_LOG_ERROR << d_clusterData_p->identity().description()
+                       << " Partition [" << partitionId << "]: "
+                       << "Primary " << destNode->nodeDescription()
+                       << " requested data up to PSN "
+                       << mqbs::printPSN(endSeqNum)
+                       << ", which does not match self's current PSN "
+                       << mqbs::printPSN(selfCit->second.d_PSN)
+                       << ". Reply with a failure ReplicaDataResponsePull.";
+
+        enqueuePartitionFSMEvent(
+            PartitionFSM::Event::e_ERROR_SENDING_DATA_CHUNKS,
+            sendPartitionFSMEventData);
+        return;  // RETURN
+    }
 
     // NOTE: In case the primary has missed rollover, it has already checked
     // during `do_primaryRemoveStorageIfNeeded` and has removed its own

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2722,6 +2722,10 @@ void StorageManager::do_failureReplicaDataResponsePull(
         status.code()    = mqbi::ClusterErrorCode::e_IRRECONCILABLE_DATA;
         status.message() = "Primary has irreconcilable data";
     }
+    else if (eventType == PartitionFSM::Event::e_END_PSN_MISMATCH) {
+        status.code()    = mqbi::ClusterErrorCode::e_END_PSN_MISMATCH;
+        status.message() = "End PSN mismatch";
+    }
     else {
         status.code()    = mqbi::ClusterErrorCode::e_STORAGE_FAILURE;
         status.message() = "Failed to send data chunks";
@@ -2849,9 +2853,8 @@ void StorageManager::do_sendDataToPrimary(
                        << mqbs::printPSN(selfCit->second.d_PSN)
                        << ". Reply with a failure ReplicaDataResponsePull.";
 
-        enqueuePartitionFSMEvent(
-            PartitionFSM::Event::e_ERROR_SENDING_DATA_CHUNKS,
-            sendPartitionFSMEventData);
+        enqueuePartitionFSMEvent(PartitionFSM::Event::e_END_PSN_MISMATCH,
+                                 sendPartitionFSMEventData);
         return;  // RETURN
     }
 

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -2827,9 +2827,8 @@ void StorageManager::do_sendDataToPrimary(
         1,
         eventData.partitionSeqNumDataRange());
 
-    const NodeToPSNCtxMap& nodeToPSNCtxMap = d_nodeToPSNCtxMapVec.at(
-        partitionId);
-    const NodeToPSNCtxMapCIter selfCit = nodeToPSNCtxMap.find(selfNode);
+    const NodeToPSNCtxMap& nodeToPSNCtxMap = d_nodeToPSNCtxMapVec[partitionId];
+    const NodeToPSNCtxMapCIter selfCit     = nodeToPSNCtxMap.find(selfNode);
     if (selfCit == nodeToPSNCtxMap.cend()) {
         BMQTSK_ALARMLOG_ALARM(PartitionFSM::k_PFSM_DEFECT_LOG_TAG)
             << d_clusterData_p->identity().description() << " Partition ["

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -4058,6 +4058,110 @@ static void test24_unknownSurvivesReplicaDataRequestPull()
     helper.d_cluster_mp->stop();
 }
 
+static void test25_replicaHealingRefusesEndPSNMismatch()
+// ------------------------------------------------------------------------
+// REPLICA HEALING REFUSES END PSN MISMATCH
+//
+// Concerns:
+//   An end PSN which does not match self's means the primary is pulling from
+//   a stale healing session, and must be told precisely that.
+//
+// Plan:
+//   1) Transition to REPLICA_HEALING, which stores self's PSN.
+//   2) Send a PULL from the primary whose end PSN is above self's.
+//   3) Verify the refusal names e_END_PSN_MISMATCH.
+//   4) Verify self stayed in e_REPLICA_HEALING.
+//
+// Testing:
+//   do_sendDataToPrimary end PSN validation
+//   do_failureReplicaDataResponsePull e_END_PSN_MISMATCH response
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("REPLICA HEALING REFUSES END PSN "
+                                      "MISMATCH");
+
+    static const int k_PARTITION_ID = 0;
+    static const int k_REQUEST_ID   = 42;
+
+    TestHelper helper;
+
+    mqbc::StorageManager storageManager(
+        helper.d_cluster_mp->_clusterDefinition(),
+        helper.d_cluster_mp.get(),
+        helper.d_cluster_mp->_clusterData(),
+        helper.d_cluster_mp->_state(),
+        helper.d_cluster_mp->_clusterData()->domainFactory(),
+        helper.d_cluster_mp->dispatcher(),
+        k_WATCHDOG_TIMEOUT_DURATION,
+        k_WATCHDOG_NUM_RETRIES,
+        mockOnRecoveryStatus,
+        mockOnPartitionPrimaryStatus,
+        bmqtst::TestHelperUtil::allocator());
+
+    const int selfNodeId = helper.d_cluster_mp->_clusterData()
+                               ->membership()
+                               .netCluster()
+                               ->selfNodeId();
+    const int primaryNodeId = selfNodeId + 1;
+
+    mqbnet::ClusterNode* primaryNode = helper.d_cluster_mp->_clusterData()
+                                           ->membership()
+                                           .netCluster()
+                                           ->lookupNode(primaryNodeId);
+    BSLS_ASSERT_OPT(primaryNode);
+
+    // 1. Transition to REPLICA_HEALING, storing self's PSN.
+    helper.transitionReplicaToHealing(&storageManager,
+                                      primaryNode,
+                                      k_PARTITION_ID);
+
+    // 2. Send a PULL whose end PSN is above the one self stored while healing.
+    bmqp_ctrlmsg::ControlMessage message;
+    message.rId() = k_REQUEST_ID;
+    bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
+        message.choice()
+            .makeClusterMessage()
+            .choice()
+            .makePartitionMessage()
+            .choice()
+            .makeReplicaDataRequest();
+
+    bmqp_ctrlmsg::PartitionSequenceNumber beginPSN;
+    beginPSN.primaryLeaseId() = 1U;
+    beginPSN.sequenceNumber() = 1U;
+
+    // Self recovers its PSN from empty storage while healing, leaving it at
+    // zero, so this range is well formed yet cannot be served.
+    bmqp_ctrlmsg::PartitionSequenceNumber endPSN;
+    endPSN.primaryLeaseId() = 1U;
+    endPSN.sequenceNumber() = 3U;
+
+    replicaDataRequest.replicaDataType() =
+        bmqp_ctrlmsg::ReplicaDataType::E_PULL;
+    replicaDataRequest.partitionId()         = k_PARTITION_ID;
+    replicaDataRequest.primaryLeaseId()      = 1U;
+    replicaDataRequest.beginSequenceNumber() = beginPSN;
+    replicaDataRequest.endSequenceNumber()   = endPSN;
+
+    storageManager.processReplicaDataRequest(message, primaryNode);
+
+    // 3. The refusal must name the mismatch, not a generic storage failure.
+    helper.verifyFailureResponse(primaryNodeId,
+                                 k_REQUEST_ID,
+                                 bmqp_ctrlmsg::StatusCategory::E_REFUSED,
+                                 mqbi::ClusterErrorCode::e_END_PSN_MISMATCH);
+
+    helper.clearChannels();
+
+    // 4. Self stayed in e_REPLICA_HEALING.
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+
+    storageManager.stopPFSMs();
+    storageManager.stop();
+    helper.d_cluster_mp->stop();
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -4075,6 +4179,7 @@ int main(int argc, char* argv[])
         //      - test21_replicaHealingReceivesReplicaDataRqstDrop();
         //      - test20_replicaHealingReceivesReplicaDataRqstPush();
         //      - test19_primaryHealedSendsDataChunks();
+    case 25: test25_replicaHealingRefusesEndPSNMismatch(); break;
     case 24: test24_unknownSurvivesReplicaDataRequestPull(); break;
     case 23: test23_replicaHealingRefusesInvalidReplicaDataRequest(); break;
     case 22: test22_rstUnknownCancelsInFlightRequests(); break;

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.t.cpp
@@ -727,10 +727,13 @@ struct TestHelper {
         }
     }
 
-    /// Verify that the node having the specified `sourceNodeId` was sent an
-    /// E_REFUSED response bearing the specified `requestId` and `errorCode`,
-    /// and that no other node in the cluster was written to.
-    void verifyRefusedResponse(int sourceNodeId, int requestId, int errorCode)
+    /// Verify that the node having the specified `sourceNodeId` was sent a
+    /// failure response bearing the specified `requestId`, `category` and
+    /// `errorCode`, and that no other node in the cluster was written to.
+    void verifyFailureResponse(int sourceNodeId,
+                               int requestId,
+                               bmqp_ctrlmsg::StatusCategory::Value category,
+                               int                                 errorCode)
     {
         for (TestChannelMapCIter cit = d_cluster_mp->_channels().cbegin();
              cit != d_cluster_mp->_channels().cend();
@@ -752,8 +755,7 @@ struct TestHelper {
 
                 const bmqp_ctrlmsg::Status& status =
                     response.choice().status();
-                BMQTST_ASSERT_EQ(status.category(),
-                                 bmqp_ctrlmsg::StatusCategory::E_REFUSED);
+                BMQTST_ASSERT_EQ(status.category(), category);
                 BMQTST_ASSERT_EQ(status.code(), errorCode);
             }
             else {
@@ -3552,11 +3554,15 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
 //
 // Concerns:
 //   When a replica in e_REPLICA_HEALING receives a ReplicaDataRequest with no
-//   request id, an invalid partitionId, or from a non-primary node, it must:
+//   request id, an invalid partitionId, an unusable sequence number range, or
+//   from a non-primary node, it must:
 //     a) Send a failure response, or none at all if there is no request id to
 //        match one against.
 //     b) Remain in e_REPLICA_HEALING.
 //     c) Continue to buffer incoming PUT messages.
+//
+//   Note that an empty range is refused for PULL but accepted for PUSH, where
+//   it tells the replica that it is already up to date with the primary.
 //
 // Plan:
 //  For each row of the table below, on a fresh cluster:
@@ -3568,8 +3574,8 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
 //   6) Verify a subsequent PUT is buffered, not processed.
 //
 // Testing:
-//   processReplicaDataRequestPull partition and source validation
-//   processReplicaDataRequestPush partition and source validation
+//   processReplicaDataRequestPull partition, source and range validation
+//   processReplicaDataRequestPush partition, source and range validation
 //   processReplicaDataRequestDrop partition and source validation
 // ------------------------------------------------------------------------
 {
@@ -3581,6 +3587,9 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
 
     // Selects the partitionId to put on the wire.
     enum PartitionSelector { e_VALID_PID, e_NEGATIVE_PID, e_TOO_LARGE_PID };
+
+    // Selects the [begin, end) sequence number range to put on the wire.
+    enum RangeSelector { e_VALID_RANGE, e_EMPTY_RANGE, e_REVERSED_RANGE };
 
     struct Test {
         /// Line of this row, reported when an assertion fails.
@@ -3598,11 +3607,18 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
         /// Which partitionId to put in the request.
         PartitionSelector d_partition;
 
+        /// Which sequence number range to put in the request.
+        RangeSelector d_range;
+
         /// Whether to send from the primary node, or from another replica.
         bool d_fromPrimary;
 
         /// Whether to unassign the partition's primary before sending.
         bool d_clearPrimary;
+
+        /// Expected status category in the refusal response.
+        /// Ignored when 'd_nullRequestId' is true, since no response is sent.
+        bmqp_ctrlmsg::StatusCategory::Value d_expectedCategory;
 
         /// Expected 'mqbi::ClusterErrorCode' in the refusal response.
         /// Ignored when 'd_nullRequestId' is true, since no response is sent.
@@ -3612,120 +3628,180 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
                    bmqp_ctrlmsg::ReplicaDataType::E_PULL,
                    true,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    -1},
                   {L_,
                    "PULL with negative partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_PULL,
                    false,
                    e_NEGATIVE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "PULL with too large partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_PULL,
                    false,
                    e_TOO_LARGE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "PULL from a node which is not the primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_PULL,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    false,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
                   {L_,
                    "PULL when the partition has no primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_PULL,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    true,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
+                  {L_,
+                   "PULL with an empty sequence number range",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PULL,
+                   false,
+                   e_VALID_PID,
+                   e_EMPTY_RANGE,
+                   true,
+                   false,
+                   bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT,
+                   mqbi::ClusterErrorCode::e_STORAGE_FAILURE},
+                  {L_,
+                   "PULL with a reversed sequence number range",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PULL,
+                   false,
+                   e_VALID_PID,
+                   e_REVERSED_RANGE,
+                   true,
+                   false,
+                   bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT,
+                   mqbi::ClusterErrorCode::e_STORAGE_FAILURE},
                   {L_,
                    "PUSH with no request id",
                    bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
                    true,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    -1},
                   {L_,
                    "PUSH with negative partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
                    false,
                    e_NEGATIVE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "PUSH with too large partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
                    false,
                    e_TOO_LARGE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "PUSH from a node which is not the primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    false,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
                   {L_,
                    "PUSH when the partition has no primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    true,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
+                  {L_,
+                   "PUSH with a reversed sequence number range",
+                   bmqp_ctrlmsg::ReplicaDataType::E_PUSH,
+                   false,
+                   e_VALID_PID,
+                   e_REVERSED_RANGE,
+                   true,
+                   false,
+                   bmqp_ctrlmsg::StatusCategory::E_INVALID_ARGUMENT,
+                   mqbi::ClusterErrorCode::e_STORAGE_FAILURE},
                   {L_,
                    "DROP with no request id",
                    bmqp_ctrlmsg::ReplicaDataType::E_DROP,
                    true,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    -1},
                   {L_,
                    "DROP with negative partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_DROP,
                    false,
                    e_NEGATIVE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "DROP with too large partitionId",
                    bmqp_ctrlmsg::ReplicaDataType::E_DROP,
                    false,
                    e_TOO_LARGE_PID,
+                   e_VALID_RANGE,
                    true,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_NO_PARTITION},
                   {L_,
                    "DROP from a node which is not the primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_DROP,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    false,
                    false,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY},
                   {L_,
                    "DROP when the partition has no primary",
                    bmqp_ctrlmsg::ReplicaDataType::E_DROP,
                    false,
                    e_VALID_PID,
+                   e_VALID_RANGE,
                    true,
                    true,
+                   bmqp_ctrlmsg::StatusCategory::E_REFUSED,
                    mqbi::ClusterErrorCode::e_SOURCE_NOT_PRIMARY}};
 
     const size_t k_NUM_DATA = sizeof(k_DATA) / sizeof(*k_DATA);
@@ -3808,6 +3884,21 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
         replicaDataRequest.partitionId()     = partitionId;
         replicaDataRequest.primaryLeaseId()  = 1U;
 
+        // A valid range spans at least one sequence number; an empty one
+        // begins where it ends, and a reversed one begins above its end.
+        bmqp_ctrlmsg::PartitionSequenceNumber beginPSN;
+        beginPSN.primaryLeaseId() = 1U;
+        beginPSN.sequenceNumber() = 1U;
+
+        bmqp_ctrlmsg::PartitionSequenceNumber endPSN;
+        endPSN.primaryLeaseId() = 1U;
+        endPSN.sequenceNumber() = test.d_range == e_VALID_RANGE   ? 2U
+                                  : test.d_range == e_EMPTY_RANGE ? 1U
+                                                                  : 0U;
+
+        replicaDataRequest.beginSequenceNumber() = beginPSN;
+        replicaDataRequest.endSequenceNumber()   = endPSN;
+
         mqbnet::ClusterNode* const source = test.d_fromPrimary ? primaryNode
                                                                : otherNode;
         const int sourceNodeId            = test.d_fromPrimary ? primaryNodeId
@@ -3822,8 +3913,9 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
             helper.verifyNoResponse();
         }
         else {
-            helper.verifyRefusedResponse(sourceNodeId,
+            helper.verifyFailureResponse(sourceNodeId,
                                          k_REQUEST_ID,
+                                         test.d_expectedCategory,
                                          test.d_expectedCode);
         }
 
@@ -3849,6 +3941,123 @@ static void test23_replicaHealingRefusesInvalidReplicaDataRequest()
     }
 }
 
+static void test24_unknownSurvivesReplicaDataRequestPull()
+// ------------------------------------------------------------------------
+// UNKNOWN SURVIVES REPLICA DATA REQUEST PULL
+//
+// Concerns:
+//   Self's PSN for a partition is stored when its FSM leaves e_UNKNOWN, and
+//   discarded when it returns there.  The cluster state keeps naming the
+//   partition's primary across that transition, so a ReplicaDataRequestPull
+//   from the primary can arrive while self holds no PSN for the partition.
+//   The broker must stay up and keep serving that partition.
+//
+// Plan:
+//   1) Transition to REPLICA_HEALING, which stores self's PSN.
+//   2) Drive the partition FSM back to e_UNKNOWN, which discards it, leaving
+//      the cluster state still naming the primary.
+//   3) Send a well formed ReplicaDataRequestPull from that primary.
+//   4) Verify self is still in e_UNKNOWN and answered nothing.
+//   5) Verify the partition can still heal, and self's PSN is stored again.
+//
+// Testing:
+//   processReplicaDataRequestPull with no stored PSN for the partition
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "UNKNOWN SURVIVES REPLICA DATA REQUEST PULL");
+
+    static const int k_PARTITION_ID = 0;
+    static const int k_REQUEST_ID   = 42;
+
+    TestHelper helper;
+
+    mqbc::StorageManager storageManager(
+        helper.d_cluster_mp->_clusterDefinition(),
+        helper.d_cluster_mp.get(),
+        helper.d_cluster_mp->_clusterData(),
+        helper.d_cluster_mp->_state(),
+        helper.d_cluster_mp->_clusterData()->domainFactory(),
+        helper.d_cluster_mp->dispatcher(),
+        k_WATCHDOG_TIMEOUT_DURATION,
+        k_WATCHDOG_NUM_RETRIES,
+        mockOnRecoveryStatus,
+        mockOnPartitionPrimaryStatus,
+        bmqtst::TestHelperUtil::allocator());
+
+    const int selfNodeId = helper.d_cluster_mp->_clusterData()
+                               ->membership()
+                               .netCluster()
+                               ->selfNodeId();
+    const int primaryNodeId = selfNodeId + 1;
+
+    mqbnet::ClusterNode* primaryNode = helper.d_cluster_mp->_clusterData()
+                                           ->membership()
+                                           .netCluster()
+                                           ->lookupNode(primaryNodeId);
+    BSLS_ASSERT_OPT(primaryNode);
+
+    // 1. Transition to REPLICA_HEALING, storing self's PSN.
+    helper.transitionReplicaToHealing(&storageManager,
+                                      primaryNode,
+                                      k_PARTITION_ID);
+
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_REPLICA_HEALING);
+
+    // 2. Drive the partition FSM back to e_UNKNOWN, discarding self's PSN.
+    storageManager.detectPrimaryLossInPFSM(k_PARTITION_ID);
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_UNKNOWN);
+
+    helper.clearChannels();
+
+    // 3. Send a well formed ReplicaDataRequestPull from the primary.
+    bmqp_ctrlmsg::ControlMessage message;
+    message.rId() = k_REQUEST_ID;
+    bmqp_ctrlmsg::ReplicaDataRequest& replicaDataRequest =
+        message.choice()
+            .makeClusterMessage()
+            .choice()
+            .makePartitionMessage()
+            .choice()
+            .makeReplicaDataRequest();
+
+    bmqp_ctrlmsg::PartitionSequenceNumber beginPSN;
+    beginPSN.primaryLeaseId() = 1U;
+    beginPSN.sequenceNumber() = 1U;
+
+    bmqp_ctrlmsg::PartitionSequenceNumber endPSN;
+    endPSN.primaryLeaseId() = 1U;
+    endPSN.sequenceNumber() = 2U;
+
+    replicaDataRequest.replicaDataType() =
+        bmqp_ctrlmsg::ReplicaDataType::E_PULL;
+    replicaDataRequest.partitionId()         = k_PARTITION_ID;
+    replicaDataRequest.primaryLeaseId()      = 1U;
+    replicaDataRequest.beginSequenceNumber() = beginPSN;
+    replicaDataRequest.endSequenceNumber()   = endPSN;
+
+    storageManager.processReplicaDataRequest(message, primaryNode);
+
+    // 4. Self is still in e_UNKNOWN, where a PULL is not actionable, so the
+    //    primary is left to time out its request.
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_UNKNOWN);
+    helper.verifyNoResponse();
+
+    // 5. The partition can still heal, storing self's PSN again.
+    storageManager.detectSelfReplicaInPFSM(k_PARTITION_ID,
+                                           primaryNode,
+                                           1);  // primaryLeaseId
+    BMQTST_ASSERT_EQ(storageManager.partitionHealthState(k_PARTITION_ID),
+                     mqbc::PartitionFSM::State::e_REPLICA_WAITING);
+
+    storageManager.stopPFSMs();
+    storageManager.stop();
+    helper.d_cluster_mp->stop();
+}
+
 // ============================================================================
 //                                 MAIN PROGRAM
 // ----------------------------------------------------------------------------
@@ -3866,6 +4075,7 @@ int main(int argc, char* argv[])
         //      - test21_replicaHealingReceivesReplicaDataRqstDrop();
         //      - test20_replicaHealingReceivesReplicaDataRqstPush();
         //      - test19_primaryHealedSendsDataChunks();
+    case 24: test24_unknownSurvivesReplicaDataRequestPull(); break;
     case 23: test23_replicaHealingRefusesInvalidReplicaDataRequest(); break;
     case 22: test22_rstUnknownCancelsInFlightRequests(); break;
     case 21: test21_watchdogMultipleRetries(); break;

--- a/src/groups/mqb/mqbi/mqbi_cluster.cpp
+++ b/src/groups/mqb/mqbi/mqbi_cluster.cpp
@@ -69,6 +69,7 @@ const char* ClusterErrorCode::toAscii(ClusterErrorCode::Enum value)
         CASE(SOURCE_NOT_PRIMARY)
         CASE(IRRECONCILABLE_DATA)
         CASE(FOLLOWER_WAITING)
+        CASE(END_PSN_MISMATCH)
     default: return "(* UNKNOWN *)";
     }
 
@@ -104,6 +105,7 @@ bool ClusterErrorCode::fromAscii(ClusterErrorCode::Enum*  out,
     CHECKVALUE(SOURCE_NOT_PRIMARY)
     CHECKVALUE(IRRECONCILABLE_DATA)
     CHECKVALUE(FOLLOWER_WAITING)
+    CHECKVALUE(END_PSN_MISMATCH)
     // Invalid string
     return false;
 

--- a/src/groups/mqb/mqbi/mqbi_cluster.h
+++ b/src/groups/mqb/mqbi/mqbi_cluster.h
@@ -168,7 +168,11 @@ struct ClusterErrorCode {
         /// RegistrationResponse, and **must** reject the FollowerLSNRequest
         /// to prevent the leader from healing self twice in a row, leading
         /// to duplicate work.
-        e_FOLLOWER_WAITING = -214
+        e_FOLLOWER_WAITING = -214,
+        /// The end sequence number a primary asked self to send data up to
+        /// does not match self's own, meaning the primary is working from a
+        /// stale view of self and needs to request self's state afresh.
+        e_END_PSN_MISMATCH = -215
     };
 
     // CLASS METHODS


### PR DESCRIPTION
## Summary

  - `processReplicaDataRequestPull` compared the requested end PSN against self's by reading `d_nodeToPSNCtxMapVec` from the cluster dispatcher thread, but `mqbc_storagemanager.h` documents that member as readable only from the queue dispatcher thread owning the partition, and the `.at()` lookup throws when self has no entry. The comparison moves to `do_sendDataToPrimary`, which already runs on the owning thread.

  - `do_sendDataToPrimary` asserted that self has a stored PSN. It now raises the Partition FSM defect alarm and re-heals, which restores the entry.

  - `beginSequenceNumber`/`endSequenceNumber` were left to `BSLS_ASSERT_SAFE`, so an unusable range aborted assert-enabled builds. PULL and PUSH now validate the range on arrival and refuse with `E_INVALID_ARGUMENT`.

  - A mismatch reached the primary as `e_STORAGE_FAILURE` / "Failed to send data chunks", which is inaccurate — no send is attempted — and indistinguishable from a real transfer failure. Adds `e_END_PSN_MISMATCH` and a Partition FSM event that keeps the replica in `e_REPLICA_HEALING`.

- Follows #1721 and #1731


