### PR TITLE
Fix[mqbs]: bound QLIST queue record parsing and drop malformed events

### DIFF
--- a/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
+++ b/src/groups/mqb/mqbblp/mqbblp_storagemanager.cpp
@@ -771,6 +771,9 @@ void StorageManager::processStorageEventDispatched(
         return;  // RETURN
     }
 
+    // The FileStore alarms on a dropped event, and this layer has no
+    // recovery action to take, so the result is not consulted here.
+
     fs->processStorageEvent(blob, false /* isPartitionSyncEvent */, source);
 }
 
@@ -926,6 +929,9 @@ void StorageManager::processPartitionSyncEventDispatched(
     mqbs::FileStore* fs =
         d_fileStores[static_cast<unsigned int>(partitionId)].get();
     BSLS_ASSERT_SAFE(fs);
+
+    // The FileStore alarms on a dropped event, and this layer has no
+    // recovery action to take, so the result is not consulted here.
 
     fs->processStorageEvent(blob, true /* isPartitionSyncEvent */, source);
 }

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -784,8 +784,7 @@ int RecoveryManager::processReceiveDataChunks(
                 recoveryCtx.d_mappedQlistFd;
             bsls::Types::Uint64& qlistFilePos =
                 recoveryCtx.d_qlistFilePosition;
-            bsls::Types::Uint64 qlistOffset = qlistFilePos;
-            BSLS_ASSERT_SAFE(0 == qlistOffset % bmqp::Protocol::k_WORD_SIZE);
+            BSLS_ASSERT_SAFE(0 == qlistFilePos % bmqp::Protocol::k_WORD_SIZE);
 
             mqbi::Storage::AppInfos appIdKeyPairs;
             rc = mqbs::FileStoreUtil::writeQueueCreationRecordImpl(
@@ -797,8 +796,7 @@ int RecoveryManager::processReceiveDataChunks(
                 recordPosition,
                 journal,
                 d_qListAware,
-                qlistFile,
-                qlistOffset);
+                qlistFile);
             if (0 != rc) {
                 return 10 * rc +
                        rc_WRITE_QUEUE_CREATION_RECORD_ERROR;  // RETURN

--- a/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_recoverymanager.cpp
@@ -648,7 +648,14 @@ int RecoveryManager::processReceiveDataChunks(
         BSLS_ASSERT_SAFE(receiveDataCtx.d_currPSN.sequenceNumber() ==
                          fs->writeHeadSeqNum());
 
-        fs->processStorageEvent(blob, true /* isPartitionSyncEvent */, source);
+        const int rc = fs->processStorageEvent(blob,
+                                               true /* isPartitionSyncEvent */,
+                                               source);
+        if (0 != rc) {
+            // The FileStore dropped the event and alarmed on it already.
+
+            return rc_INVALID_QUEUE_RECORD;  // RETURN
+        }
 
         receiveDataCtx.d_currPSN.primaryLeaseId() = fs->writeHeadLeaseId();
         receiveDataCtx.d_currPSN.sequenceNumber() = fs->writeHeadSeqNum();
@@ -797,6 +804,15 @@ int RecoveryManager::processReceiveDataChunks(
                 journal,
                 d_qListAware,
                 qlistFile);
+            if (mqbs::FileStoreUtil::k_MALFORMED_QUEUE_RECORD == rc) {
+                BMQTSK_ALARMLOG_ALARM("RECOVERY")
+                    << d_clusterData.identity().description() << " Partition ["
+                    << partitionId << "]: "
+                    << "Received a malformed queue record from node "
+                    << source->nodeDescription() << ". Ignoring this event."
+                    << BMQTSK_ALARMLOG_END;
+                return rc_INVALID_QUEUE_RECORD;  // RETURN
+            }
             if (0 != rc) {
                 return 10 * rc +
                        rc_WRITE_QUEUE_CREATION_RECORD_ERROR;  // RETURN

--- a/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
+++ b/src/groups/mqb/mqbc/mqbc_storagemanager.cpp
@@ -3140,6 +3140,9 @@ void StorageManager::do_processLiveData(
     mqbs::FileStore* fs = d_fileStores[static_cast<size_t>(partitionId)].get();
     BSLS_ASSERT_SAFE(fs && fs->isOpen());
 
+    // The FileStore alarms on a dropped event, and this layer has no
+    // recovery action to take, so the result is not consulted here.
+
     fs->processStorageEvent(eventData.storageEvent(),
                             false /* isPartitionSyncEvent */,
                             source);

--- a/src/groups/mqb/mqbs/mqbs_datastore.h
+++ b/src/groups/mqb/mqbs/mqbs_datastore.h
@@ -682,12 +682,14 @@ class DataStore : public mqbi::DispatcherClient {
     virtual void onPurgeComplete() = 0;
 
     /// Process the specified storage event `blob` containing one or more
-    /// storage messages.  The behavior is undefined unless each message in
-    /// the event belongs to this partition, and has same primary and
-    /// primary leaseId as expected by this data store instance.
-    virtual void processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                                     bool                 isPartitionSyncEvent,
-                                     mqbnet::ClusterNode* source) = 0;
+    /// storage messages.  Return zero on success, or a non-zero value if the
+    /// event was dropped because one of its records is malformed.  The
+    /// behavior is undefined unless each message in the event belongs to
+    /// this partition, and has same primary and primary leaseId as expected
+    /// by this data store instance.
+    virtual int processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                                    bool                 isPartitionSyncEvent,
+                                    mqbnet::ClusterNode* source) = 0;
 
     /// Process the specified recovery event `blob` containing one or more
     /// storage messages.  Return zero on success, non-zero value otherwise.

--- a/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filebackedstorage.t.cpp
@@ -455,10 +455,11 @@ class MockDataStore : public mqbs::DataStore {
         // NOTHING
     }
 
-    void processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>&,
-                             bool,
-                             mqbnet::ClusterNode*) BSLS_KEYWORD_OVERRIDE
+    int processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>&,
+                            bool,
+                            mqbnet::ClusterNode*) BSLS_KEYWORD_OVERRIDE
     {
+        return 0;
     }
 
     int processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>&)

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6456,10 +6456,6 @@ int FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                                     header.messageType());
         }
 
-        // A record which is not a valid record at all tells us nothing about
-        // whether self and the primary have diverged, so drop the event
-        // instead of aborting.
-
         if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
                 FileStoreUtil::k_MALFORMED_QUEUE_RECORD == rc)) {
             BSLS_PERFORMANCEHINT_UNLIKELY_HINT;

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -4460,6 +4460,9 @@ int FileStore::writeQueueCreationRecord(
         &quri,
         &queueKey,
         &queueOpType);
+    if (FileStoreUtil::k_MALFORMED_QUEUE_RECORD == rc) {
+        return rc;  // RETURN
+    }
     if (0 != rc) {
         return 10 * rc + rc_WRITE_QUEUE_CREATION_RECORD_ERROR;  // RETURN
     }
@@ -6449,6 +6452,24 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                                     blob,
                                     recordPosition,
                                     header.messageType());
+        }
+
+        // A record which is not a valid record at all tells us nothing about
+        // whether self and the primary have diverged, so drop the event
+        // instead of aborting.
+
+        if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+                FileStoreUtil::k_MALFORMED_QUEUE_RECORD == rc)) {
+            BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+            BMQTSK_ALARMLOG_ALARM("REPLICATION")
+                << partitionDesc() << "Received a malformed storage msg "
+                << header.messageType() << " from "
+                << source->nodeDescription() << " with PSN ("
+                << printPSN(recHeader->primaryLeaseId(),
+                            recHeader->sequenceNumber())
+                << "), journal offset words: " << header.journalOffsetWords()
+                << ". Ignoring entire event." << BMQTSK_ALARMLOG_END;
+            return;  // RETURN
         }
 
         // Bump up the current PSN if record was written

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -4429,8 +4429,7 @@ int FileStore::writeQueueCreationRecord(
     MappedFileDescriptor& journal      = activeFileSet->d_journal.d_file;
     bsls::Types::Uint64&  journalPos = activeFileSet->d_journal.d_filePosition;
     bsls::Types::Uint64   recordOffset = journalPos;
-    bsls::Types::Uint64   qlistOffset  = qlistFilePos;
-    BSLS_ASSERT_SAFE(0 == qlistOffset % bmqp::Protocol::k_WORD_SIZE);
+    BSLS_ASSERT_SAFE(0 == qlistFilePos % bmqp::Protocol::k_WORD_SIZE);
 
     // Ensure that JOURNAL offset of primary and self match.  Note that QLIST
     // offset is checked later in this routine.
@@ -4467,7 +4466,6 @@ int FileStore::writeQueueCreationRecord(
         journal,
         d_qListAware,
         qlistFile,
-        qlistOffset,
         &queueRecLength,
         &quri,
         &queueKey,

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -50,6 +50,7 @@
 #include <bmqp_protocolutil.h>
 #include <bmqp_storagemessageiterator.h>
 #include <bmqt_resultcode.h>
+#include <bmqt_uri.h>
 
 #include <bmqtsk_alarmlog.h>
 #include <bmqu_blobobjectproxy.h>
@@ -1851,6 +1852,7 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                 unsigned int        queueRecLength    = 0;
                 unsigned int        queueRecHeaderLen = 0;
                 unsigned int        paddedUriLen      = 0;
+                unsigned int        appIdsAreaLen     = 0;
                 unsigned int        numAppIds         = 0;
                 if (d_qListAware) {
                     BSLS_ASSERT_SAFE(0 != rec.queueUriRecordOffsetWords());
@@ -1880,75 +1882,42 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
 
                     // 'queueUriRecOffset' == offset of mqbs::QueueRecordHeader
 
+                    if (qlistFd->fileSize() <
+                        (queueUriRecOffset + sizeof(QueueRecordHeader))) {
+                        BALL_LOG_ERROR
+                            << partitionDesc()
+                            << "For QueueOp record of type [" << queueOpType
+                            << "], the QLIST file has no room for a "
+                            << "QueueRecordHeader. Journal record offset: "
+                            << jit->recordOffset()
+                            << ", journal record index: " << jit->recordIndex()
+                            << ". QLIST record offset: " << queueUriRecOffset
+                            << ". QLIST file size: " << qlistFd->fileSize()
+                            << ", PSN: "
+                            << printPSN(primaryLeaseId, sequenceNum);
+                        return rc_INVALID_QLIST_RECORD;  // RETURN
+                    }
+
                     OffsetPtr<const QueueRecordHeader> queueRecHeader(
                         qlistFd->block(),
                         queueUriRecOffset);
 
-                    if (0 == queueRecHeader->headerWords()) {
+                    const int layoutRc =
+                        FileStoreProtocolUtil::loadQueueRecordLayout(
+                            &queueRecHeaderLen,
+                            &paddedUriLen,
+                            &appIdsAreaLen,
+                            *queueRecHeader);
+                    if (0 != layoutRc) {
                         BALL_LOG_ERROR
                             << partitionDesc()
                             << "For QueueOp record of type [" << queueOpType
-                            << "], the record present in QLIST file has "
-                            << "invalid 'headerWords' field in the header. "
-                            << "Journal record offset: " << jit->recordOffset()
-                            << ", journal record index: " << jit->recordIndex()
-                            << ". QLIST record offset: " << queueUriRecOffset
-                            << ", PSN: "
-                            << printPSN(primaryLeaseId, sequenceNum);
-
-                        return rc_INVALID_QLIST_RECORD;  // RETURN
-                    }
-
-                    queueRecHeaderLen = queueRecHeader->headerWords() *
-                                        bmqp::Protocol::k_WORD_SIZE;
-
-                    if (qlistFd->fileSize() <
-                        (queueUriRecOffset + queueRecHeaderLen)) {
-                        BALL_LOG_ERROR
-                            << partitionDesc()
-                            << "For QueueOp record of type [" << queueOpType
-                            << "], the record present in QLIST file has "
-                            << "invalid header size [" << queueRecHeaderLen
-                            << "]. Journal record offset: "
+                            << "], the record present in QLIST file declares "
+                            << "an inconsistent layout, rc: " << layoutRc
+                            << ". Journal record offset: "
                             << jit->recordOffset()
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
-                            << ". QLIST file size: " << qlistFd->fileSize()
-                            << ", PSN: "
-                            << printPSN(primaryLeaseId, sequenceNum);
-                        return rc_INVALID_QLIST_RECORD;  // RETURN
-                    }
-
-                    if (0 == queueRecHeader->queueUriLengthWords()) {
-                        BALL_LOG_ERROR
-                            << partitionDesc()
-                            << "For QueueOp record of type [" << queueOpType
-                            << "], the record present in QLIST file has "
-                            << "invalid 'queueUriLengthWords' field in the "
-                            << "header. Journal record offset: "
-                            << jit->recordOffset()
-                            << ", journal record index: " << jit->recordIndex()
-                            << ". QLIST record offset: " << queueUriRecOffset
-                            << ", PSN: "
-                            << printPSN(primaryLeaseId, sequenceNum);
-                        return rc_INVALID_QLIST_RECORD;  // RETURN
-                    }
-
-                    paddedUriLen = queueRecHeader->queueUriLengthWords() *
-                                   bmqp::Protocol::k_WORD_SIZE;
-
-                    if (qlistFd->fileSize() <
-                        (queueUriRecOffset + paddedUriLen)) {
-                        BALL_LOG_ERROR
-                            << partitionDesc()
-                            << "For QueueOp record of type [" << queueOpType
-                            << "], the record present in QLIST file has "
-                            << "invalid 'queueUriLengthWords' field in the "
-                            << "header. Journal record offset: "
-                            << jit->recordOffset()
-                            << ", journal record index: " << jit->recordIndex()
-                            << ". QLIST record offset: " << queueUriRecOffset
-                            << ". QLIST file size: " << qlistFd->fileSize()
                             << ", PSN: "
                             << printPSN(primaryLeaseId, sequenceNum);
                         return rc_INVALID_QLIST_RECORD;  // RETURN
@@ -1956,21 +1925,6 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
 
                     queueRecLength = queueRecHeader->queueRecordWords() *
                                      bmqp::Protocol::k_WORD_SIZE;
-
-                    if (0 == queueRecLength) {
-                        BALL_LOG_ERROR
-                            << partitionDesc()
-                            << "For QueueOp record of type [" << queueOpType
-                            << "], the record present in QLIST file has "
-                            << "invalid 'queueRecordWords' field in the "
-                            << "header. Journal record offset: "
-                            << jit->recordOffset()
-                            << ", journal record index: " << jit->recordIndex()
-                            << ". QLIST record offset: " << queueUriRecOffset
-                            << ", PSN: "
-                            << printPSN(primaryLeaseId, sequenceNum);
-                        return rc_INVALID_QLIST_RECORD;  // RETURN
-                    }
 
                     if (qlistFd->fileSize() <
                         (queueUriRecOffset + queueRecLength)) {
@@ -2055,27 +2009,52 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                     const char* uriBegin = qlistFd->block().base() +
                                            queueUriRecOffset +
                                            queueRecHeaderLen;
-                    char lastByte = uriBegin[paddedUriLen - 1];
 
-                    if (paddedUriLen <= static_cast<unsigned int>(lastByte)) {
+                    unsigned int uriLen = 0;
+                    const int    uriRc =
+                        FileStoreProtocolUtil::loadUnpaddedLength(
+                            &uriLen,
+                            uriBegin,
+                            paddedUriLen);
+                    if (0 != uriRc) {
                         BALL_LOG_ERROR
                             << partitionDesc()
                             << "For QueueOp record of type [" << queueOpType
                             << "], the record present in QLIST file has "
-                            << "invalid padding byte for 'QueueUri' field. "
-                            << "Journal record offset: " << jit->recordOffset()
+                            << "invalid padding byte for 'QueueUri' field, "
+                            << "rc: " << uriRc << ". Journal record offset: "
+                            << jit->recordOffset()
                             << ", journal record index: " << jit->recordIndex()
                             << ". QLIST record offset: " << queueUriRecOffset
                             << ". QLIST file size: " << qlistFd->fileSize()
-                            << ". Padded URI length: " << paddedUriLen
-                            << ", last byte value (as int): "
-                            << static_cast<unsigned int>(lastByte) << ".";
+                            << ". Padded URI length: " << paddedUriLen << ".";
                         return rc_INVALID_QLIST_RECORD;  // RETURN
                     }
 
-                    bslstl::StringRef uri(uriBegin,
-                                          paddedUriLen -
-                                              uriBegin[paddedUriLen - 1]);
+                    bslstl::StringRef uri(uriBegin, uriLen);
+
+                    if (!bmqt::Uri(uri).isValid()) {
+                        // The field holds arbitrary bytes bounded only by the
+                        // QLIST file size, so log a prefix of it.
+
+                        const unsigned int k_MAX_LOGGED_URI_LEN = 64;
+
+                        BALL_LOG_ERROR
+                            << partitionDesc()
+                            << "For QueueOp record of type [" << queueOpType
+                            << "], the record present in QLIST file has an "
+                            << "unparsable 'QueueUri' field of " << uriLen
+                            << " bytes, beginning with ["
+                            << bslstl::StringRef(
+                                   uriBegin,
+                                   bsl::min(uriLen, k_MAX_LOGGED_URI_LEN))
+                            << "]. Journal record offset: "
+                            << jit->recordOffset()
+                            << ", journal record index: " << jit->recordIndex()
+                            << ". QLIST record offset: " << queueUriRecOffset
+                            << ".";
+                        return rc_INVALID_QLIST_RECORD;  // RETURN
+                    }
 
                     if (withCSL) {
                         BSLS_ASSERT_SAFE(!qinfo.canonicalQueueUri().empty());
@@ -2126,21 +2105,32 @@ int FileStore::recoverMessages(QueueKeyInfoMap*     queueKeyInfoMap,
                                   << "] with queue key [" << queueKey << "].";
 
                     // Retrieve AppId/AppKey pairs
-                    unsigned int appIdsAreaLen =
-                        queueRecLength - queueRecHeaderLen - paddedUriLen -
-                        FileStoreProtocol::k_HASH_LENGTH -
-                        sizeof(unsigned int);  // Magic
-
                     MemoryBlock appIdsBlock(
                         qlistFd->block().base() + queueUriRecOffset +
                             queueRecHeaderLen + paddedUriLen +
                             FileStoreProtocol::k_HASH_LENGTH,
                         appIdsAreaLen);
 
-                    AppInfos appIdKeyPairs(d_allocator_p);
-                    FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
-                                                        appIdsBlock,
-                                                        numAppIds);
+                    AppInfos  appIdKeyPairs(d_allocator_p);
+                    const int appIdsRc = FileStoreProtocolUtil::loadAppInfos(
+                        &appIdKeyPairs,
+                        appIdsBlock,
+                        numAppIds);
+                    if (0 != appIdsRc) {
+                        BALL_LOG_ERROR
+                            << partitionDesc()
+                            << "For QueueOp record of type [" << queueOpType
+                            << "], the record present in QLIST file declares "
+                            << numAppIds << " appIds which do not fit its "
+                            << appIdsAreaLen << " byte application-ID area, "
+                            << "rc: " << appIdsRc
+                            << ". Journal record offset: "
+                            << jit->recordOffset()
+                            << ", journal record index: " << jit->recordIndex()
+                            << ". QLIST record offset: " << queueUriRecOffset
+                            << ".";
+                        return rc_INVALID_QLIST_RECORD;  // RETURN
+                    }
 
                     for (AppInfos::const_iterator cit = appIdKeyPairs.cbegin();
                          cit != appIdKeyPairs.cend();

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6538,7 +6538,8 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
         rc_INVALID_PAYLOAD_OFFSET   = -2,
         rc_INVALID_PRIMARY_LEASE_ID = -3,
         rc_INVALID_SEQ_NUM          = -4,
-        rc_WRITE_FAILURE            = -5
+        rc_WRITE_FAILURE            = -5,
+        rc_MALFORMED_QUEUE_RECORD   = -6
     };
 
     bmqp::Event                  rawEvent(blob, d_allocator_p);
@@ -6680,6 +6681,21 @@ int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)
                                     blob,
                                     recordPosition,
                                     header.messageType());
+        }
+
+        if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(
+                FileStoreUtil::k_MALFORMED_QUEUE_RECORD == rc)) {
+            BSLS_PERFORMANCEHINT_UNLIKELY_HINT;
+            BMQTSK_ALARMLOG_ALARM("RECOVERY")
+                << partitionDesc() << "Buffered storage message "
+                << header.messageType() << " with PSN "
+                << printPSN(recHeader->primaryLeaseId(),
+                            recHeader->sequenceNumber())
+                << ", with journal "
+                << "offset (words): " << header.journalOffsetWords()
+                << " carries a malformed queue record. Ignoring entire event."
+                << BMQTSK_ALARMLOG_END;
+            return rc_MALFORMED_QUEUE_RECORD;  // RETURN
         }
 
         if (0 != rc) {

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -6327,12 +6327,14 @@ void FileStore::onPurgeComplete()
                      k_REQUESTED_JOURNAL_SPACE);
 }
 
-void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                                    bool                 isPartitionSyncEvent,
-                                    mqbnet::ClusterNode* source)
+int FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                                   bool                 isPartitionSyncEvent,
+                                   mqbnet::ClusterNode* source)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(blob);
+
+    enum { rc_SUCCESS = 0, rc_MALFORMED_QUEUE_RECORD = -1 };
 
     if (BSLS_PERFORMANCEHINT_PREDICT_UNLIKELY(d_isStopping &&
                                               d_lastSyncPtReceived)) {
@@ -6341,7 +6343,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
         // Self node is stopping and has received the "last" SyncPt.  No need
         // to process any more storage events.
 
-        return;  // RETURN
+        return rc_SUCCESS;  // RETURN
     }
 
     bmqp::Event                  rawEvent(blob, d_allocator_p);
@@ -6351,7 +6353,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
     BSLS_ASSERT_SAFE(iter.isValid());
 
     if (1 != iter.next()) {
-        return;  // RETURN
+        return rc_SUCCESS;  // RETURN
     }
     const unsigned int      pid         = iter.header().partitionId();
     FileStore::NodeContext* nodeContext = 0;
@@ -6383,7 +6385,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                                                            blob,
                                                            partitionDesc());
         if (rc != 0) {
-            return;  // RETURN
+            return rc_SUCCESS;  // RETURN
         }
 
         // For the PSN, check sequence number (only if leaseId is same).
@@ -6405,7 +6407,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                 << " Record's journal offset (in words): "
                 << header.journalOffsetWords() << ". Ignoring entire event."
                 << BMQTSK_ALARMLOG_END;
-            return;  // RETURN
+            return rc_SUCCESS;  // RETURN
         }
 
         if (d_writeHeadLeaseId == recHeader->primaryLeaseId()) {
@@ -6469,7 +6471,7 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
                             recHeader->sequenceNumber())
                 << "), journal offset words: " << header.journalOffsetWords()
                 << ". Ignoring entire event." << BMQTSK_ALARMLOG_END;
-            return;  // RETURN
+            return rc_MALFORMED_QUEUE_RECORD;  // RETURN
         }
 
         // Bump up the current PSN if record was written
@@ -6522,6 +6524,8 @@ void FileStore::processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
     } while (1 == iter.next());
 
     sendReceipt(source, nodeContext);
+
+    return rc_SUCCESS;
 }
 
 int FileStore::processRecoveryEvent(const bsl::shared_ptr<bdlbb::Blob>& blob)

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -878,13 +878,14 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     void onPurgeComplete() BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified storage event `blob` containing one or more
-    /// storage messages.  The behavior is undefined unless each message in
-    /// the event belongs to this partition, and has same primary and
-    /// primary leaseId as expected by this data store instance.
-    void
-    processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
-                        bool                 isPartitionSyncEvent,
-                        mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
+    /// storage messages.  Return zero on success, or a non-zero value if the
+    /// event was dropped because one of its records is malformed.  The
+    /// behavior is undefined unless each message in the event belongs to
+    /// this partition, and has same primary and primary leaseId as expected
+    /// by this data store instance.
+    int processStorageEvent(const bsl::shared_ptr<bdlbb::Blob>& blob,
+                            bool                 isPartitionSyncEvent,
+                            mqbnet::ClusterNode* source) BSLS_KEYWORD_OVERRIDE;
 
     /// Process the specified recovery event `blob` containing one or more
     /// storage messages.  Return zero on success, non-zero value otherwise.

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -578,6 +578,23 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                            const bsl::shared_ptr<bdlbb::Blob>& event,
                            const bmqu::BlobPosition&           recordPosition);
 
+    /// @brief Write the queue creation/addition record contained in a storage
+    /// message received from the primary.
+    ///
+    /// @details Write the queue creation/addition record carried by `event` to
+    /// the JOURNAL file and, if this file store is  QLIST-aware, the queue
+    /// record that follows it to the QLIST file.  Then  invoke the queue
+    /// creation callback and record the resulting handle against the queue's
+    /// storage.
+    ///
+    /// @param header         Storage header of the message.
+    /// @param recHeader      Record header supplying the leaseId and
+    ///                       sequence number the record is keyed on.
+    /// @param event          Blob holding the storage message.
+    /// @param recordPosition Position of the record within `event`.
+    /// @returns 0 on success, `FileStoreUtil::k_MALFORMED_QUEUE_RECORD` if
+    ///          the queue record is structurally invalid, and another non-zero
+    ///          value otherwise.
     int writeQueueCreationRecord(const bmqp::StorageHeader&          header,
                                  const mqbs::RecordHeader&           recHeader,
                                  const bsl::shared_ptr<bdlbb::Blob>& event,

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.cpp
@@ -330,39 +330,179 @@ int FileStoreProtocolUtil::calculateMd5Digest(
     return 0;
 }
 
-void FileStoreProtocolUtil::loadAppInfos(
-    mqbi::Storage::AppInfos* appIdKeyPairs,
-    const MemoryBlock&       appIdsBlock,
-    unsigned int             numAppIds)
+int FileStoreProtocolUtil::loadQueueRecordLayout(
+    unsigned int*            headerLen,
+    unsigned int*            paddedUriLen,
+    unsigned int*            appIdsAreaLen,
+    const QueueRecordHeader& header)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(headerLen);
+    BSLS_ASSERT_SAFE(paddedUriLen);
+    BSLS_ASSERT_SAFE(appIdsAreaLen);
+
+    enum RcEnum {
+        // Value for the various RC error categories
+        rc_SUCCESS             = 0,
+        rc_INVALID_HEADER_SIZE = -1,
+        rc_INVALID_URI_SIZE    = -2,
+        rc_INVALID_RECORD_SIZE = -3
+    };
+
+    const unsigned int hdrLen = header.headerWords() *
+                                bmqp::Protocol::k_WORD_SIZE;
+    if (hdrLen <
+        static_cast<unsigned int>(QueueRecordHeader::k_MIN_HEADER_SIZE)) {
+        return rc_INVALID_HEADER_SIZE;  // RETURN
+    }
+
+    const unsigned int uriLen = header.queueUriLengthWords() *
+                                bmqp::Protocol::k_WORD_SIZE;
+    if (0 == uriLen) {
+        return rc_INVALID_URI_SIZE;  // RETURN
+    }
+
+    // Length of everything but the application-ID area.
+    const unsigned int nonAppIdsAreaLen =
+        hdrLen + uriLen + FileStoreProtocol::k_HASH_LENGTH +  // Queue Key
+        static_cast<unsigned int>(sizeof(unsigned int));      // Magic word
+
+    const unsigned int recordLen = header.queueRecordWords() *
+                                   bmqp::Protocol::k_WORD_SIZE;
+    if (recordLen < nonAppIdsAreaLen) {
+        return rc_INVALID_RECORD_SIZE;  // RETURN
+    }
+
+    *headerLen     = hdrLen;
+    *paddedUriLen  = uriLen;
+    *appIdsAreaLen = recordLen - nonAppIdsAreaLen;
+
+    return rc_SUCCESS;
+}
+
+int FileStoreProtocolUtil::loadUnpaddedLength(unsigned int* length,
+                                              const char*   data,
+                                              unsigned int  paddedLength)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(length);
+    BSLS_ASSERT_SAFE(data);
+    BSLS_ASSERT_SAFE(0 < paddedLength);
+
+    enum RcEnum {
+        // Value for the various RC error categories
+        rc_SUCCESS         = 0,
+        rc_INVALID_PADDING = -1
+    };
+
+    // A WORD-padded field carries between 1 and 'k_WORD_SIZE' padding bytes,
+    // each holding the number of padding bytes.
+    const unsigned int padding = static_cast<unsigned char>(
+        data[paddedLength - 1]);
+
+    if (0 == padding ||
+        padding > static_cast<unsigned int>(bmqp::Protocol::k_WORD_SIZE) ||
+        padding > paddedLength) {
+        return rc_INVALID_PADDING;  // RETURN
+    }
+
+    *length = paddedLength - padding;
+
+    return rc_SUCCESS;
+}
+
+bool FileStoreProtocolUtil::hasValidQueueRecordMagic(
+    const MemoryBlock&  block,
+    bsls::Types::Uint64 recordOffset,
+    unsigned int        recordLen)
+{
+    // PRECONDITIONS
+    BSLS_ASSERT_SAFE(sizeof(unsigned int) <= recordLen);
+    BSLS_ASSERT_SAFE(recordOffset + recordLen <= block.size());
+
+    OffsetPtr<const bdlb::BigEndianUint32> magic(block,
+                                                 recordOffset + recordLen -
+                                                     sizeof(unsigned int));
+
+    return QueueRecordHeader::k_MAGIC == *magic;
+}
+
+int FileStoreProtocolUtil::loadAppInfos(mqbi::Storage::AppInfos* appIdKeyPairs,
+                                        const MemoryBlock&       appIdsBlock,
+                                        unsigned int             numAppIds)
 {
     // PRECONDITIONS
     BSLS_ASSERT_SAFE(appIdKeyPairs);
 
-    // 'appIdsAreaBegin' should point to the beginning of 1st 'AppIdHeader'.
-    unsigned int offset = 0;
+    enum RcEnum {
+        // Value for the various RC error categories
+        rc_SUCCESS             = 0,
+        rc_INCOMPLETE_HEADER   = -1,
+        rc_INVALID_APP_ID_SIZE = -2,
+        rc_INCOMPLETE_APP_ID   = -3,
+        rc_INVALID_PADDING     = -4,
+        rc_TRAILING_BYTES      = -5,
+        rc_EMPTY_APP_ID        = -6,
+        rc_NULL_APP_KEY        = -7
+    };
 
-    for (size_t i = 0; i < numAppIds; ++i) {
+    bslma::Allocator* const alloc = appIdKeyPairs->get_allocator();
+
+    bsls::Types::Uint64 offset = 0;
+    for (unsigned int i = 0; i < numAppIds; ++i) {
+        if ((appIdsBlock.size() - offset) < sizeof(AppIdHeader)) {
+            return rc_INCOMPLETE_HEADER;  // RETURN
+        }
+
         OffsetPtr<const AppIdHeader> appIdHeader(appIdsBlock, offset);
 
-        unsigned int paddedLen = appIdHeader->appIdLengthWords() *
-                                 bmqp::Protocol::k_WORD_SIZE;
+        const unsigned int paddedLen = appIdHeader->appIdLengthWords() *
+                                       bmqp::Protocol::k_WORD_SIZE;
+        if (0 == paddedLen) {
+            return rc_INVALID_APP_ID_SIZE;  // RETURN
+        }
+
+        const bsls::Types::Uint64 entryLen =
+            sizeof(AppIdHeader) + paddedLen +
+            FileStoreProtocol::k_HASH_LENGTH;  // AppKey
+        if ((appIdsBlock.size() - offset) < entryLen) {
+            return rc_INCOMPLETE_APP_ID;  // RETURN
+        }
+
         const char* appIdBegin = appIdsBlock.base() + offset +
                                  sizeof(AppIdHeader);
 
-        bslma::Allocator* alloc = appIdKeyPairs->get_allocator();
+        unsigned int appIdLen = 0;
+        const int    rc = loadUnpaddedLength(&appIdLen, appIdBegin, paddedLen);
+        if (0 != rc) {
+            return rc_INVALID_PADDING;  // RETURN
+        }
+
+        if (0 == appIdLen) {
+            return rc_EMPTY_APP_ID;  // RETURN
+        }
+
+        const mqbu::StorageKey appKey(mqbu::StorageKey::BinaryRepresentation(),
+                                      appIdBegin + paddedLen);
+        if (appKey.isNull()) {
+            return rc_NULL_APP_KEY;  // RETURN
+        }
+
         mqbi::Storage::AppInfos::value_type appIdKeyPair(
-            bsl::string(appIdBegin,
-                        paddedLen - appIdBegin[paddedLen - 1],
-                        alloc),
-            mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
-                             appIdBegin + paddedLen),
+            bsl::string(appIdBegin, appIdLen, alloc),
+            appKey,
             alloc);
         appIdKeyPairs->insert(appIdKeyPair);
 
         // Move to beginning of next AppIdHeader.
-        offset += sizeof(AppIdHeader) + paddedLen +
-                  FileStoreProtocol::k_HASH_LENGTH;  // AppKey
+        offset += entryLen;
     }
+
+    if (offset != appIdsBlock.size()) {
+        return rc_TRAILING_BYTES;  // RETURN
+    }
+
+    return rc_SUCCESS;
 }
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.h
@@ -107,9 +107,64 @@ struct FileStoreProtocolUtil {
                                   const bmqu::BlobPosition& startPos,
                                   unsigned int              length);
 
-    static void loadAppInfos(mqbi::Storage::AppInfos* appIdKeyPairs,
-                             const MemoryBlock&       appIdsBlock,
-                             unsigned int             numAppIds);
+    /// @brief Derive the byte lengths of the sections of a queue record.
+    ///
+    /// @details A QLIST queue record is laid out as `[QueueRecordHeader]
+    /// [Padded QueueUri][QueueUri Hash][AppId entries...][Magic word]`, and
+    /// the specified `header` declares the length of each of those sections
+    /// as well as of the record as a whole.  The caller remains responsible
+    /// for confirming that the record fits the blob or file holding it.
+    ///
+    /// @param[out] headerLen     Size of the `QueueRecordHeader`.
+    /// @param[out] paddedUriLen  Size of the padded queue URI.
+    /// @param[out] appIdsAreaLen Size of the application-ID area.
+    /// @param header             Header to derive the lengths from.
+    /// @returns 0 if the sections declared by `header` fit within the record
+    ///          length it declares, a non-zero value otherwise.
+    static int loadQueueRecordLayout(unsigned int*            headerLen,
+                                     unsigned int*            paddedUriLen,
+                                     unsigned int*            appIdsAreaLen,
+                                     const QueueRecordHeader& header);
+
+    /// @brief Derive the unpadded length of a WORD-padded field.
+    ///
+    /// @param[out] length   Length of the field excluding its padding.
+    /// @param data          First byte of the padded field.
+    /// @param paddedLength  Length of the field including its padding.
+    /// @returns 0 if the trailing padding byte of the field is valid, a
+    ///          non-zero value otherwise.
+    ///
+    /// The behavior is undefined unless `paddedLength` bytes are readable at
+    /// `data`.
+    static int loadUnpaddedLength(unsigned int* length,
+                                  const char*   data,
+                                  unsigned int  paddedLength);
+
+    /// @brief Return true if a queue record ends with the queue record magic
+    ///        word.
+    ///
+    /// @param block        Memory holding the record.
+    /// @param recordOffset Offset of the record within `block`.
+    /// @param recordLen    Length of the record.
+    ///
+    /// The behavior is undefined unless `block` holds `recordLen` bytes at
+    /// `recordOffset`, and `recordLen` is at least the size of a magic word.
+    static bool hasValidQueueRecordMagic(const MemoryBlock&  block,
+                                         bsls::Types::Uint64 recordOffset,
+                                         unsigned int        recordLen);
+
+    /// @brief Load the appId/appKey pairs of a queue record.
+    ///
+    /// @param[out] appIdKeyPairs Pairs read from `appIdsBlock`.
+    /// @param appIdsBlock        AppId area of a queue record.
+    /// @param numAppIds          Number of pairs the record declares.
+    /// @returns 0 if `appIdsBlock` holds exactly `numAppIds` complete
+    ///          entries, each with a non-empty appId and a non-null appKey,
+    ///          a non-zero value otherwise.  On failure, `appIdKeyPairs`
+    ///          holds the entries read before the offending one.
+    static int loadAppInfos(mqbi::Storage::AppInfos* appIdKeyPairs,
+                            const MemoryBlock&       appIdsBlock,
+                            unsigned int             numAppIds);
 };
 
 }  // close package namespace

--- a/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreprotocolutil.t.cpp
@@ -47,6 +47,102 @@ using namespace BloombergLP;
 using namespace bsl;
 
 // ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+namespace {
+
+// CONSTANTS
+const bsl::size_t MD5_DIGEST_BYTES = 16;
+
+// ALIASES
+typedef bsl::unordered_map<bsl::string, bsl::string> Results;
+typedef Results::const_iterator                      ResultsIt;
+
+// FUNCTIONS
+
+static void bytesFromHex(bsl::string* destination, const bsl::string& source)
+// ------------------------------------------------------------------------
+// Transforms Hex numbers from the specified 'source' string to bytes and
+// stores them in the specified 'destination' string.  Each pair of
+// characters from 'source' will be interpreted like hexadecimal number and
+// stored into 'destination' as a single char.  If length of 'source' is an
+// odd number, the last character will be ignored.
+// ------------------------------------------------------------------------
+{
+    destination->clear();
+    destination->reserve(source.size() / 2);
+    bsl::string::const_iterator src = source.begin();
+    while (src != source.end() && (src + 1) != source.end()) {
+        bslstl::StringRef sub(src, src + 2);
+        destination->push_back(static_cast<char>(bsl::stoi(sub, 0, 16)));
+        src += 2;
+    }
+}
+
+static void jobForThreadPool(const Results* testData, bslmt::Barrier* barrier)
+// ------------------------------------------------------------------------
+// Calculates MD5 hashes from keys of the specified 'testData' object and
+// compares them with corresponding values.  The specified 'barrier' is
+// used to start all the jobs simultaneously in the different threads.
+// ------------------------------------------------------------------------
+{
+    bdlbb::PooledBlobBufferFactory factory(
+        1024,
+        bmqtst::TestHelperUtil::allocator());
+    bmqu::BlobPosition startPos;
+
+    barrier->wait();
+    for (int i = 0; i < 1000; ++i) {
+        for (ResultsIt r = testData->begin(); r != testData->end(); ++r) {
+            const bsl::string& source = r->first;
+            const bsl::string& hex    = r->second;
+            bsl::string        expected(bmqtst::TestHelperUtil::allocator());
+            bytesFromHex(&expected, hex);
+
+            bdlbb::Blob localBlob(&factory,
+                                  bmqtst::TestHelperUtil::allocator());
+            localBlob.setLength(source.size());
+            bsl::memcpy(localBlob.buffer(0).data(),
+                        source.c_str(),
+                        source.size());
+            bdlde::Md5::Md5Digest buffer;
+
+            int rc = -1;
+            BMQTST_ASSERT_PASS(
+                rc = mqbs::FileStoreProtocolUtil::calculateMd5Digest(
+                    &buffer,
+                    localBlob,
+                    startPos,
+                    source.size()));
+            BMQTST_ASSERT_EQ(0, rc);
+            bsl::string result(buffer.buffer(),
+                               MD5_DIGEST_BYTES,
+                               bmqtst::TestHelperUtil::allocator());
+            BMQTST_ASSERT_EQ(result, expected);
+        }
+    }
+}
+
+/// Assert that `loadAppInfos` rejects the specified `numAppIds` entries in
+/// the specified `block` without loading any pair, reporting the specified
+/// `description` on failure.
+static void assertAppInfosRejected(const mqbs::MemoryBlock& block,
+                                   unsigned int             numAppIds,
+                                   const char*              description)
+{
+    mqbi::Storage::AppInfos appIdKeyPairs(bmqtst::TestHelperUtil::allocator());
+
+    const int rc = mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
+                                                             block,
+                                                             numAppIds);
+
+    BMQTST_ASSERT_NE_D(description, 0, rc);
+    BMQTST_ASSERT_EQ_D(description, 0u, appIdKeyPairs.size());
+}
+
+}  // close unnamed namespace
+
+// ============================================================================
 //                                    TESTS
 // ----------------------------------------------------------------------------
 
@@ -516,12 +612,274 @@ static void test3_lastJournalSyncPoint()
     }
 }
 
-static void test4_loadAppInfos()
+static void test4_loadQueueRecordLayout()
+// ------------------------------------------------------------------------
+// Testing:
+//   loadQueueRecordLayout()
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("LOAD QUEUE RECORD LAYOUT");
+
+    // A 42 character URI padded to 44 bytes, i.e. 11 WORDs.
+    const unsigned int k_URI_LEN   = 44u;
+    const unsigned int k_URI_WORDS = k_URI_LEN / bmqp::Protocol::k_WORD_SIZE;
+    const unsigned int k_HEADER_WORDS = sizeof(mqbs::QueueRecordHeader) /
+                                        bmqp::Protocol::k_WORD_SIZE;
+    // 'QueueRecordHeader' + padded URI + URI hash + magic word.
+    const unsigned int k_RECORD_WORDS = k_HEADER_WORDS + k_URI_WORDS + 4 + 1;
+
+    unsigned int headerLen     = 0;
+    unsigned int paddedUriLen  = 0;
+    unsigned int appIdsAreaLen = 0;
+
+    {
+        // A record with no appIds.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(k_URI_WORDS)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setQueueRecordWords(k_RECORD_WORDS);
+
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+        BMQTST_ASSERT_EQ(sizeof(mqbs::QueueRecordHeader), headerLen);
+        BMQTST_ASSERT_EQ(k_URI_LEN, paddedUriLen);
+        BMQTST_ASSERT_EQ(0u, appIdsAreaLen);
+    }
+
+    {
+        // The same record declaring one appId: the layout is still
+        // consistent, and it is up to 'loadAppInfos' to reject the empty
+        // application-ID area.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(k_URI_WORDS)
+            .setNumAppIds(1)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setQueueRecordWords(k_RECORD_WORDS);
+
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+        BMQTST_ASSERT_EQ(0u, appIdsAreaLen);
+    }
+
+    {
+        // A record with room for one 'AppIdHeader', a one WORD appId and its
+        // appKey.
+        const unsigned int k_APP_IDS_AREA_WORDS =
+            1 + 1 + 4;  // header + appId + appKey
+        const unsigned int k_APP_IDS_AREA_LEN = k_APP_IDS_AREA_WORDS *
+                                                bmqp::Protocol::k_WORD_SIZE;
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(k_URI_WORDS)
+            .setNumAppIds(1)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setQueueRecordWords(k_RECORD_WORDS + k_APP_IDS_AREA_WORDS);
+
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+        BMQTST_ASSERT_EQ(k_APP_IDS_AREA_LEN, appIdsAreaLen);
+    }
+
+    {
+        // 'headerWords' below 'QueueRecordHeader::k_MIN_HEADER_SIZE'.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(k_URI_WORDS)
+            .setHeaderWords(mqbs::QueueRecordHeader::k_MIN_HEADER_SIZE - 1)
+            .setQueueRecordWords(k_RECORD_WORDS);
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+    }
+
+    {
+        // Zero 'queueUriLengthWords'.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(0)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setQueueRecordWords(k_RECORD_WORDS);
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+    }
+
+    {
+        // 'queueRecordWords' one WORD short of the sections the header
+        // declares: the application-ID area size would underflow.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(k_URI_WORDS)
+            .setHeaderWords(k_HEADER_WORDS)
+            .setQueueRecordWords(k_RECORD_WORDS - 1);
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+    }
+
+    {
+        // The largest values the header fields can hold.
+
+        mqbs::QueueRecordHeader header;
+        header.setQueueUriLengthWords(0xFFFF)
+            .setHeaderWords(0xFF)
+            .setQueueRecordWords(0xFFFFFF);
+
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadQueueRecordLayout(&headerLen,
+                                                               &paddedUriLen,
+                                                               &appIdsAreaLen,
+                                                               header));
+        BMQTST_ASSERT_EQ(0xFF * 4u, headerLen);
+        BMQTST_ASSERT_EQ(0xFFFF * 4u, paddedUriLen);
+        BMQTST_ASSERT_EQ(0xFFFFFF * 4u - 0xFF * 4u - 0xFFFF * 4u - 16u - 4u,
+                         appIdsAreaLen);
+    }
+}
+
+static void test5_loadUnpaddedLength()
+// ------------------------------------------------------------------------
+// Testing:
+//   loadUnpaddedLength()
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("LOAD UNPADDED LENGTH");
+
+    char         buffer[8] = {0};
+    unsigned int length    = 0;
+
+    for (int padding = 1; padding <= 4; ++padding) {
+        buffer[7] = static_cast<char>(padding);
+
+        BMQTST_ASSERT_EQ_D(
+            padding,
+            0,
+            mqbs::FileStoreProtocolUtil::loadUnpaddedLength(&length,
+                                                            buffer,
+                                                            sizeof(buffer)));
+        BMQTST_ASSERT_EQ_D(padding, 8u - padding, length);
+    }
+
+    {
+        // A padding byte of zero.
+
+        buffer[7] = 0;
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadUnpaddedLength(&length,
+                                                            buffer,
+                                                            sizeof(buffer)));
+    }
+
+    {
+        // A padding byte larger than a WORD.
+
+        buffer[7] = bmqp::Protocol::k_WORD_SIZE + 1;
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadUnpaddedLength(&length,
+                                                            buffer,
+                                                            sizeof(buffer)));
+    }
+
+    {
+        // A padding byte which, read as a 'char', would yield a length
+        // greater than the padded one.
+
+        buffer[7] = static_cast<char>(0x80);
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadUnpaddedLength(&length,
+                                                            buffer,
+                                                            sizeof(buffer)));
+    }
+
+    {
+        // A padding byte larger than the field it pads.
+
+        buffer[1] = 4;
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadUnpaddedLength(&length,
+                                                            buffer,
+                                                            2));
+    }
+}
+
+static void test6_hasValidQueueRecordMagic()
+// ------------------------------------------------------------------------
+// Testing:
+//   hasValidQueueRecordMagic()
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("HAS VALID QUEUE RECORD MAGIC");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    const unsigned int k_RECORD_OFFSET = 8;
+    const unsigned int k_RECORD_LEN    = 16;
+    const unsigned int k_BLOCK_LEN     = k_RECORD_OFFSET + k_RECORD_LEN;
+
+    char* p = static_cast<char*>(alloc->allocate(k_BLOCK_LEN));
+    bsl::memset(p, 0, k_BLOCK_LEN);
+
+    mqbs::MemoryBlock                      block(p, k_BLOCK_LEN);
+    mqbs::OffsetPtr<bdlb::BigEndianUint32> magic(block, k_BLOCK_LEN - 4);
+
+    *magic = mqbs::QueueRecordHeader::k_MAGIC;
+    BMQTST_ASSERT(
+        mqbs::FileStoreProtocolUtil::hasValidQueueRecordMagic(block,
+                                                              k_RECORD_OFFSET,
+                                                              k_RECORD_LEN));
+
+    *magic = mqbs::QueueRecordHeader::k_MAGIC + 1;
+    BMQTST_ASSERT(
+        !mqbs::FileStoreProtocolUtil::hasValidQueueRecordMagic(block,
+                                                               k_RECORD_OFFSET,
+                                                               k_RECORD_LEN));
+
+    alloc->deallocate(p);
+}
+
+static void test7_loadAppInfos()
 // ------------------------------------------------------------------------
 // Testing:
 //   loadAppInfos()
 // ------------------------------------------------------------------------
 {
+    bmqtst::TestHelper::printTestName("LOAD APP INFOS");
+
     typedef mqbi::Storage::AppInfos AppInfos;
 
     bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
@@ -530,12 +888,14 @@ static void test4_loadAppInfos()
         // No appIds.
 
         char*             p = static_cast<char*>(alloc->allocate(1));
-        mqbs::MemoryBlock mb(p, 1);
+        mqbs::MemoryBlock mb(p, 0);
         AppInfos          appIdKeyPairs(alloc);
 
-        mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
-                                                  mb,
-                                                  0);  // no appIds
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
+                                                      mb,
+                                                      0));  // no appIds
 
         BMQTST_ASSERT_EQ(0u, appIdKeyPairs.size());
 
@@ -555,7 +915,8 @@ static void test4_loadAppInfos()
 
         // Append AppIdHeader.
         mqbs::AppIdHeader header;
-        header.setAppIdLengthWords(paddedAppIdLen / 4);
+        header.setAppIdLengthWords(paddedAppIdLen /
+                                   bmqp::Protocol::k_WORD_SIZE);
         bsl::memcpy(p,
                     reinterpret_cast<const char*>(&header),
                     sizeof(mqbs::AppIdHeader));
@@ -587,9 +948,11 @@ static void test4_loadAppInfos()
         mqbs::MemoryBlock mb(p, totalSize);
         AppInfos          appIdKeyPairs(alloc);
 
-        mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
-                                                  mb,
-                                                  1);  // 1 appId
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
+                                                      mb,
+                                                      1));  // 1 appId
 
         BMQTST_ASSERT_EQ(1U, appIdKeyPairs.size());
         BMQTST_ASSERT_EQ(appId, appIdKeyPairs.begin()->first);
@@ -599,7 +962,7 @@ static void test4_loadAppInfos()
     }
 
     {
-        // 6 appId/appKey pair.
+        // 6 appId/appKey pairs.
         const int numAppIds = 6;
         size_t    totalSize = 0;
 
@@ -635,7 +998,8 @@ static void test4_loadAppInfos()
 
             new (headerPtr.get()) mqbs::AppIdHeader;
 
-            headerPtr->setAppIdLengthWords(paddedAppIdLenVec[n] / 4);
+            headerPtr->setAppIdLengthWords(paddedAppIdLenVec[n] /
+                                           bmqp::Protocol::k_WORD_SIZE);
             offset += sizeof(mqbs::AppIdHeader);
 
             // Append AppId.
@@ -675,9 +1039,11 @@ static void test4_loadAppInfos()
         mqbs::MemoryBlock mb(p, totalSize);
         AppInfos          appIdKeyPairs(alloc);
 
-        mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
-                                                  mb,
-                                                  numAppIds);
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
+                                                      mb,
+                                                      numAppIds));
 
         BMQTST_ASSERT_EQ(static_cast<size_t>(numAppIds), appIdKeyPairs.size());
 
@@ -689,80 +1055,142 @@ static void test4_loadAppInfos()
 
         alloc->deallocate(p);
     }
-}
 
-namespace {
+    // A well-formed single entry: an 'AppIdHeader', a one WORD appId and its
+    // appKey.  Each case below corrupts one aspect of it.
 
-typedef bsl::unordered_map<bsl::string, bsl::string> Results;
-typedef Results::const_iterator                      ResultsIt;
-const bsl::size_t                                    MD5_DIGEST_BYTES = 16;
+    const unsigned int k_PADDED_APP_ID_LEN = bmqp::Protocol::k_WORD_SIZE;
+    const unsigned int k_ENTRY_LEN         = sizeof(mqbs::AppIdHeader) +
+                                     k_PADDED_APP_ID_LEN +
+                                     mqbs::FileStoreProtocol::k_HASH_LENGTH;
+    const unsigned int k_TRAILING_BYTES = 4;
 
-static void bytesFromHex(bsl::string* destination, const bsl::string& source)
-// ------------------------------------------------------------------------
-// Transforms Hex numbers from the specified 'source' string to bytes and
-// stores them in the specified 'destination' string.  Each pair of
-// characters from 'source' will be interpreted like hexadecimal number and
-// stored into 'destination' as a single char.  If length of 'source' is an
-// odd number, the last character will be ignored.
-// ------------------------------------------------------------------------
-{
-    destination->clear();
-    destination->reserve(source.size() / 2);
-    bsl::string::const_iterator src = source.begin();
-    while (src != source.end() && (src + 1) != source.end()) {
-        bslstl::StringRef sub(src, src + 2);
-        destination->push_back(static_cast<char>(bsl::stoi(sub, 0, 16)));
-        src += 2;
+    char* p = static_cast<char*>(
+        alloc->allocate(k_ENTRY_LEN + k_TRAILING_BYTES));
+    bsl::memset(p, 0, k_ENTRY_LEN + k_TRAILING_BYTES);
+
+    mqbs::MemoryBlock                  entryBlock(p, k_ENTRY_LEN);
+    mqbs::OffsetPtr<mqbs::AppIdHeader> entryHeader(entryBlock, 0);
+    new (entryHeader.get()) mqbs::AppIdHeader();
+    entryHeader->setAppIdLengthWords(k_PADDED_APP_ID_LEN /
+                                     bmqp::Protocol::k_WORD_SIZE);
+
+    p[sizeof(mqbs::AppIdHeader)] = 'a';  // AppId
+    bmqp::ProtocolUtil::appendPaddingRaw(p + sizeof(mqbs::AppIdHeader) + 1, 3);
+    p[sizeof(mqbs::AppIdHeader) + k_PADDED_APP_ID_LEN] = 'k';  // AppKey
+
+    {
+        // Sanity check.
+
+        AppInfos appIdKeyPairs(alloc);
+
+        BMQTST_ASSERT_EQ(
+            0,
+            mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs,
+                                                      entryBlock,
+                                                      1));
+        BMQTST_ASSERT_EQ(1U, appIdKeyPairs.size());
+        BMQTST_ASSERT_EQ(bsl::string("a", alloc),
+                         appIdKeyPairs.begin()->first);
     }
-}
 
-static void jobForThreadPool(const Results* testData, bslmt::Barrier* barrier)
-// ------------------------------------------------------------------------
-// Calculates MD5 hashes from keys of the specified 'testData' object and
-// compares them with corresponding values.  The specified 'barrier' is
-// used to start all the jobs simultaneously in the different threads.
-// ------------------------------------------------------------------------
-{
-    bdlbb::PooledBlobBufferFactory factory(
-        1024,
-        bmqtst::TestHelperUtil::allocator());
-    bmqu::BlobPosition startPos;
+    {
+        // Empty area.
 
-    barrier->wait();
-    for (int i = 0; i < 1000; ++i) {
-        for (ResultsIt r = testData->begin(); r != testData->end(); ++r) {
-            const bsl::string& source = r->first;
-            const bsl::string& hex    = r->second;
-            bsl::string        expected(bmqtst::TestHelperUtil::allocator());
-            bytesFromHex(&expected, hex);
-
-            bdlbb::Blob localBlob(&factory,
-                                  bmqtst::TestHelperUtil::allocator());
-            localBlob.setLength(source.size());
-            bsl::memcpy(localBlob.buffer(0).data(),
-                        source.c_str(),
-                        source.size());
-            bdlde::Md5::Md5Digest buffer;
-
-            int rc = -1;
-            BMQTST_ASSERT_PASS(
-                rc = mqbs::FileStoreProtocolUtil::calculateMd5Digest(
-                    &buffer,
-                    localBlob,
-                    startPos,
-                    source.size()));
-            BMQTST_ASSERT_EQ(0, rc);
-            bsl::string result(buffer.buffer(),
-                               MD5_DIGEST_BYTES,
-                               bmqtst::TestHelperUtil::allocator());
-            BMQTST_ASSERT_EQ(result, expected);
-        }
+        assertAppInfosRejected(mqbs::MemoryBlock(p, 0), 1, "empty area");
     }
+
+    {
+        // An 'AppIdHeader' truncated by one byte.
+
+        assertAppInfosRejected(
+            mqbs::MemoryBlock(p, sizeof(mqbs::AppIdHeader) - 1),
+            1,
+            "truncated AppIdHeader");
+    }
+
+    {
+        // An appKey truncated by one byte.
+
+        assertAppInfosRejected(mqbs::MemoryBlock(p, k_ENTRY_LEN - 1),
+                               1,
+                               "truncated appKey");
+    }
+
+    {
+        // Bytes left over after the declared number of entries.
+
+        mqbs::MemoryBlock mb(p, k_ENTRY_LEN + k_TRAILING_BYTES);
+        AppInfos          appIdKeyPairs(alloc);
+
+        BMQTST_ASSERT_NE(
+            0,
+            mqbs::FileStoreProtocolUtil::loadAppInfos(&appIdKeyPairs, mb, 1));
+        BMQTST_ASSERT_EQ(1u, appIdKeyPairs.size());
+    }
+
+    {
+        // A non-empty area declaring no appIds.
+
+        assertAppInfosRejected(entryBlock, 0, "no declared appIds");
+    }
+
+    {
+        // An invalid appId padding byte.
+
+        p[sizeof(mqbs::AppIdHeader) + k_PADDED_APP_ID_LEN - 1] = 0;
+
+        assertAppInfosRejected(entryBlock, 1, "invalid appId padding");
+
+        bmqp::ProtocolUtil::appendPaddingRaw(p + sizeof(mqbs::AppIdHeader) + 1,
+                                             3);
+    }
+
+    {
+        // An appId which is all padding.
+
+        bmqp::ProtocolUtil::appendPaddingRaw(p + sizeof(mqbs::AppIdHeader),
+                                             k_PADDED_APP_ID_LEN);
+
+        assertAppInfosRejected(entryBlock, 1, "empty appId");
+
+        p[sizeof(mqbs::AppIdHeader)] = 'a';
+        bmqp::ProtocolUtil::appendPaddingRaw(p + sizeof(mqbs::AppIdHeader) + 1,
+                                             3);
+    }
+
+    {
+        // An all-zero appKey.
+
+        bsl::memset(p + sizeof(mqbs::AppIdHeader) + k_PADDED_APP_ID_LEN,
+                    0,
+                    mqbs::FileStoreProtocol::k_HASH_LENGTH);
+
+        assertAppInfosRejected(entryBlock, 1, "null appKey");
+
+        p[sizeof(mqbs::AppIdHeader) + k_PADDED_APP_ID_LEN] = 'k';
+    }
+
+    {
+        // Zero 'appIdLengthWords'.
+
+        entryHeader->setAppIdLengthWords(0);
+
+        assertAppInfosRejected(entryBlock, 1, "zero appIdLengthWords");
+    }
+
+    {
+        // An 'appIdLengthWords' overrunning the area.
+
+        entryHeader->setAppIdLengthWords(0xFFFF);
+
+        assertAppInfosRejected(entryBlock, 1, "appIdLengthWords overrun");
+    }
+
+    alloc->deallocate(p);
 }
 
-}  // close unnamed namespace
-
-static void test5_calculateMd5Digest()
+static void test8_calculateMd5Digest()
 // ------------------------------------------------------------------------
 // Testing:
 //   calculateMd5Digest()
@@ -952,8 +1380,11 @@ int main(int argc, char* argv[])
 
     switch (_testCase) {
     case 0:
-    case 5: test5_calculateMd5Digest(); break;
-    case 4: test4_loadAppInfos(); break;
+    case 8: test8_calculateMd5Digest(); break;
+    case 7: test7_loadAppInfos(); break;
+    case 6: test6_hasValidQueueRecordMagic(); break;
+    case 5: test5_loadUnpaddedLength(); break;
+    case 4: test4_loadQueueRecordLayout(); break;
     case 3: test3_lastJournalSyncPoint(); break;
     case 2: test2_lastJournalRecord(); break;
     case 1: test1_hasBmqHeader(); break;

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.cpp
@@ -1556,7 +1556,6 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
     const MappedFileDescriptor& journal,
     bool                        qListAware,
     const MappedFileDescriptor& qlistFile,
-    bsls::Types::Uint64         qlistOffset,
     unsigned int*               queueRecLength,
     bmqt::Uri*                  quri,
     mqbu::StorageKey*           queueKey,
@@ -1571,20 +1570,21 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
     if (qListAware) {
         BSLS_ASSERT_SAFE(qlistFile.isValid());
     }
-    BSLS_ASSERT_SAFE(qlistOffset >= 0);
+
+    const bsls::Types::Uint64 qlistOffset = *qlistFilePos;
 
     enum {
-        rc_SUCCESS                     = 0,
-        rc_MISSING_QUEUE_RECORD        = -1,
-        rc_MISSING_QUEUE_RECORD_HEADER = -2,
-        rc_INCOMPLETE_QUEUE_RECORD     = -3,
-        rc_INVALID_QUEUE_RECORD        = -4,
-        rc_QLIST_OFFSET_MISMATCH       = -5
+        rc_SUCCESS               = 0,
+        rc_QLIST_OFFSET_MISMATCH = -1,
+        rc_JOURNAL_FILE_FULL     = -2
     };
 
     bmqu::BlobObjectProxy<QueueRecordHeader> queueRecHeader;
+    bmqu::BlobPosition                       queueRecBeginPos;
     unsigned int                             queueRecHeaderLen = 0;
     unsigned int                             queueRecLen       = 0;
+    unsigned int                             paddedUriLen      = 0;
+    unsigned int                             appIdsAreaLen     = 0;
     if (qListAware) {
         BSLS_ASSERT_SAFE(qlistFile.isValid());
 
@@ -1593,14 +1593,16 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
         // with journal record followed by queue record.  Queue record already
         // contains 'QueueRecordHeader' and is already WORD aligned.
 
-        bmqu::BlobPosition queueRecBeginPos;
-        int                rc = bmqu::BlobUtil::findOffsetSafe(
+        int rc = bmqu::BlobUtil::findOffsetSafe(
             &queueRecBeginPos,
             event,
             recordPosition,
             FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
         if (0 != rc) {
-            return 10 * rc + rc_MISSING_QUEUE_RECORD;  // RETURN
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Event has no queue record following the "
+                           << "journal record, rc: " << rc << ".";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
         }
 
         queueRecHeader.reset(&event,
@@ -1610,21 +1612,27 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
                              false);  // write
         if (!queueRecHeader.isSet()) {
             // Couldn't read QueueRecordHeader
-            return rc_MISSING_QUEUE_RECORD_HEADER;  // RETURN
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Event has no complete QueueRecordHeader.";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
         }
+
+        rc = FileStoreProtocolUtil::loadQueueRecordLayout(&queueRecHeaderLen,
+                                                          &paddedUriLen,
+                                                          &appIdsAreaLen,
+                                                          *queueRecHeader);
+        if (0 != rc) {
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "QueueRecordHeader declares an inconsistent "
+                           << "layout, rc: " << rc << ".";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
+        }
+
+        queueRecLen = queueRecHeader->queueRecordWords() *
+                      bmqp::Protocol::k_WORD_SIZE;
 
         // Ensure that blob has enough data as indicated by length
         // in 'queueRecordHeader'.
-
-        queueRecHeaderLen = queueRecHeader->headerWords() *
-                            bmqp::Protocol::k_WORD_SIZE;
-        queueRecLen = queueRecHeader->queueRecordWords() *
-                      bmqp::Protocol::k_WORD_SIZE;
-        BSLS_ASSERT_SAFE(qlistFile.fileSize() >=
-                         (*qlistFilePos + queueRecLen));
-        if (queueRecLength) {
-            *queueRecLength = queueRecLen;
-        }
 
         bmqu::BlobPosition queueRecEndPos;
         rc = bmqu::BlobUtil::findOffsetSafe(&queueRecEndPos,
@@ -1632,51 +1640,54 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
                                             queueRecBeginPos,
                                             queueRecLen);
         if (0 != rc) {
-            return 10 * rc + rc_INCOMPLETE_QUEUE_RECORD;  // RETURN
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Event holds fewer bytes than the "
+                           << queueRecLen << " declared by the "
+                           << "QueueRecordHeader, rc: " << rc << ".";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
         }
 
-        // Append payload to QLIST file.
+        if (qlistFile.fileSize() < (qlistOffset + queueRecLen)) {
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Queue record of " << queueRecLen << " bytes "
+                           << "does not fit in the QLIST file of "
+                           << qlistFile.fileSize() << " bytes at offset "
+                           << qlistOffset << ".";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
+        }
+    }
 
-        bmqu::BlobUtil::copyToRawBufferFromIndex(qlistFile.block().base() +
-                                                     *qlistFilePos,
-                                                 event,
-                                                 queueRecBeginPos.buffer(),
-                                                 queueRecBeginPos.byte(),
-                                                 queueRecLen);
-        *qlistFilePos += queueRecLen;
+    if (journal.fileSize() <
+        (*journalPos + 3 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE)) {
+        BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                       << "Journal file of " << journal.fileSize()
+                       << " bytes has no room for a record at offset "
+                       << *journalPos << ".";
+        return rc_JOURNAL_FILE_FULL;  // RETURN
     }
 
     // Keep track of journal record's offset.
 
-    bsls::Types::Uint64 recordOffset = *journalPos;
+    const bsls::Types::Uint64 recordOffset = *journalPos;
 
-    // Append QueueOp record to journal.
+    bmqu::BlobObjectProxy<QueueOpRecord> queueRec(&event,
+                                                  recordPosition,
+                                                  true,    // read
+                                                  false);  // write
+    if (!queueRec.isSet()) {
+        BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                       << "Event has no complete QueueOp record.";
+        return k_MALFORMED_QUEUE_RECORD;  // RETURN
+    }
 
-    BSLS_ASSERT_SAFE(
-        journal.fileSize() >=
-        (*journalPos + 3 * FileStoreProtocol::k_JOURNAL_RECORD_SIZE));
-    bmqu::BlobUtil::copyToRawBufferFromIndex(
-        journal.block().base() + recordOffset,
-        event,
-        recordPosition.buffer(),
-        recordPosition.byte(),
-        FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
-    *journalPos += FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
-
-    OffsetPtr<const QueueOpRecord> queueRec(journal.block(), recordOffset);
     if (QueueOpType::e_CREATION != queueRec->type() &&
         QueueOpType::e_ADDITION != queueRec->type()) {
         BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
                        << "Unexpected QueueOpType: " << queueRec->type();
-        return rc_INVALID_QUEUE_RECORD;  // RETURN
-    }
-    if (queueKey) {
-        *queueKey = queueRec->queueKey();
-    }
-    if (queueOpType) {
-        *queueOpType = queueRec->type();
+        return k_MALFORMED_QUEUE_RECORD;  // RETURN
     }
 
+    bmqt::Uri          uri;
     bmqu::MemOutStream queueUriAppsStr;
     if (qListAware) {
         // Check qlist offset in the replicated journal record sent
@@ -1691,37 +1702,79 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
             return rc_QLIST_OFFSET_MISMATCH;  // RETURN
         }
 
-        // Retrieve QueueKey & QueueUri from QueueOpRecord and
-        // QueueUriRecord respectively, and notify storage manager.
+        // The remaining checks read the payload back from the QLIST file.
+        // Nothing refers to these bytes until the journal record is written,
+        // so a rejected record leaves only overwritable bytes behind.
 
-        unsigned int paddedUriLen = queueRecHeader->queueUriLengthWords() *
-                                    bmqp::Protocol::k_WORD_SIZE;
+        bmqu::BlobUtil::copyToRawBufferFromIndex(qlistFile.block().base() +
+                                                     qlistOffset,
+                                                 event,
+                                                 queueRecBeginPos.buffer(),
+                                                 queueRecBeginPos.byte(),
+                                                 queueRecLen);
 
-        BSLS_ASSERT_SAFE(0 < paddedUriLen);
-
-        const char* uriBegin = qlistFile.block().base() + qlistOffset +
-                               queueRecHeaderLen;
-        bmqt::Uri uri(
-            bslstl::StringRef(uriBegin,
-                              paddedUriLen - uriBegin[paddedUriLen - 1]));
-        if (quri) {
-            *quri = uri;
+        if (!FileStoreProtocolUtil::hasValidQueueRecordMagic(qlistFile.block(),
+                                                             qlistOffset,
+                                                             queueRecLen)) {
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Queue record has an invalid magic word.";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
         }
 
-        unsigned int appIdsAreaSize = queueRecLen - queueRecHeaderLen -
-                                      paddedUriLen -
-                                      FileStoreProtocol::k_HASH_LENGTH -
-                                      sizeof(unsigned int);  // Magic word
+        // Retrieve the QueueUri from the queue record.
+        const char* uriBegin = qlistFile.block().base() + qlistOffset +
+                               queueRecHeaderLen;
+
+        unsigned int uriLen = 0;
+        int          rc = FileStoreProtocolUtil::loadUnpaddedLength(&uriLen,
+                                                           uriBegin,
+                                                           paddedUriLen);
+        if (0 != rc) {
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Queue record has an invalid padding byte for "
+                           << "the 'QueueUri' field, rc: " << rc << ".";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
+        }
+
+        rc = bmqt::UriParser::parse(&uri,
+                                    0,  // errorDescription
+                                    bslstl::StringRef(uriBegin, uriLen));
+        if (0 != rc) {
+            // The field holds arbitrary bytes bounded only by the QLIST file
+            // size, so log a prefix of it.
+
+            const unsigned int k_MAX_LOGGED_URI_LEN = 64;
+
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Queue record has an unparsable 'QueueUri' "
+                           << "field of " << uriLen << " bytes, beginning "
+                           << "with ["
+                           << bslstl::StringRef(uriBegin,
+                                                bsl::min(uriLen,
+                                                         k_MAX_LOGGED_URI_LEN))
+                           << "].";
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
+        }
+
         MemoryBlock appIdsBlock(qlistFile.block().base() + qlistOffset +
                                     queueRecHeaderLen + paddedUriLen +
                                     FileStoreProtocol::k_HASH_LENGTH,
-                                appIdsAreaSize);
+                                appIdsAreaLen);
         // NOTE: `appIdKeyPairs` is only populated if `qListAware` is true.
         // Please handle `appIdKeyPairs` properly if we want to run a cluster
         // with `qListAware = false`.
-        FileStoreProtocolUtil::loadAppInfos(appIdKeyPairs,
-                                            appIdsBlock,
-                                            queueRecHeader->numAppIds());
+        rc = FileStoreProtocolUtil::loadAppInfos(appIdKeyPairs,
+                                                 appIdsBlock,
+                                                 queueRecHeader->numAppIds());
+        if (0 != rc) {
+            BALL_LOG_ERROR << "Partition [" << partitionId << "]: "
+                           << "Queue record declares "
+                           << queueRecHeader->numAppIds() << " appIds which "
+                           << "do not fit its " << appIdsAreaLen
+                           << " byte application-ID area, rc: " << rc << ".";
+            appIdKeyPairs->clear();
+            return k_MALFORMED_QUEUE_RECORD;  // RETURN
+        }
 
         queueUriAppsStr << ", queue [" << uri << "]" << ", with ["
                         << appIdKeyPairs->size() << "] appId/appKey pairs ";
@@ -1732,6 +1785,33 @@ int FileStoreUtil::writeQueueCreationRecordImpl(
             queueUriAppsStr << " [" << cit->first << ", " << cit->second
                             << "]";
         }
+    }
+
+    // The record is valid: commit it.
+
+    bmqu::BlobUtil::copyToRawBufferFromIndex(
+        journal.block().base() + recordOffset,
+        event,
+        recordPosition.buffer(),
+        recordPosition.byte(),
+        FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
+
+    if (qListAware) {
+        *qlistFilePos += queueRecLen;
+    }
+    *journalPos += FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
+
+    if (queueRecLength) {
+        *queueRecLength = queueRecLen;
+    }
+    if (quri) {
+        *quri = uri;
+    }
+    if (queueKey) {
+        *queueKey = queueRec->queueKey();
+    }
+    if (queueOpType) {
+        *queueOpType = queueRec->type();
     }
 
     BALL_LOG_INFO << " Partition [" << partitionId

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.h
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.h
@@ -84,6 +84,14 @@ struct FileStoreUtil {
   public:
     typedef bsl::shared_ptr<FileSet> FileSetSp;
 
+    // PUBLIC CONSTANTS
+
+    /// Value returned by `writeQueueCreationRecordImpl` when the queue record
+    /// carried by the event is structurally invalid, as opposed to a failure
+    /// to apply a well-formed record.  Callers must translate it into a
+    /// result code of their own rather than propagate it.
+    static const int k_MALFORMED_QUEUE_RECORD = 1;
+
   private:
     // PRIVATE CLASS METHODS
 
@@ -363,12 +371,14 @@ struct FileStoreUtil {
         unsigned int*                refCount              = 0,
         bmqp::MessagePropertiesInfo* messagePropertiesInfo = 0);
 
-    /// Write a queue creation record loaded from `event` at `recordPosition`
-    /// for `partitionId` to the `journal`.  If `qListAware`, also write to
-    /// `qlistFile` currently at `qlistOffset`.  Store the resulting values in
-    /// `journalPos`, `qlistFilePos` and `appIdKeyPairs`, and optionally in
-    /// `queueRecLength`, `quri`, `queueKey`, and `queueOpType` if they are not
-    /// null.  Return 0 on success, non-zero value otherwise.
+    /// Write a queue creation/addition record loaded from `event` at
+    /// `recordPosition` for `partitionId` to the `journal`.  If `qListAware`,
+    /// also write to `qlistFile` at its current position `*qlistFilePos`.
+    /// Store the resulting values in `journalPos`, `qlistFilePos` and
+    /// `appIdKeyPairs`, and optionally in `queueRecLength`, `quri`,
+    /// `queueKey`, and `queueOpType` if they are not null.  Return 0 on
+    /// success, `k_MALFORMED_QUEUE_RECORD` if the record is structurally
+    /// invalid, another non-zero value otherwise.
     static int
     writeQueueCreationRecordImpl(bsls::Types::Uint64*        journalPos,
                                  bsls::Types::Uint64*        qlistFilePos,
@@ -379,7 +389,6 @@ struct FileStoreUtil {
                                  const MappedFileDescriptor& journal,
                                  bool                        qListAware,
                                  const MappedFileDescriptor& qlistFile,
-                                 bsls::Types::Uint64         qlistOffset,
                                  unsigned int*      queueRecLength = 0,
                                  bmqt::Uri*         quri           = 0,
                                  mqbu::StorageKey*  queueKey       = 0,

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.t.cpp
@@ -1,0 +1,546 @@
+// Copyright 2026 Bloomberg Finance L.P.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mqbs_filestoreutil.h>
+
+// MQB
+#include <mqbi_storage.h>
+#include <mqbs_filestoreprotocol.h>
+#include <mqbs_mappedfiledescriptor.h>
+#include <mqbs_memoryblock.h>
+#include <mqbs_offsetptr.h>
+#include <mqbu_storagekey.h>
+
+// BMQ
+#include <bmqp_protocolutil.h>
+#include <bmqu_blob.h>
+
+// BDE
+#include <bdlbb_blob.h>
+#include <bdlbb_blobutil.h>
+#include <bdlbb_pooledblobbufferfactory.h>
+#include <bsl_cstring.h>
+#include <bsl_string.h>
+#include <bsl_vector.h>
+#include <bsls_types.h>
+
+// TEST DRIVER
+#include <bmqtst_testhelper.h>
+
+// CONVENIENCE
+using namespace BloombergLP;
+using namespace bsl;
+
+// ============================================================================
+//                            TEST HELPERS UTILITY
+// ----------------------------------------------------------------------------
+
+namespace {
+
+/// Size of the buffers backing the fabricated JOURNAL and QLIST files, at
+/// least as large as any declared `fileSize` so that a test shrinking the
+/// latter leaves slack for an unchecked write to land in.
+const int k_FILE_BUFFER_SIZE = 4096;
+
+/// Write at the specified `buffer` a QLIST queue record for the specified
+/// `uri` holding the specified `appIds`, and return the length (in bytes)
+/// of the record.  The behavior is undefined unless `buffer` has room for the
+/// record.
+unsigned int buildQueueRecord(char*                           buffer,
+                              const bslstl::StringRef&        uri,
+                              const bsl::vector<bsl::string>& appIds)
+{
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    int                uriPadding = 0;
+    const unsigned int paddedUriLen =
+        bmqp::Protocol::k_WORD_SIZE *
+        bmqp::ProtocolUtil::calcNumWordsAndPadding(&uriPadding, uri.length());
+
+    unsigned int recordLen = sizeof(mqbs::QueueRecordHeader) + paddedUriLen +
+                             mqbs::FileStoreProtocol::k_HASH_LENGTH;
+
+    bsl::vector<int>          appIdPaddings(alloc);
+    bsl::vector<unsigned int> paddedAppIdLens(alloc);
+    for (size_t i = 0; i < appIds.size(); ++i) {
+        int                padding = 0;
+        const unsigned int paddedLen =
+            bmqp::Protocol::k_WORD_SIZE *
+            bmqp::ProtocolUtil::calcNumWordsAndPadding(&padding,
+                                                       appIds[i].length());
+        appIdPaddings.push_back(padding);
+        paddedAppIdLens.push_back(paddedLen);
+
+        recordLen += sizeof(mqbs::AppIdHeader) + paddedLen +
+                     mqbs::FileStoreProtocol::k_HASH_LENGTH;
+    }
+    recordLen += sizeof(unsigned int);  // Magic word
+
+    bsl::memset(buffer, 0, recordLen);
+
+    // QueueRecordHeader
+    mqbs::MemoryBlock                        recordBlock(buffer, recordLen);
+    mqbs::OffsetPtr<mqbs::QueueRecordHeader> qrh(recordBlock, 0);
+    new (qrh.get()) mqbs::QueueRecordHeader();
+    qrh->setQueueUriLengthWords(paddedUriLen / bmqp::Protocol::k_WORD_SIZE)
+        .setNumAppIds(appIds.size())
+        .setQueueRecordWords(recordLen / bmqp::Protocol::k_WORD_SIZE);
+
+    unsigned int offset = sizeof(mqbs::QueueRecordHeader);
+
+    // Padded QueueUri, followed by its (unused by the parser) hash.
+    bsl::memcpy(buffer + offset, uri.data(), uri.length());
+    offset += uri.length();
+    bmqp::ProtocolUtil::appendPaddingRaw(buffer + offset, uriPadding);
+    offset += uriPadding;
+    offset += mqbs::FileStoreProtocol::k_HASH_LENGTH;
+
+    // AppIdHeader, padded AppId and AppKey for each appId.
+    for (size_t i = 0; i < appIds.size(); ++i) {
+        mqbs::MemoryBlock                  appIdBlock(buffer + offset,
+                                     sizeof(mqbs::AppIdHeader));
+        mqbs::OffsetPtr<mqbs::AppIdHeader> aih(appIdBlock, 0);
+        new (aih.get()) mqbs::AppIdHeader();
+        aih->setAppIdLengthWords(paddedAppIdLens[i] /
+                                 bmqp::Protocol::k_WORD_SIZE);
+        offset += sizeof(mqbs::AppIdHeader);
+
+        bsl::memcpy(buffer + offset, appIds[i].c_str(), appIds[i].length());
+        offset += appIds[i].length();
+        bmqp::ProtocolUtil::appendPaddingRaw(buffer + offset,
+                                             appIdPaddings[i]);
+        offset += appIdPaddings[i];
+
+        const mqbu::StorageKey appKey(mqbu::StorageKey::BinaryRepresentation(),
+                                      "abcde");
+        bsl::memcpy(buffer + offset,
+                    appKey.data(),
+                    mqbu::StorageKey::e_KEY_LENGTH_BINARY);
+        offset += mqbs::FileStoreProtocol::k_HASH_LENGTH;
+    }
+
+    // Magic word
+    mqbs::MemoryBlock magicBlock(buffer + offset, sizeof(unsigned int));
+    mqbs::OffsetPtr<bdlb::BigEndianUint32> magic(magicBlock, 0);
+    *magic = mqbs::QueueRecordHeader::k_MAGIC;
+    offset += sizeof(unsigned int);
+
+    BSLS_ASSERT_OPT(offset == recordLen);
+
+    return recordLen;
+}
+
+/// Write at the specified `buffer` a QueueOp journal record of type
+/// `e_CREATION` for a QLIST record located at the specified `qlistOffset`,
+/// and return the length (in bytes) of the record.  The behavior is
+/// undefined unless `buffer` has room for a journal record.
+unsigned int buildQueueOpRecord(char* buffer, bsls::Types::Uint64 qlistOffset)
+{
+    bsl::memset(buffer, 0, mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
+
+    mqbs::MemoryBlock recordBlock(
+        buffer,
+        mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
+    mqbs::OffsetPtr<mqbs::QueueOpRecord> rec(recordBlock, 0);
+    new (rec.get()) mqbs::QueueOpRecord();
+
+    rec->header()
+        .setType(mqbs::RecordType::e_QUEUE_OP)
+        .setPrimaryLeaseId(1U)
+        .setSequenceNumber(1U);
+    rec->setType(mqbs::QueueOpType::e_CREATION)
+        .setQueueKey(mqbu::StorageKey(mqbu::StorageKey::BinaryRepresentation(),
+                                      "12345"))
+        .setQueueUriRecordOffsetWords(qlistOffset /
+                                      bmqp::Protocol::k_WORD_SIZE)
+        .setMagic(mqbs::RecordHeader::k_MAGIC);
+
+    return mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE;
+}
+
+/// Scaffolding for a single `writeQueueCreationRecordImpl` invocation: a
+/// fabricated JOURNAL and QLIST mapped file pair, and the replication event
+/// holding a QueueOp journal record immediately followed by its QLIST queue
+/// record.
+class Tester {
+  private:
+    // DATA
+    bslma::Allocator* d_allocator_p;
+
+    bsl::vector<char> d_journalBuffer;
+
+    bsl::vector<char> d_qlistBuffer;
+
+    mqbs::MappedFileDescriptor d_journal;
+
+    mqbs::MappedFileDescriptor d_qlist;
+
+    bdlbb::PooledBlobBufferFactory d_bufferFactory;
+
+    bdlbb::Blob d_event;
+
+    unsigned int d_queueRecordLen;
+
+  public:
+    // CREATORS
+
+    /// Create a tester whose event carries a well-formed QLIST record
+    /// holding the specified `appIds`.
+    Tester(const bsl::vector<bsl::string>& appIds, bslma::Allocator* allocator)
+    : d_allocator_p(allocator)
+    , d_journalBuffer(k_FILE_BUFFER_SIZE, '\0', allocator)
+    , d_qlistBuffer(k_FILE_BUFFER_SIZE, '\0', allocator)
+    , d_journal()
+    , d_qlist()
+    , d_bufferFactory(1024, allocator)
+    , d_event(&d_bufferFactory, allocator)
+    , d_queueRecordLen(0)
+    {
+        d_journal.setFd(1)
+            .setFileSize(k_FILE_BUFFER_SIZE)
+            .setBlock(
+                mqbs::MemoryBlock(&d_journalBuffer[0], k_FILE_BUFFER_SIZE))
+            .setMapping(&d_journalBuffer[0])
+            .setMappingSize(k_FILE_BUFFER_SIZE);
+
+        d_qlist.setFd(2)
+            .setFileSize(k_FILE_BUFFER_SIZE)
+            .setBlock(mqbs::MemoryBlock(&d_qlistBuffer[0], k_FILE_BUFFER_SIZE))
+            .setMapping(&d_qlistBuffer[0])
+            .setMappingSize(k_FILE_BUFFER_SIZE);
+
+        const char k_URI[] = "bmq://bmq.test.persistent.priority/testq123";
+        bsl::vector<char>  raw(k_FILE_BUFFER_SIZE, '\0', allocator);
+        const unsigned int journalRecLen = buildQueueOpRecord(&raw[0], 0);
+        d_queueRecordLen = buildQueueRecord(&raw[0] + journalRecLen,
+                                            k_URI,
+                                            appIds);
+
+        bdlbb::BlobUtil::append(&d_event,
+                                &raw[0],
+                                journalRecLen + d_queueRecordLen);
+    }
+
+    // MANIPULATORS
+
+    /// Return the header of the QLIST record carried by the event, so that
+    /// a test can corrupt one of its fields.
+    mqbs::QueueRecordHeader& queueRecordHeader()
+    {
+        bmqu::BlobPosition pos;
+        const int          rc = bmqu::BlobUtil::findOffsetSafe(
+            &pos,
+            d_event,
+            bmqu::BlobPosition(0, 0),
+            mqbs::FileStoreProtocol::k_JOURNAL_RECORD_SIZE);
+        BSLS_ASSERT_OPT(0 == rc);
+
+        return *reinterpret_cast<mqbs::QueueRecordHeader*>(
+            d_event.buffer(pos.buffer()).data() + pos.byte());
+    }
+
+    /// Return a modifiable reference to the byte at the specified `offset`
+    /// within the QLIST record carried by the event.
+    char& queueRecordByte(unsigned int offset)
+    {
+        return *(reinterpret_cast<char*>(&queueRecordHeader()) + offset);
+    }
+
+    /// Declare the QLIST mapped file to be of the specified `size` bytes,
+    /// leaving its (larger) backing buffer untouched.
+    void setQlistFileSize(bsls::Types::Uint64 size)
+    {
+        d_qlist.setFileSize(size);
+    }
+
+    /// Invoke `writeQueueCreationRecordImpl` on the event and return its
+    /// result code.
+    int write()
+    {
+        bsls::Types::Uint64     journalPos   = 0;
+        bsls::Types::Uint64     qlistFilePos = 0;
+        mqbi::Storage::AppInfos appIdKeyPairs(d_allocator_p);
+
+        return mqbs::FileStoreUtil::writeQueueCreationRecordImpl(
+            &journalPos,
+            &qlistFilePos,
+            &appIdKeyPairs,
+            1,  // partitionId
+            d_event,
+            bmqu::BlobPosition(0, 0),
+            d_journal,
+            true,  // qListAware
+            d_qlist,
+            0);  // qlistOffset
+    }
+
+    // ACCESSORS
+
+    /// Return the length (in bytes) of the QLIST record carried by the
+    /// event.
+    unsigned int queueRecordLen() const { return d_queueRecordLen; }
+
+    /// Return true if nothing has been written to the JOURNAL file.
+    bool isJournalPristine() const
+    {
+        for (size_t i = 0; i < d_journalBuffer.size(); ++i) {
+            if ('\0' != d_journalBuffer[i]) {
+                return false;  // RETURN
+            }
+        }
+
+        return true;
+    }
+};
+
+}  // close unnamed namespace
+
+// ============================================================================
+//                                    TESTS
+// ----------------------------------------------------------------------------
+
+static void test1_writeQueueCreationRecordImpl()
+// ------------------------------------------------------------------------
+// WRITE QUEUE CREATION RECORD IMPL
+//
+// Concerns:
+//   A well-formed QLIST queue record is applied.
+//
+// Testing:
+//   writeQueueCreationRecordImpl()
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName("WRITE QUEUE CREATION RECORD IMPL");
+
+    bslma::Allocator* alloc = bmqtst::TestHelperUtil::allocator();
+
+    {
+        // No appIds.
+        bsl::vector<bsl::string> appIds(alloc);
+        Tester                   tester(appIds, alloc);
+
+        BMQTST_ASSERT_EQ(0, tester.write());
+        BMQTST_ASSERT(!tester.isJournalPristine());
+    }
+
+    {
+        // Two appIds.
+        bsl::vector<bsl::string> appIds(alloc);
+        appIds.emplace_back("foo");
+        appIds.emplace_back("barbazqux");
+
+        Tester tester(appIds, alloc);
+
+        BMQTST_ASSERT_EQ(0, tester.write());
+        BMQTST_ASSERT(!tester.isJournalPristine());
+    }
+}
+
+static void test2_writeQueueCreationRecordImplMalformed()
+// ------------------------------------------------------------------------
+// WRITE QUEUE CREATION RECORD IMPL MALFORMED
+//
+// Concerns:
+//   A QLIST queue record whose 'QueueRecordHeader' does not describe the
+//   bytes that follow is rejected with a non-zero result code, does not
+//   read or write outside the record, and leaves the JOURNAL untouched.
+//
+// Testing:
+//   writeQueueCreationRecordImpl()
+// ------------------------------------------------------------------------
+{
+    bmqtst::TestHelper::printTestName(
+        "WRITE QUEUE CREATION RECORD IMPL MALFORMED");
+
+    bslma::Allocator*              alloc = bmqtst::TestHelperUtil::allocator();
+    const bsl::vector<bsl::string> noAppIds(alloc);
+
+    {
+        // 'numAppIds' greater than the number of entries present.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordHeader().setNumAppIds(1);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // 'queueRecordWords' too small.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordHeader().setQueueRecordWords(
+            tester.queueRecordLen() / bmqp::Protocol::k_WORD_SIZE - 1);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // 'headerWords' below 'QueueRecordHeader::k_MIN_HEADER_SIZE'.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordHeader().setHeaderWords(1);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // Zero 'queueUriLengthWords'.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordHeader().setQueueUriLengthWords(0);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // 'queueUriLengthWords' overrunning the record.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordHeader().setQueueUriLengthWords(
+            tester.queueRecordLen());
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // A record longer than the space remaining in the QLIST file.
+        Tester tester(noAppIds, alloc);
+        tester.setQlistFileSize(tester.queueRecordLen() - 1);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // A URI which does not parse.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordByte(sizeof(mqbs::QueueRecordHeader)) = '!';
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // A URI padding byte with its high bit set, which read as a signed
+        // 'char' would yield an unpadded length larger than the padded one.
+        Tester             tester(noAppIds, alloc);
+        const unsigned int paddedUriLen =
+            tester.queueRecordHeader().queueUriLengthWords() *
+            bmqp::Protocol::k_WORD_SIZE;
+        tester.queueRecordByte(sizeof(mqbs::QueueRecordHeader) + paddedUriLen -
+                               1) = static_cast<char>(0x80);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // Trailing magic word mismatch.
+        Tester tester(noAppIds, alloc);
+        tester.queueRecordByte(tester.queueRecordLen() - 1) = 0;
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // Zero 'appIdLengthWords' in the sole 'AppIdHeader'.
+        bsl::vector<bsl::string> appIds(alloc);
+        appIds.emplace_back("foo");
+
+        Tester             tester(appIds, alloc);
+        const unsigned int paddedUriLen =
+            tester.queueRecordHeader().queueUriLengthWords() *
+            bmqp::Protocol::k_WORD_SIZE;
+        const unsigned int appIdHeaderOffset =
+            sizeof(mqbs::QueueRecordHeader) + paddedUriLen +
+            mqbs::FileStoreProtocol::k_HASH_LENGTH;
+
+        mqbs::MemoryBlock appIdBlock(
+            &tester.queueRecordByte(appIdHeaderOffset),
+            sizeof(mqbs::AppIdHeader));
+        mqbs::OffsetPtr<mqbs::AppIdHeader> aih(appIdBlock, 0);
+        aih->setAppIdLengthWords(0);
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // 'appIdLengthWords' overrunning the application-ID area.
+        bsl::vector<bsl::string> appIds(alloc);
+        appIds.emplace_back("foo");
+
+        Tester             tester(appIds, alloc);
+        const unsigned int paddedUriLen =
+            tester.queueRecordHeader().queueUriLengthWords() *
+            bmqp::Protocol::k_WORD_SIZE;
+        const unsigned int appIdHeaderOffset =
+            sizeof(mqbs::QueueRecordHeader) + paddedUriLen +
+            mqbs::FileStoreProtocol::k_HASH_LENGTH;
+
+        mqbs::MemoryBlock appIdBlock(
+            &tester.queueRecordByte(appIdHeaderOffset),
+            sizeof(mqbs::AppIdHeader));
+        mqbs::OffsetPtr<mqbs::AppIdHeader> aih(appIdBlock, 0);
+        aih->setAppIdLengthWords(tester.queueRecordLen());
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+
+    {
+        // Invalid appId padding byte.
+        bsl::vector<bsl::string> appIds(alloc);
+        appIds.emplace_back("foo");
+
+        Tester             tester(appIds, alloc);
+        const unsigned int paddedUriLen =
+            tester.queueRecordHeader().queueUriLengthWords() *
+            bmqp::Protocol::k_WORD_SIZE;
+        const unsigned int appIdEndOffset =
+            sizeof(mqbs::QueueRecordHeader) + paddedUriLen +
+            mqbs::FileStoreProtocol::k_HASH_LENGTH +
+            sizeof(mqbs::AppIdHeader) + bmqp::Protocol::k_WORD_SIZE;
+
+        tester.queueRecordByte(appIdEndOffset - 1) = 0;
+
+        BMQTST_ASSERT_NE(0, tester.write());
+        BMQTST_ASSERT(tester.isJournalPristine());
+    }
+}
+
+// ============================================================================
+//                                 MAIN PROGRAM
+// ----------------------------------------------------------------------------
+
+int main(int argc, char* argv[])
+{
+    TEST_PROLOG(bmqtst::TestHelper::e_DEFAULT);
+
+    switch (_testCase) {
+    case 0:
+    case 2: test2_writeQueueCreationRecordImplMalformed(); break;
+    case 1: test1_writeQueueCreationRecordImpl(); break;
+    default: {
+        cerr << "WARNING: CASE '" << _testCase << "' NOT FOUND." << endl;
+        bmqtst::TestHelperUtil::testStatus() = -1;
+    } break;
+    }
+
+    // 'writeQueueCreationRecordImpl' builds a 'bmqt::Uri' and a log stream
+    // from the default allocator, so only the global allocator is checked.
+    TEST_EPILOG(bmqtst::TestHelper::e_CHECK_GBL_ALLOC);
+}

--- a/src/groups/mqb/mqbs/mqbs_filestoreutil.t.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestoreutil.t.cpp
@@ -282,8 +282,7 @@ class Tester {
             bmqu::BlobPosition(0, 0),
             d_journal,
             true,  // qListAware
-            d_qlist,
-            0);  // qlistOffset
+            d_qlist);
     }
 
     // ACCESSORS


### PR DESCRIPTION
  ## Summary

  - `FileStoreProtocolUtil::loadAppInfos` returned `void` and never consulted the size of the application-ID area it was handed, so a declared appId count larger than the entries present read past the end. It now reports a status and bounds every field against the block.

  - The section lengths declared by a `QueueRecordHeader` were used without a consistency check, letting the application-ID area size underflow when computed by subtraction. `loadQueueRecordLayout` now derives and validates them together.

  - `FileStoreUtil::writeQueueCreationRecordImpl` guarded QLIST and journal capacity with `BSLS_ASSERT_SAFE`, and parsed the record only after copying it into the QLIST file. Capacity is now checked at runtime, and the file positions advance only once the record is validated.

  - A malformed record was indistinguishable from a failed write in `FileStore::processStorageEvent` and reached `ExitUtil::terminate(e_STORAGE_OUT_OF_SYNC)`. Such a record says nothing about whether self and the primary have diverged, so it now drops  the event with an alarm; a genuine write failure still terminates.