### PR TITLE
CI: cleanup sanitizers runner

### DIFF
--- a/.github/workflows/sanitize.yaml
+++ b/.github/workflows/sanitize.yaml
@@ -25,14 +25,17 @@ jobs:
       - name: Purge runner
       # Strip the runner to avoid space quota exceeding
         run: |
-          sudo apt-get purge -y \
-          azure-cli microsoft-edge-stable google-cloud-cli \
-          google-chrome-stable temurin-21-jdk temurin-17-jdk \
-          temurin-11-jdk dotnet-sdk-8.0 firefox temurin-8-jdk \
-          powershell libllvm17t64 libllvm18 libllvm16t64 \
-          openjdk-21-jre-headless mysql-server-core-8.0
-          sudo apt-get autoremove
-          sudo apt-get autoclean
+          echo "=== Disk usage before purge ==="
+          df -h /
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/share/boost
+          sudo rm -rf /usr/local/.ghcup
+          sudo docker image prune --all --force
+          echo "=== Disk usage after purge ==="
+          df -h /
       - name: Build [${{ github.job }}]
         run: |
           docker build -f ${{ github.workspace }}/docker/sanitizers/Dockerfile \


### PR DESCRIPTION
# Before

```
=== Disk usage before purge ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   59G   86G  41% /

=== Disk usage after purge ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   52G   93G  37% /
```

**Cleans**: 7G

# After

```
=== Disk usage before purge ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   59G   86G  41% /

=== Disk usage after purge ===
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       145G   32G  113G  22% /
```

**Cleans**: 27G