### PR TITLE
CI[prometheus]: fix the build by installing civetweb

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -351,7 +351,9 @@ jobs:
             libgtest-dev \
             libz-dev \
             autoconf \
-            libtool
+            libtool \
+            civetweb \
+            libcivetweb-dev
       - name: Install cached non packaged dependencies
         working-directory: deps
         run: ../docker/build_deps.sh


### PR DESCRIPTION
Fixes prometheus plugin build in CI:
```
CMake Error at pull/CMakeLists.txt:1 (find_package):
  Could not find a package configuration file provided by "civetweb" with any
  of the following names:

    civetwebConfig.cmake
    civetweb-config.cmake

  Add the installation prefix of "civetweb" to CMAKE_PREFIX_PATH or set
  "civetweb_DIR" to a directory containing one of the above files.  If
  "civetweb" provides a separate development package or SDK, be sure it has
  been installed.
```