### PR TITLE
Fix[bmqbrkr]: unsafe signal handler

### DIFF
--- a/src/applications/bmqbrkr/bmqbrkr.m.cpp
+++ b/src/applications/bmqbrkr/bmqbrkr.m.cpp
@@ -117,9 +117,19 @@ extern "C" {
 /// was sent to the application.
 static void appShutdownSignal(int signal)
 {
-    bsl::cout << "Shutting down [received signal '" << strsignal(signal)
-              << "' (" << signal << ")]\n"
-              << bsl::flush;
+    char      buffer[64];
+    const int length = ::snprintf(buffer,
+                                  sizeof(buffer),
+                                  "Shutting down [received signal %d]\n",
+                                  signal);
+
+    if (0 < length) {
+        // Nothing can be done about a failed or partial write from within a
+        // signal handler, so the result is deliberately ignored.
+        const ssize_t rc = ::write(STDOUT_FILENO, buffer, length);
+        static_cast<void>(rc);
+    }
+
     if (s_taskEnv_p) {
         s_taskEnv_p->d_shutdownSemaphore.post();
     }


### PR DESCRIPTION
Fixes the following TSAN-detected failure:
```
WARNING: ThreadSanitizer: signal-unsafe call inside of a signal (pid=3932)
#0 free <null> (bmqbrkr.tsk+0x387c3de) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
#1 <null> <null> (libc.so.6+0x3d9ec) (BuildId: 240c8909736b31f963346aca80667fd00c551e32)
#2 __tsan::CallUserSignalHandler(__tsan::ThreadState*, bool, bool, int, __sanitizer::__sanitizer_siginfo*, void*) crtstuff.c (bmqbrkr.tsk+0x3885f9f) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
#3 BloombergLP::bslmt::SemaphoreImpl<BloombergLP::bslmt::Platform::PosixSemaphore>::wait() /blazingmq/deps/srcs/bde/groups/bsl/bslmt/bslmt_semaphoreimpl_pthread.cpp:46:18 (bmqbrkr.tsk+0x58ec234) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
#4 BloombergLP::bslmt::Semaphore::wait() /opt/bb/include/bslmt_semaphore.h:226:12 (bmqbrkr.tsk+0x395ec85) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
#5 run(std::__1::basic_ostream<char, std::__1::char_traits<char>>&, (anonymous namespace)::TaskEnvironment*, bool) /blazingmq/src/applications/bmqbrkr/bmqbrkr.m.cpp:576:38 (bmqbrkr.tsk+0x3905b95) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
#6 main /blazingmq/src/applications/bmqbrkr/bmqbrkr.m.cpp:749:10 (bmqbrkr.tsk+0x3903ca0) (BuildId: aacaeac3d873aa41d2b81e8992f0343aaceaa518)
```

https://github.com/bloomberg/blazingmq/actions/runs/33551195093/job/100016312809