### PR TITLE
Cleanup[bmqu::PrintUtil]: keep only manipulator print

### DIFF
--- a/src/groups/bmq/bmqu/bmqu_printutil.cpp
+++ b/src/groups/bmq/bmqu/bmqu_printutil.cpp
@@ -83,45 +83,36 @@ char* prettyNumberImp(char*              buf,
 
 namespace PrintUtil {
 
-bsl::ostream&
-prettyNumber(bsl::ostream& stream, int value, int groupSize, char separator)
-{
-    return prettyNumber(stream,
-                        static_cast<bsls::Types::Int64>(value),
-                        groupSize,
-                        separator);
-}
-
-bsl::ostream& prettyNumber(bsl::ostream&      stream,
-                           bsls::Types::Int64 value,
-                           int                groupSize,
-                           char               separator)
+bsl::ostream& operator<<(bsl::ostream&               stream,
+                         const PrettyIntManipulator& manipulator)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(groupSize > 0);
+    BSLS_ASSERT_SAFE(manipulator.d_groupSize > 0);
 
     char  buf[64];
     char* pos = buf + 63;
     *pos      = '\0';
 
-    return stream << prettyNumberImp(pos, value, groupSize, separator);
+    return stream << prettyNumberImp(pos,
+                                     manipulator.d_value,
+                                     manipulator.d_groupSize,
+                                     manipulator.d_separator);
 }
 
-bsl::ostream& prettyNumber(bsl::ostream& stream,
-                           double        value,
-                           int           precision,
-                           int           groupSize,
-                           char          separator)
+bsl::ostream& operator<<(bsl::ostream&                  stream,
+                         const PrettyDoubleManipulator& manipulator)
 {
     // PRECONDITIONS
-    BSLS_ASSERT_SAFE(groupSize > 0);
+    BSLS_ASSERT_SAFE(manipulator.d_groupSize > 0);
+
+    const int precision = manipulator.d_precision;
 
     char  buf[128];
     char* pos = buf + 127;
     *pos      = '\0';
 
     if (precision > 0) {
-        const double absValue  = bsl::abs(value);
+        const double absValue  = bsl::abs(manipulator.d_value);
         const int    remainder = static_cast<int>(
             bsl::floor((absValue - bsl::floor(absValue)) *
                        bsl::pow(static_cast<double>(10.),
@@ -136,15 +127,19 @@ bsl::ostream& prettyNumber(bsl::ostream& stream,
         pos -= precision + 2;
     }
 
-    return stream << prettyNumberImp(pos,
-                                     static_cast<bsls::Types::Int64>(value),
-                                     groupSize,
-                                     separator);
+    return stream << prettyNumberImp(
+               pos,
+               static_cast<bsls::Types::Int64>(manipulator.d_value),
+               manipulator.d_groupSize,
+               manipulator.d_separator);
 }
 
-bsl::ostream&
-prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision)
+bsl::ostream& operator<<(bsl::ostream&                 stream,
+                         const PrettyBytesManipulator& manipulator)
 {
+    bsls::Types::Int64 bytes     = manipulator.d_bytes;
+    const int          precision = manipulator.d_precision;
+
     static const char* k_UNITS[]     = {" B", "KB", "MB", "GB", "TB", "PB"};
     static const int   k_UNITS_COUNT = sizeof(k_UNITS) / sizeof(*k_UNITS);
 
@@ -228,10 +223,12 @@ prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision)
     return stream;
 }
 
-bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
-                                 bsls::Types::Int64 timeNs,
-                                 int                precision)
+bsl::ostream& operator<<(bsl::ostream&                        stream,
+                         const PrettyTimeIntervalManipulator& manipulator)
 {
+    bsls::Types::Int64 timeNs    = manipulator.d_timeNs;
+    const int          precision = manipulator.d_precision;
+
     static const char* k_UNITS[] = {"ns", "us", "ms", "s", "m", "h", "d", "w"};
     static const int   k_SIZES[] = {1000, 1000, 1000, 60, 60, 24, 7};
     static const int   k_SIZES_COUNT = sizeof(k_SIZES) / sizeof(*k_SIZES);

--- a/src/groups/bmq/bmqu/bmqu_printutil.h
+++ b/src/groups/bmq/bmqu/bmqu_printutil.h
@@ -33,22 +33,16 @@
 // bmqu::Printer
 //
 //@DESCRIPTION:
-// This component provides a set of utility functions and stream manipulators
-// for writing numbers, time intervals, and bytes amounts in a human-readable
-// format.
-// The 'pretty*' functions exist in two styles:
-//: o Procedural: The argument list consists of the destination output stream,
-//:   followed by the value to write, possibly followed by formatting
-//:   parameters (group size, group separator, etc). The function writes the
-//:   value to the stream and returns void.
-//: o Manipulator: The argument list consists of the value to write, possibly
-//:   followed by formatting parameters (group size, group separator, etc).
-//:   The function returns an object which, when inserted into an output
-//:   stream, writes the value to the stream. This is similar to the standard
-//:   library stream manipulators ('std::setw', 'std::setprecision', etc).
+// This component provides a set of stream manipulators for writing numbers,
+// time intervals, and bytes amounts in a human-readable format.
+// The argument list of a 'pretty*' function consists of the value to write,
+// possibly followed by formatting parameters (group size, group separator,
+// etc).  The function returns an object which, when inserted into an output
+// stream, writes the value to the stream.  This is similar to the standard
+// library stream manipulators ('std::setw', 'std::setprecision', etc).
 //
-// The '*indent' functions exist only as manipulators that invoke the
-// corresponding functions in the 'bdlb_print' component.
+// The '*indent' manipulators invoke the corresponding functions in the
+// 'bdlb_print' component.
 //
 // All the functions provided by this component have sensible default values
 // for the formatting parameters. Numbers are written following the US American
@@ -57,17 +51,9 @@
 //
 /// Usage
 ///-----
-// Write values using the procedural interface:
+// Write values using manipulators:
 //..
-//  // os is a bsl::ostream                  output:
-//  prettyNumber(os, 1234567, 2, '.'); // 1.23.45.67
-//  prettyNumber(os, 1234567);         // 1,234,567
-//  prettyBytes(os, 1025);             // 1.00 KB
-//  prettyTimeInterval(os, 12432);     // 12.43 us
-//..
-//
-// Write the same values using manipulators:
-//..
+//  // os is a bsl::ostream                    output:
 //  os << prettyNumber(1234567, 2, '.'); // 1.23.45.67
 //  os << prettyNumber(1234567);         // 1,234,567
 //  os << prettyBytes(1025);             // 1.00 KB
@@ -108,17 +94,6 @@ struct PrettyTimeIntervalManipulator;
 
 // FREE FUNCTIONS
 
-/// Print the specified `value` to the specified `stream` with the specified
-/// `separator` character between every `groupSize` digits.
-bsl::ostream& prettyNumber(bsl::ostream& stream,
-                           int           value,
-                           int           groupSize = 3,
-                           char          separator = ',');
-bsl::ostream& prettyNumber(bsl::ostream&      stream,
-                           bsls::Types::Int64 value,
-                           int                groupSize = 3,
-                           char               separator = ',');
-
 /// Return a stream manipulator that inserts the specified `value` with the
 /// specified `separator` character between every `groupSize` digits.
 PrettyIntManipulator
@@ -126,13 +101,6 @@ prettyNumber(int value, int groupSize = 3, char separator = ',');
 PrettyIntManipulator prettyNumber(bsls::Types::Int64 value,
                                   int                groupSize = 3,
                                   char               separator = ',');
-
-/// Value is truncated, not rounded...
-bsl::ostream& prettyNumber(bsl::ostream& stream,
-                           double        value,
-                           int           precision = 2,
-                           int           groupSize = 3,
-                           char          separator = ',');
 
 /// Return a stream manipulator that inserts the specified `value` with the
 /// specified `precision` with the specified `separator` character between
@@ -142,24 +110,11 @@ PrettyDoubleManipulator prettyNumber(double value,
                                      int    groupSize = 3,
                                      char   separator = ',');
 
-/// Print the specified `bytes` using the appropriate suffix (KB, MB, etc)
-/// to the specified `stream` with the specified `precision`. The behavior
-/// is undefined unless `precision <= 3`.
-bsl::ostream&
-prettyBytes(bsl::ostream& stream, bsls::Types::Int64 bytes, int precision = 2);
-
 /// Return a stream manipulator that inserts the specified `bytes` using the
 /// appropriate suffix (KB, MB, etc) with the specified `precision`. The
 /// behavior is undefined unless `precision <= 3`.
 PrettyBytesManipulator prettyBytes(bsls::Types::Int64 bytes,
                                    int                precision = 2);
-
-/// Print the specified `timeNs` which is assumed to be a number of
-/// nanoseconds to the specified `stream` with the specified `precision` in
-/// a readable form. Values are rounded to the nearest.
-bsl::ostream& prettyTimeInterval(bsl::ostream&      stream,
-                                 bsls::Types::Int64 timeNs,
-                                 int                precision = 2);
 
 /// Return a stream manipulator that inserts the specified `timeNs` which is
 /// assumed to be a number of nanoseconds with the specified `precision` in
@@ -182,8 +137,12 @@ NewlineAndIndentManipulator newlineAndIndent(int level, int spacesPerLevel);
 template <typename TYPE>
 Printer<TYPE> printer(const TYPE& obj);
 
-/// Print the specified `manipulator` into the specified output `stream` and
-/// return `stream`.
+/// @brief Insert the specified `manipulator` into the specified `stream`.
+///
+/// @param stream The destination output stream.
+/// @param manipulator The value and formatting parameters to insert.
+///
+/// @return A reference to the modifiable `stream`.
 bsl::ostream& operator<<(bsl::ostream&               stream,
                          const PrettyIntManipulator& manipulator);
 bsl::ostream& operator<<(bsl::ostream&                  stream,
@@ -465,49 +424,6 @@ template <typename TYPE>
 inline Printer<TYPE> PrintUtil::printer(const TYPE& obj)
 {
     return Printer<TYPE>(&obj);
-}
-
-inline bsl::ostream&
-PrintUtil::operator<<(bsl::ostream&                          stream,
-                      const PrintUtil::PrettyIntManipulator& manipulator)
-{
-    PrintUtil::prettyNumber(stream,
-                            manipulator.d_value,
-                            manipulator.d_groupSize,
-                            manipulator.d_separator);
-    return stream;
-}
-
-inline bsl::ostream&
-PrintUtil::operator<<(bsl::ostream&                  stream,
-                      const PrettyDoubleManipulator& manipulator)
-{
-    PrintUtil::prettyNumber(stream,
-                            manipulator.d_value,
-                            manipulator.d_precision,
-                            manipulator.d_groupSize,
-                            manipulator.d_separator);
-    return stream;
-}
-
-inline bsl::ostream&
-PrintUtil::operator<<(bsl::ostream&                 stream,
-                      const PrettyBytesManipulator& manipulator)
-{
-    PrintUtil::prettyBytes(stream,
-                           manipulator.d_bytes,
-                           manipulator.d_precision);
-    return stream;
-}
-
-inline bsl::ostream&
-PrintUtil::operator<<(bsl::ostream&                        stream,
-                      const PrettyTimeIntervalManipulator& manipulator)
-{
-    PrintUtil::prettyTimeInterval(stream,
-                                  manipulator.d_timeNs,
-                                  manipulator.d_precision);
-    return stream;
 }
 
 inline bsl::ostream&

--- a/src/groups/bmq/bmqu/bmqu_printutil.t.cpp
+++ b/src/groups/bmq/bmqu/bmqu_printutil.t.cpp
@@ -44,7 +44,7 @@ static void test1_prettyNumberInt64()
 //
 // Testing:
 //   Proper behavior of
-//   'prettyNumber(stream, value, groupSize, separator)'
+//   'prettyNumber(value, groupSize, separator)'
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("prettyNumber (Int64)");
@@ -78,42 +78,23 @@ static void test1_prettyNumberInt64()
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
         const Test& test = k_DATA[idx];
 
-        // function
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << "(groupSize: " << test.d_groupSize
-                            << ", separator: '" << test.d_separator
-                            << "', function)");
+        PVV(test.d_line << ": checking value '" << test.d_value << "' "
+                        << "(groupSize: " << test.d_groupSize
+                        << ", separator: '" << test.d_separator << "')");
 
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            bmqu::PrintUtil::prettyNumber(buf,
-                                          test.d_value,
-                                          test.d_groupSize,
-                                          test.d_separator);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
-
-        // manipulator
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << "(groupSize: " << test.d_groupSize
-                            << ", separator: '" << test.d_separator
-                            << "', manipulator)");
-
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            buf << bmqu::PrintUtil::prettyNumber(test.d_value,
-                                                 test.d_groupSize,
-                                                 test.d_separator);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
+        bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
+        buf << bmqu::PrintUtil::prettyNumber(test.d_value,
+                                             test.d_groupSize,
+                                             test.d_separator);
+        BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
     }
 
     PV("Ensure assertion when group size <= 0");
     {
         BMQTST_ASSERT_SAFE_FAIL(
-            bmqu::PrintUtil::prettyNumber(bsl::cout, 123, 0, ','));
+            bsl::cout << bmqu::PrintUtil::prettyNumber(1234, 0, ','));
         BMQTST_ASSERT_SAFE_FAIL(
-            bmqu::PrintUtil::prettyNumber(bsl::cout, 123, -2, ','));
+            bsl::cout << bmqu::PrintUtil::prettyNumber(123, -2, ','));
     }
 }
 
@@ -129,7 +110,7 @@ static void test2_prettyNumberDouble()
 //
 // Testing:
 //   Proper behavior of
-//   'prettyNumber(stream, value, precision, groupSize, sep)'
+//   'prettyNumber(value, precision, groupSize, sep)'
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("prettyNumber (Double)");
@@ -159,46 +140,25 @@ static void test2_prettyNumberDouble()
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
         const Test& test = k_DATA[idx];
 
-        // function
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", groupSize: " << test.d_groupSize
-                            << ", separator: '" << test.d_separator
-                            << "', function)");
+        PVV(test.d_line << ": checking value '" << test.d_value << "' "
+                        << " (precision: " << test.d_precision
+                        << ", groupSize: " << test.d_groupSize
+                        << ", separator: '" << test.d_separator << "')");
 
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            bmqu::PrintUtil::prettyNumber(buf,
-                                          test.d_value,
-                                          test.d_precision,
-                                          test.d_groupSize,
-                                          test.d_separator);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
-
-        // manipulator
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", groupSize: " << test.d_groupSize
-                            << ", separator: '" << test.d_separator
-                            << "', manipulator)");
-
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            buf << bmqu::PrintUtil::prettyNumber(test.d_value,
-                                                 test.d_precision,
-                                                 test.d_groupSize,
-                                                 test.d_separator);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
+        bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
+        buf << bmqu::PrintUtil::prettyNumber(test.d_value,
+                                             test.d_precision,
+                                             test.d_groupSize,
+                                             test.d_separator);
+        BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
     }
 
     PV("Ensure assertion when group size <= 0");
     {
         BMQTST_ASSERT_SAFE_FAIL(
-            bmqu::PrintUtil::prettyNumber(bsl::cout, 123.0, 0, 0, ','));
+            bsl::cout << bmqu::PrintUtil::prettyNumber(123.0, 0, 0, ','));
         BMQTST_ASSERT_SAFE_FAIL(
-            bmqu::PrintUtil::prettyNumber(bsl::cout, 123.0, 0, -2, ','));
+            bsl::cout << bmqu::PrintUtil::prettyNumber(123.0, 0, -2, ','));
     }
 }
 
@@ -213,7 +173,7 @@ static void test3_prettyBytes()
 //   Test various inputs.
 //
 // Testing:
-//   Proper behavior of 'prettyBytes(stream, bytes, precision)'
+//   Proper behavior of 'prettyBytes(bytes, precision)'
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("prettyBytes");
@@ -266,28 +226,12 @@ static void test3_prettyBytes()
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
         const Test& test = k_DATA[idx];
 
-        // function
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", function)");
+        PVV(test.d_line << ": checking value '" << test.d_value << "' "
+                        << " (precision: " << test.d_precision << ")");
 
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            bmqu::PrintUtil::prettyBytes(buf, test.d_value, test.d_precision);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
-
-        // manipulator
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", function)");
-
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            buf << bmqu::PrintUtil::prettyBytes(test.d_value,
-                                                test.d_precision);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
+        bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
+        buf << bmqu::PrintUtil::prettyBytes(test.d_value, test.d_precision);
+        BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
     }
 }
 
@@ -302,7 +246,7 @@ static void test4_prettyTimeInterval()
 //   Test various inputs.
 //
 // Testing:
-//   Proper behavior of 'prettyTimeInterval(stream, timeNs, precision)'
+//   Proper behavior of 'prettyTimeInterval(timeNs, precision)'
 // ------------------------------------------------------------------------
 {
     bmqtst::TestHelper::printTestName("prettyTimeInterval");
@@ -348,30 +292,13 @@ static void test4_prettyTimeInterval()
     for (size_t idx = 0; idx < k_NUM_DATA; ++idx) {
         const Test& test = k_DATA[idx];
 
-        // function
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", function)");
+        PVV(test.d_line << ": checking value '" << test.d_value << "' "
+                        << " (precision: " << test.d_precision << ")");
 
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            bmqu::PrintUtil::prettyTimeInterval(buf,
-                                                test.d_value,
-                                                test.d_precision);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
-
-        // manipulator
-        {
-            PVV(test.d_line << ": checking value '" << test.d_value << "' "
-                            << " (precision: " << test.d_precision
-                            << ", function)");
-
-            bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
-            buf << bmqu::PrintUtil::prettyTimeInterval(test.d_value,
-                                                       test.d_precision);
-            BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
-        }
+        bmqu::MemOutStream buf(bmqtst::TestHelperUtil::allocator());
+        buf << bmqu::PrintUtil::prettyTimeInterval(test.d_value,
+                                                   test.d_precision);
+        BMQTST_ASSERT_EQ_D(test.d_line, buf.str(), test.d_expected);
     }
 }
 

--- a/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
+++ b/src/groups/mqb/mqbcmd/mqbcmd_humanprinter.cpp
@@ -833,8 +833,7 @@ void printMessageGroupIdManagerIndex(
             bsl::ostringstream key;
             bsl::ostringstream timeDelta;
             key << cit->clientDescription() << "#" << cit->msgGroupId();
-            bmqu::PrintUtil::prettyTimeInterval(
-                timeDelta,
+            timeDelta << bmqu::PrintUtil::prettyTimeInterval(
                 cit->lastSeenDeltaNanoseconds());
             printer.printAttribute(key.str().c_str(), timeDelta.str());
         }


### PR DESCRIPTION
Function print interfaces like `bsl::ostream& prettyNumber(bsl::ostream& stream, int value, int groupSize, char separator)` are not used in the codebase (only 1 case with time interval). Possible to simplify the code by removing it.