### PR TITLE
IT: fix flaky consumer confirm without push

### DIFF
--- a/src/python/blazingmq/dev/it/cluster_util.py
+++ b/src/python/blazingmq/dev/it/cluster_util.py
@@ -183,13 +183,17 @@ def rollover_queues_and_apps_test(cluster: Cluster, domain_urls, trigger_rollove
             wait_ack=True,
         )
 
-    consumer = proxy.create_client("consumer")
-    consumer.open(priority_queue, flags=["read"], succeed=True)
-    consumer.open(fanout_queue + "?id=foo", flags=["read"], succeed=True)
-    consumer.confirm(priority_queue, "+1", succeed=True)
-    consumer.confirm(fanout_queue + "?id=foo", "+1", succeed=True)
-    consumer.close(priority_queue, succeed=True)
-    consumer.close(fanout_queue + "?id=foo", succeed=True)
+    consumer_priority = proxy.create_client("consumer_priority")
+    consumer_priority.open(priority_queue, flags=["read"], succeed=True)
+    assert consumer_priority.wait_push_event()
+    consumer_priority.confirm(priority_queue, "+1", succeed=True)
+    consumer_priority.close(priority_queue, succeed=True)
+
+    consumer_fanout = proxy.create_client("consumer_fanout")
+    consumer_fanout.open(fanout_queue + "?id=foo", flags=["read"], succeed=True)
+    assert consumer_fanout.wait_push_event()
+    consumer_fanout.confirm(fanout_queue + "?id=foo", "+1", succeed=True)
+    consumer_fanout.close(fanout_queue + "?id=foo", succeed=True)
 
     current_app_ids = tc.TEST_APPIDS[:] + ["quux"]
     cluster.set_app_ids(current_app_ids, du)
@@ -211,11 +215,11 @@ def rollover_queues_and_apps_test(cluster: Cluster, domain_urls, trigger_rollove
         producer.wait_state_restored()
 
     # EPILOGUE
-    check_if_queue_has_n_messages(consumer, priority_queue, 1)
-    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=foo", 2)
-    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=bar", 0)
-    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=baz", 3)
-    check_if_queue_has_n_messages(consumer, fanout_queue + "?id=quux", 1)
+    check_if_queue_has_n_messages(consumer_priority, priority_queue, 1)
+    check_if_queue_has_n_messages(consumer_fanout, fanout_queue + "?id=foo", 2)
+    check_if_queue_has_n_messages(consumer_fanout, fanout_queue + "?id=bar", 0)
+    check_if_queue_has_n_messages(consumer_fanout, fanout_queue + "?id=baz", 3)
+    check_if_queue_has_n_messages(consumer_fanout, fanout_queue + "?id=quux", 1)
 
 
 def run_storage_tool(journal_file: Path, mode: str) -> subprocess.CompletedProcess:


### PR DESCRIPTION
- Add missing `wait_push_event`

Fixes the following IT failure:
```
=========================== short test summary info ============================
FAILED test_rollover_journal.py::TestRolloverJournal::test_rollover_queues_and_apps[single_node_fsm-strong_consistency] - blazingmq.dev.it.process.client.ITError: confirm uri="bmq://bmq.test.mmap.fanout.sc/q_in_use?id=foo" guid="+1" did not complete within 15s
============= 1 failed, 158 passed, 1 skipped in 202.06s (0:03:22) =============
```