### PR TITLE
Refactor[mqbs::FileStore]: split rolloverImpl into phase helpers

### DIFF
--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2820,6 +2820,47 @@ void FileStore::logQueueRolloverSummary(
     BALL_LOG_INFO << outStream.str();
 }
 
+void FileStore::logCompactionMetrics(const FileSet& activeFileSet,
+                                     const FileSet& newActiveFileSet) const
+{
+    // Print some rollover-related metrics.
+
+    bmqu::MemOutStream out;
+    out << partitionDesc() << "Compaction metrics: \n"
+        << "    DATA file size    (new/old): "
+        << bmqu::PrintUtil::prettyBytes(newActiveFileSet.d_data.d_filePosition)
+        << "/"
+        << bmqu::PrintUtil::prettyBytes(activeFileSet.d_data.d_filePosition)
+        << " ("
+        << ((newActiveFileSet.d_data.d_filePosition * 100) /
+            activeFileSet.d_data.d_filePosition)
+        << "%)\n";
+
+    out << "    JOURNAL file size (new/old): "
+        << bmqu::PrintUtil::prettyBytes(
+               newActiveFileSet.d_journal.d_filePosition)
+        << "/"
+        << bmqu::PrintUtil::prettyBytes(activeFileSet.d_journal.d_filePosition)
+        << " ("
+        << ((newActiveFileSet.d_journal.d_filePosition * 100) /
+            activeFileSet.d_journal.d_filePosition)
+        << "%)\n";
+
+    if (d_qListAware) {
+        out << "    QLIST file size   (new/old): "
+            << bmqu::PrintUtil::prettyBytes(
+                   newActiveFileSet.d_qlist.d_filePosition)
+            << "/"
+            << bmqu::PrintUtil::prettyBytes(
+                   activeFileSet.d_qlist.d_filePosition)
+            << " ("
+            << ((newActiveFileSet.d_qlist.d_filePosition * 100) /
+                activeFileSet.d_qlist.d_filePosition)
+            << "%)";
+    }
+    BALL_LOG_INFO << out.str();
+}
+
 int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
 {
     // PRECONDITIONS
@@ -2980,44 +3021,7 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
     // No need to update outstanding bytes for the journal belonging to the new
     // file set, since we don't rollover SyncPts.
 
-    // Print some rollover-related metrics.
-
-    bmqu::MemOutStream out;
-    out << partitionDesc() << "Compaction metrics: \n"
-        << "    DATA file size    (new/old): "
-        << bmqu::PrintUtil::prettyBytes(
-               newActiveFileSetSp->d_data.d_filePosition)
-        << "/"
-        << bmqu::PrintUtil::prettyBytes(activeFileSet->d_data.d_filePosition)
-        << " ("
-        << ((newActiveFileSetSp->d_data.d_filePosition * 100) /
-            activeFileSet->d_data.d_filePosition)
-        << "%)\n";
-
-    out << "    JOURNAL file size (new/old): "
-        << bmqu::PrintUtil::prettyBytes(
-               newActiveFileSetSp->d_journal.d_filePosition)
-        << "/"
-        << bmqu::PrintUtil::prettyBytes(
-               activeFileSet->d_journal.d_filePosition)
-        << " ("
-        << ((newActiveFileSetSp->d_journal.d_filePosition * 100) /
-            activeFileSet->d_journal.d_filePosition)
-        << "%)\n";
-
-    if (d_qListAware) {
-        out << "    QLIST file size   (new/old): "
-            << bmqu::PrintUtil::prettyBytes(
-                   newActiveFileSetSp->d_qlist.d_filePosition)
-            << "/"
-            << bmqu::PrintUtil::prettyBytes(
-                   activeFileSet->d_qlist.d_filePosition)
-            << " ("
-            << ((newActiveFileSetSp->d_qlist.d_filePosition * 100) /
-                activeFileSet->d_qlist.d_filePosition)
-            << "%)";
-    }
-    BALL_LOG_INFO << out.str();
+    logCompactionMetrics(*activeFileSet, *newActiveFileSetSp);
 
     BALL_LOG_INFO_BLOCK
     {

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -1088,8 +1088,8 @@ int FileStore::openInRecoveryMode(bsl::ostream&    errorDescription,
                 BALL_LOG_WARN
                     << partitionDesc()
                     << "Conforming journal to cluster state: writing a "
-                    << "corrective QueueOp.DELETION for extra queueKey "
-                    << "[" << *it << "].";
+                    << "corrective QueueOp.DELETION for extra queueKey " << "["
+                    << *it << "].";
                 rc = writeCorrectiveQueueDeletionDuringRecovery(*it,
                                                                 timestamp);
                 if (0 != rc) {
@@ -2783,6 +2783,43 @@ int FileStore::create(FileSetSp* fileSetSp)
     return rc;
 }
 
+void FileStore::logQueueRolloverSummary(
+    const QueueKeyCounterMap& queueKeyCounterMap) const
+{
+    // Print summary of rolled over queues.
+    bmqu::MemOutStream outStream;
+    outStream << partitionDesc() << "Queue rollover summary:"
+              << "\n      QueueKey    NumMsgs   NumBytes      QueueUri";
+
+    QueueKeyCounterList queueKeyCounters;
+    queueKeyCounters.reserve(queueKeyCounterMap.size());
+    for (QueueKeyCounterMapCIter queueKeyCounterCIter =
+             queueKeyCounterMap.cbegin();
+         queueKeyCounterCIter != queueKeyCounterMap.cend();
+         ++queueKeyCounterCIter) {
+        queueKeyCounters.push_back(*queueKeyCounterCIter);
+    }
+    bsl::sort(queueKeyCounters.begin(), queueKeyCounters.end(), compareByByte);
+
+    for (QueueKeyCounterListCIter queueCountersCIter =
+             queueKeyCounters.cbegin();
+         queueCountersCIter != queueKeyCounters.cend();
+         ++queueCountersCIter) {
+        StorageMapConstIter sit = d_storages.find(queueCountersCIter->first);
+        BSLS_ASSERT_SAFE(sit != d_storages.cend());
+
+        outStream << "\n    [" << queueCountersCIter->first << "] "
+                  << bsl::setw(8)
+                  << bmqu::PrintUtil::prettyNumber(
+                         static_cast<int>(queueCountersCIter->second.first))
+                  << " " << bsl::setw(10)
+                  << bmqu::PrintUtil::prettyBytes(
+                         queueCountersCIter->second.second)
+                  << " " << sit->second->queueUri();
+    }
+    BALL_LOG_INFO << outStream.str();
+}
+
 int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
 {
     // PRECONDITIONS
@@ -2829,38 +2866,7 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
                               newActiveFileSetSp.get());
     }
 
-    // Print summary of rolled over queues.
-    bmqu::MemOutStream outStream;
-    outStream << partitionDesc() << "Queue rollover summary:"
-              << "\n      QueueKey    NumMsgs   NumBytes      QueueUri";
-
-    QueueKeyCounterList queueKeyCounters;
-    queueKeyCounters.reserve(queueKeyCounterMap.size());
-    for (QueueKeyCounterMapCIter queueKeyCounterCIter =
-             queueKeyCounterMap.cbegin();
-         queueKeyCounterCIter != queueKeyCounterMap.cend();
-         ++queueKeyCounterCIter) {
-        queueKeyCounters.push_back(*queueKeyCounterCIter);
-    }
-    bsl::sort(queueKeyCounters.begin(), queueKeyCounters.end(), compareByByte);
-
-    for (QueueKeyCounterListCIter queueCountersCIter =
-             queueKeyCounters.cbegin();
-         queueCountersCIter != queueKeyCounters.cend();
-         ++queueCountersCIter) {
-        StorageMapConstIter sit = d_storages.find(queueCountersCIter->first);
-        BSLS_ASSERT_SAFE(sit != d_storages.cend());
-
-        outStream << "\n    [" << queueCountersCIter->first << "] "
-                  << bsl::setw(8)
-                  << bmqu::PrintUtil::prettyNumber(
-                         static_cast<int>(queueCountersCIter->second.first))
-                  << " " << bsl::setw(10)
-                  << bmqu::PrintUtil::prettyBytes(
-                         queueCountersCIter->second.second)
-                  << " " << sit->second->queueUri();
-    }
-    BALL_LOG_INFO << outStream.str();
+    logQueueRolloverSummary(queueKeyCounterMap);
 
     // Local refs for convenience.
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.cpp
+++ b/src/groups/mqb/mqbs/mqbs_filestore.cpp
@@ -2861,6 +2861,23 @@ void FileStore::logCompactionMetrics(const FileSet& activeFileSet,
     BALL_LOG_INFO << out.str();
 }
 
+void FileStore::copyOutstandingRecords(QueueKeyCounterMap* queueKeyCounterMap,
+                                       FileSet*            activeFileSet,
+                                       FileSet*            newFileSet)
+{
+    // Iterate over outstanding records in the active set, and copy them to the
+    // rollover set.
+
+    for (RecordIterator recordIt = d_records.begin();
+         recordIt != d_records.end();
+         ++recordIt) {
+        writeRolledOverRecord(&(recordIt->second),
+                              queueKeyCounterMap,
+                              activeFileSet,
+                              newFileSet);
+    }
+}
+
 int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
 {
     // PRECONDITIONS
@@ -2898,14 +2915,9 @@ int FileStore::rolloverImpl(bsls::Types::Uint64 timestamp)
     // rollover set.
 
     QueueKeyCounterMap queueKeyCounterMap;
-    for (RecordIterator recordIt = d_records.begin();
-         recordIt != d_records.end();
-         ++recordIt) {
-        writeRolledOverRecord(&(recordIt->second),
-                              &queueKeyCounterMap,
-                              activeFileSet,
-                              newActiveFileSetSp.get());
-    }
+    copyOutstandingRecords(&queueKeyCounterMap,
+                           activeFileSet,
+                           newActiveFileSetSp.get());
 
     logQueueRolloverSummary(queueKeyCounterMap);
 

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -591,6 +591,18 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     void logQueueRolloverSummary(
         const QueueKeyCounterMap& queueKeyCounterMap) const;
 
+    /// @brief Log the data, journal, and qlist file-size compaction ratios
+    /// achieved by a rollover.
+    ///
+    /// @details Emits the new and old sizes of each file (and the new/old
+    /// percentage) at INFO level.  Has no effect on the state of this file
+    /// store.
+    ///
+    /// @param activeFileSet    The old (pre-rollover) file set.
+    /// @param newActiveFileSet The new (post-rollover) file set.
+    void logCompactionMetrics(const FileSet& activeFileSet,
+                              const FileSet& newActiveFileSet) const;
+
     /// Issue a sync point.
     ///
     /// THREAD: This method is called from the scheduler thread.

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -580,6 +580,17 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
                                FileSet*            oldFileSet,
                                FileSet*            newFileSet);
 
+    /// @brief Log a summary of the queues rolled over during rollover.
+    ///
+    /// @details Formats one line per queue (message count, byte count, and
+    /// queue URI), sorted by descending byte count, and emits it at INFO
+    /// level. Has no effect on the state of this file store.
+    ///
+    /// @param queueKeyCounterMap Per-queue message and byte counts gathered
+    ///         while copying the outstanding records.
+    void logQueueRolloverSummary(
+        const QueueKeyCounterMap& queueKeyCounterMap) const;
+
     /// Issue a sync point.
     ///
     /// THREAD: This method is called from the scheduler thread.

--- a/src/groups/mqb/mqbs/mqbs_filestore.h
+++ b/src/groups/mqb/mqbs/mqbs_filestore.h
@@ -603,6 +603,21 @@ class FileStore BSLS_KEYWORD_FINAL : public DataStore {
     void logCompactionMetrics(const FileSet& activeFileSet,
                               const FileSet& newActiveFileSet) const;
 
+    /// @brief Copy the outstanding records from the old file set into the
+    /// new (rollover) file set.
+    ///
+    /// @details Iterates the outstanding records and writes each into
+    /// `newFileSet`, accumulating per-queue message and byte counts into
+    /// `queueKeyCounterMap` for the rollover summary.
+    ///
+    /// @param queueKeyCounterMap Populated with per-queue message and byte
+    ///        counts for the copied records.
+    /// @param activeFileSet The old (pre-rollover) file set to copy from.
+    /// @param newFileSet    The new (rollover) file set to copy into.
+    void copyOutstandingRecords(QueueKeyCounterMap* queueKeyCounterMap,
+                                FileSet*            activeFileSet,
+                                FileSet*            newFileSet);
+
     /// Issue a sync point.
     ///
     /// THREAD: This method is called from the scheduler thread.


### PR DESCRIPTION
Splits the long `FileStore::rolloverImpl` (#1727) into private helpers, reducing it from ~325 to ~250 lines:

* Extract `copyOutstandingRecords` for the outstanding-record copy loop
* Extract `logQueueRolloverSummary` (const) for the per-queue summary logging
* Extract `logCompactionMetrics` (const) for the file-size metrics logging

Behavior-preserving; blocks moved as-is with locals passed as parameters. The order-sensitive sync-point write and final file-set swap are left inline. Verified against `mqbs_filestore.t` case 8.